### PR TITLE
feat(auth): add /login codex for messaging gateways

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10204,6 +10204,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "model":
             return await self._handle_model_command(event)
 
+        if canonical == "login":
+            return await self._handle_login_command(event)
+
         if canonical == "codex-runtime":
             return await self._handle_codex_runtime_command(event)
 
@@ -13112,6 +13115,95 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+
+    async def _handle_login_command(self, event: MessageEvent) -> str:
+        """Pair OpenAI Codex from an authorized private messaging session."""
+        source = event.source
+        provider = event.get_command_args().strip().lower() or "codex"
+        if provider not in {"codex", "openai-codex", "openai_codex"}:
+            return "Usage: /login codex"
+
+        if (source.chat_type or "").strip().lower() not in {
+            "dm",
+            "direct",
+            "private",
+        }:
+            return (
+                "For safety, Codex login codes are only sent in a private "
+                "conversation. DM this bot `/login codex` to pair Codex."
+            )
+
+        # Credential replacement is always admin-only when the operator has
+        # configured command roles. With no role split configured, the normal
+        # gateway allowlist remains the owner boundary for backward compatibility.
+        from gateway.slash_access import policy_for_source
+
+        policy = policy_for_source(self.config, source)
+        if not policy.is_admin(source.user_id):
+            return "⛔ /login is admin-only because it replaces Hermes credentials."
+
+        flow_key = (
+            str(source.profile or "default"),
+            source.platform.value if source.platform else "",
+            str(source.chat_id or ""),
+            str(source.thread_id or ""),
+            str(source.user_id or ""),
+        )
+        active_flows = getattr(self, "_active_codex_login_flows", None)
+        if active_flows is None:
+            active_flows = set()
+            self._active_codex_login_flows = active_flows
+        if flow_key in active_flows:
+            return (
+                "A Codex login code is already active for this conversation. "
+                "Complete it, or wait for it to expire before requesting a new one."
+            )
+
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return "Codex login could not find a private response path for this conversation."
+
+        loop = asyncio.get_running_loop()
+        metadata = self._thread_metadata_for_source(
+            source,
+            self._reply_anchor_for_event(event),
+        )
+
+        def _send_verification(prompt) -> None:
+            minutes = max(1, round(prompt.expires_in_seconds / 60))
+            message = (
+                "Open this link in your browser and enter the Codex pairing code:\n\n"
+                f"{prompt.verification_url}\n\n"
+                f"Code: `{prompt.user_code}`\n\n"
+                f"The code expires in about {minutes} minutes. Never share it."
+            )
+            future = asyncio.run_coroutine_threadsafe(
+                adapter.send(str(source.chat_id), message, metadata=metadata),
+                loop,
+            )
+            result = future.result(timeout=30)
+            if getattr(result, "success", True) is False:
+                raise RuntimeError("private device-code delivery failed")
+
+        active_flows.add(flow_key)
+        try:
+            from hermes_cli.auth import login_openai_codex_device
+
+            await asyncio.to_thread(
+                login_openai_codex_device,
+                _send_verification,
+            )
+            return "Codex login complete. Try your request again now."
+        except Exception:
+            logger.warning(
+                "Codex device-code login failed for %s:%s",
+                source.platform.value if source.platform else "?",
+                source.user_id,
+                exc_info=True,
+            )
+            return "Codex login did not complete. Send `/login codex` to request a new code."
+        finally:
+            active_flows.discard(flow_key)
 
     async def _handle_suggestions_command(self, event: MessageEvent) -> str:
         """Handle /suggestions in the gateway.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -152,6 +152,15 @@ SERVICE_PROVIDER_NAMES: Dict[str, str] = {
 LMSTUDIO_NOAUTH_PLACEHOLDER = "dummy-lm-api-key"
 
 
+@dataclass(frozen=True)
+class CodexDeviceCodePrompt:
+    """Safe, token-free device-code details for non-terminal auth surfaces."""
+
+    verification_url: str
+    user_code: str
+    expires_in_seconds: int
+
+
 # =============================================================================
 # Provider Registry
 # =============================================================================
@@ -7354,7 +7363,9 @@ def _xai_oauth_device_code_login(
     }
 
 
-def _codex_device_code_login() -> Dict[str, Any]:
+def _codex_device_code_login(
+    on_verification: Optional[Callable[[CodexDeviceCodePrompt], None]] = None,
+) -> Dict[str, Any]:
     """Run the OpenAI device code login flow and return credentials dict."""
     import time as _time
 
@@ -7423,6 +7434,10 @@ def _codex_device_code_login() -> Dict[str, Any]:
     user_code = device_data.get("user_code", "")
     device_auth_id = device_data.get("device_auth_id", "")
     poll_interval = max(3, int(device_data.get("interval", "5")))
+    try:
+        expires_in_seconds = max(1, int(device_data.get("expires_in") or 15 * 60))
+    except (TypeError, ValueError):
+        expires_in_seconds = 15 * 60
 
     if not user_code or not device_auth_id:
         raise AuthError(
@@ -7430,13 +7445,22 @@ def _codex_device_code_login() -> Dict[str, Any]:
             provider="openai-codex", code="device_code_incomplete",
         )
 
-    # Step 2: Show user the code
-    print("To continue, follow these steps:\n")
-    print("  1. Open this URL in your browser:")
-    print(f"     \033[94m{issuer}/codex/device\033[0m\n")
-    print("  2. Enter this code:")
-    print(f"     \033[94m{user_code}\033[0m\n")
-    print("Waiting for sign-in... (press Ctrl+C to cancel)")
+    # Step 2: Show the user the code. Non-terminal callers receive only this
+    # token-free prompt and are responsible for delivering it privately.
+    prompt = CodexDeviceCodePrompt(
+        verification_url=f"{issuer}/codex/device",
+        user_code=user_code,
+        expires_in_seconds=expires_in_seconds,
+    )
+    if on_verification is not None:
+        on_verification(prompt)
+    else:
+        print("To continue, follow these steps:\n")
+        print("  1. Open this URL in your browser:")
+        print(f"     \033[94m{prompt.verification_url}\033[0m\n")
+        print("  2. Enter this code:")
+        print(f"     \033[94m{prompt.user_code}\033[0m\n")
+        print("Waiting for sign-in... (press Ctrl+C to cancel)")
 
     # Step 3: Poll for authorization code
     max_wait = 15 * 60  # 15 minutes
@@ -7551,6 +7575,19 @@ def _codex_device_code_login() -> Dict[str, Any]:
         "auth_mode": "chatgpt",
         "source": "device-code",
     }
+
+
+def login_openai_codex_device(
+    on_verification: Callable[[CodexDeviceCodePrompt], None],
+) -> None:
+    """Run and persist a Codex device-code login for a non-terminal caller."""
+    creds = _codex_device_code_login(on_verification=on_verification)
+    _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))
+    _update_config_for_provider(
+        "openai-codex",
+        creds.get("base_url", DEFAULT_CODEX_BASE_URL),
+    )
+    unsuppress_credential_source("openai-codex", "device_code")
 
 
 # ==================== MiniMax Portal OAuth ====================

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -136,6 +136,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]"),
+    CommandDef("login", "Pair Codex with a private device code", "Configuration",
+               gateway_only=True, args_hint="[codex]"),
 
     CommandDef("personality", "Set a predefined personality", "Configuration",
                args_hint="[name]"),

--- a/tests/gateway/test_login_command.py
+++ b/tests/gateway/test_login_command.py
@@ -1,0 +1,140 @@
+"""Channel-safe Codex device-code login command tests."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from hermes_cli.auth import CodexDeviceCodePrompt
+
+
+def _event(text: str = "/login codex", *, chat_type: str = "dm", user_id: str = "owner"):
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            user_id=user_id,
+            user_name="tester",
+            chat_type=chat_type,
+        ),
+    )
+
+
+def _runner(*, extra=None):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra=extra or {},
+            )
+        }
+    )
+    adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(success=True))
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    return runner, adapter
+
+
+def test_login_is_registered_for_gateway_and_telegram_menu():
+    from hermes_cli.commands import (
+        GATEWAY_KNOWN_COMMANDS,
+        telegram_bot_commands,
+    )
+
+    assert "login" in GATEWAY_KNOWN_COMMANDS
+    assert ("login", "Pair Codex with a private device code") in telegram_bot_commands()
+
+
+@pytest.mark.asyncio
+async def test_login_codex_sends_code_before_completion(monkeypatch):
+    runner, adapter = _runner()
+
+    def fake_login(on_verification):
+        on_verification(
+            CodexDeviceCodePrompt(
+                verification_url="https://auth.openai.com/codex/device",
+                user_code="ABCD-EFGH",
+                expires_in_seconds=900,
+            )
+        )
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.login_openai_codex_device",
+        fake_login,
+    )
+
+    result = await runner._handle_login_command(_event())
+
+    assert result == "Codex login complete. Try your request again now."
+    sent = adapter.send.await_args.args[1]
+    assert "https://auth.openai.com/codex/device" in sent
+    assert "ABCD-EFGH" in sent
+    assert "Never share it" in sent
+
+
+@pytest.mark.asyncio
+async def test_login_codex_rejects_group_without_starting_auth(monkeypatch):
+    runner, adapter = _runner()
+    login = AsyncMock()
+    monkeypatch.setattr("hermes_cli.auth.login_openai_codex_device", login)
+
+    result = await runner._handle_login_command(_event(chat_type="group"))
+
+    assert "only sent in a private conversation" in result
+    login.assert_not_awaited()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_login_codex_is_admin_only_when_command_roles_are_configured(monkeypatch):
+    runner, adapter = _runner(extra={"allow_admin_from": ["owner"]})
+    login = AsyncMock()
+    monkeypatch.setattr("hermes_cli.auth.login_openai_codex_device", login)
+
+    result = await runner._handle_login_command(_event(user_id="member"))
+
+    assert result == "⛔ /login is admin-only because it replaces Hermes credentials."
+    login.assert_not_awaited()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_login_codex_dedupes_active_conversation_flow(monkeypatch):
+    runner, _adapter = _runner()
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_login(on_verification):
+        on_verification(
+            CodexDeviceCodePrompt(
+                verification_url="https://auth.openai.com/codex/device",
+                user_code="FIRST-CODE",
+                expires_in_seconds=900,
+            )
+        )
+        started.set()
+        release.wait(timeout=5)
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.login_openai_codex_device",
+        blocking_login,
+    )
+
+    first = asyncio.create_task(runner._handle_login_command(_event()))
+    await asyncio.to_thread(started.wait, 5)
+    second = await runner._handle_login_command(_event())
+    release.set()
+
+    assert "already active" in second
+    assert await first == "Codex login complete. Try your request again now."

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -1065,6 +1065,96 @@ def test_device_code_login_retries_on_429_then_succeeds(monkeypatch):
     assert 1 in sleeps
 
 
+def test_device_code_login_emits_token_free_verification_prompt(monkeypatch, capsys):
+    """Non-terminal callers receive URL/code/expiry without console disclosure."""
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    _patch_httpx_post(
+        monkeypatch,
+        [
+            _FakeResp(
+                200,
+                {
+                    "user_code": "ABCD-EFGH",
+                    "device_auth_id": "dev-1",
+                    "interval": "5",
+                    "expires_in": 900,
+                },
+            ),
+            _FakeResp(
+                200,
+                {"authorization_code": "auth-code", "code_verifier": "verifier"},
+            ),
+            _FakeResp(
+                200,
+                {"access_token": "at", "refresh_token": "rt", "expires_in": 3600},
+            ),
+        ],
+    )
+    prompts = []
+
+    creds = auth_mod._codex_device_code_login(on_verification=prompts.append)
+
+    assert creds["tokens"]["access_token"] == "at"
+    assert prompts == [
+        auth_mod.CodexDeviceCodePrompt(
+            verification_url="https://auth.openai.com/codex/device",
+            user_code="ABCD-EFGH",
+            expires_in_seconds=900,
+        )
+    ]
+    assert "ABCD-EFGH" not in capsys.readouterr().out
+
+
+def test_non_terminal_device_login_persists_and_selects_codex(monkeypatch):
+    """The service wrapper stores the grant and activates the Codex provider."""
+    from hermes_cli import auth as auth_mod
+
+    prompt_callback = object()
+    creds = {
+        "tokens": {"access_token": "at", "refresh_token": "rt"},
+        "last_refresh": "2026-07-17T00:00:00Z",
+        "base_url": DEFAULT_CODEX_BASE_URL,
+    }
+    calls = []
+    monkeypatch.setattr(
+        auth_mod,
+        "_codex_device_code_login",
+        lambda on_verification: (
+            calls.append(("login", on_verification)),
+            creds,
+        )[1],
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "_save_codex_tokens",
+        lambda tokens, last_refresh=None: calls.append(
+            ("save", tokens, last_refresh)
+        ),
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "_update_config_for_provider",
+        lambda provider, base_url: calls.append(("select", provider, base_url)),
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "unsuppress_credential_source",
+        lambda provider, source: calls.append(("unsuppress", provider, source)),
+    )
+
+    result = auth_mod.login_openai_codex_device(prompt_callback)
+
+    assert result is None
+    assert calls == [
+        ("login", prompt_callback),
+        ("save", creds["tokens"], creds["last_refresh"]),
+        ("select", "openai-codex", DEFAULT_CODEX_BASE_URL),
+        ("unsuppress", "openai-codex", "device_code"),
+    ]
+
+
 def test_device_code_login_persistent_429_raises_rate_limited(monkeypatch):
     """A persistent 429 surfaces a clear rate-limit error, not a bare status."""
     from hermes_cli import auth as auth_mod


### PR DESCRIPTION
## What changed

- adds a shared gateway `/login codex` command through `COMMAND_REGISTRY`
- reuses Hermes' existing OpenAI Codex device-code flow
- exposes a token-free verification callback containing only URL, user code, and expiry
- sends the pairing link/code before polling for completion
- persists the refreshed Codex grant and selects `openai-codex` after success
- deduplicates active login flows per profile/conversation

## Safety

- rejects group/channel use before starting auth
- requires an authorized gateway sender
- requires an admin when `allow_admin_from` command roles are configured
- does not return access or refresh tokens to the gateway caller
- does not print the device code to the gateway process console

## User experience

From a private Telegram, Discord, Slack, or other Hermes gateway conversation:

```text
/login codex
```

Hermes sends the OpenAI device URL and pairing code immediately, waits for authorization, then confirms that Codex is ready.

## Validation

- `scripts/run_tests.sh tests/gateway/test_login_command.py tests/hermes_cli/test_auth_codex_provider.py tests/gateway/test_gateway_command_help.py tests/gateway/test_gateway_command_dispatch_minimal.py tests/gateway/test_command_bypass_active_session.py -q`
  - 86 passed
- `ruff check gateway/run.py hermes_cli/auth.py hermes_cli/commands.py tests/gateway/test_login_command.py tests/hermes_cli/test_auth_codex_provider.py`
- `git diff --check`

Related to #55360. This PR implements the explicit channel-safe `/login codex` entry point; automatic reauth-required event propagation can remain a follow-up slice of that issue.
