### PR TITLE
feat(kanban): support fenced external runners

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -18,6 +18,7 @@ import argparse
 import contextlib
 import json
 import os
+import secrets
 import shlex
 import sys
 import time
@@ -81,6 +82,17 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
     }
+
+
+def _redact_claim_credentials(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: ("[redacted]" if key in {"lock", "claim_lock"} and item else _redact_claim_credentials(item))
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_claim_credentials(item) for item in value]
+    return value
 
 
 def _run_state_kwargs(args: argparse.Namespace) -> Optional[dict[str, str]]:
@@ -504,6 +516,23 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_unlink.add_argument("parent_id")
     p_unlink.add_argument("child_id")
 
+    p_external_contract = sub.add_parser(
+        "external-runner-contract",
+        help="Report the machine-readable external runner CLI contract",
+    )
+    p_external_contract.add_argument("--json", action="store_true")
+
+    # --- external runner lane lease ---
+    p_lane_lease = sub.add_parser(
+        "lane-lease",
+        help="Acquire, renew, or release a board-local external runner lane lease",
+    )
+    p_lane_lease.add_argument("operation", choices=("acquire", "release"))
+    p_lane_lease.add_argument("lane")
+    p_lane_lease.add_argument("--owner", required=True)
+    p_lane_lease.add_argument("--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS)
+    p_lane_lease.add_argument("--json", action="store_true")
+
     # --- claim ---
     p_claim = sub.add_parser(
         "claim",
@@ -512,6 +541,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_claim.add_argument("task_id")
     p_claim.add_argument("--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS,
                          help="Claim TTL in seconds (default: 900)")
+    p_claim.add_argument(
+        "--json", action="store_true",
+        help="Emit the claim, run, lease, and resolved workspace as JSON",
+    )
 
     # --- comment / complete / block / unblock / archive ---
     p_comment = sub.add_parser("comment", help="Append a comment")
@@ -550,6 +583,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_complete.add_argument("--metadata", default=None,
                             help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
                                  '"tests_run": 12}\'). Stored on the closing run.')
+    p_complete.add_argument(
+        "--run-id", type=int, default=None,
+        help="Fence a single-task completion to this running attempt id",
+    )
+    p_complete.add_argument(
+        "--claim-lock", default=None,
+        help="Also require this live claim token; requires --run-id",
+    )
 
     p_edit = sub.add_parser(
         "edit",
@@ -578,6 +619,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_block.add_argument("--ids", nargs="+", default=None,
                          help="Additional task ids to block with the same reason (bulk mode)")
     p_block.add_argument(
+        "--run-id", type=int, default=None,
+        help="Fence a single-task block to this running attempt id",
+    )
+    p_block.add_argument(
+        "--claim-lock", default=None,
+        help="Also require this live claim token; requires --run-id",
+    )
+    p_block.add_argument(
         "--kind", default=None, choices=sorted(kb.VALID_BLOCK_KINDS),
         help=(
             "Typed block reason. 'dependency' waits in todo (auto-promoted "
@@ -593,6 +642,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_schedule.add_argument("reason", nargs="*", help="Reason/timing note (also appended as a comment)")
     p_schedule.add_argument("--ids", nargs="+", default=None,
                             help="Additional task ids to schedule with the same reason (bulk mode)")
+    p_schedule.add_argument(
+        "--run-id", type=int, default=None,
+        help="Fence a single-task schedule to this running attempt id",
+    )
+    p_schedule.add_argument(
+        "--claim-lock", default=None,
+        help="Also require this live claim token; requires --run-id",
+    )
 
     p_unblock = sub.add_parser("unblock", help="Return one or more blocked/scheduled tasks to ready")
     p_unblock.add_argument(
@@ -778,6 +835,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_hb.add_argument("task_id")
     p_hb.add_argument("--note", default=None,
                       help="Optional short note attached to the heartbeat event")
+    p_hb.add_argument(
+        "--claim-lock", default=None,
+        help="Stable claim token returned by `claim --json`; requires --run-id",
+    )
+    p_hb.add_argument(
+        "--run-id", type=int, default=None,
+        help="Running attempt id returned by `claim --json`; requires --claim-lock",
+    )
+    p_hb.add_argument(
+        "--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS,
+        help="When renewing an external claim, extend its lease by this many seconds",
+    )
+    p_hb.add_argument("--json", action="store_true", help="Emit JSON result")
 
     # --- assignees ---
     p_asg = sub.add_parser(
@@ -967,6 +1037,8 @@ def kanban_command(args: argparse.Namespace) -> int:
             "diag":     _cmd_diagnostics,
             "link":     _cmd_link,
             "unlink":   _cmd_unlink,
+            "external-runner-contract": _cmd_external_runner_contract,
+            "lane-lease": _cmd_lane_lease,
             "claim":    _cmd_claim,
             "comment":  _cmd_comment,
             "attach":   _cmd_attach,
@@ -1290,17 +1362,49 @@ def _cmd_init(args: argparse.Namespace) -> int:
 
 
 def _cmd_heartbeat(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        ok = kb.heartbeat_worker(
-            conn,
-            args.task_id,
-            note=getattr(args, "note", None),
-            expected_run_id=_worker_run_id_for(args.task_id),
+    claim_lock = getattr(args, "claim_lock", None)
+    run_id = getattr(args, "run_id", None)
+    if (claim_lock is None) != (run_id is None):
+        print(
+            "kanban: --claim-lock and --run-id must be provided together",
+            file=sys.stderr,
         )
+        return 2
+
+    claim_expires = None
+    with kb.connect_closing() as conn:
+        if claim_lock is not None:
+            claim_expires = kb.heartbeat_external_claim(
+                conn,
+                args.task_id,
+                claim_lock=claim_lock,
+                expected_run_id=run_id,
+                ttl_seconds=getattr(args, "ttl", None),
+                note=getattr(args, "note", None),
+            )
+            ok = claim_expires is not None
+        else:
+            ok = kb.heartbeat_worker(
+                conn,
+                args.task_id,
+                note=getattr(args, "note", None),
+                expected_run_id=_worker_run_id_for(args.task_id),
+            )
     if not ok:
-        print(f"cannot heartbeat {args.task_id} (not running?)", file=sys.stderr)
+        print(
+            f"cannot heartbeat {args.task_id} (not running or claim superseded?)",
+            file=sys.stderr,
+        )
         return 1
-    print(f"Heartbeat recorded for {args.task_id}")
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "task_id": args.task_id,
+            "run_id": run_id,
+            "claim_expires": claim_expires,
+            "renewed": claim_lock is not None,
+        }, indent=2, ensure_ascii=False))
+    else:
+        print(f"Heartbeat recorded for {args.task_id}")
     return 0
 
 
@@ -1501,7 +1605,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
             "events": [
                 {
                     "kind": e.kind,
-                    "payload": e.payload,
+                    "payload": _redact_claim_credentials(e.payload),
                     "created_at": e.created_at,
                     "run_id": e.run_id,
                 }
@@ -1834,9 +1938,72 @@ def _cmd_unlink(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_external_runner_contract(args: argparse.Namespace) -> int:
+    payload = {
+        "contract_version": 1,
+        "capabilities": [
+            "atomic_lane_lease",
+            "claim_json_credentials",
+            "renewable_claim_lock",
+            "fenced_terminal_transitions",
+        ],
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2))
+    else:
+        print("External runner contract v1")
+    return 0
+
+
+def _cmd_lane_lease(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        if args.operation == "acquire":
+            expires = kb.acquire_external_lane_lease(
+                conn,
+                args.lane,
+                owner=args.owner,
+                ttl_seconds=args.ttl,
+            )
+            if expires is None:
+                print(f"lane {args.lane!r} is leased by another owner", file=sys.stderr)
+                return 1
+            payload = {
+                "lane": args.lane,
+                "owner": args.owner,
+                "expires_at": expires,
+                "acquired": True,
+            }
+        else:
+            released = kb.release_external_lane_lease(
+                conn,
+                args.lane,
+                owner=args.owner,
+            )
+            if not released:
+                print(f"cannot release lane {args.lane!r}: owner mismatch", file=sys.stderr)
+                return 1
+            payload = {
+                "lane": args.lane,
+                "owner": args.owner,
+                "released": True,
+            }
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        verb = "Acquired" if args.operation == "acquire" else "Released"
+        print(f"{verb} lane lease {args.lane} for {args.owner}")
+    return 0
+
+
 def _cmd_claim(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
-        task = kb.claim_task(conn, args.task_id, ttl_seconds=args.ttl)
+        task = kb.claim_task(
+            conn,
+            args.task_id,
+            ttl_seconds=args.ttl,
+            claimer=f"external:{secrets.token_urlsafe(32)}"
+            if getattr(args, "json", False) else None,
+        )
         if task is None:
             # Report why
             existing = kb.get_task(conn, args.task_id)
@@ -1845,14 +2012,38 @@ def _cmd_claim(args: argparse.Namespace) -> int:
                 return 1
             print(
                 f"cannot claim {args.task_id}: status={existing.status} "
-                f"lock={existing.claim_lock or '(none)'}",
+                "(already claimed or not ready)",
                 file=sys.stderr,
             )
             return 1
+        claim_lock = task.claim_lock
+        run_id = task.current_run_id
         workspace = kb.resolve_workspace(task)
-        kb.set_workspace_path(conn, task.id, str(workspace))
-    print(f"Claimed {task.id}")
-    print(f"Workspace: {workspace}")
+        if not kb.set_workspace_path_if_claim_owned(
+            conn,
+            task.id,
+            str(workspace),
+            claim_lock=claim_lock,
+            expected_run_id=run_id,
+        ):
+            print(
+                f"cannot claim {task.id}: claim expired or was superseded while "
+                "resolving workspace; workspace preserved",
+                file=sys.stderr,
+            )
+            return 1
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "task_id": task.id,
+            "run_id": run_id,
+            "status": task.status,
+            "workspace": str(workspace),
+            "claim_lock": claim_lock,
+            "claim_expires": task.claim_expires,
+        }, indent=2, ensure_ascii=False))
+    else:
+        print(f"Claimed {task.id}")
+        print(f"Workspace: {workspace}")
     return 0
 
 
@@ -1962,22 +2153,49 @@ def _worker_run_id_for(task_id: str) -> Optional[int]:
         return None
 
 
+def _expected_run_id_for(args: argparse.Namespace, task_id: str) -> Optional[int]:
+    explicit = getattr(args, "run_id", None)
+    return int(explicit) if explicit is not None else _worker_run_id_for(task_id)
+
+
+def _explicit_claim_lock_for(args: argparse.Namespace) -> Optional[str]:
+    value = getattr(args, "claim_lock", None)
+    return str(value) if value is not None else None
+
+
+def _validate_terminal_fence(args: argparse.Namespace) -> bool:
+    has_lock = _explicit_claim_lock_for(args) is not None
+    has_run = getattr(args, "run_id", None) is not None
+    if has_lock != has_run:
+        print(
+            "kanban: --run-id and --claim-lock must be provided together",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def _cmd_complete(args: argparse.Namespace) -> int:
     """Mark one or more tasks done. Supports a single id or a list."""
     ids = list(args.task_ids or [])
     if not ids:
         print("at least one task_id is required", file=sys.stderr)
         return 1
+    if not _validate_terminal_fence(args):
+        return 2
     summary = getattr(args, "summary", None)
     raw_meta = getattr(args, "metadata", None)
     # Guard: structured handoff fields are per-run, so they'd be
     # copy-pasted identically across N runs — almost always a footgun.
     # Refuse instead of silently doing the wrong thing.
-    if len(ids) > 1 and (summary or raw_meta):
+    if len(ids) > 1 and (
+        summary or raw_meta or getattr(args, "run_id", None) is not None
+        or _explicit_claim_lock_for(args) is not None
+    ):
         print(
-            "kanban: --summary / --metadata are per-task and can't be used "
-            "with multiple ids (would apply the same handoff to every task). "
-            "Complete tasks one at a time, or drop the flags for the bulk close.",
+            "kanban: --summary / --metadata / --run-id are per-task and can't "
+            "be used with multiple ids. Complete tasks one at a time, or drop "
+            "the per-task flags for the bulk close.",
             file=sys.stderr,
         )
         return 2
@@ -1998,7 +2216,8 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 result=args.result,
                 summary=summary,
                 metadata=metadata,
-                expected_run_id=_worker_run_id_for(tid),
+                expected_run_id=_expected_run_id_for(args, tid),
+                expected_claim_lock=_explicit_claim_lock_for(args),
             ):
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
@@ -2036,25 +2255,34 @@ def _cmd_edit(args: argparse.Namespace) -> int:
 
 
 def _cmd_block(args: argparse.Namespace) -> int:
+    if not _validate_terminal_fence(args):
+        return 2
     reason = " ".join(args.reason).strip() if args.reason else None
     kind = getattr(args, "kind", None)
     author = _profile_author()
     ids = [args.task_id] + list(getattr(args, "ids", None) or [])
+    if len(ids) > 1 and (
+        getattr(args, "run_id", None) is not None
+        or _explicit_claim_lock_for(args) is not None
+    ):
+        print("kanban: claim fencing cannot be used with multiple task ids", file=sys.stderr)
+        return 2
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
             if not kb.block_task(
                 conn,
                 tid,
                 reason=reason,
                 kind=kind,
-                expected_run_id=_worker_run_id_for(tid),
+                expected_run_id=_expected_run_id_for(args, tid),
+                expected_claim_lock=_explicit_claim_lock_for(args),
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
                 # Report where the task actually landed — dependency blocks go
                 # to todo, and a tripped unblock-loop breaker routes to triage.
                 landed = kb.get_task(conn, tid)
@@ -2073,23 +2301,32 @@ def _cmd_block(args: argparse.Namespace) -> int:
 
 
 def _cmd_schedule(args: argparse.Namespace) -> int:
+    if not _validate_terminal_fence(args):
+        return 2
     reason = " ".join(args.reason).strip() if args.reason else None
     author = _profile_author()
     ids = [args.task_id] + list(getattr(args, "ids", None) or [])
+    if len(ids) > 1 and (
+        getattr(args, "run_id", None) is not None
+        or _explicit_claim_lock_for(args) is not None
+    ):
+        print("kanban: claim fencing cannot be used with multiple task ids", file=sys.stderr)
+        return 2
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"SCHEDULED: {reason}")
             if not kb.schedule_task(
                 conn,
                 tid,
                 reason=reason,
-                expected_run_id=_worker_run_id_for(tid),
+                expected_run_id=_expected_run_id_for(args, tid),
+                expected_claim_lock=_explicit_claim_lock_for(args),
             ):
                 failed.append(tid)
                 print(f"cannot schedule {tid}", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"SCHEDULED: {reason}")
                 print(f"Scheduled {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1252,6 +1252,13 @@ CREATE TABLE IF NOT EXISTS task_attachments (
 -- task. The gateway's kanban-notifier watcher tails task_events and
 -- pushes ``completed`` / ``blocked`` / ``spawn_auto_blocked`` events to
 -- the original requester so human-in-the-loop workflows close the loop.
+CREATE TABLE IF NOT EXISTS external_lane_leases (
+    lane       TEXT PRIMARY KEY,
+    owner      TEXT NOT NULL,
+    expires_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     task_id       TEXT NOT NULL,
     platform      TEXT NOT NULL,
@@ -3209,6 +3216,18 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
     return out
 
 
+def _redact_event_claim_credentials(value: Any) -> Any:
+    credential_keys = {"lock", "claim_lock", "prev_lock", "stale_lock", "claimer"}
+    if isinstance(value, dict):
+        return {
+            key: ("[redacted]" if key in credential_keys and item else _redact_event_claim_credentials(item))
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_event_claim_credentials(item) for item in value]
+    return value
+
+
 def _append_event(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3225,7 +3244,8 @@ def _append_event(
     and the row carries NULL.
     """
     now = int(time.time())
-    pl = json.dumps(payload, ensure_ascii=False) if payload else None
+    safe_payload = _redact_event_claim_credentials(payload) if payload else None
+    pl = json.dumps(safe_payload, ensure_ascii=False) if safe_payload else None
     conn.execute(
         "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
         "VALUES (?, ?, ?, ?, ?)",
@@ -3481,6 +3501,50 @@ def recompute_ready(
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
+def acquire_external_lane_lease(
+    conn: sqlite3.Connection,
+    lane: str,
+    *,
+    owner: str,
+    ttl_seconds: int,
+) -> Optional[int]:
+    """Acquire or renew one board-local external runner lane lease."""
+    lane = lane.strip()
+    owner = owner.strip()
+    if not lane or not owner:
+        raise ValueError("lane and owner are required")
+    if ttl_seconds < 1:
+        raise ValueError("ttl_seconds must be positive")
+    with write_txn(conn):
+        now = int(time.time())
+        expires = now + int(ttl_seconds)
+        cur = conn.execute(
+            "INSERT INTO external_lane_leases(lane, owner, expires_at, updated_at) "
+            "VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(lane) DO UPDATE SET owner = excluded.owner, "
+            "expires_at = excluded.expires_at, updated_at = excluded.updated_at "
+            "WHERE external_lane_leases.owner = excluded.owner "
+            "OR external_lane_leases.expires_at < ?",
+            (lane, owner, expires, now, now),
+        )
+        return expires if cur.rowcount == 1 else None
+
+
+def release_external_lane_lease(
+    conn: sqlite3.Connection,
+    lane: str,
+    *,
+    owner: str,
+) -> bool:
+    """Release a lane lease only when ``owner`` still holds it."""
+    with write_txn(conn):
+        cur = conn.execute(
+            "DELETE FROM external_lane_leases WHERE lane = ? AND owner = ?",
+            (lane.strip(), owner.strip()),
+        )
+        return cur.rowcount == 1
+
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3707,6 +3771,53 @@ def heartbeat_claim(
                 )
             return True
         return False
+
+
+def heartbeat_external_claim(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    claim_lock: str,
+    expected_run_id: int,
+    ttl_seconds: Optional[int] = None,
+    note: Optional[str] = None,
+) -> Optional[int]:
+    """Atomically renew and heartbeat a claim owned by an external runner.
+
+    The stable ``claim_lock`` and ``expected_run_id`` fence a delayed runner
+    from extending or updating a newer attempt. Returns the new expiry epoch
+    when the caller still owns the claim, otherwise ``None``.
+    """
+    with write_txn(conn):
+        now = int(time.time())
+        expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
+        cur = conn.execute(
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ? AND status = 'running' AND claim_lock = ? "
+            "AND current_run_id = ? AND claim_expires >= ?",
+            (expires, now, task_id, claim_lock, int(expected_run_id), now),
+        )
+        if cur.rowcount != 1:
+            return None
+        run_cur = conn.execute(
+            "UPDATE task_runs SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ? AND task_id = ? AND status = 'running' "
+            "AND claim_lock = ? AND ended_at IS NULL AND claim_expires >= ?",
+            (expires, now, int(expected_run_id), task_id, claim_lock, now),
+        )
+        if run_cur.rowcount != 1:
+            raise RuntimeError(
+                f"running task {task_id} has no matching run {expected_run_id}"
+            )
+        _append_event(
+            conn,
+            task_id,
+            "heartbeat",
+            {"note": note, "claim_expires": expires}
+            if note else {"claim_expires": expires},
+            run_id=int(expected_run_id),
+        )
+    return expires
 
 
 def release_stale_claims(
@@ -4091,6 +4202,23 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+def _live_claim_matches(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: Optional[int],
+    expected_claim_lock: str,
+) -> bool:
+    if expected_run_id is None:
+        return False
+    row = conn.execute(
+        "SELECT 1 FROM tasks WHERE id = ? AND status = 'running' "
+        "AND current_run_id = ? AND claim_lock = ? AND claim_expires >= ?",
+        (task_id, int(expected_run_id), expected_claim_lock, int(time.time())),
+    ).fetchone()
+    return row is not None
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4100,6 +4228,7 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -4162,6 +4291,13 @@ def complete_task(
         conn, task_id, metadata, summary=summary, result=result,
     )
     with write_txn(conn):
+        if expected_claim_lock is not None and not _live_claim_matches(
+            conn,
+            task_id,
+            expected_run_id=expected_run_id,
+            expected_claim_lock=expected_claim_lock,
+        ):
+            return False
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -4880,6 +5016,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -4915,6 +5052,13 @@ def block_task(
     routed_to = "blocked"
     recurrences = 0
     with write_txn(conn):
+        if expected_claim_lock is not None and not _live_claim_matches(
+            conn,
+            task_id,
+            expected_run_id=expected_run_id,
+            expected_claim_lock=expected_claim_lock,
+        ):
+            return False
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
             (task_id,),
@@ -5909,6 +6053,26 @@ def set_workspace_path(
         )
 
 
+def set_workspace_path_if_claim_owned(
+    conn: sqlite3.Connection,
+    task_id: str,
+    path: Path | str,
+    *,
+    claim_lock: str,
+    expected_run_id: int,
+) -> bool:
+    """Persist a resolved workspace only while the original claim is live."""
+    with write_txn(conn):
+        now = int(time.time())
+        cur = conn.execute(
+            "UPDATE tasks SET workspace_path = ? WHERE id = ? "
+            "AND status = 'running' AND claim_lock = ? "
+            "AND current_run_id = ? AND claim_expires >= ?",
+            (str(path), task_id, claim_lock, int(expected_run_id), now),
+        )
+        return cur.rowcount == 1
+
+
 def set_branch_name(
     conn: sqlite3.Connection, task_id: str, branch_name: str
 ) -> None:
@@ -5926,6 +6090,7 @@ def schedule_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
 ) -> bool:
     """Park a task in ``scheduled`` so it is waiting on time, not human input.
 
@@ -5934,6 +6099,13 @@ def schedule_task(
     to ``ready`` (or ``todo`` if parents are still incomplete).
     """
     with write_txn(conn):
+        if expected_claim_lock is not None and not _live_claim_matches(
+            conn,
+            task_id,
+            expected_run_id=expected_run_id,
+            expected_claim_lock=expected_claim_lock,
+        ):
+            return False
         params: list[Any] = [task_id]
         sql = """
             UPDATE tasks

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1180,6 +1180,192 @@ def test_cli_heartbeat_verb(kanban_home):
         conn.close()
 
 
+def test_cli_reports_external_runner_contract(kanban_home):
+    payload = json.loads(run_slash("external-runner-contract --json"))
+    assert payload["contract_version"] == 1
+    assert "atomic_lane_lease" in payload["capabilities"]
+    assert "fenced_terminal_transitions" in payload["capabilities"]
+
+
+def test_cli_external_lane_lease_contract(kanban_home):
+    acquired = json.loads(run_slash(
+        "lane-lease acquire external-pi --owner host-a --ttl 300 --json"
+    ))
+    assert acquired["acquired"] is True
+    assert acquired["owner"] == "host-a"
+    refused = run_slash(
+        "lane-lease acquire external-pi --owner host-b --ttl 300 --json"
+    )
+    assert "another owner" in refused
+    released = json.loads(run_slash(
+        "lane-lease release external-pi --owner host-a --json"
+    ))
+    assert released["released"] is True
+
+
+def test_failed_cli_claim_does_not_disclose_current_claim_token(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="claimed", assignee="external-pi")
+        kb.claim_task(conn, tid, claimer="secret-current-claim")
+
+    out = run_slash(f"claim {tid} --json")
+    assert "cannot claim" in out
+    assert "secret-current-claim" not in out
+
+
+def test_cli_external_claim_and_heartbeat_json_contract(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="external", assignee="external-pi")
+    finally:
+        conn.close()
+
+    claim = json.loads(run_slash(f"claim {tid} --ttl 60 --json"))
+    assert claim["task_id"] == tid
+    assert claim["run_id"] > 0
+    assert claim["claim_lock"].startswith("external:")
+    assert len(claim["claim_lock"]) > 40
+    assert claim["claim_expires"] > int(time.time())
+    assert Path(claim["workspace"]).is_dir()
+    shown = json.loads(run_slash(f"show {tid} --json"))
+    claimed_event = next(e for e in shown["events"] if e["kind"] == "claimed")
+    assert claimed_event["payload"]["lock"] == "[redacted]"
+    assert claim["claim_lock"] not in json.dumps(shown)
+
+    heartbeat = json.loads(run_slash(
+        f"heartbeat {tid} --claim-lock {claim['claim_lock']} "
+        f"--run-id {claim['run_id']} --ttl 3600 --note working --json"
+    ))
+    assert heartbeat == {
+        "task_id": tid,
+        "run_id": claim["run_id"],
+        "claim_expires": heartbeat["claim_expires"],
+        "renewed": True,
+    }
+    assert heartbeat["claim_expires"] > claim["claim_expires"]
+
+    out = run_slash(
+        f"complete {tid} --run-id {claim['run_id']} "
+        f"--claim-lock {claim['claim_lock']} --summary verified"
+    )
+    assert f"Completed {tid}" in out
+
+
+def test_cli_claim_does_not_return_replacement_credentials_after_workspace_race(
+    kanban_home, monkeypatch, tmp_path,
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="workspace race", assignee="external-pi")
+    finally:
+        conn.close()
+
+    target = tmp_path / "resolved-but-superseded"
+
+    def race_during_resolution(_task):
+        target.mkdir()
+        with kb.connect() as race_conn:
+            assert kb.reclaim_task(race_conn, tid, reason="test race")
+            replacement = kb.claim_task(
+                race_conn, tid, claimer="external:replacement",
+            )
+            assert replacement is not None
+        return target
+
+    monkeypatch.setattr(kb, "resolve_workspace", race_during_resolution)
+    out = run_slash(f"claim {tid} --json")
+    assert "superseded" in out
+
+    with kb.connect() as check_conn:
+        task = kb.get_task(check_conn, tid)
+        assert task.status == "running"
+        assert task.claim_lock == "external:replacement"
+        assert task.workspace_path is None
+
+
+def test_cli_claim_json_never_rereads_replacement_credentials(
+    kanban_home, monkeypatch,
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="post-persist race", assignee="external-pi")
+    finally:
+        conn.close()
+
+    original_set = kb.set_workspace_path_if_claim_owned
+
+    def replace_after_persist(conn, task_id, path, **kwargs):
+        assert original_set(conn, task_id, path, **kwargs)
+        assert kb.reclaim_task(conn, task_id, reason="post-persist race")
+        replacement = kb.claim_task(conn, task_id, claimer="external:replacement")
+        assert replacement is not None
+        return True
+
+    monkeypatch.setattr(kb, "set_workspace_path_if_claim_owned", replace_after_persist)
+    payload = json.loads(run_slash(f"claim {tid} --json"))
+    assert payload["claim_lock"] != "external:replacement"
+
+    with kb.connect() as check_conn:
+        current = kb.get_task(check_conn, tid)
+        assert current.claim_lock == "external:replacement"
+        assert current.current_run_id != payload["run_id"]
+
+
+def test_cli_terminal_fence_requires_run_and_lock_together(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="paired fence", assignee="external-pi")
+        task = kb.claim_task(conn, tid, claimer="external:stable")
+
+    out = run_slash(f"complete {tid} --run-id {task.current_run_id}")
+    assert "must be provided together" in out
+    out = run_slash(f"block {tid} late --claim-lock external:stable")
+    assert "must be provided together" in out
+
+
+def test_cli_terminal_transition_run_id_fences_stale_external_runner(
+    kanban_home, monkeypatch,
+):
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="guarded", assignee="external-pi")
+        kb.claim_task(conn, tid)
+        stale_run = kb.latest_run(conn, tid)
+        kb._set_worker_pid(conn, tid, 98765)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        assert kb.detect_crashed_workers(conn) == [tid]
+        kb.claim_task(conn, tid)
+        current_run = kb.latest_run(conn, tid)
+    finally:
+        conn.close()
+
+    out = run_slash(
+        f"complete {tid} --run-id {stale_run.id} --claim-lock stale:claim"
+    )
+    assert "cannot complete" in out
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        assert task.current_run_id == current_run.id
+    finally:
+        conn.close()
+
+    out = run_slash(
+        f"block {tid} too-late --run-id {stale_run.id} --claim-lock stale:claim"
+    )
+    assert "cannot block" in out
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        comments = kb.list_comments(conn, tid)
+        assert all("too-late" not in comment.body for comment in comments)
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Event vocab rename + spawned event (item 3 from Multica)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1139,6 +1139,166 @@ def test_heartbeat_uses_env_default_ttl(kanban_home, monkeypatch):
         assert new > int(time.time()) + 3000
 
 
+def test_external_heartbeat_atomically_renews_matching_run(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="x", assignee="external")
+        task = kb.claim_task(
+            conn, task_id, claimer="external:stable", ttl_seconds=60,
+        )
+        run_id = task.current_run_id
+        short_expiry = int(time.time()) + 30
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (short_expiry, task_id),
+        )
+        conn.execute(
+            "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+            (short_expiry, run_id),
+        )
+
+        expires = kb.heartbeat_external_claim(
+            conn,
+            task_id,
+            claim_lock="external:stable",
+            expected_run_id=run_id,
+            ttl_seconds=3600,
+            note="still working",
+        )
+
+        assert expires is not None
+        assert expires > int(time.time()) + 3000
+        task = kb.get_task(conn, task_id)
+        assert task.claim_expires == expires
+        run = kb.list_runs(conn, task_id)[0]
+        assert run.claim_expires == expires
+        assert run.last_heartbeat_at is not None
+
+
+def test_external_heartbeat_rejects_stale_lock_run_or_expired_lease(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="x", assignee="external")
+        task = kb.claim_task(conn, task_id, claimer="external:stable")
+        original_expiry = task.claim_expires
+
+        assert kb.heartbeat_external_claim(
+            conn,
+            task_id,
+            claim_lock="external:stale",
+            expected_run_id=task.current_run_id,
+        ) is None
+        assert kb.heartbeat_external_claim(
+            conn,
+            task_id,
+            claim_lock="external:stable",
+            expected_run_id=task.current_run_id + 1,
+        ) is None
+        assert kb.get_task(conn, task_id).claim_expires == original_expiry
+
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 1, task_id),
+        )
+        conn.execute(
+            "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 1, task.current_run_id),
+        )
+        assert kb.heartbeat_external_claim(
+            conn,
+            task_id,
+            claim_lock="external:stable",
+            expected_run_id=task.current_run_id,
+        ) is None
+
+
+def test_external_terminal_transition_requires_live_claim(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="x", assignee="external")
+        task = kb.claim_task(conn, task_id, claimer="external:stable")
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 1, task_id),
+        )
+        conn.execute(
+            "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 1, task.current_run_id),
+        )
+
+        assert not kb.complete_task(
+            conn,
+            task_id,
+            expected_run_id=task.current_run_id,
+            expected_claim_lock="external:stable",
+        )
+        assert not kb.block_task(
+            conn,
+            task_id,
+            reason="late",
+            expected_run_id=task.current_run_id,
+            expected_claim_lock="external:stable",
+        )
+        assert kb.get_task(conn, task_id).status == "running"
+
+
+def test_workspace_persist_is_fenced_by_live_claim(kanban_home, tmp_path):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="x", assignee="external")
+        task = kb.claim_task(conn, task_id, claimer="external:stable")
+        target = tmp_path / "workspace"
+
+        assert not kb.set_workspace_path_if_claim_owned(
+            conn,
+            task_id,
+            target,
+            claim_lock="external:stale",
+            expected_run_id=task.current_run_id,
+        )
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 1, task_id),
+        )
+        assert not kb.set_workspace_path_if_claim_owned(
+            conn,
+            task_id,
+            target,
+            claim_lock="external:stable",
+            expected_run_id=task.current_run_id,
+        )
+        assert kb.get_task(conn, task_id).workspace_path is None
+
+
+def test_external_lane_lease_is_atomic_and_owner_fenced(kanban_home):
+    with kb.connect() as conn:
+        first = kb.acquire_external_lane_lease(
+            conn, "external-pi", owner="host-a", ttl_seconds=300,
+        )
+        assert first is not None
+        assert kb.acquire_external_lane_lease(
+            conn, "external-pi", owner="host-b", ttl_seconds=300,
+        ) is None
+        renewed = kb.acquire_external_lane_lease(
+            conn, "external-pi", owner="host-a", ttl_seconds=600,
+        )
+        assert renewed > first
+        assert not kb.release_external_lane_lease(
+            conn, "external-pi", owner="host-b",
+        )
+        assert kb.release_external_lane_lease(
+            conn, "external-pi", owner="host-a",
+        )
+
+
+def test_concurrent_external_lane_lease_has_one_winner(kanban_home):
+    def attempt(owner):
+        with kb.connect() as conn:
+            return kb.acquire_external_lane_lease(
+                conn, "external-pi", owner=owner, ttl_seconds=300,
+            )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(attempt, [f"host-{i}" for i in range(8)]))
+    assert sum(result is not None for result in results) == 1
+
+
 def test_concurrent_claims_only_one_wins(kanban_home):
     """Fire N threads claiming the same task; exactly one must win."""
     with kb.connect() as conn:


### PR DESCRIPTION
## Summary
- add a machine-readable external runner contract and atomic board-local lane leases
- return random fenced claim credentials as JSON and renew them with live lease checks
- require run + claim fencing for external complete/block/schedule transitions
- redact claim capabilities from durable events and task views
- fence workspace resolution against reclaim races

## Verification
- `python -m pytest -q tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py` — 463 passed, 1 skipped
- `python -m ruff check hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_db.py`
- disposable external claim → heartbeat → complete E2E
- disposable gmux external runner E2E