### PR TITLE
fix: authorize verified Ollama subscription pool

### DIFF
--- a/agent/subscription_pool.py
+++ b/agent/subscription_pool.py
@@ -1,0 +1,344 @@
+"""Fail-closed subscription-pool selection for delegated workers.
+
+The selector is deliberately independent of profile selection.  A profile owns
+identity, workspace context, and records; a pool route supplies execution
+surface, provider, model, billing attribution, and quota state.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import re
+from typing import Any, Iterable, Mapping, Sequence
+from urllib.parse import urlparse
+
+
+class PoolConfigurationError(ValueError):
+    """A pool route is invalid or ambiguous and must not be executed."""
+
+
+@dataclass(frozen=True)
+class PoolVerification:
+    installed: bool
+    authenticated: bool
+    models_available: bool
+    headless: bool
+    workspace: bool
+    tools: bool
+    quota_visible: bool
+    billing_verified: bool
+    cloud_verified: bool = True
+    # Ollama's local and Cloud model names can overlap. A Cloud endpoint alone
+    # is not enough to establish that the configured model is hosted.
+    cloud_model_verified: bool = True
+
+    @property
+    def complete(self) -> bool:
+        checks = asdict(self)
+        # Ollama Cloud does not expose remaining subscription quota. Quota
+        # visibility is reportable state, not route-verification completeness.
+        checks.pop("quota_visible")
+        return all(checks.values())
+
+
+@dataclass(frozen=True)
+class PoolRouteConfig:
+    route_id: str
+    provider: str
+    model: str
+    execution_surface: str
+    subscription_pool: str
+    billing_mode: str
+    capabilities: tuple[str, ...]
+    priority: int
+    verification: PoolVerification
+    enabled: bool = True
+    paid_usage_possible: bool = False
+    quota_state: str = "available"
+    available_usage: Mapping[str, Any] = field(default_factory=dict)
+    soft_reserve_percent: float | None = None
+    remaining_percent: float | None = None
+    recent_success: float = 1.0
+    verification_burden: int = 0
+    endpoint_host: str = ""
+    # This is the authenticated runtime endpoint observed during route
+    # selection, not policy metadata.  Ollama Cloud routes are only executable
+    # when this concrete value is an approved HTTPS endpoint.
+    runtime_base_url: str = ""
+    model_family: str = ""
+    minimum_generation: int | None = None
+    blockers: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class PoolSelection:
+    selected: PoolRouteConfig
+    rejected: tuple[dict[str, str], ...]
+    fallback_order: tuple[str, ...]
+    selection_reason: str
+
+
+_ALLOWED_SURFACES = {"hermes", "cli"}
+_ALLOWED_BILLING = {"subscription", "metered", "unverified"}
+_ALLOWED_QUOTA = {"available", "soft_reserve", "exhausted", "unknown", "auth_failed"}
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+_OLLAMA_CLOUD_PROVIDERS = {"ollama", "ollama-cloud"}
+_APPROVED_OLLAMA_CLOUD_HOSTS = {"ollama.com"}
+
+
+def _reason(route: PoolRouteConfig, code: str, detail: str) -> dict[str, str]:
+    return {"route_id": route.route_id, "code": code, "reason": detail}
+
+
+def _is_local(route: PoolRouteConfig) -> bool:
+    provider = route.provider.strip().lower()
+    host = route.endpoint_host.strip().lower()
+    return (
+        provider == "local"
+        or provider.startswith("local:")
+        or host in _LOOPBACK_HOSTS
+        or host.endswith(".local")
+    )
+
+
+def _is_ollama_cloud_candidate(route: PoolRouteConfig) -> bool:
+    return route.provider.strip().lower() in _OLLAMA_CLOUD_PROVIDERS
+
+
+def is_approved_ollama_cloud_endpoint(endpoint: str) -> bool:
+    """Accept only the configured HTTPS Ollama Cloud service, never a daemon."""
+    value = str(endpoint or "").strip()
+    if "://" not in value:
+        return value.lower() in _APPROVED_OLLAMA_CLOUD_HOSTS
+    try:
+        parsed = urlparse(value)
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.lower() == "https"
+        and (parsed.hostname or "").lower() in _APPROVED_OLLAMA_CLOUD_HOSTS
+        and port in {None, 443}
+    )
+
+
+def _has_approved_ollama_cloud_runtime(route: PoolRouteConfig) -> bool:
+    return bool(route.runtime_base_url) and is_approved_ollama_cloud_endpoint(route.runtime_base_url)
+
+
+def _configured_subscription_attribution(route: PoolRouteConfig) -> bool:
+    """Ollama's configured API-key pool binding is its billing authority."""
+    return (
+        _is_ollama_cloud_candidate(route)
+        and route.billing_mode == "subscription"
+        and bool(route.subscription_pool.strip())
+    )
+
+
+def validate_pool_route(route: PoolRouteConfig) -> None:
+    """Reject invalid or ambiguous attribution before any execution begins."""
+    if not route.route_id.strip():
+        raise PoolConfigurationError("Pool route id is required.")
+    if not route.provider.strip() or route.provider.strip().lower() in {"auto", "custom"}:
+        raise PoolConfigurationError(f"Route {route.route_id!r} has an ambiguous provider.")
+    if not route.model.strip():
+        raise PoolConfigurationError(f"Route {route.route_id!r} has no resolved model.")
+    if route.execution_surface not in _ALLOWED_SURFACES:
+        raise PoolConfigurationError(
+            f"Route {route.route_id!r} has unsupported execution surface {route.execution_surface!r}."
+        )
+    if not route.subscription_pool.strip():
+        raise PoolConfigurationError(f"Route {route.route_id!r} has no authenticated pool attribution.")
+    if route.billing_mode not in _ALLOWED_BILLING:
+        raise PoolConfigurationError(
+            f"Route {route.route_id!r} has ambiguous billing mode {route.billing_mode!r}."
+        )
+    if route.enabled and route.billing_mode == "unverified":
+        raise PoolConfigurationError(
+            f"Route {route.route_id!r} cannot be enabled with unverified billing."
+        )
+    if route.quota_state not in _ALLOWED_QUOTA:
+        raise PoolConfigurationError(
+            f"Route {route.route_id!r} has invalid quota state {route.quota_state!r}."
+        )
+    if not route.capabilities:
+        raise PoolConfigurationError(f"Route {route.route_id!r} declares no task capability.")
+    if not 0.0 <= route.recent_success <= 1.0:
+        raise PoolConfigurationError(f"Route {route.route_id!r} recent_success must be between 0 and 1.")
+    if route.soft_reserve_percent is not None and not 0.0 <= route.soft_reserve_percent <= 100.0:
+        raise PoolConfigurationError(
+            f"Route {route.route_id!r} soft_reserve_percent must be between 0 and 100."
+        )
+    if route.remaining_percent is not None and not 0.0 <= route.remaining_percent <= 100.0:
+        raise PoolConfigurationError(
+            f"Route {route.route_id!r} remaining_percent must be between 0 and 100."
+        )
+
+
+def _reserve_active(route: PoolRouteConfig) -> bool:
+    if route.quota_state == "soft_reserve":
+        return True
+    return (
+        route.soft_reserve_percent is not None
+        and route.remaining_percent is not None
+        and route.remaining_percent <= route.soft_reserve_percent
+    )
+
+
+def _rank(route: PoolRouteConfig) -> tuple[int, int, int, float, int, str]:
+    # A soft reserve influences routing but does not disable the route.  It is
+    # considered after otherwise eligible non-reserved subscription capacity.
+    return (
+        int(_reserve_active(route)),
+        # An eligible Cloud Ollama route is the preferred included-capacity
+        # surface. Its configured pool association remains authoritative.
+        int(not _is_ollama_cloud_candidate(route)),
+        route.priority,
+        -route.recent_success,
+        route.verification_burden,
+        route.route_id,
+    )
+
+
+def select_subscription_route(
+    routes: Iterable[PoolRouteConfig],
+    *,
+    capability: str,
+    allow_metered: bool = False,
+    allow_paid_usage: bool = False,
+    explicit_quality_requirement: bool = False,
+) -> PoolSelection:
+    """Select the cheapest verified capable route and explain every skip.
+
+    Paid and metered capacity is fail-closed by default. Only an explicitly
+    operator-authorized call path may set the corresponding allow flag.
+    """
+    candidates = tuple(routes)
+    if not candidates:
+        raise PoolConfigurationError("No subscription-pool routes are configured.")
+    ids = [item.route_id for item in candidates]
+    if len(ids) != len(set(ids)):
+        raise PoolConfigurationError("Subscription-pool route ids must be unique.")
+
+    eligible: list[PoolRouteConfig] = []
+    rejected: list[dict[str, str]] = []
+    required = capability.strip().lower() or "general"
+    for route in candidates:
+        validate_pool_route(route)
+        capabilities = {item.strip().lower() for item in route.capabilities}
+        if _is_local(route):
+            rejected.append(_reason(route, "local_model_forbidden", "production routing never selects local models"))
+        elif _is_ollama_cloud_candidate(route) and not _has_approved_ollama_cloud_runtime(route):
+            rejected.append(_reason(
+                route,
+                "unapproved_ollama_runtime_endpoint",
+                "authenticated Ollama runtime is not an approved Cloud HTTPS endpoint",
+            ))
+        elif _is_ollama_cloud_candidate(route) and not route.verification.cloud_verified:
+            rejected.append(_reason(route, "unverified_cloud_route", "Ollama route is not verified as cloud-hosted"))
+        elif _is_ollama_cloud_candidate(route) and not route.verification.cloud_model_verified:
+            rejected.append(_reason(route, "non_cloud_model_forbidden", "Ollama model is not verified as cloud-hosted"))
+        elif not route.enabled:
+            detail = "; ".join(route.blockers) or "route is disabled pending verification or integration"
+            rejected.append(_reason(route, "route_disabled", detail))
+        elif not route.verification.installed:
+            rejected.append(_reason(route, "installation_missing", "execution surface is not installed"))
+        elif not route.verification.authenticated or route.quota_state == "auth_failed":
+            rejected.append(_reason(route, "authentication_failed", "authenticated pool is unavailable"))
+        elif not route.verification.models_available:
+            rejected.append(_reason(route, "model_unavailable", "runtime model roster has no capable model"))
+        elif not route.verification.headless:
+            rejected.append(_reason(route, "headless_unsupported", "headless execution is unavailable"))
+        elif not route.verification.workspace:
+            rejected.append(_reason(route, "workspace_unsupported", "workspace execution is unavailable"))
+        elif not route.verification.tools:
+            rejected.append(_reason(route, "tools_unsupported", "required tool support is unavailable"))
+        elif not route.verification.billing_verified and not _configured_subscription_attribution(route):
+            rejected.append(_reason(route, "billing_unverified", "subscription versus metered billing is unverified"))
+        elif route.quota_state == "exhausted":
+            rejected.append(_reason(route, "quota_exhausted", "authenticated pool is exhausted"))
+        elif required not in capabilities and "general" not in capabilities:
+            rejected.append(_reason(route, "missing_capability", f"route lacks {required} capability"))
+        elif route.billing_mode == "metered" and not allow_metered:
+            rejected.append(_reason(route, "metered_not_authorized", "metered usage is disabled for subscription pools"))
+        elif route.paid_usage_possible and not allow_paid_usage:
+            rejected.append(_reason(route, "paid_usage_not_authorized", "route can trigger charges or paid overage"))
+        else:
+            if not route.verification.quota_visible or route.quota_state == "unknown":
+                rejected.append(_reason(route, "quota_unknown", "remaining quota is not visible"))
+            eligible.append(route)
+
+    if not eligible:
+        summary = "; ".join(f"{item['route_id']}: {item['code']}" for item in rejected)
+        raise PoolConfigurationError(f"No eligible route for {required!r}. {summary}")
+
+    eligible.sort(key=_rank)
+    selected = eligible[0]
+    fallback_order = tuple(item.route_id for item in eligible[1:])
+    for item in eligible[1:]:
+        rejected.append(_reason(item, "lower_ranked_fallback", "eligible fallback retained in pool order"))
+    for item in rejected:
+        item["next_route"] = selected.route_id
+
+    reserve_note = " after honoring a soft reserve" if any(_reserve_active(item) for item in candidates) else ""
+    quality_note = " for the explicit quality requirement" if explicit_quality_requirement else ""
+    quota_note = "; quota is unknown" if (
+        not selected.verification.quota_visible or selected.quota_state == "unknown"
+    ) else ""
+    authorization: list[str] = []
+    if selected.billing_mode == "metered":
+        authorization.append("metered usage explicitly authorized")
+    elif allow_metered:
+        authorization.append("metered usage explicitly authorized but not selected")
+    else:
+        authorization.append("metered usage not authorized")
+    if selected.paid_usage_possible:
+        authorization.append("paid overage explicitly authorized")
+    elif allow_paid_usage:
+        authorization.append("paid overage explicitly authorized but not selected")
+    else:
+        authorization.append("paid overage not authorized")
+    authorization_note = "; ".join(authorization)
+    reason = (
+        f"selected {selected.route_id} from pool {selected.subscription_pool}: "
+        f"selected {selected.billing_mode} billing; {authorization_note}; "
+        f"verified capable route{reserve_note}{quality_note}{quota_note}; "
+        "unselected metered and paid-overage routes remain fail-closed"
+    )
+    return PoolSelection(selected, tuple(rejected), fallback_order, reason)
+
+
+def _generation(name: str, family: str) -> int | None:
+    match = re.search(rf"{re.escape(family)}[-_ ]?(\d+)", name, flags=re.IGNORECASE)
+    return int(match.group(1)) if match else None
+
+
+def select_model_from_roster(
+    roster: Sequence[str],
+    *,
+    exact: str = "",
+    family: str = "",
+    minimum_generation: int | None = None,
+) -> str:
+    """Resolve a model from a runtime roster without baking transient IDs into policy."""
+    models = tuple(str(item).strip() for item in roster if str(item).strip())
+    if exact:
+        if exact not in models:
+            raise PoolConfigurationError(f"Configured model {exact!r} is absent from the runtime roster.")
+        return exact
+    if not family:
+        raise PoolConfigurationError("Model selection requires an exact id or a family preference.")
+    matching: list[tuple[int, str]] = []
+    for model in models:
+        generation = _generation(model, family)
+        if generation is None:
+            continue
+        if minimum_generation is None or generation >= minimum_generation:
+            matching.append((generation, model))
+    if not matching:
+        raise PoolConfigurationError(
+            f"No runtime model matches family {family!r} at generation {minimum_generation!r}."
+        )
+    # Prefer the newest matching family.  A Sonnet-family rule can therefore
+    # never silently drift to Opus merely because Opus is stronger.
+    matching.sort(key=lambda item: (-item[0], item[1]))
+    return matching[0][1]

--- a/agent/task_routing.py
+++ b/agent/task_routing.py
@@ -1,0 +1,793 @@
+"""Authoritative, side-effect-free task routing for CLI, dashboard, and delegation.
+
+This module deliberately selects *configured* profile/model/provider capacity only.
+It does not resolve credentials or make a model call.  Execution surfaces persist
+its returned receipt alongside their existing SessionDB records.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field, replace
+import re
+from typing import Any, Iterable, Iterator, Mapping, Sequence
+
+from agent.subscription_pool import (
+    PoolConfigurationError,
+    PoolRouteConfig,
+    PoolVerification,
+    is_approved_ollama_cloud_endpoint,
+    select_model_from_roster,
+    select_subscription_route,
+)
+
+
+class ProfileResolutionError(ValueError):
+    """A requested profile cannot safely participate in task routing."""
+
+
+class _OllamaRuntimeProbeError(PoolConfigurationError):
+    """Retain the observed endpoint so selection can reject it precisely."""
+
+    def __init__(self, message: str, base_url: str) -> None:
+        super().__init__(message)
+        self.base_url = base_url
+
+
+@dataclass(frozen=True)
+class ProfileRouteConfig:
+    profile: str
+    home: str
+    provider: str
+    model: str
+    capabilities: tuple[str, ...]
+    budget_tokens: int
+    pool_alias: str
+    pool_type: str
+    cost_mode: str
+
+
+@dataclass(frozen=True)
+class TaskRoute:
+    task: str
+    role: str
+    profile: str
+    provider: str
+    model: str
+    pool_alias: str
+    pool_type: str
+    cost_mode: str
+    budget_tokens: int
+    delegated: bool
+    fallback_reason: str | None = None
+    rejected: tuple[dict[str, str], ...] = field(default_factory=tuple)
+    home: str = ""
+    task_class: str = "general"
+    execution_surface: str = "hermes"
+    subscription_pool: str = ""
+    billing_mode: str = "subscription"
+    quota_state: str = "unknown"
+    available_usage: dict[str, Any] = field(default_factory=dict)
+    paid_usage_possible: bool = False
+    fallback_order: tuple[str, ...] = field(default_factory=tuple)
+    selection_reason: str = ""
+    runtime_base_url: str = ""
+    pool_route_id: str = ""
+    allow_metered: bool = False
+    allow_paid_usage: bool = False
+    _fallback_routes: tuple[PoolRouteConfig, ...] = field(
+        default_factory=tuple, repr=False, compare=False
+    )
+
+    def explain(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload.pop("_fallback_routes", None)
+        return payload
+
+
+@dataclass(frozen=True)
+class ProfileGovernorSettings:
+    """Effective profile-scoped controls used by main and routed agents."""
+
+    max_turns: int
+    max_request_input_tokens: int
+    compression_threshold: float
+
+
+_ROLE_ALIASES = {
+    "coding": "implementation",
+    "strategic-synthesis": "research",
+    "strategic_synthesis": "research",
+    "synthesis": "research",
+    "review": "verification",
+    "testing": "verification",
+    "test": "verification",
+    "verify": "verification",
+    "verifier": "verification",
+    "continuity": "operations",
+    "recordkeeping": "operations",
+    "records": "operations",
+    "localcred-domain": "localcred",
+    "martial-os": "martial",
+    "martial_os": "martial",
+    "general": "generic",
+    "small": "generic",
+}
+
+_ROLE_CAPABILITIES = {
+    "orchestrator": "general",
+    "implementation": "coding",
+    "research": "research",
+    "verification": "verification",
+    "operations": "operations",
+    "localcred": "localcred",
+    "martial": "martial",
+    "generic": "general",
+}
+
+_ROLE_PREFERENCES = {
+    "orchestrator": "default",
+    "implementation": "engineering",
+    "research": "intelligence",
+    "verification": "assurance",
+    "operations": "operations",
+    "localcred": "localcred",
+    "martial": "martial",
+    "generic": "default",
+}
+
+# Never use registry enumeration as a tiebreaker: it is an implementation
+# detail, not routing policy.  Default stays ahead of unrelated specialists
+# when a preferred specialist is unavailable, and that fallback is recorded.
+_FALLBACK_PROFILE_ORDER = (
+    "default", "operations", "engineering", "assurance", "intelligence", "localcred", "martial",
+)
+
+
+def _normalized_role(role: str) -> str:
+    normalized = str(role or "orchestrator").strip().lower().replace(" ", "-")
+    return _ROLE_ALIASES.get(normalized, normalized)
+
+
+def _domain_role(task: str) -> str | None:
+    """Classify only explicit portfolio-domain references; generic work stays generic."""
+    normalized = str(task or "").lower()
+    if re.search(r"\blocalcred\b", normalized):
+        return "localcred"
+    if re.search(r"\bmartial[ _-]+os\b", normalized):
+        return "martial"
+    return None
+
+
+def _routing_policy(task: str, role: str) -> tuple[str, str, str]:
+    """Return canonical role, required capability, and preferred profile.
+
+    Explicit domain references outrank generic role preferences, but caller
+    profile selection is handled separately and remains authoritative.
+    """
+    canonical_role = _domain_role(task) or _normalized_role(role)
+    capability = _ROLE_CAPABILITIES.get(canonical_role, "general")
+    preferred = _ROLE_PREFERENCES.get(canonical_role, "default")
+    return canonical_role, capability, preferred
+
+
+def _fallback_sort_key(candidate: ProfileRouteConfig) -> tuple[int, int, int, str]:
+    """Stable capacity-aware fallback order independent of registry order."""
+    try:
+        policy_rank = _FALLBACK_PROFILE_ORDER.index(candidate.profile)
+    except ValueError:
+        policy_rank = len(_FALLBACK_PROFILE_ORDER)
+    return (candidate.cost_mode != "included", candidate.pool_type == "api_key", policy_rank, candidate.profile)
+
+
+def _profile_configs(profile: str | None = None) -> Iterable[ProfileRouteConfig]:
+    """Read all valid profiles through the canonical profile registry."""
+    from hermes_cli.profiles import get_profile_registry
+
+    registry = get_profile_registry()
+    names = (profile,) if profile else registry.names()
+    for name in names:
+        record = registry.resolve(name)
+        cfg = record.config
+        model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+        model = str(model_cfg.get("default") or model_cfg.get("model") or "").strip()
+        provider = str(model_cfg.get("provider") or "auto").strip()
+        if not model:
+            continue
+        routing_cfg = cfg.get("task_routing") if isinstance(cfg.get("task_routing"), dict) else {}
+        capabilities = routing_cfg.get("capabilities", ("coding", "research", "verification", "general"))
+        if not isinstance(capabilities, (list, tuple, set)):
+            capabilities = ()
+        budget = routing_cfg.get("task_budget_tokens", 16000)
+        try:
+            budget = max(1, int(budget))
+        except (TypeError, ValueError):
+            budget = 16000
+        pool_alias, pool_type, cost_mode = _pool_for(provider)
+        yield ProfileRouteConfig(
+            profile=record.name, home=str(record.home), provider=provider, model=model,
+            capabilities=tuple(str(item).lower() for item in capabilities), budget_tokens=budget,
+            pool_alias=pool_alias, pool_type=pool_type, cost_mode=cost_mode,
+        )
+
+
+def _pool_for(provider: str) -> tuple[str, str, str]:
+    """Return a non-secret alias and capacity attribution for a configured provider."""
+    normalized = provider.lower()
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool(provider)
+        entry = pool.current() or next(iter(pool.entries()), None)
+    except Exception:
+        entry = None
+    if entry is not None:
+        auth_type = str(getattr(entry, "auth_type", "") or "").lower()
+        source = str(getattr(entry, "source", "") or "").lower()
+        # OAuth / installed-subscription credentials are included capacity; API
+        # keys remain metered.  The alias deliberately exposes no account label.
+        included = auth_type in {"oauth", "oauth_token", "subscription"} or any(
+            marker in source for marker in ("codex", "claude_code", "oauth", "subscription")
+        )
+        return f"{normalized}:pool", "oauth" if included else "api_key", "included" if included else "metered"
+    if normalized in {"ollama", "local"}:
+        return f"{normalized}:local", "local", "included"
+    return f"{normalized}:configured", "configured", "metered"
+
+
+def _runtime_roster(source: str, profile_home: str) -> tuple[str, ...]:
+    """Discover the current provider roster without making a model call."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(profile_home)
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested=source)
+        if source == "openai-codex":
+            from hermes_cli.codex_models import get_codex_model_ids
+
+            return tuple(get_codex_model_ids(runtime.get("api_key")))
+
+    finally:
+        reset_hermes_home_override(token)
+    raise PoolConfigurationError(f"Unsupported runtime model source {source!r}.")
+
+
+def _authenticated_ollama_cloud_roster(
+    profile_home: str,
+    *,
+    provider: str,
+    target_model: str,
+) -> tuple[str, tuple[str, ...]]:
+    """Probe only the authenticated Ollama Cloud ``/v1/models`` roster.
+
+    This deliberately bypasses the merged discovery helper: models.dev and its
+    disk cache cannot prove that this credential can execute this model.
+    """
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(profile_home)
+    try:
+        from hermes_cli.models import fetch_api_models_strict
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested=provider, target_model=target_model)
+    finally:
+        reset_hermes_home_override(token)
+    api_key = str(runtime.get("api_key") or "").strip()
+    base_url = str(runtime.get("base_url") or "").strip()
+    if not api_key:
+        raise _OllamaRuntimeProbeError("authenticated Ollama runtime has no API credential", base_url)
+    if not is_approved_ollama_cloud_endpoint(base_url):
+        raise _OllamaRuntimeProbeError(
+            "authenticated Ollama runtime is not an approved Cloud HTTPS endpoint", base_url
+        )
+    roster = fetch_api_models_strict(api_key, base_url)
+    if not roster:
+        raise _OllamaRuntimeProbeError("authenticated Ollama runtime returned no model roster", base_url)
+    return base_url, tuple(str(model).strip() for model in roster if str(model).strip())
+
+
+def _runtime_usage(source: str, profile_home: str) -> tuple[str, float | None, dict[str, Any]]:
+    """Resolve visible subscription usage without exposing account credentials."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(profile_home)
+    try:
+        from agent.account_usage import fetch_account_usage
+
+        snapshot = fetch_account_usage(source)
+    finally:
+        reset_hermes_home_override(token)
+    if snapshot is None or not snapshot.available or not snapshot.windows:
+        return "unknown", None, {"source": source, "available": False}
+    used = max(float(window.used_percent) for window in snapshot.windows)
+    remaining = max(0.0, 100.0 - used)
+    state = "exhausted" if used >= 100.0 else "available"
+    return state, remaining, {
+        "source": snapshot.source,
+        "plan": snapshot.plan,
+        "windows": [
+            {"label": window.label, "used_percent": float(window.used_percent)}
+            for window in snapshot.windows
+        ],
+    }
+
+
+def _verification(
+    raw: Mapping[str, Any],
+    route_id: str,
+    *,
+    configured_subscription_pool: bool,
+    require_cloud_model: bool,
+) -> PoolVerification:
+    required = {
+        "installed", "authenticated", "models_available", "headless",
+        "workspace", "tools", "quota_visible",
+    }
+    missing = sorted(required.difference(raw))
+    if missing:
+        raise PoolConfigurationError(
+            f"Route {route_id!r} verification is incomplete: missing {', '.join(missing)}."
+        )
+    return PoolVerification(
+        installed=raw["installed"] is True,
+        authenticated=raw["authenticated"] is True,
+        models_available=raw["models_available"] is True,
+        headless=raw["headless"] is True,
+        workspace=raw["workspace"] is True,
+        tools=raw["tools"] is True,
+        quota_visible=raw["quota_visible"] is True,
+        # Ollama's configured API-key-to-pool binding is durable route policy,
+        # not request metadata. It therefore supplies billing attribution
+        # without a per-request billing field.
+        billing_verified=(
+            raw.get("billing_verified") is True or configured_subscription_pool
+        ),
+        cloud_verified=raw.get("cloud_verified", True) is True,
+        cloud_model_verified=(
+            raw.get("cloud_model_verified", not require_cloud_model) is True
+        ),
+    )
+
+
+def _configured_pool_routes(
+    profile: ProfileRouteConfig,
+    raw_routes: Sequence[Mapping[str, Any]] | None = None,
+) -> tuple[PoolRouteConfig, ...]:
+    """Load caller policy while retaining the selected profile's identity/model."""
+    if raw_routes is None:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        routing = config.get("task_routing") if isinstance(config.get("task_routing"), dict) else {}
+        configured = routing.get("pools", ())
+        if not isinstance(configured, list):
+            raise PoolConfigurationError("task_routing.pools must be a list.")
+        raw_routes = configured
+    parsed: list[PoolRouteConfig] = []
+    for raw in raw_routes:
+        if not isinstance(raw, Mapping):
+            raise PoolConfigurationError("Each task_routing.pools entry must be a mapping.")
+        route_id = str(raw.get("id") or "").strip()
+        enabled = raw.get("enabled", True) is True
+        provider = str(raw.get("provider") or "").strip()
+        subscription_pool = str(raw.get("subscription_pool") or "").strip()
+        billing_mode = str(raw.get("billing_mode") or "").strip()
+        is_ollama = provider.lower() in {"ollama", "ollama-cloud"}
+        model = str(raw.get("model") or "").strip()
+        family = str(raw.get("model_family") or "").strip()
+        generation = raw.get("minimum_generation")
+        if generation is not None:
+            try:
+                generation = int(generation)
+            except (TypeError, ValueError) as exc:
+                raise PoolConfigurationError(
+                    f"Route {route_id!r} minimum_generation must be an integer."
+                ) from exc
+        if model == "profile":
+            model = profile.model
+        source = str(raw.get("model_source") or "").strip()
+        runtime_base_url = ""
+        runtime_failure = ""
+        if enabled and is_ollama:
+            try:
+                runtime_base_url, roster = _authenticated_ollama_cloud_roster(
+                    profile.home, provider=provider, target_model=model
+                )
+                model = select_model_from_roster(
+                    roster, exact=model, family=family, minimum_generation=generation
+                )
+            except PoolConfigurationError as exc:
+                # The route remains inspectable so the frozen eligible fallback
+                # order can advance to OpenAI rather than surfacing an opaque
+                # routing-unavailable error.
+                runtime_failure = str(exc)
+                runtime_base_url = str(getattr(exc, "base_url", runtime_base_url) or "")
+        elif enabled and source:
+            roster = _runtime_roster(source, profile.home)
+            model = select_model_from_roster(
+                roster, exact=model, family=family, minimum_generation=generation
+            )
+        elif not model:
+            # Disabled routes still require unambiguous attribution, but their
+            # live roster is intentionally not probed during ordinary routing.
+            model = f"{family}-family" if family else "unavailable"
+
+        quota_state = str(raw.get("quota_state") or "unknown").strip().lower()
+        remaining = raw.get("remaining_percent")
+        available_usage = raw.get("available_usage")
+        if not isinstance(available_usage, dict):
+            available_usage = {}
+        usage_source = str(raw.get("usage_source") or "").strip()
+        if enabled and usage_source:
+            quota_state, remaining, available_usage = _runtime_usage(usage_source, profile.home)
+        if remaining is not None:
+            try:
+                remaining = float(remaining)
+            except (TypeError, ValueError) as exc:
+                raise PoolConfigurationError(
+                    f"Route {route_id!r} remaining_percent must be numeric."
+                ) from exc
+
+        verification_raw = raw.get("verification")
+        if not isinstance(verification_raw, Mapping):
+            raise PoolConfigurationError(f"Route {route_id!r} requires a verification mapping.")
+        capabilities = raw.get("capabilities")
+        if not isinstance(capabilities, list):
+            raise PoolConfigurationError(f"Route {route_id!r} capabilities must be a list.")
+        verification = _verification(
+            verification_raw,
+            route_id,
+            configured_subscription_pool=(
+                is_ollama
+                and billing_mode == "subscription"
+                and bool(subscription_pool)
+            ),
+            require_cloud_model=is_ollama,
+        )
+        if runtime_failure:
+            if "no API credential" in runtime_failure:
+                verification = replace(verification, authenticated=False)
+            elif "approved Cloud HTTPS endpoint" not in runtime_failure:
+                verification = replace(verification, models_available=False)
+        parsed.append(PoolRouteConfig(
+            route_id=route_id,
+            provider=provider,
+            model=model,
+            execution_surface=str(raw.get("execution_surface") or "").strip(),
+            subscription_pool=subscription_pool,
+            billing_mode=billing_mode,
+            capabilities=tuple(str(item).strip().lower() for item in capabilities),
+            priority=int(raw.get("priority", 100)),
+            verification=verification,
+            enabled=enabled,
+            paid_usage_possible=raw.get("paid_usage_possible", True) is True,
+            quota_state=quota_state,
+            available_usage=available_usage,
+            soft_reserve_percent=(
+                float(raw["soft_reserve_percent"])
+                if raw.get("soft_reserve_percent") is not None else None
+            ),
+            remaining_percent=remaining,
+            recent_success=float(raw.get("recent_success", 1.0)),
+            verification_burden=int(raw.get("verification_burden", 0)),
+            endpoint_host=str(raw.get("endpoint_host") or "").strip(),
+            runtime_base_url=runtime_base_url,
+            model_family=family,
+            minimum_generation=generation,
+            blockers=tuple(
+                str(item).strip()
+                for item in raw.get("blockers", ())
+                if str(item).strip()
+            ),
+        ))
+    return tuple(parsed)
+
+
+def resolve_task_route(
+    task: str,
+    *,
+    role: str = "orchestrator",
+    profile: str | None = None,
+    pool_routes: Sequence[PoolRouteConfig] | None = None,
+    allow_metered: bool = False,
+    allow_paid_usage: bool = False,
+    explicit_quality_requirement: bool = False,
+) -> TaskRoute:
+    """Select one configured route and list rejected candidates without calling a model."""
+    role, capability, preferred_profile = _routing_policy(task, role)
+    candidates = list(_profile_configs(profile))
+    rejected: list[dict[str, str]] = []
+    eligible: list[ProfileRouteConfig] = []
+    fallback_reason: str | None = None
+    for candidate in candidates:
+        if capability not in candidate.capabilities and "general" not in candidate.capabilities:
+            rejected.append({"profile": candidate.profile, "reason": f"missing {capability} capability"})
+        else:
+            eligible.append(candidate)
+    if not eligible:
+        requested = f" profile {profile!r}" if profile else " any registered profile"
+        raise ProfileResolutionError(f"No configured route for {role!r} using{requested}.")
+
+    # An explicit selection is a caller contract, not a routing hint.
+    if profile is not None:
+        selected = eligible[0]
+    else:
+        preferred = next((item for item in eligible if item.profile == preferred_profile), None)
+        if preferred is not None:
+            selected = preferred
+        else:
+            configured_preferred = next(
+                (item for item in candidates if item.profile == preferred_profile), None
+            )
+            if configured_preferred is None:
+                fallback_reason = f"preferred profile {preferred_profile!r} is unavailable"
+            else:
+                fallback_reason = (
+                    f"preferred profile {preferred_profile!r} is missing {capability} capability"
+                )
+            rejected.append({"profile": preferred_profile, "reason": fallback_reason})
+            eligible.sort(key=_fallback_sort_key)
+            selected = eligible[0]
+
+    for candidate in eligible:
+        if candidate.profile != selected.profile:
+            rejected.append({"profile": candidate.profile, "reason": "lower-ranked policy fallback"})
+
+    configured_pools = tuple(pool_routes) if pool_routes is not None else _configured_pool_routes(selected)
+    if configured_pools:
+        pool_selection = select_subscription_route(
+            configured_pools,
+            capability=capability,
+            allow_metered=allow_metered,
+            allow_paid_usage=allow_paid_usage,
+            explicit_quality_requirement=explicit_quality_requirement,
+        )
+        worker = pool_selection.selected
+        rejected.extend(pool_selection.rejected)
+        provider = worker.provider
+        model = worker.model
+        pool_alias = worker.subscription_pool
+        pool_type = "subscription" if worker.billing_mode == "subscription" else "api_key"
+        cost_mode = "included" if worker.billing_mode == "subscription" else "metered"
+        execution_surface = worker.execution_surface
+        quota_state = worker.quota_state
+        available_usage = dict(worker.available_usage)
+        paid_usage_possible = worker.paid_usage_possible
+        fallback_order = pool_selection.fallback_order
+        selection_reason = pool_selection.selection_reason
+        billing_mode = worker.billing_mode
+        runtime_base_url = worker.runtime_base_url
+        pool_route_id = worker.route_id
+        by_id = {item.route_id: item for item in configured_pools}
+        fallback_routes = tuple(
+            by_id[route_id] for route_id in fallback_order if route_id in by_id
+        )
+    else:
+        provider, model = selected.provider, selected.model
+        pool_alias, pool_type, cost_mode = selected.pool_alias, selected.pool_type, selected.cost_mode
+        execution_surface = "hermes"
+        quota_state = "unknown"
+        available_usage = {}
+        paid_usage_possible = cost_mode == "metered"
+        fallback_order = ()
+        selection_reason = "legacy configured profile route; no subscription-pool policy is configured"
+        billing_mode = "subscription" if cost_mode == "included" else "metered"
+        runtime_base_url = ""
+        pool_route_id = ""
+        fallback_routes = ()
+    return TaskRoute(
+        task=task, role=role, profile=selected.profile, provider=provider, home=selected.home,
+        model=model, pool_alias=pool_alias, pool_type=pool_type,
+        cost_mode=cost_mode, budget_tokens=selected.budget_tokens,
+        delegated=role not in {"orchestrator", "generic"},
+        fallback_reason=fallback_reason, rejected=tuple(rejected),
+        task_class=capability, execution_surface=execution_surface,
+        subscription_pool=pool_alias, billing_mode=billing_mode,
+        quota_state=quota_state, available_usage=available_usage,
+        paid_usage_possible=paid_usage_possible, fallback_order=fallback_order,
+        selection_reason=selection_reason, runtime_base_url=runtime_base_url,
+        pool_route_id=pool_route_id, allow_metered=allow_metered,
+        allow_paid_usage=allow_paid_usage, _fallback_routes=fallback_routes,
+    )
+
+
+@contextmanager
+def profile_runtime_scope(route: TaskRoute) -> Iterator[None]:
+    """Temporarily resolve config/auth from a selected profile only.
+
+    This is intentionally a tiny adapter around the existing profile-home
+    override.  It does not copy credentials or mutate the selected profile.
+    """
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(route.home)
+    try:
+        yield
+    finally:
+        reset_hermes_home_override(token)
+
+
+def resolve_profile_governor(route: TaskRoute) -> ProfileGovernorSettings:
+    """Load effective governor values from the selected profile's schema."""
+    with profile_runtime_scope(route):
+        from agent.usage_guardrails import UsageGuardrail
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    agent_config = config.get("agent") if isinstance(config.get("agent"), dict) else {}
+    compression = config.get("compression") if isinstance(config.get("compression"), dict) else {}
+    try:
+        max_turns = int(agent_config.get("max_turns"))
+    except (TypeError, ValueError) as exc:
+        raise ProfileResolutionError(
+            f"Profile {route.profile!r} has invalid agent.max_turns."
+        ) from exc
+    if max_turns < 1:
+        raise ProfileResolutionError(f"Profile {route.profile!r} agent.max_turns must be positive.")
+    try:
+        threshold = float(compression.get("threshold"))
+    except (TypeError, ValueError) as exc:
+        raise ProfileResolutionError(
+            f"Profile {route.profile!r} has invalid compression.threshold."
+        ) from exc
+    if not 0.0 < threshold <= 1.0:
+        raise ProfileResolutionError(
+            f"Profile {route.profile!r} compression.threshold must be in (0, 1]."
+        )
+    guardrail = UsageGuardrail.from_config(
+        config,
+        scope="interactive",
+        subscription_included=route.billing_mode == "subscription",
+    )
+    return ProfileGovernorSettings(
+        max_turns=max_turns,
+        max_request_input_tokens=guardrail.limits.max_request_input_tokens,
+        compression_threshold=threshold,
+    )
+
+
+def _resolve_route_runtime_once(route: TaskRoute) -> dict[str, Any]:
+    """Resolve one frozen route's runtime inside its profile scope.
+
+    The returned dict is execution-only and can contain an in-memory credential;
+    callers must persist ``routing_receipt`` instead.  A specialist route never
+    retries through the caller's default/fallback chain.
+    """
+    if route.execution_surface != "hermes":
+        raise ProfileResolutionError(
+            f"Route {route.subscription_pool!r} requires unsupported execution surface "
+            f"{route.execution_surface!r}; it cannot be dispatched by Hermes yet."
+        )
+    if route.delegated and route.provider.lower() in {"", "auto"}:
+        raise ProfileResolutionError(
+            f"Specialist route for profile {route.profile!r} has no explicit provider."
+        )
+    with profile_runtime_scope(route):
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = dict(resolve_runtime_provider(
+            requested=route.provider,
+            target_model=route.model,
+        ))
+    if route.provider.lower() in {"ollama", "ollama-cloud"}:
+        base_url = str(runtime.get("base_url") or "").strip()
+        if not route.runtime_base_url or base_url != route.runtime_base_url:
+            raise ProfileResolutionError(
+                f"Route {route.subscription_pool!r} runtime endpoint changed after selection."
+            )
+        if not is_approved_ollama_cloud_endpoint(base_url):
+            raise ProfileResolutionError(
+                f"Route {route.subscription_pool!r} has an unapproved Ollama runtime endpoint."
+            )
+        api_key = str(runtime.get("api_key") or "").strip()
+        if not api_key:
+            raise ProfileResolutionError(
+                f"Route {route.subscription_pool!r} has no runtime API credential."
+            )
+        from hermes_cli.models import fetch_api_models_strict
+
+        roster = fetch_api_models_strict(api_key, base_url)
+        if not roster or route.model not in roster:
+            raise ProfileResolutionError(
+                f"Route {route.subscription_pool!r} selected model is absent from its live runtime roster."
+            )
+    if not runtime.get("base_url"):
+        raise ProfileResolutionError(
+            f"Route {route.profile!r}/{route.provider!r} is unavailable: no runtime base URL."
+        )
+    if not runtime.get("api_key") and route.pool_type != "local":
+        raise ProfileResolutionError(
+            f"Route {route.profile!r}/{route.provider!r} is unavailable: no runtime credential."
+        )
+    return runtime
+
+
+def _runtime_failure_code(route: TaskRoute, error: Exception) -> str:
+    detail = str(error).lower()
+    if route.provider.lower() in {"ollama", "ollama-cloud"}:
+        if "endpoint" in detail:
+            return "endpoint_validation_failed"
+        if "credential" in detail or "auth" in detail:
+            return "authentication_failed"
+        if "roster" in detail or "model" in detail:
+            return "model_unavailable"
+    return "runtime_unavailable"
+
+
+def _fallback_task_route(
+    route: TaskRoute,
+    worker: PoolRouteConfig,
+    remaining: tuple[PoolRouteConfig, ...],
+    error: Exception,
+) -> TaskRoute:
+    code = _runtime_failure_code(route, error)
+    failure = {
+        "route_id": route.pool_route_id or route.subscription_pool,
+        "code": code,
+        "reason": str(error),
+        "next_route": worker.route_id,
+    }
+    return replace(
+        route,
+        provider=worker.provider,
+        model=worker.model,
+        pool_alias=worker.subscription_pool,
+        pool_type="subscription" if worker.billing_mode == "subscription" else "api_key",
+        cost_mode="included" if worker.billing_mode == "subscription" else "metered",
+        execution_surface=worker.execution_surface,
+        subscription_pool=worker.subscription_pool,
+        billing_mode=worker.billing_mode,
+        quota_state=worker.quota_state,
+        available_usage=dict(worker.available_usage),
+        paid_usage_possible=worker.paid_usage_possible,
+        fallback_reason=f"{route.pool_route_id or route.subscription_pool}: {code}",
+        rejected=route.rejected + (failure,),
+        fallback_order=tuple(item.route_id for item in remaining),
+        selection_reason=(
+            f"runtime fallback from {route.pool_route_id or route.subscription_pool} "
+            f"to {worker.route_id}: {code}"
+        ),
+        runtime_base_url=worker.runtime_base_url,
+        pool_route_id=worker.route_id,
+        _fallback_routes=remaining,
+    )
+
+
+def resolve_route_runtime(route: TaskRoute) -> dict[str, Any]:
+    """Resolve a frozen route, advancing only through its frozen eligible fallbacks."""
+    current = route
+    while True:
+        try:
+            runtime = _resolve_route_runtime_once(current)
+            runtime["_task_route"] = current
+            return runtime
+        except ProfileResolutionError as error:
+            if not current._fallback_routes:
+                raise
+            worker, *rest = current._fallback_routes
+            current = _fallback_task_route(current, worker, tuple(rest), error)
+
+
+def routing_receipt(route: TaskRoute, *, task_id: str, parent_session_id: str | None = None,
+                    child_session_id: str | None = None, token_usage: dict[str, int] | None = None,
+                    cost_attribution: str | None = None, fallback_reason: str | None = None,
+                    status: str = "dispatched", elapsed_time: float | None = None,
+                    acceptance_evidence: Sequence[str] = (), escalation_reason: Mapping[str, Any] | None = None,
+                    next_route: str | None = None, parent_profile: str | None = None) -> dict[str, Any]:
+    """Canonical serializable receipt; callers may append it to existing session metadata."""
+    receipt = route.explain()
+    receipt.update({
+        "task_id": task_id, "parent_session_id": parent_session_id,
+        "child_session_id": child_session_id, "token_usage": token_usage or {},
+        "cost_attribution": cost_attribution or route.cost_mode,
+        "fallback_reason": fallback_reason or route.fallback_reason,
+        "elapsed_time": elapsed_time,
+        "acceptance_evidence": list(acceptance_evidence),
+        "escalation_reason": dict(escalation_reason or {}),
+        "next_route": next_route,
+        "parent_profile": parent_profile,
+        "child_delegation": route.delegated,
+        "status": status,
+    })
+    return receipt

--- a/agent/usage_guardrails.py
+++ b/agent/usage_guardrails.py
@@ -1,0 +1,231 @@
+"""Per-turn model-call and input-usage guardrails.
+
+Gross prompt traffic remains an observability and per-request safety measure.
+Subscription-included Codex routes use a separate weighted cumulative budget:
+uncached input + cache writes + 10% of cache reads.  The 10% factor is Hermes
+policy only; it is not a statement about provider allowance accounting.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+_CACHE_READ_WEIGHT = 0.10
+_DEFAULTS = {
+    "interactive": {
+        "max_model_calls": 44,
+        "max_subscription_weighted_input_tokens": 1_120_000,
+        "max_request_input_tokens": 140_000,
+        # 3 is reachable and stops sustained 100k+ prompts while leaving a
+        # normal one-off large context request available.
+        "max_consecutive_large_requests": 3,
+        "large_request_tokens": 100_000,
+    },
+    "cron": {
+        "max_model_calls": 2,
+        "max_subscription_weighted_input_tokens": 75_000,
+        "max_request_input_tokens": 75_000,
+        "max_consecutive_large_requests": 3,
+        "large_request_tokens": 60_000,
+    },
+}
+
+GOVERNOR_STOP_REASONS = frozenset({
+    "model_call_limit",
+    "subscription_weighted_input_token_limit",
+    "request_input_token_limit",
+    "consecutive_large_request_limit",
+})
+
+
+def is_governor_stop(turn_result: Any) -> bool:
+    if not isinstance(turn_result, Mapping):
+        return False
+    return bool(turn_result.get("governor_stop")) or str(
+        turn_result.get("turn_exit_reason") or ""
+    ) in GOVERNOR_STOP_REASONS
+
+
+def default_usage_guardrails_config() -> dict[str, Any]:
+    return {"operator_authorized": False, **{k: dict(v) for k, v in _DEFAULTS.items()}}
+
+
+@dataclass(frozen=True)
+class UsageLimits:
+    max_model_calls: int
+    max_subscription_weighted_input_tokens: int
+    max_request_input_tokens: int
+    max_consecutive_large_requests: int
+    large_request_tokens: int
+
+
+class UsageGuardrail:
+    """Fail-closed turn budget; subscription enforcement is explicitly opt-in."""
+
+    def __init__(self, limits: UsageLimits, *, scope: str, subscription_included: bool = False) -> None:
+        self.limits = limits
+        self.scope = scope
+        self.subscription_included = subscription_included
+        self.session_usage = self._empty_usage()
+        self._reset_turn_usage()
+
+    @staticmethod
+    def _empty_usage() -> dict[str, int]:
+        return {
+            "uncached_input_tokens": 0, "cache_read_tokens": 0,
+            "cache_write_tokens": 0, "gross_input_tokens": 0,
+            "weighted_input_tokens": 0, "output_tokens": 0,
+            "reasoning_tokens": 0, "model_calls": 0,
+        }
+
+    def _reset_turn_usage(self) -> None:
+        self.calls = 0
+        self.uncached_input_tokens = 0
+        self.cache_read_tokens = 0
+        self.cache_write_tokens = 0
+        self.gross_input_tokens = 0
+        self.weighted_input_tokens = 0
+        self.output_tokens = 0
+        self.reasoning_tokens = 0
+        self.consecutive_large_requests = 0
+        self.receipts: list[dict[str, int | str]] = []
+        self.stop_reason: str | None = None
+        self._request_stop_details: dict[str, Any] | None = None
+
+    @classmethod
+    def from_config(
+        cls, config: Mapping[str, Any] | None, *, scope: str,
+        subscription_included: bool = False,
+    ) -> "UsageGuardrail":
+        defaults = _DEFAULTS[scope]
+        raw = (config or {}).get("usage_guardrails", {})
+        raw = raw if isinstance(raw, Mapping) else {}
+        candidate = raw.get(scope, {})
+        candidate = candidate if isinstance(candidate, Mapping) else {}
+        authorized = raw.get("operator_authorized") is True
+        # Legacy gross cumulative configuration is intentionally ignored: it
+        # named the wrong quantity for subscription enforcement.
+        resolved: dict[str, int] = {}
+        for key, default in defaults.items():
+            try:
+                value = int(candidate.get(key, default))
+            except (TypeError, ValueError):
+                value = default
+            resolved[key] = value if value <= default or authorized else default
+        return cls(UsageLimits(**resolved), scope=scope, subscription_included=subscription_included)
+
+    def begin_user_turn(self) -> None:
+        """Reset this explicit turn only; lifetime session observability remains."""
+        self._reset_turn_usage()
+
+    def request_input_limit_exceeded(self, estimate: int) -> bool:
+        return max(0, int(estimate or 0)) > self.limits.max_request_input_tokens
+
+    def before_request(self, estimated_gross_input_tokens: int) -> str | None:
+        estimate = max(0, int(estimated_gross_input_tokens or 0))
+        if self.calls >= self.limits.max_model_calls:
+            return self._stop("model_call_limit")
+        if self.request_input_limit_exceeded(estimate):
+            return self._stop("request_input_token_limit")
+        # The exact cache mix is known only after a provider response. Do not
+        # use a gross preflight estimate as a weighted allowance surrogate;
+        # record_usage() enforces the cumulative weighted budget from actual
+        # uncached/cache-read/cache-write buckets.
+        if self.subscription_included and (
+            self.weighted_input_tokens >= self.limits.max_subscription_weighted_input_tokens
+        ):
+            return self._stop("subscription_weighted_input_token_limit")
+        if self.consecutive_large_requests >= self.limits.max_consecutive_large_requests:
+            return self._stop("consecutive_large_request_limit")
+        return None
+
+    def stop_for_request_input_limit(
+        self, *, estimated_request_tokens: int, context_window: int | None,
+        compaction_attempted: bool, post_compaction_estimate: int | None,
+    ) -> str:
+        self._request_stop_details = {
+            "estimated_request_tokens": max(0, int(estimated_request_tokens or 0)),
+            "request_limit": self.limits.max_request_input_tokens,
+            "context_window": context_window if isinstance(context_window, int) and context_window > 0 else None,
+            "compaction_attempted": bool(compaction_attempted),
+            "post_compaction_estimate": post_compaction_estimate,
+        }
+        return self._stop("request_input_token_limit")
+
+    def begin_request(self, estimated_gross_input_tokens: int) -> str | None:
+        stop = self.before_request(estimated_gross_input_tokens)
+        if stop is None:
+            self.calls += 1
+            self.session_usage["model_calls"] += 1
+        return stop
+
+    def record_usage(
+        self, *, input_tokens: int, cache_read_tokens: int, cache_write_tokens: int = 0,
+        output_tokens: int = 0, reasoning_tokens: int = 0,
+    ) -> None:
+        uncached = max(0, int(input_tokens or 0))
+        cached_read = max(0, int(cache_read_tokens or 0))
+        cached_write = max(0, int(cache_write_tokens or 0))
+        output = max(0, int(output_tokens or 0))
+        reasoning = max(0, int(reasoning_tokens or 0))
+        gross = uncached + cached_read + cached_write
+        weighted = uncached + cached_write + round(cached_read * _CACHE_READ_WEIGHT)
+        for target in (self.__dict__, self.session_usage):
+            target["uncached_input_tokens"] = target.get("uncached_input_tokens", 0) + uncached
+            target["cache_read_tokens"] = target.get("cache_read_tokens", 0) + cached_read
+            target["cache_write_tokens"] = target.get("cache_write_tokens", 0) + cached_write
+            target["gross_input_tokens"] = target.get("gross_input_tokens", 0) + gross
+            target["weighted_input_tokens"] = target.get("weighted_input_tokens", 0) + weighted
+            target["output_tokens"] = target.get("output_tokens", 0) + output
+            target["reasoning_tokens"] = target.get("reasoning_tokens", 0) + reasoning
+        self.consecutive_large_requests = self.consecutive_large_requests + 1 if gross >= self.limits.large_request_tokens else 0
+        self.receipts.append({
+            "call": self.calls, "uncached_input_tokens": uncached,
+            "cache_read_tokens": cached_read, "cache_write_tokens": cached_write,
+            "gross_input_tokens": gross, "weighted_input_tokens": weighted,
+            "output_tokens": output, "reasoning_tokens": reasoning,
+        })
+        if self.subscription_included and self.weighted_input_tokens >= self.limits.max_subscription_weighted_input_tokens:
+            self._stop("subscription_weighted_input_token_limit")
+
+    def turn_usage_summary(self) -> dict[str, Any]:
+        largest = max((int(r.get("gross_input_tokens", 0)) for r in self.receipts), default=0)
+        return {
+            "model_calls": self.calls, "max_model_calls": self.limits.max_model_calls,
+            "uncached_input_tokens": self.uncached_input_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
+            "gross_input_tokens": self.gross_input_tokens,
+            "weighted_input_tokens": self.weighted_input_tokens,
+            "max_subscription_weighted_input_tokens": self.limits.max_subscription_weighted_input_tokens,
+            "output_tokens": self.output_tokens, "reasoning_tokens": self.reasoning_tokens,
+            "largest_request_tokens": largest, "stop_reason": self.stop_reason,
+            "subscription_included": self.subscription_included,
+            "session_usage": dict(self.session_usage),
+        }
+
+    def checkpoint(self) -> str:
+        reason = self.stop_reason or "budget_limit"
+        text = (
+            f"Usage guardrail stopped this {self.scope} run: {reason}. "
+            f"Checkpoint: {self.calls}/{self.limits.max_model_calls} model calls; "
+            f"{self.gross_input_tokens:,} gross input tokens; "
+            f"{self.weighted_input_tokens:,}/{self.limits.max_subscription_weighted_input_tokens:,} weighted subscription input tokens."
+        )
+        if self._request_stop_details is not None:
+            detail = self._request_stop_details
+            context = detail["context_window"] if detail["context_window"] is not None else "unknown"
+            post = detail["post_compaction_estimate"]
+            post_text = "not available" if post is None else f"{int(post):,}"
+            text += (
+                f" Request estimate={detail['estimated_request_tokens']:,}; "
+                f"request limit={detail['request_limit']:,}; context window={context}; "
+                f"compaction attempted={detail['compaction_attempted']}; "
+                f"post-compaction estimate={post_text}."
+            )
+        return text
+
+    def _stop(self, reason: str) -> str:
+        self.stop_reason = reason
+        return self.checkpoint()

--- a/cli.py
+++ b/cli.py
@@ -12260,6 +12260,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if agent is None:
             return None
 
+        # Persist the frozen, non-secret route before this CLI turn dispatches.
+        # Specialist children use their own profile DB in delegate_tool; this
+        # is the primary-turn counterpart in the existing SessionDB.
+        _frozen_route = turn_route.get("task_route")
+        if _frozen_route is not None and getattr(agent, "_session_db", None) is not None:
+            try:
+                from agent.task_routing import routing_receipt
+                agent._session_db.create_session(
+                    session_id=agent.session_id, source="cli", model=_frozen_route.model,
+                    model_config=getattr(agent, "_session_init_model_config", None),
+                    profile_name=_frozen_route.profile,
+                )
+                agent._session_db.persist_routing_receipt(
+                    agent.session_id,
+                    routing_receipt(_frozen_route, task_id=agent.session_id,
+                                    child_session_id=agent.session_id),
+                )
+                agent._session_db_created = True
+            except Exception as exc:
+                logging.warning("Could not persist CLI routing receipt: %s", exc)
+
         # Route image attachments based on the active model's vision capability.
         # "native" → pass pixels as OpenAI-style content parts (adapters
         #            translate for Anthropic/Gemini/Bedrock).
@@ -12926,6 +12947,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 preview = _leftover_steer[:60] + ("..." if len(_leftover_steer) > 60 else "")
                 print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
                 self._pending_input.put(_leftover_steer)
+
+            if _frozen_route is not None and getattr(agent, "_session_db", None) is not None:
+                try:
+                    agent._session_db.reconcile_routing_receipt(
+                        agent.session_id, task_id=agent.session_id,
+                        status="completed" if result and result.get("completed") else "failed",
+                        token_usage={
+                            "input": int(getattr(agent, "session_prompt_tokens", 0) or 0),
+                            "output": int(getattr(agent, "session_completion_tokens", 0) or 0),
+                        },
+                        cost_attribution=getattr(agent, "session_cost_source", None),
+                    )
+                except Exception as exc:
+                    logging.warning("Could not reconcile CLI routing receipt: %s", exc)
 
             return response
             

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1712,6 +1712,8 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        task_route=None,
+        task_runtime: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1746,6 +1748,16 @@ class APIServerAdapter(BasePlatformAdapter):
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
+
+        if task_route is not None and task_runtime is not None:
+            # The task resolver freezes profile/provider/model before agent
+            # construction.  Credentials remain execution-only in this dict.
+            model = task_route.model
+            runtime_kwargs.update({
+                key: task_runtime[key]
+                for key in ("api_key", "base_url", "provider", "api_mode", "command", "args", "credential_pool")
+                if key in task_runtime
+            })
 
         # When the primary provider's auth fails (expired token / 429 quota
         # cap), _resolve_runtime_agent_kwargs() falls through to the fallback
@@ -4565,6 +4577,17 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id or "",
                 )
                 try:
+                    try:
+                        from agent.task_routing import resolve_route_runtime, resolve_task_route
+
+                        task_route = resolve_task_route(user_message, role="orchestrator")
+                        task_runtime = resolve_route_runtime(task_route)
+                        task_route = task_runtime.pop("_task_route", task_route)
+                    except Exception as exc:
+                        return ({
+                            "final_response": f"Routing unavailable: {exc}", "messages": [],
+                            "api_calls": 0, "completed": False, "failed": True, "error": str(exc),
+                        }, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
                         session_id=session_id,
@@ -4574,10 +4597,28 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key,
                         route=route,
+                        task_route=task_route,
+                        task_runtime=task_runtime,
                     )
                     if agent_ref is not None:
                         agent_ref[0] = agent
                     effective_task_id = session_id or str(uuid.uuid4())
+                    route_db = getattr(agent, "_session_db", None)
+                    if route_db is not None:
+                        from agent.task_routing import routing_receipt
+
+                        route_db.create_session(
+                            session_id=agent.session_id, source="api_server",
+                            model=task_route.model,
+                            model_config=getattr(agent, "_session_init_model_config", None),
+                            profile_name=task_route.profile,
+                        )
+                        route_db.persist_routing_receipt(
+                            agent.session_id,
+                            routing_receipt(task_route, task_id=effective_task_id,
+                                            child_session_id=agent.session_id),
+                        )
+                        agent._session_db_created = True
                     result = agent.run_conversation(
                         user_message=user_message,
                         conversation_history=conversation_history,
@@ -4588,6 +4629,13 @@ class APIServerAdapter(BasePlatformAdapter):
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                         "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
                     }
+                    if route_db is not None:
+                        route_db.reconcile_routing_receipt(
+                            agent.session_id, task_id=effective_task_id,
+                            status="completed" if result.get("completed") else "failed",
+                            token_usage={"input": usage["input_tokens"], "output": usage["output_tokens"]},
+                            cost_attribution=getattr(agent, "session_cost_source", None),
+                        )
                     # Include the effective session ID in the result so callers
                     # (e.g. X-Hermes-Session-Id header) can track compression-
                     # triggered session rotations. (#16938)

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -211,6 +211,36 @@ class CLIAgentSetupMixin:
             ),
         }
 
+        # CLI turns use the same pure resolver as dashboard/API construction.
+        # General-route failure remains visible in the normal runtime resolver;
+        # specialist delegation is the fail-closed path in delegate_tool.
+        try:
+            from agent.task_routing import resolve_route_runtime, resolve_task_route
+
+            frozen_route = resolve_task_route(str(user_message or ""), role="orchestrator")
+            frozen_runtime = resolve_route_runtime(frozen_route)
+            frozen_route = frozen_runtime.pop("_task_route", frozen_route)
+            runtime.update({
+                "api_key": frozen_runtime.get("api_key"),
+                "base_url": frozen_runtime.get("base_url"),
+                "provider": frozen_runtime.get("provider"),
+                "api_mode": frozen_runtime.get("api_mode"),
+                "command": frozen_runtime.get("command"),
+                "args": list(frozen_runtime.get("args") or []),
+                "credential_pool": frozen_runtime.get("credential_pool"),
+            })
+            route["model"] = frozen_route.model
+            route["task_route"] = frozen_route
+            route["signature"] = (
+                frozen_route.profile, frozen_route.provider, frozen_route.model,
+                runtime["base_url"], runtime["api_mode"], runtime["command"],
+                tuple(runtime["args"]),
+            )
+        except Exception:
+            # Existing unprofiled CLI installs remain usable; the resolver's
+            # specialist path never takes this fallback.
+            route["task_route"] = None
+
         service_tier = getattr(self, "service_tier", None)
         if not service_tier:
             route["request_overrides"] = None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1169,6 +1169,17 @@ DEFAULT_CONFIG = {
         "reasoning_overrides": {},
     },
 
+    # Subscription-pool policy is opt-in and fail-closed: no configured pool
+    # means the existing runtime route remains unchanged.  Metered billing and
+    # paid overage both require explicit per-call authorization.
+    "task_routing": {
+        "capabilities": ["coding", "research", "verification", "operations", "general"],
+        "task_budget_tokens": 16000,
+        "allow_metered": False,
+        "allow_paid_usage": False,
+        "pools": [],
+    },
+
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",
@@ -8415,7 +8426,19 @@ def set_config_value(key: str, value: str):
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
     coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
+    default_value = _default_value_for_key(key)
+    if isinstance(default_value, (list, dict)):
+        try:
+            structured_value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            print(f"Invalid JSON value for structured setting '{key}': {exc}", file=sys.stderr)
+            sys.exit(1)
+        if not isinstance(structured_value, type(default_value)):
+            expected = "array" if isinstance(default_value, list) else "object"
+            print(f"Configuration setting '{key}' requires a JSON {expected}.", file=sys.stderr)
+            sys.exit(1)
+        coerced_value = structured_value
+    elif not isinstance(default_value, str):
         if value.lower() in {'true', 'yes', 'on'}:
             coerced_value = True
         elif value.lower() in {'false', 'no', 'off'}:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4045,6 +4045,42 @@ def fetch_api_models(
     ).get("models")
 
 
+def fetch_api_models_strict(
+    api_key: Optional[str],
+    base_url: Optional[str],
+    timeout: float = 5.0,
+) -> Optional[list[str]]:
+    """Fetch exactly the authenticated ``/v1/models`` endpoint.
+
+    This deliberately does not delegate to merged Ollama discovery, its cache,
+    or registry fallbacks: only this credential's live endpoint can authorize a
+    configured subscription-pool model.
+    """
+    normalized = str(base_url or "").rstrip("/")
+    if not api_key or not normalized.endswith("/v1"):
+        return None
+    request = urllib.request.Request(
+        normalized + "/models",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "User-Agent": _HERMES_USER_AGENT,
+        },
+    )
+    try:
+        with _urlopen_model_catalog_request(request, timeout=timeout) as response:
+            data = json.loads(response.read().decode())
+    except Exception:
+        return None
+    models = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(models, list):
+        return None
+    return [
+        str(model["id"]).strip()
+        for model in models
+        if isinstance(model, dict) and str(model.get("id") or "").strip()
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Ollama Cloud — merged model discovery with disk cache
 # ---------------------------------------------------------------------------

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1857,6 +1857,70 @@ def get_active_profile_name() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Authoritative profile registry
+# ---------------------------------------------------------------------------
+# Keep profile ingress fail-closed.  Older callers may still use
+# ``get_profile_dir`` for filesystem management, but task execution must use
+# this registry so a typo or broken config cannot become the default profile.
+
+
+@dataclass(frozen=True)
+class ProfileRecord:
+    name: str
+    home: Path
+    config: dict
+
+
+class ProfileRegistry:
+    """Validated view of the on-disk profile registry."""
+
+    def names(self) -> tuple[str, ...]:
+        root = _get_profiles_root()
+        named = []
+        if root.is_dir():
+            for entry in sorted(root.iterdir(), key=lambda item: item.name):
+                if entry.is_dir() and _PROFILE_ID_RE.match(entry.name):
+                    named.append(entry.name)
+        return ("default", *named)
+
+    def resolve(self, name: str) -> ProfileRecord:
+        canon = normalize_profile_name(name)
+        validate_profile_name(canon)
+        home = get_profile_dir(canon)
+        if not home.is_dir():
+            raise FileNotFoundError(
+                f"Profile '{canon}' does not exist. Create it with: hermes profile create {canon}"
+            )
+        config_path = home / "config.yaml"
+        if not config_path.exists():
+            return ProfileRecord(canon, home, {})
+        try:
+            import yaml
+            loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        except Exception as exc:
+            raise ProfileResolutionError(
+                f"Profile '{canon}' has malformed config.yaml: {exc}"
+            ) from exc
+        if not isinstance(loaded, dict):
+            raise ProfileResolutionError(
+                f"Profile '{canon}' config.yaml must contain a mapping, not {type(loaded).__name__}."
+            )
+        return ProfileRecord(canon, home, loaded)
+
+
+class ProfileResolutionError(ValueError):
+    """A profile cannot safely be used for execution."""
+
+
+_PROFILE_REGISTRY = ProfileRegistry()
+
+
+def get_profile_registry() -> ProfileRegistry:
+    """Return the sole profile registry used by task-routing ingress points."""
+    return _PROFILE_REGISTRY
+
+
+# ---------------------------------------------------------------------------
 # Export / Import
 # ---------------------------------------------------------------------------
 
@@ -2212,14 +2276,4 @@ def resolve_profile_env(profile_name: str) -> str:
     Called early in the CLI entry point, before any hermes modules
     are imported, to set the HERMES_HOME environment variable.
     """
-    canon = normalize_profile_name(profile_name)
-    validate_profile_name(canon)
-    profile_dir = get_profile_dir(canon)
-
-    if canon != "default" and not profile_dir.is_dir():
-        raise FileNotFoundError(
-            f"Profile '{canon}' does not exist. "
-            f"Create it with: hermes profile create {canon}"
-        )
-
-    return str(profile_dir)
+    return str(get_profile_registry().resolve(profile_name).home)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1011,7 +1011,9 @@ class SessionDB:
     _IMPORT_MAX_TOTAL_BYTES = 25 * 1024 * 1024
 
     def __init__(self, db_path: Path = None, read_only: bool = False):
-        self.db_path = db_path or DEFAULT_DB_PATH
+        # Resolve the default at construction time so a profile-scoped routed
+        # child never writes its receipt into the parent's state database.
+        self.db_path = db_path or (get_hermes_home() / "state.db")
         self.read_only = read_only
 
         self._lock = threading.Lock()
@@ -2685,6 +2687,70 @@ class SessionDB:
             conn.execute(
                 "UPDATE sessions SET model_config = ?, model = COALESCE(?, model) WHERE id = ?",
                 (model_config_json, model, session_id),
+            )
+        self._execute_write(_do)
+
+    def persist_routing_receipt(self, session_id: str, receipt: Dict[str, Any]) -> None:
+        """Append a non-secret route receipt before a routed dispatch.
+
+        Receipts deliberately live in the existing session metadata column so
+        routing adds no competing session store.  The caller is responsible for
+        omitting runtime credentials; this method defensively drops common
+        secret-bearing keys as well.
+        """
+        safe = {
+            key: value for key, value in dict(receipt or {}).items()
+            if key not in {"api_key", "access_token", "refresh_token", "credential", "credentials"}
+        }
+
+        def _do(conn):
+            row = conn.execute("SELECT model_config FROM sessions WHERE id = ?", (session_id,)).fetchone()
+            try:
+                meta = json.loads(row[0] or "{}") if row else {}
+            except (TypeError, json.JSONDecodeError):
+                meta = {}
+            if not isinstance(meta, dict):
+                meta = {}
+            receipts = meta.get("routing_receipts")
+            if not isinstance(receipts, list):
+                receipts = []
+            receipts.append(safe)
+            meta["routing_receipts"] = receipts[-32:]
+            conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ?",
+                (json.dumps(meta, ensure_ascii=False), session_id),
+            )
+        self._execute_write(_do)
+
+    def reconcile_routing_receipt(
+        self,
+        session_id: str,
+        *,
+        task_id: str,
+        status: str,
+        token_usage: Optional[Dict[str, int]] = None,
+        cost_attribution: Optional[str] = None,
+    ) -> None:
+        """Reconcile one persisted route receipt after routed execution."""
+        def _do(conn):
+            row = conn.execute("SELECT model_config FROM sessions WHERE id = ?", (session_id,)).fetchone()
+            try:
+                meta = json.loads(row[0] or "{}") if row else {}
+            except (TypeError, json.JSONDecodeError):
+                meta = {}
+            receipts = meta.get("routing_receipts") if isinstance(meta, dict) else None
+            if not isinstance(receipts, list):
+                return
+            for item in reversed(receipts):
+                if isinstance(item, dict) and item.get("task_id") == task_id:
+                    item["status"] = status
+                    item["token_usage"] = dict(token_usage or {})
+                    if cost_attribution is not None:
+                        item["cost_attribution"] = cost_attribution
+                    break
+            conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ?",
+                (json.dumps(meta, ensure_ascii=False), session_id),
             )
         self._execute_write(_do)
 

--- a/scripts/evaluate_subscription_routes.py
+++ b/scripts/evaluate_subscription_routes.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python
+"""Negligible-quota subscription-route evaluation harness.
+
+Default mode performs read-only installation/auth/model/quota probes and makes
+no model calls.  ``--smoke`` is opt-in and runs exactly one tiny, tool-disabled
+request; it never performs a broad comparison.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+POOL_ORDER = (
+    "ollama-cloud",
+    "openai-subscription",
+    "google-antigravity",
+    "anthropic-subscription",
+)
+
+
+def _command(command: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _usage(provider: str) -> dict[str, Any]:
+    from agent.account_usage import fetch_account_usage
+
+    snapshot = fetch_account_usage(provider)
+    if snapshot is None:
+        return {"visible": False, "state": "unknown", "windows": []}
+    windows = [
+        {"label": item.label, "used_percent": float(item.used_percent)}
+        for item in snapshot.windows
+    ]
+    used = max((item["used_percent"] for item in windows), default=None)
+    return {
+        "visible": snapshot.available and used is not None,
+        "state": "exhausted" if used is not None and used >= 100.0 else "available",
+        "plan": snapshot.plan,
+        "source": snapshot.source,
+        "windows": windows,
+        "unavailable_reason": snapshot.unavailable_reason,
+    }
+
+
+def _openai_paid_usage_possible() -> bool | None:
+    try:
+        import httpx
+        from agent.account_usage import _resolve_codex_usage_credentials, _resolve_codex_usage_url
+
+        token, base_url, account_id = _resolve_codex_usage_credentials(None, None)
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "User-Agent": "codex-cli",
+        }
+        if account_id:
+            headers["ChatGPT-Account-Id"] = account_id
+        response = httpx.get(_resolve_codex_usage_url(base_url), headers=headers, timeout=15.0)
+        response.raise_for_status()
+        credits = (response.json() or {}).get("credits") or {}
+        return bool(credits.get("has_credits"))
+    except Exception:
+        return None
+
+
+def _anthropic_paid_usage_possible() -> bool | None:
+    try:
+        import httpx
+        from agent.anthropic_adapter import resolve_anthropic_token
+
+        token = (resolve_anthropic_token() or "").strip()
+        response = httpx.get(
+            "https://api.anthropic.com/api/oauth/usage",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "anthropic-beta": "oauth-2025-04-20",
+                "User-Agent": "claude-code/2.1.0",
+            },
+            timeout=15.0,
+        )
+        response.raise_for_status()
+        return bool(((response.json() or {}).get("extra_usage") or {}).get("is_enabled"))
+    except Exception:
+        return None
+
+
+def _configured_ollama_subscription_pool() -> dict[str, Any]:
+    """Read the configured API-key pool association without resolving secrets."""
+    from hermes_cli.config import load_config
+
+    config = load_config()
+    routing = config.get("task_routing") if isinstance(config.get("task_routing"), dict) else {}
+    pools = routing.get("pools") if isinstance(routing.get("pools"), list) else []
+    for pool in pools:
+        if not isinstance(pool, dict):
+            continue
+        if str(pool.get("provider") or "").strip().lower() not in {"ollama", "ollama-cloud"}:
+            continue
+        if pool.get("enabled", True) is not True:
+            continue
+        if str(pool.get("billing_mode") or "").strip().lower() != "subscription":
+            continue
+        if str(pool.get("subscription_pool") or "").strip():
+            return dict(pool)
+    return {}
+
+
+def _ollama_probe() -> dict[str, Any]:
+    from agent.subscription_pool import is_approved_ollama_cloud_endpoint
+    from hermes_cli.models import fetch_api_models_strict
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(requested="ollama-cloud")
+    base_url = str(runtime.get("base_url") or "")
+    api_key = runtime.get("api_key")
+    pool = _configured_ollama_subscription_pool()
+    subscription_pool = str(pool.get("subscription_pool") or "").strip()
+    cloud_verified = is_approved_ollama_cloud_endpoint(base_url)
+    # models.dev is discovery data, not proof that this API key authenticated
+    # or that a model is available on the configured Cloud subscription.
+    live_models = fetch_api_models_strict(api_key, base_url) if api_key and cloud_verified else None
+    authenticated = bool(api_key and live_models is not None)
+    models = live_models or []
+    cloud_model_verified = bool(models)
+    paid_usage_possible = pool.get("paid_usage_possible")
+    eligible = all((
+        authenticated,
+        cloud_verified,
+        cloud_model_verified,
+        bool(subscription_pool),
+        paid_usage_possible is False,
+    ))
+    blocked: list[str] = []
+    if not api_key:
+        blocked.append("Ollama Cloud API key is not configured")
+    elif cloud_verified and live_models is None:
+        blocked.append("Ollama Cloud authentication or model-roster probe failed")
+    if not cloud_verified:
+        blocked.append("endpoint is not an approved Ollama Cloud endpoint")
+    if not cloud_model_verified:
+        blocked.append("Cloud model roster is unavailable")
+    if not subscription_pool:
+        blocked.append("configured API key has no explicit subscription-pool association")
+    if paid_usage_possible is not False:
+        blocked.append("paid overage must be explicitly disabled")
+    return {
+        "pool": "ollama-cloud",
+        "provider": "ollama-cloud",
+        "execution_surface": "hermes",
+        "installed": True,
+        "authenticated": authenticated,
+        "headless": True,
+        "workspace": True,
+        "tools": True,
+        "cloud_verified": cloud_verified,
+        "cloud_model_verified": cloud_model_verified,
+        "model_roster": models,
+        "model_roster_source": "authenticated live /v1/models",
+        "quota": {"visible": False, "state": "unknown"},
+        "subscription_pool": subscription_pool,
+        "billing_mode": "subscription" if subscription_pool else "unverified",
+        "paid_usage_possible": paid_usage_possible,
+        "execution_supported": True,
+        # Unknown quota is observable but not a gate for a configured,
+        # subscription-backed Cloud pool.
+        "eligible": eligible,
+        "blocked_by": blocked,
+    }
+
+
+def _antigravity_probe() -> dict[str, Any]:
+    executable = shutil.which("agy")
+    models = _command([executable, "models"]) if executable else None
+    help_result = _command([executable, "--help"]) if executable else None
+    help_text = help_result.stdout if help_result else ""
+    roster = [line.strip() for line in (models.stdout if models else "").splitlines() if line.strip()]
+    return {
+        "pool": "google-antigravity",
+        "provider": "google-antigravity-cli",
+        "execution_surface": "cli",
+        "installed": executable is not None,
+        "authenticated": bool(models and models.returncode == 0 and roster),
+        "headless": "--print" in help_text,
+        "workspace": "--add-dir" in help_text,
+        "tools": "--sandbox" in help_text,
+        "model_roster": roster,
+        "model_roster_source": "agy models",
+        "quota": {"visible": False, "state": "unknown"},
+        "billing_mode": "unverified",
+        "paid_usage_possible": None,
+        "execution_supported": False,
+        "eligible": False,
+        "blocked_by": [
+            "Google AI Pro billing not exposed by CLI",
+            "quota not exposed headlessly",
+            "Hermes CLI-worker bridge not implemented",
+        ],
+    }
+
+
+def _openai_probe() -> dict[str, Any]:
+    from hermes_cli.codex_models import get_codex_model_ids
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(requested="openai-codex")
+    usage = _usage("openai-codex")
+    paid = _openai_paid_usage_possible()
+    models = get_codex_model_ids(runtime.get("api_key"))
+    eligible = bool(runtime.get("api_key") and models and usage["visible"] and paid is False)
+    blocked = []
+    if not models:
+        blocked.append("runtime model roster unavailable")
+    if not usage["visible"]:
+        blocked.append("quota unavailable")
+    if paid is not False:
+        blocked.append("paid credits or overage cannot be ruled out")
+    return {
+        "pool": "openai-subscription",
+        "provider": "openai-codex",
+        "execution_surface": "hermes",
+        "installed": shutil.which("codex") is not None,
+        "authenticated": bool(runtime.get("api_key")),
+        "headless": True,
+        "workspace": True,
+        "tools": True,
+        "model_roster": models,
+        "model_roster_source": "Codex runtime models endpoint",
+        "quota": usage,
+        "billing_mode": "subscription" if usage.get("plan") else "unverified",
+        "paid_usage_possible": paid,
+        "execution_supported": True,
+        "eligible": eligible,
+        "blocked_by": blocked,
+    }
+
+
+def _anthropic_probe() -> dict[str, Any]:
+    executable = shutil.which("claude")
+    auth = _command([executable, "auth", "status"]) if executable else None
+    auth_payload: dict[str, Any] = {}
+    try:
+        auth_payload = json.loads(auth.stdout) if auth else {}
+    except json.JSONDecodeError:
+        pass
+    usage = _usage("anthropic")
+    paid = _anthropic_paid_usage_possible()
+    return {
+        "pool": "anthropic-subscription",
+        "provider": "anthropic-cli",
+        "execution_surface": "cli",
+        "installed": executable is not None,
+        "authenticated": bool(auth_payload.get("loggedIn")),
+        "headless": True,
+        "workspace": True,
+        "tools": True,
+        "model_roster": [],
+        "model_roster_source": "requires one explicit --smoke anthropic run",
+        "model_preference": {"family": "sonnet", "minimum_generation": 5},
+        "quota": usage,
+        "billing_mode": "subscription" if auth_payload.get("subscriptionType") else "unverified",
+        "paid_usage_possible": paid,
+        "execution_supported": False,
+        "eligible": False,
+        "blocked_by": ["Hermes CLI-worker bridge not implemented", "runtime roster needs explicit smoke"],
+    }
+
+
+def _smoke(name: str) -> dict[str, Any]:
+    if name == "anthropic":
+        result = _command([
+            "claude", "-p", "Reply exactly: ROUTE_SMOKE_OK. Do not use tools.",
+            "--model", "sonnet", "--tools", "", "--permission-mode", "dontAsk",
+            "--output-format", "json", "--no-session-persistence",
+        ], timeout=90)
+        payload = json.loads(result.stdout) if result.returncode == 0 else {}
+        return {
+            "route": name,
+            "ok": result.returncode == 0 and payload.get("result") == "ROUTE_SMOKE_OK",
+            "models": sorted((payload.get("modelUsage") or {}).keys()),
+            "turns": payload.get("num_turns"),
+        }
+    raise ValueError("Only the Anthropic roster requires an opt-in smoke; other rosters use read-only APIs.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--smoke", choices=("anthropic",), help="run one tiny tool-disabled request")
+    args = parser.parse_args()
+
+    probes = [_ollama_probe(), _openai_probe(), _antigravity_probe(), _anthropic_probe()]
+    report: dict[str, Any] = {
+        "pool_order": list(POOL_ORDER),
+        "probes": probes,
+        "automatic_metered_usage": False,
+        "automatic_paid_overage": False,
+        "smoke": _smoke(args.smoke) if args.smoke else None,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    raise SystemExit(main())

--- a/tests/agent/test_profile_governor.py
+++ b/tests/agent/test_profile_governor.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from agent.agent_init import _resolve_compression_threshold
+from agent.auxiliary_client import _compression_threshold_for_model
+from agent.task_routing import (
+    ProfileRouteConfig,
+    TaskRoute,
+    _profile_configs,
+    _configured_pool_routes,
+    profile_runtime_scope,
+    resolve_profile_governor,
+)
+from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+from hermes_cli.config import load_config
+from hermes_cli import profiles
+
+
+def _write_profile(
+    home: Path,
+    *,
+    turns: int,
+    request_tokens: int,
+    threshold: float,
+    route_id: str,
+    codex_autoraise: bool = True,
+) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    config = {
+        "agent": {"max_turns": turns},
+        "model": {"provider": "openai-codex", "default": "gpt-5.6-terra"},
+        "compression": {
+            "threshold": threshold,
+            "codex_gpt55_autoraise": codex_autoraise,
+        },
+        "usage_guardrails": {
+            "operator_authorized": True,
+            "interactive": {
+                "max_model_calls": 512,
+                "max_subscription_weighted_input_tokens": 3_000_000,
+                "max_request_input_tokens": request_tokens,
+                "max_consecutive_large_requests": 24,
+                "large_request_tokens": 150_000,
+            },
+        },
+        "cron": {"script_timeout_seconds": 60},
+        "delegation": {"max_concurrent_children": 2},
+        "task_routing": {
+            "pools": [
+                {
+                    "id": route_id,
+                    "enabled": False,
+                    "priority": 10,
+                    "provider": "openai-codex",
+                    "model": "profile",
+                    "execution_surface": "hermes",
+                    "subscription_pool": route_id,
+                    "billing_mode": "subscription",
+                    "capabilities": ["general"],
+                    "quota_state": "available",
+                    "paid_usage_possible": False,
+                    "blockers": ["test fixture is disabled"],
+                    "verification": {
+                        "installed": True,
+                        "authenticated": True,
+                        "models_available": True,
+                        "headless": True,
+                        "workspace": True,
+                        "tools": True,
+                        "quota_visible": True,
+                        "billing_verified": True,
+                    },
+                }
+            ]
+        },
+    }
+    (home / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
+def _route(profile: str, home: Path) -> TaskRoute:
+    return TaskRoute(
+        task="fixture",
+        role="generic",
+        profile=profile,
+        provider="openai-codex",
+        model="runtime-model",
+        pool_alias="subscription",
+        pool_type="subscription",
+        cost_mode="included",
+        budget_tokens=1_000,
+        delegated=True,
+        home=str(home),
+        subscription_pool="subscription",
+        billing_mode="subscription",
+    )
+
+
+def _profile(route: TaskRoute) -> ProfileRouteConfig:
+    return ProfileRouteConfig(
+        route.profile,
+        route.home,
+        route.provider,
+        route.model,
+        ("general",),
+        1_000,
+        route.pool_alias,
+        route.pool_type,
+        route.cost_mode,
+    )
+
+
+def test_profile_governors_load_effectively_and_preserve_other_limits(tmp_path):
+    root = tmp_path / "hermes"
+    engineering = root / "profiles" / "engineering"
+    assurance = root / "profiles" / "assurance"
+    _write_profile(root, turns=80, request_tokens=200_000, threshold=0.50, route_id="dru-pool")
+    _write_profile(
+        engineering,
+        turns=120,
+        request_tokens=220_000,
+        threshold=0.55,
+        route_id="brok-pool",
+        codex_autoraise=False,
+    )
+    _write_profile(assurance, turns=80, request_tokens=200_000, threshold=0.50, route_id="tyr-pool")
+    active_profile = root / "active_profile"
+    active_profile.write_text("default\n", encoding="utf-8")
+
+    token = set_hermes_home_override(root)
+    try:
+        for profile, home, expected in (
+            ("default", root, (80, 200_000, 0.50)),
+            ("engineering", engineering, (120, 220_000, 0.55)),
+            ("assurance", assurance, (80, 200_000, 0.50)),
+        ):
+            route = _route(profile, home)
+            governor = resolve_profile_governor(route)
+            assert (
+                governor.max_turns,
+                governor.max_request_input_tokens,
+                governor.compression_threshold,
+            ) == expected
+            with profile_runtime_scope(route):
+                config = load_config()
+                assert config["cron"]["script_timeout_seconds"] == 60
+                assert config["delegation"]["max_concurrent_children"] == 2
+                interactive = config["usage_guardrails"]["interactive"]
+                assert {
+                    "max_model_calls": interactive["max_model_calls"],
+                    "max_subscription_weighted_input_tokens": interactive[
+                        "max_subscription_weighted_input_tokens"
+                    ],
+                    "max_consecutive_large_requests": interactive[
+                        "max_consecutive_large_requests"
+                    ],
+                    "large_request_tokens": interactive["large_request_tokens"],
+                } == {
+                    "max_model_calls": 512,
+                    "max_subscription_weighted_input_tokens": 3_000_000,
+                    "max_consecutive_large_requests": 24,
+                    "large_request_tokens": 150_000,
+                }
+        assert get_hermes_home() == root
+        assert active_profile.read_text(encoding="utf-8") == "default\n"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_pool_configuration_is_profile_scoped_without_leakage(tmp_path):
+    root = tmp_path / "hermes"
+    engineering = root / "profiles" / "engineering"
+    _write_profile(root, turns=80, request_tokens=200_000, threshold=0.50, route_id="dru-pool")
+    _write_profile(engineering, turns=120, request_tokens=220_000, threshold=0.55, route_id="brok-pool")
+    dru = _route("default", root)
+    brok = _route("engineering", engineering)
+
+    token = set_hermes_home_override(root)
+    try:
+        with profile_runtime_scope(dru):
+            dru_pools = _configured_pool_routes(_profile(dru))
+        with profile_runtime_scope(brok):
+            brok_pools = _configured_pool_routes(_profile(brok))
+    finally:
+        reset_hermes_home_override(token)
+
+    assert [item.route_id for item in dru_pools] == ["dru-pool"]
+    assert [item.route_id for item in brok_pools] == ["brok-pool"]
+
+
+def test_brok_profile_threshold_disables_codex_autoraise(tmp_path):
+    root = tmp_path / "hermes"
+    engineering = root / "profiles" / "engineering"
+    _write_profile(
+        engineering,
+        turns=120,
+        request_tokens=220_000,
+        threshold=0.55,
+        route_id="brok-pool",
+        codex_autoraise=False,
+    )
+    route = _route("engineering", engineering)
+
+    with profile_runtime_scope(route):
+        config = load_config()
+    governor = resolve_profile_governor(route)
+    codex_autoraise = config["compression"]["codex_gpt55_autoraise"]
+    model_threshold = _compression_threshold_for_model(
+        "gpt-5.6-terra",
+        "openai-codex",
+        allow_codex_gpt55_autoraise=codex_autoraise,
+    )
+    effective_threshold, notice = _resolve_compression_threshold(
+        governor.compression_threshold,
+        model_threshold,
+        model="gpt-5.6-terra",
+        is_codex_autoraise=True,
+    )
+
+    assert codex_autoraise is False
+    assert model_threshold is None
+    assert effective_threshold == 0.55
+    assert notice is None
+
+
+def test_authoritative_profile_registry_feeds_task_routing_loader(tmp_path, monkeypatch):
+    root = tmp_path / "hermes"
+    engineering = root / "profiles" / "engineering"
+    _write_profile(
+        root,
+        turns=80,
+        request_tokens=200_000,
+        threshold=0.50,
+        route_id="dru-pool",
+    )
+    _write_profile(
+        engineering,
+        turns=120,
+        request_tokens=220_000,
+        threshold=0.55,
+        route_id="brok-pool",
+        codex_autoraise=False,
+    )
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: root)
+
+    candidates = {candidate.profile: candidate for candidate in _profile_configs()}
+
+    assert candidates["default"].home == str(root)
+    assert candidates["default"].model == "gpt-5.6-terra"
+    assert candidates["engineering"].home == str(engineering)
+    assert candidates["engineering"].model == "gpt-5.6-terra"

--- a/tests/agent/test_subscription_pool.py
+++ b/tests/agent/test_subscription_pool.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from agent.subscription_pool import (
+    PoolConfigurationError,
+    PoolRouteConfig,
+    PoolVerification,
+    select_model_from_roster,
+    select_subscription_route,
+)
+
+
+def _verified(
+    *,
+    cloud: bool = True,
+    cloud_model: bool = True,
+    auth: bool = True,
+    models: bool = True,
+    quota: bool = True,
+) -> PoolVerification:
+    return PoolVerification(
+        installed=True,
+        authenticated=auth,
+        models_available=models,
+        headless=True,
+        workspace=True,
+        tools=True,
+        quota_visible=quota,
+        billing_verified=True,
+        cloud_verified=cloud,
+        cloud_model_verified=cloud_model,
+    )
+
+
+def _route(
+    route_id: str,
+    priority: int,
+    *,
+    provider: str = "openai-codex",
+    model: str = "runtime-model",
+    capabilities: tuple[str, ...] = ("coding",),
+    billing: str = "subscription",
+    quota: str = "available",
+    verification: PoolVerification | None = None,
+    paid: bool = False,
+    surface: str = "hermes",
+    host: str = "chatgpt.com",
+    remaining: float | None = 80.0,
+    reserve: float | None = 10.0,
+) -> PoolRouteConfig:
+    runtime_base_url = f"https://{host}/v1" if provider in {"ollama", "ollama-cloud"} else ""
+    return PoolRouteConfig(
+        route_id=route_id,
+        provider=provider,
+        model=model,
+        execution_surface=surface,
+        subscription_pool=f"{route_id}:authenticated",
+        billing_mode=billing,
+        capabilities=capabilities,
+        priority=priority,
+        verification=verification or _verified(),
+        paid_usage_possible=paid,
+        quota_state=quota,
+        remaining_percent=remaining,
+        soft_reserve_percent=reserve,
+        endpoint_host=host,
+        runtime_base_url=runtime_base_url,
+    )
+
+
+@pytest.mark.parametrize("host", ("localhost", "127.0.0.1", "::1", "0.0.0.0"))
+def test_local_and_loopback_ollama_endpoints_are_never_selected(host):
+    local = _route("local", 1, provider="ollama-cloud", host=host)
+    cloud = _route("cloud", 2)
+
+    selected = select_subscription_route((local, cloud), capability="coding")
+
+    assert selected.selected.route_id == "cloud"
+    assert selected.rejected[0]["code"] == "local_model_forbidden"
+
+
+def test_ollama_requires_verified_cloud_route():
+    unverified = _route(
+        "ollama-unverified",
+        1,
+        provider="ollama-cloud",
+        host="ollama.com",
+        verification=_verified(cloud=False),
+    )
+    fallback = _route("openai", 3)
+
+    selected = select_subscription_route((unverified, fallback), capability="coding")
+
+    assert selected.selected.route_id == "openai"
+    assert any(item["code"] == "unverified_cloud_route" for item in selected.rejected)
+
+
+def test_configured_ollama_cloud_pool_with_unknown_quota_is_preferred_and_explained():
+    ollama = replace(
+        _route(
+            "ollama",
+            50,
+            provider="ollama",
+            model="qwen3-coder:cloud",
+            host="ollama.com",
+            quota="unknown",
+            verification=_verified(quota=False),
+        ),
+        subscription_pool="ollama-api-key:pro",
+    )
+    openai = _route("openai", 1)
+
+    selected = select_subscription_route((openai, ollama), capability="coding")
+
+    assert selected.selected.route_id == "ollama"
+    assert any(
+        item["route_id"] == "ollama" and item["code"] == "quota_unknown"
+        for item in selected.rejected
+    )
+    assert "pool ollama-api-key:pro" in selected.selection_reason
+    assert "quota is unknown" in selected.selection_reason
+
+
+def test_ollama_rejects_unapproved_endpoints_and_non_cloud_models():
+    unapproved = _route(
+        "ollama-unapproved",
+        1,
+        provider="ollama",
+        host="unapproved.example",
+    )
+    non_cloud_model = _route(
+        "ollama-local-model",
+        2,
+        provider="ollama",
+        host="ollama.com",
+        verification=_verified(cloud_model=False),
+    )
+    openai = _route("openai", 3)
+
+    selected = select_subscription_route(
+        (unapproved, non_cloud_model, openai), capability="coding"
+    )
+
+    assert selected.selected.route_id == "openai"
+    assert {item["code"] for item in selected.rejected} >= {
+        "unapproved_ollama_runtime_endpoint",
+        "non_cloud_model_forbidden",
+    }
+
+
+def test_ollama_selection_trusts_authenticated_runtime_not_endpoint_host_metadata():
+    ollama = replace(
+        _route("ollama", 1, provider="ollama", host="metadata.example"),
+        runtime_base_url="https://ollama.com/v1",
+    )
+    openai = _route("openai", 2)
+
+    selected = select_subscription_route((ollama, openai), capability="coding")
+
+    assert selected.selected.route_id == "ollama"
+
+
+def test_cheapest_capable_subscription_route_wins_and_incapable_is_skipped():
+    incapable = _route("cheap-research", 1, capabilities=("research",))
+    cheapest = _route("cheap-coding", 2)
+    expensive = _route("expensive-coding", 3)
+
+    selected = select_subscription_route((incapable, expensive, cheapest), capability="coding")
+
+    assert selected.selected.route_id == "cheap-coding"
+    assert selected.fallback_order == ("expensive-coding",)
+    assert any(item["code"] == "missing_capability" for item in selected.rejected)
+
+
+def test_ollama_exhaustion_auth_failure_and_model_unavailability_advance_to_openai():
+    exhausted = _route(
+        "ollama-exhausted", 1, provider="ollama-cloud", host="ollama.com", quota="exhausted"
+    )
+    auth_failed = _route(
+        "ollama-auth", 2, provider="ollama-cloud", host="ollama.com",
+        quota="auth_failed", verification=_verified(auth=False),
+    )
+    unavailable = _route(
+        "ollama-unavailable", 3, provider="ollama-cloud", host="ollama.com",
+        verification=_verified(models=False),
+    )
+    openai = _route("openai", 4)
+
+    selected = select_subscription_route(
+        (exhausted, auth_failed, unavailable, openai), capability="coding"
+    )
+
+    assert selected.selected.route_id == "openai"
+    assert [item["code"] for item in selected.rejected[:3]] == [
+        "quota_exhausted",
+        "authentication_failed",
+        "model_unavailable",
+    ]
+    assert all(item["next_route"] == "openai" for item in selected.rejected)
+
+
+def test_soft_reserve_influences_routing_without_disabling_pool():
+    reserved = _route("cheap-reserved", 1, remaining=5.0, reserve=10.0)
+    available = _route("next-pool", 2, remaining=80.0)
+
+    selected = select_subscription_route((reserved, available), capability="coding")
+
+    assert selected.selected.route_id == "next-pool"
+    assert selected.fallback_order == ("cheap-reserved",)
+    assert "soft reserve" in selected.selection_reason
+
+
+def test_metered_and_paid_overage_routes_remain_disabled_without_authorization():
+    metered = _route("metered", 1, billing="metered")
+    overage = _route("overage", 2, paid=True)
+    subscription = _route("subscription", 3)
+
+    selected = select_subscription_route((metered, overage, subscription), capability="coding")
+
+    assert selected.selected.route_id == "subscription"
+    assert {item["code"] for item in selected.rejected} >= {
+        "metered_not_authorized",
+        "paid_usage_not_authorized",
+    }
+
+
+def test_selection_reason_reports_selected_metered_and_overage_authorizations():
+    authorized = _route("authorized", 1, billing="metered", paid=True)
+
+    selected = select_subscription_route(
+        (authorized,), capability="coding", allow_metered=True, allow_paid_usage=True
+    )
+
+    assert selected.selected.route_id == "authorized"
+    assert "metered billing" in selected.selection_reason
+    assert "metered usage explicitly authorized" in selected.selection_reason
+    assert "paid overage explicitly authorized" in selected.selection_reason
+
+
+def test_provider_pool_and_billing_attribution_are_required_before_execution():
+    ambiguous = replace(_route("bad", 1), subscription_pool="")
+
+    with pytest.raises(PoolConfigurationError, match="authenticated pool attribution"):
+        select_subscription_route((ambiguous,), capability="coding")
+
+
+def test_configured_pool_only_bypasses_request_billing_metadata_for_ollama():
+    generic = _route(
+        "generic", 1,
+        verification=replace(_verified(), billing_verified=False),
+    )
+    fallback = _route("openai", 2)
+
+    selected = select_subscription_route((generic, fallback), capability="coding")
+
+    assert selected.selected.route_id == "openai"
+    assert any(item["code"] == "billing_unverified" for item in selected.rejected)
+
+
+def test_sonnet_five_is_default_anthropic_family_not_opus():
+    roster = (
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+        "claude-sonnet-4-6",
+    )
+
+    assert select_model_from_roster(
+        roster, family="sonnet", minimum_generation=5
+    ) == "claude-sonnet-5"
+
+
+def test_unknown_quota_is_reported_without_disabling_the_pool():
+    unavailable = _route("first", 1, verification=_verified(quota=False), quota="unknown")
+    fallback = _route("second", 2)
+
+    selected = select_subscription_route((unavailable, fallback), capability="coding")
+    reason = next(item for item in selected.rejected if item["code"] == "quota_unknown")
+
+    assert reason == {
+        "route_id": "first",
+        "code": "quota_unknown",
+        "reason": "remaining quota is not visible",
+        "next_route": "first",
+    }
+    assert selected.selected.route_id == "first"
+    assert unavailable.verification.complete is True
+
+
+def test_read_only_ollama_evaluation_reports_configured_subscription_pool(monkeypatch):
+    script_path = Path(__file__).parents[2] / "scripts" / "evaluate_subscription_routes.py"
+    spec = importlib.util.spec_from_file_location("subscription_route_evaluation", script_path)
+    assert spec is not None and spec.loader is not None
+    evaluation = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(evaluation)
+
+    from hermes_cli import config, models, runtime_provider
+
+    monkeypatch.setattr(
+        config,
+        "load_config",
+        lambda: {
+            "task_routing": {
+                "pools": [{
+                    "provider": "ollama",
+                    "subscription_pool": "ollama-api-key:pro",
+                    "billing_mode": "subscription",
+                    "paid_usage_possible": False,
+                }]
+            }
+        },
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_: {"api_key": "test-key", "base_url": "https://ollama.com/v1"},
+    )
+    monkeypatch.setattr(models, "fetch_api_models_strict", lambda *_: ["qwen3-coder:cloud"])
+
+    report = evaluation._ollama_probe()
+
+    assert evaluation.POOL_ORDER[:2] == ("ollama-cloud", "openai-subscription")
+    assert report["eligible"] is True
+    assert report["subscription_pool"] == "ollama-api-key:pro"
+    assert report["quota"] == {"visible": False, "state": "unknown"}
+    assert report["blocked_by"] == []
+
+
+def test_read_only_ollama_evaluation_requires_successful_authentication(monkeypatch):
+    script_path = Path(__file__).parents[2] / "scripts" / "evaluate_subscription_routes.py"
+    spec = importlib.util.spec_from_file_location("subscription_route_auth_evaluation", script_path)
+    assert spec is not None and spec.loader is not None
+    evaluation = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(evaluation)
+
+    from hermes_cli import config, models, runtime_provider
+
+    monkeypatch.setattr(
+        config,
+        "load_config",
+        lambda: {
+            "task_routing": {
+                "pools": [{
+                    "provider": "ollama-cloud",
+                    "subscription_pool": "ollama-subscription",
+                    "billing_mode": "subscription",
+                    "paid_usage_possible": False,
+                }]
+            }
+        },
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_: {"api_key": "configured-key", "base_url": "https://ollama.com/v1"},
+    )
+    monkeypatch.setattr(models, "fetch_api_models_strict", lambda *_: None)
+
+    report = evaluation._ollama_probe()
+
+    assert report["authenticated"] is False
+    assert report["eligible"] is False
+    assert "authentication or model-roster probe failed" in "; ".join(report["blocked_by"])
+
+
+def test_disabled_integration_exposes_configured_blockers():
+    disabled = replace(
+        _route("antigravity", 1),
+        enabled=False,
+        billing_mode="unverified",
+        blockers=("billing unavailable", "worker bridge missing"),
+    )
+    fallback = _route("openai", 2)
+
+    selected = select_subscription_route((disabled, fallback), capability="coding")
+
+    assert selected.selected.route_id == "openai"
+    assert selected.rejected[0]["code"] == "route_disabled"
+    assert selected.rejected[0]["reason"] == "billing unavailable; worker bridge missing"
+
+
+def test_unverified_billing_cannot_be_enabled():
+    route = replace(_route("ambiguous", 1), billing_mode="unverified")
+
+    with pytest.raises(PoolConfigurationError, match="cannot be enabled"):
+        select_subscription_route((route,), capability="coding")
+
+
+@pytest.mark.parametrize(
+    "change,match",
+    [
+        ({"provider": "auto"}, "ambiguous provider"),
+        ({"billing_mode": "maybe"}, "ambiguous billing mode"),
+        ({"quota_state": "stale"}, "invalid quota state"),
+        ({"execution_surface": "mystery"}, "unsupported execution surface"),
+    ],
+)
+def test_invalid_or_ambiguous_configuration_fails_visibly(change, match):
+    route = replace(_route("bad", 1), **change)
+
+    with pytest.raises(PoolConfigurationError, match=match):
+        select_subscription_route((route,), capability="coding")

--- a/tests/agent/test_task_routing.py
+++ b/tests/agent/test_task_routing.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.task_routing import (
+    ProfileResolutionError,
+    ProfileRouteConfig,
+    _configured_pool_routes,
+    resolve_route_runtime,
+    resolve_task_route,
+    routing_receipt,
+)
+from agent.subscription_pool import PoolRouteConfig, PoolVerification
+from hermes_cli import profiles
+
+
+@pytest.fixture(autouse=True)
+def _isolate_pool_policy(monkeypatch):
+    """Legacy profile tests must not depend on the operator's live pool config."""
+    monkeypatch.setattr("agent.task_routing._configured_pool_routes", lambda profile: ())
+
+
+def _candidate(profile: str, capabilities: tuple[str, ...] = ("general",)) -> ProfileRouteConfig:
+    return ProfileRouteConfig(
+        profile, f"/p/{profile}", "openai-codex", f"{profile}-model", capabilities,
+        1000, "openai-codex:pool", "oauth", "included",
+    )
+
+
+def _canonical_candidates() -> tuple[ProfileRouteConfig, ...]:
+    return tuple(_candidate(name) for name in (
+        "default", "intelligence", "engineering", "assurance", "operations", "localcred", "martial",
+    ))
+
+
+def test_routes_coding_research_and_verifier_to_configured_profiles(monkeypatch):
+    candidates = (
+        ProfileRouteConfig("engineering", "/p/engineering", "zai", "glm-4.7", ("coding",), 12000,
+                           "zai:pool", "oauth", "included"),
+        ProfileRouteConfig("intelligence", "/p/intelligence", "kimi-coding", "kimi-k2.5", ("research",), 9000,
+                           "kimi-coding:pool", "oauth", "included"),
+        ProfileRouteConfig("assurance", "/p/assurance", "custom:verify", "verify-1", ("verification",), 7000,
+                           "custom:verify:pool", "api_key", "metered"),
+    )
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: candidates)
+
+    assert resolve_task_route("implement parser", role="implementation").profile == "engineering"
+    assert resolve_task_route("research providers", role="research").profile == "intelligence"
+    verifier = resolve_task_route("verify parser", role="verification")
+    assert verifier.profile == "assurance"
+    assert verifier.delegated is True
+
+
+def test_included_capacity_preferred_and_fallback_visible(monkeypatch):
+    candidates = (
+        ProfileRouteConfig("api", "/p/api", "custom:api", "api-model", ("coding",), 100,
+                           "custom:api:configured", "configured", "metered"),
+        ProfileRouteConfig("oauth", "/p/oauth", "zai", "glm-4.7", ("coding",), 200,
+                           "zai:pool", "oauth", "included"),
+    )
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: candidates)
+    route = resolve_task_route("code", role="coding")
+    assert (route.profile, route.cost_mode) == ("oauth", "included")
+    assert route.fallback_reason == "preferred profile 'engineering' is unavailable"
+    assert {"profile": "api", "reason": "lower-ranked policy fallback"} in route.rejected
+
+
+@pytest.mark.parametrize(("role", "task", "expected"), [
+    ("orchestrator", "coordinate the local disposable acceptance", "default"),
+    ("implementation", "repair the disposable parser fixture", "engineering"),
+    ("coding", "implement a harmless fixture", "engineering"),
+    ("research", "synthesize the acceptance evidence", "intelligence"),
+    ("strategic-synthesis", "compare the acceptance evidence", "intelligence"),
+    ("verification", "review the fixture result", "assurance"),
+    ("testing", "test the fixture result", "assurance"),
+    ("operations", "maintain continuity records", "operations"),
+    ("generic", "format this tiny generic note", "default"),
+])
+def test_role_preferences_are_deterministic(monkeypatch, role, task, expected):
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: _canonical_candidates())
+    assert resolve_task_route(task, role=role).profile == expected
+
+
+@pytest.mark.parametrize(("task", "role", "expected"), [
+    ("Prepare the LocalCred customer acceptance note", "implementation", "localcred"),
+    ("Prepare the Martial OS test checklist", "verification", "martial"),
+])
+def test_explicit_domain_work_outranks_generic_role_preference(monkeypatch, task, role, expected):
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: _canonical_candidates())
+    route = resolve_task_route(task, role=role)
+    assert (route.role, route.profile, route.delegated) == (expected, expected, True)
+
+
+def test_explicit_profile_request_is_authoritative(monkeypatch):
+    candidates = _canonical_candidates()
+    monkeypatch.setattr(
+        "agent.task_routing._profile_configs",
+        lambda profile=None: tuple(item for item in candidates if profile in {None, item.profile}),
+    )
+    route = resolve_task_route("implement a harmless fixture", role="implementation", profile="assurance")
+    assert route.profile == "assurance"
+    assert route.fallback_reason is None
+
+
+def test_explicit_profile_identity_remains_authoritative_with_worker_pool(monkeypatch):
+    candidates = _canonical_candidates()
+    monkeypatch.setattr(
+        "agent.task_routing._profile_configs",
+        lambda profile=None: tuple(item for item in candidates if profile in {None, item.profile}),
+    )
+    pool = PoolRouteConfig(
+        route_id="openai-subscription",
+        provider="openai-codex",
+        model="runtime-model",
+        execution_surface="hermes",
+        subscription_pool="chatgpt-team",
+        billing_mode="subscription",
+        capabilities=("coding",),
+        priority=30,
+        verification=PoolVerification(True, True, True, True, True, True, True, True),
+        quota_state="available",
+    )
+
+    route = resolve_task_route(
+        "implement fixture", role="implementation", profile="assurance", pool_routes=(pool,)
+    )
+
+    assert route.profile == "assurance"
+    assert route.provider == "openai-codex"
+    assert route.subscription_pool == "chatgpt-team"
+
+
+def test_configured_ollama_api_key_pool_is_authoritative_without_request_billing_metadata():
+    raw = {
+        "id": "ollama-cloud",
+        "provider": "ollama",
+        "model": "qwen3-coder:cloud",
+        "execution_surface": "hermes",
+        "subscription_pool": "ollama-api-key:pro",
+        "billing_mode": "subscription",
+        "capabilities": ["coding"],
+        "priority": 1,
+        "endpoint_host": "ollama.com",
+        "paid_usage_possible": False,
+        "quota_state": "unknown",
+        "verification": {
+            "installed": True,
+            "authenticated": True,
+            "models_available": True,
+            "headless": True,
+            "workspace": True,
+            "tools": True,
+            "quota_visible": False,
+            "cloud_verified": True,
+            "cloud_model_verified": True,
+        },
+    }
+
+    (pool,) = _configured_pool_routes(_candidate("engineering", ("coding",)), (raw,))
+
+    assert pool.subscription_pool == "ollama-api-key:pro"
+    assert pool.verification.billing_verified is True
+
+
+def test_unavailable_preferred_profile_has_visible_default_fallback(monkeypatch):
+    candidates = tuple(item for item in _canonical_candidates() if item.profile != "engineering")
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: candidates)
+    route = resolve_task_route("implement a harmless fixture", role="implementation")
+    assert route.profile == "default"
+    assert route.fallback_reason == "preferred profile 'engineering' is unavailable"
+    assert {"profile": "engineering", "reason": route.fallback_reason} in route.rejected
+
+
+def test_incapable_preferred_profile_has_visible_default_fallback(monkeypatch):
+    candidates = tuple(
+        _candidate(item.profile, ("research",) if item.profile == "engineering" else item.capabilities)
+        for item in _canonical_candidates()
+    )
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: candidates)
+    route = resolve_task_route("implement a harmless fixture", role="implementation")
+    assert route.profile == "default"
+    assert route.fallback_reason == "preferred profile 'engineering' is missing coding capability"
+    assert {"profile": "engineering", "reason": route.fallback_reason} in route.rejected
+
+
+def test_specialist_selection_does_not_depend_on_registry_order(monkeypatch):
+    candidates = tuple(reversed(_canonical_candidates()))
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: candidates)
+    assert resolve_task_route("implement a harmless fixture", role="implementation").profile == "engineering"
+
+
+def test_receipt_preserves_child_route_and_lineage(monkeypatch):
+    candidate = ProfileRouteConfig("engineering", "/p/engineering", "zai", "glm-4.7", ("coding",), 12000,
+                                   "zai:pool", "oauth", "included")
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: (candidate,))
+    route = resolve_task_route("implement", role="implementation")
+    receipt = routing_receipt(route, task_id="task-1", parent_session_id="parent", child_session_id="child",
+                              token_usage={"input": 3, "output": 2})
+    assert receipt["profile"] == "engineering"
+    assert receipt["model"] == "glm-4.7"
+    assert receipt["pool_alias"] == "zai:pool"
+    assert receipt["parent_session_id"] == "parent"
+    assert receipt["child_session_id"] == "child"
+    assert receipt["token_usage"] == {"input": 3, "output": 2}
+
+
+def test_receipt_records_attempt_attribution_and_structured_handoff(monkeypatch):
+    candidate = _candidate("engineering", ("coding",))
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: (candidate,))
+    route = resolve_task_route("implement", role="implementation")
+
+    receipt = routing_receipt(
+        route,
+        task_id="task-2",
+        parent_profile="default",
+        elapsed_time=1.25,
+        acceptance_evidence=("pytest: passed",),
+        escalation_reason={"code": "quota_exhausted", "detail": "pool one exhausted"},
+        next_route="openai-subscription",
+        status="failed",
+    )
+
+    assert receipt["task_class"] == "coding"
+    assert receipt["execution_surface"] == "hermes"
+    assert receipt["billing_mode"] in {"subscription", "metered"}
+    assert receipt["parent_profile"] == "default"
+    assert receipt["child_delegation"] is True
+    assert receipt["elapsed_time"] == 1.25
+    assert receipt["escalation_reason"]["code"] == "quota_exhausted"
+    assert receipt["next_route"] == "openai-subscription"
+
+
+def _ollama_pool_raw() -> dict[str, object]:
+    return {
+        "id": "ollama-cloud",
+        "provider": "ollama-cloud",
+        "model": "qwen3-coder:cloud",
+        "model_source": "ollama-cloud",
+        "execution_surface": "hermes",
+        "subscription_pool": "ollama-subscription",
+        "billing_mode": "subscription",
+        "capabilities": ["coding"],
+        "priority": 1,
+        "paid_usage_possible": False,
+        "quota_state": "available",
+        "verification": {
+            "installed": True,
+            "authenticated": True,
+            "models_available": True,
+            "headless": True,
+            "workspace": True,
+            "tools": True,
+            "quota_visible": False,
+            "cloud_verified": True,
+            "cloud_model_verified": True,
+        },
+    }
+
+
+def test_configured_ollama_route_uses_live_authenticated_roster_and_binds_runtime_url(monkeypatch):
+    from hermes_cli import models, runtime_provider
+
+    candidate = _candidate("engineering", ("coding",))
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_: {"api_key": "live-key", "base_url": "https://ollama.com/v1"},
+    )
+    monkeypatch.setattr(
+        models,
+        "fetch_api_models_strict",
+        lambda api_key, base_url: calls.append((api_key, base_url)) or ["qwen3-coder:cloud"],
+    )
+
+    (route,) = _configured_pool_routes(candidate, (_ollama_pool_raw(),))
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: (candidate,))
+    task_route = resolve_task_route("implement fixture", role="implementation", pool_routes=(route,))
+    runtime = resolve_route_runtime(task_route)
+
+    assert calls == [
+        ("live-key", "https://ollama.com/v1"),
+        ("live-key", "https://ollama.com/v1"),
+    ]
+    assert route.model == "qwen3-coder:cloud"
+    assert route.runtime_base_url == "https://ollama.com/v1"
+    assert task_route.runtime_base_url == "https://ollama.com/v1"
+    assert runtime["base_url"] == task_route.runtime_base_url
+
+
+@pytest.mark.parametrize(("runtime", "expected_code"), (
+    ({"api_key": "live-key", "base_url": "http://ollama.com/v1"}, "unapproved_ollama_runtime_endpoint"),
+    ({"api_key": "live-key", "base_url": "https://ollama.com/v1"}, "model_unavailable"),
+    ({"api_key": "", "base_url": "https://ollama.com/v1"}, "authentication_failed"),
+))
+def test_live_ollama_endpoint_auth_or_roster_failure_advances_to_openai(
+    monkeypatch, runtime, expected_code
+):
+    from hermes_cli import models, runtime_provider
+
+    candidate = _candidate("engineering", ("coding",))
+    openai = PoolRouteConfig(
+        route_id="openai-subscription", provider="openai-codex", model="gpt-5",
+        execution_surface="hermes", subscription_pool="openai-subscription",
+        billing_mode="subscription", capabilities=("coding",), priority=2,
+        verification=PoolVerification(True, True, True, True, True, True, True, True),
+    )
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", lambda **_: runtime)
+    monkeypatch.setattr(models, "fetch_api_models_strict", lambda *_: None)
+
+    pools = _configured_pool_routes(candidate, (_ollama_pool_raw(),)) + (openai,)
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: (candidate,))
+    route = resolve_task_route("implement fixture", role="implementation", pool_routes=pools)
+
+    assert route.provider == "openai-codex"
+    assert route.fallback_order == ()
+    rejected = next(item for item in route.rejected if item["route_id"] == "ollama-cloud")
+    assert rejected["code"] == expected_code
+    assert rejected["next_route"] == "openai-subscription"
+
+
+@pytest.mark.parametrize(("ollama_runtime", "roster", "expected_code"), (
+    ({"api_key": "live-key", "base_url": "http://ollama.com/v1"}, ["qwen3-coder:cloud"],
+     "endpoint_validation_failed"),
+    ({"api_key": "", "base_url": "https://ollama.com/v1"}, ["qwen3-coder:cloud"],
+     "authentication_failed"),
+    ({"api_key": "live-key", "base_url": "https://ollama.com/v1"}, [],
+     "model_unavailable"),
+))
+def test_post_selection_ollama_runtime_failure_uses_frozen_openai_fallback(
+    monkeypatch, ollama_runtime, roster, expected_code
+):
+    from hermes_cli import models, runtime_provider
+
+    candidate = _candidate("engineering", ("coding",))
+    ollama = PoolRouteConfig(
+        route_id="ollama-cloud", provider="ollama-cloud", model="qwen3-coder:cloud",
+        execution_surface="hermes", subscription_pool="ollama-subscription",
+        billing_mode="subscription", capabilities=("coding",), priority=1,
+        verification=PoolVerification(True, True, True, True, True, True, False, True),
+        quota_state="unknown", endpoint_host="ollama.com",
+        runtime_base_url="https://ollama.com/v1",
+    )
+    openai = PoolRouteConfig(
+        route_id="openai-subscription", provider="openai-codex", model="gpt-5",
+        execution_surface="hermes", subscription_pool="chatgpt-team",
+        billing_mode="subscription", capabilities=("coding",), priority=2,
+        verification=PoolVerification(True, True, True, True, True, True, True, True),
+    )
+    monkeypatch.setattr("agent.task_routing._profile_configs", lambda profile=None: (candidate,))
+    route = resolve_task_route(
+        "implement fixture", role="implementation", pool_routes=(ollama, openai)
+    )
+
+    def resolve_runtime_provider(*, requested, **_):
+        if requested == "ollama-cloud":
+            return ollama_runtime
+        return {
+            "provider": "openai-codex", "api_key": "team-token",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", resolve_runtime_provider)
+    monkeypatch.setattr(models, "fetch_api_models_strict", lambda *_: roster)
+
+    runtime = resolve_route_runtime(route)
+    effective = runtime.pop("_task_route")
+
+    assert effective.provider == "openai-codex"
+    assert effective.model == "gpt-5"
+    assert effective.fallback_order == ()
+    assert effective.rejected[-1] == {
+        "route_id": "ollama-cloud",
+        "code": expected_code,
+        "reason": effective.rejected[-1]["reason"],
+        "next_route": "openai-subscription",
+    }
+    assert runtime["provider"] == "openai-codex"
+
+
+def test_strict_ollama_roster_probe_never_falls_back_from_v1(monkeypatch):
+    from hermes_cli import models
+
+    requested: list[str] = []
+
+    def fail(request, **_):
+        requested.append(request.full_url)
+        raise OSError("unavailable")
+
+    monkeypatch.setattr(models, "_urlopen_model_catalog_request", fail)
+
+    assert models.fetch_api_models_strict("live-key", "https://ollama.com/v1") is None
+    assert models.fetch_api_models_strict("live-key", "https://ollama.com") is None
+    assert requested == ["https://ollama.com/v1/models"]

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -697,8 +697,13 @@ class TestAgentExecution:
         mock_agent.session_prompt_tokens = 1
         mock_agent.session_completion_tokens = 2
         mock_agent.session_total_tokens = 3
+        mock_agent._session_db = None
 
-        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+        with (
+            patch("agent.task_routing.resolve_task_route", return_value=MagicMock(model="route-model")),
+            patch("agent.task_routing.resolve_route_runtime", return_value={}),
+            patch.object(adapter, "_create_agent", return_value=mock_agent),
+        ):
             result, usage = await adapter._run_agent(
                 user_message="hello",
                 conversation_history=[],
@@ -3927,11 +3932,16 @@ class TestSessionKeyHeader:
             mock_agent.session_prompt_tokens = 0
             mock_agent.session_completion_tokens = 0
             mock_agent.session_total_tokens = 0
+            mock_agent._session_db = None
             return mock_agent
 
         app = _create_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(auth_adapter, "_create_agent", side_effect=_fake_create_agent):
+            with (
+                patch("agent.task_routing.resolve_task_route", return_value=MagicMock(model="route-model")),
+                patch("agent.task_routing.resolve_route_runtime", return_value={}),
+                patch.object(auth_adapter, "_create_agent", side_effect=_fake_create_agent),
+            ):
                 resp = await cli.post(
                     "/v1/chat/completions",
                     headers={

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -5,6 +5,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from hermes_cli.config import set_config_value, config_command
 
@@ -123,6 +124,20 @@ class TestConfigYamlRouting:
             "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=true" in env_content
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
+
+    def test_structured_pool_routes_are_parsed_from_json(self, _isolated_hermes_home):
+        value = '[{"id":"openai","enabled":true,"capabilities":["coding"]}]'
+
+        set_config_value("task_routing.pools", value)
+
+        config = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert config["task_routing"]["pools"] == [
+            {"id": "openai", "enabled": True, "capabilities": ["coding"]}
+        ]
+
+    def test_structured_pool_routes_reject_non_array_json(self):
+        with pytest.raises(SystemExit):
+            set_config_value("task_routing.pools", '{"id":"openai"}')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3159,5 +3159,80 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+class TestSubscriptionPoolDelegationIntegration(unittest.TestCase):
+    """The selected worker pool and profile governor reach child construction."""
+
+    def test_selected_pool_governor_and_receipt_reach_routed_child(self):
+        from types import SimpleNamespace
+
+        from agent.subscription_pool import PoolRouteConfig, PoolVerification
+        from agent.task_routing import ProfileRouteConfig, resolve_task_route
+
+        profile = ProfileRouteConfig(
+            "engineering", "/profiles/engineering", "openai-codex", "profile-model",
+            ("coding",), 16_000, "legacy", "oauth", "included",
+        )
+        pool = PoolRouteConfig(
+            route_id="openai-subscription",
+            provider="openai-codex",
+            model="runtime-model",
+            execution_surface="hermes",
+            subscription_pool="chatgpt-team",
+            billing_mode="subscription",
+            capabilities=("coding",),
+            priority=30,
+            verification=PoolVerification(True, True, True, True, True, True, True, True),
+            quota_state="available",
+            paid_usage_possible=False,
+        )
+        with patch("agent.task_routing._profile_configs", return_value=(profile,)):
+            route = resolve_task_route(
+                "implement fixture", role="implementation", profile="engineering",
+                pool_routes=(pool,),
+            )
+
+        parent = _make_mock_parent(depth=0)
+        parent.session_id = "parent-session"
+        parent._session_db = MagicMock()
+        routed_db = MagicMock()
+        child = MagicMock()
+        child.session_id = "child-session"
+        child._session_init_model_config = {}
+
+        with (
+            patch("run_agent.AIAgent", return_value=child) as MockAgent,
+            patch(
+                "agent.task_routing.resolve_profile_governor",
+                return_value=SimpleNamespace(max_turns=120),
+            ),
+        ):
+            built = _build_child_agent(
+                task_index=0,
+                goal="implement fixture",
+                context=None,
+                toolsets=None,
+                model=route.model,
+                max_iterations=50,
+                parent_agent=parent,
+                task_count=1,
+                override_provider=route.provider,
+                override_base_url="https://chatgpt.com/backend-api/codex",
+                override_api_key="test-token",
+                override_credential_pool=object(),
+                routing_route=route,
+                routing_session_db=routed_db,
+            )
+
+        self.assertIs(built, child)
+        self.assertEqual(MockAgent.call_args.kwargs["max_iterations"], 120)
+        self.assertEqual(MockAgent.call_args.kwargs["provider"], "openai-codex")
+        receipt = routed_db.persist_routing_receipt.call_args.args[1]
+        self.assertEqual(receipt["profile"], "engineering")
+        self.assertEqual(receipt["subscription_pool"], "chatgpt-team")
+        self.assertEqual(receipt["billing_mode"], "subscription")
+        self.assertEqual(receipt["execution_surface"], "hermes")
+        parent._session_db.persist_routing_receipt.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -351,6 +351,18 @@ def _normalize_role(r: Optional[str]) -> str:
     return "leaf"
 
 
+def _normalize_task_role(value: Optional[str]) -> Optional[str]:
+    """Return an opt-in specialist role without changing spawn-role semantics."""
+    if value is None or not str(value).strip():
+        return None
+    normalized = str(value).strip().lower()
+    aliases = {"coding": "implementation", "verify": "verification", "verifier": "verification"}
+    normalized = aliases.get(normalized, normalized)
+    if normalized in {"implementation", "research", "verification"}:
+        return normalized
+    raise ValueError("task_role must be implementation, research, or verification")
+
+
 def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
@@ -1057,6 +1069,7 @@ def _build_child_agent(
     override_api_mode: Optional[str] = None,
     override_request_overrides: Optional[Dict[str, Any]] = None,
     override_max_tokens: Optional[int] = None,
+    override_credential_pool=None,
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -1064,6 +1077,8 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    routing_route=None,
+    routing_session_db=None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1277,7 +1292,9 @@ def _build_child_agent(
     # from rate-limits and credential exhaustion exactly like the top-level
     # agent does.  _fallback_chain is a list accepted by AIAgent's
     # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    parent_fallback = None if routing_route is not None else (
+        getattr(parent_agent, "_fallback_chain", None) or None
+    )
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -1317,6 +1334,22 @@ def _build_child_agent(
     if isinstance(child_max_tokens, int):
         child_optional_kwargs["max_tokens"] = child_max_tokens
 
+    # A specialist route supplies its own already-resolved pool.  Do not look
+    # it up again after the selected profile scope has been left: that could
+    # silently substitute the caller's default-profile pool.
+    child_pool = override_credential_pool
+    if child_pool is None:
+        child_pool = _resolve_child_credential_pool(
+            effective_provider, parent_agent, effective_base_url
+        )
+
+    # Profile-targeted workers use the selected profile's supported
+    # agent.max_turns value. Untyped helpers retain delegation.max_iterations.
+    if routing_route is not None:
+        from agent.task_routing import resolve_profile_governor
+
+        max_iterations = resolve_profile_governor(routing_route).max_turns
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
@@ -1330,6 +1363,7 @@ def _build_child_agent(
         reasoning_config=child_reasoning,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         fallback_model=parent_fallback,
+        credential_pool=child_pool,
         enabled_toolsets=child_toolsets,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,
@@ -1339,7 +1373,7 @@ def _build_child_agent(
         skip_memory=True,
         clarify_callback=None,
         thinking_callback=child_thinking_cb,
-        session_db=getattr(parent_agent, "_session_db", None),
+        session_db=routing_session_db or getattr(parent_agent, "_session_db", None),
         parent_session_id=getattr(parent_agent, "session_id", None),
         providers_allowed=child_providers_allowed,
         providers_ignored=child_providers_ignored,
@@ -1357,6 +1391,10 @@ def _build_child_agent(
         iteration_budget=None,  # fresh budget per subagent
         **child_optional_kwargs,
     )
+    # Keep the resolved pool on the child explicitly.  AIAgent normally does
+    # this from its constructor argument, while this assignment also preserves
+    # the established invariant for compatible construction shims and mocks.
+    child._credential_pool = child_pool
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     # Now the child exists, its session id can ride on every relayed event
     # (including the spawn_requested below — first emit happens after this).
@@ -1372,6 +1410,8 @@ def _build_child_agent(
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
+    child._routing_route = routing_route
+    child._routing_task_id = subagent_id
     # Stable sidebar marker: delegate subagent sessions must stay out of
     # session pickers even when a parent delete orphans them (parent_session_id
     # → NULL). Mirrors /branch's ``_branched_from`` pattern — see
@@ -1380,13 +1420,38 @@ def _build_child_agent(
     if parent_sid and getattr(child, "_session_init_model_config", None) is not None:
         child._session_init_model_config["_delegate_from"] = parent_sid
 
-    # Share a credential pool with the child when possible so subagents can
-    # rotate credentials on rate limits instead of getting pinned to one key.
-    child_pool = _resolve_child_credential_pool(
-        effective_provider, parent_agent, effective_base_url
-    )
-    if child_pool is not None:
-        child._credential_pool = child_pool
+    # A routed child owns a profile-scoped SessionDB.  Persist the same
+    # non-secret receipt in the parent's existing database for lineage lookup.
+    if routing_route is not None and routing_session_db is not None:
+        try:
+            from agent.task_routing import routing_receipt
+
+            receipt = routing_receipt(
+                routing_route,
+                task_id=subagent_id,
+                parent_session_id=parent_sid,
+                child_session_id=child.session_id,
+            )
+            routing_session_db.create_session(
+                session_id=child.session_id,
+                source="subagent",
+                model=routing_route.model,
+                model_config=getattr(child, "_session_init_model_config", None),
+                parent_session_id=parent_sid,
+                profile_name=routing_route.profile,
+            )
+            routing_session_db.persist_routing_receipt(child.session_id, receipt)
+            parent_routing_session_db = getattr(parent_agent, "_session_db", None)
+            if (
+                parent_sid
+                and parent_routing_session_db is not None
+                and parent_routing_session_db is not routing_session_db
+            ):
+                parent_routing_session_db.persist_routing_receipt(parent_sid, receipt)
+            child._routing_parent_session_db = parent_routing_session_db
+            child._session_db_created = True
+        except Exception as exc:
+            raise ValueError(f"Cannot persist routed child receipt: {exc}") from exc
 
     # Register child for interrupt propagation
     if hasattr(parent_agent, "_active_children"):
@@ -2182,6 +2247,33 @@ def _run_single_child(
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
+        routing_db = getattr(child, "_session_db", None)
+        parent_routing_db = getattr(child, "_routing_parent_session_db", None)
+        routing_task_id = getattr(child, "_routing_task_id", None)
+        if getattr(child, "_routing_route", None) is not None and routing_task_id:
+            token_usage = {
+                "input": int(_input_tokens or 0),
+                "output": int(_output_tokens or 0),
+            }
+            reconciled_dbs = set()
+            for receipt_db, receipt_session_id in (
+                (routing_db, child.session_id),
+                (parent_routing_db, getattr(child, "_parent_session_id", None)),
+            ):
+                if receipt_db is None or not receipt_session_id or id(receipt_db) in reconciled_dbs:
+                    continue
+                reconciled_dbs.add(id(receipt_db))
+                try:
+                    receipt_db.reconcile_routing_receipt(
+                        receipt_session_id,
+                        task_id=routing_task_id,
+                        status=status,
+                        token_usage=token_usage,
+                        cost_attribution=getattr(child, "session_cost_source", None),
+                    )
+                except Exception:
+                    logger.warning("Could not reconcile routed child receipt", exc_info=True)
+
         # Cross-agent file-state reminder.  If this subagent wrote any
         # files the parent had already read, surface it so the parent
         # knows to re-read before editing — the scenario that motivated
@@ -2384,6 +2476,7 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    task_role: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
@@ -2461,8 +2554,9 @@ def delegate_task(
     # bundle (base_url, api_key, api_mode) via the same runtime provider system
     # used by CLI/gateway startup.  When unconfigured, returns None values so
     # children inherit from the parent.
+    creds = None
     try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
+        top_task_role = _normalize_task_role(task_role)
     except ValueError as exc:
         return tool_error(str(exc))
 
@@ -2485,7 +2579,7 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "role": top_role}]
+        task_list = [{"goal": goal, "context": context, "role": top_role, "task_role": top_task_role}]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -2500,6 +2594,18 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+        try:
+            task["_task_role"] = _normalize_task_role(task.get("task_role", top_task_role))
+        except ValueError as exc:
+            return tool_error(f"Task {i}: {exc}")
+
+    # Preserve legacy delegation resolution for untyped calls only. Specialist
+    # calls below resolve their selected profile exactly and fail closed.
+    if any(task.get("_task_role") is None for task in task_list):
+        try:
+            creds = _resolve_delegation_credentials(cfg, parent_agent)
+        except ValueError as exc:
+            return tool_error(str(exc))
 
     overall_start = time.monotonic()
     results = []
@@ -2519,12 +2625,50 @@ def delegate_task(
     # Wrapped in try/finally so the global is always restored even if a
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
     children = []
+    verification_children = []
     try:
         for i, t in enumerate(task_list):
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
-            child = _build_child_agent(
+            route = None
+            runtime = None
+            routing_session_db = None
+            if t.get("_task_role") is not None:
+                try:
+                    from agent.task_routing import (
+                        ProfileResolutionError,
+                        profile_runtime_scope,
+                        resolve_route_runtime,
+                        resolve_task_route,
+                    )
+                    from hermes_state import SessionDB
+
+                    route = resolve_task_route(t["goal"], role=t["_task_role"])
+                    runtime = resolve_route_runtime(route)
+                    route = runtime.pop("_task_route", route)
+                    with profile_runtime_scope(route):
+                        routing_session_db = SessionDB()
+                        child = _build_child_agent(
+                            task_index=i, goal=t["goal"], context=t.get("context"),
+                            toolsets=None, model=route.model, max_iterations=effective_max_iter,
+                            task_count=n_tasks, parent_agent=parent_agent,
+                            override_provider=runtime.get("provider"),
+                            override_base_url=runtime.get("base_url"),
+                            override_api_key=runtime.get("api_key"),
+                            override_api_mode=runtime.get("api_mode"),
+                            override_request_overrides=runtime.get("request_overrides"),
+                            override_max_tokens=runtime.get("max_output_tokens"),
+                            override_credential_pool=runtime.get("credential_pool"),
+                            override_acp_command=runtime.get("command"),
+                            override_acp_args=runtime.get("args"), role=effective_role,
+                            routing_route=route, routing_session_db=routing_session_db,
+                        )
+                except (ProfileResolutionError, ValueError, FileNotFoundError) as exc:
+                    return tool_error(f"Specialist route unavailable: {exc}")
+            else:
+                assert creds is not None
+                child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
@@ -2544,10 +2688,47 @@ def delegate_task(
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
                 role=effective_role,
-            )
+                )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
             children.append((i, t, child))
+            if t.get("_task_role") == "implementation":
+                try:
+                    from agent.task_routing import profile_runtime_scope, resolve_route_runtime, resolve_task_route
+                    from hermes_state import SessionDB
+
+                    verifier_route = resolve_task_route(
+                        f"Verify implementation: {t['goal']}", role="verification"
+                    )
+                    verifier_runtime = resolve_route_runtime(verifier_route)
+                    verifier_route = verifier_runtime.pop("_task_route", verifier_route)
+                    verifier_goal = (
+                        "Independently verify the implementation task below. Inspect the "
+                        "working tree and run relevant local checks; report failures plainly.\n\n"
+                        f"Implementation task: {t['goal']}"
+                    )
+                    verifier_index = n_tasks + len(verification_children)
+                    with profile_runtime_scope(verifier_route):
+                        verifier = _build_child_agent(
+                            task_index=verifier_index, goal=verifier_goal,
+                            context=t.get("context"), toolsets=None,
+                            model=verifier_route.model, max_iterations=effective_max_iter,
+                            task_count=n_tasks + 1, parent_agent=parent_agent,
+                            override_provider=verifier_runtime.get("provider"),
+                            override_base_url=verifier_runtime.get("base_url"),
+                            override_api_key=verifier_runtime.get("api_key"),
+                            override_api_mode=verifier_runtime.get("api_mode"),
+                            override_request_overrides=verifier_runtime.get("request_overrides"),
+                            override_max_tokens=verifier_runtime.get("max_output_tokens"),
+                            override_credential_pool=verifier_runtime.get("credential_pool"),
+                            override_acp_command=verifier_runtime.get("command"),
+                            override_acp_args=verifier_runtime.get("args"), role="leaf",
+                            routing_route=verifier_route, routing_session_db=SessionDB(),
+                        )
+                    verifier._delegate_saved_tool_names = _parent_tool_names
+                    verification_children.append((i, verifier_index, verifier_goal, verifier))
+                except (ProfileResolutionError, ValueError, FileNotFoundError) as exc:
+                    return tool_error(f"Verification route unavailable: {exc}")
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
@@ -2687,8 +2868,17 @@ def delegate_task(
                             except Exception as e:
                                 logger.debug("Spinner update_text failed: %s", e)
 
-            # Sort by task_index so results match input order
-            results.sort(key=lambda r: r["task_index"])
+        # Verification is a separate child, resolved and receipted before
+        # dispatch, but executes only after its implementation sibling.
+        for implementation_index, verifier_index, verifier_goal, verifier in verification_children:
+            verification = _run_single_child(
+                verifier_index, verifier_goal, verifier, parent_agent
+            )
+            verification["verification_of"] = implementation_index
+            results.append(verification)
+
+        # Sort by task_index so results match input order.
+        results.sort(key=lambda r: r["task_index"])
 
         # Cap subagent summaries against the parent's remaining context
         # headroom (split across the batch) before they enter the parent's
@@ -3448,6 +3638,11 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "task_role": {
+                            "type": "string",
+                            "enum": ["implementation", "research", "verification"],
+                            "description": "Optional specialist execution role.",
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3460,6 +3655,11 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "task_role": {
+                "type": "string",
+                "enum": ["implementation", "research", "verification"],
+                "description": "Optional specialist execution role. Implementation creates a separately routed verifier child.",
             },
             "background": {
                 "type": "boolean",


### PR DESCRIPTION
## What does this PR do?

Corrects Ollama Cloud subscription-pool attribution and routing. A configured authenticated Ollama API key may establish authoritative attribution to an explicitly subscription-backed pool; Ollama does not need to expose separate per-request subscription billing metadata.

The route remains fail-closed: it must use an approved non-local HTTPS Ollama Cloud endpoint, a cloud-hosted model present in the authenticated live `/v1/models` roster, and must not enable metered billing or paid overage. Unknown quota is reported as `quota_unknown` but does not disable an otherwise verified subscription route.

The same frozen route, profile-scoped governor, and non-secret routing receipt are used by CLI, gateway, and delegation execution paths.

## Related Issue

Related: #45646

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add strict subscription-pool policy and focused evaluator in `agent/subscription_pool.py` and `scripts/evaluate_subscription_routes.py`.
- Add profile-aware deterministic routing, live Ollama Cloud `/v1/models` verification, capability filtering, fallback advancement, and non-secret receipts in `agent/task_routing.py`.
- Add the authoritative profile registry and profile-scoped usage governor needed by routed execution.
- Bind effective frozen routes into CLI, gateway, and delegation execution without enabling automatic metered or paid-overage fallback.
- Add tests for API-key-to-pool attribution, unknown quota, endpoint rejection, capability order, authentication/quota failure fallback, billing gates, route explanations, durable receipts, and effective Dru/Brok/Tyr governor values.

## How to Test

1. Run focused policy and integration tests:
   `python -m pytest -q tests/hermes_cli/test_set_config_value.py tests/tools/test_delegate.py::TestSubscriptionPoolDelegationIntegration tests/agent/test_subscription_pool.py tests/agent/test_task_routing.py tests/agent/test_profile_governor.py tests/gateway/test_api_server.py::TestAgentExecution::test_run_agent_uses_session_id_as_task_id tests/gateway/test_api_server.py::TestSessionKeyHeader::test_session_key_threads_into_create_agent`
2. Run broader affected surface tests:
   `python -m pytest -q tests/tools/test_delegate.py tests/gateway/test_api_server.py`
3. Run static checks:
   `ruff check <changed Python files>`, `python -m py_compile <changed Python files>`, and `git diff --check`.

Local results on Windows 10:
- Focused policy/integration: **120 passed**
- Gateway/delegation surfaces: **358 passed, 1 skipped**
- Ruff, `py_compile`, and `git diff --check`: passed
- Live read-only evaluator: Ollama Cloud eligible with `quota_unknown`; OpenAI ChatGPT Team eligible; no automatic metered usage or paid overage.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (policy and evaluator docstrings included)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. Focused test and evaluator evidence is summarized above.
