### PR TITLE
fix(acp): emit current_mode_update after set_session_mode and set_config_option

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -41,6 +41,7 @@ from acp.schema import (
     PromptCapabilities,
     PromptResponse,
     ResumeSessionResponse,
+    CurrentModeUpdate,
     SetSessionConfigOptionResponse,
     SetSessionModelResponse,
     SetSessionModeResponse,
@@ -733,6 +734,30 @@ class HermesACPAgent(acp.Agent):
                 "Could not build ACP session provenance for %s", acp_session_id, exc_info=True
             )
             return None
+
+    async def _send_current_mode_update(self, session_id: str, mode_id: str) -> None:
+        """Send a current_mode_update notification to the connected ACP client.
+
+        ACP clients like AionCore poll the session's advertised mode snapshot
+        after a set_mode/set_config_option call to confirm the change took
+        effect. Without this notification the snapshot is never updated and
+        the poll times out (10s), causing the UI to show
+        "Failed to apply setting. The previous state is still shown."
+        """
+        if not self._conn:
+            return
+        try:
+            update = CurrentModeUpdate(current_mode_id=mode_id, session_update="current_mode_update")
+            await self._conn.session_update(
+                session_id=session_id,
+                update=update,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to send ACP current_mode_update for session %s",
+                session_id,
+                exc_info=True,
+            )
 
     async def _send_session_info_update(
         self,
@@ -2051,6 +2076,7 @@ class HermesACPAgent(acp.Agent):
         setattr(state, "mode", normalized_mode)
         self.session_manager.save_session(session_id)
         logger.info("Session %s: mode switched to %s", session_id, normalized_mode)
+        await self._send_current_mode_update(session_id, normalized_mode)
         return SetSessionModeResponse()
 
     async def set_config_option(
@@ -2073,4 +2099,6 @@ class HermesACPAgent(acp.Agent):
             setattr(state, "config_options", options)
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
+        if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
+            await self._send_current_mode_update(session_id, mode)
         return SetSessionConfigOptionResponse(config_options=[])

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -83,6 +83,99 @@ async def test_set_config_option_persists_edit_approval_policy_without_advertisi
 
 
 # ---------------------------------------------------------------------------
+# set_session_mode / set_config_option — ACP notification emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_session_mode_emits_current_mode_update(agent):
+    """After set_session_mode, a current_mode_update notification must be sent
+    so ACP clients (AionCore) can confirm the observed value.
+
+    Regression: AionCore polls config_snapshot() for 10s waiting for the
+    advertised mode to match the requested value. Without this notification
+    the poll times out and the UI shows "Failed to apply setting."
+    """
+    new_resp = await agent.new_session(cwd="/tmp")
+
+    sent_updates: list[tuple[str, Any]] = []
+    mock_conn = AsyncMock()
+    mock_conn.session_update = AsyncMock(
+        side_effect=lambda session_id, update: sent_updates.append((session_id, update))
+    )
+    agent._conn = mock_conn
+
+    await agent.set_session_mode(mode_id="accept_edits", session_id=new_resp.session_id)
+
+    assert len(sent_updates) == 1, "expected exactly one session_update notification"
+    sid, update = sent_updates[0]
+    assert sid == new_resp.session_id
+    assert update.session_update == "current_mode_update"
+    assert update.current_mode_id == "accept_edits"
+
+
+@pytest.mark.asyncio
+async def test_set_session_mode_emits_current_mode_update_dont_ask(agent):
+    """The dont_ask mode must also emit a notification."""
+    new_resp = await agent.new_session(cwd="/tmp")
+
+    sent_updates: list[tuple[str, Any]] = []
+    mock_conn = AsyncMock()
+    mock_conn.session_update = AsyncMock(
+        side_effect=lambda session_id, update: sent_updates.append((session_id, update))
+    )
+    agent._conn = mock_conn
+
+    await agent.set_session_mode(mode_id="dont_ask", session_id=new_resp.session_id)
+
+    assert len(sent_updates) == 1
+    _, update = sent_updates[0]
+    assert update.session_update == "current_mode_update"
+    assert update.current_mode_id == "dont_ask"
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_emits_current_mode_update_for_edit_approval(agent):
+    """set_config_option with edit_approval_policy must also emit a
+    current_mode_update since it changes the session mode internally."""
+    new_resp = await agent.new_session(cwd="/tmp")
+
+    sent_updates: list[tuple[str, Any]] = []
+    mock_conn = AsyncMock()
+    mock_conn.session_update = AsyncMock(
+        side_effect=lambda session_id, update: sent_updates.append((session_id, update))
+    )
+    agent._conn = mock_conn
+
+    await agent.set_config_option(
+        "edit_approval_policy",
+        new_resp.session_id,
+        "session",
+    )
+
+    assert len(sent_updates) == 1
+    _, update = sent_updates[0]
+    assert update.session_update == "current_mode_update"
+    assert update.current_mode_id == "dont_ask"
+
+
+@pytest.mark.asyncio
+async def test_set_session_mode_no_notification_when_no_conn(agent):
+    """When no ACP client is connected, the mode change must still succeed
+    without errors (graceful degradation)."""
+    new_resp = await agent.new_session(cwd="/tmp")
+    agent._conn = None
+
+    resp = await agent.set_session_mode(
+        mode_id="dont_ask", session_id=new_resp.session_id
+    )
+
+    assert isinstance(resp, SetSessionModeResponse)
+    state = agent.session_manager.get_session(new_resp.session_id)
+    assert getattr(state, "mode", None) == "dont_ask"
+
+
+# ---------------------------------------------------------------------------
 # initialize
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

ACP clients like AionCore poll the session's advertised mode snapshot for up to 10 seconds after a `session/set_mode` or `session/set_config_option` call to confirm the change took effect. Hermes was persisting the mode change internally but never sending a `current_mode_update` notification, so the snapshot never updated and the poll timed out.

This caused the AionUI to show **"Failed to apply setting. The previous state is still shown."** when switching the permission mode to "Don't Ask" or "Accept Edits".

## Root Cause

In `acp_adapter/server.py`:

- `set_session_mode()` persisted the new mode via `setattr(state, "mode", ...)` and `save_session()`, then returned `SetSessionModeResponse()` — but never called `self._conn.session_update()` with a `CurrentModeUpdate` notification.
- `set_config_option()` had the same gap when the config ID was `edit_approval_policy` (which internally maps to a mode change).
- The ACP `SetSessionModeResponse` schema has no `current_mode_id` field, so the response alone cannot confirm the change — the notification is required.

## Fix

1. **Import `CurrentModeUpdate`** from `acp.schema`.
2. **Add `_send_current_mode_update()` helper** that sends a `CurrentModeUpdate` notification via the ACP client connection. Graceful degradation: if no client is connected (`self._conn is None`), the notification is skipped silently.
3. **Call it from `set_session_mode()`** after persisting the new mode.
4. **Call it from `set_config_option()`** when `edit_approval_policy` changes (since that also updates the internal mode).

## Tests

4 regression tests added in `tests/acp/test_server.py`:

- `test_set_session_mode_emits_current_mode_update` — verifies `accept_edits` emits the correct notification
- `test_set_session_mode_emits_current_mode_update_dont_ask` — verifies `dont_ask` mode
- `test_set_config_option_emits_current_mode_update_for_edit_approval` — verifies the `set_config_option` → `edit_approval_policy` path
- `test_set_session_mode_no_notification_when_no_conn` — graceful degradation when no ACP client connected

All 86 existing tests still pass.

## Verification

Manually tested on AionUI + AionCore against a live Hermes ACP session:
- Before fix: switching to "Don't Ask" or "Accept Edits" → "Failed to apply setting" error after 10s timeout
- After fix: switching → "Mode switched successfully" immediately

> **Note**: This PR is a clean split containing only the ACP `current_mode_update` fix. The unrelated `parse_model_input` repair lives in a separate branch.