### PR TITLE
fix(moa_loop): add timeout to ThreadPoolExecutor future.result() in reference gathering

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -431,7 +431,14 @@ def _run_references_parallel(
         # Collect every reference before returning — the aggregator needs the
         # complete set, so there is no early-exit / first-completed path here.
         for future, idx in futures.items():
-            results[idx] = future.result()
+            try:
+                results[idx] = future.result(timeout=120)
+            except TimeoutError:
+                results[idx] = (
+                    "unknown",
+                    "[skipped: reference LLM call timed out after 120s]",
+                    _RefAccounting(CanonicalUsage()),
+                )
 
     return [r for r in results if r is not None]
 


### PR DESCRIPTION
## Summary

Add a 120s timeout to `future.result()` when collecting MoA reference model results, and gracefully handle timeout by returning a skip placeholder.

## Problem

In `agent/moa_loop.py`, `_gather_reference_contexts()` calls `future.result()` without a timeout on ThreadPoolExecutor futures. If a reference LLM call stalls indefinitely (e.g. network hang, unresponsive provider), the main agent turn blocks forever with no recovery path — the entire conversation freezes silently.

## Fix

- Add `timeout=120` to `future.result()`
- Catch `TimeoutError` and return a graceful skip placeholder instead of blocking indefinitely
- The 120s timeout matches typical LLM call durations while still allowing long reference calls to complete

## Testing
- Syntax check passed (py_compile)
- Behavior verified: timeout path returns structured fallback tuple matching expected return type