### PR TITLE
fix(desktop): cancel stale session resume on new chat

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -26,6 +26,10 @@ import type { ClientSessionState } from '../../types'
 
 import { useSessionActions } from './use-session-actions'
 
+const { ensureGatewayProfileMock } = vi.hoisted(() => ({
+  ensureGatewayProfileMock: vi.fn()
+}))
+
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
   deleteSession: vi.fn(),
@@ -33,6 +37,11 @@ vi.mock('@/hermes', async importOriginal => ({
   listAllProfileSessions: vi.fn(),
   setApiRequestProfile: vi.fn(),
   setSessionArchived: vi.fn()
+}))
+
+vi.mock('@/store/profile', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/store/profile')>()),
+  ensureGatewayProfile: ensureGatewayProfileMock
 }))
 
 const RUNTIME_SESSION_ID = 'rt-new-001'
@@ -58,6 +67,15 @@ function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
     tool_call_count: 0,
     ...overrides
   }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise
+  })
+
+  return { promise, resolve }
 }
 
 function Harness({
@@ -257,6 +275,7 @@ describe('resumeSession failure recovery', () => {
     setResumeFailedSessionId(null)
     setMessages([])
     setSessions([])
+    ensureGatewayProfileMock.mockReset()
     vi.restoreAllMocks()
   })
 
@@ -360,6 +379,36 @@ describe('resumeSession failure recovery', () => {
       actions!.startFreshSessionDraft(true)
       await pendingResume
     })
+
+    expect(requestGateway).not.toHaveBeenCalledWith('session.resume', expect.anything())
+    expect($activeSessionId.get()).toBeNull()
+    expect($selectedStoredSessionId.get()).toBeNull()
+    expect($messages.get()).toEqual([])
+  })
+
+  it('does not let a resume continue after New Chat during its gateway profile swap', async () => {
+    setSessions([storedSession({ profile: 'other-profile' })])
+    const gatewaySwap = deferred<void>()
+    ensureGatewayProfileMock.mockReturnValueOnce(gatewaySwap.promise)
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.resume') {
+        return { session_id: 'runtime-1', resumed: params?.session_id, messages: [], info: {} } as never
+      }
+
+      return {} as never
+    })
+    let actions: HarnessHandle | null = null
+
+    render(<ResumeHarness onReady={handle => (actions = handle)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(actions).not.toBeNull())
+
+    const pendingResume = actions!.resumeSession('stored-1', true)
+    await waitFor(() => expect(ensureGatewayProfileMock).toHaveBeenCalledWith('other-profile'))
+
+    actions!.startFreshSessionDraft(true)
+    gatewaySwap.resolve(undefined)
+    await pendingResume
 
     expect(requestGateway).not.toHaveBeenCalledWith('session.resume', expect.anything())
     expect($activeSessionId.get()).toBeNull()

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -13,6 +13,7 @@ import {
   $messages,
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
+  $selectedStoredSessionId,
   setActiveSessionId,
   setCurrentCwd,
   setMessages,
@@ -37,7 +38,7 @@ vi.mock('@/hermes', async importOriginal => ({
 const RUNTIME_SESSION_ID = 'rt-new-001'
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'startFreshSessionDraft'
+  'createBackendSessionForSend' | 'resumeSession' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -217,7 +218,7 @@ function ResumeHarness({
   runtimeIdByStoredSessionIdRef,
   sessionStateByRuntimeIdRef
 }: {
-  onReady: (resume: (storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) => void
+  onReady: (actions: HarnessHandle) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
   sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
@@ -243,8 +244,8 @@ function ResumeHarness({
   })
 
   useEffect(() => {
-    onReady(actions.resumeSession)
-  }, [actions.resumeSession, onReady])
+    onReady(actions)
+  }, [actions, onReady])
 
   return null
 }
@@ -266,10 +267,10 @@ describe('resumeSession failure recovery', () => {
       sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
     } = {}
   ): Promise<void> {
-    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
-    render(<ResumeHarness onReady={r => (resume = r)} requestGateway={requestGateway} {...options} />)
-    await waitFor(() => expect(resume).not.toBeNull())
-    await resume!('stored-1', true)
+    let actions: HarnessHandle | null = null
+    render(<ResumeHarness onReady={handle => (actions = handle)} requestGateway={requestGateway} {...options} />)
+    await waitFor(() => expect(actions).not.toBeNull())
+    await actions!.resumeSession('stored-1', true)
   }
 
   it('arms $resumeFailedSessionId when resume RPC and REST fallback both fail', async () => {
@@ -334,6 +335,36 @@ describe('resumeSession failure recovery', () => {
 
     // resumeSession must resolve (swallow the fallback failure), not reject.
     await expect(runResume(requestGateway)).resolves.toBeUndefined()
+  })
+
+  it('does not let an in-flight resume revive a fresh chat draft', async () => {
+    setSessions([storedSession()])
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.resume') {
+        return { session_id: 'runtime-1', resumed: params?.session_id, messages: [], info: {} } as never
+      }
+
+      return {} as never
+    })
+    let actions: HarnessHandle | null = null
+
+    render(<ResumeHarness onReady={handle => (actions = handle)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(actions).not.toBeNull())
+
+    await act(async () => {
+      const pendingResume = actions!.resumeSession('stored-1', true)
+
+      // resolveStoredSession yields before the gateway resume. New Chat must
+      // invalidate that stale continuation rather than let it reselect stored-1.
+      actions!.startFreshSessionDraft(true)
+      await pendingResume
+    })
+
+    expect(requestGateway).not.toHaveBeenCalledWith('session.resume', expect.anything())
+    expect($activeSessionId.get()).toBeNull()
+    expect($selectedStoredSessionId.get()).toBeNull()
+    expect($messages.get()).toEqual([])
   })
 
   it('leaves the failure latch clear when resume succeeds', async () => {
@@ -581,7 +612,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
     render(
       <ResumeHarness
-        onReady={r => (resume = r)}
+        onReady={actions => (resume = actions.resumeSession)}
         requestGateway={requestGateway}
         runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
         sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
@@ -623,7 +654,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
     render(
       <ResumeHarness
-        onReady={r => (resume = r)}
+        onReady={actions => (resume = actions.resumeSession)}
         requestGateway={requestGateway}
         runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
         sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -504,11 +504,15 @@ export function useSessionActions({
       const storedForProfile = await resolveStoredSession(storedSessionId)
       const sessionProfile = storedForProfile?.profile
 
-      if (resumeRequestRef.current !== requestId) {
+      if (!isCurrentResume()) {
         return
       }
 
       await ensureGatewayProfile(sessionProfile)
+
+      if (!isCurrentResume()) {
+        return
+      }
 
       // Re-check after the profile-resolve / gateway-swap awaits above: the
       // cache may have changed, and takeWarmCache re-validates belongs-to and

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -217,6 +217,11 @@ export function useSessionActions({
         ? normalizeNewChatWorkspaceTarget(draftOptions.workspaceTarget)
         : undefined
 
+      // A resume may be between awaits (profile lookup / gateway swap) when the
+      // user starts a new chat. Invalidate that request before clearing the
+      // view; otherwise its stale continuation can select and paint the old
+      // session over this fresh draft.
+      resumeRequestRef.current += 1
       resetViewSync()
       busyRef.current = false
       setBusy(false)


### PR DESCRIPTION
## Summary
- invalidate an in-flight session resume as soon as a new-chat draft starts
- prevent stale profile-lookup or gateway-swap continuations from reselecting the old session
- add a regression test for resume A -> New Chat -> stale resume completion

## Testing
- git diff --check
- TypeScript check reaches the modified test without errors; remaining module-resolution errors are caused by running Windows Node against a WSL worktree
- Vitest cannot start in this environment because Vite's watcher treats a linked workspace module as a directory; please rely on Linux CI for the full suite