### PR TITLE
fix: model picker groups selected model under CUSTOM instead of correct provider (#66329)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -983,7 +983,7 @@ def _resolve_named_custom_runtime(
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
+    pool_result = _try_resolve_from_custom_pool(base_url, requested_provider, custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -1022,7 +1022,7 @@ def _resolve_named_custom_runtime(
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
     result = {
-        "provider": "custom",
+        "provider": requested_provider,
         "api_mode": custom_provider.get("api_mode")
         or _detect_api_mode_for_url(base_url)
         or "chat_completions",


### PR DESCRIPTION
## Description

Fixes #66329 — Model picker groups selected model under "CUSTOM ENDPOINT" instead of the correct named provider section.

### Root Cause

In `hermes_cli/runtime_provider.py`, the function `_resolve_named_custom_runtime()` hardcoded `"provider": "custom"` for **ALL** named custom providers, regardless of the actual provider name. This caused the model picker's grouping logic to always classify the selected model under the "CUSTOM ENDPOINT" fallback row.

### Changes

1. **Line 1025** (`result` dict): Changed `"provider": "custom"` → `"provider": requested_provider` so the actual provider name (e.g., `"ocg"`) is preserved in the runtime result.

2. **Line 986** (`_try_resolve_from_custom_pool` call): Changed `"custom"` → `requested_provider` for the `provider_label` parameter, so the credential pool path also returns the correct provider name instead of `"custom"`.

### Data Flow After Fix

| Step | File | Before (broken) | After (fixed) |
|------|------|-----------------|---------------|
| Config read | `inventory.py:91` | `current_provider = "ocg"` | same |
| Runtime resolution | `runtime_provider.py:1025` | `result["provider"] = "custom"` | `result["provider"] = "ocg"` |
| CLI init | `cli.py:3828` | `self.provider = "custom"` | `self.provider = "ocg"` |
| Picker context | `cli.py:8070` | `ctx.current_provider = "custom"` | `ctx.current_provider = "ocg"` |
| Picker grouping | `model_switch.py:1548` | matches CUSTOM row | matches correct provider section |

### Testing

- `python3 -c "import ast; ast.parse(open('hermes_cli/runtime_provider.py').read()); print('PARSE OK')"` ✅
- All existing tests pass