### PR TITLE
fix(desktop): load runtime plugins from the local hermes home when /api/status omits hermes_home

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8052,6 +8052,11 @@ ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
   return `data:${mimeTypeForPath(resolvedPath)};base64,${data.toString('base64')}`
 })
 
+// The LOCAL hermes home, for features that live on the desktop's own disk.
+// Runtime plugins need it when the gateway's public /api/status withholds
+// `hermes_home` (auth-gated remote binds strip it) — see runtime-loader.ts.
+ipcMain.handle('hermes:getHermesHome', () => HERMES_HOME)
+
 ipcMain.handle('hermes:readFileText', async (_event, filePath) => {
   const { resolvedPath, stat } = await resolveReadableFileForIpc(filePath, {
     maxBytes: TEXT_PREVIEW_SOURCE_MAX_BYTES,

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -61,6 +61,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
   readFileDataUrl: filePath => ipcRenderer.invoke('hermes:readFileDataUrl', filePath),
   readFileText: filePath => ipcRenderer.invoke('hermes:readFileText', filePath),
+  getHermesHome: () => ipcRenderer.invoke('hermes:getHermesHome'),
   selectPaths: options => ipcRenderer.invoke('hermes:selectPaths', options),
   writeClipboard: text => ipcRenderer.invoke('hermes:writeClipboard', text),
   saveImageFromUrl: url => ipcRenderer.invoke('hermes:saveImageFromUrl', url),

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -5,8 +5,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
-import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
-import { getStatus } from '@/hermes'
+import { discoverRuntimePlugins, resolveHermesHome } from '@/contrib/runtime-loader'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Package } from '@/lib/icons'
@@ -22,10 +21,17 @@ function reveal(file: string) {
 
 async function revealPluginsDir() {
   try {
-    const { hermes_home } = await getStatus()
+    const home = await resolveHermesHome()
+
+    if (!home) {
+      notifyError('hermes_home unavailable and no local fallback', 'Could not resolve the plugins folder')
+
+      return
+    }
+
     // openDir (not reveal): the door often doesn't exist on first use, and
     // showItemInFolder on a missing path silently no-ops (esp. Windows).
-    const result = await window.hermesDesktop?.openDir?.(`${hermes_home}/desktop-plugins`)
+    const result = await window.hermesDesktop?.openDir?.(`${home}/desktop-plugins`)
 
     if (result && !result.ok) {
       notifyError(result.error ?? 'unknown error', 'Could not open the plugins folder')

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -234,6 +234,23 @@ async function loadDiskPlugin(name: string, file: string): Promise<void> {
   }
 }
 
+/** Hermes home for the on-disk plugin door. Prefers the gateway-reported
+ *  value (profile-scoped), but a remote gateway on an auth-gated bind strips
+ *  `hermes_home` from the public /api/status payload ("deployment recon"),
+ *  which silently disabled runtime plugins for remote topologies — fall back
+ *  to the desktop's own local home, since the disk door reads the LOCAL
+ *  filesystem either way. A gateway-unreachable error still propagates,
+ *  preserving each caller's existing no-gateway handling. */
+export async function resolveHermesHome(): Promise<null | string> {
+  const { hermes_home } = await getStatus()
+
+  if (hermes_home) {
+    return hermes_home
+  }
+
+  return (await window.hermesDesktop?.getHermesHome?.()) ?? null
+}
+
 async function scanDiskPlugins(): Promise<void> {
   const desktop = window.hermesDesktop
 
@@ -246,8 +263,13 @@ async function scanDiskPlugins(): Promise<void> {
   scanning = true
 
   try {
-    const { hermes_home } = await getStatus()
-    const { entries } = await desktop.readDir(`${hermes_home}/desktop-plugins`)
+    const home = await resolveHermesHome()
+
+    if (!home) {
+      return
+    }
+
+    const { entries } = await desktop.readDir(`${home}/desktop-plugins`)
     const seen = new Set<string>()
 
     for (const dir of entries.filter(e => e.isDirectory)) {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -76,6 +76,7 @@ declare global {
       requestMicrophoneAccess: () => Promise<boolean>
       readFileDataUrl: (filePath: string) => Promise<string>
       readFileText: (filePath: string) => Promise<HermesReadFileTextResult>
+      getHermesHome: () => Promise<string>
       selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
       writeClipboard: (text: string) => Promise<boolean>
       saveImageFromUrl: (url: string) => Promise<boolean>


### PR DESCRIPTION
## Problem

On any remote-gateway connection whose dashboard bind is auth-gated (every non-loopback bind, since `--insecure` no longer disables the gate), **no runtime desktop plugin can ever load — silently**.

Root cause chain:

1. `apps/desktop/src/contrib/runtime-loader.ts` (`scanDiskPlugins`) builds its scan path as `` `${status.hermes_home}/desktop-plugins` `` and reads it via `desktop.readDir` — a **local** fs IPC with a **gateway-provided** path prefix.
2. `/api/status` is in `PUBLIC_API_PATHS`, so on a gated bind `hermes_cli/web_server.py` deliberately omits `hermes_home` ("deployment recon" — the loopback/gated split drawn by `should_require_auth`). This applies even to authenticated callers, because the endpoint itself is public.
3. The template yields the literal path `undefined/desktop-plugins`, the ENOENT is swallowed by the loader's catch, and the 5s reconcile poll no-ops forever. Settings → Plugins shows "0 installed" with no error anywhere; the only visible evidence is Settings → Plugins → **Open plugins folder** toasting `ENOENT: no such file or directory, mkdir 'undefined'` (same template in `plugins-settings.tsx`).

### Reproduction

1. Machine B: `hermes serve --host 0.0.0.0 --port 9119` (any auth-gated bind).
2. Machine A: Hermes Desktop → Settings → Gateway → Remote gateway → connect.
3. Drop the official template plugin into `~/.hermes/desktop-plugins/hello/plugin.js` on machine A.
4. It never loads; Rescan does nothing; "Open plugins folder" shows the `mkdir 'undefined'` toast.

## Fix

Runtime desktop plugins live on the desktop's own disk, so resolve their folder from the **local** hermes home whenever the gateway legitimately withholds the field:

- `electron/main.ts`: new `hermes:getHermesHome` IPC returning the existing `HERMES_HOME` (from `resolveHermesHome()`), exposed through the preload as `hermesDesktop.getHermesHome()`.
- `runtime-loader.ts`: new exported `resolveHermesHome()` — prefers `status.hermes_home` (profile-scoped, unchanged behavior for local gateways), falls back to the local home only when the field is absent. Gateway-unreachable errors still propagate, preserving the existing no-gateway handling in both call sites.
- `plugins-settings.tsx` (`revealPluginsDir`): same resolver, with an explicit error toast if no home is resolvable.

Conservative by construction: local-gateway setups take the exact same path as before; only the previously-broken remote case gains the fallback.

### Testing

- `npm run typecheck` (both tsconfigs) and `npx vitest run` — 214 files, 1777 tests passing; eslint clean.
- Field-verified the failure mode end-to-end on a real two-machine setup (macOS desktop → remote `hermes serve` behind basic auth): plugins silently absent, `mkdir 'undefined'` toast, and the loader working again once `hermes_home` was made available. (We currently run a loopback-rebind + SSH-tunnel workaround; this patch removes the need for it.)

## Related observation (separate issue if you prefer)

While debugging this we also found that plugin **render** errors escape isolation: a `ReferenceError` thrown during a statusbar contribution's render brought down the entire renderer ("Something broke in the interface", recoverable via Retry). Load/registration isolation works; contribution render sites appear to lack a per-plugin error boundary. Happy to file separately with details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
