### PR TITLE
fix(webhook): move INSECURE_NO_AUTH opt-in to config.yaml allow_insecure key

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -51,7 +51,7 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import Platform, PlatformConfig, _coerce_bool
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -167,11 +167,21 @@ class WebhookAdapter(BasePlatformAdapter):
         # Validate routes at startup — secret is required per route
         for name, route in self._routes.items():
             secret = route.get("secret", self._global_secret)
+            # allow_insecure: true in config.yaml is a config-native alternative to
+            # setting secret: INSECURE_NO_AUTH. Coerced strictly (fail-closed) via
+            # _coerce_bool so a quoted YAML "false" does NOT enable the HMAC bypass.
+            _allow_insecure_cfg = _coerce_bool(route.get("allow_insecure"), default=False)
+            if _allow_insecure_cfg and not secret:
+                # Map allow_insecure: true to the sentinel so existing validation
+                # and loopback-safety-rail paths handle it uniformly.
+                secret = _INSECURE_NO_AUTH
+
             if not secret:
                 raise ValueError(
                     f"[webhook] Route '{name}' has no HMAC secret. "
                     f"Set 'secret' on the route or globally. "
-                    f"For testing without auth, set secret to '{_INSECURE_NO_AUTH}'."
+                    f"For testing without auth, set secret to '{_INSECURE_NO_AUTH}' "
+                    f"or allow_insecure: true in config.yaml."
                 )
 
             # Safety rail: refuse to start if INSECURE_NO_AUTH is combined with a

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1247,3 +1247,43 @@ class TestInsecureNoAuthSafetyRail:
         finally:
             await adapter.disconnect()
 
+
+
+class TestAllowInsecureConfig:
+    """Regression tests for allow_insecure: true config key (PR #47347)."""
+
+    @pytest.mark.asyncio
+    async def test_allow_insecure_true_on_loopback_allowed(self):
+        routes = {"r1": {"allow_insecure": True, "prompt": "x"}}
+        adapter = _make_adapter(routes=routes, host="127.0.0.1", port=0)
+        try:
+            with patch.object(adapter, "_reload_dynamic_routes"):
+                result = await adapter.connect()
+            assert result is True
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_allow_insecure_true_on_public_bind_rejected(self):
+        routes = {"r1": {"allow_insecure": True, "prompt": "x"}}
+        adapter = _make_adapter(routes=routes, host="0.0.0.0", port=0)
+        with pytest.raises(ValueError, match="non-loopback|INSECURE_NO_AUTH"):
+            await adapter.connect()
+
+    @pytest.mark.asyncio
+    async def test_allow_insecure_false_string_fails_closed(self):
+        routes = {"r1": {"allow_insecure": "false", "prompt": "x"}}
+        adapter = _make_adapter(routes=routes, host="127.0.0.1", port=0)
+        with pytest.raises(ValueError, match="no HMAC secret|secret"):
+            await adapter.connect()
+
+    @pytest.mark.asyncio
+    async def test_allow_insecure_true_string_acts_as_true(self):
+        routes = {"r1": {"allow_insecure": "true", "prompt": "x"}}
+        adapter = _make_adapter(routes=routes, host="127.0.0.1", port=0)
+        try:
+            with patch.object(adapter, "_reload_dynamic_routes"):
+                result = await adapter.connect()
+            assert result is True
+        finally:
+            await adapter.disconnect()


### PR DESCRIPTION
Coerce allow_insecure via _coerce_bool(default=False) so quoted YAML false string does NOT enable HMAC bypass. Maps to INSECURE_NO_AUTH sentinel so loopback safety rail applies uniformly. 4/4 tests pass. Fixes #47329