### PR TITLE
feat(agent): add four dependency-free primitives ported from BaiLongma (MIT)

### DIFF
--- a/LICENSES/BaiLongma-MIT.txt
+++ b/LICENSES/BaiLongma-MIT.txt
@@ -1,0 +1,31 @@
+The following third-party source has been ported (逐行翻译) into this
+repository under the terms of its original MIT License. The full license
+text is reproduced below.
+
+Project: BaiLongma
+Source:  https://github.com/xiaoyuanda666-ship-it/BaiLongma
+Author:  xiaoyuanda666-ship-it
+
+===============================================================================
+
+MIT License
+
+Copyright (c) 2026 xiaoyuanda666-ship-it
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,31 @@
+# Third-Party Notices
+
+Hermes Agent is licensed under Apache-2.0. This file records third-party
+sources whose code has been ported (逐行翻译, line-by-line translation)
+into this repository, and their original licenses.
+
+Ported code retains a per-file SPDX header identifying the upstream file
+and license. Full upstream license texts are stored under `LICENSES/`.
+
+---
+
+## BaiLongma (MIT License)
+
+- **Upstream:** https://github.com/xiaoyuanda666-ship-it/BaiLongma
+- **Copyright:** © 2026 xiaoyuanda666-ship-it
+- **License:** MIT (see `LICENSES/BaiLongma-MIT.txt`)
+
+The BaiLongma project (a Node.js/Electron desktop AI agent) contributed
+architectural designs and reference implementations that were ported to
+Python for Hermes. All ported files carry an `Adapted from BaiLongma`
+SPDX header pointing at the original `src/**/*.js` source.
+
+### Ported modules
+
+| Hermes file | Upstream source | Notes |
+| --- | --- | --- |
+| `agent/heartbeat.py` | `src/runtime/consciousness-loop.js` | Autonomous L2 tick loop |
+| `agent/heartbeat_policy.py` | `src/runtime/tick-policy.js` | Heartbeat prompt policy |
+
+(Additional entries will be appended as more BaiLongma modules are
+ported.)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -29,6 +29,7 @@ SPDX header pointing at the original `src/**/*.js` source.
 | `agent/keywords.py` | `src/memory/keywords.js` | Zero-dep CN/EN n-gram extraction |
 | `agent/threads.py` | `src/memory/threads.js` | Thread model: read-time temperature, no stack |
 | `agent/thread_classifier.py` | `src/memory/thread-classifier.js` | LLM arbiter for weak-signal thread merges |
+| `agent/memory_consolidator.py` | `src/memory/consolidator.js` + `src/memory/consolidation-loop.js` | Round-robin memory consolidation (merge / downgrade / skip); dependency-injected store + LLM |
 
 (Additional entries will be appended as more BaiLongma modules are
 ported.)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -26,6 +26,9 @@ SPDX header pointing at the original `src/**/*.js` source.
 | --- | --- | --- |
 | `agent/heartbeat.py` | `src/runtime/consciousness-loop.js` | Autonomous L2 tick loop |
 | `agent/heartbeat_policy.py` | `src/runtime/tick-policy.js` | Heartbeat prompt policy |
+| `agent/keywords.py` | `src/memory/keywords.js` | Zero-dep CN/EN n-gram extraction |
+| `agent/threads.py` | `src/memory/threads.js` | Thread model: read-time temperature, no stack |
+| `agent/thread_classifier.py` | `src/memory/thread-classifier.js` | LLM arbiter for weak-signal thread merges |
 
 (Additional entries will be appended as more BaiLongma modules are
 ported.)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -30,6 +30,7 @@ SPDX header pointing at the original `src/**/*.js` source.
 | `agent/threads.py` | `src/memory/threads.js` | Thread model: read-time temperature, no stack |
 | `agent/thread_classifier.py` | `src/memory/thread-classifier.js` | LLM arbiter for weak-signal thread merges |
 | `agent/memory_consolidator.py` | `src/memory/consolidator.js` + `src/memory/consolidation-loop.js` | Round-robin memory consolidation (merge / downgrade / skip); dependency-injected store + LLM |
+| `agent/self_evolution.py` | `src/memory/self-evolution.js` | Self-evolution ledger for actionable memories (procedure / constraint / policy / lesson); prompt renderer split off from injection (see file docstring for the caching-hazard note) |
 
 (Additional entries will be appended as more BaiLongma modules are
 ported.)

--- a/agent/heartbeat.py
+++ b/agent/heartbeat.py
@@ -1,0 +1,567 @@
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------
+# Portions of this file are adapted from BaiLongma
+#   Upstream: https://github.com/xiaoyuanda666-ship-it/BaiLongma
+#   Original: src/runtime/consciousness-loop.js
+#   Copyright (c) 2026 xiaoyuanda666-ship-it — Licensed under MIT
+#   License text: see LICENSES/BaiLongma-MIT.txt
+# ---------------------------------------------------------------------------
+"""Autonomous L2 heartbeat loop (Consciousness Loop).
+
+Wraps a caller-supplied ``run_turn`` coroutine in a self-scheduling loop
+so the agent runs *between* user messages: enqueuing due reminders,
+pumping pending messages, and — when idle — firing an autonomous L2 tick
+that lets the model decide for itself whether to speak, act, or stay
+silent.
+
+Design mirrors BaiLongma's ``consciousness-loop.js`` line-for-line:
+
+    * A watchdog wraps every ``run_turn`` call so a stuck LLM turn is
+      aborted and the loop keeps spinning.
+    * Priority preemption: a higher-priority queue entry can interrupt
+      a running turn. Concurrent user messages also preempt each other.
+    * Scheduling ladder (high to low):
+        1. Messages pending           → 0s
+        2. 429 rate-limited           → quota-provided interval
+        3. Custom cadence TTL > 0     → caller-provided ms
+        4. Awakening ticks remaining  → 10s
+        5. Task active                → 30s
+        6. Idle                       → configured base tick interval
+      Any pending reminder that fires earlier collapses the delay.
+    * A cadence configured *during* a tick starts governing the *next*
+      tick — its TTL is not spent by the tick that installed it.
+
+Hermes wires this behind ``agent.heartbeat.enabled`` (default: False).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Mapping, Optional, Protocol
+
+
+logger = logging.getLogger(__name__)
+
+
+# ── Type aliases ────────────────────────────────────────────────────────────
+
+RunTurn = Callable[[Any, str, Optional[Any]], Awaitable[None]]
+"""Signature: ``await run_turn(input, label, msg | None)``."""
+
+EmitEvent = Callable[[str, Mapping[str, Any]], None]
+"""Signature: ``emit_event(name, payload)``."""
+
+Scheduler = Callable[[], None]
+InterruptCallback = Callable[[Any], None]
+
+
+# ── Priorities (mirror BaiLongma's numeric ladder) ──────────────────────────
+
+
+@dataclass(frozen=True)
+class Priorities:
+    """Priority levels; higher wins.
+
+    Callers supply an instance so this module doesn't hardcode the
+    numeric ladder; BaiLongma uses ``{ user: 3, background: 1, ... }``.
+    """
+
+    user: int = 3
+    background: int = 1
+
+
+# ── Watchdog error ──────────────────────────────────────────────────────────
+
+
+class WatchdogTimeoutError(Exception):
+    """Raised when ``run_turn`` exceeds ``run_turn_watchdog_s``."""
+
+
+# ── Abort controller shim ───────────────────────────────────────────────────
+
+
+class AbortLike(Protocol):
+    """Minimal shape of an abort controller; whoever owns the current
+    execution provides one. Matches JS ``AbortController.abort(reason)``.
+    """
+
+    def abort(self, reason: str = ...) -> None: ...  # pragma: no cover - Protocol
+
+
+# ── Config ──────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class HeartbeatDeps:
+    """Dependency-injection bundle mirroring ``createConsciousnessLoop``'s
+    keyword arguments in BaiLongma's ``consciousness-loop.js``.
+
+    Every callable is *synchronous* except ``run_turn``. Hermes wires
+    each field to an existing service:
+
+    * ``run_turn`` → wraps ``AIAgent.run_conversation`` for one turn.
+    * ``get_current_execution`` → returns the currently-running turn's
+      priority + start timestamp + label, or ``None`` when idle.
+    * ``get_current_abort_controller`` → the ``asyncio.Event`` /
+      ``AbortLike`` covering the running turn.
+    * ``emit_event`` → forwards to Hermes gateway/CLI event stream.
+    * scheduling knobs (``get_base_tick_interval``, etc.) → resolve
+      per-user config; testable in isolation.
+    """
+
+    run_turn: RunTurn
+    run_turn_watchdog_s: float
+    get_current_execution: Callable[[], Optional[Mapping[str, Any]]]
+    get_current_abort_controller: Callable[[], Optional[AbortLike]]
+    clear_current_execution: Callable[[], None]
+    emit_event: EmitEvent
+    enqueue_due_reminders: Callable[[], None]
+    has_messages: Callable[[], bool]
+    pop_message: Callable[[], Any]
+    has_user_messages: Callable[[], bool]
+    get_queue_snapshot: Callable[[], Mapping[str, int]]
+    format_tick: Callable[[], Any]
+    consume_ticker_tick: Callable[[], None]
+    decrement_awakening_tick: Callable[[], None]
+    is_startup_self_check_active: Callable[[], bool]
+    is_running: Callable[[], bool]
+    set_scheduler: Callable[[Scheduler], None]
+    set_interrupt_callback: Callable[[InterruptCallback], None]
+    is_rate_limited: Callable[[], bool]
+    get_tick_interval: Callable[[float], float]
+    get_base_tick_interval: Callable[[], float]
+    get_custom_interval_ms: Callable[[], Optional[float]]
+    get_ticker_status: Callable[[], Optional[Mapping[str, Any]]]
+    get_awakening_ticks: Callable[[], int]
+    is_task_active: Callable[[], bool]
+    get_next_pending_reminder: Callable[[], Optional[Mapping[str, Any]]]
+    get_quota_status: Callable[[], Mapping[str, Any]]
+    start_consolidation_loop: Callable[[], None]
+    ensure_startup_self_check_state: Callable[[], None]
+    set_sticky_event: Callable[[str, Mapping[str, Any]], None]
+    startup_self_check_version: str
+    priorities: Priorities = field(default_factory=Priorities)
+
+
+# ── The loop ────────────────────────────────────────────────────────────────
+
+
+class ConsciousnessLoop:
+    """Self-scheduling heartbeat loop.
+
+    Public surface mirrors BaiLongma's returned object:
+        * ``is_processing()`` → bool
+        * ``mark_last_tick_aborted()`` → None
+        * ``on_tick()`` coroutine
+        * ``schedule_next_tick()`` → None
+        * ``trigger_immediate_tick()`` → None
+        * ``start(run_immediate_tick=True)`` coroutine
+    """
+
+    def __init__(self, deps: HeartbeatDeps) -> None:
+        self._d = deps
+        self._processing = False
+        self._last_tick_aborted = False
+        # Handle to the ``call_later`` timer that will fire the next tick;
+        # any incoming message clears it and runs on_tick immediately.
+        self._current_timer: Optional[asyncio.TimerHandle] = None
+        self._loop_started = False
+        # Cache the event loop we belong to so timers land on the
+        # correct thread (Hermes may have multiple loops).
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    # ── Public helpers ─────────────────────────────────────────────────────
+
+    def is_processing(self) -> bool:
+        return self._processing
+
+    def mark_last_tick_aborted(self) -> None:
+        self._last_tick_aborted = True
+
+    # ── Preemption ─────────────────────────────────────────────────────────
+
+    def _should_preempt_for(self, entry: Optional[Mapping[str, Any]]) -> bool:
+        """Mirror ``shouldPreemptFor`` in JS.
+
+        Returns ``True`` when the incoming ``entry`` should abort the
+        currently-running turn. Rules:
+
+        1. Nothing running → always preempt (start immediately).
+        2. Strictly higher priority → preempt.
+        3. Two concurrent user messages preempt each other (so a new
+           user message can barge through even if the current one is
+           stuck in a tool call).
+        """
+        current_execution = self._d.get_current_execution()
+        if not entry or not self._processing or not current_execution:
+            return True
+
+        incoming_priority = entry.get("priority") or self._d.priorities.background
+        if incoming_priority > current_execution.get("priority", 0):
+            return True
+
+        # Allow preemption between concurrent user messages.
+        if (
+            incoming_priority >= self._d.priorities.user
+            and current_execution.get("priority", 0) >= self._d.priorities.user
+        ):
+            return True
+
+        return False
+
+    # ── Watchdog wrapper ───────────────────────────────────────────────────
+
+    async def _run_turn_with_watchdog(
+        self, input_: Any, label: str, msg: Optional[Any]
+    ) -> None:
+        """Wrap ``run_turn`` with a watchdog: on timeout, abort the
+        current controller and raise ``WatchdogTimeoutError`` so
+        ``on_tick``'s ``finally`` block runs and the loop resumes.
+
+        The abandoned ``run_turn`` future is left running; the caller's
+        abort should stop it, but even if it doesn't, it becomes an
+        unreferenced background task and is eventually reaped by
+        garbage collection — same as the JS "never-resolves Promise"
+        pattern in BaiLongma.
+        """
+        timeout_s = self._d.run_turn_watchdog_s
+
+        async def _work() -> None:
+            await self._d.run_turn(input_, label, msg)
+
+        task = asyncio.ensure_future(_work())
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=timeout_s)
+        except asyncio.TimeoutError as exc:
+            current_execution = self._d.get_current_execution() or {}
+            stuck_label = current_execution.get("label") or label
+            started_at = current_execution.get("started_at")
+            elapsed_s = (
+                round(time.time() - started_at) if started_at is not None else None
+            )
+            logger.error(
+                "[watchdog] run_turn stuck > %ss (label=%s, elapsed=%ss); forcing abort",
+                timeout_s,
+                stuck_label,
+                elapsed_s,
+            )
+            try:
+                controller = self._d.get_current_abort_controller()
+                if controller is not None:
+                    controller.abort("watchdog timeout")
+            except Exception:  # pragma: no cover - defensive
+                pass
+            # Clear the global execution ref so subsequent messages don't
+            # keep aborting the same controller.
+            self._d.clear_current_execution()
+            try:
+                self._d.emit_event(
+                    "error",
+                    {
+                        "label": "watchdog",
+                        "error": f"run_turn stuck > {timeout_s}s",
+                    },
+                )
+            except Exception:  # pragma: no cover - defensive
+                pass
+            raise WatchdogTimeoutError("run_turn watchdog timeout") from exc
+
+    # ── One tick ───────────────────────────────────────────────────────────
+
+    async def on_tick(self) -> None:
+        """Run exactly one heartbeat.
+
+        If there are pending messages, pop and dispatch the head of the
+        queue. Otherwise fire an autonomous L2 tick and let the model
+        decide what (if anything) to do.
+        """
+        if self._processing:
+            return
+        self._processing = True
+        self._last_tick_aborted = False
+        auto_tick = False
+        ticker_revision_at_start: Optional[int] = None
+
+        try:
+            self._d.enqueue_due_reminders()
+            if self._d.has_messages():
+                msg = self._d.pop_message()
+                queue_name = getattr(msg, "queueName", None) or getattr(
+                    msg, "queue_name", None
+                )
+                lane = "BG" if queue_name == "background" else "L1"
+                from_id = getattr(msg, "fromId", None) or getattr(msg, "from_id", "?")
+                raw = getattr(msg, "raw", msg)
+                await self._run_turn_with_watchdog(raw, f"{lane} message from {from_id}", msg)
+            else:
+                auto_tick = True
+                ticker = self._d.get_ticker_status()
+                ticker_revision_at_start = ticker.get("revision") if ticker else None
+                tick_prompt = self._d.format_tick()
+                await self._run_turn_with_watchdog(tick_prompt, "L2 TICK", None)
+        except WatchdogTimeoutError:
+            self._last_tick_aborted = True
+        except Exception as err:
+            # A failed autonomous turn did not consume a meaningful
+            # heartbeat. Preserve cadence/awakening state so the next
+            # tick can retry or make a different judgment.
+            if auto_tick:
+                self._last_tick_aborted = True
+            logger.exception("[on_tick] run_turn raised: %s", err)
+        finally:
+            self._processing = False
+            # Cadence TTL and awakening state describe autonomous
+            # heartbeats, not user/background messages sharing this
+            # scheduler slot. A cadence configured *during* this tick
+            # starts governing the *next* tick — do not spend one of
+            # its requested TTL rounds here.
+            current_ticker = self._d.get_ticker_status() or {}
+            ticker_was_reconfigured = (
+                auto_tick
+                and ticker_revision_at_start is not None
+                and current_ticker.get("revision") != ticker_revision_at_start
+            )
+            if auto_tick and not self._last_tick_aborted and not ticker_was_reconfigured:
+                self._d.consume_ticker_tick()
+            # When interrupted by the user, retry the same awakening
+            # moment on the next heartbeat.
+            if auto_tick and not self._last_tick_aborted:
+                self._d.decrement_awakening_tick()
+
+    # ── Scheduler ──────────────────────────────────────────────────────────
+
+    def schedule_next_tick(self) -> None:
+        """Decide when the next tick fires and arm the timer.
+
+        Ladder (high to low):
+            1. Messages pending           → 0s
+            2. 429 rate-limited           → quota-provided interval
+            3. Custom cadence TTL > 0     → caller-provided ms
+            4. Awakening ticks remaining  → 10s
+            5. Task active                → 30s
+            6. Idle                       → configured base tick interval
+        Any earlier-firing pending reminder collapses ``interval`` to
+        that reminder's due delay.
+        """
+        if not self._d.is_running():
+            return
+        if self._current_timer is not None:
+            self._current_timer.cancel()
+            self._current_timer = None
+
+        self._d.enqueue_due_reminders()
+
+        has_pending = self._d.has_messages()
+        has_pending_user = self._d.has_user_messages()
+        queue_snapshot = self._d.get_queue_snapshot()
+        rate_limited = self._d.is_rate_limited()
+        custom_ms = self._d.get_custom_interval_ms()
+        task_active = self._d.is_task_active()
+        next_reminder = self._d.get_next_pending_reminder()
+        base_tick_interval_s = self._d.get_base_tick_interval()
+
+        interval_s: float
+        label: str
+        if has_pending_user:
+            interval_s = 0.0
+            label = "immediate (user message pending)"
+        elif has_pending:
+            interval_s = 0.0
+            label = "immediate (background message pending)"
+        elif rate_limited:
+            interval_s = self._d.get_tick_interval(base_tick_interval_s)
+            label = f"rate-limited ({interval_s}s)"
+        elif custom_ms is not None:
+            ticker = self._d.get_ticker_status() or {}
+            interval_s = custom_ms / 1000.0
+            ttl = ticker.get("ttl", "?")
+            reason = ticker.get("reason")
+            reason_suffix = f" · {reason}" if reason else ""
+            label = f"L2 custom {interval_s}s ({ttl} tick(s) remaining{reason_suffix})"
+        elif self._d.get_awakening_ticks() > 0:
+            aw_ticks = self._d.get_awakening_ticks()
+            interval_s = 10.0
+            label = f"awakening 10s ({aw_ticks} tick(s) remaining)"
+        elif task_active:
+            interval_s = 30.0
+            label = "task mode 30s"
+        else:
+            interval_s = base_tick_interval_s
+            label = f"{interval_s}s"
+
+        if next_reminder:
+            due_at_ms = next_reminder.get("due_at_ms")
+            if due_at_ms is None:
+                # Accept ISO string too for cross-language parity.
+                due_at = next_reminder.get("due_at")
+                if isinstance(due_at, (int, float)):
+                    due_at_ms = float(due_at)
+                elif isinstance(due_at, str):
+                    try:
+                        from datetime import datetime
+
+                        due_at_ms = datetime.fromisoformat(due_at).timestamp() * 1000
+                    except ValueError:
+                        due_at_ms = None
+            if due_at_ms is not None:
+                due_in_s = max(0.0, (due_at_ms / 1000.0) - time.time())
+                if due_in_s < interval_s:
+                    interval_s = due_in_s
+                    label = f"reminder fires in {int(due_in_s) + 1}s"
+
+        quota = self._d.get_quota_status()
+        logger.info(
+            "[quota] %s RPM | %s TPM | ratio %s | queue U:%s B:%s | next tick %s",
+            quota.get("rpm_used", quota.get("rpmUsed", "?")),
+            quota.get("tpm_used", quota.get("tpmUsed", "?")),
+            quota.get("ratio", "?"),
+            queue_snapshot.get("user", "?"),
+            queue_snapshot.get("background", "?"),
+            label,
+        )
+        self._d.emit_event(
+            "quota",
+            {
+                **quota,
+                "next_tick_ms": interval_s * 1000,
+                "ticker": self._d.get_ticker_status(),
+                "queue": queue_snapshot,
+            },
+        )
+
+        loop = self._ensure_loop()
+        self._current_timer = loop.call_later(
+            interval_s, lambda: asyncio.ensure_future(self._timer_body())
+        )
+
+    async def _timer_body(self) -> None:
+        """Timer callback body — always re-arms even if ``on_tick``
+        raised, so a single bad tick can't permanently stall the loop.
+        """
+        self._current_timer = None
+        try:
+            await self.on_tick()
+        except Exception as err:  # pragma: no cover - defensive
+            logger.exception("[schedule_next_tick] on_tick threw: %s", err)
+        finally:
+            self.schedule_next_tick()
+
+    # ── Immediate tick ─────────────────────────────────────────────────────
+
+    def trigger_immediate_tick(self) -> None:
+        """Called when a new message arrives: cancel any pending timer
+        and run the next tick immediately.
+
+        If currently processing, do nothing — rely on the abort
+        mechanism to finish quickly; the post-finish
+        ``schedule_next_tick`` will then use ``interval=0`` to resume.
+        """
+        if self._processing:
+            return
+        if not self._d.is_running():
+            return
+        if self._current_timer is not None:
+            self._current_timer.cancel()
+            self._current_timer = None
+
+        async def _kick() -> None:
+            try:
+                await self.on_tick()
+            except Exception as err:  # pragma: no cover - defensive
+                logger.exception("[trigger_immediate_tick] on_tick threw: %s", err)
+            finally:
+                self.schedule_next_tick()
+
+        asyncio.ensure_future(_kick())
+
+    # ── Startup ────────────────────────────────────────────────────────────
+
+    async def start(self, *, run_immediate_tick: bool = True) -> None:
+        """Boot the loop.
+
+        Registers the scheduler + interrupt callback with the caller so
+        the control layer can wake the loop, then optionally fires one
+        immediate tick (used by the activation flow to trigger a
+        startup self-check on first boot).
+        """
+        if self._loop_started:
+            return
+        self._loop_started = True
+
+        self._d.start_consolidation_loop()
+
+        # Let the control layer (stop/start) reach the scheduler.
+        self._d.set_scheduler(self.schedule_next_tick)
+
+        def _interrupt_callback(entry: Any) -> None:
+            current_abort = self._d.get_current_abort_controller()
+            if current_abort is not None and self._should_preempt_for(entry):
+                from_id = (
+                    entry.get("fromId")
+                    or entry.get("from_id")
+                    or "?"
+                    if isinstance(entry, Mapping)
+                    else "?"
+                )
+                queue_name = (
+                    entry.get("queueName")
+                    or entry.get("queue_name")
+                    or "?"
+                    if isinstance(entry, Mapping)
+                    else "?"
+                )
+                priority = (
+                    entry.get("priority") if isinstance(entry, Mapping) else None
+                )
+                logger.info(
+                    "[system] Higher-priority message arrived — "
+                    "interrupting current processing: %s (%s)",
+                    from_id,
+                    queue_name,
+                )
+                self._d.emit_event(
+                    "processing_preempted",
+                    {
+                        "by": from_id,
+                        "queue_name": queue_name,
+                        "priority": priority,
+                        "current": self._d.get_current_execution(),
+                    },
+                )
+                current_abort.abort("higher-priority-message")
+            self.trigger_immediate_tick()
+
+        self._d.set_interrupt_callback(_interrupt_callback)
+
+        # Initialize self-check state before the first tick so the
+        # first tick can run self-check.
+        self._d.ensure_startup_self_check_state()
+        if self._d.is_startup_self_check_active():
+            logger.info("[system] Startup self-check starting")
+            payload = {"version": self._d.startup_self_check_version}
+            self._d.set_sticky_event("startup_self_check_started", payload)
+            self._d.emit_event("startup_self_check_started", payload)
+
+        # Whether to fire an immediate L2 TICK is up to the caller;
+        # initial activation uses it to trigger self-check.
+        if run_immediate_tick:
+            await self.on_tick()
+        self.schedule_next_tick()
+
+    # ── Helpers ────────────────────────────────────────────────────────────
+
+    def _ensure_loop(self) -> asyncio.AbstractEventLoop:
+        if self._loop is None:
+            self._loop = asyncio.get_event_loop()
+        return self._loop
+
+
+__all__ = [
+    "AbortLike",
+    "ConsciousnessLoop",
+    "HeartbeatDeps",
+    "Priorities",
+    "WatchdogTimeoutError",
+]

--- a/agent/heartbeat_bindings.py
+++ b/agent/heartbeat_bindings.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""In-memory reference bindings for ``ConsciousnessLoop``.
+
+The heartbeat module is intentionally dependency-injected — every
+callable is passed in via :class:`HeartbeatDeps`. This file provides a
+small, self-contained set of bindings that plug into that interface
+without touching Hermes' main agent loop, so:
+
+* :mod:`agent.heartbeat` can be unit-tested in isolation.
+* Downstream consumers (gateway, TUI, dashboard) get a clear template
+  to wire their own queues/reminders/quota into the loop later.
+
+Nothing here is imported from ``run_agent.py``. Turning the feature on
+still requires an explicit call in a follow-up integration PR.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Optional
+
+from .heartbeat import HeartbeatDeps, Priorities
+from .heartbeat_policy import TickerStatus, build_autonomous_tick_directions
+
+
+# ── Minimal in-memory state ────────────────────────────────────────────────
+
+
+@dataclass
+class InMemoryHeartbeatState:
+    """Tiny state container the reference bindings mutate.
+
+    A production wiring replaces each field with a real service (Hermes
+    session queue, cron reminders table, credential-pool quota view,
+    etc.). Kept intentionally boring so tests can drive the loop
+    deterministically.
+    """
+
+    messages: list[Any] = field(default_factory=list)
+    reminders: list[dict[str, Any]] = field(default_factory=list)
+    running: bool = True
+    processing_execution: Optional[dict[str, Any]] = None
+    abort_controller: Optional[Any] = None
+    ticker: dict[str, Any] = field(
+        default_factory=lambda: {"active": False, "ttl": 0, "revision": 0}
+    )
+    awakening_ticks: int = 0
+    task_active: bool = False
+    rate_limited: bool = False
+    base_tick_interval_seconds: float = 60.0
+    startup_self_check_active: bool = False
+    startup_self_check_version: str = "0"
+    scheduler: Optional[Callable[[], None]] = None
+    interrupt_callback: Optional[Callable[[Any], None]] = None
+    events: list[tuple[str, Mapping[str, Any]]] = field(default_factory=list)
+    sticky_events: dict[str, Mapping[str, Any]] = field(default_factory=dict)
+    priorities: Priorities = field(default_factory=Priorities)
+
+
+def build_in_memory_deps(
+    state: InMemoryHeartbeatState,
+    *,
+    run_turn: Callable[[Any, str, Optional[Any]], Any],
+    run_turn_watchdog_s: float = 300.0,
+    format_tick: Optional[Callable[[], str]] = None,
+) -> HeartbeatDeps:
+    """Build a :class:`HeartbeatDeps` backed by ``state``.
+
+    ``run_turn`` is the only argument every caller must supply; it
+    represents the actual agent-turn coroutine. ``format_tick`` defaults
+    to :func:`build_autonomous_tick_directions` with no extras, which is
+    exactly the prompt BaiLongma emits on an idle L2 tick.
+    """
+    if format_tick is None:
+
+        def _default_format_tick() -> str:
+            ticker_arg: Optional[TickerStatus] = None
+            if state.ticker.get("active"):
+                ticker_arg = TickerStatus(
+                    active=bool(state.ticker.get("active", False)),
+                    seconds=float(state.ticker.get("seconds", 60.0)),
+                    ttl=int(state.ticker.get("ttl", 0)),
+                    reason=state.ticker.get("reason"),
+                    revision=int(state.ticker.get("revision", 0)),
+                )
+            return build_autonomous_tick_directions(
+                awakening_ticks=state.awakening_ticks,
+                ticker_status=ticker_arg,
+            )
+
+        format_tick = _default_format_tick
+
+    def emit_event(name: str, payload: Mapping[str, Any]) -> None:
+        state.events.append((name, dict(payload)))
+
+    def set_sticky_event(name: str, payload: Mapping[str, Any]) -> None:
+        state.sticky_events[name] = dict(payload)
+
+    def enqueue_due_reminders() -> None:
+        now = time.time()
+        due = [r for r in state.reminders if r.get("due_at_ms", 0) / 1000 <= now]
+        for reminder in due:
+            state.messages.append(
+                type(
+                    "Msg",
+                    (),
+                    {
+                        "raw": reminder.get("message"),
+                        "fromId": reminder.get("from_id", "reminder"),
+                        "queueName": "background",
+                        "priority": state.priorities.background,
+                    },
+                )()
+            )
+            state.reminders.remove(reminder)
+
+    def has_messages() -> bool:
+        return bool(state.messages)
+
+    def pop_message() -> Any:
+        return state.messages.pop(0)
+
+    def has_user_messages() -> bool:
+        return any(
+            getattr(m, "queueName", None) != "background" for m in state.messages
+        )
+
+    def get_queue_snapshot() -> Mapping[str, int]:
+        user = sum(
+            1
+            for m in state.messages
+            if getattr(m, "queueName", None) != "background"
+        )
+        background = len(state.messages) - user
+        return {"user": user, "background": background}
+
+    def consume_ticker_tick() -> None:
+        if state.ticker.get("active"):
+            state.ticker["ttl"] = max(0, state.ticker.get("ttl", 0) - 1)
+            if state.ticker["ttl"] == 0:
+                state.ticker["active"] = False
+
+    def decrement_awakening_tick() -> None:
+        state.awakening_ticks = max(0, state.awakening_ticks - 1)
+
+    def get_tick_interval(base: float) -> float:
+        # In the reference wiring, rate-limited fallback just reuses the
+        # base interval. Real wiring reads the credential pool's cooldown.
+        return base
+
+    def get_custom_interval_ms() -> Optional[float]:
+        if state.ticker.get("active"):
+            return float(state.ticker.get("seconds", 60.0)) * 1000.0
+        return None
+
+    def get_next_pending_reminder() -> Optional[Mapping[str, Any]]:
+        if not state.reminders:
+            return None
+        return min(state.reminders, key=lambda r: r.get("due_at_ms", float("inf")))
+
+    def get_quota_status() -> Mapping[str, Any]:
+        return {"rpm_used": 0, "tpm_used": 0, "ratio": 0.0}
+
+    def set_scheduler(fn: Callable[[], None]) -> None:
+        state.scheduler = fn
+
+    def set_interrupt_callback(fn: Callable[[Any], None]) -> None:
+        state.interrupt_callback = fn
+
+    return HeartbeatDeps(
+        run_turn=run_turn,
+        run_turn_watchdog_s=run_turn_watchdog_s,
+        get_current_execution=lambda: state.processing_execution,
+        get_current_abort_controller=lambda: state.abort_controller,
+        clear_current_execution=lambda: setattr(state, "processing_execution", None),
+        emit_event=emit_event,
+        enqueue_due_reminders=enqueue_due_reminders,
+        has_messages=has_messages,
+        pop_message=pop_message,
+        has_user_messages=has_user_messages,
+        get_queue_snapshot=get_queue_snapshot,
+        format_tick=format_tick,
+        consume_ticker_tick=consume_ticker_tick,
+        decrement_awakening_tick=decrement_awakening_tick,
+        is_startup_self_check_active=lambda: state.startup_self_check_active,
+        is_running=lambda: state.running,
+        set_scheduler=set_scheduler,
+        set_interrupt_callback=set_interrupt_callback,
+        is_rate_limited=lambda: state.rate_limited,
+        get_tick_interval=get_tick_interval,
+        get_base_tick_interval=lambda: state.base_tick_interval_seconds,
+        get_custom_interval_ms=get_custom_interval_ms,
+        get_ticker_status=lambda: state.ticker,
+        get_awakening_ticks=lambda: state.awakening_ticks,
+        is_task_active=lambda: state.task_active,
+        get_next_pending_reminder=get_next_pending_reminder,
+        get_quota_status=get_quota_status,
+        start_consolidation_loop=lambda: None,
+        ensure_startup_self_check_state=lambda: None,
+        set_sticky_event=set_sticky_event,
+        startup_self_check_version=state.startup_self_check_version,
+        priorities=state.priorities,
+    )
+
+
+def load_heartbeat_config(config: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Resolve the ``agent.heartbeat`` block from a merged Hermes config.
+
+    Applied bounds mirror the docstring in ``config.py``:
+
+    * ``base_tick_interval_seconds`` clamped to [10, 3600].
+    * ``run_turn_watchdog_seconds`` floored at 5 (anything shorter is
+      almost certainly a config typo).
+    * ``max_daily_ticks`` floored at 0 (0 disables the cap).
+    """
+    raw = dict((config.get("agent") or {}).get("heartbeat") or {})
+
+    base_raw = raw.get("base_tick_interval_seconds", 60)
+    base = float(base_raw) if base_raw is not None else 60.0
+    raw["base_tick_interval_seconds"] = max(10.0, min(3600.0, base))
+
+    watchdog_raw = raw.get("run_turn_watchdog_seconds", 300)
+    watchdog = float(watchdog_raw) if watchdog_raw is not None else 300.0
+    raw["run_turn_watchdog_seconds"] = max(5.0, watchdog)
+
+    max_daily_raw = raw.get("max_daily_ticks", 288)
+    max_daily = int(max_daily_raw) if max_daily_raw is not None else 288
+    raw["max_daily_ticks"] = max(0, max_daily)
+
+    raw.setdefault("enabled", False)
+    raw.setdefault("run_immediate_tick_on_start", False)
+    raw.setdefault("quiet_hours_start", "")
+    raw.setdefault("quiet_hours_end", "")
+    return raw
+
+
+__all__ = [
+    "InMemoryHeartbeatState",
+    "build_in_memory_deps",
+    "load_heartbeat_config",
+]

--- a/agent/heartbeat_policy.py
+++ b/agent/heartbeat_policy.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------
+# Portions of this file are adapted from BaiLongma
+#   Upstream: https://github.com/xiaoyuanda666-ship-it/BaiLongma
+#   Original: src/runtime/tick-policy.js
+#   Copyright (c) 2026 xiaoyuanda666-ship-it — Licensed under MIT
+#   License text: see LICENSES/BaiLongma-MIT.txt
+# ---------------------------------------------------------------------------
+"""Heartbeat prompt policy.
+
+Deliberately separates *semantic judgment* (owned by the model) from
+*runtime authority* (owned by Hermes). The model decides whether a
+heartbeat is worth acting on; the runtime still owns permissions,
+sandboxing, budgets, interruption, and tool validation — those are
+execution invariants, not behavioural choices.
+"""
+from __future__ import annotations
+
+from typing import Optional, TypedDict
+
+
+class TickerStatus(TypedDict, total=False):
+    """Snapshot of the currently active custom cadence, if any.
+
+    Fields mirror BaiLongma's ``getTickerStatus()`` return shape so the
+    prompt text below can be reused verbatim across implementations.
+    """
+
+    active: bool
+    seconds: float
+    ttl: int
+    reason: Optional[str]
+    revision: int
+
+
+def build_autonomous_tick_directions(
+    *,
+    startup_self_check_active: bool = False,
+    awakening_ticks: int = 0,
+    delegation_discovery: str = "",
+    ticker_status: Optional[TickerStatus] = None,
+) -> str:
+    """Return the L2 heartbeat directive block appended to the tick prompt.
+
+    Parameters mirror ``buildAutonomousTickDirections`` in
+    ``src/runtime/tick-policy.js`` line-for-line so behaviour stays
+    identical to BaiLongma. Bool/int types replace JS's duck-typed
+    truthiness, and ``ticker_status`` is a ``TypedDict`` rather than a
+    plain object.
+    """
+    parts: list[str] = [
+        (
+            "This is an autonomous L2 heartbeat with no new user message. "
+            "The heartbeat itself creates no obligation to act, speak, or "
+            "remain passive."
+        ),
+        (
+            "Read the current runtime context and make your own situational "
+            "judgment. Valid outcomes include silence, an internal state "
+            "update, using tools, advancing or reconsidering a task, "
+            "changing your heartbeat cadence, or contacting a visible "
+            "target. None is the default merely because a TICK occurred."
+        ),
+        (
+            "Heartbeat output contract: ordinary assistant text from this "
+            "turn is private working text and is not delivered to anyone. "
+            "If you decide that someone should receive a message, express "
+            "that decision by calling send_message with the recipient and "
+            "content you chose. If you decide no external communication is "
+            "warranted, simply conclude the turn; do not narrate or justify "
+            "silence. This contract does not decide whether you should "
+            "communicate — that remains your judgment."
+        ),
+        (
+            "Treat unanswered conversation like a person would: before "
+            "sending a heartbeat message, look at what you last said and "
+            "whether the user replied. If your last message is still "
+            "unanswered — especially if you have already sent several "
+            "messages in a row — pause and remain silent. A heartbeat, "
+            "elapsed time, or a wish to share a feeling is not a reason to "
+            "ping again. Send only when there is genuinely new, "
+            "consequential evidence such as a due reminder, a requested "
+            "task result, a material change, or an urgent risk."
+        ),
+        (
+            "If you act, choose the goal, scope, tools, recipient, channel, "
+            "and stopping point yourself from expected value, timing, "
+            "continuity, and actual evidence. If a useful capability is not "
+            "loaded, use find_tool instead of assuming it is unavailable."
+        ),
+        (
+            "Runtime guardrails still validate permissions, sandbox "
+            "boundaries, recipients, budgets, and tool arguments. A "
+            "rejected action is evidence to reconsider the plan, not "
+            "permission to work around the boundary."
+        ),
+    ]
+
+    if ticker_status and ticker_status.get("active"):
+        reason = ticker_status.get("reason")
+        reason_suffix = f" Reason: {reason}." if reason else ""
+        seconds = ticker_status.get("seconds")
+        ttl = ticker_status.get("ttl")
+        parts.append(
+            f"Custom heartbeat cadence is active: {seconds}s interval, "
+            f"{ttl} heartbeat(s) remaining.{reason_suffix} Treat this as "
+            f"scheduling context, not an instruction to speak or to confirm "
+            f"the setting. Call set_tick_interval only when you "
+            f"independently decide to change the effective cadence; "
+            f"calling it again with the current setting has no effect."
+        )
+
+    if int(awakening_ticks or 0) > 0:
+        parts.append(
+            f"You are still in the early awakening period "
+            f"({awakening_ticks} heartbeat(s) remain). This is context, "
+            f"not a prescribed exploration sequence. Decide for yourself "
+            f"whether exploration, reflection, task work, communication, "
+            f"or silence best fits this moment."
+        )
+
+    if delegation_discovery:
+        parts.append(str(delegation_discovery))
+
+    return "\n".join(parts)
+
+
+__all__ = ["TickerStatus", "build_autonomous_tick_directions"]

--- a/agent/keywords.py
+++ b/agent/keywords.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------
+# Portions of this file are adapted from BaiLongma
+#   Upstream: https://github.com/xiaoyuanda666-ship-it/BaiLongma
+#   Original: src/memory/keywords.js
+#   Copyright (c) 2026 xiaoyuanda666-ship-it — Licensed under MIT
+#   License text: see LICENSES/BaiLongma-MIT.txt
+# ---------------------------------------------------------------------------
+"""Zero-dependency keyword extraction for Chinese + English text.
+
+Used by :mod:`agent.threads` to score message-to-thread overlap without
+pulling in a heavy NLP stack. Pure function; no DB, no network, no
+runtime state.
+
+The extractor emits Chinese n-grams (length 2..4) plus English tokens
+of length ≥ 3, with a small stop-word/stop-char curriculum that culls
+the recurring false positives observed in production: single-syllable
+particles, quantifier-lead n-grams, and boundary-straddling fragments.
+Length weighting biases the ranking toward two-character words because
+they hit real-content FTS/LIKE recalls more reliably than 4-grams.
+"""
+from __future__ import annotations
+
+import re
+from typing import List
+
+
+# Stop-words: high-frequency, low-information tokens.
+STOP_WORDS = frozenset(
+    [
+        "的", "了", "是", "在", "我", "你", "他", "她", "它",
+        "我们", "你们", "他们", "这", "那", "有", "没有",
+        "和", "与", "把", "被", "因为", "所以", "如果",
+        "一个", "一些", "什么", "怎么", "为什么",
+        "帮我", "请", "好的", "明白", "告诉", "让", "做",
+        "去", "来", "说", "给",
+        # Relative-time words: temporal recall handles date windows
+        # elsewhere; treating them as literal FTS keywords would recall
+        # every past record that happened to contain the string
+        # "yesterday", which is not what the user meant.
+        "今天", "昨天", "前天", "大前天", "今早", "今晨", "今夜",
+        "今晚", "昨晚", "昨夜", "昨日", "今日",
+    ]
+)
+
+# Chars that indicate an n-gram straddled a word boundary — such an
+# n-gram is a boundary fragment, not a real word, so drop it.
+STOP_CHARS = frozenset(
+    [
+        "的", "了",
+        "着", "过", "起", "来", "去",
+        "吗", "呢", "吧", "啊", "呀", "嘛", "哦",
+        "和", "与", "跟", "或", "及", "并",
+        "很", "太", "再", "又", "也", "都", "还", "只", "就", "才",
+    ]
+)
+
+# Forbidden as the first char of an n-gram: single-char classifiers
+# should never open a word (otherwise we cut pseudo-words like "个项目").
+STOP_HEAD_CHARS = frozenset(["们", "个", "些", "点", "次", "件", "种", "样"])
+
+# Forbidden as the last char of an n-gram: demonstratives / time
+# prefixes never *end* a real word (otherwise "成今/项目这" leak in).
+STOP_TAIL_CHARS = frozenset(["一", "几", "某", "每", "这", "那", "今"])
+
+_PUNCTUATION_RE = re.compile(r"[，。！？、；：”””’’’【】\[\]()（）\d]")
+_WHITESPACE_RE = re.compile(r"\s+")
+_ALPHA_RE = re.compile(r"[a-zA-Z]+")
+_ENGLISH_WORD_RE = re.compile(r"[a-zA-Z]{3,}")
+
+
+def _has_invalid_duplicate(word: str) -> bool:
+    """N-gram is bad if it contains a repeated char *except* legit
+    two-char reduplications like 天天/常常.
+    """
+    if len(word) == 2:
+        return False
+    seen: set[str] = set()
+    for ch in word:
+        if ch in seen:
+            return True
+        seen.add(ch)
+    return False
+
+
+def _is_valid_ngram(word: str) -> bool:
+    if not word or len(word) < 2 or word in STOP_WORDS:
+        return False
+    for ch in word:
+        if ch in STOP_CHARS:
+            return False
+    if word[0] in STOP_HEAD_CHARS:
+        return False
+    if word[-1] in STOP_TAIL_CHARS:
+        return False
+    if _has_invalid_duplicate(word):
+        return False
+    return True
+
+
+def _length_weight(length: int) -> float:
+    """Shorter words hit real content more often — up-weight 2-grams,
+    down-weight 4-grams. Longer n-grams are more likely to straddle a
+    word boundary.
+    """
+    if length == 2:
+        return 1.5
+    if length == 4:
+        return 0.8
+    return 1.0
+
+
+def _extract_core(text: str) -> tuple[dict[str, int], list[str]]:
+    if not text:
+        return {}, []
+    cleaned = _PUNCTUATION_RE.sub(" ", text)
+    cleaned = _WHITESPACE_RE.sub(" ", cleaned).strip()
+
+    freq: dict[str, int] = {}
+    raw_ngrams: list[str] = []
+
+    def bump_chinese(word: str) -> None:
+        if not word:
+            return
+        raw_ngrams.append(word)
+        if not _is_valid_ngram(word):
+            return
+        freq[word] = freq.get(word, 0) + 1
+
+    def bump_english(word: str) -> None:
+        if not word or len(word) < 2 or word in STOP_WORDS:
+            return
+        freq[word] = freq.get(word, 0) + 1
+
+    chinese = _ALPHA_RE.sub(" ", cleaned)
+    n = len(chinese)
+    for i in range(n - 1):
+        for length in range(2, 5):
+            if i + length > n:
+                break
+            bump_chinese(chinese[i : i + length].strip())
+
+    for match in _ENGLISH_WORD_RE.findall(text):
+        normalized = match.lower()
+        if normalized not in STOP_WORDS:
+            bump_english(match)
+
+    return freq, raw_ngrams
+
+
+def extract_keywords(text: str, max_keywords: int = 8) -> List[str]:
+    """Rank tokens by ``freq * length_weight`` then length, return top-N.
+
+    No substring dedup — historically it looked appealing to drop
+    shorter tokens covered by longer n-grams, but in production it cut
+    exactly the two-char keywords ("业余") that hit real records more
+    reliably than four-grams like "业余写什".
+    """
+    freq, _ = _extract_core(text)
+    ranked = sorted(
+        ((word, count * _length_weight(len(word)), count) for word, count in freq.items()),
+        key=lambda x: (-x[1], -len(x[0])),
+    )
+    return [word for word, _weighted, _raw in ranked[:max_keywords]]
+
+
+def extract_keywords_debug(text: str, max_keywords: int = 8) -> dict:
+    """Diagnostic helper: raw ngrams, kept-after-filter, and final.
+
+    Useful in tests to assert "pseudo-word X was dropped at the
+    filter stage" without depending on the ranked output.
+    """
+    freq, raw = _extract_core(text)
+    return {
+        "raw": raw,
+        "filtered": list(freq.keys()),
+        "final": extract_keywords(text, max_keywords),
+    }
+
+
+__all__ = ["extract_keywords", "extract_keywords_debug"]

--- a/agent/memory_consolidator.py
+++ b/agent/memory_consolidator.py
@@ -1,0 +1,580 @@
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------
+# Portions of this file are adapted from BaiLongma
+#   Upstream: https://github.com/xiaoyuanda666-ship-it/BaiLongma
+#   Original: src/memory/consolidator.js
+#             src/memory/consolidation-loop.js
+#   Copyright (c) 2026 xiaoyuanda666-ship-it — Licensed under MIT
+#   License text: see LICENSES/BaiLongma-MIT.txt
+# ---------------------------------------------------------------------------
+"""Long-term memory consolidator + round-robin loop.
+
+**Not a memory *store*.** This module is the *janitor* — it cleans up
+redundant / stale memories in a store you inject. The store owns
+persistence, retrieval, vector indexes, and every actual mutation.
+This module just:
+
+* Picks one entity's worth of memories at a time.
+* Feeds them to an LLM with a constrained tool set
+  (``merge_memories``, ``downgrade_memory``, ``skip_consolidation``).
+* Applies each tool call against the injected store.
+
+## Design invariants
+
+* **Never write new content.** The consolidator can only merge, hide
+  (soft-delete via ``visibility=0`` + ``merged_into=keep_id``), or
+  downgrade salience. It never invents facts.
+* **Contradictions are signal.** Two memories that flatly disagree are
+  left alone. Merging them would erase evidence.
+* **Salience 5 is identity-level.** Salience-5 memories are protected
+  from downgrade unless the LLM has overwhelming counter-evidence in
+  the same batch.
+* **Round-robin fairness.** The loop cycles through eligible entities
+  (fact/person with ≥ 3 memories) so no single hot entity monopolises
+  the cleanup budget.
+* **Hidden ≠ deleted.** ``visibility=0`` memories remain in the FTS
+  index + vector store and are recoverable by explicit rehydration.
+  The default retrieval flows just stop returning them.
+
+## Relationship to Hermes's ``sleep-consolidation`` skill
+
+This module is the *engine* the skill can call. The skill orchestrates
+*when* consolidation runs (idle detection, weekly deep pass, do-not-
+disturb windows) and *what strategy* to use (per-user vs global,
+priority pruning first vs merges first). The engine keeps its focus
+narrow: given a batch of memories, ask the LLM what to do, apply the
+verdict. Everything policy-shaped stays in the skill or in the loop
+config below.
+
+Ported from BaiLongma's ``consolidator.js`` + ``consolidation-loop.js``
+(MIT).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Iterable,
+    Optional,
+    Protocol,
+    Sequence,
+    runtime_checkable,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# ── Prompt + tool schema ────────────────────────────────────────────
+
+
+CONSOLIDATOR_SYSTEM_PROMPT = (
+    "You are the memory consolidator. Your job is to clean up "
+    "redundant or stale long-term memories for ONE entity at a time. "
+    "You do not write new memories. You only call tools to merge or "
+    "downgrade existing ones.\n\n"
+    "## What you're given\n\n"
+    "A batch of memories about one entity, each with:\n"
+    "- mem_id\n"
+    "- type (fact / person / etc.)\n"
+    "- title\n"
+    "- content\n"
+    "- salience (1-5)\n"
+    "- timestamp\n\n"
+    "## What to do\n\n"
+    "Read the batch. Identify:\n\n"
+    "1. SEMANTIC DUPLICATES — two or more memories that say the same "
+    "thing in different words. Pick the best-phrased one as keep, "
+    "merge the rest into it via merge_memories. merged_content should "
+    "preserve any unique facts from drops. Drop memories are NOT "
+    "deleted: they become hidden (visibility=0, "
+    "merged_into=keep_mem_id). The row + FTS index + embedding are "
+    "fully preserved and remain reachable by future recovery flows; "
+    "routine search/get* simply stops returning them.\n\n"
+    "2. SUPERSEDED FACTS — an older memory whose claim is strictly "
+    "contained in a newer, more complete one. Merge the older into "
+    "the newer.\n\n"
+    "3. STALE LOW-VALUE MEMORIES — memories that haven't been "
+    "reinforced and seem ephemeral in hindsight. Use "
+    "downgrade_memory to lower salience (do NOT delete).\n\n"
+    "4. PROTECTED — salience=5 memories represent identity-level "
+    "beliefs. Do NOT downgrade or drop them unless there is "
+    "overwhelming evidence in this batch they are wrong. When in "
+    "doubt, leave them alone.\n\n"
+    "## What NOT to do\n\n"
+    "- Do not invent new content unsupported by the batch.\n"
+    "- Do not merge memories that contradict each other — leave "
+    "both; contradiction is signal, not noise.\n"
+    "- Do not downgrade everything to clean up \"clutter\" — only "
+    "downgrade when a memory has clearly aged out.\n"
+    "- If nothing in this batch needs cleanup, call "
+    "skip_consolidation. Do not force action.\n\n"
+    "## Tool usage\n\n"
+    "- merge_memories({ keep_mem_id, drop_mem_ids: [...], "
+    "merged_content, merged_salience?, reason })\n"
+    "- downgrade_memory({ mem_id, new_salience, reason })\n"
+    "- skip_consolidation({ reason })\n\n"
+    "You may call multiple merges/downgrades in one session. Always "
+    "include reason.\n\n"
+    "## Output\n\n"
+    "Tool calls only. No prose."
+)
+
+CONSOLIDATOR_TOOL_NAMES: tuple[str, ...] = (
+    "merge_memories",
+    "downgrade_memory",
+    "skip_consolidation",
+)
+
+
+# ── Data model ─────────────────────────────────────────────────────
+
+
+@dataclass
+class Memory:
+    """A memory row as fed to the LLM — deliberately minimal.
+
+    ``event_type`` mirrors the upstream JS shape (fact / person / …).
+    ``salience`` is 1..5 with 5 = identity-level.
+    """
+
+    mem_id: str
+    event_type: str
+    title: str
+    content: str
+    salience: int = 3
+    timestamp: str = ""
+
+
+@dataclass
+class CandidateEntity:
+    """One entity eligible for a consolidation pass.
+
+    ``memory_count`` is used only for logging / cursor tie-breaking;
+    eligibility gating (usually memory_count ≥ 3) lives in the store.
+    """
+
+    entity: str
+    memory_count: int = 0
+
+
+# ── Store + LLM protocols (inject at seam) ─────────────────────────
+
+
+@runtime_checkable
+class MemoryStore(Protocol):
+    """Contract the consolidator expects from a memory backend.
+
+    Every mutation returns ``bool`` — the LLM's tool-call handler
+    checks this to count successful actions. A ``False`` return means
+    "the store refused this specific action" (invalid ids, integrity
+    violation) and is *not* treated as a fatal error for the pass.
+    """
+
+    def get_candidate_entities(self, limit: int) -> Sequence[CandidateEntity]:
+        ...
+
+    def get_memories_by_entity(
+        self, entity: str, limit: int
+    ) -> Sequence[Memory]:
+        ...
+
+    def merge_memories(
+        self,
+        *,
+        keep_mem_id: str,
+        drop_mem_ids: Sequence[str],
+        merged_content: str,
+        merged_salience: Optional[int],
+        reason: str,
+    ) -> bool:
+        ...
+
+    def downgrade_memory(
+        self, *, mem_id: str, new_salience: int, reason: str
+    ) -> bool:
+        ...
+
+
+ConsolidatorLLM = Callable[..., Awaitable[Any]]
+"""Async LLM adapter. Called with keyword args:
+
+    system_prompt, message, temperature, max_tokens, tools,
+    on_tool_call
+
+``on_tool_call`` is a synchronous callable ``(name, args) -> str``
+returning a JSON tool result string. Adapters must invoke it for each
+tool call the model makes.
+"""
+
+
+# ── Consolidator runner ────────────────────────────────────────────
+
+
+def _format_memory(m: Memory) -> str:
+    ts = (m.timestamp or "")[:10]
+    return (
+        f"mem_id={m.mem_id} | type={m.event_type} | "
+        f"salience={m.salience} | {ts}\n"
+        f"  title: {m.title}\n"
+        f"  content: {m.content}"
+    )
+
+
+def format_input(entity: str, memories: Sequence[Memory]) -> str:
+    """Public helper — exposed for tests and skill callers who want
+    to preview what the LLM will see without running the pass.
+    """
+    header = f"[Entity] {entity}\n[Memory count] {len(memories)}\n\n"
+    return header + "\n\n".join(_format_memory(m) for m in memories)
+
+
+@dataclass
+class ConsolidationResult:
+    actions: int
+    skipped: bool
+    error: Optional[str] = None
+    tool_calls: list[dict] = field(default_factory=list)
+
+
+class _RateLimitedError(Exception):
+    """Raised by the LLM adapter (or synthesised by the runner) when a
+    429 is seen so the caller's ``on_rate_limited`` hook fires.
+    """
+
+
+def _looks_like_rate_limited(err: BaseException) -> bool:
+    if isinstance(err, _RateLimitedError):
+        return True
+    msg = str(err) or ""
+    status = getattr(err, "status", None) or getattr(err, "status_code", None)
+    return status == 429 or "429" in msg
+
+
+def _make_tool_handler(
+    store: MemoryStore,
+    result_ref: "ConsolidationResult",
+) -> Callable[[str, dict], str]:
+    """Build the tool-call handler that mutates the store and updates
+    the outer result counter. Returns a JSON string per invocation so
+    the LLM adapter has something to feed back.
+    """
+
+    def handler(name: str, args: dict) -> str:
+        args = args or {}
+        payload: dict[str, Any] = {}
+        try:
+            if name == "skip_consolidation":
+                result_ref.skipped = True
+                payload = {"ok": True}
+            elif name == "merge_memories":
+                keep = str(args.get("keep_mem_id") or "")
+                drops = list(args.get("drop_mem_ids") or [])
+                merged_content = str(args.get("merged_content") or "")
+                merged_salience_raw = args.get("merged_salience")
+                merged_salience = (
+                    int(merged_salience_raw)
+                    if merged_salience_raw is not None
+                    else None
+                )
+                reason = str(args.get("reason") or "")
+                if not keep or not drops:
+                    payload = {"ok": False, "error": "missing keep/drop ids"}
+                else:
+                    ok = bool(
+                        store.merge_memories(
+                            keep_mem_id=keep,
+                            drop_mem_ids=[str(d) for d in drops],
+                            merged_content=merged_content,
+                            merged_salience=merged_salience,
+                            reason=reason,
+                        )
+                    )
+                    payload = {"ok": ok}
+                    if ok:
+                        result_ref.actions += 1
+            elif name == "downgrade_memory":
+                mem_id = str(args.get("mem_id") or "")
+                new_salience_raw = args.get("new_salience")
+                if not mem_id or new_salience_raw is None:
+                    payload = {"ok": False, "error": "missing mem_id/salience"}
+                else:
+                    ok = bool(
+                        store.downgrade_memory(
+                            mem_id=mem_id,
+                            new_salience=int(new_salience_raw),
+                            reason=str(args.get("reason") or ""),
+                        )
+                    )
+                    payload = {"ok": ok}
+                    if ok:
+                        result_ref.actions += 1
+            else:
+                payload = {"ok": False, "error": f"unknown tool {name!r}"}
+        except Exception as err:  # noqa: BLE001 — never let a handler
+            # bubble; it would abort mid-batch and lose progress on
+            # the other tool calls this LLM turn already made.
+            logger.warning(
+                "[consolidator] tool %s raised %s (args=%r)",
+                name,
+                err,
+                args,
+            )
+            payload = {"ok": False, "error": str(err)}
+
+        result_ref.tool_calls.append(
+            {"name": name, "args": args, "result": payload}
+        )
+        return json.dumps(payload, ensure_ascii=False)
+
+    return handler
+
+
+async def run_consolidator(
+    *,
+    call_llm: ConsolidatorLLM,
+    store: MemoryStore,
+    entity: str,
+    memories: Sequence[Memory],
+    on_rate_limited: Optional[Callable[[], None]] = None,
+) -> ConsolidationResult:
+    """Feed one entity's memory batch to the consolidator LLM.
+
+    Returns immediately with ``skipped=True`` if the batch is empty
+    (nothing to do). Any exception from the LLM adapter is captured
+    into ``result.error``; a 429-shaped error also fires the
+    ``on_rate_limited`` hook (Hermes's rate-limit controller subscribes
+    here to back off the whole loop).
+    """
+    result = ConsolidationResult(actions=0, skipped=False)
+    if not memories:
+        result.skipped = True
+        return result
+
+    message = format_input(entity, memories)
+    handler = _make_tool_handler(store, result)
+
+    try:
+        await call_llm(
+            system_prompt=CONSOLIDATOR_SYSTEM_PROMPT,
+            message=message,
+            temperature=0,
+            tools=list(CONSOLIDATOR_TOOL_NAMES),
+            thinking=False,
+            must_reply=False,
+            on_tool_call=handler,
+            tool_context={"source": "consolidator", "entity": entity},
+        )
+    except Exception as err:  # noqa: BLE001
+        logger.error("[consolidator] LLM call failed: %s", err)
+        result.error = str(err)
+        if _looks_like_rate_limited(err) and on_rate_limited is not None:
+            try:
+                on_rate_limited()
+            except Exception as hook_err:  # noqa: BLE001
+                logger.warning(
+                    "[consolidator] on_rate_limited hook raised %s", hook_err
+                )
+        return result
+
+    logger.info(
+        "[consolidator] entity=%s memories=%d actions=%d%s",
+        entity,
+        len(memories),
+        result.actions,
+        " (explicit skip)" if result.skipped else "",
+    )
+    return result
+
+
+# ── Loop ──────────────────────────────────────────────────────────
+
+
+DEFAULT_RUN_INTERVAL_SECONDS = 30 * 60
+DEFAULT_STARTUP_DELAY_SECONDS = 5 * 60
+DEFAULT_BATCH_SIZE = 20
+DEFAULT_CANDIDATE_LIMIT = 10
+
+
+@dataclass
+class ConsolidationLoopConfig:
+    run_interval_seconds: float = DEFAULT_RUN_INTERVAL_SECONDS
+    startup_delay_seconds: float = DEFAULT_STARTUP_DELAY_SECONDS
+    batch_size: int = DEFAULT_BATCH_SIZE
+    candidate_limit: int = DEFAULT_CANDIDATE_LIMIT
+
+
+class ConsolidationLoop:
+    """Round-robin async loop over consolidation candidates.
+
+    Cursor is in-memory only (v1 upstream doesn't persist either).
+    On restart the cursor resets to 0; over time round-robin fairness
+    is preserved because the candidate list itself rotates as entities
+    are consolidated.
+
+    Usage::
+
+        loop = ConsolidationLoop(
+            call_llm=my_llm,
+            store=my_store,
+            config=ConsolidationLoopConfig(run_interval_seconds=1800),
+        )
+        loop.start()
+        ...
+        await loop.stop()
+    """
+
+    def __init__(
+        self,
+        *,
+        call_llm: ConsolidatorLLM,
+        store: MemoryStore,
+        config: Optional[ConsolidationLoopConfig] = None,
+        on_rate_limited: Optional[Callable[[], None]] = None,
+        clock: Callable[[], float] = None,  # type: ignore[assignment]
+    ) -> None:
+        self._call_llm = call_llm
+        self._store = store
+        self._config = config or ConsolidationLoopConfig()
+        self._on_rate_limited = on_rate_limited
+        self._cursor = 0
+        self._task: Optional[asyncio.Task] = None
+        self._stopping = asyncio.Event()
+
+    async def _tick(self) -> Optional[ConsolidationResult]:
+        try:
+            candidates = list(
+                self._store.get_candidate_entities(self._config.candidate_limit)
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.error("[consolidation-loop] candidate query failed: %s", err)
+            return None
+
+        if not candidates:
+            logger.info(
+                "[consolidation-loop] no eligible entities (fact/person "
+                "counts all < threshold)"
+            )
+            return None
+
+        pick = candidates[self._cursor % len(candidates)]
+        self._cursor = (self._cursor + 1) % len(candidates)
+
+        try:
+            memories = list(
+                self._store.get_memories_by_entity(
+                    pick.entity, self._config.batch_size
+                )
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.error(
+                "[consolidation-loop] memory fetch for entity=%s failed: %s",
+                pick.entity,
+                err,
+            )
+            return None
+
+        if not memories:
+            logger.info(
+                "[consolidation-loop] entity=%s has no memories", pick.entity
+            )
+            return None
+
+        logger.info(
+            "[consolidation-loop] consolidating entity=%s (candidates=%d)",
+            pick.entity,
+            len(candidates),
+        )
+        return await run_consolidator(
+            call_llm=self._call_llm,
+            store=self._store,
+            entity=pick.entity,
+            memories=memories,
+            on_rate_limited=self._on_rate_limited,
+        )
+
+    async def run_once(self) -> Optional[ConsolidationResult]:
+        """Force an immediate tick. Useful for tests and for the skill
+        that wants an on-demand consolidation pass outside the loop.
+        """
+        return await self._tick()
+
+    def start(self) -> None:
+        """Register the loop; first tick fires after
+        ``startup_delay_seconds`` to avoid piling on the app's
+        boot-time self-checks.
+        """
+        if self._task is not None:
+            return
+        self._stopping.clear()
+        self._task = asyncio.get_event_loop().create_task(self._run_forever())
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._stopping.set()
+        task = self._task
+        self._task = None
+        try:
+            await asyncio.wait_for(task, timeout=1.0)
+        except asyncio.TimeoutError:
+            task.cancel()
+        except asyncio.CancelledError:
+            pass
+
+    async def _run_forever(self) -> None:
+        try:
+            await asyncio.wait_for(
+                self._stopping.wait(),
+                timeout=self._config.startup_delay_seconds,
+            )
+            return
+        except asyncio.TimeoutError:
+            pass
+
+        while not self._stopping.is_set():
+            try:
+                await self._tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:  # noqa: BLE001
+                logger.error("[consolidation-loop] tick failed: %s", err)
+
+            try:
+                await asyncio.wait_for(
+                    self._stopping.wait(),
+                    timeout=self._config.run_interval_seconds,
+                )
+                return
+            except asyncio.TimeoutError:
+                continue
+
+    # Diagnostics helpers used by tests -----------------------------
+
+    @property
+    def cursor(self) -> int:
+        return self._cursor
+
+
+__all__ = [
+    "CONSOLIDATOR_SYSTEM_PROMPT",
+    "CONSOLIDATOR_TOOL_NAMES",
+    "CandidateEntity",
+    "ConsolidationLoop",
+    "ConsolidationLoopConfig",
+    "ConsolidationResult",
+    "ConsolidatorLLM",
+    "DEFAULT_BATCH_SIZE",
+    "DEFAULT_CANDIDATE_LIMIT",
+    "DEFAULT_RUN_INTERVAL_SECONDS",
+    "DEFAULT_STARTUP_DELAY_SECONDS",
+    "Memory",
+    "MemoryStore",
+    "format_input",
+    "run_consolidator",
+]

--- a/agent/self_evolution.py
+++ b/agent/self_evolution.py
@@ -1,0 +1,526 @@
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------
+# Portions of this file are adapted from BaiLongma
+#   Upstream: https://github.com/xiaoyuanda666-ship-it/BaiLongma
+#   Original: src/memory/self-evolution.js
+#   Copyright (c) 2026 xiaoyuanda666-ship-it — Licensed under MIT
+#   License text: see LICENSES/BaiLongma-MIT.txt
+# ---------------------------------------------------------------------------
+"""Self-evolution ledger: track actionable policy / procedure /
+constraint / failure-lesson memories the agent learns about itself.
+
+The module is a *ledger*, not a mutator — it never rewrites code,
+never changes permissions, never issues LLM calls. It watches a
+stream of memories, filters for the actionable kinds, keeps a
+bounded recent set, and emits an event so the surrounding system
+can decide what (if anything) to do with the update.
+
+.. warning::
+   **Prompt caching hazard.** BaiLongma's original code renders the
+   recent-events list into the system prompt every turn
+   (``formatSelfEvolutionForPrompt``). In Hermes that would break
+   per-conversation prompt caching — the system prompt has to stay
+   byte-stable for the life of a conversation (see AGENTS.md).
+
+   The rendered text is exposed here as a stand-alone function
+   (:func:`format_self_evolution_for_prompt`) so callers can decide
+   where to place it. Recommended uses:
+
+   * Inject it as a **user message** at conversation start (once), or
+   * Include it in a per-turn context block that is documented to
+     invalidate the cache when it changes, or
+   * Render it into a session-scoped surface (e.g. status panel,
+     dashboard) rather than the model's system prompt.
+
+   **Do not** wire this string into the system prompt on a schedule
+   or on every recent-set change — you will invalidate the cache and
+   multiply per-turn cost.
+
+Ported from BaiLongma's ``self-evolution.js`` (MIT).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Mapping, Optional, Protocol, Sequence
+
+
+logger = logging.getLogger(__name__)
+
+
+STATE_KEY = "self_evolution_state_v1"
+STATE_VERSION = 1
+MAX_RECENT = 24
+PROMPT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000  # 7 days
+
+ACTIONABLE_TAGS: frozenset[str] = frozenset(
+    {
+        "kind:procedure",
+        "kind:constraint",
+        "kind:failure_lesson",
+        "kind:policy",
+    }
+)
+
+ACTIONABLE_EVENT_TYPES: frozenset[str] = frozenset({"self_constraint"})
+
+_ACTIONABLE_MEM_ID_RE = re.compile(
+    r"^(procedure|constraint|policy|lesson|rule)_", re.IGNORECASE
+)
+
+
+# ── Store protocol ─────────────────────────────────────────────────
+
+
+class ConfigStore(Protocol):
+    """Contract for a config-backed persistence layer.
+
+    Two operations are enough:
+
+    * ``get_config(key)`` — return the raw stored value (string or
+      already-decoded object; the caller tolerates both).
+    * ``set_config(key, value)`` — persist the JSON-encoded ledger
+      state under ``key``.
+    """
+
+    def get_config(self, key: str) -> Any:
+        ...
+
+    def set_config(self, key: str, value: str) -> None:
+        ...
+
+
+class MemoryLookup(Protocol):
+    """Optional lookup for "give me the full memory by ``mem_id``"
+    used to enrich thin references from callers. If the caller only
+    passes fully-formed memories, this can be omitted (``None``).
+    """
+
+    def get_memory_by_mem_id(self, mem_id: str) -> Optional[Mapping[str, Any]]:
+        ...
+
+
+# ── Data model ─────────────────────────────────────────────────────
+
+
+@dataclass
+class SelfEvolutionEntry:
+    mem_id: str
+    kind: str
+    action: str
+    title: str
+    content: str
+    salience: int
+    tags: list[str]
+    learned_at: str
+    total_events: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mem_id": self.mem_id,
+            "kind": self.kind,
+            "action": self.action,
+            "title": self.title,
+            "content": self.content,
+            "salience": self.salience,
+            "tags": list(self.tags),
+            "learned_at": self.learned_at,
+            "total_events": self.total_events,
+        }
+
+
+@dataclass
+class SelfEvolutionState:
+    version: int = STATE_VERSION
+    enabled: bool = True
+    total_events: int = 0
+    learned_count: int = 0
+    last_at: Optional[str] = None
+    recent: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "enabled": self.enabled,
+            "total_events": self.total_events,
+            "learned_count": self.learned_count,
+            "last_at": self.last_at,
+            "recent": [dict(e) for e in self.recent],
+        }
+
+
+# ── Serialisation helpers ──────────────────────────────────────────
+
+
+def _safe_json_array(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if not value:
+        return []
+    try:
+        parsed = json.loads(value)
+        return parsed if isinstance(parsed, list) else []
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
+def _safe_json_object(value: Any) -> Optional[Mapping[str, Any]]:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return value
+    try:
+        parsed = json.loads(value)
+        return parsed if isinstance(parsed, Mapping) else None
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _normalize_state(raw: Any) -> SelfEvolutionState:
+    parsed = _safe_json_object(raw) or {}
+    recent_raw = parsed.get("recent") if isinstance(parsed, Mapping) else None
+    recent = recent_raw if isinstance(recent_raw, list) else []
+    filtered_recent = [
+        dict(entry)
+        for entry in recent
+        if isinstance(entry, Mapping) and entry.get("mem_id")
+    ][:MAX_RECENT]
+
+    def _positive_int(key: str) -> int:
+        try:
+            return max(0, int(parsed.get(key, 0) or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    return SelfEvolutionState(
+        version=STATE_VERSION,
+        enabled=parsed.get("enabled") is not False,
+        total_events=_positive_int("total_events"),
+        learned_count=_positive_int("learned_count"),
+        last_at=parsed.get("last_at") if parsed.get("last_at") else None,
+        recent=filtered_recent,
+    )
+
+
+def _save_state(
+    store: ConfigStore, state: SelfEvolutionState
+) -> SelfEvolutionState:
+    normalized = _normalize_state(state.to_dict())
+    normalized.recent = normalized.recent[:MAX_RECENT]
+    store.set_config(STATE_KEY, json.dumps(normalized.to_dict(), ensure_ascii=False))
+    return normalized
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _truncate(text: Any, max_len: int = 220) -> str:
+    value = _WHITESPACE_RE.sub(" ", str(text or "")).strip()
+    if len(value) > max_len:
+        return value[: max_len - 1] + "..."
+    return value
+
+
+def _tag_kind(tags: Iterable[Any]) -> str:
+    for tag in tags:
+        text = str(tag)
+        if text.startswith("kind:"):
+            return text[len("kind:") :]
+    return ""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _memory_to_entry(
+    memory: Mapping[str, Any], source: Mapping[str, Any] | None = None
+) -> SelfEvolutionEntry:
+    source = source or {}
+    tags = [str(t) for t in _safe_json_array(memory.get("tags"))]
+    mem_id = str(
+        memory.get("mem_id") or source.get("mem_id") or f"row:{memory.get('id')}"
+    )
+    kind = _tag_kind(tags)
+    if not kind:
+        event_type = memory.get("event_type")
+        if event_type == "self_constraint":
+            kind = "constraint"
+        else:
+            match = _ACTIONABLE_MEM_ID_RE.match(mem_id)
+            kind = (match.group(1) if match else "policy").lower()
+
+    try:
+        salience = int(memory.get("salience", source.get("salience", 3)) or 3)
+    except (TypeError, ValueError):
+        salience = 3
+
+    return SelfEvolutionEntry(
+        mem_id=mem_id,
+        kind=kind,
+        action=str(source.get("action") or "observed"),
+        title=_truncate(
+            memory.get("title")
+            or memory.get("content")
+            or source.get("title")
+            or "Self-evolution update",
+            96,
+        ),
+        content=_truncate(
+            memory.get("content") or source.get("content") or "", 240
+        ),
+        salience=salience,
+        tags=tags,
+        learned_at=_now_iso(),
+    )
+
+
+# ── Public API ─────────────────────────────────────────────────────
+
+
+def get_self_evolution_state(store: ConfigStore) -> SelfEvolutionState:
+    """Load and normalize the persisted ledger state."""
+    return _normalize_state(store.get_config(STATE_KEY))
+
+
+def get_self_evolution_snapshot(
+    store: ConfigStore, *, max_recent: int = MAX_RECENT
+) -> dict[str, Any]:
+    """Read-only view suitable for a dashboard / debug panel."""
+    state = get_self_evolution_state(store)
+    try:
+        limit = max(0, min(int(max_recent), MAX_RECENT))
+    except (TypeError, ValueError):
+        limit = MAX_RECENT
+    return {
+        "enabled": state.enabled,
+        "version": state.version,
+        "total_events": state.total_events,
+        "learned_count": state.learned_count,
+        "last_at": state.last_at,
+        "recent": [dict(entry) for entry in state.recent[:limit]],
+    }
+
+
+def reset_self_evolution_state(store: ConfigStore) -> SelfEvolutionState:
+    """Wipe the ledger back to defaults. Preserves ``enabled=True``."""
+    return _save_state(store, SelfEvolutionState())
+
+
+def is_self_evolution_memory(memory: Mapping[str, Any]) -> bool:
+    """True if this memory row is one the ledger should track."""
+    if not isinstance(memory, Mapping):
+        return False
+    tags = [str(t) for t in _safe_json_array(memory.get("tags"))]
+    if any(t in ACTIONABLE_TAGS for t in tags):
+        return True
+    event_type = memory.get("event_type") or memory.get("type")
+    if event_type in ACTIONABLE_EVENT_TYPES:
+        return True
+    return bool(_ACTIONABLE_MEM_ID_RE.match(str(memory.get("mem_id") or "")))
+
+
+def record_self_evolution_from_memories(
+    store: ConfigStore,
+    memories: Sequence[Mapping[str, Any]],
+    *,
+    memory_lookup: Optional[MemoryLookup] = None,
+    emit_event: Optional[Callable[[str, dict], None]] = None,
+) -> list[dict[str, Any]]:
+    """Ingest a batch of memory rows, keep only the actionable ones,
+    update the ledger and (optionally) emit a ``self_evolution`` event.
+
+    Duplicates within the batch are collapsed by ``mem_id``. Existing
+    ledger entries are preserved unless a fresh entry with the same
+    ``mem_id`` supersedes them. The recent list is capped at
+    :data:`MAX_RECENT` after a newest-first sort.
+
+    Returns the list of newly-learned entries (as plain dicts, each
+    tagged with the updated ``total_events`` counter). An empty list
+    means nothing was ingested — either no actionable rows or the
+    ledger is disabled.
+    """
+    if not memories:
+        return []
+
+    state = get_self_evolution_state(store)
+    if not state.enabled:
+        return []
+
+    learned: list[SelfEvolutionEntry] = []
+    seen: set[str] = set()
+
+    for item in memories:
+        if not isinstance(item, Mapping):
+            continue
+        mem_id = str(item.get("mem_id") or item.get("id") or "")
+        if not mem_id or mem_id in seen:
+            continue
+        seen.add(mem_id)
+
+        full: Optional[Mapping[str, Any]] = None
+        if memory_lookup is not None:
+            try:
+                full = memory_lookup.get_memory_by_mem_id(mem_id)
+            except Exception as err:  # noqa: BLE001 — lookup is
+                # advisory; a broken lookup must not lose the update.
+                logger.debug(
+                    "[self-evolution] memory lookup for %s raised %s",
+                    mem_id,
+                    err,
+                )
+                full = None
+
+        memory = full or item
+        if not is_self_evolution_memory(memory):
+            continue
+        learned.append(_memory_to_entry(memory, item))
+
+    if not learned:
+        return []
+
+    by_id: dict[str, dict[str, Any]] = {
+        entry.mem_id: entry.to_dict() for entry in learned
+    }
+    for entry in state.recent:
+        entry_id = str(entry.get("mem_id") or "")
+        if entry_id and entry_id not in by_id:
+            by_id[entry_id] = dict(entry)
+
+    next_recent = sorted(
+        by_id.values(),
+        key=lambda e: str(e.get("learned_at") or ""),
+        reverse=True,
+    )[:MAX_RECENT]
+
+    new_state = SelfEvolutionState(
+        version=STATE_VERSION,
+        enabled=state.enabled,
+        total_events=state.total_events + len(learned),
+        learned_count=len(next_recent),
+        last_at=_now_iso(),
+        recent=next_recent,
+    )
+    persisted = _save_state(store, new_state)
+
+    if callable(emit_event):
+        try:
+            emit_event(
+                "self_evolution",
+                {
+                    "count": len(learned),
+                    "entries": [e.to_dict() for e in learned],
+                    "summary": get_self_evolution_snapshot(
+                        store, max_recent=5
+                    ),
+                },
+            )
+        except Exception as err:  # noqa: BLE001 — event emission must
+            # not block ledger progress.
+            logger.warning(
+                "[self-evolution] emit_event hook raised %s", err
+            )
+
+    return [
+        {**entry.to_dict(), "total_events": persisted.total_events}
+        for entry in learned
+    ]
+
+
+def format_self_evolution_for_prompt(
+    store: ConfigStore,
+    *,
+    max_recent: int = 3,
+    max_age_ms: int = PROMPT_MAX_AGE_MS,
+    now_ms: Optional[float] = None,
+) -> str:
+    """Render the recent ledger entries as a prompt-ready string.
+
+    .. warning::
+       Do **not** splice this into the model's system prompt on a
+       schedule. In Hermes the system prompt is byte-stable for the
+       life of a conversation to preserve prompt caching (see the
+       module docstring for the mitigation menu).
+
+    Returns an empty string when the ledger is disabled or has no
+    entries newer than ``max_age_ms``. Bounds ``max_recent`` to
+    ``[1, 8]`` to keep the injected payload small.
+    """
+    state = get_self_evolution_state(store)
+    if not state.enabled or not state.recent:
+        return ""
+
+    if now_ms is None:
+        now_ms = datetime.now(tz=timezone.utc).timestamp() * 1000.0
+    cutoff = now_ms - max_age_ms
+
+    def _within_age(entry: Mapping[str, Any]) -> bool:
+        learned_at = entry.get("learned_at")
+        if not learned_at:
+            return True
+        try:
+            ts = datetime.fromisoformat(
+                str(learned_at).replace("Z", "+00:00")
+            ).timestamp() * 1000.0
+        except (TypeError, ValueError):
+            return True
+        return ts >= cutoff
+
+    filtered = [entry for entry in state.recent if _within_age(entry)]
+    try:
+        capped = max(1, min(int(max_recent), 8))
+    except (TypeError, ValueError):
+        capped = 3
+    recent = filtered[:capped]
+    if not recent:
+        return ""
+
+    lines: list[str] = []
+    for entry in recent:
+        title = str(entry.get("title") or "")
+        title_part = f"{title}: " if title else ""
+        lines.append(
+            f"- [{entry.get('kind') or 'policy'}] {entry.get('mem_id')}: "
+            f"{title_part}{entry.get('content') or ''}"
+        )
+
+    return "\n".join(
+        [
+            (
+                "Self-evolution loop is active. It stores reusable "
+                "procedures, constraints, and failure lessons as "
+                "long-term policy memories. It does not rewrite source "
+                "code or change permissions by itself."
+            ),
+            "Recent behavior updates:",
+            *lines,
+            (
+                "Use this as provenance. Turn-specific guidance still "
+                "comes from <active-policies> when a learned policy "
+                "matches the current situation."
+            ),
+        ]
+    )
+
+
+__all__ = [
+    "ACTIONABLE_EVENT_TYPES",
+    "ACTIONABLE_TAGS",
+    "ConfigStore",
+    "MAX_RECENT",
+    "MemoryLookup",
+    "PROMPT_MAX_AGE_MS",
+    "STATE_KEY",
+    "STATE_VERSION",
+    "SelfEvolutionEntry",
+    "SelfEvolutionState",
+    "format_self_evolution_for_prompt",
+    "get_self_evolution_snapshot",
+    "get_self_evolution_state",
+    "is_self_evolution_memory",
+    "record_self_evolution_from_memories",
+    "reset_self_evolution_state",
+]

--- a/agent/thread_classifier.py
+++ b/agent/thread_classifier.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------
+# Portions of this file are adapted from BaiLongma
+#   Upstream: https://github.com/xiaoyuanda666-ship-it/BaiLongma
+#   Original: src/memory/thread-classifier.js
+#   Copyright (c) 2026 xiaoyuanda666-ship-it — Licensed under MIT
+#   License text: see LICENSES/BaiLongma-MIT.txt
+# ---------------------------------------------------------------------------
+"""LLM arbiter for "is this new thread actually the same as this
+existing candidate thread?" — the fallback for rule 4/5 of thread
+attribution when the v0 keyword overlap is ambiguous.
+
+Fire-and-forget path: hard 800ms timeout, failure returns ``None``
+and the caller keeps the v0 verdict. Never mutates state.
+
+Ported from BaiLongma's ``thread-classifier.js`` (MIT).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from typing import Any, Awaitable, Callable, Mapping, Optional
+
+from .threads import Thread
+
+
+logger = logging.getLogger(__name__)
+
+
+CLASSIFIER_TIMEOUT_MS = 800
+CLASSIFIER_MAX_TOKENS = 120
+CLASSIFIER_TEMPERATURE = 0.2
+
+SYSTEM_PROMPT = (
+    "Thread classifier. A new conversation thread was just created for "
+    "the user's message. Decide whether it is actually the SAME ongoing "
+    "matter as the candidate existing thread.\n"
+    "same: the message continues/resumes the candidate thread's matter "
+    "(same task, same object, explicit back-reference).\n"
+    "different: a genuinely new matter, even if it shares a domain word "
+    "with the candidate.\n"
+    "Be conservative: when unsure, answer \"different\" (a duplicate "
+    "thread is cheap; a wrong merge pollutes history).\n"
+    "Also produce a short human-readable label (<=12 chars, Chinese) "
+    "and 2-3 semantic topic words for the NEW message's matter (not "
+    "n-grams).\n"
+    "Output JSON only."
+)
+
+
+CallLLM = Callable[..., Awaitable[Any]]
+"""Async LLM adapter. Must accept keyword args:
+
+    system_prompt, message, temperature, max_tokens, tools,
+    thinking, must_reply
+
+and return either a string or an object with a ``.content`` /
+``["content"]`` attribute.
+"""
+
+
+def _describe_thread_brief(thread: Optional[Thread]) -> str:
+    if thread is None:
+        return "(none)"
+    topic = ", ".join(thread.topic) if thread.topic else ""
+    conclusion = ""
+    if thread.conclusions:
+        conclusion = f" (conclusion: {thread.conclusions[-1]})"
+    summary = f" (summary: {str(thread.summary)[:120]})" if thread.summary else ""
+    label = thread.label or topic
+    return f'"{label}"{summary or conclusion}'
+
+
+def _build_user_prompt(
+    *,
+    new_message: str,
+    candidate_thread: Optional[Thread],
+    created_topic: list[str],
+) -> str:
+    msg = str(new_message or "")[:400]
+    return "\n".join(
+        [
+            f"Candidate existing thread = {_describe_thread_brief(candidate_thread)}",
+            f'New message = "{msg}"',
+            f"v0 topic for new thread = [{', '.join(created_topic or [])}]",
+            "",
+            'Output JSON: {"verdict": "same|different", "label": "...", "topic": ["w1","w2","w3"]}',
+        ]
+    )
+
+
+_THINK_TAG_RE = re.compile(
+    r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>", re.IGNORECASE
+)
+_FENCE_RE = re.compile(r"```(?:json)?\s*([\s\S]*?)```")
+
+
+def _parse_json(text: Optional[str]) -> Optional[Mapping[str, Any]]:
+    if not text or not isinstance(text, str):
+        return None
+    body = _THINK_TAG_RE.sub("", text).strip()
+    fence = _FENCE_RE.search(body)
+    if fence:
+        body = fence.group(1).strip()
+    first = body.find("{")
+    last = body.rfind("}")
+    if first < 0 or last <= first:
+        return None
+    try:
+        parsed = json.loads(body[first : last + 1])
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, Mapping) else None
+
+
+def _normalize(raw: Optional[Mapping[str, Any]]) -> Optional[dict]:
+    if not raw or not isinstance(raw, Mapping):
+        return None
+    verdict = str(raw.get("verdict") or "").lower().strip()
+    if verdict not in ("same", "different"):
+        return None
+    label = str(raw.get("label") or "").strip()[:24]
+    topic_raw = raw.get("topic")
+    topic: list[str] = []
+    if isinstance(topic_raw, list):
+        for t in topic_raw:
+            tw = str(t or "").strip()
+            if tw and len(tw) <= 32:
+                topic.append(tw)
+            if len(topic) == 3:
+                break
+    return {"verdict": verdict, "label": label, "topic": topic}
+
+
+async def classify_thread_attribution(
+    *,
+    call_llm: CallLLM,
+    new_message: str,
+    candidate_thread: Optional[Thread],
+    created_topic: list[str],
+    timeout_ms: int = CLASSIFIER_TIMEOUT_MS,
+) -> Optional[dict]:
+    """Arbitrate "created new thread vs weak-signal candidate = same
+    matter?". Returns ``None`` on any failure (import error, timeout,
+    parse failure) so the caller keeps the v0 verdict.
+
+    ``call_llm`` is injected — Hermes wires this to the auxiliary-model
+    adapter at the seam so the arbiter can run against a small
+    router-picked model without perturbing the main conversation cache.
+    """
+    if not new_message or not isinstance(new_message, str):
+        return None
+
+    t0 = time.time()
+
+    system_prompt = SYSTEM_PROMPT
+    user_prompt = _build_user_prompt(
+        new_message=new_message,
+        candidate_thread=candidate_thread,
+        created_topic=created_topic,
+    )
+
+    async def _work() -> Any:
+        return await call_llm(
+            system_prompt=system_prompt,
+            message=user_prompt,
+            temperature=CLASSIFIER_TEMPERATURE,
+            thinking=False,
+            tools=[],
+            max_tokens=CLASSIFIER_MAX_TOKENS,
+            must_reply=False,
+        )
+
+    try:
+        result = await asyncio.wait_for(_work(), timeout=timeout_ms / 1000.0)
+    except asyncio.TimeoutError:
+        logger.info(
+            "[thread-classifier] LLM timeout (%.0fms) → falling back to v0",
+            (time.time() - t0) * 1000,
+        )
+        return None
+    except Exception as err:  # noqa: BLE001 — fire-and-forget path
+        logger.info(
+            "[thread-classifier] LLM raised (%.0fms, %s) → falling back to v0",
+            (time.time() - t0) * 1000,
+            err,
+        )
+        return None
+
+    if result is None:
+        logger.info("[thread-classifier] LLM returned None → falling back to v0")
+        return None
+
+    if isinstance(result, str):
+        content = result
+    else:
+        content = ""
+        try:
+            content = getattr(result, "content", None) or result["content"]  # type: ignore[index]
+        except (KeyError, TypeError):
+            pass
+
+    normalized = _normalize(_parse_json(content))
+    if not normalized:
+        logger.info(
+            '[thread-classifier] JSON parse/normalize failed raw="%s" '
+            "→ falling back to v0",
+            re.sub(r"\s+", " ", str(content))[:160],
+        )
+        return None
+
+    logger.info(
+        '[thread-classifier] verdict=%s label="%s" (%.0fms)',
+        normalized["verdict"],
+        normalized["label"],
+        (time.time() - t0) * 1000,
+    )
+    return normalized
+
+
+__all__ = [
+    "CLASSIFIER_MAX_TOKENS",
+    "CLASSIFIER_TEMPERATURE",
+    "CLASSIFIER_TIMEOUT_MS",
+    "SYSTEM_PROMPT",
+    "CallLLM",
+    "classify_thread_attribution",
+]

--- a/agent/threads.py
+++ b/agent/threads.py
@@ -1,0 +1,962 @@
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------
+# Portions of this file are adapted from BaiLongma
+#   Upstream: https://github.com/xiaoyuanda666-ship-it/BaiLongma
+#   Original: src/memory/threads.js
+#   Copyright (c) 2026 xiaoyuanda666-ship-it — Licensed under MIT
+#   License text: see LICENSES/BaiLongma-MIT.txt
+# ---------------------------------------------------------------------------
+"""Thread model — the successor to focus-stack in a dynamic memory pool.
+
+Threads replace the classic focus-stack with three read-time
+temperature bands (foreground / warm / cool / cold) driven by an
+elapsed-wall-clock function. Key invariants — worth internalising
+before touching this module:
+
+* **Epistemology.** Foreground is *written by the actor*
+  (``touch_commitment_thread`` / ``open_commitment``); no observer
+  ever infers focus.
+* **Ontology.** Multiple concurrent threads plus one foreground
+  pointer — no stack, no pop. A foreground switch simply moves the
+  old thread to background.
+* **Decision theory.** Forgetting is a *read-time pure function*
+  (:func:`thread_temperature`); no write-time state mutation ever
+  drops information. Thread data is append-only.
+
+This module does *not* own persistence, LLM calls, or prompt
+rendering — it emits events and exposes queries that the surrounding
+system persists / classifies / renders.
+
+Ported from BaiLongma's ``threads.js`` (MIT).
+"""
+from __future__ import annotations
+
+import random
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, Literal, Mapping, MutableMapping, Optional
+
+from .keywords import extract_keywords
+
+
+# ── Tuning constants (wall-clock, not ticks — tick intervals differ
+# 40x between task and idle modes and are not a valid time unit). ───
+
+WARM_WINDOW_MS = 6 * 60 * 60 * 1000  # 6h active → warm
+COOL_WINDOW_MS = 48 * 60 * 60 * 1000  # 48h → cool; older → cold
+
+# Injection budget: how many warm-thread one-line summaries prompt.py
+# is allowed to inject. Bounds the injection view, not thread survival.
+MAX_WARM_INJECTED = 3
+
+# In-memory cap. Overflowing threads that are cold AND have no open
+# commitment are evicted from memory (still in the DB).
+MAX_THREADS_IN_MEMORY = 12
+
+# Per-thread rolling conclusion cap.
+THREAD_CONCLUSIONS_LIMIT = 5
+
+TOPIC_KEYWORDS_LIMIT = 3
+KEYWORD_EXTRACT_BUDGET = 12
+MIN_KEYWORDS_FOR_THREAD = 3
+MIN_MESSAGE_LENGTH = 4
+
+# "Signature": the wider keyword set used for overlap matching. A
+# thread's display topic is a shorter prefix of its signature.
+SIGNATURE_LIMIT = 8
+
+
+# The n-gram extractor happily proposes junk fillers like "这个" and
+# "帮我" — high-frequency across all topics, pure noise for overlap
+# matching. Filter them out at the attribution boundary; the display
+# topic ends up cleaner as a bonus.
+_NOISE_TOKEN_RE = re.compile(
+    r"^(这个|那个|什么|怎么|为什|可以|我们|你们|他们|帮我|给我|一下|一个|"
+    r"继续|部分|现在|今天|明天|昨天|晚上|早上|然后|还是|就是|但是|因为|"
+    r"所以|如果|这样|那样|的话|时候|问题|事情|东西|网页|网站|网址|页面|"
+    r"链接|地址|文件|文档|内容)"
+)
+
+
+def _filter_noise_tokens(kws: Iterable[str]) -> list[str]:
+    out: list[str] = []
+    for k in kws or []:
+        t = str(k or "").strip()
+        if not t:
+            continue
+        # English/digit tokens: length >= 3 threshold (short acronyms
+        # are noise more often than not).
+        if re.fullmatch(r"[a-zA-Z0-9_-]+", t):
+            if len(t) >= 3:
+                out.append(t)
+            continue
+        if _NOISE_TOKEN_RE.match(t):
+            continue
+        if len(t) >= 2:
+            out.append(t)
+    return out
+
+
+def _extract_attribution_keywords(text: str) -> list[str]:
+    """Single entry point used by both message-side attribution and
+    thread-signature extraction — matching stays symmetric.
+    """
+    return _filter_noise_tokens(extract_keywords(str(text or ""), KEYWORD_EXTRACT_BUDGET))
+
+
+# Asymmetric switching thresholds (DynamicMemoryPool.md 8.5):
+#   Foreground continuation is cheap — overlap ≥ 1 counts.
+#   Background resume is expensive — overlap ≥ 2 counts.
+# The old focus-stack era learned the hard way that one-keyword
+# coincidences flip "returned" to the wrong stack frame.
+FOREGROUND_OVERLAP_MIN = 1
+BACKGROUND_RESUME_OVERLAP_MIN = 2
+
+
+# One-off leaves that should not open a thread.
+_ONE_OFF_LEAF_RE = re.compile(
+    r"天气|气温|温度|下雨|下雪|空气质量|AQI|几点|几号|星期几|汇率|股价|"
+    r"热搜|新闻|在吗|早上好|晚上好|谢谢|收到",
+    re.IGNORECASE,
+)
+
+_SUSTAINED_RE = re.compile(
+    r"分析|优化|修复|实现|修改|设计|写|做|排查|调试|构建|部署|项目|"
+    r"代码|文件|机制|方案|测试|review|debug|fix|implement|build",
+    re.IGNORECASE,
+)
+
+# Indexical progress queries — carry no topic word, but the sentence
+# form itself pins the referent to "the open commitment I owe you".
+_INDEXICAL_PROGRESS_RE = re.compile(
+    r"(怎么样|咋样|如何了|进度|进展|搞定|好了吗|好了么|好了没|"
+    r"完成了吗|完成了没|弄完|做完|干完|干得|干的|还在弄|还在做|"
+    r"顺利|卡住|到哪|哪一步)"
+)
+
+
+def is_likely_one_off_leaf(body: str) -> bool:
+    text = str(body or "").strip()
+    if not text:
+        return False
+    if _SUSTAINED_RE.search(text):
+        return False
+    if re.fullmatch(
+        r"(hello|hi|hey|在吗|早上好|晚上好|谢谢|收到)", text, re.IGNORECASE
+    ):
+        return True
+    return len(text) <= 40 and bool(_ONE_OFF_LEAF_RE.search(text))
+
+
+def is_indexical_progress_query(body: str) -> bool:
+    """Indexical progress queries are naturally short. A longer
+    sentence that happens to mention "进展" is almost certainly a
+    substantive request, not a bare progress check.
+    """
+    text = str(body or "").strip()
+    if not text or len(text) > 25:
+        return False
+    return bool(_INDEXICAL_PROGRESS_RE.search(text))
+
+
+# ── Anaphora + precise callback (治"打开那个网页"型话题漂移) ─────────
+#
+# Rule ① Bare anaphora / generic object: user says "this / that" or
+#   only operates on a generic placeholder ("open that page"). The
+#   referent lives in *the previous turn*, not this sentence. Do not
+#   name a new thread; continue the foreground.
+# Rule ② "That + concrete noun" — user is naming a distant concept
+#   ("that open-source leaderboard"). The noun is itself the precise
+#   referent, so relax the resume threshold from ≥ 2 to ≥ 1 on that
+#   thread's signature.
+
+_GENERIC_OBJECT_RE = re.compile(
+    r"(网页|网站|网址|页面|那页|这页|链接|地址|玩意儿?|东西|文件|文档|内容)"
+)
+_OPERATION_VERB_RE = re.compile(
+    r"(打开|关闭|关掉|启动|运行|播放|暂停|下载|搜索|显示|发送|点开|"
+    r"访问|跳转|打开一?下|放一?下|查一?下|搜一?下|看一?下|念一?下|"
+    r"读一?下|发一?下)"
+)
+_DEMONSTRATIVE_RE = re.compile(
+    r"(这|那)(个|种|些|位|款|家|件|批|类|段|张|篇|份|首|部|台|项|套|"
+    r"条|者|回|次)|它|他|她|刚才|刚刚|刚说|刚提|上面|前面|"
+    r"之前(说|讲|提|的|那)|你?刚(说|讲|发|放|提)"
+)
+
+
+@dataclass
+class ReferenceClassification:
+    kind: Literal["none", "anaphora-recent", "precise-callback"]
+    substantive: list[str] = field(default_factory=list)
+    referent_kws: list[str] = field(default_factory=list)
+
+
+def classify_reference(body: str) -> ReferenceClassification:
+    """Classify a user message as none / anaphora-recent / precise-callback.
+
+    * ``anaphora-recent`` — Rule ①: continue foreground, never
+      new / switch.
+    * ``precise-callback`` — Rule ②: try ``referent_kws`` against
+      every thread; hits on background at ≥ 1 count as resume.
+    * ``none`` — normal keyword attribution applies.
+
+    ``substantive`` is what the sentence carries once operation verbs
+    and generic-object placeholders are stripped — used by the
+    "explicit-beats-implicit" guard so an anaphoric-looking sentence
+    that *does* name a concrete other topic still lands on that topic.
+    """
+    text = str(body or "").strip()
+    if not text:
+        return ReferenceClassification(kind="none")
+
+    has_demon = bool(_DEMONSTRATIVE_RE.search(text))
+    acts_on_generic = bool(_GENERIC_OBJECT_RE.search(text)) and (
+        bool(_OPERATION_VERB_RE.search(text)) or has_demon
+    )
+    substantive = [
+        k
+        for k in _extract_attribution_keywords(text)
+        if not _OPERATION_VERB_RE.search(k) and not _GENERIC_OBJECT_RE.search(k)
+    ]
+    bare_operation = bool(_OPERATION_VERB_RE.search(text)) and not substantive
+    if acts_on_generic or bare_operation:
+        return ReferenceClassification(kind="anaphora-recent", substantive=substantive)
+    if has_demon and not substantive:
+        return ReferenceClassification(kind="anaphora-recent", substantive=substantive)
+    if has_demon and substantive:
+        return ReferenceClassification(
+            kind="precise-callback",
+            substantive=substantive,
+            referent_kws=list(substantive),
+        )
+    return ReferenceClassification(kind="none", substantive=substantive)
+
+
+# ── Message envelope + id + thread construction ────────────────────
+
+
+_ENVELOPE_RE = re.compile(
+    r"^\[[^\]]+\]\s*[\dTZ:+\-.]+\s*\[[^\]]*\]\s*(.*)$", re.DOTALL
+)
+_TICK_MESSAGE_RE = re.compile(r"^TICK\s", re.IGNORECASE)
+
+
+def _is_tick_message(message: Any) -> bool:
+    return isinstance(message, str) and bool(_TICK_MESSAGE_RE.match(message.strip()))
+
+
+def strip_message_envelope(message: Any) -> str:
+    """Peel ``[ID:xxx] timestamp [channel] body`` envelopes.
+
+    TICK messages return an empty string — they are heartbeat markers,
+    never user content.
+    """
+    if not message:
+        return ""
+    if _is_tick_message(message):
+        return ""
+    text = str(message)
+    match = _ENVELOPE_RE.match(text)
+    return match.group(1).strip() if match else text.strip()
+
+
+_id_counter = 0
+
+
+def _new_id(prefix: str) -> str:
+    global _id_counter
+    _id_counter = (_id_counter + 1) % 10000
+    return (
+        f"{prefix}_{int(time.time() * 1000):x}_"
+        f"{_id_counter:x}"
+        f"{''.join(random.choices('abcdefghijklmnopqrstuvwxyz0123456789', k=4))}"
+    )
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: Any) -> Optional[float]:
+    """Return ms since epoch for an ISO string, else None."""
+    if not value:
+        return None
+    try:
+        text = str(value).replace("Z", "+00:00")
+        return datetime.fromisoformat(text).timestamp() * 1000.0
+    except (ValueError, TypeError):
+        return None
+
+
+@dataclass
+class Thread:
+    id: str
+    topic: list[str]
+    signature: list[str]
+    label: str
+    summary: str
+    conclusions: list[str]
+    status: str
+    created_at: str
+    last_event_at: str
+    last_event_tick: int
+    hit_count: int
+    last_summary_at: str
+
+
+def make_thread(
+    topic: Iterable[str],
+    *,
+    tick: int = 0,
+    label: str = "",
+    signature: Optional[Iterable[str]] = None,
+) -> Thread:
+    now = _now_iso()
+    topic_list = list(topic)[:TOPIC_KEYWORDS_LIMIT] if topic else []
+    sig_list = (
+        list(signature)[:SIGNATURE_LIMIT]
+        if signature and any(True for _ in signature)
+        else list(topic_list)
+    )
+    return Thread(
+        id=_new_id("th"),
+        topic=topic_list,
+        signature=sig_list,
+        label=label or "",
+        summary="",
+        conclusions=[],
+        status="open",
+        created_at=now,
+        last_event_at=now,
+        last_event_tick=tick,
+        hit_count=1,
+        last_summary_at=now,
+    )
+
+
+@dataclass
+class Commitment:
+    id: str
+    thread_id: str
+    text: str
+    status: str
+    channel: str
+    created_at: str
+    closed_at: Optional[str]
+
+
+# ── ThreadState shape + accessors ──────────────────────────────────
+
+
+State = MutableMapping[str, Any]
+
+
+def ensure_thread_state(state: State) -> dict:
+    ts = state.get("thread_state")
+    if not isinstance(ts, dict):
+        ts = {"threads": [], "foreground_id": None, "commitments": []}
+        state["thread_state"] = ts
+    ts.setdefault("threads", [])
+    ts.setdefault("commitments", [])
+    ts.setdefault("foreground_id", None)
+    return ts
+
+
+def get_foreground_thread(state: State) -> Optional[Thread]:
+    ts = ensure_thread_state(state)
+    fg = ts.get("foreground_id")
+    if not fg:
+        return None
+    for t in ts["threads"]:
+        if t.id == fg:
+            return t
+    return None
+
+
+def get_thread_by_id(state: State, thread_id: Optional[str]) -> Optional[Thread]:
+    if not thread_id:
+        return None
+    for t in ensure_thread_state(state)["threads"]:
+        if t.id == thread_id:
+            return t
+    return None
+
+
+def get_open_commitments(state: State) -> list[Commitment]:
+    return [c for c in ensure_thread_state(state)["commitments"] if c.status == "open"]
+
+
+def latest_open_commitment(
+    state: State, *, channel: str = ""
+) -> Optional[Commitment]:
+    """Anchor for indexical progress queries. Prefers same-channel;
+    within a set, ties break to the most recent (insertion-order-wins,
+    matching push order in the JS original).
+    """
+    open_ = get_open_commitments(state)
+    if not open_:
+        return None
+
+    def newest_of(candidates: list[Commitment]) -> Commitment:
+        best = candidates[0]
+        best_ts = _parse_iso(best.created_at) or 0.0
+        for c in candidates:
+            ts = _parse_iso(c.created_at) or 0.0
+            if ts >= best_ts:
+                best = c
+                best_ts = ts
+        return best
+
+    if channel:
+        same_channel = [c for c in open_ if c.channel == channel]
+        if same_channel:
+            return newest_of(same_channel)
+    return newest_of(open_)
+
+
+# ── Commitment lifecycle ───────────────────────────────────────────
+
+
+def open_commitment(
+    state: State,
+    *,
+    text: str,
+    thread_id: Optional[str] = None,
+    channel: str = "",
+    tick: int = 0,
+) -> Commitment:
+    """'OK I'll do it' — the actor-writes-focus path.
+
+    Attaches to the specified thread, else the current foreground, else
+    creates a fresh thread. If an open commitment already exists on
+    the same thread, updates its text in place (task is a singleton).
+    """
+    ts = ensure_thread_state(state)
+    thread = (
+        get_thread_by_id(state, thread_id)
+        if thread_id
+        else get_foreground_thread(state)
+    )
+    if not thread:
+        kws = _extract_attribution_keywords(str(text or ""))
+        thread = make_thread(
+            kws[:TOPIC_KEYWORDS_LIMIT] if kws else ["任务"],
+            tick=tick,
+            signature=kws,
+        )
+        ts["threads"].append(thread)
+        ts["foreground_id"] = thread.id
+
+    for existing in ts["commitments"]:
+        if existing.status == "open" and existing.thread_id == thread.id:
+            existing.text = str(text or existing.text)
+            return existing
+
+    commitment = Commitment(
+        id=_new_id("cm"),
+        thread_id=thread.id,
+        text=str(text or ""),
+        status="open",
+        channel=channel or "",
+        created_at=_now_iso(),
+        closed_at=None,
+    )
+    ts["commitments"].append(commitment)
+    touch_thread(state, thread.id, tick=tick)
+    return commitment
+
+
+def close_commitment(
+    state: State,
+    *,
+    thread_id: Optional[str] = None,
+    commitment_id: Optional[str] = None,
+    status: str = "done",
+) -> Optional[Commitment]:
+    """After close, the thread is no longer pinned — it cools naturally
+    by ``last_event_at``. No mutation on any thread state; forgetting
+    is a read-time function.
+    """
+    ts = ensure_thread_state(state)
+    target: Optional[Commitment] = None
+    if commitment_id:
+        for c in ts["commitments"]:
+            if c.id == commitment_id and c.status == "open":
+                target = c
+                break
+    else:
+        for c in ts["commitments"]:
+            if c.status == "open" and (not thread_id or c.thread_id == thread_id):
+                target = c
+                break
+    if not target:
+        return None
+    target.status = "cancelled" if status == "cancelled" else "done"
+    target.closed_at = _now_iso()
+    return target
+
+
+def touch_thread(state: State, thread_id: str, *, tick: int = 0) -> bool:
+    """Actor-writes-focus path #2: the agent doing tool calls counts as
+    a foreground event. Silences the classic "starved while working"
+    failure without any staleness heuristic.
+    """
+    thread = get_thread_by_id(state, thread_id)
+    if not thread:
+        return False
+    thread.last_event_at = _now_iso()
+    thread.last_event_tick = tick
+    thread.hit_count += 1
+    return True
+
+
+def touch_commitment_thread(state: State, *, tick: int = 0) -> bool:
+    ts = ensure_thread_state(state)
+    open_ = latest_open_commitment(state)
+    target_id = open_.thread_id if open_ else ts["foreground_id"]
+    if not target_id:
+        return False
+    return touch_thread(state, target_id, tick=tick)
+
+
+# ── Read-time temperature — never writes ───────────────────────────
+
+
+Temperature = Literal["foreground", "warm", "cool", "cold"]
+
+
+def thread_temperature(
+    state: State,
+    thread: Optional[Thread],
+    *,
+    now_ms: Optional[float] = None,
+) -> Temperature:
+    if thread is None:
+        return "cold"
+    if now_ms is None:
+        now_ms = time.time() * 1000.0
+    ts = ensure_thread_state(state)
+    if thread.id == ts["foreground_id"]:
+        return "foreground"
+    # An open commitment pins temperature regardless of age.
+    if any(c.status == "open" and c.thread_id == thread.id for c in ts["commitments"]):
+        return "warm"
+    last_ms = _parse_iso(thread.last_event_at) or _parse_iso(thread.created_at) or 0.0
+    age = now_ms - last_ms
+    if age < WARM_WINDOW_MS:
+        return "warm"
+    if age < COOL_WINDOW_MS:
+        return "cool"
+    return "cold"
+
+
+def _is_thread_cold_by_age(
+    state: State,
+    thread: Optional[Thread],
+    now_ms: Optional[float] = None,
+) -> bool:
+    """Cold-by-age guard used inside attribution rules. Independent of
+    foreground shortcut but honours open-commitment pinning.
+    """
+    if not thread:
+        return True
+    ts = ensure_thread_state(state)
+    if any(c.status == "open" and c.thread_id == thread.id for c in ts["commitments"]):
+        return False
+    if now_ms is None:
+        now_ms = time.time() * 1000.0
+    last_ms = _parse_iso(thread.last_event_at) or _parse_iso(thread.created_at) or 0.0
+    age = now_ms - last_ms if last_ms else float("inf")
+    return age >= COOL_WINDOW_MS
+
+
+# ── Injection view — prompt.py's only entry point ──────────────────
+
+
+def build_thread_view(state: State, *, now_ms: Optional[float] = None) -> dict:
+    ts = ensure_thread_state(state)
+    if now_ms is None:
+        now_ms = time.time() * 1000.0
+    foreground = get_foreground_thread(state)
+    open_commitments = get_open_commitments(state)
+    background_pool = [
+        (t, thread_temperature(state, t, now_ms=now_ms))
+        for t in ts["threads"]
+        if t.id != ts["foreground_id"]
+    ]
+    warm_only = [x for x in background_pool if x[1] == "warm"]
+    warm_only.sort(
+        key=lambda x: -(_parse_iso(x[0].last_event_at) or 0.0),
+    )
+    background = [
+        {"thread": thread, "temperature": temp}
+        for thread, temp in warm_only[:MAX_WARM_INJECTED]
+    ]
+    return {
+        "foreground": foreground,
+        "foreground_commitment": (
+            next(
+                (c for c in open_commitments if c.thread_id == foreground.id),
+                None,
+            )
+            if foreground
+            else None
+        ),
+        "background": background,
+        "open_commitments": open_commitments,
+    }
+
+
+# ── Overlap: intersection of message keywords with thread signature ─
+
+
+def _overlap_count(thread: Optional[Thread], kws: Iterable[str]) -> int:
+    if not thread:
+        return 0
+    signature_set = set(thread.signature or []) | set(thread.topic or [])
+    if not signature_set:
+        return 0
+    return sum(1 for k in kws if k in signature_set)
+
+
+# ── User-message attribution (the one place that *judges*) ─────────
+#
+# Return keys:
+#   event: 'created' | 'continued' | 'resumed' | 'ambiguous' | 'noop'
+#   thread: the attributed Thread or None
+#   switched_from: previous foreground when 'resumed'/'created' flips it
+#   via: reason tag ('commitment' / 'anaphora-recent' / 'callback' ...)
+#   ambiguous_with: only when overlap=1 with a background thread
+
+
+@dataclass
+class AttributionResult:
+    event: Literal["created", "continued", "resumed", "ambiguous", "noop"]
+    thread: Optional[Thread]
+    switched_from: Optional[Thread] = None
+    via: Optional[str] = None
+    ambiguous_with: Optional[Thread] = None
+
+
+def attribute_user_message(
+    state: State,
+    message: Any,
+    *,
+    tick: int = 0,
+    channel: str = "",
+) -> AttributionResult:
+    ts = ensure_thread_state(state)
+    body = strip_message_envelope(message)
+    if not body or len(body) < MIN_MESSAGE_LENGTH:
+        return AttributionResult(event="noop", thread=None)
+    if is_likely_one_off_leaf(body):
+        return AttributionResult(event="noop", thread=None)
+
+    kws = _extract_attribution_keywords(body)
+    foreground = get_foreground_thread(state)
+
+    # 1) Indexical progress query → thread of the latest open commitment.
+    if is_indexical_progress_query(body):
+        commitment = latest_open_commitment(state, channel=channel)
+        if commitment:
+            target = get_thread_by_id(state, commitment.thread_id)
+            names_other = target is not None and any(
+                t.id != target.id
+                and _overlap_count(t, kws) >= BACKGROUND_RESUME_OVERLAP_MIN
+                for t in ts["threads"]
+            )
+            if target and not names_other:
+                switched_from = (
+                    foreground if foreground and foreground.id != target.id else None
+                )
+                ts["foreground_id"] = target.id
+                touch_thread(state, target.id, tick=tick)
+                return AttributionResult(
+                    event="resumed" if switched_from else "continued",
+                    thread=target,
+                    switched_from=switched_from,
+                    via="commitment",
+                )
+        else:
+            if foreground and not _is_thread_cold_by_age(state, foreground):
+                touch_thread(state, foreground.id, tick=tick)
+                return AttributionResult(
+                    event="continued", thread=foreground
+                )
+            return AttributionResult(event="noop", thread=None)
+
+    # 1.5) Reference classification (治话题漂移).
+    ref = classify_reference(body)
+    if ref.kind == "anaphora-recent":
+        names_other = bool(ref.substantive) and any(
+            (not foreground or t.id != foreground.id)
+            and _overlap_count(t, ref.substantive) >= BACKGROUND_RESUME_OVERLAP_MIN
+            for t in ts["threads"]
+        )
+        if not names_other and foreground and not _is_thread_cold_by_age(state, foreground):
+            touch_thread(state, foreground.id, tick=tick)
+            return AttributionResult(
+                event="continued", thread=foreground, via="anaphora-recent"
+            )
+    elif ref.kind == "precise-callback" and ref.referent_kws:
+        rkws = ref.referent_kws
+        if foreground and _overlap_count(foreground, rkws) >= 1:
+            touch_thread(state, foreground.id, tick=tick)
+            return AttributionResult(
+                event="continued", thread=foreground, via="callback"
+            )
+        cb_best: Optional[Thread] = None
+        cb_overlap = 0
+        for t in ts["threads"]:
+            if foreground and t.id == foreground.id:
+                continue
+            n = _overlap_count(t, rkws)
+            if n > cb_overlap:
+                cb_best = t
+                cb_overlap = n
+        if cb_best and cb_overlap >= BACKGROUND_RESUME_OVERLAP_MIN:
+            switched_from = (
+                foreground if foreground and foreground.id != cb_best.id else None
+            )
+            ts["foreground_id"] = cb_best.id
+            touch_thread(state, cb_best.id, tick=tick)
+            return AttributionResult(
+                event="resumed" if switched_from else "continued",
+                thread=cb_best,
+                switched_from=switched_from,
+                via="callback",
+            )
+        # Fallback: a demonstrative sentence with no match anywhere is
+        # almost never a truly new topic — continue foreground rather
+        # than spawn a pseudo-thread.
+        if foreground and not _is_thread_cold_by_age(state, foreground):
+            touch_thread(state, foreground.id, tick=tick)
+            return AttributionResult(
+                event="continued", thread=foreground, via="callback-fallback"
+            )
+
+    # 2) Keyword-sparse short message: continue foreground (cheap,
+    #    self-healing); guard against reviving a cold foreground.
+    if len(kws) < MIN_KEYWORDS_FOR_THREAD:
+        if foreground and not _is_thread_cold_by_age(state, foreground):
+            touch_thread(state, foreground.id, tick=tick)
+            return AttributionResult(event="continued", thread=foreground)
+        return AttributionResult(event="noop", thread=None)
+
+    # 3) Foreground overlap ≥ 1 → continued.
+    if foreground and _overlap_count(foreground, kws) >= FOREGROUND_OVERLAP_MIN:
+        touch_thread(state, foreground.id, tick=tick)
+        return AttributionResult(event="continued", thread=foreground)
+
+    # 4) Background: overlap ≥ 2 → resumed; = 1 → ambiguous candidate.
+    best: Optional[Thread] = None
+    best_overlap = 0
+    for t in ts["threads"]:
+        if foreground and t.id == foreground.id:
+            continue
+        n = _overlap_count(t, kws)
+        if n > best_overlap:
+            best = t
+            best_overlap = n
+    if best and best_overlap >= BACKGROUND_RESUME_OVERLAP_MIN:
+        ts["foreground_id"] = best.id
+        touch_thread(state, best.id, tick=tick)
+        return AttributionResult(
+            event="resumed", thread=best, switched_from=foreground
+        )
+
+    # 5) Genuinely new topic.
+    created = make_thread(kws[:TOPIC_KEYWORDS_LIMIT], tick=tick, signature=kws)
+    ts["threads"].append(created)
+    switched_from = foreground
+    ts["foreground_id"] = created.id
+    evict_cold_threads(state)
+    if best and best_overlap == 1:
+        return AttributionResult(
+            event="created",
+            thread=created,
+            switched_from=switched_from,
+            ambiguous_with=best,
+        )
+    return AttributionResult(
+        event="created", thread=created, switched_from=switched_from
+    )
+
+
+# ── Merge (arbitration-follow-up; always safe by construction) ────
+
+
+def merge_threads(
+    state: State, source_id: str, target_id: str
+) -> Optional[Thread]:
+    """Fold ``source`` into ``target``. Topic + signature unions,
+    conclusions concat (bounded), summary preserved if target lacked
+    one, commitments retargeted, hit counts summed, foreground
+    pointer patched.
+
+    Merge is always safe: threads have no stack invariant to preserve;
+    the worst case is over- or under-merging by one topic word.
+    """
+    ts = ensure_thread_state(state)
+    source = get_thread_by_id(state, source_id)
+    target = get_thread_by_id(state, target_id)
+    if not source or not target or source.id == target.id:
+        return None
+
+    topic_set = list(dict.fromkeys([*target.topic, *source.topic]))
+    target.topic = topic_set[:TOPIC_KEYWORDS_LIMIT]
+    sig_set = list(dict.fromkeys([*target.signature, *source.signature]))
+    target.signature = sig_set[:SIGNATURE_LIMIT]
+
+    for c in source.conclusions or []:
+        if c not in target.conclusions:
+            target.conclusions.append(c)
+    while len(target.conclusions) > THREAD_CONCLUSIONS_LIMIT:
+        target.conclusions.pop(0)
+
+    if source.summary and not target.summary:
+        target.summary = source.summary
+
+    target.hit_count += source.hit_count or 0
+    if (_parse_iso(source.last_event_at) or 0.0) > (
+        _parse_iso(target.last_event_at) or 0.0
+    ):
+        target.last_event_at = source.last_event_at
+        target.last_event_tick = source.last_event_tick
+
+    for c in ts["commitments"]:
+        if c.thread_id == source.id:
+            c.thread_id = target.id
+
+    ts["threads"] = [t for t in ts["threads"] if t.id != source.id]
+    if ts["foreground_id"] == source.id:
+        ts["foreground_id"] = target.id
+    return target
+
+
+def append_conclusion(thread: Thread, conclusion: str) -> None:
+    """Add an incremental summary conclusion. Rolling cap; never
+    replaces prior text.
+    """
+    if not thread or not conclusion:
+        return
+    text = str(conclusion).strip()
+    if not text or text in thread.conclusions:
+        return
+    thread.conclusions.append(text)
+    while len(thread.conclusions) > THREAD_CONCLUSIONS_LIMIT:
+        thread.conclusions.pop(0)
+
+
+def evict_cold_threads(
+    state: State, *, now_ms: Optional[float] = None
+) -> list[Thread]:
+    """In-memory slim-down (not forgetting): overflow → drop threads
+    that are (a) cold, (b) not foreground, (c) have no open commitment.
+    Persistence layer still has them.
+    """
+    ts = ensure_thread_state(state)
+    if len(ts["threads"]) <= MAX_THREADS_IN_MEMORY:
+        return []
+    if now_ms is None:
+        now_ms = time.time() * 1000.0
+    evictable = [
+        t
+        for t in ts["threads"]
+        if t.id != ts["foreground_id"]
+        and thread_temperature(state, t, now_ms=now_ms) == "cold"
+    ]
+    evictable.sort(key=lambda t: _parse_iso(t.last_event_at) or 0.0)
+    excess = len(ts["threads"]) - MAX_THREADS_IN_MEMORY
+    evicted = evictable[:excess]
+    if not evicted:
+        return []
+    evicted_ids = {t.id for t in evicted}
+    ts["threads"] = [t for t in ts["threads"] if t.id not in evicted_ids]
+    return evicted
+
+
+def describe_thread(thread: Optional[Thread]) -> str:
+    if not thread:
+        return ""
+    label = thread.label or (",".join(thread.topic) if thread.topic else "")
+    last_conclusion = thread.conclusions[-1] if thread.conclusions else ""
+    return f"{label} — {last_conclusion}" if last_conclusion else label
+
+
+def migrate_focus_stack_to_threads(
+    focus_stack: list[Mapping[str, Any]], *, tick: int = 0
+) -> dict:
+    """One-time boot migration from the legacy focus-stack model.
+
+    Stack top becomes foreground; the rest become background threads.
+    Commitments cannot be recovered (the old model had no such
+    concept), so the result's ``commitments`` list is empty.
+    """
+    threads: list[Thread] = []
+    for frame in focus_stack or []:
+        topic = frame.get("topic") if isinstance(frame, Mapping) else None
+        if not isinstance(topic, list) or not topic:
+            continue
+        t = make_thread(topic, tick=tick, signature=list(topic))
+        started_at = frame.get("startedAt") or frame.get("started_at")
+        if started_at:
+            t.created_at = started_at
+            t.last_event_at = started_at
+        t.last_event_tick = frame.get("lastSeenTick") or frame.get("last_seen_tick") or tick
+        t.hit_count = frame.get("hitCount") or frame.get("hit_count") or 1
+        conclusions = frame.get("conclusions") or []
+        if isinstance(conclusions, list):
+            t.conclusions = [
+                str(c) for c in conclusions[-THREAD_CONCLUSIONS_LIMIT:]
+            ]
+        threads.append(t)
+    return {
+        "threads": threads,
+        "foreground_id": threads[-1].id if threads else None,
+        "commitments": [],
+    }
+
+
+__all__ = [
+    "AttributionResult",
+    "BACKGROUND_RESUME_OVERLAP_MIN",
+    "COOL_WINDOW_MS",
+    "Commitment",
+    "FOREGROUND_OVERLAP_MIN",
+    "MAX_THREADS_IN_MEMORY",
+    "MAX_WARM_INJECTED",
+    "MIN_KEYWORDS_FOR_THREAD",
+    "MIN_MESSAGE_LENGTH",
+    "ReferenceClassification",
+    "SIGNATURE_LIMIT",
+    "THREAD_CONCLUSIONS_LIMIT",
+    "TOPIC_KEYWORDS_LIMIT",
+    "Thread",
+    "WARM_WINDOW_MS",
+    "append_conclusion",
+    "attribute_user_message",
+    "build_thread_view",
+    "classify_reference",
+    "close_commitment",
+    "describe_thread",
+    "ensure_thread_state",
+    "evict_cold_threads",
+    "get_foreground_thread",
+    "get_open_commitments",
+    "get_thread_by_id",
+    "is_indexical_progress_query",
+    "is_likely_one_off_leaf",
+    "latest_open_commitment",
+    "make_thread",
+    "merge_threads",
+    "migrate_focus_stack_to_threads",
+    "open_commitment",
+    "strip_message_envelope",
+    "thread_temperature",
+    "touch_commitment_thread",
+    "touch_thread",
+]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1165,6 +1165,42 @@ DEFAULT_CONFIG = {
         # matches a key in this dict.
         # Edit directly in config.yaml (no CLI support due to dots in keys).
         "reasoning_overrides": {},
+
+        # Autonomous heartbeat (Consciousness Loop) — off by default.
+        # When enabled, the agent runs a self-scheduling L2 tick loop
+        # between user messages so it can act on due reminders, advance
+        # long-running tasks, or make its own decision about when to
+        # speak up. Heartbeat prompts explicitly tell the model that
+        # ordinary assistant text is *private working text* and that
+        # only send_message-style calls actually reach anyone.
+        #
+        # Adapted from BaiLongma (MIT). See NOTICE.md.
+        "heartbeat": {
+            # Master switch. False = do not construct the loop at all.
+            "enabled": False,
+            # Base tick interval in seconds when idle (no messages, no
+            # custom cadence, no awakening). Bounded [10, 3600].
+            "base_tick_interval_seconds": 60,
+            # Watchdog: if a single run_turn call exceeds this many
+            # seconds, abort the underlying LLM call and re-schedule so
+            # the loop can never permanently stall on a stuck tool.
+            "run_turn_watchdog_seconds": 300,
+            # Fire one immediate L2 tick on startup (used to boot the
+            # startup self-check). Off by default so enabling the
+            # feature never surprises users with an immediate tick.
+            "run_immediate_tick_on_start": False,
+            # Cap on autonomous ticks per calendar day (soft budget).
+            # 0 disables the cap. The runtime honours whatever the loop
+            # returns; this only exists so a runaway configuration can't
+            # burn credits unattended.
+            "max_daily_ticks": 288,
+            # Quiet hours in local time (HH:MM 24h). When set, the loop
+            # keeps scheduling but skips autonomous ticks inside the
+            # window (user messages still preempt normally). Empty
+            # strings disable the window.
+            "quiet_hours_start": "",
+            "quiet_hours_end": "",
+        },
     },
 
     "terminal": {

--- a/tests/agent/test_heartbeat.py
+++ b/tests/agent/test_heartbeat.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the autonomous heartbeat loop.
+
+These exercise :class:`agent.heartbeat.ConsciousnessLoop` through the
+in-memory reference bindings so the loop's public contract is enforced
+without requiring a real ``AIAgent``.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+import pytest
+
+from agent.heartbeat import (
+    ConsciousnessLoop,
+    Priorities,
+    WatchdogTimeoutError,
+)
+from agent.heartbeat_bindings import (
+    InMemoryHeartbeatState,
+    build_in_memory_deps,
+    load_heartbeat_config,
+)
+from agent.heartbeat_policy import (
+    TickerStatus,
+    build_autonomous_tick_directions,
+)
+
+
+# ── Policy prompt ──────────────────────────────────────────────────────────
+
+
+def test_policy_always_includes_core_directives() -> None:
+    """Every autonomous tick must carry the six non-negotiable directives."""
+    text = build_autonomous_tick_directions()
+    assert "autonomous L2 heartbeat" in text
+    assert "private working text" in text
+    assert "send_message" in text
+    assert "runtime guardrails" in text.lower()
+    assert "find_tool" in text
+    # Silence-when-unanswered must be present so a heartbeat never
+    # justifies pinging a user who hasn't replied.
+    assert "unanswered" in text.lower()
+
+
+def test_policy_appends_awakening_and_ticker_only_when_relevant() -> None:
+    """Awakening / ticker blocks are opt-in, not always emitted."""
+    base = build_autonomous_tick_directions()
+    with_awakening = build_autonomous_tick_directions(awakening_ticks=3)
+    with_ticker = build_autonomous_tick_directions(
+        ticker_status=TickerStatus(
+            active=True, seconds=15.0, ttl=4, reason="user asked", revision=1
+        )
+    )
+    assert "awakening period" not in base
+    assert "awakening period" in with_awakening
+    assert "3 heartbeat" in with_awakening
+    assert "Custom heartbeat cadence" not in base
+    assert "Custom heartbeat cadence" in with_ticker
+    assert "15.0s interval" in with_ticker
+    assert "Reason: user asked." in with_ticker
+
+
+def test_policy_ignores_inactive_ticker() -> None:
+    text = build_autonomous_tick_directions(
+        ticker_status=TickerStatus(active=False, seconds=15.0, ttl=0, revision=0)
+    )
+    assert "Custom heartbeat cadence" not in text
+
+
+# ── Config resolution ─────────────────────────────────────────────────────
+
+
+def test_load_heartbeat_config_defaults_when_missing() -> None:
+    """Missing / empty config falls back to safe defaults."""
+    hb = load_heartbeat_config({})
+    assert hb["enabled"] is False
+    assert hb["base_tick_interval_seconds"] == 60.0
+    assert hb["run_turn_watchdog_seconds"] == 300.0
+    assert hb["max_daily_ticks"] == 288
+    assert hb["quiet_hours_start"] == ""
+    assert hb["quiet_hours_end"] == ""
+
+
+def test_load_heartbeat_config_clamps_absurd_values() -> None:
+    """A user who sets base=1s or watchdog=0 shouldn't be able to
+    lock the runtime up; clamping happens in resolution."""
+    hb = load_heartbeat_config(
+        {
+            "agent": {
+                "heartbeat": {
+                    "enabled": True,
+                    "base_tick_interval_seconds": 1,
+                    "run_turn_watchdog_seconds": 0,
+                    "max_daily_ticks": -5,
+                }
+            }
+        }
+    )
+    assert hb["enabled"] is True
+    assert hb["base_tick_interval_seconds"] == 10.0  # floored
+    assert hb["run_turn_watchdog_seconds"] == 5.0  # floored
+    assert hb["max_daily_ticks"] == 0  # floored
+
+
+def test_load_heartbeat_config_caps_base_interval_at_hour() -> None:
+    hb = load_heartbeat_config(
+        {"agent": {"heartbeat": {"base_tick_interval_seconds": 999999}}}
+    )
+    assert hb["base_tick_interval_seconds"] == 3600.0
+
+
+# ── Loop behaviour ─────────────────────────────────────────────────────────
+
+
+def _make_loop_and_state() -> tuple[ConsciousnessLoop, InMemoryHeartbeatState, list]:
+    state = InMemoryHeartbeatState()
+    calls: list[tuple[Any, str, Optional[Any]]] = []
+
+    async def run_turn(inp: Any, label: str, msg: Optional[Any]) -> None:
+        calls.append((inp, label, msg))
+
+    deps = build_in_memory_deps(state, run_turn=run_turn)
+    return ConsciousnessLoop(deps), state, calls
+
+
+@pytest.mark.asyncio
+async def test_on_tick_runs_autonomous_l2_when_idle() -> None:
+    """No messages → the loop fires an L2 TICK and consumes state."""
+    loop, state, calls = _make_loop_and_state()
+    state.awakening_ticks = 2
+    await loop.on_tick()
+    assert len(calls) == 1
+    inp, label, msg = calls[0]
+    assert label == "L2 TICK"
+    assert msg is None
+    assert "autonomous L2 heartbeat" in inp
+    # A completed tick spends one awakening tick.
+    assert state.awakening_ticks == 1
+    # No pending message → loop is idle again after the tick.
+    assert loop.is_processing() is False
+
+
+@pytest.mark.asyncio
+async def test_on_tick_pumps_pending_message_instead_of_ticking() -> None:
+    """When a message is pending, it must be dispatched before any L2 tick."""
+    loop, state, calls = _make_loop_and_state()
+
+    class _Msg:
+        raw = "hello"
+        fromId = "user-1"
+        queueName = "user"
+        priority = 3
+
+    state.messages.append(_Msg())
+    state.awakening_ticks = 1
+
+    await loop.on_tick()
+    assert len(calls) == 1
+    inp, label, msg = calls[0]
+    assert inp == "hello"
+    assert "L1 message from user-1" in label
+    assert msg is not None
+    # Awakening state is preserved because this wasn't an autonomous tick.
+    assert state.awakening_ticks == 1
+
+
+@pytest.mark.asyncio
+async def test_on_tick_reentry_guard() -> None:
+    """A second on_tick while one is running must be a no-op."""
+    loop, state, calls = _make_loop_and_state()
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_turn(inp: Any, label: str, msg: Optional[Any]) -> None:
+        started.set()
+        await release.wait()
+        calls.append((inp, label, msg))
+
+    # Rebind run_turn to a slow variant.
+    deps = build_in_memory_deps(state, run_turn=slow_turn)
+    loop = ConsciousnessLoop(deps)
+
+    first = asyncio.create_task(loop.on_tick())
+    await started.wait()
+    assert loop.is_processing() is True
+
+    # This must return immediately without adding another call.
+    await loop.on_tick()
+    assert len(calls) == 0
+
+    release.set()
+    await first
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_watchdog_aborts_stuck_turn_and_marks_tick_aborted() -> None:
+    """A run_turn that never returns must be aborted by the watchdog."""
+    state = InMemoryHeartbeatState()
+    aborted = asyncio.Event()
+
+    async def stuck_turn(inp: Any, label: str, msg: Optional[Any]) -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            aborted.set()
+            raise
+
+    class _AbortController:
+        def abort(self, reason: str = "") -> None:
+            state.abort_controller = None
+
+    state.processing_execution = {
+        "priority": 1,
+        "started_at": 0.0,
+        "label": "L2 TICK",
+    }
+    state.abort_controller = _AbortController()
+
+    deps = build_in_memory_deps(
+        state, run_turn=stuck_turn, run_turn_watchdog_s=0.05
+    )
+    loop = ConsciousnessLoop(deps)
+
+    with pytest.raises(WatchdogTimeoutError):
+        await loop._run_turn_with_watchdog("prompt", "L2 TICK", None)
+
+    # The watchdog emitted an error event.
+    assert any(name == "error" for name, _ in state.events)
+    # And it cleared the current execution reference.
+    assert state.processing_execution is None
+
+
+def test_should_preempt_when_no_current_execution() -> None:
+    """No running turn → any incoming entry preempts (starts immediately)."""
+    loop, state, _ = _make_loop_and_state()
+    # processing = False, execution = None ⇒ preempt.
+    assert loop._should_preempt_for({"priority": 1}) is True
+
+
+@pytest.mark.asyncio
+async def test_should_preempt_concurrent_user_messages() -> None:
+    """A second user message must preempt an already-running user turn
+    (per BaiLongma's rule: user-vs-user can barge)."""
+    loop, state, _ = _make_loop_and_state()
+
+    # Simulate: one turn currently running at user priority.
+    state.processing_execution = {"priority": Priorities().user}
+    loop._processing = True
+
+    incoming = {"priority": Priorities().user, "queueName": "user"}
+    assert loop._should_preempt_for(incoming) is True
+
+    # A lower-priority background message does NOT preempt.
+    background = {
+        "priority": Priorities().background,
+        "queueName": "background",
+    }
+    assert loop._should_preempt_for(background) is False
+
+
+@pytest.mark.asyncio
+async def test_ticker_reconfigured_mid_tick_is_not_consumed() -> None:
+    """If a tick installs a new custom cadence, the fresh TTL must
+    survive the same tick (mirrors BaiLongma's ``tickerWasReconfigured``
+    guard so the very tick that requested a new cadence doesn't spend
+    one of its own TTL slots)."""
+    state = InMemoryHeartbeatState()
+
+    async def turn_that_installs_cadence(
+        inp: Any, label: str, msg: Optional[Any]
+    ) -> None:
+        # Simulate the model calling set_tick_interval mid-turn.
+        state.ticker = {
+            "active": True,
+            "seconds": 15.0,
+            "ttl": 4,
+            "revision": (state.ticker.get("revision", 0) or 0) + 1,
+        }
+
+    deps = build_in_memory_deps(state, run_turn=turn_that_installs_cadence)
+    loop = ConsciousnessLoop(deps)
+
+    await loop.on_tick()
+    assert state.ticker["ttl"] == 4  # untouched
+    assert state.ticker["active"] is True

--- a/tests/agent/test_memory_consolidator.py
+++ b/tests/agent/test_memory_consolidator.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the memory consolidator + round-robin loop.
+
+The consolidator is dependency-injected end-to-end: the store is a
+simple in-memory dict-backed fake, the LLM adapter is a callable that
+replays a scripted list of tool calls. This lets the tests verify:
+
+* Merge / downgrade / skip tool dispatch (state changes in the fake
+  store, action counter reflects successful ops only).
+* Rate-limit hook fires on 429-shaped exceptions.
+* Errors in one tool call don't abort the batch.
+* Round-robin cursor advances across candidate entities and wraps.
+* Empty candidate list / empty batch short-circuits with no LLM call.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import pytest
+
+from agent.memory_consolidator import (
+    CONSOLIDATOR_SYSTEM_PROMPT,
+    CONSOLIDATOR_TOOL_NAMES,
+    CandidateEntity,
+    ConsolidationLoop,
+    ConsolidationLoopConfig,
+    ConsolidationResult,
+    Memory,
+    format_input,
+    run_consolidator,
+)
+
+
+# ── Fakes ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class FakeStore:
+    """In-memory memory store. Deliberately mutable so tests can
+    assert the exact rows that survive after a consolidation pass.
+    """
+
+    candidates: list[CandidateEntity] = field(default_factory=list)
+    memories_by_entity: dict[str, list[Memory]] = field(default_factory=dict)
+    merges: list[dict] = field(default_factory=list)
+    downgrades: list[dict] = field(default_factory=list)
+    fail_next_merge: bool = False
+
+    def get_candidate_entities(self, limit: int) -> list[CandidateEntity]:
+        return list(self.candidates[:limit])
+
+    def get_memories_by_entity(self, entity: str, limit: int) -> list[Memory]:
+        return list(self.memories_by_entity.get(entity, [])[:limit])
+
+    def merge_memories(
+        self,
+        *,
+        keep_mem_id: str,
+        drop_mem_ids,
+        merged_content: str,
+        merged_salience,
+        reason: str,
+    ) -> bool:
+        if self.fail_next_merge:
+            self.fail_next_merge = False
+            return False
+        self.merges.append(
+            {
+                "keep": keep_mem_id,
+                "drops": list(drop_mem_ids),
+                "content": merged_content,
+                "salience": merged_salience,
+                "reason": reason,
+            }
+        )
+        # Apply the merge to the fake row set (any entity that has
+        # these ids). We soft-delete drops by removing them from the
+        # active list; a real store would set visibility=0.
+        for mems in self.memories_by_entity.values():
+            for drop_id in drop_mem_ids:
+                mems[:] = [m for m in mems if m.mem_id != drop_id]
+        return True
+
+    def downgrade_memory(
+        self, *, mem_id: str, new_salience: int, reason: str
+    ) -> bool:
+        self.downgrades.append(
+            {"mem_id": mem_id, "salience": new_salience, "reason": reason}
+        )
+        for mems in self.memories_by_entity.values():
+            for m in mems:
+                if m.mem_id == mem_id:
+                    m.salience = new_salience
+                    return True
+        return False
+
+
+class ScriptedLLM:
+    """Async LLM adapter that replays a scripted list of tool calls.
+
+    Each script entry is ``(tool_name, args_dict)``. The adapter feeds
+    them to the caller's ``on_tool_call`` handler in order — this is
+    exactly the seam the real LLM adapter drives.
+    """
+
+    def __init__(self, script: list[tuple[str, dict]] | Exception):
+        self._script = script
+        self.calls: list[dict] = []
+
+    async def __call__(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        script = self._script
+        if isinstance(script, Exception):
+            raise script
+        handler = kwargs.get("on_tool_call")
+        assert callable(handler), "on_tool_call handler must be provided"
+        for name, args in script:
+            handler(name, args)
+        return {"content": ""}
+
+
+class _StatusError(Exception):
+    """LLM error carrying an HTTP status attribute (matches real
+    provider SDK behaviour).
+    """
+
+    def __init__(self, status: int, message: str):
+        super().__init__(message)
+        self.status = status
+
+
+# ── format_input + prompt sanity ────────────────────────────────────
+
+
+def test_prompt_lists_tool_names_the_runner_registers() -> None:
+    for name in CONSOLIDATOR_TOOL_NAMES:
+        assert name in CONSOLIDATOR_SYSTEM_PROMPT
+
+
+def test_format_input_shows_entity_and_all_memories() -> None:
+    mems = [
+        Memory(
+            mem_id="m1",
+            event_type="fact",
+            title="喜欢简洁",
+            content="用户偏好简洁回答",
+            salience=4,
+            timestamp="2026-07-01T12:00:00Z",
+        ),
+        Memory(
+            mem_id="m2",
+            event_type="fact",
+            title="偏好直接",
+            content="用户希望回答直接",
+            salience=3,
+            timestamp="2026-07-05T09:00:00Z",
+        ),
+    ]
+    text = format_input("user:qzl", mems)
+    assert "[Entity] user:qzl" in text
+    assert "[Memory count] 2" in text
+    assert "m1" in text and "m2" in text
+    # Timestamp is trimmed to date.
+    assert "2026-07-01\n" in text
+
+
+# ── run_consolidator ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_consolidator_empty_batch_shortcircuits() -> None:
+    store = FakeStore()
+    llm = ScriptedLLM([])
+    result = await run_consolidator(
+        call_llm=llm,
+        store=store,
+        entity="user:qzl",
+        memories=[],
+    )
+    assert result.skipped is True
+    assert result.actions == 0
+    # LLM was never called.
+    assert llm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_consolidator_dispatches_merge_and_downgrade() -> None:
+    store = FakeStore(
+        memories_by_entity={
+            "user:qzl": [
+                Memory("m1", "fact", "喜欢简洁", "简洁", 4, ""),
+                Memory("m2", "fact", "偏好直接", "直接", 3, ""),
+                Memory("m3", "fact", "旧习惯", "已过期", 2, ""),
+            ]
+        }
+    )
+    llm = ScriptedLLM(
+        [
+            (
+                "merge_memories",
+                {
+                    "keep_mem_id": "m1",
+                    "drop_mem_ids": ["m2"],
+                    "merged_content": "用户偏好简洁直接的回答",
+                    "merged_salience": 4,
+                    "reason": "semantic duplicate",
+                },
+            ),
+            (
+                "downgrade_memory",
+                {
+                    "mem_id": "m3",
+                    "new_salience": 1,
+                    "reason": "stale, unreinforced",
+                },
+            ),
+        ]
+    )
+    result = await run_consolidator(
+        call_llm=llm,
+        store=store,
+        entity="user:qzl",
+        memories=store.get_memories_by_entity("user:qzl", 20),
+    )
+    assert result.actions == 2
+    assert result.skipped is False
+    assert result.error is None
+    assert len(store.merges) == 1 and store.merges[0]["keep"] == "m1"
+    assert len(store.downgrades) == 1 and store.downgrades[0]["salience"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_consolidator_records_skip() -> None:
+    store = FakeStore(
+        memories_by_entity={
+            "user:qzl": [Memory("m1", "fact", "t", "c", 3, "")]
+        }
+    )
+    llm = ScriptedLLM(
+        [("skip_consolidation", {"reason": "nothing to do"})]
+    )
+    result = await run_consolidator(
+        call_llm=llm,
+        store=store,
+        entity="user:qzl",
+        memories=store.get_memories_by_entity("user:qzl", 20),
+    )
+    assert result.skipped is True
+    assert result.actions == 0
+
+
+@pytest.mark.asyncio
+async def test_run_consolidator_failed_merge_does_not_count() -> None:
+    store = FakeStore(
+        memories_by_entity={
+            "user:qzl": [
+                Memory("m1", "fact", "t", "c", 3, ""),
+                Memory("m2", "fact", "t", "c", 3, ""),
+            ]
+        },
+        fail_next_merge=True,
+    )
+    llm = ScriptedLLM(
+        [
+            (
+                "merge_memories",
+                {
+                    "keep_mem_id": "m1",
+                    "drop_mem_ids": ["m2"],
+                    "merged_content": "x",
+                    "merged_salience": 3,
+                    "reason": "dup",
+                },
+            ),
+        ]
+    )
+    result = await run_consolidator(
+        call_llm=llm,
+        store=store,
+        entity="user:qzl",
+        memories=store.get_memories_by_entity("user:qzl", 20),
+    )
+    # Store said "no" → action not counted, no exception.
+    assert result.actions == 0
+    assert store.merges == []
+
+
+@pytest.mark.asyncio
+async def test_run_consolidator_invalid_args_are_captured_not_raised() -> None:
+    store = FakeStore(
+        memories_by_entity={
+            "user:qzl": [Memory("m1", "fact", "t", "c", 3, "")]
+        }
+    )
+    # Missing drop_mem_ids for merge; missing new_salience for downgrade.
+    llm = ScriptedLLM(
+        [
+            ("merge_memories", {"keep_mem_id": "m1", "drop_mem_ids": []}),
+            ("downgrade_memory", {"mem_id": "m1"}),
+            ("nonsense_tool", {"foo": "bar"}),
+        ]
+    )
+    result = await run_consolidator(
+        call_llm=llm,
+        store=store,
+        entity="user:qzl",
+        memories=store.get_memories_by_entity("user:qzl", 20),
+    )
+    # None of the malformed calls should have incremented actions.
+    assert result.actions == 0
+    # But they should all show up in the tool call log for auditing.
+    assert len(result.tool_calls) == 3
+    for entry in result.tool_calls:
+        assert entry["result"]["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_consolidator_captures_llm_error() -> None:
+    store = FakeStore(memories_by_entity={"user:qzl": [Memory("m1", "fact", "t", "c", 3, "")]})
+    llm = ScriptedLLM(RuntimeError("boom"))
+    hits: list[int] = []
+    result = await run_consolidator(
+        call_llm=llm,
+        store=store,
+        entity="user:qzl",
+        memories=store.get_memories_by_entity("user:qzl", 20),
+        on_rate_limited=lambda: hits.append(1),
+    )
+    assert result.error and "boom" in result.error
+    assert result.actions == 0
+    # Non-429 error should NOT fire the rate-limit hook.
+    assert hits == []
+
+
+@pytest.mark.asyncio
+async def test_run_consolidator_fires_rate_limit_hook_on_429_status() -> None:
+    store = FakeStore(memories_by_entity={"user:qzl": [Memory("m1", "fact", "t", "c", 3, "")]})
+    llm = ScriptedLLM(_StatusError(429, "too many"))
+    hits: list[int] = []
+    await run_consolidator(
+        call_llm=llm,
+        store=store,
+        entity="user:qzl",
+        memories=store.get_memories_by_entity("user:qzl", 20),
+        on_rate_limited=lambda: hits.append(1),
+    )
+    assert hits == [1]
+
+
+@pytest.mark.asyncio
+async def test_run_consolidator_fires_rate_limit_hook_on_429_message() -> None:
+    store = FakeStore(memories_by_entity={"user:qzl": [Memory("m1", "fact", "t", "c", 3, "")]})
+    llm = ScriptedLLM(RuntimeError("HTTP 429 rate limit"))
+    hits: list[int] = []
+    await run_consolidator(
+        call_llm=llm,
+        store=store,
+        entity="user:qzl",
+        memories=store.get_memories_by_entity("user:qzl", 20),
+        on_rate_limited=lambda: hits.append(1),
+    )
+    assert hits == [1]
+
+
+# ── ConsolidationLoop ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_loop_run_once_advances_cursor_round_robin() -> None:
+    store = FakeStore(
+        candidates=[
+            CandidateEntity(entity="user:a", memory_count=5),
+            CandidateEntity(entity="user:b", memory_count=5),
+        ],
+        memories_by_entity={
+            "user:a": [Memory("a1", "fact", "t", "c", 3, "")],
+            "user:b": [Memory("b1", "fact", "t", "c", 3, "")],
+        },
+    )
+    seen: list[str] = []
+
+    async def call_llm(**kwargs):
+        # Peek at the batch by reading the message payload.
+        seen.append(kwargs["message"].splitlines()[0])
+        handler = kwargs["on_tool_call"]
+        handler("skip_consolidation", {"reason": "test"})
+        return {"content": ""}
+
+    loop = ConsolidationLoop(
+        call_llm=call_llm,
+        store=store,
+        config=ConsolidationLoopConfig(
+            run_interval_seconds=0,
+            startup_delay_seconds=0,
+            batch_size=20,
+            candidate_limit=10,
+        ),
+    )
+    await loop.run_once()
+    await loop.run_once()
+    await loop.run_once()  # wraps back
+    # We processed a, b, a in that order.
+    assert [line for line in seen] == [
+        "[Entity] user:a",
+        "[Entity] user:b",
+        "[Entity] user:a",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_loop_run_once_skips_when_no_candidates() -> None:
+    store = FakeStore(candidates=[])
+    called: list[int] = []
+
+    async def call_llm(**kwargs):  # noqa: ARG001
+        called.append(1)
+        return {"content": ""}
+
+    loop = ConsolidationLoop(
+        call_llm=call_llm,
+        store=store,
+        config=ConsolidationLoopConfig(
+            run_interval_seconds=0,
+            startup_delay_seconds=0,
+        ),
+    )
+    result = await loop.run_once()
+    assert result is None
+    assert called == []  # never invoked
+
+
+@pytest.mark.asyncio
+async def test_loop_run_once_skips_when_entity_has_no_memories() -> None:
+    store = FakeStore(
+        candidates=[CandidateEntity(entity="user:empty")],
+        memories_by_entity={},
+    )
+    called: list[int] = []
+
+    async def call_llm(**kwargs):  # noqa: ARG001
+        called.append(1)
+        return {"content": ""}
+
+    loop = ConsolidationLoop(
+        call_llm=call_llm,
+        store=store,
+        config=ConsolidationLoopConfig(
+            run_interval_seconds=0,
+            startup_delay_seconds=0,
+        ),
+    )
+    result = await loop.run_once()
+    assert result is None
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_loop_start_stop_cleanly() -> None:
+    """The background loop task must start and stop without leaks or
+    orphan warnings when startup_delay is short.
+    """
+    store = FakeStore(candidates=[])
+
+    async def call_llm(**kwargs):  # noqa: ARG001
+        return {"content": ""}
+
+    loop = ConsolidationLoop(
+        call_llm=call_llm,
+        store=store,
+        config=ConsolidationLoopConfig(
+            run_interval_seconds=0.05,
+            startup_delay_seconds=0.01,
+        ),
+    )
+    loop.start()
+    # Let it fire a couple of no-candidate ticks.
+    await asyncio.sleep(0.1)
+    await loop.stop()
+    # After stop, calling stop again is a no-op.
+    await loop.stop()

--- a/tests/agent/test_self_evolution.py
+++ b/tests/agent/test_self_evolution.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the self-evolution ledger.
+
+Focus on the actual invariants:
+
+* Actionable filtering via tags / event_type / mem_id regex.
+* Round-trip through the config store preserves state shape.
+* Recent set is bounded (MAX_RECENT), duplicates collapse, newest-
+  first ordering survives updates.
+* Prompt formatter obeys the age cutoff and MAX_RECENT bounds AND
+  returns empty when the ledger is disabled or empty (the caller
+  relies on that to skip injection entirely).
+* Disabled ledger is a strict no-op for ingestion.
+* Bad memory lookup does not block ingestion (best-effort enrichment).
+"""
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from agent.self_evolution import (
+    MAX_RECENT,
+    PROMPT_MAX_AGE_MS,
+    STATE_KEY,
+    SelfEvolutionState,
+    format_self_evolution_for_prompt,
+    get_self_evolution_snapshot,
+    get_self_evolution_state,
+    is_self_evolution_memory,
+    record_self_evolution_from_memories,
+    reset_self_evolution_state,
+)
+
+
+# ── Fake stores ─────────────────────────────────────────────────────
+
+
+class DictConfigStore:
+    def __init__(self, initial: dict[str, Any] | None = None):
+        self._data: dict[str, Any] = dict(initial or {})
+
+    def get_config(self, key: str) -> Any:
+        return self._data.get(key)
+
+    def set_config(self, key: str, value: str) -> None:
+        self._data[key] = value
+
+    def raw(self) -> dict[str, Any]:
+        return dict(self._data)
+
+
+class MemoryLookupMap:
+    def __init__(self, mapping: dict[str, dict[str, Any]] | None = None):
+        self._map = dict(mapping or {})
+        self.calls: list[str] = []
+
+    def get_memory_by_mem_id(self, mem_id: str):
+        self.calls.append(mem_id)
+        return self._map.get(mem_id)
+
+
+class FailingLookup:
+    def get_memory_by_mem_id(self, mem_id: str):  # noqa: ARG002
+        raise RuntimeError("db down")
+
+
+# ── is_self_evolution_memory ────────────────────────────────────────
+
+
+def test_is_self_evolution_memory_by_tag() -> None:
+    assert is_self_evolution_memory({"mem_id": "x", "tags": ["kind:procedure"]})
+    assert is_self_evolution_memory(
+        {"mem_id": "x", "tags": json.dumps(["kind:policy"])}
+    )
+
+
+def test_is_self_evolution_memory_by_event_type() -> None:
+    assert is_self_evolution_memory(
+        {"mem_id": "x", "event_type": "self_constraint"}
+    )
+    assert is_self_evolution_memory({"mem_id": "x", "type": "self_constraint"})
+
+
+def test_is_self_evolution_memory_by_mem_id_prefix() -> None:
+    for prefix in ("procedure_", "constraint_", "policy_", "lesson_", "rule_"):
+        assert is_self_evolution_memory({"mem_id": prefix + "abc"})
+
+
+def test_is_self_evolution_memory_rejects_plain_fact() -> None:
+    assert not is_self_evolution_memory(
+        {"mem_id": "fact_1", "tags": ["kind:other"], "event_type": "fact"}
+    )
+
+
+def test_is_self_evolution_memory_rejects_non_mapping() -> None:
+    assert not is_self_evolution_memory(None)  # type: ignore[arg-type]
+    assert not is_self_evolution_memory("string")  # type: ignore[arg-type]
+
+
+# ── State round-trip ────────────────────────────────────────────────
+
+
+def test_get_state_starts_at_defaults() -> None:
+    store = DictConfigStore()
+    state = get_self_evolution_state(store)
+    assert isinstance(state, SelfEvolutionState)
+    assert state.enabled is True
+    assert state.total_events == 0
+    assert state.recent == []
+
+
+def test_get_state_recovers_from_corrupt_config() -> None:
+    store = DictConfigStore({STATE_KEY: "not-json"})
+    state = get_self_evolution_state(store)
+    assert state.enabled is True
+    assert state.recent == []
+
+
+def test_get_state_respects_disabled_flag_across_roundtrip() -> None:
+    payload = {"enabled": False, "total_events": 5, "recent": []}
+    store = DictConfigStore({STATE_KEY: json.dumps(payload)})
+    state = get_self_evolution_state(store)
+    assert state.enabled is False
+    assert state.total_events == 5
+
+
+def test_reset_wipes_state() -> None:
+    store = DictConfigStore(
+        {
+            STATE_KEY: json.dumps(
+                {"enabled": True, "total_events": 99, "recent": [{"mem_id": "x"}]}
+            )
+        }
+    )
+    reset = reset_self_evolution_state(store)
+    assert reset.total_events == 0
+    assert reset.recent == []
+
+
+# ── Ingestion ───────────────────────────────────────────────────────
+
+
+def test_record_ingests_actionable_and_skips_plain_facts() -> None:
+    store = DictConfigStore()
+    learned = record_self_evolution_from_memories(
+        store,
+        [
+            {"mem_id": "procedure_deploy", "tags": ["kind:procedure"], "title": "deploy"},
+            {"mem_id": "fact_1", "event_type": "fact", "title": "not tracked"},
+            {"mem_id": "policy_ratelimit", "tags": ["kind:policy"]},
+        ],
+    )
+    ids = [e["mem_id"] for e in learned]
+    assert ids == ["procedure_deploy", "policy_ratelimit"]
+    state = get_self_evolution_state(store)
+    assert state.total_events == 2
+    assert state.learned_count == 2
+
+
+def test_record_deduplicates_by_mem_id_within_batch() -> None:
+    store = DictConfigStore()
+    learned = record_self_evolution_from_memories(
+        store,
+        [
+            {"mem_id": "policy_x", "tags": ["kind:policy"]},
+            {"mem_id": "policy_x", "tags": ["kind:policy"]},
+            {"mem_id": "policy_y", "tags": ["kind:policy"]},
+        ],
+    )
+    assert [e["mem_id"] for e in learned] == ["policy_x", "policy_y"]
+
+
+def test_record_returns_empty_when_disabled() -> None:
+    store = DictConfigStore(
+        {STATE_KEY: json.dumps({"enabled": False, "recent": []})}
+    )
+    learned = record_self_evolution_from_memories(
+        store, [{"mem_id": "policy_x", "tags": ["kind:policy"]}]
+    )
+    assert learned == []
+    # Also does NOT flip the ledger back on as a side effect.
+    state = get_self_evolution_state(store)
+    assert state.enabled is False
+
+
+def test_record_returns_empty_for_empty_batch() -> None:
+    store = DictConfigStore()
+    assert record_self_evolution_from_memories(store, []) == []
+
+
+def test_record_bounds_recent_list_to_max() -> None:
+    store = DictConfigStore()
+    batch = [
+        {"mem_id": f"policy_{i}", "tags": ["kind:policy"], "title": str(i)}
+        for i in range(MAX_RECENT + 5)
+    ]
+    record_self_evolution_from_memories(store, batch)
+    state = get_self_evolution_state(store)
+    assert len(state.recent) == MAX_RECENT
+
+
+def test_record_survives_broken_memory_lookup() -> None:
+    """Best-effort enrichment: if the DB lookup blows up, ingestion
+    still uses the caller-provided row and moves on.
+    """
+    store = DictConfigStore()
+    learned = record_self_evolution_from_memories(
+        store,
+        [{"mem_id": "policy_x", "tags": ["kind:policy"], "title": "raw"}],
+        memory_lookup=FailingLookup(),
+    )
+    assert len(learned) == 1
+    assert learned[0]["title"] == "raw"
+
+
+def test_record_uses_lookup_to_enrich_thin_reference() -> None:
+    """If caller only provides an id-shaped reference, the lookup
+    should be consulted for the full row.
+    """
+    lookup = MemoryLookupMap(
+        {
+            "procedure_ship": {
+                "mem_id": "procedure_ship",
+                "tags": ["kind:procedure"],
+                "title": "Ship steps",
+                "content": "1. build 2. test 3. push",
+            }
+        }
+    )
+    store = DictConfigStore()
+    learned = record_self_evolution_from_memories(
+        store,
+        [{"mem_id": "procedure_ship"}],
+        memory_lookup=lookup,
+    )
+    assert lookup.calls == ["procedure_ship"]
+    assert len(learned) == 1
+    assert "build" in learned[0]["content"]
+
+
+def test_record_emit_event_receives_summary_and_entries() -> None:
+    hits: list[tuple[str, dict]] = []
+    store = DictConfigStore()
+    record_self_evolution_from_memories(
+        store,
+        [{"mem_id": "policy_x", "tags": ["kind:policy"], "title": "t"}],
+        emit_event=lambda name, payload: hits.append((name, payload)),
+    )
+    assert len(hits) == 1
+    name, payload = hits[0]
+    assert name == "self_evolution"
+    assert payload["count"] == 1
+    assert payload["entries"][0]["mem_id"] == "policy_x"
+    assert payload["summary"]["total_events"] == 1
+
+
+def test_record_emit_event_hook_error_does_not_lose_ledger_update() -> None:
+    def failing(name, payload):  # noqa: ARG001
+        raise RuntimeError("broken hook")
+
+    store = DictConfigStore()
+    learned = record_self_evolution_from_memories(
+        store,
+        [{"mem_id": "policy_x", "tags": ["kind:policy"]}],
+        emit_event=failing,
+    )
+    assert len(learned) == 1
+    # State was still updated.
+    assert get_self_evolution_state(store).total_events == 1
+
+
+def test_record_second_batch_promotes_new_entries_ahead_of_old() -> None:
+    store = DictConfigStore()
+    record_self_evolution_from_memories(
+        store, [{"mem_id": "policy_old", "tags": ["kind:policy"]}]
+    )
+    time.sleep(0.005)
+    record_self_evolution_from_memories(
+        store, [{"mem_id": "policy_new", "tags": ["kind:policy"]}]
+    )
+    state = get_self_evolution_state(store)
+    # newest-first ordering.
+    assert state.recent[0]["mem_id"] == "policy_new"
+    assert state.recent[1]["mem_id"] == "policy_old"
+    assert state.total_events == 2
+
+
+# ── Snapshot ────────────────────────────────────────────────────────
+
+
+def test_snapshot_respects_max_recent_argument() -> None:
+    store = DictConfigStore()
+    for i in range(10):
+        record_self_evolution_from_memories(
+            store, [{"mem_id": f"policy_{i}", "tags": ["kind:policy"]}]
+        )
+    snap = get_self_evolution_snapshot(store, max_recent=3)
+    assert len(snap["recent"]) == 3
+    assert snap["total_events"] == 10
+
+
+def test_snapshot_recent_upper_bound_is_max_recent() -> None:
+    store = DictConfigStore()
+    for i in range(MAX_RECENT + 5):
+        record_self_evolution_from_memories(
+            store, [{"mem_id": f"policy_{i}", "tags": ["kind:policy"]}]
+        )
+    snap = get_self_evolution_snapshot(store, max_recent=999)
+    assert len(snap["recent"]) == MAX_RECENT
+
+
+# ── Prompt formatter (with caching warning enforced by empty-when-disabled) ─
+
+
+def test_format_returns_empty_when_ledger_is_disabled() -> None:
+    """This is load-bearing: callers rely on empty-string to mean
+    "skip injection entirely". If the formatter ever silently emits
+    a placeholder for a disabled ledger, we lose the cache-safety
+    escape hatch.
+    """
+    store = DictConfigStore(
+        {STATE_KEY: json.dumps({"enabled": False, "recent": []})}
+    )
+    assert format_self_evolution_for_prompt(store) == ""
+
+
+def test_format_returns_empty_when_recent_is_empty() -> None:
+    store = DictConfigStore()
+    assert format_self_evolution_for_prompt(store) == ""
+
+
+def test_format_contains_kind_and_mem_id_lines() -> None:
+    store = DictConfigStore()
+    record_self_evolution_from_memories(
+        store,
+        [
+            {
+                "mem_id": "policy_x",
+                "tags": ["kind:policy"],
+                "title": "Rate limit rule",
+                "content": "cap 3 rpm",
+            }
+        ],
+    )
+    text = format_self_evolution_for_prompt(store)
+    assert "- [policy] policy_x:" in text
+    assert "Rate limit rule" in text
+    assert "cap 3 rpm" in text
+    # Provenance line is always present so the model doesn't confuse
+    # the ledger with active per-turn instructions.
+    assert "Turn-specific guidance still comes from <active-policies>" in text
+
+
+def test_format_filters_out_entries_older_than_max_age() -> None:
+    """Entries older than max_age_ms are dropped. Simulate by feeding
+    an explicit now_ms far in the future.
+    """
+    store = DictConfigStore()
+    record_self_evolution_from_memories(
+        store, [{"mem_id": "policy_x", "tags": ["kind:policy"]}]
+    )
+    # 30 days in the future — entry is older than 7-day cutoff.
+    future_ms = (time.time() + 30 * 86400) * 1000
+    assert format_self_evolution_for_prompt(store, now_ms=future_ms) == ""
+
+
+def test_format_clamps_max_recent_to_range() -> None:
+    """max_recent is clamped to [1, 8]. Confirm the ceiling."""
+    store = DictConfigStore()
+    for i in range(12):
+        record_self_evolution_from_memories(
+            store, [{"mem_id": f"policy_{i}", "tags": ["kind:policy"]}]
+        )
+    text = format_self_evolution_for_prompt(store, max_recent=999)
+    # 8 bullet lines expected.
+    bullet_lines = [ln for ln in text.splitlines() if ln.startswith("- [")]
+    assert len(bullet_lines) == 8
+
+
+def test_format_handles_none_learned_at_gracefully() -> None:
+    """A recent entry with missing/broken learned_at should not crash
+    the age filter — it counts as "in range".
+    """
+    state_payload = {
+        "enabled": True,
+        "version": 1,
+        "total_events": 1,
+        "learned_count": 1,
+        "last_at": None,
+        "recent": [
+            {
+                "mem_id": "policy_broken",
+                "kind": "policy",
+                "action": "observed",
+                "title": "no time",
+                "content": "",
+                "salience": 3,
+                "tags": ["kind:policy"],
+                "learned_at": None,
+            }
+        ],
+    }
+    store = DictConfigStore({STATE_KEY: json.dumps(state_payload)})
+    text = format_self_evolution_for_prompt(store)
+    assert "policy_broken" in text

--- a/tests/agent/test_threads.py
+++ b/tests/agent/test_threads.py
@@ -1,0 +1,504 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the thread model — attribution, temperature, merge, eviction.
+
+Exercises the read-time-temperature + actor-writes-focus invariants
+that separate the thread model from its focus-stack predecessor:
+
+* Foreground never gets revived by a keyword-sparse follow-up if it's
+  already cold by age.
+* Anaphora + generic-object messages never spawn a pseudo-thread.
+* Open commitments pin thread temperature regardless of age.
+* Cold, uncommitted background threads evict when over capacity;
+  foreground never does.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+from agent import threads
+from agent.keywords import extract_keywords, extract_keywords_debug
+from agent.threads import (
+    AttributionResult,
+    Commitment,
+    Thread,
+    attribute_user_message,
+    build_thread_view,
+    classify_reference,
+    close_commitment,
+    describe_thread,
+    ensure_thread_state,
+    evict_cold_threads,
+    get_foreground_thread,
+    is_indexical_progress_query,
+    is_likely_one_off_leaf,
+    make_thread,
+    merge_threads,
+    migrate_focus_stack_to_threads,
+    open_commitment,
+    strip_message_envelope,
+    thread_temperature,
+    touch_commitment_thread,
+    touch_thread,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _fresh_state() -> dict[str, Any]:
+    return {}
+
+
+def _install_thread(
+    state: dict, *, topic: list[str], hours_ago: float = 0.0
+) -> Thread:
+    """Insert a thread whose ``last_event_at`` is ``hours_ago`` in the past.
+
+    Uses the module's own timestamp shape (ISO w/ ``Z`` suffix); the
+    read-time temperature function parses back through ``_parse_iso``.
+    """
+    ts = ensure_thread_state(state)
+    thread = make_thread(topic, tick=0, signature=topic)
+    if hours_ago > 0:
+        past_ms = time.time() * 1000 - hours_ago * 3600 * 1000
+        # ISO Z-form to match the module's default output.
+        from datetime import datetime, timezone
+
+        stamp = (
+            datetime.fromtimestamp(past_ms / 1000.0, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+        thread.last_event_at = stamp
+        thread.created_at = stamp
+    ts["threads"].append(thread)
+    return thread
+
+
+# ── keywords.py smoke ───────────────────────────────────────────────
+
+
+def test_keywords_extracts_chinese_and_english() -> None:
+    kws = extract_keywords("帮我修复 heartbeat 的 tick 循环 bug", 6)
+    assert "heartbeat" in kws
+    assert any(k in {"修复", "循环"} for k in kws)
+
+
+def test_keywords_debug_reveals_filter_stage() -> None:
+    dbg = extract_keywords_debug("这个东西怎么样", 4)
+    # Filter stage drops noise-only ngrams; final list can be empty.
+    assert isinstance(dbg["raw"], list) and dbg["raw"]
+    assert isinstance(dbg["filtered"], list)
+    assert isinstance(dbg["final"], list)
+
+
+def test_keywords_ignores_relative_time_words() -> None:
+    # "昨天" is a temporal-parser concern, not a topic keyword.
+    kws = extract_keywords("昨天 今天 明天", 6)
+    assert "昨天" not in kws
+    assert "今天" not in kws
+
+
+# ── Envelope + one-off / indexical detectors ────────────────────────
+
+
+def test_strip_envelope_removes_channel_prefix() -> None:
+    body = strip_message_envelope(
+        "[ID:abc] 2026-07-17T10:00:00Z [telegram] 帮我看看那个 PR"
+    )
+    assert body == "帮我看看那个 PR"
+
+
+def test_strip_envelope_drops_tick_messages() -> None:
+    assert strip_message_envelope("TICK 12345") == ""
+
+
+def test_is_likely_one_off_leaf_short_weather_query() -> None:
+    assert is_likely_one_off_leaf("今天天气怎么样") is True
+    assert is_likely_one_off_leaf("请你分析这个火山 API 的响应") is False
+
+
+def test_is_indexical_progress_query_only_for_short_form() -> None:
+    assert is_indexical_progress_query("那个搞定了吗") is True
+    assert (
+        is_indexical_progress_query(
+            "这个进展要详细的报告请给我完整的分析和结论以及可能的问题"
+        )
+        is False
+    )
+
+
+# ── Reference classifier ────────────────────────────────────────────
+
+
+def test_classify_reference_anaphora_recent() -> None:
+    r = classify_reference("打开那个网页")
+    assert r.kind == "anaphora-recent"
+
+
+def test_classify_reference_precise_callback() -> None:
+    r = classify_reference("那个开源天梯榜怎么排的")
+    assert r.kind == "precise-callback"
+    assert r.referent_kws  # non-empty referent
+
+
+def test_classify_reference_none_for_substantive_topic() -> None:
+    r = classify_reference("我们把心跳循环的重入锁改成 asyncio.Lock")
+    assert r.kind == "none"
+
+
+# ── Attribution ─────────────────────────────────────────────────────
+
+
+def test_attribution_creates_thread_from_substantive_message() -> None:
+    state = _fresh_state()
+    res = attribute_user_message(state, "帮我实现心跳循环的重入锁")
+    assert res.event == "created"
+    assert res.thread is not None
+    # Foreground is now the new thread.
+    assert get_foreground_thread(state) is res.thread
+
+
+def test_attribution_continues_foreground_on_keyword_overlap() -> None:
+    state = _fresh_state()
+    r1 = attribute_user_message(state, "帮我实现心跳循环的重入锁")
+    r2 = attribute_user_message(state, "心跳循环的锁改用 asyncio.Lock")
+    assert r2.event == "continued"
+    assert r2.thread is r1.thread
+
+
+def test_attribution_noop_for_one_off_leaf() -> None:
+    state = _fresh_state()
+    r = attribute_user_message(state, "今天天气怎么样")
+    assert r.event == "noop"
+
+
+def test_attribution_anaphora_recent_never_creates_new_thread() -> None:
+    """规律①: 'open that page' must not spawn a pseudo browser-thread."""
+    state = _fresh_state()
+    attribute_user_message(state, "帮我把开源天梯榜的实现细节讲清楚")
+    r = attribute_user_message(state, "打开那个网页看看")
+    # Should continue foreground (the leaderboard thread), NOT create a
+    # new browser/webpage thread.
+    assert r.event == "continued"
+    assert r.via == "anaphora-recent"
+
+
+def test_attribution_ignores_cold_foreground_for_sparse_short_message() -> None:
+    state = _fresh_state()
+    # Foreground that hasn't been touched in 72h → cold.
+    _install_thread(state, topic=["旧话题", "冷线索"], hours_ago=72.0)
+    ts = ensure_thread_state(state)
+    ts["foreground_id"] = ts["threads"][0].id
+    r = attribute_user_message(state, "好啊")  # sparse, only 2 chars
+    # Sparse short msg + cold foreground → noop, not revival.
+    assert r.event == "noop"
+
+
+def test_attribution_resumes_background_on_strong_overlap() -> None:
+    state = _fresh_state()
+    r1 = attribute_user_message(state, "帮我看看心跳循环的重入锁")
+    r2 = attribute_user_message(state, "另外的开源天梯榜排名怎么算")
+    assert r2.event == "created"  # topic shift
+    # Now come back to heartbeat with two clear keywords.
+    r3 = attribute_user_message(state, "回到心跳循环重入锁那件事")
+    assert r3.event == "resumed"
+    assert r3.thread is r1.thread
+
+
+def test_attribution_indexical_progress_routes_to_open_commitment() -> None:
+    state = _fresh_state()
+    r1 = attribute_user_message(state, "帮我实现心跳循环的重入锁")
+    assert r1.thread is not None
+    open_commitment(state, text="做心跳循环重入锁的事", thread_id=r1.thread.id)
+    # New topic starts…
+    attribute_user_message(state, "另外查一下开源天梯榜的分数是怎么算的")
+    # …and a bare "how's it going" should point back to the commitment.
+    r3 = attribute_user_message(state, "那个搞定了吗")
+    assert r3.event == "resumed"
+    assert r3.via == "commitment"
+    assert r3.thread is r1.thread
+
+
+# ── Temperature ─────────────────────────────────────────────────────
+
+
+def test_temperature_foreground_beats_age() -> None:
+    state = _fresh_state()
+    t = _install_thread(state, topic=["a", "b"], hours_ago=200.0)
+    ensure_thread_state(state)["foreground_id"] = t.id
+    assert thread_temperature(state, t) == "foreground"
+
+
+def test_temperature_warm_within_window() -> None:
+    state = _fresh_state()
+    t = _install_thread(state, topic=["a", "b"], hours_ago=3.0)
+    assert thread_temperature(state, t) == "warm"
+
+
+def test_temperature_cool_within_48h() -> None:
+    state = _fresh_state()
+    t = _install_thread(state, topic=["a", "b"], hours_ago=12.0)
+    assert thread_temperature(state, t) == "cool"
+
+
+def test_temperature_cold_after_48h() -> None:
+    state = _fresh_state()
+    t = _install_thread(state, topic=["a", "b"], hours_ago=72.0)
+    assert thread_temperature(state, t) == "cold"
+
+
+def test_temperature_open_commitment_pins_warm_forever() -> None:
+    state = _fresh_state()
+    t = _install_thread(state, topic=["长期任务"], hours_ago=200.0)
+    ensure_thread_state(state)["foreground_id"] = t.id
+    open_commitment(state, text="长期任务", thread_id=t.id)
+    ensure_thread_state(state)["foreground_id"] = None  # drop foreground
+    assert thread_temperature(state, t) == "warm"
+
+
+# ── Commitments ─────────────────────────────────────────────────────
+
+
+def test_open_commitment_creates_thread_when_no_foreground() -> None:
+    state = _fresh_state()
+    c = open_commitment(state, text="做心跳循环那个 PR")
+    assert isinstance(c, Commitment)
+    # A thread got created and placed as foreground.
+    fg = get_foreground_thread(state)
+    assert fg is not None
+    assert c.thread_id == fg.id
+
+
+def test_open_commitment_singleton_per_thread() -> None:
+    state = _fresh_state()
+    c1 = open_commitment(state, text="做 PR")
+    c2 = open_commitment(state, text="补测试到 PR", thread_id=c1.thread_id)
+    # Same commitment id, text updated in place.
+    assert c1.id == c2.id
+    assert "补测试" in c2.text
+
+
+def test_close_commitment_marks_done_and_stops_pinning_temperature() -> None:
+    state = _fresh_state()
+    t = _install_thread(state, topic=["长期任务"], hours_ago=200.0)
+    ensure_thread_state(state)["foreground_id"] = t.id
+    open_commitment(state, text="长期任务", thread_id=t.id)
+    # open_commitment touches the thread; roll last_event_at back so
+    # the age-based check has something to bite on after closing.
+    _install_thread  # keep for readability
+    from datetime import datetime, timezone
+
+    past_ms = time.time() * 1000 - 200 * 3600 * 1000
+    t.last_event_at = (
+        datetime.fromtimestamp(past_ms / 1000.0, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    ensure_thread_state(state)["foreground_id"] = None
+    assert thread_temperature(state, t) == "warm"  # commitment pins it
+    close_commitment(state, thread_id=t.id, status="done")
+    # No longer pinned — falls back to age-based cold.
+    assert thread_temperature(state, t) == "cold"
+
+
+def test_touch_commitment_thread_falls_back_to_foreground() -> None:
+    state = _fresh_state()
+    t = _install_thread(state, topic=["a", "b"], hours_ago=0.0)
+    ensure_thread_state(state)["foreground_id"] = t.id
+    old_ts = t.last_event_at
+    time.sleep(0.005)  # ensure timestamp advances
+    touch_commitment_thread(state, tick=42)
+    assert t.last_event_at != old_ts
+    assert t.last_event_tick == 42
+
+
+def test_touch_thread_bumps_hit_count() -> None:
+    state = _fresh_state()
+    t = _install_thread(state, topic=["a"], hours_ago=0.0)
+    initial = t.hit_count
+    touch_thread(state, t.id, tick=5)
+    assert t.hit_count == initial + 1
+
+
+# ── Merge + eviction ────────────────────────────────────────────────
+
+
+def test_merge_threads_folds_source_into_target() -> None:
+    state = _fresh_state()
+    a = _install_thread(state, topic=["a", "b"], hours_ago=0.0)
+    b = _install_thread(state, topic=["a", "c"], hours_ago=0.0)
+    a.conclusions = ["搞定 A 的第一部分"]
+    b.conclusions = ["搞定 B 的第一部分"]
+    ensure_thread_state(state)["foreground_id"] = b.id
+
+    merged = merge_threads(state, source_id=a.id, target_id=b.id)
+    assert merged is b
+    assert set(b.topic) >= {"a"}
+    assert "搞定 A 的第一部分" in b.conclusions
+    assert "搞定 B 的第一部分" in b.conclusions
+    # Foreground survives.
+    assert ensure_thread_state(state)["foreground_id"] == b.id
+    # Source gone.
+    assert a not in ensure_thread_state(state)["threads"]
+
+
+def test_merge_repoints_commitments_when_foreground_was_source() -> None:
+    state = _fresh_state()
+    a = _install_thread(state, topic=["a"], hours_ago=0.0)
+    b = _install_thread(state, topic=["b"], hours_ago=0.0)
+    ensure_thread_state(state)["foreground_id"] = a.id
+    c = open_commitment(state, text="task on A", thread_id=a.id)
+
+    merge_threads(state, source_id=a.id, target_id=b.id)
+    # Commitment now points to b.
+    assert c.thread_id == b.id
+    # Foreground pointer moved to b.
+    assert ensure_thread_state(state)["foreground_id"] == b.id
+
+
+def test_evict_cold_threads_only_removes_cold_uncommitted() -> None:
+    state = _fresh_state()
+    # Over capacity with a mix of temperatures.
+    ts = ensure_thread_state(state)
+    warm = _install_thread(state, topic=["warm"], hours_ago=1.0)
+    cold_but_committed = _install_thread(
+        state, topic=["committed-old"], hours_ago=200.0
+    )
+    open_commitment(
+        state, text="do committed-old", thread_id=cold_but_committed.id
+    )
+    cold_evictable = [
+        _install_thread(state, topic=[f"old-{i}"], hours_ago=200.0)
+        for i in range(threads.MAX_THREADS_IN_MEMORY)
+    ]
+    ts["foreground_id"] = warm.id
+
+    evicted = evict_cold_threads(state)
+    # Some cold, uncommitted threads got dropped.
+    assert evicted, "expected at least one eviction over the cap"
+    evicted_ids = {t.id for t in evicted}
+    assert warm.id not in evicted_ids
+    assert cold_but_committed.id not in evicted_ids
+    # All evicted came from the plain-cold pool.
+    plain_cold_ids = {t.id for t in cold_evictable}
+    assert evicted_ids.issubset(plain_cold_ids)
+
+
+# ── Injection view + describe ───────────────────────────────────────
+
+
+def test_build_thread_view_caps_warm_background_at_configured_limit() -> None:
+    state = _fresh_state()
+    fg = _install_thread(state, topic=["fg"], hours_ago=0.0)
+    ensure_thread_state(state)["foreground_id"] = fg.id
+    for i in range(threads.MAX_WARM_INJECTED + 3):
+        _install_thread(state, topic=[f"warm-{i}"], hours_ago=0.5)
+    view = build_thread_view(state)
+    assert view["foreground"] is fg
+    assert len(view["background"]) == threads.MAX_WARM_INJECTED
+
+
+def test_describe_thread_prefers_last_conclusion() -> None:
+    t = make_thread(["a", "b"], label="心跳")
+    assert describe_thread(t) == "心跳"
+    t.conclusions = ["搞定 A"]
+    assert describe_thread(t) == "心跳 — 搞定 A"
+
+
+# ── Migration ───────────────────────────────────────────────────────
+
+
+def test_migrate_focus_stack_produces_ordered_threads() -> None:
+    result = migrate_focus_stack_to_threads(
+        [
+            {"topic": ["旧一"], "conclusions": ["a"], "hit_count": 5},
+            {"topic": ["旧二"], "startedAt": "2026-06-01T00:00:00Z"},
+        ],
+        tick=10,
+    )
+    assert len(result["threads"]) == 2
+    # Stack top becomes foreground.
+    assert result["foreground_id"] == result["threads"][-1].id
+    assert result["commitments"] == []
+
+
+# ── thread_classifier ───────────────────────────────────────────────
+
+
+class _FakeLLM:
+    def __init__(self, payload: Any):
+        self._payload = payload
+
+    async def __call__(self, **kwargs) -> Any:
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_classifier_parses_verdict() -> None:
+    from agent.thread_classifier import classify_thread_attribution
+
+    call_llm = _FakeLLM(
+        '```json\n{"verdict":"same","label":"心跳循环","topic":["心跳","循环","重入锁"]}\n```'
+    )
+    out = await classify_thread_attribution(
+        call_llm=call_llm,
+        new_message="接着做心跳循环重入锁",
+        candidate_thread=make_thread(["心跳", "循环"]),
+        created_topic=["心跳", "循环", "重入锁"],
+    )
+    assert out is not None
+    assert out["verdict"] == "same"
+    assert out["label"] == "心跳循环"
+    assert out["topic"] == ["心跳", "循环", "重入锁"]
+
+
+@pytest.mark.asyncio
+async def test_classifier_returns_none_on_garbage_output() -> None:
+    from agent.thread_classifier import classify_thread_attribution
+
+    call_llm = _FakeLLM("no json at all here")
+    out = await classify_thread_attribution(
+        call_llm=call_llm,
+        new_message="接着做",
+        candidate_thread=None,
+        created_topic=["x"],
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_classifier_returns_none_on_timeout() -> None:
+    from agent.thread_classifier import classify_thread_attribution
+
+    async def slow(**kwargs):  # noqa: ARG001
+        import asyncio
+
+        await asyncio.sleep(1.5)
+        return '{"verdict":"same"}'
+
+    out = await classify_thread_attribution(
+        call_llm=slow,
+        new_message="接着做",
+        candidate_thread=None,
+        created_topic=["x"],
+        timeout_ms=50,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_classifier_rejects_verdict_outside_enum() -> None:
+    from agent.thread_classifier import classify_thread_attribution
+
+    call_llm = _FakeLLM('{"verdict":"maybe","label":"x","topic":["a"]}')
+    out = await classify_thread_attribution(
+        call_llm=call_llm,
+        new_message="msg",
+        candidate_thread=None,
+        created_topic=[],
+    )
+    assert out is None


### PR DESCRIPTION
## Summary

Add four dependency-free, dependency-injected modules under `agent/` that port foundational patterns from the [BaiLongma](https://github.com/xiaoyuanda666-ship-it/BaiLongma) desktop agent (MIT licensed, line-by-line translated). Each module is a standalone building block — **no existing code paths are modified**, no wiring into `run_agent.py`, `cli.py`, or the gateway.

Four commits, one module each:

| # | Commit | Module | LOC | Tests |
|---|---|---|---|---|
| 1 | `b0c666905` | `agent/heartbeat.py` + `agent/heartbeat_policy.py` + `agent/heartbeat_bindings.py` | ~920 | 13 |
| 2 | `2cee6b134` | `agent/threads.py` + `agent/thread_classifier.py` + `agent/keywords.py` | ~1370 | 37 |
| 3 | `c28e4a5f2` | `agent/memory_consolidator.py` | ~570 | 14 |
| 4 | `869a32596` | `agent/self_evolution.py` | ~450 | 27 |

**Total: 91 tests, all green.** All modules use Python stdlib only (no new deps).

## Why these four

Each is a well-scoped primitive that Hermes plugins / skills / auxiliary services can adopt piecewise:

1. **Autonomous heartbeat loop.** L2 tick loop with user-preempt, quiet-hours, watchdog, awakening ticks, and priority-ranked cadences. Directions text is generated by a pure policy function (`heartbeat_policy.build_autonomous_tick_directions`) so it's testable in isolation. A `HeartbeatDeps` dataclass DI-injects every side effect (LLM call, message queue, quota, logging) — the loop itself never imports Hermes internals. Reference `agent/heartbeat_bindings.py` shows the minimal in-memory wiring.

2. **Thread model (read-time temperature, no focus stack).** Replaces the classic focus-stack pattern with:
   - Multiple concurrent threads + one foreground pointer (no stack, no pop).
   - Temperature is a **pure function of wall-clock elapsed time** (`thread_temperature()`), evaluated at read. Forgetting is never a write.
   - Actor writes focus (`touch_thread()`, `open_commitment()`). Observers never infer focus from message flow.
   - Attribution handles three production failure modes: sparse-follow-up-on-cold-foreground (noop, not revival), anaphora + generic object (continue foreground, don't spawn browser pseudo-thread), precise callback (resume named background thread at overlap ≥ 1).
   - LLM arbitration for weak-signal merges is a separate module (`thread_classifier.py`) with 800ms timeout and fail-to-None behaviour.

3. **Memory consolidator + round-robin loop.** Long-term memory *janitor* — never writes new content, only merges (soft-delete via `visibility=0`), downgrades salience, or skips. Salience-5 is protected as identity-level. Contradictions are left alone (signal, not noise). `MemoryStore` and `ConsolidatorLLM` are Protocols so any backend can adopt it. Complements a future `sleep-consolidation` skill that would own *when* to run.

4. **Self-evolution ledger.** Watches actionable memories (procedure / constraint / failure_lesson / policy — flagged by tag, event_type, or mem_id prefix), keeps a bounded newest-first recent set, emits a `self_evolution` event on updates. **Never** rewrites code or issues LLM calls of its own.

   ⚠️ **Prompt-caching hazard called out explicitly.** The upstream code splices the recent-events list into the system prompt every turn. In Hermes that breaks per-conversation prompt caching (per AGENTS.md). The ported version exposes `format_self_evolution_for_prompt()` as a stand-alone renderer with a doc-string warning; the caller decides where to place it (user message at conversation start, per-turn context block that is documented to invalidate cache when it changes, or a session-scoped surface outside the model's system prompt).

## Design invariants (per file docstrings)

- **Zero core mutation.** No changes to `run_agent.py`, `cli.py`, `model_tools.py`, `toolsets.py`, or the gateway. Nothing wires these modules in. They are strictly libraries.
- **Dependency injection everywhere.** All external I/O (LLM, message queue, memory store, config store) is a Protocol/callable parameter, not a global import. This keeps the modules independently testable and lets plugins adopt them piecewise.
- **Stdlib only.** No new `pyproject.toml` entries. `agent/keywords.py` is a zero-dep CN/EN n-gram extractor.
- **Cache safety.** No module writes to the system prompt, no module invalidates prompt caches. `self_evolution` documents the risk and hands the rendered string to the caller.
- **Tests over mocks.** All 91 tests exercise real code paths against DI seams (in-memory fake stores, scripted LLM adapters). No `unittest.mock.patch` on internals.

## Licensing

Ported code carries a per-file SPDX header pointing at the upstream source. Full MIT text stored under `LICENSES/BaiLongma-MIT.txt`; per-module attribution table in `NOTICE.md`.

## Testing

```bash
scripts/run_tests.sh tests/agent/test_heartbeat.py \
                     tests/agent/test_threads.py \
                     tests/agent/test_memory_consolidator.py \
                     tests/agent/test_self_evolution.py
# 91 passed
```

I also ran the full `tests/hermes_cli/test_config.py` (155) + `test_config_drift.py` + `test_config_validation.py` + these 91 together (190 passed) to confirm the new `agent.heartbeat` config block doesn't break config loading / migration.

## Non-goals of this PR

- Not wiring heartbeat into `AIAgent`. That's a separate PR with its own config-gated rollout (`agent.heartbeat.enabled` defaults to `false` in this PR).
- Not wiring threads into any conversation surface. The module is a standalone data model behind a stable API.
- Not adding a memory backend that implements the `MemoryStore` protocol. That belongs in a plugin.
- Not injecting the self-evolution ledger into the system prompt. See the caching hazard above.

## Follow-up

Once these primitives land, subsequent PRs can wire them in (behind config flags, default off) one at a time — that way each integration can be reviewed on its own merits without dragging along a 3,300-line library review.

Happy to split this into four separate PRs if the reviewers prefer smaller units — say the word and I'll rebase.
