### PR TITLE
fix(cli): don't emit duplicate 'Custom endpoint' row for named custom…

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2142,6 +2142,18 @@ def list_authenticated_providers(
             == str(current_base_url).strip().rstrip("/").lower()
             for _cp in (custom_providers or [])
         )
+        # A named ``providers:`` entry (section 3) can already represent this
+        # endpoint even when it isn't in ``custom_providers``. Its row matches
+        # the active model via base_url (``_ep_is_current``), so emitting the
+        # bare "Custom endpoint" fallback too would leave TWO is_current rows
+        # and group the model under "CUSTOM ENDPOINT" instead of its real
+        # provider (#66329). Skip when an already-emitted row covers the URL.
+        and not any(
+            str(_r.get("api_url", "")).strip().rstrip("/").lower()
+            == _current_base_url_norm
+            for _r in results
+            if _r.get("api_url")
+        )
     ):
         _models = [current_model] if current_model else []
         if refresh or probe_current_custom_provider:

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -1235,3 +1235,64 @@ def test_current_custom_model_not_leaked_into_other_provider_rows(monkeypatch):
     for row in providers:
         if row["slug"] != "openrouter" and not row.get("is_current"):
             assert custom not in row.get("models", []), f"leaked into {row['slug']}"
+
+
+# =============================================================================
+# #66329: a named providers: entry whose runtime provider resolves to "custom"
+# must group the active model under the named provider, not a duplicate bare
+# "Custom endpoint" fallback row.
+# =============================================================================
+
+def test_named_provider_current_via_custom_alias_no_duplicate_row(monkeypatch):
+    """Runtime clobbers a named ``providers:`` entry to provider='custom', but
+    the picker must mark ONLY the named provider row current — not also emit a
+    bare 'Custom endpoint' fallback for the same endpoint (#66329)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "ocg": {
+            "name": "OpenCode Go",
+            "api": "http://localhost:20128/v1",
+            "models": {"ocg/mimo-v2.5": {}},
+        }
+    }
+    providers = list_authenticated_providers(
+        current_provider="custom",  # runtime resolves named provider -> "custom"
+        current_base_url="http://localhost:20128/v1",
+        current_model="ocg/mimo-v2.5",
+        user_providers=user_providers,
+        custom_providers=[],
+        probe_custom_providers=False,
+        max_models=50,
+    )
+
+    current_rows = [p for p in providers if p.get("is_current")]
+    assert [p["slug"] for p in current_rows] == ["ocg"], (
+        f"expected only the named provider current, got "
+        f"{[(p['slug'], p['name']) for p in current_rows]}"
+    )
+    # The spurious bare fallback row must not be emitted at all.
+    assert not any(p["slug"] == "custom" for p in providers)
+
+
+def test_bare_custom_endpoint_still_surfaced_when_no_named_provider(monkeypatch):
+    """Guard against over-suppression: a genuine ``model.provider: custom`` +
+    ``base_url`` with no matching ``providers:`` entry must still surface the
+    'Custom endpoint' row so /model doesn't look like it ignored config."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="http://localhost:9999/v1",
+        current_model="local/foo",
+        user_providers=None,
+        custom_providers=[],
+        probe_custom_providers=False,
+        max_models=50,
+    )
+
+    assert any(
+        p["slug"] == "custom" and p.get("is_current") for p in providers
+    ), f"bare custom endpoint row missing: {[(p['slug'], p.get('is_current')) for p in providers]}"


### PR DESCRIPTION
## What does this PR do?

After selecting a model from a named custom provider (configured under `providers:`), reopening `/model` grouped it under "CUSTOM ENDPOINT" instead of its real provider (e.g. "OpenCode Go"). A named custom provider intentionally resolves at runtime to `provider="custom"` (that's how the custom provider profile routes), so the fix is at the display layer, not in `runtime_provider.py`.

In `list_authenticated_providers()`, section 3 already marks the named provider row current by matching the active `base_url`, but section 3b also emitted a bare "Custom endpoint" fallback row (is_current) whenever `provider=="custom"` — suppressed only when a `custom_providers` list entry matched the URL. When the provider lives only in the `providers:` dict, that guard missed, leaving TWO current rows. Section 3b now also skips when an already-emitted row covers the current base_url.

## Related Issue

Fixes #66329

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`: in `list_authenticated_providers()`, extend the section-3b guard so the bare "Custom endpoint" fallback is not emitted when an already-emitted row (e.g. a section-3 named `providers:` entry) already covers the current `base_url`.
- `tests/hermes_cli/test_user_providers_model_switch.py`: add regression tests (named-provider-via-custom-alias yields exactly one current row; bare-custom endpoint still surfaced).

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_user_providers_model_switch.py -q` — new tests pass.
2. `scripts/run_tests.sh tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_opencode_go_in_model_list.py tests/hermes_cli/test_overlay_slug_resolution.py tests/hermes_cli/test_ollama_cloud_provider.py tests/hermes_cli/test_inventory.py` — 174 passed, 0 failed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite (`scripts/run_tests.sh`, the repo's sanctioned wrapper) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure Python list/string logic, no platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A