### PR TITLE
fix(slash-commands): add dedup detection in _build_command_lookup (#66327)

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -261,12 +261,39 @@ COMMAND_REGISTRY: list[CommandDef] = [
 # ---------------------------------------------------------------------------
 
 def _build_command_lookup() -> dict[str, CommandDef]:
-    """Map every name and alias to its CommandDef."""
+    """Map every name and alias to its CommandDef.
+
+    If a name or alias is registered more than once, the **first** entry
+    wins and a warning is logged so the duplicate can be investigated.
+    """
     lookup: dict[str, CommandDef] = {}
     for cmd in COMMAND_REGISTRY:
-        lookup[cmd.name] = cmd
+        if cmd.name in lookup:
+            logger.warning(
+                "Duplicate slash command name %r — first defined by %s, "
+                "ignoring duplicate from %s",
+                cmd.name,
+                lookup[cmd.name].description,
+                cmd.description,
+            )
+        else:
+            lookup[cmd.name] = cmd
         for alias in cmd.aliases:
-            lookup[alias] = cmd
+            if alias in lookup:
+                existing = lookup[alias]
+                # Only warn when two different *canonical* commands clash
+                # via alias; identical-meaning underscore/hyphen variants
+                # (e.g. reload-mcp's alias reload_mcp) are harmless.
+                if existing.name != cmd.name:
+                    logger.warning(
+                        "Duplicate slash command alias %r — claimed by %s (%s) "
+                        "and %s (%s); keeping first",
+                        alias,
+                        existing.name, existing.description,
+                        cmd.name, cmd.description,
+                    )
+            else:
+                lookup[alias] = cmd
     return lookup
 
 


### PR DESCRIPTION
## Summary

Adds deduplication detection to `_build_command_lookup()` in `hermes_cli/commands.py`. If a command name or alias is registered more than once in `COMMAND_REGISTRY`, the **first** definition wins and a `logger.warning()` is emitted — keeping the lookup deterministic and surfacing the duplicate for investigation.

Fixes #66327

## Changes

- **`_build_command_lookup()`** — now warns on duplicate name/alias registration via `logger.warning()`
- **First-wins semantics** — the first `CommandDef` to claim a name/alias is kept; later duplicates are silently dropped (still logged)
- **Alias dedup** — alias conflicts between different canonical commands are warned; underscore/hyphen variants of the same command (e.g. `reload-mcp` → `reload_mcp`) are silently deduplicated since they're intentional

## Verification

- No warnings emitted at import time with the current `COMMAND_REGISTRY` (no existing duplicates)
- All existing command lookups (`/help`, `/new`, `/compress`, `/codex-runtime`, `/codex_runtime`, `/reload-mcp`, `/reload_mcp`) resolve correctly
- `python3 -c "import ast; ast.parse(open('hermes_cli/commands.py').read()); print('PARSE OK')"` — passes