### PR TITLE
fix: add provider/model/endpoint context to terminal API error messages (#66351)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4035,8 +4035,12 @@ def run_conversation(
                             final_response=_policy_response,
                             error_detail=_nonretryable_summary,
                         )
+                    _api_context = (
+                        f"(provider: {_provider}, model: {_model}, "
+                        f"endpoint: {_base})"
+                    )
                     return {
-                        "final_response": _nonretryable_summary,
+                        "final_response": f"{_nonretryable_summary}\n{_api_context}",
                         "messages": messages,
                         "api_calls": api_call_count,
                         "completed": False,
@@ -4200,7 +4204,11 @@ def run_conversation(
                         if _billing_guidance:
                             _final_response += f"\n\n{_billing_guidance}"
                     else:
-                        _final_response = f"API call failed after {max_retries} retries: {_final_summary}"
+                        _final_response = (
+                            f"API call failed after {max_retries} retries: {_final_summary}\n"
+                            f"(provider: {_provider}, model: {_model}, "
+                            f"endpoint: {_base})"
+                        )
                     if _is_thinking_timeout:
                         # Thinking-timeout guidance overrides the generic
                         # stream-drop guidance — the latter is wrong for


### PR DESCRIPTION
**Bug:** Terminal API failure messages only showed generic error text without provider, model, or endpoint context, making debugging difficult.

**Fix:** Added provider/model/endpoint context to both non-recoverable abort responses and retry-exhausted responses in `conversation_loop.py`. Error field format preserved for downstream consumers.

Closes #66351