### PR TITLE
feat(feishu): OpenClaw-style runtime footer with card note

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12328,6 +12328,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _footer_line = ""
             try:
                 from gateway.runtime_footer import build_footer_line as _bfl
+                # Provider can be None on some paths (e.g. after a fallback
+                # switch where the agent object wasn't round-tripped).  Fall
+                # back to config.yaml's model.provider so the footer always
+                # shows the configured backend.
+                _footer_provider = agent_result.get("provider")
+                if not _footer_provider:
+                    try:
+                        _footer_provider = (_load_gateway_config().get("model") or {}).get("provider")
+                    except Exception:
+                        _footer_provider = None
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
@@ -12335,6 +12345,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    provider=_footer_provider,
+                    agent=agent_result.get("agent") or agent_result.get("agent_id") or "main",
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19903,6 +19903,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "provider": getattr(_agent, "provider", None),
                     "context_length": _context_length,
                 }
             
@@ -20019,6 +20020,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": getattr(_agent, "provider", None),
                 "context_length": _context_length,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -31,6 +31,13 @@ from typing import Any, Iterable, Optional
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " · "
 
+# OpenClaw-style labeled footer: "Agent: main | Model: k3 | Provider: kimi".
+# Opt-in via ``display.runtime_footer.style: openclaw`` (or by setting
+# ``fields`` to the agent/model/provider trio).  Uses a pipe separator and a
+# "Label: value" format so it mirrors OpenClaw's card note exactly.
+_OPENCLAW_STYLE_FIELDS: tuple[str, ...] = ("agent", "model", "provider")
+_OPENCLAW_SEP = " | "
+
 
 def _home_relative_cwd(cwd: str) -> str:
     """Return *cwd* with ``$HOME`` collapsed to ``~``.  Empty string if unset."""
@@ -64,7 +71,7 @@ def resolve_footer_config(
         2. ``display.runtime_footer``
         3. ``display.platforms.<platform_key>.runtime_footer``
     """
-    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS)}
+    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS), "style": None}
     cfg = (user_config or {}).get("display") or {}
 
     global_cfg = cfg.get("runtime_footer")
@@ -73,6 +80,8 @@ def resolve_footer_config(
             resolved["enabled"] = bool(global_cfg.get("enabled"))
         if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
             resolved["fields"] = [str(f) for f in global_cfg["fields"]]
+        if isinstance(global_cfg.get("style"), str) and global_cfg["style"].strip():
+            resolved["style"] = global_cfg["style"].strip()
 
     if platform_key:
         platforms = cfg.get("platforms") or {}
@@ -84,6 +93,8 @@ def resolve_footer_config(
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+                if isinstance(plat_footer.get("style"), str) and plat_footer["style"].strip():
+                    resolved["style"] = plat_footer["style"].strip()
 
     return resolved
 
@@ -95,14 +106,45 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    provider: Optional[str] = None,
+    agent: Optional[str] = None,
+    style: Optional[str] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
     Fields are skipped silently when their underlying data is missing — a
     partially-populated footer is better than a line with ``?%`` or empty slots.
+
+    When ``style`` is ``"openclaw"`` (or ``fields`` is exactly the
+    agent/model/provider trio), render the OpenClaw labeled form
+    ``Agent: x | Model: y | Provider: z`` joined by pipes.  Otherwise render
+    the compact form joined by `` · ``.
     """
-    parts: list[str] = []
-    for field in fields:
+    field_list = [str(f) for f in fields]
+    openclaw = (style == "openclaw") or (
+        tuple(field_list) == _OPENCLAW_STYLE_FIELDS
+    )
+
+    if openclaw:
+        parts: list[str] = []
+        for field in field_list:
+            key = field.strip().lower()
+            if key == "agent":
+                val = (agent or "main").strip()
+                if val:
+                    parts.append(f"Agent: {val}")
+            elif key == "model":
+                m = _model_short(model)
+                if m:
+                    parts.append(f"Model: {m}")
+            elif key == "provider":
+                p = (provider or "").strip()
+                if p:
+                    parts.append(f"Provider: {p}")
+        return _OPENCLAW_SEP.join(parts) if parts else ""
+
+    parts = []
+    for field in field_list:
         if field == "model":
             m = _model_short(model)
             if m:
@@ -115,6 +157,14 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "agent":
+            val = (agent or "main").strip()
+            if val:
+                parts.append(val)
+        elif field == "provider":
+            p = (provider or "").strip()
+            if p:
+                parts.append(p)
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -130,6 +180,8 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    provider: Optional[str] = None,
+    agent: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -146,4 +198,7 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        provider=provider,
+        agent=agent,
+        style=cfg.get("style"),
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -109,6 +109,12 @@ def resolve_footer_config(
                 if isinstance(plat_footer.get("style"), str) and plat_footer["style"].strip():
                     resolved["style"] = plat_footer["style"].strip()
 
+    # OpenClaw style implies the labeled agent/model/provider trio when the
+    # user hasn't explicitly chosen fields — the compact defaults
+    # [model, context_pct, cwd] are meaningless to the OpenClaw renderer.
+    if resolved["style"] == "openclaw" and resolved["fields"] == list(_DEFAULT_FIELDS):
+        resolved["fields"] = list(_OPENCLAW_STYLE_FIELDS)
+
     return resolved
 
 

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -60,6 +60,19 @@ def _model_short(model: Optional[str]) -> str:
     return model.rsplit("/", 1)[-1]
 
 
+def _format_duration(seconds: Optional[float]) -> str:
+    """Render a duration in a human-readable short form.
+
+    ``3.4s`` → ``3.4s``; ``72.1s`` → ``1m12s``; ``125s`` → ``2m5s``.
+    """
+    if seconds is None or seconds < 0:
+        return ""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    mins, secs = divmod(int(seconds), 60)
+    return f"{mins}m{secs}s"
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,
@@ -109,6 +122,7 @@ def format_runtime_footer(
     provider: Optional[str] = None,
     agent: Optional[str] = None,
     style: Optional[str] = None,
+    duration: Optional[float] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -145,23 +159,28 @@ def format_runtime_footer(
 
     parts = []
     for field in field_list:
-        if field == "model":
+        key = field.strip().lower()
+        if key == "model":
             m = _model_short(model)
             if m:
                 parts.append(m)
-        elif field == "context_pct":
+        elif key in {"context_pct", "ctx"}:
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
-                parts.append(f"{pct}%")
-        elif field == "cwd":
+                parts.append(f"ctx {pct}%" if key == "ctx" else f"{pct}%")
+        elif key in {"cwd", "cwd_label"}:
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
-                parts.append(rel)
-        elif field == "agent":
+                parts.append(f"cwd {rel}" if key == "cwd_label" else rel)
+        elif key == "duration":
+            d = _format_duration(duration)
+            if d:
+                parts.append(d)
+        elif key == "agent":
             val = (agent or "main").strip()
             if val:
                 parts.append(val)
-        elif field == "provider":
+        elif key == "provider":
             p = (provider or "").strip()
             if p:
                 parts.append(p)
@@ -182,6 +201,7 @@ def build_footer_line(
     cwd: Optional[str] = None,
     provider: Optional[str] = None,
     agent: Optional[str] = None,
+    duration: Optional[float] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -201,4 +221,5 @@ def build_footer_line(
         provider=provider,
         agent=agent,
         style=cfg.get("style"),
+        duration=duration,
     )

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -160,6 +160,14 @@ _MARKDOWN_HINT_RE = re.compile(
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
+
+# Runtime-footer trailing line appended by gateway/run.py as "\n\n<footer>".
+# Matches the OpenClaw-style labeled footer so we can hoist it into a card note.
+# e.g. "Agent: main | Model: k3 | Provider: kimi". Capture the whole footer line.
+_RUNTIME_FOOTER_RE = re.compile(
+    r"\n\n(Agent:\s*[^\n]*?\|\s*Model:\s*[^\n]*)\s*$",
+    re.DOTALL,
+)
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
@@ -1891,9 +1899,28 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a Feishu message."""
+        """Send a Feishu message. If the content ends with a runtime-footer
+        line, hoist it into a Feishu card note (OpenClaw-style) instead of
+        leaving it as trailing text."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+
+        # Hoist trailing runtime footer into a card note (OpenClaw-style).
+        # Only when the card feature is enabled and a footer is present.
+        if self._footer_card_enabled():
+            body, footer = self._split_body_and_footer(content)
+            if footer:
+                card_result = await self._send_footer_card(
+                    chat_id=chat_id,
+                    body=body,
+                    footer=footer,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+                if card_result is not None:
+                    return card_result
+                # card failed → fall through to normal text/post path with the
+                # original content (footer stays as trailing text).
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -4543,6 +4570,111 @@ class FeishuAdapter(BasePlatformAdapter):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
+
+    # ------------------------------------------------------------------
+    # Runtime-footer card support (OpenClaw-style note footer)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _split_body_and_footer(content: str) -> tuple[str, str]:
+        """Split a final-response body from its trailing runtime-footer line.
+
+        Returns ``(body, footer)``. ``footer`` is empty when no footer line is
+        detected at the end of ``content``.
+        """
+        m = _RUNTIME_FOOTER_RE.search(content)
+        if not m:
+            return content, ""
+        footer = m.group(1).strip()
+        body = content[: m.start()].rstrip()
+        return body, footer
+
+    @staticmethod
+    def _build_footer_card_json(body: str, footer: str) -> dict:
+        """Build a Feishu schema-2.0 card that mirrors OpenClaw's note footer.
+
+        Body goes in a markdown ``content`` element; the footer goes in a grey
+        ``note`` element separated by a horizontal rule — identical visual to
+        OpenClaw's ``Agent: x | Model: y | Provider: z`` note.
+        """
+        elements: list[dict] = [
+            {"tag": "markdown", "content": body, "element_id": "content"},
+        ]
+        if footer:
+            elements.append({"tag": "hr"})
+            elements.append(
+                {
+                    "tag": "markdown",
+                    "content": f"<font color='grey'>{footer}</font>",
+                    "element_id": "note",
+                }
+            )
+        return {
+            "schema": "2.0",
+            "body": {"elements": elements},
+        }
+
+    async def _send_footer_card(
+        self,
+        *,
+        chat_id: str,
+        body: str,
+        footer: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[SendResult]:
+        """Create a schema-2.0 card via cardkit, then send it as an interactive
+        message.  Returns None on any card failure so the caller falls back to
+        the normal post/text path."""
+        if not self._client:
+            return None
+        card_json = self._build_footer_card_json(body, footer)
+        try:
+            req = (
+                BaseRequest.builder()
+                .http_method(HttpMethod.POST)
+                .uri("/open-apis/cardkit/v1/cards")
+                .token_types({AccessTokenType.TENANT})
+                .body({"type": "card_json", "data": json.dumps(card_json, ensure_ascii=False)})
+                .build()
+            )
+            resp = await self._run_blocking(self._client.request, req)
+            raw = getattr(resp, "raw", None)
+            content_bytes = getattr(raw, "content", None)
+            data = {}
+            if content_bytes:
+                try:
+                    data = json.loads(content_bytes.decode("utf-8"))
+                except Exception:
+                    data = {}
+            card_id = data.get("data", {}).get("card_id") or data.get("card_id")
+            if not card_id:
+                raise RuntimeError(f"cardkit create returned no card_id: {data!r}")
+            interactive_payload = json.dumps(
+                {"type": "card", "data": {"card_id": card_id}},
+                ensure_ascii=False,
+            )
+            return await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=interactive_payload,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[Feishu] footer card send failed (%s); falling back to post/text",
+                exc,
+            )
+            return None  # signal caller to use the normal text/post path
+
+    def _footer_card_enabled(self) -> bool:
+        """Whether to hoist the runtime footer into a Feishu card note.
+
+        Enabled by default; can be disabled with ``FEISHU_FOOTER_CARD=0`` in the
+        profile's .env (revert to plain trailing-text footer)."""
+        import os as _os
+
+        return _os.environ.get("FEISHU_FOOTER_CARD", "1").strip() not in {"0", "false", "off"}
 
     async def _send_uploaded_file_message(
         self,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -164,8 +164,10 @@ _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 # Runtime-footer trailing line appended by gateway/run.py as "\n\n<footer>".
 # Matches the OpenClaw-style labeled footer so we can hoist it into a card note.
 # e.g. "Agent: main | Model: k3 | Provider: kimi". Capture the whole footer line.
+# Also matches when the entire content IS the footer line (streaming sends the
+# footer as a separate trailing message with no preceding "\n\n").
 _RUNTIME_FOOTER_RE = re.compile(
-    r"\n\n(Agent:\s*[^\n]*?\|\s*Model:\s*[^\n]*)\s*$",
+    r"(?:^|\n\n)(Agent:\s*[^\n]*?\|\s*Model:\s*[^\n]*?)\s*$",
     re.DOTALL,
 )
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -4596,11 +4598,12 @@ class FeishuAdapter(BasePlatformAdapter):
         ``note`` element separated by a horizontal rule — identical visual to
         OpenClaw's ``Agent: x | Model: y | Provider: z`` note.
         """
-        elements: list[dict] = [
-            {"tag": "markdown", "content": body, "element_id": "content"},
-        ]
+        elements: list[dict] = []
+        if body:
+            elements.append({"tag": "markdown", "content": body, "element_id": "content"})
         if footer:
-            elements.append({"tag": "hr"})
+            if elements:
+                elements.append({"tag": "hr"})
             elements.append(
                 {
                     "tag": "markdown",
@@ -4653,13 +4656,21 @@ class FeishuAdapter(BasePlatformAdapter):
                 {"type": "card", "data": {"card_id": card_id}},
                 ensure_ascii=False,
             )
-            return await self._feishu_send_with_retry(
+            response = await self._feishu_send_with_retry(
                 chat_id=chat_id,
                 msg_type="interactive",
                 payload=interactive_payload,
                 reply_to=reply_to,
                 metadata=metadata,
             )
+            if not self._response_succeeded(response):
+                logger.warning(
+                    "[Feishu] footer card interactive send rejected (code=%s msg=%s); falling back to post/text",
+                    getattr(response, "code", "?"),
+                    getattr(response, "msg", "?"),
+                )
+                return None  # signal caller to use the normal text/post path
+            return self._finalize_send_result(response, "footer card send failed")
         except Exception as exc:
             logger.warning(
                 "[Feishu] footer card send failed (%s); falling back to post/text",
@@ -4670,11 +4681,34 @@ class FeishuAdapter(BasePlatformAdapter):
     def _footer_card_enabled(self) -> bool:
         """Whether to hoist the runtime footer into a Feishu card note.
 
-        Enabled by default; can be disabled with ``FEISHU_FOOTER_CARD=0`` in the
-        profile's .env (revert to plain trailing-text footer)."""
+        Enabled by default; disable via config.yaml::
+
+            display:
+              platforms:
+                feishu:
+                  runtime_footer:
+                    card: false
+
+        reverts to the plain trailing-text footer.  The legacy
+        ``FEISHU_FOOTER_CARD=0`` .env escape hatch is still honoured for
+        backward compatibility."""
         import os as _os
 
-        return _os.environ.get("FEISHU_FOOTER_CARD", "1").strip() not in {"0", "false", "off"}
+        env = _os.environ.get("FEISHU_FOOTER_CARD", "").strip().lower()
+        if env in {"0", "false", "off"}:
+            return False
+        try:
+            from hermes_cli.config import read_raw_config
+
+            cfg = read_raw_config() or {}
+            platforms = (cfg.get("display") or {}).get("platforms") or {}
+            feishu_cfg = platforms.get("feishu") or {}
+            footer_cfg = feishu_cfg.get("runtime_footer") or {}
+            if isinstance(footer_cfg, dict) and "card" in footer_cfg:
+                return bool(footer_cfg["card"])
+        except Exception:
+            pass
+        return True
 
     async def _send_uploaded_file_message(
         self,

--- a/tests/gateway/test_feishu_footer_card.py
+++ b/tests/gateway/test_feishu_footer_card.py
@@ -1,0 +1,248 @@
+"""Tests for the Feishu footer-card hoisting path in the adapter.
+
+Covers the three delivery scenarios:
+1. Non-streamed: footer appended to body → card with body + note.
+2. Streamed: footer sent alone as trailing message → card with note only.
+3. Card failure: falls back to plain text/post.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from gateway.platforms.base import SendResult
+
+
+def _make_adapter():
+    """Minimal FeishuAdapter with the methods _send_footer_card needs."""
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    adapter = object.__new__(FeishuAdapter)
+    adapter._client = Mock()  # truthy — passes the "not connected" check
+    return adapter
+
+
+def _ok_response(message_id: str = "om_card_1"):
+    """Fake a successful lark SDK response."""
+    resp = SimpleNamespace()
+    resp.code = 0
+    resp.msg = "success"
+    resp.success = lambda: True
+    resp.data = SimpleNamespace(message_id=message_id)
+    return resp
+
+
+def _err_response(code: int = 230001, msg: str = "card rejected"):
+    resp = SimpleNamespace()
+    resp.code = code
+    resp.msg = msg
+    resp.success = lambda: False
+    resp.data = None
+    return resp
+
+
+def _cardkit_response(card_id: str = "card_1"):
+    """Fake the cardkit create response."""
+    resp = SimpleNamespace()
+    resp.raw = SimpleNamespace(
+        content=json.dumps({"data": {"card_id": card_id}}).encode()
+    )
+    return resp
+
+
+class TestFooterCardSend(unittest.TestCase):
+    """_send_footer_card returns SendResult on success, None on failure."""
+
+    def test_success_returns_send_result(self):
+        adapter = _make_adapter()
+        adapter._run_blocking = AsyncMock(return_value=_cardkit_response())
+        adapter._feishu_send_with_retry = AsyncMock(return_value=_ok_response())
+
+        import asyncio
+
+        result = asyncio.run(
+            adapter._send_footer_card(
+                chat_id="oc_1",
+                body="Hello",
+                footer="Agent: main | Model: k3 | Provider: kimi",
+                reply_to=None,
+                metadata=None,
+            )
+        )
+        self.assertIsInstance(result, SendResult)
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_card_1")
+
+    def test_unsuccessful_interactive_response_returns_none(self):
+        """Interactive response with non-zero code → None (fallback)."""
+        adapter = _make_adapter()
+        adapter._run_blocking = AsyncMock(return_value=_cardkit_response())
+        adapter._feishu_send_with_retry = AsyncMock(return_value=_err_response())
+
+        import asyncio
+
+        result = asyncio.run(
+            adapter._send_footer_card(
+                chat_id="oc_1",
+                body="Hello",
+                footer="Agent: main | Model: k3 | Provider: kimi",
+                reply_to=None,
+                metadata=None,
+            )
+        )
+        self.assertIsNone(result)
+
+    def test_exception_returns_none(self):
+        """Any exception → None (fallback)."""
+        adapter = _make_adapter()
+        adapter._run_blocking = AsyncMock(side_effect=RuntimeError("network"))
+
+        import asyncio
+
+        result = asyncio.run(
+            adapter._send_footer_card(
+                chat_id="oc_1",
+                body="Hello",
+                footer="Agent: main | Model: k3 | Provider: kimi",
+                reply_to=None,
+                metadata=None,
+            )
+        )
+        self.assertIsNone(result)
+
+    def test_cardkit_no_card_id_returns_none(self):
+        """Cardkit response missing card_id → None (fallback)."""
+        adapter = _make_adapter()
+        resp = SimpleNamespace()
+        resp.raw = SimpleNamespace(content=b'{"data": {}}')
+        adapter._run_blocking = AsyncMock(return_value=resp)
+
+        import asyncio
+
+        result = asyncio.run(
+            adapter._send_footer_card(
+                chat_id="oc_1",
+                body="Hello",
+                footer="Agent: main | Model: k3 | Provider: kimi",
+                reply_to=None,
+                metadata=None,
+            )
+        )
+        self.assertIsNone(result)
+
+
+class TestSplitBodyAndFooter(unittest.TestCase):
+    """_split_body_and_footer handles both \\n\\n-prefixed and bare footers."""
+
+    def _split(self, content: str):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        return FeishuAdapter._split_body_and_footer(content)
+
+    def test_body_with_footer(self):
+        body, footer = self._split("Hello world\n\nAgent: main | Model: k3 | Provider: kimi")
+        self.assertEqual(body, "Hello world")
+        self.assertEqual(footer, "Agent: main | Model: k3 | Provider: kimi")
+
+    def test_bare_footer_streamed(self):
+        """Streaming sends the footer as a standalone message (no \\n\\n prefix)."""
+        body, footer = self._split("Agent: main | Model: k3 | Provider: kimi")
+        self.assertEqual(body, "")
+        self.assertEqual(footer, "Agent: main | Model: k3 | Provider: kimi")
+
+    def test_no_footer(self):
+        body, footer = self._split("Hello world")
+        self.assertEqual(body, "Hello world")
+        self.assertEqual(footer, "")
+
+    def test_footer_without_provider(self):
+        body, footer = self._split("text\n\nAgent: main | Model: k3")
+        self.assertEqual(body, "text")
+        self.assertEqual(footer, "Agent: main | Model: k3")
+
+
+class TestBuildFooterCardJson(unittest.TestCase):
+    """Card JSON builder handles body-only, footer-only, and body+footer."""
+
+    def _build(self, body: str, footer: str):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        return FeishuAdapter._build_footer_card_json(body, footer)
+
+    def test_body_and_footer(self):
+        card = self._build("Hello", "Agent: a | Model: m | Provider: p")
+        elements = card["body"]["elements"]
+        self.assertEqual(len(elements), 3)  # markdown + hr + note
+        self.assertEqual(elements[0]["tag"], "markdown")
+        self.assertEqual(elements[1]["tag"], "hr")
+        self.assertIn("grey", elements[2]["content"])
+
+    def test_footer_only_streamed(self):
+        """Streamed trailing footer → note element only, no empty markdown."""
+        card = self._build("", "Agent: a | Model: m | Provider: p")
+        elements = card["body"]["elements"]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0]["tag"], "markdown")
+        self.assertIn("grey", elements[0]["content"])
+
+
+class TestFooterCardEnabled(unittest.TestCase):
+    """_footer_card_enabled reads from config.yaml, not just .env."""
+
+    def test_default_enabled(self):
+        adapter = _make_adapter()
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(adapter._footer_card_enabled())
+
+    def test_env_disable(self):
+        adapter = _make_adapter()
+        with patch.dict(os.environ, {"FEISHU_FOOTER_CARD": "0"}):
+            self.assertFalse(adapter._footer_card_enabled())
+
+    def test_config_disable(self):
+        adapter = _make_adapter()
+        fake_cfg = {
+            "display": {
+                "platforms": {
+                    "feishu": {"runtime_footer": {"card": False}},
+                },
+            },
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("hermes_cli.config.read_raw_config", return_value=fake_cfg):
+                self.assertFalse(adapter._footer_card_enabled())
+
+    def test_config_enable_overrides_nothing(self):
+        adapter = _make_adapter()
+        fake_cfg = {
+            "display": {
+                "platforms": {
+                    "feishu": {"runtime_footer": {"card": True}},
+                },
+            },
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("hermes_cli.config.read_raw_config", return_value=fake_cfg):
+                self.assertTrue(adapter._footer_card_enabled())
+
+    def test_env_disable_wins_over_config(self):
+        """.env escape hatch takes precedence (backward compat)."""
+        adapter = _make_adapter()
+        fake_cfg = {
+            "display": {
+                "platforms": {
+                    "feishu": {"runtime_footer": {"card": True}},
+                },
+            },
+        }
+        with patch.dict(os.environ, {"FEISHU_FOOTER_CARD": "0"}):
+            with patch("hermes_cli.config.read_raw_config", return_value=fake_cfg):
+                self.assertFalse(adapter._footer_card_enabled())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -404,3 +404,63 @@ def test_format_footer_cwd_label_alias(tmp_path):
     )
     assert out.startswith("cwd ")
     assert "proj" in out
+
+
+# ---------------------------------------------------------------------------
+# style: openclaw without explicit fields → implied agent/model/provider
+# ---------------------------------------------------------------------------
+
+
+def test_openclaw_style_only_supplies_default_trio():
+    """style: openclaw without explicit fields resolves to agent/model/provider."""
+    user = {"display": {"runtime_footer": {"enabled": True, "style": "openclaw"}}}
+    cfg = resolve_footer_config(user, "feishu")
+    assert cfg["style"] == "openclaw"
+    assert cfg["fields"] == ["agent", "model", "provider"]
+
+
+def test_openclaw_style_only_platform_override_supplies_trio():
+    """Platform-level style: openclaw without fields also resolves the trio."""
+    user = {
+        "display": {
+            "runtime_footer": {"enabled": True},
+            "platforms": {
+                "feishu": {"runtime_footer": {"style": "openclaw"}},
+            },
+        },
+    }
+    cfg = resolve_footer_config(user, "feishu")
+    assert cfg["fields"] == ["agent", "model", "provider"]
+
+
+def test_openclaw_style_explicit_fields_not_overridden():
+    """Explicit fields alongside style: openclaw are respected."""
+    user = {
+        "display": {
+            "runtime_footer": {
+                "enabled": True,
+                "style": "openclaw",
+                "fields": ["model", "provider"],
+            },
+        },
+    }
+    cfg = resolve_footer_config(user, "feishu")
+    assert cfg["fields"] == ["model", "provider"]
+
+
+def test_openclaw_style_only_end_to_end():
+    """build_footer_line with style: openclaw and no fields renders the labeled trio."""
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {"enabled": True, "style": "openclaw"},
+            },
+        },
+        platform_key="feishu",
+        model="k3",
+        context_tokens=0,
+        context_length=None,
+        provider="kimi",
+        agent="main",
+    )
+    assert out == "Agent: main | Model: k3 | Provider: kimi"

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -347,3 +347,60 @@ def test_build_footer_openclaw_end_to_end():
         agent="main",
     )
     assert out == "Agent: main | Model: k3 | Provider: kimi"
+
+
+# ---------------------------------------------------------------------------
+# duration field (consolidated from #52443)
+# ---------------------------------------------------------------------------
+
+def test_format_footer_duration_seconds():
+    from gateway.runtime_footer import format_runtime_footer
+
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=100,
+        cwd="", duration=3.4, fields=("duration",),
+    )
+    assert out == "3.4s"
+
+
+def test_format_footer_duration_minutes():
+    from gateway.runtime_footer import format_runtime_footer
+
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=100,
+        cwd="", duration=72.3, fields=("duration",),
+    )
+    assert out == "1m12s"
+
+
+def test_format_footer_duration_none_skipped():
+    from gateway.runtime_footer import format_runtime_footer
+
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=100,
+        cwd="", duration=None, fields=("duration",),
+    )
+    assert out == ""
+
+
+def test_format_footer_ctx_alias():
+    from gateway.runtime_footer import format_runtime_footer
+
+    out = format_runtime_footer(
+        model="", context_tokens=50, context_length=100,
+        cwd="", fields=("ctx",),
+    )
+    assert out == "ctx 50%"
+
+
+def test_format_footer_cwd_label_alias(tmp_path):
+    from gateway.runtime_footer import format_runtime_footer
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    out = format_runtime_footer(
+        model="", context_tokens=0, context_length=None,
+        cwd=str(proj), fields=("cwd_label",),
+    )
+    assert out.startswith("cwd ")
+    assert "proj" in out

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -153,7 +153,7 @@ def test_format_footer_unknown_field_silently_ignored():
 
 def test_resolve_defaults_off_empty_config():
     cfg = resolve_footer_config({}, "telegram")
-    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"]}
+    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"], "style": None}
 
 
 def test_resolve_global_enable():
@@ -260,3 +260,90 @@ def test_build_footer_no_data_returns_empty_even_when_enabled():
     # With no TERMINAL_CWD env either
     if not os.environ.get("TERMINAL_CWD"):
         assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# OpenClaw-style labeled footer
+# ---------------------------------------------------------------------------
+
+def test_openclaw_style_via_fields_trio():
+    from gateway.runtime_footer import format_runtime_footer
+
+    out = format_runtime_footer(
+        model="k3",
+        context_tokens=0,
+        context_length=None,
+        provider="kimi",
+        agent="main",
+        fields=["agent", "model", "provider"],
+    )
+    assert out == "Agent: main | Model: k3 | Provider: kimi"
+
+
+def test_openclaw_style_via_style_flag():
+    from gateway.runtime_footer import format_runtime_footer
+
+    out = format_runtime_footer(
+        model="moonshot/k3",
+        context_tokens=0,
+        context_length=None,
+        provider="kimi",
+        agent="chief",
+        fields=["agent", "model", "provider"],
+        style="openclaw",
+    )
+    # model vendor prefix dropped, custom agent id honoured
+    assert out == "Agent: chief | Model: k3 | Provider: kimi"
+
+
+def test_openclaw_style_missing_provider_omits_segment():
+    from gateway.runtime_footer import format_runtime_footer
+
+    out = format_runtime_footer(
+        model="k3",
+        context_tokens=0,
+        context_length=None,
+        provider=None,
+        agent="main",
+        fields=["agent", "model", "provider"],
+    )
+    assert out == "Agent: main | Model: k3"
+
+
+def test_openclaw_style_config_resolves_style():
+    user = {"display": {"runtime_footer": {"enabled": True, "style": "openclaw"}}}
+    cfg = resolve_footer_config(user, "feishu")
+    assert cfg["style"] == "openclaw"
+
+
+def test_openclaw_style_platform_override():
+    user = {
+        "display": {
+            "runtime_footer": {"enabled": True},
+            "platforms": {
+                "feishu": {"runtime_footer": {"style": "openclaw"}},
+            },
+        },
+    }
+    assert resolve_footer_config(user, "feishu")["style"] == "openclaw"
+    assert resolve_footer_config(user, "telegram")["style"] is None
+
+
+def test_build_footer_openclaw_end_to_end():
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["agent", "model", "provider"],
+                },
+            },
+        },
+        platform_key="feishu",
+        model="k3",
+        context_tokens=0,
+        context_length=None,
+        provider="kimi",
+        agent="main",
+    )
+    assert out == "Agent: main | Model: k3 | Provider: kimi"


### PR DESCRIPTION
## What

Adds an opt-in **OpenClaw-style runtime footer** and, on Feishu, renders it as a **card note** (the grey caption area at the bottom of an interactive card) instead of trailing plain text.

Footer output:
```
Agent: main | Model: k3 | Provider: kimi
```

## Why

The built-in footer (`model · context% · cwd`) is compact but appends a plain-text line to the message body. OpenClaw's Feishu integration shows the same runtime info as a labeled card note, which reads much more cleanly. This PR brings that labeled format into `runtime_footer` and lets the Feishu adapter hoist it into a proper card note.

## Changes

**`gateway/runtime_footer.py`**
- New footer fields: `agent`, `provider` (alongside the existing `model` / `context_pct` / `cwd`).
- New `style: openclaw` config option. It is also auto-enabled when `fields` is exactly `[agent, model, provider]`. The default compact style is unchanged (fully backward compatible).
- `resolve_footer_config` now surfaces `style` (global + per-platform).

**`gateway/run.py`**
- Pass `provider` / `agent` through to the footer builder.
- Fall back to `config model.provider` when the agent result has no provider (e.g. after a provider-fallback switch), so the footer always shows the configured backend.

**`plugins/platforms/feishu/adapter.py`**
- Detect a trailing runtime-footer line in the final response and, when present, send the message as a schema-2.0 interactive card via `cardkit/v1/cards`: body in a markdown `content` element, `<hr>`, then the footer in a grey `note` element (`<font color='grey'>…</font>`).
- Falls back to the normal post/text path on any card failure (footer stays as trailing text), so a card error can never lose a message.
- Gated by `FEISHU_FOOTER_CARD` (default on; set to `0`/`false`/`off` to revert to plain-text footer).

**`tests/gateway/test_runtime_footer.py`**
- 7 new cases: openclaw style via fields-trio and via `style` flag, missing-provider segment omission, style config resolution, per-platform override, and an end-to-end `build_footer_line` check.
- Updated the `resolve_footer_config` defaults assertion for the new `style` key.

## Config

```yaml
display:
  runtime_footer:
    enabled: true
    style: openclaw            # or just set the fields trio below
    fields: [agent, model, provider]
```

## Testing

- `tests/gateway/test_runtime_footer.py`: **31 passed**.
- Verified end-to-end on a live Feishu bot: the footer renders as a grey card note (`Agent: main | Model: k3 | Provider: kimi`), and disabling the feature / card failures both fall back to plain text cleanly.

## Backward compatibility

- Default footer style is untouched; existing `display.runtime_footer` configs behave exactly as before.
- Card sending is additive and opt-out via `FEISHU_FOOTER_CARD`.
