### PR TITLE
feat(agent): add prefetch runner + reminders domain model (BaiLongma port, part 2)

### DIFF
--- a/LICENSES/BaiLongma-MIT.txt
+++ b/LICENSES/BaiLongma-MIT.txt
@@ -1,0 +1,31 @@
+The following third-party source has been ported (逐行翻译) into this
+repository under the terms of its original MIT License. The full license
+text is reproduced below.
+
+Project: BaiLongma
+Source:  https://github.com/xiaoyuanda666-ship-it/BaiLongma
+Author:  xiaoyuanda666-ship-it
+
+===============================================================================
+
+MIT License
+
+Copyright (c) 2026 xiaoyuanda666-ship-it
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,30 @@
+# Third-Party Notices
+
+Hermes Agent is licensed under Apache-2.0. This file records third-party
+sources whose code has been ported (逐行翻译, line-by-line translation)
+into this repository, and their original licenses.
+
+Ported code retains a per-file SPDX header identifying the upstream file
+and license. Full upstream license texts are stored under `LICENSES/`.
+
+---
+
+## BaiLongma (MIT License)
+
+- **Upstream:** https://github.com/xiaoyuanda666-ship-it/BaiLongma
+- **Copyright:** © 2026 xiaoyuanda666-ship-it
+- **License:** MIT (see `LICENSES/BaiLongma-MIT.txt`)
+
+The BaiLongma project (a Node.js/Electron desktop AI agent) contributed
+architectural designs and reference implementations that were ported to
+Python for Hermes. All ported files carry an `Adapted from BaiLongma`
+SPDX header pointing at the original `src/**/*.js` source.
+
+### Ported modules
+
+| Hermes file | Upstream source | Notes |
+| --- | --- | --- |
+| `agent/prefetch.py` | `src/prefetch/runner.js` | Background prefetch runner (framework only; no built-in tasks) |
+
+(Additional entries will be appended as more BaiLongma modules are
+ported.)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -25,6 +25,7 @@ SPDX header pointing at the original `src/**/*.js` source.
 | Hermes file | Upstream source | Notes |
 | --- | --- | --- |
 | `agent/prefetch.py` | `src/prefetch/runner.js` | Background prefetch runner (framework only; no built-in tasks) |
+| `agent/reminders.py` | `src/capabilities/tools/reminders.js` + `src/db/repositories/reminders.js` | User-facing reminders domain model + one-off / recurrence engine (`ReminderStore` protocol, `ReminderManager`) |
 
 (Additional entries will be appended as more BaiLongma modules are
 ported.)

--- a/agent/prefetch.py
+++ b/agent/prefetch.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------
+# Portions of this file are adapted from BaiLongma
+#   Upstream: https://github.com/xiaoyuanda666-ship-it/BaiLongma
+#   Original: src/prefetch/runner.js
+#             src/db/repositories/prefetch.js (cache schema shape only)
+#   Copyright (c) 2026 xiaoyuanda666-ship-it — Licensed under MIT
+#   License text: see LICENSES/BaiLongma-MIT.txt
+# ---------------------------------------------------------------------------
+"""Background prefetch runner.
+
+Runs a set of registered "prefetch tasks" concurrently, each producing
+a text payload that gets stored in a caller-supplied cache. Tasks
+declare their own TTL and tag set; the cache decides when to expire
+them and how to serve them back to future tool calls (or memory
+retrieval).
+
+## Why this is a *primitive*, not a set of tasks
+
+BaiLongma's upstream file bundles the framework AND three hardcoded
+tasks (Beijing weather, Lufeng weather, HackerNews top). Those are
+business logic — they don't belong in a general-purpose agent. This
+port keeps only the **framework**:
+
+* :class:`PrefetchTask`      — task descriptor + async fetcher
+* :class:`PrefetchRunner`    — register/run/settle-all orchestrator
+* :class:`PrefetchCacheStore` — protocol the caller implements
+
+The runner has **zero built-in tasks**. Callers register their own
+via :meth:`PrefetchRunner.register` or pass a dynamic-task provider
+callable (mirroring BaiLongma's DB-backed ``getEnabledPrefetchTasks``
+without hardcoding a DB).
+
+## Design invariants
+
+* **Never blocks the caller.** All tasks run under
+  :func:`asyncio.gather` with ``return_exceptions=True`` — a single
+  failing task never aborts the batch.
+* **Cache-agnostic.** The runner never touches the filesystem, sqlite,
+  or HTTP directly. Task fetchers own the "get me content" side;
+  the store owns the "persist for later" side.
+* **Best-effort logging.** Failures log at WARNING and are returned
+  as :class:`PrefetchOutcome` entries with ``error`` populated — no
+  exceptions escape :meth:`PrefetchRunner.run`.
+* **Stdlib only.** No new deps.
+
+Ported from BaiLongma's ``src/prefetch/runner.js`` (MIT).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Iterable,
+    Optional,
+    Protocol,
+    Sequence,
+    runtime_checkable,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# ── Types ──────────────────────────────────────────────────────────
+
+
+PrefetchFetcher = Callable[[], Awaitable[str]]
+"""Async callable that returns the text payload for one prefetch pass.
+
+Fetchers should be self-contained — they own their HTTP client, their
+timeout, and their parsing. The runner passes them no arguments.
+"""
+
+
+@dataclass
+class PrefetchTask:
+    """One prefetch task descriptor.
+
+    ``source`` is the primary cache key — pick something stable and
+    filter-friendly like ``"weather:Beijing"`` or ``"news:hn"``.
+    ``tags`` is optional metadata the cache can use for tag-based
+    invalidation / lookup.
+    """
+
+    source: str
+    fetch: PrefetchFetcher
+    ttl_minutes: int = 60
+    label: str = ""
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PrefetchOutcome:
+    """Per-task result after a run.
+
+    ``ok=True`` means the fetcher completed and the cache write was
+    invoked. Cache-write failures are treated as fatal for the entry
+    (the outcome switches to ``ok=False`` with ``error`` populated).
+    """
+
+    source: str
+    label: str
+    ok: bool
+    error: Optional[str] = None
+
+
+@runtime_checkable
+class PrefetchCacheStore(Protocol):
+    """Contract for the caller's cache backend.
+
+    Two synchronous ops are enough — this deliberately doesn't force
+    the caller to hand us an async store; a sync SQLite / dict / file
+    store is the common case.
+    """
+
+    def save(
+        self,
+        *,
+        source: str,
+        content: str,
+        ttl_minutes: int,
+        tags: Sequence[str],
+    ) -> None:
+        ...
+
+    def clear_expired(self) -> None:
+        ...
+
+
+# Optional dynamic-task provider — BaiLongma's DB-backed task list.
+# In Hermes this is just a callable, so the caller can plug in any
+# source (DB, config file, plugin registry) without the runner caring.
+DynamicTaskProvider = Callable[[], Iterable[PrefetchTask]]
+
+
+# ── Runner ─────────────────────────────────────────────────────────
+
+
+class PrefetchRunner:
+    """Register prefetch tasks and run them concurrently.
+
+    Usage::
+
+        cache = MyCacheStore()   # implements PrefetchCacheStore
+        runner = PrefetchRunner(cache=cache)
+        runner.register(PrefetchTask(
+            source="weather:beijing",
+            fetch=fetch_beijing_weather,
+            ttl_minutes=60,
+            label="Beijing weather",
+            tags=["weather", "beijing"],
+        ))
+        outcomes = await runner.run()
+    """
+
+    def __init__(
+        self,
+        *,
+        cache: PrefetchCacheStore,
+        dynamic_provider: Optional[DynamicTaskProvider] = None,
+    ) -> None:
+        self._cache = cache
+        self._dynamic_provider = dynamic_provider
+        self._tasks: dict[str, PrefetchTask] = {}
+
+    # ── Registration ───────────────────────────────────────────────
+
+    def register(self, task: PrefetchTask) -> None:
+        """Register (or overwrite) a task by ``source``.
+
+        BaiLongma's upstream uses list-append semantics; we prefer
+        keyed replacement because two tasks with the same source
+        would race on the cache row.
+        """
+        if not task.source:
+            raise ValueError("PrefetchTask.source must be a non-empty string")
+        if not callable(task.fetch):
+            raise ValueError("PrefetchTask.fetch must be an async callable")
+        self._tasks[task.source] = task
+
+    def unregister(self, source: str) -> bool:
+        return self._tasks.pop(source, None) is not None
+
+    def registered_sources(self) -> list[str]:
+        return sorted(self._tasks.keys())
+
+    # ── Task assembly ──────────────────────────────────────────────
+
+    def _resolve_dynamic_tasks(self) -> list[PrefetchTask]:
+        if self._dynamic_provider is None:
+            return []
+        try:
+            provided = list(self._dynamic_provider())
+        except Exception as err:  # noqa: BLE001 — a broken provider
+            # must not block the static tasks.
+            logger.warning(
+                "[prefetch] dynamic task provider raised %s", err
+            )
+            return []
+        # Reject duplicates so the static registry always wins.
+        return [t for t in provided if t.source not in self._tasks]
+
+    def _select_tasks(
+        self, sources: Optional[Sequence[str]] = None
+    ) -> list[PrefetchTask]:
+        all_tasks = list(self._tasks.values()) + self._resolve_dynamic_tasks()
+        if sources is None:
+            return all_tasks
+        wanted = set(sources)
+        return [t for t in all_tasks if t.source in wanted]
+
+    # ── Execution ─────────────────────────────────────────────────
+
+    async def _run_one(self, task: PrefetchTask) -> PrefetchOutcome:
+        try:
+            content = await task.fetch()
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                "[prefetch] ✗ %s: fetch failed: %s",
+                task.label or task.source,
+                err,
+            )
+            return PrefetchOutcome(
+                source=task.source,
+                label=task.label,
+                ok=False,
+                error=str(err) or err.__class__.__name__,
+            )
+
+        try:
+            self._cache.save(
+                source=task.source,
+                content=content,
+                ttl_minutes=task.ttl_minutes,
+                tags=list(task.tags),
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                "[prefetch] ✗ %s: cache write failed: %s",
+                task.label or task.source,
+                err,
+            )
+            return PrefetchOutcome(
+                source=task.source,
+                label=task.label,
+                ok=False,
+                error=str(err) or err.__class__.__name__,
+            )
+
+        logger.info(
+            "[prefetch] ✓ %s (ttl=%dm, tags=%s)",
+            task.label or task.source,
+            task.ttl_minutes,
+            task.tags,
+        )
+        return PrefetchOutcome(
+            source=task.source, label=task.label, ok=True
+        )
+
+    async def run(
+        self, task_sources: Optional[Sequence[str]] = None
+    ) -> list[PrefetchOutcome]:
+        """Run all (or a subset of) registered tasks concurrently.
+
+        Expired cache entries are cleaned up first, then tasks run
+        under :func:`asyncio.gather`. Individual failures are captured
+        in the returned outcome list — this method never raises.
+        """
+        try:
+            self._cache.clear_expired()
+        except Exception as err:  # noqa: BLE001 — expiration cleanup
+            # is best-effort; failing here would defeat the runner.
+            logger.warning(
+                "[prefetch] clear_expired failed: %s", err
+            )
+
+        tasks = self._select_tasks(task_sources)
+        if not tasks:
+            logger.info("[prefetch] no matching tasks")
+            return []
+
+        outcomes = await asyncio.gather(
+            *(self._run_one(task) for task in tasks),
+            return_exceptions=False,
+        )
+        return list(outcomes)
+
+
+__all__ = [
+    "DynamicTaskProvider",
+    "PrefetchCacheStore",
+    "PrefetchFetcher",
+    "PrefetchOutcome",
+    "PrefetchRunner",
+    "PrefetchTask",
+]

--- a/agent/reminders.py
+++ b/agent/reminders.py
@@ -1,0 +1,595 @@
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------
+# Portions of this file are adapted from BaiLongma
+#   Upstream: https://github.com/xiaoyuanda666-ship-it/BaiLongma
+#   Original: src/capabilities/tools/reminders.js
+#             src/db/repositories/reminders.js (schema shape only)
+#   Copyright (c) 2026 xiaoyuanda666-ship-it — Licensed under MIT
+#   License text: see LICENSES/BaiLongma-MIT.txt
+# ---------------------------------------------------------------------------
+"""User-facing reminders: domain model + one-off/recurrence engine.
+
+## Why this is not just cron
+
+Hermes already ships :mod:`cron` for scheduled *agent jobs* — cron
+runs prompts on a schedule against a full agent session. Reminders
+solve a different problem:
+
+* They belong to a *user* (or conversation party), not to the agent.
+* They can be **merged** at the same wall-clock minute so a burst of
+  "remind me at 6pm to X / to Y / to Z" collapses to one row.
+* They cancel by id, list what's pending for a user, and advance
+  their own ``due_at`` after firing when they're recurring.
+* They persist their firing status so a late-woken agent knows what
+  it missed (``fired`` / ``cancelled`` / ``pending``) instead of
+  double-firing.
+
+The module here is a **domain library** — no I/O, no tool wiring,
+no message routing. The caller supplies a :class:`ReminderStore`
+protocol implementation (SQLite, dict, ORM — whatever fits) and an
+optional event hook. The manager handles all the recurrence maths
+and merge logic in pure Python.
+
+## Design invariants
+
+* **Time is monotonic and injectable.** The manager takes a
+  ``now_fn`` callable so tests aren't at the mercy of wall clock.
+  All produced timestamps are ISO 8601 with an offset (never naive).
+* **Merging is opt-in via minute-key.** A one-off reminder in the
+  same UTC minute for the same user is a merge candidate; anything
+  else creates a fresh row. This matches BaiLongma's SQL
+  ``substr(due_at, 1, 16)`` semantics.
+* **Recurrence math is pure.** :func:`calculate_next_due_at` is a
+  standalone function with no state and no store dependency —
+  callers can use it directly to preview "when is the next Tuesday
+  09:00?" without persisting anything.
+* **due_at must be in the future for one-offs.** The manager rejects
+  past-times for ``once`` reminders (matches upstream); recurrence
+  math always advances to the next matching slot.
+* **Stdlib only.** No ``dateutil``, no ``pytz``.
+
+Ported from BaiLongma's ``src/capabilities/tools/reminders.js`` +
+``src/db/repositories/reminders.js`` (MIT).
+"""
+from __future__ import annotations
+
+import calendar
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Optional, Protocol, Sequence
+
+
+logger = logging.getLogger(__name__)
+
+
+ISO_MINUTE_LEN = 16  # "YYYY-MM-DDTHH:MM"
+
+RecurrenceKind = str  # "daily" | "weekly" | "monthly"
+_VALID_RECURRENCE: frozenset[str] = frozenset({"daily", "weekly", "monthly"})
+
+_HHMM_RE = re.compile(r"^(\d{1,2}):(\d{2})$")
+
+
+# ── Data model ─────────────────────────────────────────────────────
+
+
+@dataclass
+class Reminder:
+    """One reminder row.
+
+    Field names mirror BaiLongma's SQLite schema so a straight
+    port of the reminders table works as an in-memory implementation
+    of :class:`ReminderStore`.
+    """
+
+    id: int
+    user_id: str
+    due_at: str  # ISO 8601 with offset
+    task: str
+    status: str = "pending"  # "pending" | "fired" | "cancelled"
+    source: str = ""
+    recurrence_type: Optional[RecurrenceKind] = None
+    recurrence_config: Optional[dict[str, Any]] = None
+    fired_at: Optional[str] = None
+    cancelled_at: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class ReminderStore(Protocol):
+    """Persistence contract for the manager.
+
+    A minimal implementation only needs the eight methods below; the
+    manager never assumes anything about your indexing strategy or
+    transaction model. Return values match BaiLongma's semantics:
+
+    * ``create`` / ``append_task`` / ``cancel`` / ``mark_fired`` /
+      ``advance_due_at`` return the persisted / updated row (or
+      ``None`` if nothing changed).
+    * ``find_mergeable_one_off`` returns ``None`` when no candidate
+      exists.
+    """
+
+    def create(self, reminder: Reminder) -> Reminder:
+        ...
+
+    def find_mergeable_one_off(
+        self, *, user_id: str, minute_key: str
+    ) -> Optional[Reminder]:
+        ...
+
+    def append_task(
+        self, *, reminder_id: int, additional_task: str
+    ) -> Optional[Reminder]:
+        ...
+
+    def get_by_id(self, reminder_id: int) -> Optional[Reminder]:
+        ...
+
+    def cancel(
+        self, *, reminder_id: int, cancelled_at: str
+    ) -> Optional[Reminder]:
+        ...
+
+    def mark_fired(
+        self, *, reminder_id: int, fired_at: str
+    ) -> Optional[Reminder]:
+        ...
+
+    def advance_due_at(
+        self, *, reminder_id: int, next_due_at: str
+    ) -> Optional[Reminder]:
+        ...
+
+    def list_pending(self, limit: int = 50) -> Sequence[Reminder]:
+        ...
+
+    def list_due(
+        self, *, now_iso: str, limit: int = 20
+    ) -> Sequence[Reminder]:
+        ...
+
+    def next_pending(self) -> Optional[Reminder]:
+        ...
+
+
+# ── Recurrence engine (pure) ───────────────────────────────────────
+
+
+def _parse_hour_minute(value: Any, label: str = "time") -> tuple[int, int]:
+    text = str(value or "").strip()
+    match = _HHMM_RE.match(text)
+    if not match:
+        raise ValueError(
+            f"{label} must use HH:MM format, for example 09:00"
+        )
+    hour = int(match.group(1))
+    minute = int(match.group(2))
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError(f"{label} is outside the valid range")
+    return hour, minute
+
+
+def _iso_utc(dt: datetime) -> str:
+    """Serialise as UTC ISO 8601 with a ``Z`` suffix (BaiLongma
+    compatibility). Naive datetimes are treated as UTC."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (
+        dt.astimezone(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _parse_iso(value: str) -> datetime:
+    text = value.strip()
+    # datetime.fromisoformat handles "Z" only on 3.11+; be explicit
+    # so behaviour is consistent across supported versions.
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    return datetime.fromisoformat(text)
+
+
+def calculate_next_due_at(
+    kind: RecurrenceKind,
+    config: dict[str, Any],
+    *,
+    from_dt: Optional[datetime] = None,
+) -> datetime:
+    """Return the next matching wall-clock instant strictly after
+    ``from_dt`` (default: :func:`datetime.now` in local tz).
+
+    The returned datetime carries the same tzinfo as ``from_dt``.
+    """
+    if from_dt is None:
+        from_dt = datetime.now().astimezone()
+    hour, minute = _parse_hour_minute(config.get("time"), "time")
+
+    if kind == "daily":
+        next_dt = from_dt.replace(
+            hour=hour, minute=minute, second=0, microsecond=0
+        )
+        if next_dt <= from_dt:
+            next_dt = next_dt + timedelta(days=1)
+        return next_dt
+
+    if kind == "weekly":
+        target_weekday_raw = config.get("weekday")
+        try:
+            target_weekday = int(target_weekday_raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            target_weekday = -1
+        if not (0 <= target_weekday <= 6):
+            raise ValueError(
+                "weekday must be an integer from 0 to 6 (0=Sunday)"
+            )
+        # BaiLongma uses JS getDay(): 0=Sunday..6=Saturday.
+        # Python weekday() is 0=Mon..6=Sun; isoweekday() is 1=Mon..7=Sun.
+        # Convert to 0=Sun..6=Sat: (isoweekday % 7).
+        js_weekday_now = from_dt.isoweekday() % 7
+        candidate = from_dt.replace(
+            hour=hour, minute=minute, second=0, microsecond=0
+        )
+        diff = (target_weekday - js_weekday_now + 7) % 7
+        if diff == 0 and candidate <= from_dt:
+            diff = 7
+        return candidate + timedelta(days=diff)
+
+    if kind == "monthly":
+        target_day_raw = config.get("day_of_month")
+        try:
+            target_day = int(target_day_raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            target_day = -1
+        if not (1 <= target_day <= 31):
+            raise ValueError(
+                "day_of_month must be an integer from 1 to 31"
+            )
+        year = from_dt.year
+        month = from_dt.month
+        for _ in range(12):
+            _, last_day = calendar.monthrange(year, month)
+            if target_day <= last_day:
+                candidate = from_dt.replace(
+                    year=year,
+                    month=month,
+                    day=target_day,
+                    hour=hour,
+                    minute=minute,
+                    second=0,
+                    microsecond=0,
+                )
+                if candidate > from_dt:
+                    return candidate
+            month += 1
+            if month > 12:
+                month = 1
+                year += 1
+        raise ValueError("Could not find the next matching month")
+
+    raise ValueError(f"Unknown recurrence kind: {kind!r}")
+
+
+# ── Formatting ─────────────────────────────────────────────────────
+
+
+_WEEKDAY_ZH = ["周日", "周一", "周二", "周三", "周四", "周五", "周六"]
+
+
+def format_reminder_row(row: Reminder) -> str:
+    """Human-readable one-line rendering matching BaiLongma's format.
+
+    Kept i18n-neutral apart from the weekday labels (upstream uses
+    Chinese; this preserves them so ported tests stay behavioural).
+    """
+    if row.recurrence_type:
+        config = row.recurrence_config or {}
+        try:
+            if isinstance(config, str):
+                config = json.loads(config or "{}")
+        except (TypeError, ValueError):
+            config = {}
+        if row.recurrence_type == "daily":
+            recur_txt = f"每天 {config.get('time')}"
+        elif row.recurrence_type == "weekly":
+            weekday_idx = int(config.get("weekday", 0))
+            weekday_name = (
+                _WEEKDAY_ZH[weekday_idx]
+                if 0 <= weekday_idx < len(_WEEKDAY_ZH)
+                else str(weekday_idx)
+            )
+            recur_txt = f"每{weekday_name} {config.get('time')}"
+        elif row.recurrence_type == "monthly":
+            recur_txt = (
+                f"每月 {config.get('day_of_month')} 号 "
+                f"{config.get('time')}"
+            )
+        else:
+            recur_txt = json.dumps(config, ensure_ascii=False)
+        recurrence = f"[{row.recurrence_type}] {recur_txt}"
+    else:
+        recurrence = "[once]"
+    return (
+        f"#{row.id} {recurrence} 下次 {row.due_at} → "
+        f"{row.user_id}：{row.task}"
+    )
+
+
+# ── Manager (write-side orchestration) ─────────────────────────────
+
+
+@dataclass
+class ReminderCreateRequest:
+    """Structured input for :meth:`ReminderManager.create`.
+
+    A dataclass instead of a bag of kwargs so callers can programmatically
+    build requests without stringly-typed argument juggling. The tool
+    layer (whichever surface exposes this to the model) is expected to
+    parse the raw JSON into this shape before invoking the manager.
+    """
+
+    user_id: str
+    task: str
+    kind: RecurrenceKind = "once"  # "once" | "daily" | "weekly" | "monthly"
+    due_at: Optional[str] = None
+    time: Optional[str] = None  # HH:MM (recurrence only)
+    weekday: Optional[int] = None  # 0=Sun..6=Sat (weekly only)
+    day_of_month: Optional[int] = None  # 1..31 (monthly only)
+    source: str = ""
+
+
+class ReminderManager:
+    """Domain-level orchestration for reminders."""
+
+    def __init__(
+        self,
+        *,
+        store: ReminderStore,
+        now_fn: Optional[Callable[[], datetime]] = None,
+        emit_event: Optional[Callable[[str, dict[str, Any]], None]] = None,
+    ) -> None:
+        self._store = store
+        self._now_fn = now_fn or (lambda: datetime.now(tz=timezone.utc))
+        self._emit_event = emit_event
+
+    # ── Time / dispatch helpers ────────────────────────────────────
+
+    def _now(self) -> datetime:
+        return self._now_fn()
+
+    def _emit(self, event: str, payload: dict[str, Any]) -> None:
+        if self._emit_event is None:
+            return
+        try:
+            self._emit_event(event, payload)
+        except Exception as err:  # noqa: BLE001 — event emission is
+            # advisory; a broken hook must not lose state changes.
+            logger.warning(
+                "[reminders] emit_event(%s) raised %s", event, err
+            )
+
+    # ── Public API ────────────────────────────────────────────────
+
+    def create(self, request: ReminderCreateRequest) -> Reminder:
+        """Create (or merge into) a reminder for ``request.user_id``.
+
+        For ``kind='once'``, ``due_at`` is required and must be in
+        the future. A one-off in the same wall-clock minute for the
+        same user merges: the merge target's ``task`` is extended
+        (``"task1; task2"``) and the original id is returned.
+
+        For recurring kinds, ``due_at`` is ignored — the next slot
+        is computed by :func:`calculate_next_due_at` using ``time``
+        (and ``weekday`` / ``day_of_month`` where relevant).
+        """
+        task_text = (request.task or "").strip()
+        if not task_text:
+            raise ValueError("task must be a non-empty string")
+        if not request.user_id:
+            raise ValueError("user_id must be a non-empty string")
+
+        kind = request.kind or "once"
+
+        if kind == "once":
+            if not request.due_at:
+                raise ValueError(
+                    "due_at is required for one-off reminders"
+                )
+            try:
+                due_dt = _parse_iso(request.due_at)
+            except ValueError as err:
+                raise ValueError(
+                    "due_at must be a valid ISO 8601 absolute time, "
+                    "for example 2026-04-21T06:00:00+08:00"
+                ) from err
+            if due_dt.tzinfo is None:
+                due_dt = due_dt.replace(tzinfo=timezone.utc)
+            now = self._now()
+            if due_dt <= now:
+                raise ValueError(
+                    "due_at must be strictly in the future"
+                )
+            iso_due_at = _iso_utc(due_dt)
+            minute_key = iso_due_at[:ISO_MINUTE_LEN]
+
+            merge_target = self._store.find_mergeable_one_off(
+                user_id=request.user_id, minute_key=minute_key
+            )
+            if merge_target is not None:
+                merged = self._store.append_task(
+                    reminder_id=merge_target.id,
+                    additional_task=task_text,
+                )
+                if merged is None:
+                    raise RuntimeError(
+                        f"failed to merge into reminder #{merge_target.id}"
+                    )
+                self._emit(
+                    "reminder_merged",
+                    {
+                        "id": merge_target.id,
+                        "user_id": request.user_id,
+                        "due_at": merge_target.due_at,
+                        "task": merged.task,
+                    },
+                )
+                return merged
+
+            new_row = Reminder(
+                id=0,  # store assigns real id
+                user_id=request.user_id,
+                due_at=iso_due_at,
+                task=task_text,
+                status="pending",
+                source=request.source,
+                recurrence_type=None,
+                recurrence_config=None,
+            )
+            created = self._store.create(new_row)
+            self._emit(
+                "reminder_created",
+                {
+                    "id": created.id,
+                    "user_id": created.user_id,
+                    "due_at": created.due_at,
+                    "task": created.task,
+                },
+            )
+            return created
+
+        if kind not in _VALID_RECURRENCE:
+            raise ValueError(
+                f"Unknown kind {kind!r}: supports once/daily/weekly/monthly"
+            )
+
+        config: dict[str, Any] = {"time": request.time}
+        if kind == "weekly":
+            config["weekday"] = request.weekday
+        elif kind == "monthly":
+            config["day_of_month"] = request.day_of_month
+
+        next_dt = calculate_next_due_at(kind, config, from_dt=self._now())
+        iso_due_at = _iso_utc(next_dt)
+        new_row = Reminder(
+            id=0,
+            user_id=request.user_id,
+            due_at=iso_due_at,
+            task=task_text,
+            status="pending",
+            source=request.source,
+            recurrence_type=kind,
+            recurrence_config=dict(config),
+        )
+        created = self._store.create(new_row)
+        self._emit(
+            "reminder_created",
+            {
+                "id": created.id,
+                "user_id": created.user_id,
+                "due_at": created.due_at,
+                "task": created.task,
+                "recurrence_type": kind,
+                "recurrence_config": dict(config),
+            },
+        )
+        return created
+
+    def cancel(self, reminder_id: int) -> Reminder:
+        """Cancel a pending reminder. Raises :class:`ValueError` on
+        unknown / non-pending rows so tool layers can format a
+        message from the exception."""
+        existing = self._store.get_by_id(reminder_id)
+        if existing is None:
+            raise ValueError(f"reminder #{reminder_id} not found")
+        if existing.status != "pending":
+            raise ValueError(
+                f"reminder #{reminder_id} is {existing.status}, "
+                "cannot cancel"
+            )
+        cancelled = self._store.cancel(
+            reminder_id=reminder_id,
+            cancelled_at=_iso_utc(self._now()),
+        )
+        if cancelled is None:
+            raise RuntimeError(
+                f"failed to cancel reminder #{reminder_id}"
+            )
+        self._emit(
+            "reminder_cancelled",
+            {
+                "id": cancelled.id,
+                "user_id": cancelled.user_id,
+                "task": cancelled.task,
+            },
+        )
+        return cancelled
+
+    def list_pending(self, limit: int = 50) -> list[Reminder]:
+        return list(self._store.list_pending(limit=limit))
+
+    def get(self, reminder_id: int) -> Optional[Reminder]:
+        return self._store.get_by_id(reminder_id)
+
+    def due_now(self, *, limit: int = 20) -> list[Reminder]:
+        """Return reminders whose ``due_at`` has passed. Callers are
+        expected to fire them and then invoke :meth:`mark_fired` or
+        :meth:`advance_recurring`."""
+        return list(
+            self._store.list_due(
+                now_iso=_iso_utc(self._now()), limit=limit
+            )
+        )
+
+    def mark_fired(self, reminder_id: int) -> Reminder:
+        """Mark a one-off reminder as fired. For recurring reminders,
+        prefer :meth:`advance_recurring` which reschedules in place.
+        """
+        fired = self._store.mark_fired(
+            reminder_id=reminder_id, fired_at=_iso_utc(self._now())
+        )
+        if fired is None:
+            raise RuntimeError(
+                f"reminder #{reminder_id} could not be marked fired "
+                "(unknown id or not pending)"
+            )
+        return fired
+
+    def advance_recurring(self, reminder_id: int) -> Reminder:
+        """Compute the *next* ``due_at`` for a recurring reminder and
+        update in place. No-op semantics for one-offs (raises)."""
+        existing = self._store.get_by_id(reminder_id)
+        if existing is None:
+            raise ValueError(f"reminder #{reminder_id} not found")
+        if not existing.recurrence_type or not existing.recurrence_config:
+            raise ValueError(
+                f"reminder #{reminder_id} is not recurring"
+            )
+        next_dt = calculate_next_due_at(
+            existing.recurrence_type,
+            existing.recurrence_config,
+            from_dt=self._now(),
+        )
+        advanced = self._store.advance_due_at(
+            reminder_id=reminder_id,
+            next_due_at=_iso_utc(next_dt),
+        )
+        if advanced is None:
+            raise RuntimeError(
+                f"failed to advance reminder #{reminder_id}"
+            )
+        return advanced
+
+
+__all__ = [
+    "ISO_MINUTE_LEN",
+    "Reminder",
+    "ReminderCreateRequest",
+    "ReminderManager",
+    "ReminderStore",
+    "RecurrenceKind",
+    "calculate_next_due_at",
+    "format_reminder_row",
+]

--- a/tests/agent/test_prefetch.py
+++ b/tests/agent/test_prefetch.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the prefetch runner.
+
+Focus on the framework contract, not any specific task shape:
+
+* Registration replaces on same source (avoid cache races).
+* Concurrent execution: one slow task doesn't hold the batch.
+* Fetch errors → captured in outcome, do not raise, do not abort peers.
+* Cache-write errors → captured too.
+* Dynamic-provider task list is merged; broken provider is silently
+  ignored (static tasks still run).
+* Selective run by task_sources filters correctly.
+* clear_expired is always called first; failures there don't abort.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Sequence
+
+import pytest
+
+from agent.prefetch import (
+    PrefetchOutcome,
+    PrefetchRunner,
+    PrefetchTask,
+)
+
+
+# ── Fake cache store ───────────────────────────────────────────────
+
+
+class FakeCache:
+    def __init__(self, *, fail_expire: bool = False, fail_save_for: str | None = None):
+        self.saved: list[dict] = []
+        self.cleared: int = 0
+        self.fail_expire = fail_expire
+        self.fail_save_for = fail_save_for
+
+    def save(
+        self,
+        *,
+        source: str,
+        content: str,
+        ttl_minutes: int,
+        tags: Sequence[str],
+    ) -> None:
+        if self.fail_save_for and self.fail_save_for == source:
+            raise RuntimeError(f"cache disk full for {source}")
+        self.saved.append(
+            {
+                "source": source,
+                "content": content,
+                "ttl_minutes": ttl_minutes,
+                "tags": list(tags),
+            }
+        )
+
+    def clear_expired(self) -> None:
+        self.cleared += 1
+        if self.fail_expire:
+            raise RuntimeError("clear failed")
+
+
+# ── Registration ────────────────────────────────────────────────────
+
+
+def test_register_rejects_empty_source() -> None:
+    runner = PrefetchRunner(cache=FakeCache())
+    with pytest.raises(ValueError):
+        runner.register(PrefetchTask(source="", fetch=lambda: asyncio.sleep(0)))  # type: ignore[arg-type]
+
+
+def test_register_rejects_non_callable_fetch() -> None:
+    runner = PrefetchRunner(cache=FakeCache())
+    with pytest.raises(ValueError):
+        runner.register(PrefetchTask(source="x", fetch="not callable"))  # type: ignore[arg-type]
+
+
+def test_register_overwrites_on_same_source() -> None:
+    """Same-source duplicates would race on the cache row, so keyed
+    replacement is safer than list append.
+    """
+    runner = PrefetchRunner(cache=FakeCache())
+
+    async def a() -> str:
+        return "A"
+
+    async def b() -> str:
+        return "B"
+
+    runner.register(PrefetchTask(source="x", fetch=a))
+    runner.register(PrefetchTask(source="x", fetch=b, label="second"))
+    assert runner.registered_sources() == ["x"]
+
+
+def test_unregister_returns_removal_status() -> None:
+    runner = PrefetchRunner(cache=FakeCache())
+
+    async def f() -> str:
+        return ""
+
+    runner.register(PrefetchTask(source="x", fetch=f))
+    assert runner.unregister("x") is True
+    assert runner.unregister("x") is False
+
+
+# ── Execution ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_writes_to_cache_on_success() -> None:
+    cache = FakeCache()
+    runner = PrefetchRunner(cache=cache)
+
+    async def fetch_weather() -> str:
+        return "sunny, 25C"
+
+    runner.register(
+        PrefetchTask(
+            source="weather:x",
+            fetch=fetch_weather,
+            ttl_minutes=30,
+            label="Weather X",
+            tags=["weather", "x"],
+        )
+    )
+    outcomes = await runner.run()
+    assert outcomes == [
+        PrefetchOutcome(source="weather:x", label="Weather X", ok=True)
+    ]
+    assert cache.saved == [
+        {
+            "source": "weather:x",
+            "content": "sunny, 25C",
+            "ttl_minutes": 30,
+            "tags": ["weather", "x"],
+        }
+    ]
+    assert cache.cleared == 1  # clear_expired invoked once
+
+
+@pytest.mark.asyncio
+async def test_run_returns_empty_when_no_tasks() -> None:
+    cache = FakeCache()
+    runner = PrefetchRunner(cache=cache)
+    outcomes = await runner.run()
+    assert outcomes == []
+    # cache.cleared is still called — a run with nothing to fetch
+    # still gets a chance to sweep expired rows.
+    assert cache.cleared == 1
+
+
+@pytest.mark.asyncio
+async def test_run_captures_fetch_exception() -> None:
+    cache = FakeCache()
+    runner = PrefetchRunner(cache=cache)
+
+    async def broken() -> str:
+        raise RuntimeError("no network")
+
+    runner.register(PrefetchTask(source="x", fetch=broken, label="X"))
+    outcomes = await runner.run()
+    assert outcomes[0].ok is False
+    assert outcomes[0].error is not None
+    assert "no network" in outcomes[0].error
+    assert cache.saved == []
+
+
+@pytest.mark.asyncio
+async def test_run_captures_cache_write_exception() -> None:
+    cache = FakeCache(fail_save_for="x")
+    runner = PrefetchRunner(cache=cache)
+
+    async def ok() -> str:
+        return "content"
+
+    runner.register(PrefetchTask(source="x", fetch=ok))
+    outcomes = await runner.run()
+    assert outcomes[0].ok is False
+    assert "disk full" in (outcomes[0].error or "")
+    assert cache.saved == []
+
+
+@pytest.mark.asyncio
+async def test_run_isolates_failing_task_from_healthy_peers() -> None:
+    """One broken task must not abort the batch."""
+    cache = FakeCache()
+    runner = PrefetchRunner(cache=cache)
+
+    async def good() -> str:
+        return "OK"
+
+    async def bad() -> str:
+        raise RuntimeError("oops")
+
+    runner.register(PrefetchTask(source="good", fetch=good))
+    runner.register(PrefetchTask(source="bad", fetch=bad))
+    outcomes = await runner.run()
+    by_source = {o.source: o for o in outcomes}
+    assert by_source["good"].ok is True
+    assert by_source["bad"].ok is False
+    assert [row["source"] for row in cache.saved] == ["good"]
+
+
+@pytest.mark.asyncio
+async def test_run_executes_concurrently() -> None:
+    """A slow task shouldn't hold a fast one — verify by checking the
+    total wall-clock time is closer to max(t) than sum(t).
+    """
+    cache = FakeCache()
+    runner = PrefetchRunner(cache=cache)
+
+    async def slow() -> str:
+        await asyncio.sleep(0.15)
+        return "slow"
+
+    async def fast() -> str:
+        await asyncio.sleep(0.01)
+        return "fast"
+
+    runner.register(PrefetchTask(source="slow", fetch=slow))
+    runner.register(PrefetchTask(source="fast", fetch=fast))
+
+    started = time.monotonic()
+    outcomes = await runner.run()
+    elapsed = time.monotonic() - started
+
+    assert all(o.ok for o in outcomes)
+    # Sequential would be ~0.16s; concurrent should be ~0.15s.
+    # Give it plenty of slack for CI variance but rule out sequential.
+    assert elapsed < 0.30, f"batch took {elapsed:.3f}s — looks sequential"
+
+
+@pytest.mark.asyncio
+async def test_run_filters_by_task_sources() -> None:
+    cache = FakeCache()
+    runner = PrefetchRunner(cache=cache)
+
+    async def a() -> str:
+        return "A"
+
+    async def b() -> str:
+        return "B"
+
+    runner.register(PrefetchTask(source="a", fetch=a))
+    runner.register(PrefetchTask(source="b", fetch=b))
+
+    outcomes = await runner.run(task_sources=["a"])
+    assert [o.source for o in outcomes] == ["a"]
+    assert [row["source"] for row in cache.saved] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_run_survives_failing_clear_expired() -> None:
+    cache = FakeCache(fail_expire=True)
+    runner = PrefetchRunner(cache=cache)
+
+    async def ok() -> str:
+        return "content"
+
+    runner.register(PrefetchTask(source="x", fetch=ok))
+    outcomes = await runner.run()
+    assert outcomes[0].ok is True
+    assert cache.saved[0]["source"] == "x"
+
+
+# ── Dynamic task provider ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dynamic_provider_supplies_additional_tasks() -> None:
+    cache = FakeCache()
+
+    async def dyn_fetch() -> str:
+        return "dyn"
+
+    def provider() -> list[PrefetchTask]:
+        return [
+            PrefetchTask(source="dyn:x", fetch=dyn_fetch, ttl_minutes=15)
+        ]
+
+    runner = PrefetchRunner(cache=cache, dynamic_provider=provider)
+    outcomes = await runner.run()
+    assert [o.source for o in outcomes] == ["dyn:x"]
+    assert cache.saved[0]["ttl_minutes"] == 15
+
+
+@pytest.mark.asyncio
+async def test_dynamic_provider_does_not_shadow_static_task() -> None:
+    """If a dynamic task uses the same source as a static one, the
+    static registration wins — otherwise a plugin could silently
+    replace a core task.
+    """
+    cache = FakeCache()
+
+    async def static_fetch() -> str:
+        return "static"
+
+    async def dyn_fetch() -> str:
+        return "dyn"
+
+    def provider() -> list[PrefetchTask]:
+        return [PrefetchTask(source="shared", fetch=dyn_fetch, ttl_minutes=99)]
+
+    runner = PrefetchRunner(cache=cache, dynamic_provider=provider)
+    runner.register(PrefetchTask(source="shared", fetch=static_fetch, ttl_minutes=10))
+    outcomes = await runner.run()
+    assert len(outcomes) == 1
+    assert cache.saved[0]["content"] == "static"
+    assert cache.saved[0]["ttl_minutes"] == 10
+
+
+@pytest.mark.asyncio
+async def test_dynamic_provider_error_is_absorbed() -> None:
+    cache = FakeCache()
+
+    def broken_provider() -> list[PrefetchTask]:
+        raise RuntimeError("db offline")
+
+    async def ok() -> str:
+        return "static"
+
+    runner = PrefetchRunner(cache=cache, dynamic_provider=broken_provider)
+    runner.register(PrefetchTask(source="s", fetch=ok))
+    outcomes = await runner.run()
+    # Static task still ran.
+    assert [o.source for o in outcomes] == ["s"]
+    assert outcomes[0].ok is True

--- a/tests/agent/test_reminders.py
+++ b/tests/agent/test_reminders.py
@@ -1,0 +1,552 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the reminders domain module.
+
+Focus on invariants, not on any concrete store implementation:
+
+* calculate_next_due_at is a pure function — daily/weekly/monthly all
+  produce the strictly-next matching wall-clock instant.
+* Same-minute one-off for the same user merges (BaiLongma parity).
+* Past-time one-offs are rejected.
+* Recurrence config errors surface as ValueError.
+* emit_event hook receives payloads for create / merged / cancelled;
+  a broken hook does NOT lose state changes.
+* Manager time is injectable via now_fn — no wall-clock dependence.
+* advance_recurring updates due_at using the SAME recurrence config
+  the row was created with (not whatever the caller happens to send).
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Sequence
+
+import pytest
+
+from agent.reminders import (
+    Reminder,
+    ReminderCreateRequest,
+    ReminderManager,
+    calculate_next_due_at,
+    format_reminder_row,
+)
+
+
+# ── In-memory store ────────────────────────────────────────────────
+
+
+class InMemoryReminderStore:
+    """A dict-backed reference implementation of ReminderStore."""
+
+    def __init__(self) -> None:
+        self._rows: dict[int, Reminder] = {}
+        self._next_id = 1
+
+    # Write-side ------------------------------------------------------
+
+    def create(self, reminder: Reminder) -> Reminder:
+        new = replace(reminder, id=self._next_id)
+        self._rows[self._next_id] = new
+        self._next_id += 1
+        return new
+
+    def find_mergeable_one_off(
+        self, *, user_id: str, minute_key: str
+    ) -> Optional[Reminder]:
+        for r in sorted(self._rows.values(), key=lambda x: x.id):
+            if (
+                r.status == "pending"
+                and r.recurrence_type is None
+                and r.user_id == user_id
+                and r.due_at[:16] == minute_key
+            ):
+                return r
+        return None
+
+    def append_task(
+        self, *, reminder_id: int, additional_task: str
+    ) -> Optional[Reminder]:
+        row = self._rows.get(reminder_id)
+        if row is None or row.status != "pending":
+            return None
+        merged = replace(row, task=f"{row.task}; {additional_task}")
+        self._rows[reminder_id] = merged
+        return merged
+
+    def get_by_id(self, reminder_id: int) -> Optional[Reminder]:
+        return self._rows.get(reminder_id)
+
+    def cancel(
+        self, *, reminder_id: int, cancelled_at: str
+    ) -> Optional[Reminder]:
+        row = self._rows.get(reminder_id)
+        if row is None or row.status != "pending":
+            return None
+        updated = replace(row, status="cancelled", cancelled_at=cancelled_at)
+        self._rows[reminder_id] = updated
+        return updated
+
+    def mark_fired(
+        self, *, reminder_id: int, fired_at: str
+    ) -> Optional[Reminder]:
+        row = self._rows.get(reminder_id)
+        if row is None or row.status != "pending":
+            return None
+        updated = replace(row, status="fired", fired_at=fired_at)
+        self._rows[reminder_id] = updated
+        return updated
+
+    def advance_due_at(
+        self, *, reminder_id: int, next_due_at: str
+    ) -> Optional[Reminder]:
+        row = self._rows.get(reminder_id)
+        if row is None or row.status != "pending":
+            return None
+        updated = replace(row, due_at=next_due_at)
+        self._rows[reminder_id] = updated
+        return updated
+
+    # Read-side -------------------------------------------------------
+
+    def list_pending(self, limit: int = 50) -> Sequence[Reminder]:
+        rows = [r for r in self._rows.values() if r.status == "pending"]
+        return sorted(rows, key=lambda r: (r.due_at, r.id))[:limit]
+
+    def list_due(self, *, now_iso: str, limit: int = 20) -> Sequence[Reminder]:
+        rows = [
+            r
+            for r in self._rows.values()
+            if r.status == "pending" and r.due_at <= now_iso
+        ]
+        return sorted(rows, key=lambda r: (r.due_at, r.id))[:limit]
+
+    def next_pending(self) -> Optional[Reminder]:
+        pending = self.list_pending(limit=1)
+        return pending[0] if pending else None
+
+
+def _fixed_now(dt: datetime):
+    return lambda: dt
+
+
+# ── Recurrence engine ──────────────────────────────────────────────
+
+
+def test_calculate_next_due_at_daily_wraps_to_next_day() -> None:
+    now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+    result = calculate_next_due_at("daily", {"time": "09:00"}, from_dt=now)
+    assert result == datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc)
+
+
+def test_calculate_next_due_at_daily_uses_today_if_time_still_ahead() -> None:
+    now = datetime(2026, 4, 21, 5, 0, 0, tzinfo=timezone.utc)
+    result = calculate_next_due_at("daily", {"time": "09:00"}, from_dt=now)
+    assert result == datetime(2026, 4, 21, 9, 0, tzinfo=timezone.utc)
+
+
+def test_calculate_next_due_at_weekly_uses_sunday_zero_convention() -> None:
+    """BaiLongma follows JS getDay(): 0=Sunday. 2026-04-21 is a Tuesday
+    (JS getDay=2). Asking for weekday=2 with a time still in the future
+    should land on the same day."""
+    now = datetime(2026, 4, 21, 7, 0, 0, tzinfo=timezone.utc)
+    result = calculate_next_due_at(
+        "weekly", {"time": "09:00", "weekday": 2}, from_dt=now
+    )
+    assert result == datetime(2026, 4, 21, 9, 0, tzinfo=timezone.utc)
+
+
+def test_calculate_next_due_at_weekly_advances_seven_days_when_slot_passed() -> None:
+    """Same weekday, but the slot has already passed → next week."""
+    now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)  # Tue
+    result = calculate_next_due_at(
+        "weekly", {"time": "09:00", "weekday": 2}, from_dt=now
+    )
+    assert result == datetime(2026, 4, 28, 9, 0, tzinfo=timezone.utc)
+
+
+def test_calculate_next_due_at_weekly_rejects_invalid_weekday() -> None:
+    now = datetime(2026, 4, 21, tzinfo=timezone.utc)
+    with pytest.raises(ValueError, match="weekday must be"):
+        calculate_next_due_at(
+            "weekly", {"time": "09:00", "weekday": 7}, from_dt=now
+        )
+
+
+def test_calculate_next_due_at_monthly_skips_short_months() -> None:
+    """Asking for day 31 in a January that's already past its 31st
+    should return the next month with 31 days (March)."""
+    now = datetime(2026, 2, 5, 12, 0, tzinfo=timezone.utc)
+    result = calculate_next_due_at(
+        "monthly", {"time": "09:00", "day_of_month": 31}, from_dt=now
+    )
+    assert result == datetime(2026, 3, 31, 9, 0, tzinfo=timezone.utc)
+
+
+def test_calculate_next_due_at_monthly_rejects_invalid_day() -> None:
+    now = datetime(2026, 4, 21, tzinfo=timezone.utc)
+    with pytest.raises(ValueError, match="day_of_month must be"):
+        calculate_next_due_at(
+            "monthly", {"time": "09:00", "day_of_month": 32}, from_dt=now
+        )
+
+
+def test_calculate_next_due_at_rejects_bad_time_format() -> None:
+    now = datetime(2026, 4, 21, tzinfo=timezone.utc)
+    with pytest.raises(ValueError, match="HH:MM"):
+        calculate_next_due_at(
+            "daily", {"time": "9-00"}, from_dt=now
+        )
+
+
+def test_calculate_next_due_at_rejects_unknown_kind() -> None:
+    now = datetime(2026, 4, 21, tzinfo=timezone.utc)
+    with pytest.raises(ValueError, match="Unknown recurrence kind"):
+        calculate_next_due_at("hourly", {"time": "09:00"}, from_dt=now)
+
+
+# ── Manager.create — one-off ───────────────────────────────────────
+
+
+def _mk_manager(now: datetime, emit=None):
+    return ReminderManager(
+        store=InMemoryReminderStore(), now_fn=_fixed_now(now), emit_event=emit
+    )
+
+
+def test_create_one_off_stores_row() -> None:
+    now = datetime(2026, 4, 21, 6, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    created = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="drink water", due_at="2026-04-21T08:00:00+00:00"
+        )
+    )
+    assert created.id == 1
+    assert created.user_id == "u1"
+    assert created.task == "drink water"
+    assert created.due_at.startswith("2026-04-21T08:00")
+    assert created.status == "pending"
+    assert created.recurrence_type is None
+
+
+def test_create_one_off_rejects_empty_task() -> None:
+    mgr = _mk_manager(datetime(2026, 4, 21, tzinfo=timezone.utc))
+    with pytest.raises(ValueError, match="task must be"):
+        mgr.create(
+            ReminderCreateRequest(
+                user_id="u1", task="   ", due_at="2026-04-21T08:00Z"
+            )
+        )
+
+
+def test_create_one_off_rejects_past_due_at() -> None:
+    now = datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    with pytest.raises(ValueError, match="strictly in the future"):
+        mgr.create(
+            ReminderCreateRequest(
+                user_id="u1",
+                task="ping",
+                due_at="2026-04-21T06:00:00+00:00",
+            )
+        )
+
+
+def test_create_one_off_rejects_missing_due_at() -> None:
+    mgr = _mk_manager(datetime(2026, 4, 21, tzinfo=timezone.utc))
+    with pytest.raises(ValueError, match="due_at is required"):
+        mgr.create(ReminderCreateRequest(user_id="u1", task="ping"))
+
+
+def test_create_one_off_rejects_malformed_due_at() -> None:
+    mgr = _mk_manager(datetime(2026, 4, 21, tzinfo=timezone.utc))
+    with pytest.raises(ValueError, match="valid ISO 8601"):
+        mgr.create(
+            ReminderCreateRequest(
+                user_id="u1", task="ping", due_at="not-a-date"
+            )
+        )
+
+
+def test_create_one_off_merges_same_minute_same_user() -> None:
+    now = datetime(2026, 4, 21, 6, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    first = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="alpha", due_at="2026-04-21T08:00:00Z"
+        )
+    )
+    second = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="beta", due_at="2026-04-21T08:00:59Z"
+        )
+    )
+    assert second.id == first.id
+    assert second.task == "alpha; beta"
+    # Only one row stored.
+    assert len(mgr.list_pending()) == 1
+
+
+def test_create_one_off_different_user_does_not_merge() -> None:
+    now = datetime(2026, 4, 21, 6, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    a = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="alpha", due_at="2026-04-21T08:00:00Z"
+        )
+    )
+    b = mgr.create(
+        ReminderCreateRequest(
+            user_id="u2", task="beta", due_at="2026-04-21T08:00:00Z"
+        )
+    )
+    assert a.id != b.id
+    assert len(mgr.list_pending()) == 2
+
+
+def test_create_one_off_different_minute_does_not_merge() -> None:
+    now = datetime(2026, 4, 21, 6, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    a = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="alpha", due_at="2026-04-21T08:00:00Z"
+        )
+    )
+    b = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="beta", due_at="2026-04-21T08:01:00Z"
+        )
+    )
+    assert a.id != b.id
+
+
+# ── Manager.create — recurrence ────────────────────────────────────
+
+
+def test_create_daily_computes_next_slot() -> None:
+    now = datetime(2026, 4, 21, 12, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    row = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="wake up", kind="daily", time="09:00"
+        )
+    )
+    assert row.recurrence_type == "daily"
+    assert row.recurrence_config == {"time": "09:00"}
+    assert row.due_at.startswith("2026-04-22T09:00")
+
+
+def test_create_weekly_requires_weekday() -> None:
+    mgr = _mk_manager(datetime(2026, 4, 21, tzinfo=timezone.utc))
+    with pytest.raises(ValueError):
+        mgr.create(
+            ReminderCreateRequest(
+                user_id="u1", task="review", kind="weekly", time="10:00"
+            )
+        )
+
+
+def test_create_monthly_stores_config() -> None:
+    now = datetime(2026, 4, 21, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    row = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1",
+            task="rent",
+            kind="monthly",
+            time="09:00",
+            day_of_month=25,
+        )
+    )
+    assert row.recurrence_type == "monthly"
+    assert row.recurrence_config == {"time": "09:00", "day_of_month": 25}
+
+
+def test_create_rejects_unknown_kind() -> None:
+    mgr = _mk_manager(datetime(2026, 4, 21, tzinfo=timezone.utc))
+    with pytest.raises(ValueError, match="Unknown kind"):
+        mgr.create(
+            ReminderCreateRequest(
+                user_id="u1", task="x", kind="hourly", time="09:00"
+            )
+        )
+
+
+# ── cancel / list / mark_fired / advance_recurring ─────────────────
+
+
+def test_cancel_marks_row_cancelled() -> None:
+    now = datetime(2026, 4, 21, 6, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    created = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="ping", due_at="2026-04-21T08:00Z"
+        )
+    )
+    cancelled = mgr.cancel(created.id)
+    assert cancelled.status == "cancelled"
+    assert cancelled.cancelled_at is not None
+    assert mgr.list_pending() == []
+
+
+def test_cancel_rejects_unknown_id() -> None:
+    mgr = _mk_manager(datetime(2026, 4, 21, tzinfo=timezone.utc))
+    with pytest.raises(ValueError, match="not found"):
+        mgr.cancel(999)
+
+
+def test_cancel_rejects_already_fired_row() -> None:
+    now = datetime(2026, 4, 21, 6, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    created = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="ping", due_at="2026-04-21T08:00Z"
+        )
+    )
+    mgr.mark_fired(created.id)
+    with pytest.raises(ValueError, match="fired"):
+        mgr.cancel(created.id)
+
+
+def test_due_now_returns_only_past_due_pending() -> None:
+    now = datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    # One in the past (past due), one in the future (not due)
+    mgr._now_fn = _fixed_now(  # bypass "future" check for setup
+        datetime(2026, 4, 21, 5, 0, tzinfo=timezone.utc)
+    )
+    r1 = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="past", due_at="2026-04-21T06:00Z"
+        )
+    )
+    r2 = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="future", due_at="2026-04-21T10:00Z"
+        )
+    )
+    mgr._now_fn = _fixed_now(now)  # restore
+    due = mgr.due_now()
+    assert [r.id for r in due] == [r1.id]
+    # r2 is still pending, just not due yet.
+    assert r2.id in {r.id for r in mgr.list_pending()}
+
+
+def test_mark_fired_rejects_unknown_or_non_pending() -> None:
+    mgr = _mk_manager(datetime(2026, 4, 21, tzinfo=timezone.utc))
+    with pytest.raises(RuntimeError):
+        mgr.mark_fired(999)
+
+
+def test_advance_recurring_reschedules_daily() -> None:
+    now = datetime(2026, 4, 21, 5, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    row = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="wake", kind="daily", time="09:00"
+        )
+    )
+    # first fire: due_at = 2026-04-21 09:00 (today's future)
+    assert row.due_at.startswith("2026-04-21T09:00")
+
+    # Simulate firing at 09:05 and advancing.
+    mgr._now_fn = _fixed_now(
+        datetime(2026, 4, 21, 9, 5, tzinfo=timezone.utc)
+    )
+    advanced = mgr.advance_recurring(row.id)
+    assert advanced.due_at.startswith("2026-04-22T09:00")
+
+
+def test_advance_recurring_rejects_one_off() -> None:
+    now = datetime(2026, 4, 21, 5, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now)
+    row = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="ping", due_at="2026-04-21T08:00Z"
+        )
+    )
+    with pytest.raises(ValueError, match="not recurring"):
+        mgr.advance_recurring(row.id)
+
+
+# ── emit_event ─────────────────────────────────────────────────────
+
+
+def test_emit_event_fires_on_create_and_cancel() -> None:
+    hits: list[tuple[str, dict]] = []
+    now = datetime(2026, 4, 21, 6, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now, emit=lambda n, p: hits.append((n, p)))
+    row = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="alpha", due_at="2026-04-21T08:00Z"
+        )
+    )
+    mgr.cancel(row.id)
+    assert [h[0] for h in hits] == ["reminder_created", "reminder_cancelled"]
+    assert hits[0][1]["task"] == "alpha"
+    assert hits[1][1]["id"] == row.id
+
+
+def test_emit_event_fires_reminder_merged_on_same_minute_second_create() -> None:
+    hits: list[tuple[str, dict]] = []
+    now = datetime(2026, 4, 21, 6, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now, emit=lambda n, p: hits.append((n, p)))
+    mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="alpha", due_at="2026-04-21T08:00Z"
+        )
+    )
+    mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="beta", due_at="2026-04-21T08:00Z"
+        )
+    )
+    event_names = [h[0] for h in hits]
+    assert event_names == ["reminder_created", "reminder_merged"]
+    assert hits[1][1]["task"] == "alpha; beta"
+
+
+def test_emit_event_hook_error_does_not_lose_state_change() -> None:
+    def broken(name, payload):  # noqa: ARG001
+        raise RuntimeError("hook down")
+
+    now = datetime(2026, 4, 21, 6, 0, tzinfo=timezone.utc)
+    mgr = _mk_manager(now, emit=broken)
+    row = mgr.create(
+        ReminderCreateRequest(
+            user_id="u1", task="ping", due_at="2026-04-21T08:00Z"
+        )
+    )
+    assert row.id == 1
+    assert mgr.get(row.id) is not None
+
+
+# ── formatter ─────────────────────────────────────────────────────
+
+
+def test_format_reminder_row_one_off() -> None:
+    row = Reminder(
+        id=42,
+        user_id="u1",
+        due_at="2026-04-21T08:00:00Z",
+        task="ping",
+    )
+    text = format_reminder_row(row)
+    assert text.startswith("#42 [once]")
+    assert "2026-04-21T08:00:00Z" in text
+    assert "u1" in text
+    assert "ping" in text
+
+
+def test_format_reminder_row_weekly_uses_zh_weekday() -> None:
+    row = Reminder(
+        id=7,
+        user_id="u1",
+        due_at="2026-04-27T09:00:00Z",
+        task="review",
+        recurrence_type="weekly",
+        recurrence_config={"time": "09:00", "weekday": 1},
+    )
+    text = format_reminder_row(row)
+    assert "[weekly]" in text
+    assert "每周一" in text
+    assert "09:00" in text


### PR DESCRIPTION
## Summary

Add two more dependency-free `agent/` primitives ported from [BaiLongma](https://github.com/xiaoyuanda666-ship-it/BaiLongma) (MIT). Same recipe as PR #66371 — line-by-line translation, per-file SPDX header, no existing code paths touched, no new deps.

Two commits, one module each:

| # | Commit | Module | LOC | Tests |
|---|---|---|---|---|
| 1 | `5ad4fe2e8` | `agent/prefetch.py` | ~340 | 15 |
| 2 | `5854bf377` | `agent/reminders.py` | ~500 | 33 |

**Total: 48 tests, all green.** Stdlib only.

## What each module does — and what it isn't

### `agent/prefetch.py` — background prefetch runner

Concurrent async-batch runner for pre-warming caches (weather, news, whatever the caller has a fetcher for). BaiLongma's upstream `src/prefetch/runner.js` bundled the framework with three hardcoded business tasks (Beijing weather / Lufeng weather / HackerNews top). The port keeps **only the framework**:

- `PrefetchTask` — task descriptor (source, async `fetch`, `ttl_minutes`, `label`, `tags`).
- `PrefetchRunner` — orchestrator with `register()` / `unregister()` / `run()`.
- `PrefetchCacheStore` — Protocol the caller implements (`save()` + `clear_expired()`).
- `DynamicTaskProvider` — optional callable so DB-backed / plugin-backed task lists compose in without the runner caring.

**Invariants**:
- Never blocks or aborts. `asyncio.gather` with per-task exception isolation — one failure never affects peers.
- Both fetch and cache-write errors captured into `PrefetchOutcome`; `run()` never raises.
- Static registrations always win over dynamic-provider tasks with the same source (so a plugin can't silently replace a core task).
- Broken dynamic providers are absorbed; static tasks still run.
- `clear_expired` failures don't abort the batch.
- Same-source `register()` **replaces** (rather than appends) so two tasks can't race on the cache row.

**Not included**: The three hardcoded business tasks. Those belong in a plugin, not in Hermes core.

### `agent/reminders.py` — user-facing reminders (NOT cron)

Hermes already ships `cron/` for scheduling *agent jobs*. Reminders solve a different problem — they belong to a **user** (or conversation party), and they have their own semantics that cron doesn't:

- **Same-minute merging.** A one-off reminder in the same UTC minute for the same user merges into the existing row: `"remind me at 6pm to X / to Y / to Z"` → one entry with `task = "X; Y; Z"`. Matches BaiLongma's SQL `substr(due_at, 1, 16)` semantics.
- **Recurrence with per-kind config.** Daily / weekly / monthly with pure-function `calculate_next_due_at()` — usable standalone to preview "when is the next Tuesday 09:00?" without persisting anything.
- **Fired-status tracking.** Rows persist `pending` / `fired` / `cancelled` so a late-woken agent knows what it missed instead of double-firing.
- **In-place recurrence advancement.** `advance_recurring()` reschedules using the recurrence config the row was created with — not whatever the caller happens to send.

**Domain library, not a tool layer.** The module exposes:
- `Reminder` / `ReminderCreateRequest` dataclasses.
- `ReminderStore` Protocol (10 methods: create / find_mergeable_one_off / append_task / get_by_id / cancel / mark_fired / advance_due_at / list_pending / list_due / next_pending).
- `ReminderManager` — orchestrates create/cancel/list/due_now/mark_fired/advance_recurring against a DI store.
- `calculate_next_due_at()` — pure recurrence math, no store dependency.
- `format_reminder_row()` — human-readable formatter (Chinese weekday labels preserved for parity with upstream tests).

**Not included**: `buildSystemMessage()`, `emitEvent`, `PRIMARY_USER_ID`, `normalizeConversationPartyId()`. Those are BaiLongma's business plumbing — identity, message routing, event bus. They belong in whatever adapter surfaces reminders to a user, not in Hermes core.

**Weekday convention**: BaiLongma uses JS `getDay()` (0=Sunday..6=Saturday). The port preserves this to keep the behaviour identical — using Python's default 0=Monday would silently change the meaning of `weekday=2` for users porting existing reminder rules.

## Design invariants (both modules)

- **Zero core mutation.** No changes to `run_agent.py`, `cli.py`, `model_tools.py`, `toolsets.py`, or the gateway. Nothing wires these in. They are strictly libraries.
- **Dependency injection everywhere.** All external I/O (HTTP, DB, event bus, wall clock) is a Protocol / callable parameter. No module reaches for a global.
- **Stdlib only.** No new `pyproject.toml` entries.
- **Cache safety.** Neither module writes to the system prompt or touches per-conversation caching.
- **Tests over mocks.** All 48 tests exercise real code paths against DI seams (in-memory fake stores, scripted fetchers, injected `now_fn`).

## Licensing

Same recipe as PR #66371: per-file SPDX header pointing at the upstream source, full MIT text at `LICENSES/BaiLongma-MIT.txt`, per-module attribution table in `NOTICE.md`.

This branch was cut from `upstream/main` (not from PR #66371's branch) so it can be reviewed and merged independently. If #66371 lands first, this branch will still apply cleanly — the only file both branches touch is `NOTICE.md`, and this branch's row is a strict append.

## Testing

```bash
scripts/run_tests.sh tests/agent/test_prefetch.py tests/agent/test_reminders.py
# 48 passed
```

## Non-goals of this PR

- Not adding built-in prefetch tasks. (Weather / news belong in a plugin.)
- Not wiring reminders into any adapter. That's per-surface work.
- Not adding a SQLite backend for `ReminderStore`. (Straightforward, but a separate concern from the domain model.)

## Follow-up

Once these land, a follow-up plugin (or a thin adapter in each gateway surface) can register concrete tasks / stores. Each integration reviews on its own merits without dragging a 500-line library review along with it.

Happy to split into two PRs if reviewers prefer smaller units.
