### PR TITLE
fix: allow tool.completed events to dispatch through gateway progress callback (#66360)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18050,8 +18050,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not tool_progress_enabled:
                 return
 
-            # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
-            if event_type not in {"tool.started",}:
+            # Act on tool.started and tool.completed events (ignore reasoning.available, etc.)
+            if event_type not in {"tool.started", "tool.completed",}:
                 return
 
             # Suppress tool-progress bubbles once the user has sent `stop`.


### PR DESCRIPTION
**Bug:** Codex app-server tool events (results) never dispatched to the UI because the gateway progress callback in `gateway/run.py:18054` explicitly dropped all events except `tool.started`.

**Fix:** Added `"tool.completed"` to the allowed event types set. Events `tool.completed` now pass through and reach the gateway, enabling tool results to be displayed.

**Note:** The `tool.completed` handler already existed at line 18011 (long-tool hint logic), but the guard at 18054 always caught it before any bubble was dispatched.

Closes #66360