### PR TITLE
fix: deliver oneshot final before bounded cleanup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -90,6 +90,8 @@ except Exception:
 import threading
 import queue
 
+from hermes_cli.exit_watchdog import arm_exit_watchdog as _arm_exit_watchdog
+
 def CanonicalUsage(*args, **kwargs):
     from agent.usage_pricing import CanonicalUsage as _CanonicalUsage
 
@@ -991,71 +993,6 @@ def _prepare_deferred_agent_startup() -> None:
             exc_info=True,
         )
 
-def _arm_exit_watchdog(timeout_s: float | None = None) -> None:
-    """Guarantee the process actually exits once shutdown has begun.
-
-    Two hang classes have kept "dead" CLI processes alive for minutes:
-
-      1. A cleanup step wedged on network I/O (memory provider
-         ``on_session_end``, MCP teardown, remote terminal cleanup).
-      2. Interpreter teardown blocked joining non-daemon threads —
-         stdlib ``ThreadPoolExecutor`` workers are joined unconditionally
-         by ``concurrent.futures``' atexit hook even after
-         ``shutdown(wait=False)``, so one tool thread wedged on a socket
-         held the process open forever (#27563 class).
-
-    The shared daemon pool (``tools.daemon_pool``) removes the main cause
-    of (2); this watchdog is the backstop for both. It arms a daemon
-    timer when ``_run_cleanup`` starts; if the process is still alive
-    after ``timeout_s`` it flushes logging/stdio and calls ``os._exit(0)``.
-    Daemon threads keep running through ``Py_FinalizeEx``'s thread joins,
-    so the timer fires even when the main thread is stuck in teardown.
-
-    Tune with ``HERMES_EXIT_WATCHDOG_S`` (seconds); ``0`` disables.
-    """
-    if timeout_s is None:
-        try:
-            timeout_s = float(os.getenv("HERMES_EXIT_WATCHDOG_S", "30"))
-        except (TypeError, ValueError):
-            timeout_s = 30.0
-    if timeout_s <= 0:
-        return
-    # Never arm under pytest: tests invoke _run_cleanup() directly and a
-    # 30s-delayed os._exit(0) would silently kill the test worker.
-    if os.environ.get("PYTEST_CURRENT_TEST"):
-        return
-
-    def _watchdog():
-        time.sleep(timeout_s)
-        # Still alive — cleanup or interpreter teardown is wedged.
-        try:
-            logger.warning(
-                "Exit watchdog fired after %.0fs — forcing process exit "
-                "(a cleanup step or non-daemon thread is wedged).",
-                timeout_s,
-            )
-        except Exception:
-            pass
-        try:
-            import logging as _lg
-            _lg.shutdown()
-        except Exception:
-            pass
-        for _stream in (sys.stdout, sys.stderr):
-            try:
-                _stream.flush()
-            except Exception:
-                pass
-        os._exit(0)
-
-    try:
-        threading.Thread(
-            target=_watchdog, daemon=True, name="exit-watchdog"
-        ).start()
-    except Exception:
-        pass  # best-effort — never block shutdown on watchdog setup
-
-
 _signal_watchdog_armed = False
 
 
@@ -1098,8 +1035,6 @@ def _arm_exit_watchdog_on_shutdown_signal() -> None:
         _arm_exit_watchdog(timeout_s=base * 2)
     except Exception:
         pass  # never let the backstop break signal handling
-
-
 def _run_cleanup(*, notify_session_finalize: bool = True):
     """Run resource cleanup exactly once."""
     global _cleanup_done

--- a/cli.py
+++ b/cli.py
@@ -1045,7 +1045,16 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
     # Bound total shutdown time: if cleanup (or the interpreter's
     # thread-join teardown after it) wedges, force-exit instead of
     # leaving a zombie CLI holding the terminal for minutes.
-    _arm_exit_watchdog()
+    try:
+        _arm_exit_watchdog()
+    except BaseException as exc:
+        # Cleanup remains best-effort even if the watchdog thread itself
+        # cannot start. Keep this payload-free: shutdown exceptions may carry
+        # user or tool data.
+        logger.warning(
+            "CLI exit watchdog failed exception_type=%s",
+            type(exc).__name__,
+        )
 
     # Reset terminal input modes first, before the slower resource teardown
     # below (MCP / browser / memory shutdown can take seconds). On Ctrl+C the

--- a/hermes_cli/exit_watchdog.py
+++ b/hermes_cli/exit_watchdog.py
@@ -1,0 +1,59 @@
+"""Shared bounded-exit watchdog for interactive and one-shot CLI shutdown."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+
+
+logger = logging.getLogger(__name__)
+
+
+def arm_exit_watchdog(
+    timeout_s: float | None = None,
+    exit_code: int = 0,
+) -> None:
+    """Force process exit when cleanup or interpreter teardown wedges."""
+    if timeout_s is None:
+        try:
+            timeout_s = float(os.getenv("HERMES_EXIT_WATCHDOG_S", "30"))
+        except (TypeError, ValueError):
+            timeout_s = 30.0
+    if timeout_s <= 0:
+        return
+    # Tests invoke cleanup directly; a delayed os._exit would kill the worker.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return
+
+    def _watchdog() -> None:
+        time.sleep(timeout_s)
+        try:
+            logger.warning(
+                "Exit watchdog fired after %.0fs — forcing process exit "
+                "(a cleanup step or non-daemon thread is wedged).",
+                timeout_s,
+            )
+        except Exception:
+            pass
+        try:
+            logging.shutdown()
+        except Exception:
+            pass
+        for stream in (sys.stdout, sys.stderr):
+            try:
+                stream.flush()
+            except Exception:
+                pass
+        os._exit(exit_code)
+
+    try:
+        threading.Thread(
+            target=_watchdog,
+            daemon=True,
+            name="exit-watchdog",
+        ).start()
+    except Exception:
+        pass

--- a/hermes_cli/exit_watchdog.py
+++ b/hermes_cli/exit_watchdog.py
@@ -2,14 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 import os
-import sys
 import threading
 import time
-
-
-logger = logging.getLogger(__name__)
 
 
 def arm_exit_watchdog(
@@ -30,30 +25,13 @@ def arm_exit_watchdog(
 
     def _watchdog() -> None:
         time.sleep(timeout_s)
-        try:
-            logger.warning(
-                "Exit watchdog fired after %.0fs — forcing process exit "
-                "(a cleanup step or non-daemon thread is wedged).",
-                timeout_s,
-            )
-        except Exception:
-            pass
-        try:
-            logging.shutdown()
-        except Exception:
-            pass
-        for stream in (sys.stdout, sys.stderr):
-            try:
-                stream.flush()
-            except Exception:
-                pass
+        # Nothing may run between the deadline and forced exit: logging,
+        # handler locks, stream flushes, and user callbacks can all block.
+        # Final one-shot stdout is flushed before this watchdog is armed.
         os._exit(exit_code)
 
-    try:
-        threading.Thread(
-            target=_watchdog,
-            daemon=True,
-            name="exit-watchdog",
-        ).start()
-    except Exception:
-        pass
+    threading.Thread(
+        target=_watchdog,
+        daemon=True,
+        name="exit-watchdog",
+    ).start()

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -36,41 +36,73 @@ from hermes_cli.fallback_config import get_fallback_chain
 logger = logging.getLogger(__name__)
 
 
+_terminal_suppression_lock = threading.RLock()
+_terminal_suppression_count = 0
+_terminal_suppressed_levels: dict[logging.Handler, int] = {}
+_terminal_original_add_handler: (
+    Callable[[logging.Logger, logging.Handler], None] | None
+) = None
+
+
+def _is_terminal_log_handler(handler: logging.Handler) -> bool:
+    return isinstance(handler, logging.StreamHandler) and not isinstance(
+        handler,
+        logging.FileHandler,
+    )
+
+
+def _remember_terminal_log_handler(handler: logging.Handler) -> None:
+    if not _is_terminal_log_handler(handler):
+        return
+    if handler not in _terminal_suppressed_levels:
+        _terminal_suppressed_levels[handler] = handler.level
+    handler.setLevel(logging.CRITICAL + 1)
+
+
+def _add_handler_while_terminal_suppressed(
+    target_logger: logging.Logger,
+    handler: logging.Handler,
+) -> None:
+    with _terminal_suppression_lock:
+        _remember_terminal_log_handler(handler)
+        original = _terminal_original_add_handler
+        if original is None:
+            raise RuntimeError("terminal log suppression lost addHandler owner")
+        original(target_logger, handler)
+
+
 @contextmanager
 def _suppress_terminal_log_handlers() -> Iterator[None]:
-    """Silence existing console handlers without disabling file logging."""
-    handlers: list[logging.Handler] = []
-    seen: set[int] = set()
+    """Refcount console silence while preserving every file handler."""
+    global _terminal_original_add_handler, _terminal_suppression_count
 
-    def remember(handler: logging.Handler) -> None:
-        if id(handler) in seen:
-            return
-        if not isinstance(handler, logging.StreamHandler):
-            return
-        # FileHandler deliberately subclasses StreamHandler. It is the
-        # persistent diagnostic channel one-shot mode must preserve.
-        if isinstance(handler, logging.FileHandler):
-            return
-        seen.add(id(handler))
-        handlers.append(handler)
+    with _terminal_suppression_lock:
+        if _terminal_suppression_count == 0:
+            _terminal_original_add_handler = logging.Logger.addHandler
+            logging.Logger.addHandler = _add_handler_while_terminal_suppressed
+        _terminal_suppression_count += 1
+        for handler in logging.getLogger().handlers:
+            _remember_terminal_log_handler(handler)
+        for candidate in logging.Logger.manager.loggerDict.values():
+            if isinstance(candidate, logging.Logger):
+                for handler in candidate.handlers:
+                    _remember_terminal_log_handler(handler)
+        if logging.lastResort is not None:
+            _remember_terminal_log_handler(logging.lastResort)
 
-    for handler in logging.getLogger().handlers:
-        remember(handler)
-    for candidate in logging.Logger.manager.loggerDict.values():
-        if isinstance(candidate, logging.Logger):
-            for handler in candidate.handlers:
-                remember(handler)
-    if logging.lastResort is not None:
-        remember(logging.lastResort)
-
-    original_levels = [(handler, handler.level) for handler in handlers]
     try:
-        for handler, _level in original_levels:
-            handler.setLevel(logging.CRITICAL + 1)
         yield
     finally:
-        for handler, level in original_levels:
-            handler.setLevel(level)
+        with _terminal_suppression_lock:
+            _terminal_suppression_count -= 1
+            if _terminal_suppression_count == 0:
+                for handler, level in _terminal_suppressed_levels.items():
+                    handler.setLevel(level)
+                _terminal_suppressed_levels.clear()
+                original = _terminal_original_add_handler
+                _terminal_original_add_handler = None
+                if original is not None:
+                    logging.Logger.addHandler = original
 
 
 class _IncompleteFinalWriteError(OSError):
@@ -134,8 +166,11 @@ class _FinalDelivery:
             self._delivered = True
         try:
             self._on_delivered()
-        except Exception:
-            logger.exception("oneshot final-delivery completion callback failed")
+        except Exception as exc:
+            logger.warning(
+                "oneshot final-delivery completion callback failed exception_type=%s",
+                type(exc).__name__,
+            )
         return True
 
 
@@ -483,6 +518,7 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
     """
     if not path:
         return
+    temporary: Path | None = None
     try:
         import json
 
@@ -513,9 +549,35 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
             report["failure"] = failure
         out = Path(path).expanduser()
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        temporary = out.with_name(f".{out.name}.tmp-{uuid.uuid4().hex}")
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(json.dumps(report, indent=2) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        except BaseException:
+            # fdopen owns the descriptor after successful construction. If
+            # construction itself failed, close the still-open descriptor.
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+            raise
+        os.replace(temporary, out)
+        temporary = None
     except Exception:
         pass
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink(missing_ok=True)
+            except Exception:
+                pass
 
 
 def run_oneshot(
@@ -611,6 +673,12 @@ def run_oneshot(
                         failure = exc
                 if failure is None and resources.cleanup_failed:
                     failure = _OneshotCleanupError()
+            if failure is None:
+                _write_usage_file(usage_file, result)
+            elif isinstance(failure, (KeyboardInterrupt, SystemExit)):
+                _write_usage_file(usage_file, result, failure=repr(failure))
+            else:
+                _write_usage_file(usage_file, result, failure=str(failure))
     finally:
         try:
             devnull.close()
@@ -621,14 +689,10 @@ def run_oneshot(
         # Re-raise control-flow exceptions so the parent handles them as usual
         # (Ctrl-C / explicit sys.exit() inside the agent).
         if isinstance(failure, (KeyboardInterrupt, SystemExit)):
-            _write_usage_file(usage_file, result, failure=repr(failure))
             raise failure
-        _write_usage_file(usage_file, result, failure=str(failure))
         real_stderr.write(f"hermes -z: agent failed: {failure}\n")
         real_stderr.flush()
         return 1
-
-    _write_usage_file(usage_file, result)
 
     if (result.get("failed") or result.get("partial")) and not delivery.delivered:
         return 2

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -606,18 +606,17 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
             0o600,
         )
         try:
-            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-                handle.write(json.dumps(report, indent=2) + "\n")
-                handle.flush()
-                os.fsync(handle.fileno())
+            handle = os.fdopen(descriptor, "w", encoding="utf-8")
         except BaseException:
-            # fdopen owns the descriptor after successful construction. If
-            # construction itself failed, close the still-open descriptor.
             try:
                 os.close(descriptor)
             except OSError:
                 pass
             raise
+        with handle:
+            handle.write(json.dumps(report, indent=2) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
         os.replace(temporary, out)
         temporary = None
     except Exception:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -23,10 +23,8 @@ from __future__ import annotations
 
 import logging
 import os
-import stat
 import sys
 import threading
-import time
 import uuid
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -58,7 +56,38 @@ def _remember_terminal_log_handler(handler: logging.Handler) -> None:
         return
     if handler not in _terminal_suppressed_levels:
         _terminal_suppressed_levels[handler] = handler.level
-    handler.setLevel(logging.CRITICAL + 1)
+    handler.level = logging.CRITICAL + 1
+
+
+@contextmanager
+def _hold_logging_registry_lock() -> Iterator[None]:
+    acquire = getattr(logging, "_acquireLock", None)
+    release = getattr(logging, "_releaseLock", None)
+    if not callable(acquire) or not callable(release):
+        yield
+        return
+    acquire()
+    try:
+        yield
+    finally:
+        release()
+
+
+def _snapshot_terminal_log_handlers_locked() -> list[logging.Handler]:
+    loggers = [logging.root]
+    loggers.extend(
+        candidate
+        for candidate in list(logging.Logger.manager.loggerDict.values())
+        if isinstance(candidate, logging.Logger)
+    )
+    handlers = [
+        handler
+        for candidate in loggers
+        for handler in list(candidate.handlers)
+    ]
+    if logging.lastResort is not None:
+        handlers.append(logging.lastResort)
+    return handlers
 
 
 def _suppressed_add_handler_wrapper(
@@ -72,10 +101,11 @@ def _suppressed_add_handler_wrapper(
         # execute it only after the final owner restores Logger.addHandler.
         # The stable captured original guarantees exactly one delegation; the
         # count check prevents stale calls from mutating handler levels.
-        with _terminal_suppression_lock:
-            if _terminal_suppression_count > 0:
-                _remember_terminal_log_handler(handler)
-            original(target_logger, handler)
+        with _hold_logging_registry_lock():
+            with _terminal_suppression_lock:
+                if _terminal_suppression_count > 0:
+                    _remember_terminal_log_handler(handler)
+                original(target_logger, handler)
 
     return add_handler
 
@@ -85,35 +115,44 @@ def _suppress_terminal_log_handlers() -> Iterator[None]:
     """Refcount console silence while preserving every file handler."""
     global _terminal_original_add_handler, _terminal_suppression_count
 
-    with _terminal_suppression_lock:
-        if _terminal_suppression_count == 0:
-            _terminal_original_add_handler = logging.Logger.addHandler
-            logging.Logger.addHandler = _suppressed_add_handler_wrapper(
-                _terminal_original_add_handler
-            )
-        _terminal_suppression_count += 1
-        for handler in logging.getLogger().handlers:
-            _remember_terminal_log_handler(handler)
-        for candidate in logging.Logger.manager.loggerDict.values():
-            if isinstance(candidate, logging.Logger):
-                for handler in candidate.handlers:
+    with _hold_logging_registry_lock():
+        with _terminal_suppression_lock:
+            starting_count = _terminal_suppression_count
+            starting_levels = set(_terminal_suppressed_levels)
+            starting_add_handler = logging.Logger.addHandler
+            starting_owner = _terminal_original_add_handler
+            try:
+                if starting_count == 0:
+                    _terminal_original_add_handler = starting_add_handler
+                    logging.Logger.addHandler = _suppressed_add_handler_wrapper(
+                        starting_add_handler
+                    )
+                _terminal_suppression_count += 1
+                for handler in _snapshot_terminal_log_handlers_locked():
                     _remember_terminal_log_handler(handler)
-        if logging.lastResort is not None:
-            _remember_terminal_log_handler(logging.lastResort)
+            except BaseException:
+                for handler in set(_terminal_suppressed_levels) - starting_levels:
+                    handler.level = _terminal_suppressed_levels.pop(handler)
+                _terminal_suppression_count = starting_count
+                _terminal_original_add_handler = starting_owner
+                if starting_count == 0:
+                    logging.Logger.addHandler = starting_add_handler
+                raise
 
     try:
         yield
     finally:
-        with _terminal_suppression_lock:
-            _terminal_suppression_count -= 1
-            if _terminal_suppression_count == 0:
-                for handler, level in _terminal_suppressed_levels.items():
-                    handler.setLevel(level)
-                _terminal_suppressed_levels.clear()
-                original = _terminal_original_add_handler
-                _terminal_original_add_handler = None
-                if original is not None:
-                    logging.Logger.addHandler = original
+        with _hold_logging_registry_lock():
+            with _terminal_suppression_lock:
+                _terminal_suppression_count -= 1
+                if _terminal_suppression_count == 0:
+                    for handler, level in _terminal_suppressed_levels.items():
+                        handler.level = level
+                    _terminal_suppressed_levels.clear()
+                    original = _terminal_original_add_handler
+                    _terminal_original_add_handler = None
+                    if original is not None:
+                        logging.Logger.addHandler = original
 
 
 class _IncompleteFinalWriteError(OSError):
@@ -447,84 +486,6 @@ def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
     return [item for item in normalized if item] or None
 
 
-_USAGE_TEMP_SCAN_LIMIT = 64
-_USAGE_TEMP_DELETE_LIMIT = 8
-_USAGE_TEMP_MIN_AGE_S = 60
-_LOWER_HEX = frozenset("0123456789abcdef")
-
-
-def _usage_temp_pid_from_name(out: Path, name: str) -> int | None:
-    prefix = f".{out.name}.tmp-"
-    if not name.startswith(prefix):
-        return None
-    remainder = name[len(prefix) :]
-    try:
-        pid_text, token = remainder.split("-", 1)
-    except ValueError:
-        return None
-    if (
-        not pid_text.isascii()
-        or not pid_text.isdigit()
-        or len(pid_text) > 10
-    ):
-        return None
-    if len(token) != 32 or any(character not in _LOWER_HEX for character in token):
-        return None
-    pid = int(pid_text)
-    if pid <= 0 or pid > 2_147_483_647:
-        return None
-    return pid
-
-
-def _usage_temp_pid_is_running(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except (PermissionError, OSError):
-        return True
-    return True
-
-
-def _cleanup_stale_usage_temps(out: Path) -> None:
-    """Bound cleanup to dead-owner regular temp siblings only."""
-    scanned = 0
-    deleted = 0
-    now = time.time()
-    current_uid = os.getuid() if hasattr(os, "getuid") else None
-    try:
-        entries = os.scandir(out.parent)
-    except OSError:
-        return
-    with entries:
-        for entry in entries:
-            scanned += 1
-            if scanned > _USAGE_TEMP_SCAN_LIMIT:
-                break
-            pid = _usage_temp_pid_from_name(out, entry.name)
-            if pid is None:
-                continue
-            try:
-                metadata = entry.stat(follow_symlinks=False)
-            except OSError:
-                continue
-            if not stat.S_ISREG(metadata.st_mode):
-                continue
-            if current_uid is not None and metadata.st_uid != current_uid:
-                continue
-            if now - metadata.st_mtime < _USAGE_TEMP_MIN_AGE_S:
-                continue
-            if _usage_temp_pid_is_running(pid):
-                continue
-            try:
-                os.unlink(entry.path)
-            except OSError:
-                continue
-            deleted += 1
-            if deleted >= _USAGE_TEMP_DELETE_LIMIT:
-                break
-
-
 def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | None, str | None]:
     normalized = _normalize_toolsets(toolsets)
     if normalized is None:
@@ -638,10 +599,7 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
             report["failure"] = failure
         out = Path(path).expanduser()
         out.parent.mkdir(parents=True, exist_ok=True)
-        _cleanup_stale_usage_temps(out)
-        temporary = out.with_name(
-            f".{out.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}"
-        )
+        temporary = out.with_name(f".{out.name}.tmp-{uuid.uuid4().hex}")
         descriptor = os.open(
             temporary,
             os.O_WRONLY | os.O_CREAT | os.O_EXCL,

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -36,6 +36,20 @@ from hermes_cli.fallback_config import get_fallback_chain
 logger = logging.getLogger(__name__)
 
 
+class _IncompleteFinalWriteError(OSError):
+    """A final-response stream accepted fewer characters than requested."""
+
+    def __init__(self) -> None:
+        super().__init__("oneshot final response write was incomplete")
+
+
+class _IncompleteCleanupError(RuntimeError):
+    """A bounded cleanup operation reported that it did not complete."""
+
+    def __init__(self) -> None:
+        super().__init__("oneshot bounded cleanup did not complete")
+
+
 class _FinalDelivery:
     """Claim, write, and flush the one-shot final response exactly once."""
 
@@ -62,9 +76,13 @@ class _FinalDelivery:
                 return False
             self._claimed = True
             try:
-                self._stream.write(value)
+                written = self._stream.write(value)
+                if type(written) is not int or written != len(value):
+                    raise _IncompleteFinalWriteError()
                 if not value.endswith("\n"):
-                    self._stream.write("\n")
+                    newline_written = self._stream.write("\n")
+                    if type(newline_written) is not int or newline_written != 1:
+                        raise _IncompleteFinalWriteError()
                 self._stream.flush()
             except BaseException as exc:
                 self._delivery_error = exc
@@ -93,10 +111,13 @@ class _OneshotResources:
         with self._state_lock:
             if self._watchdog_armed:
                 return
-            self._watchdog_armed = True
-        from hermes_cli.exit_watchdog import arm_exit_watchdog
+            from hermes_cli.exit_watchdog import arm_exit_watchdog
 
-        arm_exit_watchdog(exit_code=exit_code)
+            # Keep the lock through setup so concurrent callers cannot start
+            # duplicate successful timers. A BaseException exits before the
+            # latch is claimed, allowing cleanup to retry safely.
+            arm_exit_watchdog(exit_code=exit_code)
+            self._watchdog_armed = True
 
     @staticmethod
     def _log_failure(operation: str, exc: BaseException) -> None:
@@ -180,7 +201,8 @@ class _OneshotResources:
             manager = getattr(agent, "_memory_manager", None) if agent is not None else None
             flush_pending = getattr(manager, "flush_pending", None)
             if callable(flush_pending):
-                flush_pending(timeout=10)
+                if flush_pending(timeout=10) is False:
+                    raise _IncompleteCleanupError()
 
         attempt("memory_flush", flush_memory)
 
@@ -245,28 +267,70 @@ class _OneshotResources:
             raise control_failure
 
 
+class _DeliveryDispatcherState:
+    def __init__(self, manager) -> None:
+        self.manager = manager
+        self.deliveries: dict[str, _FinalDelivery] = {}
+        self.dispatcher: Callable[..., None] | None = None
+
+
+_delivery_dispatch_lock = threading.RLock()
+_delivery_dispatchers: dict[int, _DeliveryDispatcherState] = {}
+
+
 @contextmanager
 def _install_final_delivery_hook(
     delivery: _FinalDelivery,
     resources: _OneshotResources,
 ) -> Iterator[None]:
-    """Temporarily deliver transformed output before all existing post hooks."""
+    """Route matching one-shot task output through one transient first hook."""
     from hermes_cli.plugins import get_plugin_manager
 
     manager = get_plugin_manager()
+    task_id = resources.task_id
+    if not task_id:
+        raise ValueError("one-shot task_id must be set before installing delivery hook")
 
-    def _deliver_hook(assistant_response: str = "", **_kwargs) -> None:
-        delivery.deliver(assistant_response)
+    manager_key = id(manager)
+    with _delivery_dispatch_lock:
+        state = _delivery_dispatchers.get(manager_key)
+        if state is None or state.manager is not manager:
+            state = _DeliveryDispatcherState(manager)
 
-    callbacks = manager._hooks.setdefault("post_llm_call", [])
-    callbacks.insert(0, _deliver_hook)
+            def _dispatch(
+                assistant_response: str = "",
+                task_id: str | None = None,
+                **_kwargs,
+            ) -> None:
+                # Snapshot under the registry lock. Context removal after this
+                # point cannot revoke the rightful in-flight delivery.
+                with _delivery_dispatch_lock:
+                    target = state.deliveries.get(task_id or "")
+                if target is not None:
+                    target.deliver(assistant_response)
+
+            state.dispatcher = _dispatch
+            callbacks = manager._hooks.setdefault("post_llm_call", [])
+            callbacks.insert(0, _dispatch)
+            _delivery_dispatchers[manager_key] = state
+        if task_id in state.deliveries:
+            raise RuntimeError("duplicate active one-shot task_id")
+        state.deliveries[task_id] = delivery
+
     try:
         yield
     finally:
-        current = manager._hooks.get("post_llm_call", [])
-        for index in range(len(current) - 1, -1, -1):
-            if current[index] is _deliver_hook:
-                del current[index]
+        with _delivery_dispatch_lock:
+            current_state = _delivery_dispatchers.get(manager_key)
+            if current_state is state:
+                if state.deliveries.get(task_id) is delivery:
+                    del state.deliveries[task_id]
+                if not state.deliveries:
+                    current = manager._hooks.get("post_llm_call", [])
+                    for index in range(len(current) - 1, -1, -1):
+                        if current[index] is state.dispatcher:
+                            del current[index]
+                    del _delivery_dispatchers[manager_key]
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -24,11 +24,249 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from contextlib import redirect_stderr, redirect_stdout
+import threading
+import uuid
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Iterator, Optional, TextIO
 
 from hermes_cli.fallback_config import get_fallback_chain
+
+
+logger = logging.getLogger(__name__)
+
+
+class _FinalDelivery:
+    """Claim, write, and flush the one-shot final response exactly once."""
+
+    def __init__(self, real_stdout: TextIO, on_delivered: Callable[[], None]) -> None:
+        self._stream = real_stdout
+        self._on_delivered = on_delivered
+        self._lock = threading.Lock()
+        self._claimed = False
+        self._delivered = False
+        self._delivery_error: BaseException | None = None
+
+    @property
+    def delivered(self) -> bool:
+        return self._delivered
+
+    def deliver(self, text: str | None) -> bool:
+        value = text or ""
+        if not value.strip():
+            return False
+        with self._lock:
+            if self._claimed:
+                if self._delivery_error is not None:
+                    raise self._delivery_error
+                return False
+            self._claimed = True
+            try:
+                self._stream.write(value)
+                if not value.endswith("\n"):
+                    self._stream.write("\n")
+                self._stream.flush()
+            except BaseException as exc:
+                self._delivery_error = exc
+                raise
+            self._delivered = True
+        try:
+            self._on_delivered()
+        except Exception:
+            logger.exception("oneshot final-delivery completion callback failed")
+        return True
+
+
+class _OneshotResources:
+    """Single idempotent owner for every resource created by one-shot mode."""
+
+    def __init__(self) -> None:
+        self.agent = None
+        self.session_db = None
+        self.task_id: str | None = None
+        self._state_lock = threading.Lock()
+        self._watchdog_armed = False
+        self._final_marked = False
+        self._closed = False
+
+    def _arm_watchdog_once(self, exit_code: int = 70) -> None:
+        with self._state_lock:
+            if self._watchdog_armed:
+                return
+            self._watchdog_armed = True
+        from hermes_cli.exit_watchdog import arm_exit_watchdog
+
+        arm_exit_watchdog(exit_code=exit_code)
+
+    @staticmethod
+    def _log_failure(operation: str, exc: BaseException) -> None:
+        logger.warning(
+            "oneshot lifecycle operation failed operation=%s exception_type=%s",
+            operation,
+            type(exc).__name__,
+        )
+
+    def mark_final_delivered(self) -> None:
+        with self._state_lock:
+            if self._final_marked:
+                return
+            self._final_marked = True
+
+        control_failure: BaseException | None = None
+        try:
+            self._arm_watchdog_once(exit_code=70)
+        except BaseException as exc:
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                control_failure = exc
+            else:
+                self._log_failure("watchdog", exc)
+
+        agent = self.agent
+        session_db = self.session_db
+        session_id = getattr(agent, "session_id", None) if agent is not None else None
+        if agent is not None and session_db is not None and session_id:
+            try:
+                session_db.end_session(session_id, "oneshot_complete")
+            except BaseException as exc:
+                if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                    if control_failure is None:
+                        control_failure = exc
+                else:
+                    self._log_failure("session_end", exc)
+            else:
+                agent._end_session_on_close = False
+
+        logger.info(
+            "oneshot final delivered session_id=%s task_id=%s",
+            session_id or "",
+            self.task_id or "",
+        )
+        if control_failure is not None:
+            raise control_failure
+
+    def close(self, primary_failure: BaseException | None = None) -> None:
+        with self._state_lock:
+            if self._closed:
+                return
+            self._closed = True
+
+        control_failure: BaseException | None = None
+        had_failure = False
+
+        def attempt(operation: str, callback: Callable[[], None]) -> None:
+            nonlocal control_failure, had_failure
+            try:
+                callback()
+            except BaseException as exc:
+                had_failure = True
+                if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                    if control_failure is None:
+                        control_failure = exc
+                else:
+                    self._log_failure(operation, exc)
+
+        attempt("watchdog", lambda: self._arm_watchdog_once(exit_code=70))
+
+        def interrupt_delegations() -> None:
+            from tools.async_delegation import interrupt_all
+
+            interrupt_all(reason="oneshot shutdown")
+
+        attempt("async_delegation", interrupt_delegations)
+
+        agent = self.agent
+
+        def flush_memory() -> None:
+            manager = getattr(agent, "_memory_manager", None) if agent is not None else None
+            flush_pending = getattr(manager, "flush_pending", None)
+            if callable(flush_pending):
+                flush_pending(timeout=10)
+
+        attempt("memory_flush", flush_memory)
+
+        def shutdown_memory() -> None:
+            if agent is None:
+                return
+            shutdown = getattr(agent, "shutdown_memory_provider", None)
+            if not callable(shutdown):
+                return
+            messages = list(getattr(agent, "_session_messages", None) or [])
+            shutdown(messages)
+
+        attempt("memory_shutdown", shutdown_memory)
+
+        def kill_processes() -> None:
+            if not self.task_id:
+                return
+            from tools.process_registry import process_registry
+
+            process_registry.kill_all(task_id=self.task_id)
+
+        attempt("process_cleanup", kill_processes)
+
+        def cleanup_task_resources() -> None:
+            if agent is not None and self.task_id:
+                cleanup = getattr(agent, "_cleanup_task_resources", None)
+                if callable(cleanup):
+                    cleanup(self.task_id)
+
+        attempt("task_cleanup", cleanup_task_resources)
+        attempt(
+            "agent_close",
+            lambda: agent.close() if agent is not None else None,
+        )
+
+        def shutdown_mcp() -> None:
+            from tools.mcp_tool import shutdown_mcp_servers
+
+            shutdown_mcp_servers()
+
+        attempt("mcp_shutdown", shutdown_mcp)
+
+        def shutdown_auxiliary_clients() -> None:
+            from agent.auxiliary_client import shutdown_cached_clients
+
+            shutdown_cached_clients()
+
+        attempt("auxiliary_shutdown", shutdown_auxiliary_clients)
+        attempt(
+            "session_db_close",
+            lambda: self.session_db.close() if self.session_db is not None else None,
+        )
+
+        session_id = getattr(agent, "session_id", None) if agent is not None else None
+        if not had_failure:
+            logger.info(
+                "oneshot cleanup completed session_id=%s task_id=%s",
+                session_id or "",
+                self.task_id or "",
+            )
+        if primary_failure is None and control_failure is not None:
+            raise control_failure
+
+
+@contextmanager
+def _install_final_delivery_hook(
+    delivery: _FinalDelivery,
+    resources: _OneshotResources,
+) -> Iterator[None]:
+    """Temporarily deliver transformed output before all existing post hooks."""
+    from hermes_cli.plugins import get_plugin_manager
+
+    manager = get_plugin_manager()
+
+    def _deliver_hook(assistant_response: str = "", **_kwargs) -> None:
+        delivery.deliver(assistant_response)
+
+    callbacks = manager._hooks.setdefault("post_llm_call", [])
+    callbacks.insert(0, _deliver_hook)
+    try:
+        yield
+    finally:
+        current = manager._hooks.get("post_llm_call", [])
+        for index in range(len(current) - 1, -1, -1):
+            if current[index] is _deliver_hook:
+                del current[index]
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -189,11 +427,9 @@ def run_oneshot(
 
     Returns the exit code.  Caller should sys.exit() with the return.
     """
-    # Silence every stdlib logger for the duration.  AIAgent, tools, and
-    # provider adapters all log to stderr through the root logger; file
-    # handlers added by setup_logging() keep working (they're attached to
-    # the root logger's handler list, not affected by level), but no
-    # bytes reach the terminal.
+    # Silence every stdlib logger for the duration.  Task 4 replaces this
+    # process-global switch with handler-scoped terminal suppression while
+    # preserving file logs.
     logging.disable(logging.CRITICAL)
 
     # --provider without --model is ambiguous: carrying the user's configured
@@ -229,6 +465,8 @@ def run_oneshot(
     response: Optional[str] = None
     result: dict = {}
     failure: BaseException | None = None
+    resources = _OneshotResources()
+    delivery = _FinalDelivery(real_stdout, resources.mark_final_delivered)
     try:
         with redirect_stdout(devnull), redirect_stderr(devnull):
             try:
@@ -238,7 +476,10 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    delivery=delivery,
+                    resources=resources,
                 )
+                delivery.deliver(response)
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
                 # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
@@ -248,6 +489,11 @@ def run_oneshot(
                 # cron / SSH / subprocess context is the worst failure mode.
                 # See #30623.
                 failure = exc
+            try:
+                resources.close(primary_failure=failure)
+            except BaseException as exc:  # noqa: BLE001
+                if failure is None:
+                    failure = exc
     finally:
         try:
             devnull.close()
@@ -267,16 +513,10 @@ def run_oneshot(
 
     _write_usage_file(usage_file, result)
 
-    if response:
-        real_stdout.write(response)
-        if not response.endswith("\n"):
-            real_stdout.write("\n")
-        real_stdout.flush()
-
-    if (result.get("failed") or result.get("partial")) and not (response or "").strip():
+    if (result.get("failed") or result.get("partial")) and not delivery.delivered:
         return 2
 
-    if not (response or "").strip():
+    if not delivery.delivered:
         real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
         real_stderr.flush()
         return 1
@@ -302,10 +542,12 @@ def _create_session_db_for_oneshot():
 
 def _run_agent(
     prompt: str,
-    model: Optional[str] = None,
-    provider: Optional[str] = None,
-    toolsets: object = None,
-    use_config_toolsets: bool = True,
+    model: Optional[str],
+    provider: Optional[str],
+    toolsets: object,
+    use_config_toolsets: bool,
+    delivery: _FinalDelivery,
+    resources: _OneshotResources,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -386,6 +628,7 @@ def _run_agent(
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
     session_db = _create_session_db_for_oneshot()
+    resources.session_db = session_db
     # Read the effective fallback chain from profile config so oneshot workers
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
@@ -415,6 +658,7 @@ def _run_agent(
         #   - skill secret capture → returns gracefully when no callback set
         clarify_callback=_oneshot_clarify_callback,
     )
+    resources.agent = agent
 
     # Belt-and-braces: make sure AIAgent doesn't invoke any streaming
     # display callbacks that would bypass our stdout capture.
@@ -422,7 +666,9 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    result = agent.run_conversation(prompt)
+    resources.task_id = str(uuid.uuid4())
+    with _install_final_delivery_hook(delivery, resources):
+        result = agent.run_conversation(prompt, task_id=resources.task_id)
     return (result.get("final_response") or "", result)
 
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -50,6 +50,13 @@ class _IncompleteCleanupError(RuntimeError):
         super().__init__("oneshot bounded cleanup did not complete")
 
 
+class _OneshotCleanupError(RuntimeError):
+    """A fixed, payload-free signal that one or more cleanup owners failed."""
+
+    def __init__(self) -> None:
+        super().__init__("oneshot cleanup did not complete")
+
+
 class _FinalDelivery:
     """Claim, write, and flush the one-shot final response exactly once."""
 
@@ -106,6 +113,11 @@ class _OneshotResources:
         self._watchdog_armed = False
         self._final_marked = False
         self._closed = False
+        self._cleanup_failed = False
+
+    @property
+    def cleanup_failed(self) -> bool:
+        return self._cleanup_failed
 
     def _arm_watchdog_once(self, exit_code: int = 70) -> None:
         with self._state_lock:
@@ -257,6 +269,7 @@ class _OneshotResources:
         )
 
         session_id = getattr(agent, "session_id", None) if agent is not None else None
+        self._cleanup_failed = had_failure
         if not had_failure:
             logger.info(
                 "oneshot cleanup completed session_id=%s task_id=%s",
@@ -534,30 +547,34 @@ def run_oneshot(
     try:
         with redirect_stdout(devnull), redirect_stderr(devnull):
             try:
-                response, result = _run_agent(
-                    prompt,
-                    model=model,
-                    provider=provider,
-                    toolsets=explicit_toolsets,
-                    use_config_toolsets=use_config_toolsets,
-                    delivery=delivery,
-                    resources=resources,
-                )
-                delivery.deliver(response)
-            except BaseException as exc:  # noqa: BLE001
-                # Capture anything that escapes the agent (including OSError
-                # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
-                # KeyboardInterrupt, SystemExit, etc.) so we can surface it on
-                # the real stderr instead of crashing past the redirect with a
-                # traceback that the caller never sees. A silent exit in a
-                # cron / SSH / subprocess context is the worst failure mode.
-                # See #30623.
-                failure = exc
-            try:
-                resources.close(primary_failure=failure)
-            except BaseException as exc:  # noqa: BLE001
-                if failure is None:
+                try:
+                    response, result = _run_agent(
+                        prompt,
+                        model=model,
+                        provider=provider,
+                        toolsets=explicit_toolsets,
+                        use_config_toolsets=use_config_toolsets,
+                        delivery=delivery,
+                        resources=resources,
+                    )
+                    delivery.deliver(response)
+                except BaseException as exc:  # noqa: BLE001
+                    # Capture anything that escapes the agent (including OSError
+                    # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
+                    # KeyboardInterrupt, SystemExit, etc.) so we can surface it on
+                    # the real stderr instead of crashing past the redirect with a
+                    # traceback that the caller never sees. A silent exit in a
+                    # cron / SSH / subprocess context is the worst failure mode.
+                    # See #30623.
                     failure = exc
+            finally:
+                try:
+                    resources.close(primary_failure=failure)
+                except BaseException as exc:  # noqa: BLE001
+                    if failure is None:
+                        failure = exc
+                if failure is None and resources.cleanup_failed:
+                    failure = _OneshotCleanupError()
     finally:
         try:
             devnull.close()

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -36,6 +36,43 @@ from hermes_cli.fallback_config import get_fallback_chain
 logger = logging.getLogger(__name__)
 
 
+@contextmanager
+def _suppress_terminal_log_handlers() -> Iterator[None]:
+    """Silence existing console handlers without disabling file logging."""
+    handlers: list[logging.Handler] = []
+    seen: set[int] = set()
+
+    def remember(handler: logging.Handler) -> None:
+        if id(handler) in seen:
+            return
+        if not isinstance(handler, logging.StreamHandler):
+            return
+        # FileHandler deliberately subclasses StreamHandler. It is the
+        # persistent diagnostic channel one-shot mode must preserve.
+        if isinstance(handler, logging.FileHandler):
+            return
+        seen.add(id(handler))
+        handlers.append(handler)
+
+    for handler in logging.getLogger().handlers:
+        remember(handler)
+    for candidate in logging.Logger.manager.loggerDict.values():
+        if isinstance(candidate, logging.Logger):
+            for handler in candidate.handlers:
+                remember(handler)
+    if logging.lastResort is not None:
+        remember(logging.lastResort)
+
+    original_levels = [(handler, handler.level) for handler in handlers]
+    try:
+        for handler, _level in original_levels:
+            handler.setLevel(logging.CRITICAL + 1)
+        yield
+    finally:
+        for handler, level in original_levels:
+            handler.setLevel(level)
+
+
 class _IncompleteFinalWriteError(OSError):
     """A final-response stream accepted fewer characters than requested."""
 
@@ -504,11 +541,6 @@ def run_oneshot(
 
     Returns the exit code.  Caller should sys.exit() with the return.
     """
-    # Silence every stdlib logger for the duration.  Task 4 replaces this
-    # process-global switch with handler-scoped terminal suppression while
-    # preserving file logs.
-    logging.disable(logging.CRITICAL)
-
     # --provider without --model is ambiguous: carrying the user's configured
     # model across to a different provider is usually wrong (that provider may
     # not host it), and silently picking the provider's catalog default hides
@@ -545,7 +577,11 @@ def run_oneshot(
     resources = _OneshotResources()
     delivery = _FinalDelivery(real_stdout, resources.mark_final_delivered)
     try:
-        with redirect_stdout(devnull), redirect_stderr(devnull):
+        with (
+            _suppress_terminal_log_handlers(),
+            redirect_stdout(devnull),
+            redirect_stderr(devnull),
+        ):
             try:
                 try:
                     response, result = _run_agent(

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -23,8 +23,10 @@ from __future__ import annotations
 
 import logging
 import os
+import stat
 import sys
 import threading
+import time
 import uuid
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -59,16 +61,23 @@ def _remember_terminal_log_handler(handler: logging.Handler) -> None:
     handler.setLevel(logging.CRITICAL + 1)
 
 
-def _add_handler_while_terminal_suppressed(
-    target_logger: logging.Logger,
-    handler: logging.Handler,
-) -> None:
-    with _terminal_suppression_lock:
-        _remember_terminal_log_handler(handler)
-        original = _terminal_original_add_handler
-        if original is None:
-            raise RuntimeError("terminal log suppression lost addHandler owner")
-        original(target_logger, handler)
+def _suppressed_add_handler_wrapper(
+    original: Callable[[logging.Logger, logging.Handler], None],
+) -> Callable[[logging.Logger, logging.Handler], None]:
+    def add_handler(
+        target_logger: logging.Logger,
+        handler: logging.Handler,
+    ) -> None:
+        # A caller can bind this wrapper while suppression is active, then
+        # execute it only after the final owner restores Logger.addHandler.
+        # The stable captured original guarantees exactly one delegation; the
+        # count check prevents stale calls from mutating handler levels.
+        with _terminal_suppression_lock:
+            if _terminal_suppression_count > 0:
+                _remember_terminal_log_handler(handler)
+            original(target_logger, handler)
+
+    return add_handler
 
 
 @contextmanager
@@ -79,7 +88,9 @@ def _suppress_terminal_log_handlers() -> Iterator[None]:
     with _terminal_suppression_lock:
         if _terminal_suppression_count == 0:
             _terminal_original_add_handler = logging.Logger.addHandler
-            logging.Logger.addHandler = _add_handler_while_terminal_suppressed
+            logging.Logger.addHandler = _suppressed_add_handler_wrapper(
+                _terminal_original_add_handler
+            )
         _terminal_suppression_count += 1
         for handler in logging.getLogger().handlers:
             _remember_terminal_log_handler(handler)
@@ -436,6 +447,84 @@ def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
     return [item for item in normalized if item] or None
 
 
+_USAGE_TEMP_SCAN_LIMIT = 64
+_USAGE_TEMP_DELETE_LIMIT = 8
+_USAGE_TEMP_MIN_AGE_S = 60
+_LOWER_HEX = frozenset("0123456789abcdef")
+
+
+def _usage_temp_pid_from_name(out: Path, name: str) -> int | None:
+    prefix = f".{out.name}.tmp-"
+    if not name.startswith(prefix):
+        return None
+    remainder = name[len(prefix) :]
+    try:
+        pid_text, token = remainder.split("-", 1)
+    except ValueError:
+        return None
+    if (
+        not pid_text.isascii()
+        or not pid_text.isdigit()
+        or len(pid_text) > 10
+    ):
+        return None
+    if len(token) != 32 or any(character not in _LOWER_HEX for character in token):
+        return None
+    pid = int(pid_text)
+    if pid <= 0 or pid > 2_147_483_647:
+        return None
+    return pid
+
+
+def _usage_temp_pid_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except (PermissionError, OSError):
+        return True
+    return True
+
+
+def _cleanup_stale_usage_temps(out: Path) -> None:
+    """Bound cleanup to dead-owner regular temp siblings only."""
+    scanned = 0
+    deleted = 0
+    now = time.time()
+    current_uid = os.getuid() if hasattr(os, "getuid") else None
+    try:
+        entries = os.scandir(out.parent)
+    except OSError:
+        return
+    with entries:
+        for entry in entries:
+            scanned += 1
+            if scanned > _USAGE_TEMP_SCAN_LIMIT:
+                break
+            pid = _usage_temp_pid_from_name(out, entry.name)
+            if pid is None:
+                continue
+            try:
+                metadata = entry.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            if not stat.S_ISREG(metadata.st_mode):
+                continue
+            if current_uid is not None and metadata.st_uid != current_uid:
+                continue
+            if now - metadata.st_mtime < _USAGE_TEMP_MIN_AGE_S:
+                continue
+            if _usage_temp_pid_is_running(pid):
+                continue
+            try:
+                os.unlink(entry.path)
+            except OSError:
+                continue
+            deleted += 1
+            if deleted >= _USAGE_TEMP_DELETE_LIMIT:
+                break
+
+
 def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | None, str | None]:
     normalized = _normalize_toolsets(toolsets)
     if normalized is None:
@@ -549,7 +638,10 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
             report["failure"] = failure
         out = Path(path).expanduser()
         out.parent.mkdir(parents=True, exist_ok=True)
-        temporary = out.with_name(f".{out.name}.tmp-{uuid.uuid4().hex}")
+        _cleanup_stale_usage_temps(out)
+        temporary = out.with_name(
+            f".{out.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}"
+        )
         descriptor = os.open(
             temporary,
             os.O_WRONLY | os.O_CREAT | os.O_EXCL,

--- a/tests/cli/test_tui_terminal_reset_on_exit.py
+++ b/tests/cli/test_tui_terminal_reset_on_exit.py
@@ -10,6 +10,7 @@ on ``_tui_input_modes_active`` so non-TUI one-shot CLI runs (which share
 ``_run_cleanup`` via ``atexit``) don't emit codes for modes they never set.
 """
 
+import os
 import unittest
 from unittest.mock import mock_open, patch
 
@@ -206,6 +207,78 @@ class TestRunCleanupWiring(unittest.TestCase):
         cli_mod = _import_cli()
         mock_reset = self._run_cleanup_isolated(cli_mod, terminals_raise=True)
         mock_reset.assert_called_once()
+
+    def test_watchdog_start_failure_keeps_all_later_cli_cleanup_owners(self):
+        cli_mod = _import_cli()
+        events = []
+
+        class StartFailureThread:
+            def __init__(self, **_kwargs):
+                pass
+
+            def start(self):
+                raise RuntimeError("private watchdog detail")
+
+        original_done = cli_mod._cleanup_done
+        cli_mod._cleanup_done = False
+        try:
+            with (
+                patch(
+                    "hermes_cli.exit_watchdog.threading.Thread",
+                    StartFailureThread,
+                ),
+                patch.dict(os.environ, {"PYTEST_CURRENT_TEST": ""}),
+                patch.object(
+                    cli_mod,
+                    "_reset_terminal_input_modes_on_exit",
+                    side_effect=lambda: events.append("terminal_reset"),
+                ),
+                patch.object(
+                    cli_mod,
+                    "_cleanup_all_terminals",
+                    side_effect=lambda: events.append("terminals"),
+                ),
+                patch(
+                    "tools.async_delegation.interrupt_all",
+                    side_effect=lambda **_kwargs: events.append("delegations"),
+                ),
+                patch.object(
+                    cli_mod,
+                    "_cleanup_all_browsers",
+                    side_effect=lambda: events.append("browsers"),
+                ),
+                patch(
+                    "tools.mcp_tool.shutdown_mcp_servers",
+                    side_effect=lambda: events.append("mcp"),
+                ),
+                patch(
+                    "agent.auxiliary_client.shutdown_cached_clients",
+                    side_effect=lambda: events.append("auxiliary"),
+                ),
+                patch.object(cli_mod, "_active_agent_ref", None),
+                patch.object(cli_mod.logger, "warning") as warning,
+            ):
+                result = cli_mod._run_cleanup(notify_session_finalize=False)
+
+            self.assertIsNone(result)
+            self.assertEqual(
+                events,
+                [
+                    "terminal_reset",
+                    "terminals",
+                    "delegations",
+                    "browsers",
+                    "mcp",
+                    "auxiliary",
+                ],
+            )
+            warning.assert_called_once_with(
+                "CLI exit watchdog failed exception_type=%s",
+                "RuntimeError",
+            )
+            self.assertNotIn("private watchdog detail", repr(warning.call_args_list))
+        finally:
+            cli_mod._cleanup_done = original_done
 
 
 if __name__ == "__main__":

--- a/tests/hermes_cli/test_exit_watchdog.py
+++ b/tests/hermes_cli/test_exit_watchdog.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+import textwrap
 import types
+from pathlib import Path
+
+import pytest
 
 from hermes_cli import exit_watchdog
 
@@ -18,7 +25,6 @@ def _capture_watchdog(monkeypatch, *, timeout_s=None, exit_code=0):
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.setattr(exit_watchdog.threading, "Thread", ImmediateThread)
     monkeypatch.setattr(exit_watchdog.time, "sleep", lambda seconds: captured.update(sleep=seconds))
-    monkeypatch.setattr(exit_watchdog.logging, "shutdown", lambda: None)
     monkeypatch.setattr(exit_watchdog.os, "_exit", lambda code: captured.update(exit_code=code))
     exit_watchdog.arm_exit_watchdog(timeout_s=timeout_s, exit_code=exit_code)
     return captured
@@ -65,3 +71,67 @@ def test_watchdog_is_disabled_under_pytest(monkeypatch):
     )
     exit_watchdog.arm_exit_watchdog(timeout_s=0.01)
     assert started == []
+
+
+def test_watchdog_start_failure_propagates_and_oneshot_owner_can_retry(monkeypatch):
+    from hermes_cli.oneshot import _OneshotResources
+
+    starts = []
+
+    class FailingThenStartingThread:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def start(self):
+            starts.append(self.kwargs)
+            if len(starts) == 1:
+                raise RuntimeError("thread start failed")
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(exit_watchdog.threading, "Thread", FailingThenStartingThread)
+    resources = _OneshotResources()
+
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        resources._arm_watchdog_once()
+    resources._arm_watchdog_once()
+    resources._arm_watchdog_once()
+
+    assert len(starts) == 2
+
+
+def test_watchdog_timer_bypasses_blocking_logging_handler_and_exits_bounded():
+    script = textwrap.dedent(
+        """
+        import logging
+        import os
+        import threading
+
+        os.environ.pop("PYTEST_CURRENT_TEST", None)
+        from hermes_cli.exit_watchdog import arm_exit_watchdog
+
+        class BlockingHandler(logging.Handler):
+            def emit(self, record):
+                threading.Event().wait()
+
+        root = logging.getLogger()
+        root.handlers[:] = [BlockingHandler()]
+        root.setLevel(logging.DEBUG)
+        arm_exit_watchdog(timeout_s=0.2, exit_code=70)
+        threading.Event().wait()
+        """
+    )
+    env = os.environ.copy()
+    env.pop("PYTEST_CURRENT_TEST", None)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        timeout=3,
+    )
+
+    assert completed.returncode == 70
+    assert completed.stdout == b""
+    assert completed.stderr == b""

--- a/tests/hermes_cli/test_exit_watchdog.py
+++ b/tests/hermes_cli/test_exit_watchdog.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import types
+
+from hermes_cli import exit_watchdog
+
+
+def _capture_watchdog(monkeypatch, *, timeout_s=None, exit_code=0):
+    captured = {}
+
+    class ImmediateThread:
+        def __init__(self, *, target, daemon, name):
+            captured.update(target=target, daemon=daemon, name=name)
+
+        def start(self):
+            captured["started"] = True
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(exit_watchdog.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(exit_watchdog.time, "sleep", lambda seconds: captured.update(sleep=seconds))
+    monkeypatch.setattr(exit_watchdog.logging, "shutdown", lambda: None)
+    monkeypatch.setattr(exit_watchdog.os, "_exit", lambda code: captured.update(exit_code=code))
+    exit_watchdog.arm_exit_watchdog(timeout_s=timeout_s, exit_code=exit_code)
+    return captured
+
+
+def test_watchdog_default_cli_exit_code_remains_zero(monkeypatch):
+    captured = _capture_watchdog(monkeypatch, timeout_s=0.01)
+    captured["target"]()
+    assert captured["exit_code"] == 0
+
+
+def test_watchdog_accepts_explicit_oneshot_exit_code(monkeypatch):
+    captured = _capture_watchdog(monkeypatch, timeout_s=0.01, exit_code=70)
+    captured["target"]()
+    assert captured["exit_code"] == 70
+
+
+def test_watchdog_invalid_timeout_uses_existing_default(monkeypatch):
+    monkeypatch.setenv("HERMES_EXIT_WATCHDOG_S", "invalid")
+    captured = _capture_watchdog(monkeypatch, timeout_s=None)
+    captured["target"]()
+    assert captured["sleep"] == 30.0
+
+
+def test_watchdog_zero_timeout_disables_arming(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    started = []
+    monkeypatch.setattr(
+        exit_watchdog.threading,
+        "Thread",
+        lambda **_kwargs: types.SimpleNamespace(start=lambda: started.append(True)),
+    )
+    exit_watchdog.arm_exit_watchdog(timeout_s=0)
+    assert started == []
+
+
+def test_watchdog_is_disabled_under_pytest(monkeypatch):
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "active")
+    started = []
+    monkeypatch.setattr(
+        exit_watchdog.threading,
+        "Thread",
+        lambda **_kwargs: types.SimpleNamespace(start=lambda: started.append(True)),
+    )
+    exit_watchdog.arm_exit_watchdog(timeout_s=0.01)
+    assert started == []

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import io
+import json
 import logging
+import os
 import sys
 import threading
 import types
 import uuid
-from unittest.mock import Mock, call
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 
@@ -724,3 +727,414 @@ def test_run_agent_passes_explicit_uuid_task_id_and_installs_hook(monkeypatch):
     assert captured["prompt"] == "prompt"
     assert captured["hook_present"] is True
     assert manager._hooks["post_llm_call"] == []
+
+
+def test_terminal_delivery_resolves_rotated_session_after_flush_and_ends_it_once(
+    monkeypatch,
+):
+    events: list[str] = []
+
+    class OrderedStream(io.StringIO):
+        def write(self, value):
+            events.append("stdout_write")
+            return super().write(value)
+
+        def flush(self):
+            events.append("stdout_flush")
+            return super().flush()
+
+    stream = OrderedStream()
+    resources = oneshot._OneshotResources()
+    resources.task_id = str(uuid.uuid4())
+
+    db = types.SimpleNamespace(
+        end_session=Mock(side_effect=lambda *_args: events.append("session_end")),
+        close=Mock(side_effect=lambda: events.append("db_close")),
+    )
+
+    def close_agent():
+        events.append("agent_close")
+        if agent._end_session_on_close:
+            db.end_session(agent.session_id, "agent_close")
+
+    agent = types.SimpleNamespace(
+        session_id="compression-parent",
+        _end_session_on_close=True,
+        _session_messages=[],
+        _memory_manager=None,
+        shutdown_memory_provider=Mock(side_effect=lambda _messages: events.append("memory_stop")),
+        _cleanup_task_resources=Mock(side_effect=lambda _task_id: events.append("task_cleanup")),
+        close=Mock(side_effect=close_agent),
+    )
+    resources.agent = agent
+    resources.session_db = db
+    _install_cleanup_modules(monkeypatch, events)
+    monkeypatch.setattr(
+        resources,
+        "_arm_watchdog_once",
+        Mock(side_effect=lambda exit_code=70: events.append("watchdog")),
+    )
+    delivery = oneshot._FinalDelivery(
+        stream,
+        lambda: (events.append("delivered_callback"), resources.mark_final_delivered()),
+    )
+
+    agent.session_id = "compression-child"
+    assert delivery.deliver("final") is True
+    resources.mark_final_delivered()
+    resources.close()
+    resources.close()
+
+    assert stream.getvalue() == "final\n"
+    assert events.index("stdout_flush") < events.index("watchdog")
+    assert events.index("watchdog") < events.index("session_end")
+    assert db.end_session.call_args_list == [
+        call("compression-child", "oneshot_complete")
+    ]
+    assert agent._end_session_on_close is False
+    assert agent.close.call_count == 1
+    assert db.close.call_count == 1
+
+
+def test_memory_shutdown_receives_a_copy_of_session_messages(monkeypatch):
+    events: list[str] = []
+    _install_cleanup_modules(monkeypatch, events)
+    monkeypatch.setattr(oneshot._OneshotResources, "_arm_watchdog_once", Mock())
+    original = [{"role": "user", "content": "first"}]
+    captured = []
+
+    def shutdown(messages):
+        captured.append(messages)
+        original.append({"role": "assistant", "content": "late mutation"})
+
+    resources = oneshot._OneshotResources()
+    resources.task_id = str(uuid.uuid4())
+    resources.agent = types.SimpleNamespace(
+        session_id="child",
+        _session_messages=original,
+        _memory_manager=None,
+        shutdown_memory_provider=shutdown,
+        _cleanup_task_resources=Mock(),
+        close=Mock(),
+    )
+    resources.session_db = types.SimpleNamespace(close=Mock())
+
+    resources.close()
+
+    assert captured == [[{"role": "user", "content": "first"}]]
+    assert captured[0] is not original
+
+
+@pytest.mark.parametrize(
+    "failing_owner",
+    [
+        "watchdog",
+        "async_delegation",
+        "memory_flush",
+        "memory_shutdown",
+        "process_cleanup",
+        "task_cleanup",
+        "agent_close",
+        "mcp_shutdown",
+        "auxiliary_shutdown",
+        "session_db_close",
+    ],
+)
+def test_each_cleanup_owner_failure_still_runs_every_later_owner(
+    monkeypatch,
+    failing_owner,
+):
+    events: list[str] = []
+
+    def action(owner):
+        def run(*_args, **_kwargs):
+            events.append(owner)
+            if owner == failing_owner:
+                raise RuntimeError("private cleanup detail")
+            return True
+
+        return Mock(side_effect=run)
+
+    def module(name, **attrs):
+        value = types.ModuleType(name)
+        for key, item in attrs.items():
+            setattr(value, key, item)
+        monkeypatch.setitem(sys.modules, name, value)
+
+    watchdog = action("watchdog")
+    monkeypatch.setattr(
+        oneshot._OneshotResources,
+        "_arm_watchdog_once",
+        lambda self, exit_code=70: watchdog(exit_code=exit_code),
+    )
+    module("tools.async_delegation", interrupt_all=action("async_delegation"))
+    module(
+        "tools.process_registry",
+        process_registry=types.SimpleNamespace(kill_all=action("process_cleanup")),
+    )
+    module("tools.mcp_tool", shutdown_mcp_servers=action("mcp_shutdown"))
+    module(
+        "agent.auxiliary_client",
+        shutdown_cached_clients=action("auxiliary_shutdown"),
+    )
+    resources = oneshot._OneshotResources()
+    resources.task_id = str(uuid.uuid4())
+    resources.agent = types.SimpleNamespace(
+        session_id="child",
+        _session_messages=[],
+        _memory_manager=types.SimpleNamespace(flush_pending=action("memory_flush")),
+        shutdown_memory_provider=action("memory_shutdown"),
+        _cleanup_task_resources=action("task_cleanup"),
+        close=action("agent_close"),
+    )
+    resources.session_db = types.SimpleNamespace(close=action("session_db_close"))
+
+    resources.close()
+
+    owners = [
+        "watchdog",
+        "async_delegation",
+        "memory_flush",
+        "memory_shutdown",
+        "process_cleanup",
+        "task_cleanup",
+        "agent_close",
+        "mcp_shutdown",
+        "auxiliary_shutdown",
+        "session_db_close",
+    ]
+    assert events == owners
+
+
+@pytest.mark.parametrize(
+    ("run_failure", "delivers", "expected"),
+    [
+        (None, True, 0),
+        (RuntimeError("before"), False, 1),
+        (RuntimeError("after"), True, 1),
+        (KeyboardInterrupt(), False, KeyboardInterrupt),
+        (SystemExit(23), False, SystemExit),
+    ],
+)
+def test_outer_lifecycle_closes_once_for_success_error_and_interrupt(
+    monkeypatch,
+    run_failure,
+    delivers,
+    expected,
+):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    close_calls = Mock()
+    monkeypatch.setattr(oneshot._OneshotResources, "close", close_calls)
+
+    def run(*_args, delivery, resources, **_kwargs):
+        resources.task_id = "task"
+        if delivers:
+            delivery.deliver("final")
+        if run_failure is not None:
+            raise run_failure
+        return "final", {"failed": False, "session_id": "child"}
+
+    monkeypatch.setattr(oneshot, "_run_agent", run)
+    try:
+        if isinstance(expected, type) and issubclass(expected, BaseException):
+            with pytest.raises(expected) as raised:
+                oneshot.run_oneshot("prompt")
+            assert raised.value is run_failure
+        else:
+            assert oneshot.run_oneshot("prompt") == expected
+    finally:
+        logging.disable(logging.NOTSET)
+
+    assert close_calls.call_count == 1
+    assert stdout.getvalue() == ("final\n" if delivers else "")
+
+
+def test_outer_lifecycle_retains_flush_failure_without_retry_and_still_closes(
+    monkeypatch,
+):
+    failure = OSError("flush failed")
+
+    class FlushFailure(io.StringIO):
+        def __init__(self):
+            super().__init__()
+            self.flush_calls = 0
+
+        def flush(self):
+            self.flush_calls += 1
+            raise failure
+
+    stream = FlushFailure()
+    monkeypatch.setattr(sys, "stdout", stream)
+    close_calls = Mock()
+    monkeypatch.setattr(oneshot._OneshotResources, "close", close_calls)
+    monkeypatch.setattr(
+        oneshot,
+        "_run_agent",
+        lambda *_args, **_kwargs: ("private final", {"failed": False}),
+    )
+
+    try:
+        assert oneshot.run_oneshot("prompt") == 1
+    finally:
+        logging.disable(logging.NOTSET)
+
+    assert stream.getvalue() == "private final\n"
+    assert stream.flush_calls == 1
+    assert close_calls.call_count == 1
+
+
+def test_outer_lifecycle_reports_ordinary_cleanup_failure_after_all_owners(
+    monkeypatch,
+):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    events: list[str] = []
+    _install_cleanup_modules(monkeypatch, events)
+    monkeypatch.setattr(oneshot._OneshotResources, "_arm_watchdog_once", Mock())
+
+    def run(*_args, delivery, resources, **_kwargs):
+        resources.task_id = str(uuid.uuid4())
+        resources.agent = types.SimpleNamespace(
+            session_id="child",
+            _session_messages=[],
+            _memory_manager=types.SimpleNamespace(
+                flush_pending=Mock(side_effect=RuntimeError("private memory detail"))
+            ),
+            shutdown_memory_provider=Mock(side_effect=lambda _messages: events.append("memory")),
+            _cleanup_task_resources=Mock(side_effect=lambda _task_id: events.append("task")),
+            close=Mock(side_effect=lambda: events.append("agent")),
+        )
+        resources.session_db = types.SimpleNamespace(
+            close=Mock(side_effect=lambda: events.append("db"))
+        )
+        delivery.deliver("final")
+        return "final", {"failed": False, "session_id": "child"}
+
+    monkeypatch.setattr(oneshot, "_run_agent", run)
+    try:
+        assert oneshot.run_oneshot("prompt") == 1
+    finally:
+        logging.disable(logging.NOTSET)
+
+    assert stdout.getvalue() == "final\n"
+    assert "private memory detail" not in stderr.getvalue()
+    assert events == [
+        "interrupt",
+        "memory",
+        "processes",
+        "task",
+        "agent",
+        "mcp",
+        "aux",
+        "db",
+    ]
+
+
+def test_cleanup_terminal_chatter_stays_inside_redirected_streams(monkeypatch):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    def run(*_args, delivery, **_kwargs):
+        delivery.deliver("final")
+        return "final", {"failed": False}
+
+    def noisy_close(*_args, **_kwargs):
+        print("cleanup stdout chatter")
+        print("cleanup stderr chatter", file=sys.stderr)
+
+    monkeypatch.setattr(oneshot, "_run_agent", run)
+    monkeypatch.setattr(oneshot._OneshotResources, "close", noisy_close)
+    try:
+        assert oneshot.run_oneshot("prompt") == 0
+    finally:
+        logging.disable(logging.NOTSET)
+
+    assert stdout.getvalue() == "final\n"
+    assert stderr.getvalue() == ""
+
+
+def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
+    tmp_path: Path,
+    monkeypatch,
+):
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent = "oneshot-parent"
+    db.create_session(parent, source="cli", model="test/model")
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            platform="cli",
+            quiet_mode=True,
+            session_db=db,
+            session_id=parent,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "tail"},
+    ]
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_summary_auth_failure = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    agent.context_compressor = compressor
+    agent.compression_in_place = False
+    messages = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}
+        for i in range(20)
+    ]
+
+    agent._compress_context(messages, "sys", approx_tokens=120_000)
+    child = agent.session_id
+    assert child != parent
+    task_id = str(uuid.uuid4())
+    events: list[str] = []
+    _, kill_all, _, _ = _install_cleanup_modules(monkeypatch, events)
+    resources = oneshot._OneshotResources()
+    resources.agent = agent
+    resources.session_db = db
+    resources.task_id = task_id
+    monkeypatch.setattr(resources, "_arm_watchdog_once", Mock())
+
+    close_fallback = Mock(
+        side_effect=lambda: db.end_session(agent.session_id, "agent_close")
+        if agent._end_session_on_close
+        else None
+    )
+    monkeypatch.setattr(agent, "close", close_fallback)
+    resources.mark_final_delivered()
+
+    result = {"session_id": agent.session_id, "failed": False}
+    usage_path = tmp_path / "usage.json"
+    oneshot._write_usage_file(str(usage_path), result)
+    resources.close()
+
+    reopened = SessionDB(db_path=tmp_path / "state.db")
+    parent_row = reopened.get_session(parent)
+    child_row = reopened.get_session(child)
+    assert parent_row["end_reason"] == "compression"
+    assert child_row["end_reason"] == "oneshot_complete"
+    assert result["session_id"] == child
+    assert json.loads(usage_path.read_text())["session_id"] == child
+    assert kill_all.call_args_list == [call(task_id=task_id)]
+    assert close_fallback.call_count == 1
+    assert agent._end_session_on_close is False
+    reopened.close()

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -43,15 +43,23 @@ def _cleanup_real_oneshot_fixture(state: dict) -> None:
 
     resources = state.get("resources")
     if resources is not None:
-        attempt(resources.close)
+        if not state.get("resources_handled"):
+            attempt(resources.close)
+            state["resources_handled"] = True
+    else:
+        agent = state.get("agent")
+        if agent is not None and not state.get("agent_handled"):
+            attempt(agent.close)
+            state["agent_handled"] = True
 
-    agent = state.get("agent")
-    if agent is not None:
-        attempt(agent.close)
+        db = state.get("db")
+        if db is not None and not state.get("db_handled"):
+            attempt(db.close)
+            state["db_handled"] = True
 
     task_id = state.get("task_id")
     terminal_tool = state.get("terminal_tool")
-    if terminal_tool is not None and task_id:
+    if terminal_tool is not None and task_id and not state.get("terminal_handled"):
         def cleanup_terminal():
             try:
                 terminal_tool.cleanup_vm(task_id)
@@ -61,9 +69,10 @@ def _cleanup_real_oneshot_fixture(state: dict) -> None:
                 terminal_tool._creation_locks.pop(task_id, None)
 
         attempt(cleanup_terminal)
+        state["terminal_handled"] = True
 
     browser_tool = state.get("browser_tool")
-    if browser_tool is not None and task_id:
+    if browser_tool is not None and task_id and not state.get("browser_handled"):
         def cleanup_browser():
             try:
                 browser_tool.cleanup_browser(task_id)
@@ -73,13 +82,15 @@ def _cleanup_real_oneshot_fixture(state: dict) -> None:
                 browser_tool._last_active_session_key.pop(task_id, None)
 
         attempt(cleanup_browser)
+        state["browser_handled"] = True
 
-    db = state.get("db")
-    if db is not None:
-        attempt(db.close)
+    verification_db = state.get("verification_db")
+    if verification_db is not None and not state.get("verification_db_handled"):
+        attempt(verification_db.close)
+        state["verification_db_handled"] = True
 
     process = state.get("process")
-    if process is not None:
+    if process is not None and not state.get("process_handled"):
         def reap_process():
             if process.poll() is not None:
                 return
@@ -91,6 +102,7 @@ def _cleanup_real_oneshot_fixture(state: dict) -> None:
                 process.wait(timeout=5)
 
         attempt(reap_process)
+        state["process_handled"] = True
 
 
 def test_delivery_orders_write_flush_and_callback_and_is_idempotent():
@@ -1179,15 +1191,30 @@ def test_real_fixture_cleanup_survives_failures_and_force_kills_stuck_process():
     )
 
     resources.close.assert_called_once_with()
-    agent.close.assert_called_once_with()
-    db.close.assert_called_once_with()
+    agent.close.assert_not_called()
+    db.close.assert_not_called()
     assert task_id not in terminal._active_environments
     assert task_id not in terminal._last_activity
     assert task_id not in terminal._creation_locks
     assert task_id not in browser._active_sessions
     assert task_id not in browser._session_last_activity
     assert task_id not in browser._last_active_session_key
-    assert events == ["agent", "db", "terminate", ("wait", 5), "kill", ("wait", 5)]
+    assert events == ["terminate", ("wait", 5), "kill", ("wait", 5)]
+
+
+def test_real_fixture_cleanup_owns_agent_and_db_only_before_resources_exist():
+    events: list[str] = []
+    task_id = str(uuid.uuid4())
+    agent = types.SimpleNamespace(close=Mock(side_effect=lambda: events.append("agent")))
+    db = types.SimpleNamespace(close=Mock(side_effect=lambda: events.append("db")))
+    state = {"task_id": task_id, "agent": agent, "db": db}
+
+    _cleanup_real_oneshot_fixture(state)
+    _cleanup_real_oneshot_fixture(state)
+
+    agent.close.assert_called_once_with()
+    db.close.assert_called_once_with()
+    assert events == ["agent", "db"]
 
 
 def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
@@ -1210,13 +1237,20 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
     parent = "oneshot-parent"
     db.create_session(parent, source="cli", model="test/model")
     end_calls: list[tuple[str, str]] = []
+    db_close_calls: list[str] = []
     real_end_session = db.end_session
+    real_db_close = db.close
 
     def tracked_end_session(session_id, reason):
         end_calls.append((session_id, reason))
         return real_end_session(session_id, reason)
 
+    def tracked_db_close():
+        db_close_calls.append("db")
+        return real_db_close()
+
     monkeypatch.setattr(db, "end_session", tracked_end_session)
+    monkeypatch.setattr(db, "close", tracked_db_close)
     with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
         agent = AIAgent(
             api_key="test-key",
@@ -1230,6 +1264,14 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
             skip_memory=True,
         )
     cleanup_state["agent"] = agent
+    agent_close_calls: list[str] = []
+    real_agent_close = agent.close
+
+    def tracked_agent_close():
+        agent_close_calls.append("agent")
+        return real_agent_close()
+
+    monkeypatch.setattr(agent, "close", tracked_agent_close)
     compressor = MagicMock()
     compressor.compress.return_value = [
         {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
@@ -1351,9 +1393,26 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
         )
     usage_path = tmp_path / "usage.json"
     oneshot._write_usage_file(str(usage_path), result)
-    _cleanup_real_oneshot_fixture(cleanup_state)
+    resources.close()
+    cleanup_state["resources_handled"] = True
+
+    assert agent_close_calls == ["agent"]
+    assert db_close_calls == ["db"]
+    assert registry.has_active_processes(task_id) is False
+    assert process_session.id not in registry._running
+    assert process.poll() is not None
+    assert task_id not in terminal_tool._active_environments
+    assert task_id not in browser_tool._active_sessions
+    assert terminal_cleaned == [task_id]
+    assert agent._end_session_on_close is False
+    cleanup_state.update(
+        terminal_handled=True,
+        browser_handled=True,
+        process_handled=True,
+    )
 
     reopened = SessionDB(db_path=tmp_path / "state.db")
+    cleanup_state["verification_db"] = reopened
     parent_row = reopened.get_session(parent)
     child_row = reopened.get_session(child)
     assert parent_row["end_reason"] == "compression"
@@ -1368,11 +1427,5 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
     ]
     assert hook_task_ids == [task_id, task_id]
     assert resources.task_id == task_id
-    assert registry.has_active_processes(task_id) is False
-    assert process_session.id not in registry._running
-    assert process.poll() is not None
-    assert task_id not in terminal_tool._active_environments
-    assert task_id not in browser_tool._active_sessions
-    assert terminal_cleaned == [task_id]
-    assert agent._end_session_on_close is False
     reopened.close()
+    cleanup_state["verification_db_handled"] = True

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -297,6 +297,47 @@ def test_delivery_swallows_ordinary_callback_failure_after_flush(caplog):
     assert "completion callback failed" in caplog.text
 
 
+def test_delivery_callback_failure_log_is_sanitized_without_secret_text(
+    tmp_path,
+):
+    path = tmp_path / "agent.log"
+    terminal = io.StringIO()
+    handler = logging.FileHandler(path, encoding="utf-8")
+    terminal_handler = logging.StreamHandler(terminal)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    terminal_handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    old_level = oneshot.logger.level
+    old_propagate = oneshot.logger.propagate
+    oneshot.logger.setLevel(logging.WARNING)
+    oneshot.logger.propagate = False
+    oneshot.logger.addHandler(handler)
+    oneshot.logger.addHandler(terminal_handler)
+
+    def fail():
+        raise RuntimeError("private prompt response tool-output secret")
+
+    try:
+        delivery = oneshot._FinalDelivery(io.StringIO(), fail)
+        assert delivery.deliver("private response") is True
+    finally:
+        oneshot.logger.removeHandler(handler)
+        oneshot.logger.removeHandler(terminal_handler)
+        oneshot.logger.setLevel(old_level)
+        oneshot.logger.propagate = old_propagate
+        handler.close()
+        terminal_handler.close()
+
+    body = path.read_text(encoding="utf-8")
+    assert body == (
+        "WARNING oneshot final-delivery completion callback failed "
+        "exception_type=RuntimeError\n"
+    )
+    assert terminal.getvalue() == body
+    for secret in ("private prompt", "private response", "tool-output", "secret"):
+        assert secret not in body
+        assert secret not in terminal.getvalue()
+
+
 @pytest.mark.parametrize("failure", [KeyboardInterrupt(), SystemExit(19)])
 def test_delivery_propagates_control_flow_callback_after_flush_without_retry(failure):
     events: list[tuple[str, object]] = []
@@ -1250,6 +1291,52 @@ def test_oneshot_logging_preserves_file_logs_and_suppresses_preexisting_terminal
     assert terminal_handler.level == logging.INFO
 
 
+def test_logging_terminal_handler_suppression_overlaps_and_restores_once_in_reverse_order():
+    original_add_handler = logging.Logger.addHandler
+    first = logging.StreamHandler(io.StringIO())
+    first.setLevel(logging.INFO)
+    logger = logging.getLogger("hermes.tests.oneshot.task4.overlap")
+    logger.addHandler(first)
+    first_context = oneshot._suppress_terminal_log_handlers()
+    second_context = oneshot._suppress_terminal_log_handlers()
+    try:
+        first_context.__enter__()
+        second_context.__enter__()
+        assert first.level == logging.CRITICAL + 1
+
+        # Exit in the opposite order from context nesting. Suppression must
+        # remain owned by the still-active second context.
+        first_context.__exit__(None, None, None)
+        assert first.level == logging.CRITICAL + 1
+
+        added_during_overlap = logging.StreamHandler(io.StringIO())
+        added_during_overlap.setLevel(logging.ERROR)
+        logger.addHandler(added_during_overlap)
+        assert added_during_overlap.level == logging.CRITICAL + 1
+
+        added_file_handler = logging.FileHandler(os.devnull)
+        added_file_handler.setLevel(logging.WARNING)
+        logger.addHandler(added_file_handler)
+        assert added_file_handler.level == logging.WARNING
+
+        second_context.__exit__(None, None, None)
+        assert first.level == logging.INFO
+        assert added_during_overlap.level == logging.ERROR
+        assert added_file_handler.level == logging.WARNING
+        assert logging.Logger.addHandler is original_add_handler
+        assert oneshot._terminal_suppression_count == 0
+        assert oneshot._terminal_suppressed_levels == {}
+    finally:
+        # __exit__ is idempotent for generator context managers only when it
+        # has not already completed, so cleanup the handlers directly here.
+        logger.removeHandler(first)
+        if "added_during_overlap" in locals():
+            logger.removeHandler(added_during_overlap)
+        if "added_file_handler" in locals():
+            logger.removeHandler(added_file_handler)
+            added_file_handler.close()
+
+
 def _run_watchdog_subprocess(
     mode: str,
     usage_path: Path | None = None,
@@ -1312,12 +1399,39 @@ def _run_watchdog_subprocess(
                 worker = threading.Thread(target=stop.wait, daemon=False)
                 worker.start()
             if mode != "cleanup_without_final":
-                delivery.deliver("final")
-            if mode == "late_hook_after_final":
-                threading.Event().wait()
+                if mode == "late_hook_after_final":
+                    import hermes_cli.plugins as plugins
+
+                    def blocking_late_hook(**_kwargs):
+                        threading.Event().wait()
+
+                    manager = types.SimpleNamespace(
+                        _hooks={{"post_llm_call": [blocking_late_hook]}}
+                    )
+                    plugins.get_plugin_manager = lambda: manager
+                    with oneshot._install_final_delivery_hook(delivery, resources):
+                        for callback in list(manager._hooks["post_llm_call"]):
+                            callback(
+                                assistant_response="final",
+                                task_id=resources.task_id,
+                            )
+                else:
+                    delivery.deliver("final")
             return ("final" if mode != "cleanup_without_final" else "", {{"failed": False}})
 
         oneshot._run_agent = run
+        if mode == "usage_replace_stall":
+            import logging
+
+            terminal_handler = logging.StreamHandler(sys.stderr)
+            logging.getLogger().handlers[:] = [terminal_handler]
+            logging.getLogger().setLevel(logging.INFO)
+
+            def blocking_replace(*_args, **_kwargs):
+                logging.warning("usage bookkeeping must stay terminal-clean")
+                threading.Event().wait()
+
+            oneshot.os.replace = blocking_replace
         raise SystemExit(
             oneshot.run_oneshot("private prompt", usage_file={usage_literal})
         )
@@ -1367,6 +1481,20 @@ def test_watchdog_forces_bounded_exit_during_cleanup_without_final(
         assert json.loads(usage_path.read_text()) == {"sentinel": "earlier-valid"}
     else:
         assert not usage_path.exists()
+
+
+def test_watchdog_during_atomic_usage_preserves_exact_previous_bytes(tmp_path):
+    usage_path = tmp_path / "usage.json"
+    original = b'{ "sentinel" : "earlier-valid", "spacing": true }\n\n'
+    usage_path.write_bytes(original)
+
+    completed = _run_watchdog_subprocess("usage_replace_stall", usage_path)
+
+    assert completed.returncode == 70
+    assert completed.stdout == "final\n"
+    assert completed.stderr == ""
+    assert completed.elapsed < 3
+    assert usage_path.read_bytes() == original
 
 
 def test_normal_cleanup_releases_non_daemon_mcp_like_thread():

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -1371,6 +1371,93 @@ def test_logging_stale_add_handler_wrapper_race_delegates_once_without_mutation(
         logger.removeHandler(handler)
 
 
+def test_logging_suppression_entry_rolls_back_after_mutating_values_failure():
+    original_add_handler = logging.Logger.addHandler
+    original_logger_dict = logging.Logger.manager.loggerDict
+    candidate = logging.Logger("transaction-candidate")
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setLevel(logging.INFO)
+    candidate.addHandler(handler)
+
+    class MutatingValues(dict):
+        def values(self):
+            self["created-during-values"] = logging.Logger("created-during-values")
+
+            def iterate():
+                yield candidate
+                raise RuntimeError("loggerDict mutated while snapshotting")
+
+            return iterate()
+
+    logging.Logger.manager.loggerDict = MutatingValues()
+    context = oneshot._suppress_terminal_log_handlers()
+    try:
+        with pytest.raises(RuntimeError, match="loggerDict mutated"):
+            context.__enter__()
+
+        assert handler.level == logging.INFO
+        assert logging.Logger.addHandler is original_add_handler
+        assert oneshot._terminal_suppression_count == 0
+        assert oneshot._terminal_suppressed_levels == {}
+        assert oneshot._terminal_original_add_handler is None
+    finally:
+        logging.Logger.manager.loggerDict = original_logger_dict
+        # Failure diagnostics must not poison the rest of the test worker even
+        # when the implementation under test is still RED.
+        for changed_handler, level in list(oneshot._terminal_suppressed_levels.items()):
+            changed_handler.level = level
+        oneshot._terminal_suppressed_levels.clear()
+        oneshot._terminal_suppression_count = 0
+        oneshot._terminal_original_add_handler = None
+        logging.Logger.addHandler = original_add_handler
+        candidate.removeHandler(handler)
+
+
+def test_logging_concurrent_getlogger_creation_survives_reversed_context_exits():
+    first_context = oneshot._suppress_terminal_log_handlers()
+    second_context = oneshot._suppress_terminal_log_handlers()
+    first_context.__enter__()
+    second_context.__enter__()
+    begin = threading.Event()
+    attached = threading.Event()
+    errors = []
+    state = {}
+
+    def create_logger_and_handler():
+        begin.wait()
+        try:
+            logger = logging.getLogger(
+                f"hermes.tests.oneshot.concurrent.{uuid.uuid4().hex}"
+            )
+            handler = logging.StreamHandler(io.StringIO())
+            handler.setLevel(logging.ERROR)
+            logger.addHandler(handler)
+            state.update(logger=logger, handler=handler)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            attached.set()
+
+    worker = threading.Thread(target=create_logger_and_handler)
+    worker.start()
+    begin.set()
+    assert attached.wait(timeout=2)
+    first_context.__exit__(None, None, None)
+    try:
+        assert errors == []
+        assert state["handler"].level == logging.CRITICAL + 1
+        second_context.__exit__(None, None, None)
+        assert state["handler"].level == logging.ERROR
+        assert oneshot._terminal_suppression_count == 0
+        assert oneshot._terminal_suppressed_levels == {}
+    finally:
+        worker.join(timeout=2)
+        if oneshot._terminal_suppression_count:
+            second_context.__exit__(None, None, None)
+        if "logger" in state:
+            state["logger"].removeHandler(state["handler"])
+
+
 def _run_watchdog_subprocess(
     mode: str,
     usage_path: Path | None = None,
@@ -1529,31 +1616,6 @@ def test_watchdog_during_atomic_usage_preserves_exact_previous_bytes(tmp_path):
     assert completed.stderr == ""
     assert completed.elapsed < 3
     assert usage_path.read_bytes() == original
-
-
-def test_usage_write_cleans_only_safe_stale_owned_temp_siblings(
-    monkeypatch,
-    tmp_path,
-):
-    usage_path = tmp_path / "usage.json"
-    stale = tmp_path / (".usage.json.tmp-424242-" + "a" * 32)
-    stale.write_text("stale private usage", encoding="utf-8")
-    os.utime(stale, (0, 0))
-    target = tmp_path / "must-survive"
-    target.write_text("target", encoding="utf-8")
-    symlink = tmp_path / (".usage.json.tmp-424243-" + "b" * 32)
-    symlink.symlink_to(target)
-    arbitrary = tmp_path / ".usage.json.tmp-not-owned"
-    arbitrary.write_text("arbitrary", encoding="utf-8")
-    monkeypatch.setattr(oneshot, "_usage_temp_pid_is_running", lambda _pid: False)
-
-    oneshot._write_usage_file(str(usage_path), {"completed": True})
-
-    assert usage_path.exists()
-    assert not stale.exists()
-    assert symlink.is_symlink()
-    assert target.read_text(encoding="utf-8") == "target"
-    assert arbitrary.read_text(encoding="utf-8") == "arbitrary"
 
 
 def test_atomic_usage_replace_error_removes_current_temp_and_preserves_target(

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import sys
 import threading
 import types
@@ -115,6 +116,95 @@ def test_delivery_io_failure_is_retained_and_never_retried(failure_point):
     assert delivery.delivered is False
 
 
+@pytest.mark.parametrize("short_phase", ["content", "newline"])
+def test_delivery_retains_short_write_failure_without_duplicate(short_phase):
+    class ShortWriteStream(RecordingStdout):
+        def __init__(self):
+            super().__init__([])
+            self.calls = 0
+
+        def write(self, value):
+            self.calls += 1
+            if short_phase == "content" and self.calls == 1:
+                super().write(value[:2])
+                return 2
+            if short_phase == "newline" and value == "\n":
+                return 0
+            return super().write(value)
+
+    stream = ShortWriteStream()
+    delivery = oneshot._FinalDelivery(stream, lambda: None)
+
+    with pytest.raises(oneshot._IncompleteFinalWriteError) as first:
+        delivery.deliver("answer")
+    calls_after_first = stream.calls
+    with pytest.raises(oneshot._IncompleteFinalWriteError) as second:
+        delivery.deliver("fallback")
+
+    assert first.value is second.value
+    assert "answer" not in str(first.value)
+    assert stream.calls == calls_after_first
+    assert delivery.delivered is False
+
+
+def test_delivery_rejects_non_integer_write_result_and_retains_failure():
+    class InvalidWriteStream(RecordingStdout):
+        def write(self, value):
+            self.events.append(("write", value))
+            return None
+
+    stream = InvalidWriteStream([])
+    delivery = oneshot._FinalDelivery(stream, lambda: None)
+
+    with pytest.raises(oneshot._IncompleteFinalWriteError) as first:
+        delivery.deliver("private response")
+    with pytest.raises(oneshot._IncompleteFinalWriteError) as second:
+        delivery.deliver("fallback")
+
+    assert first.value is second.value
+    assert "private response" not in str(first.value)
+    assert stream.events == [("write", "private response")]
+
+
+@pytest.mark.parametrize("short_phase", ["content", "newline"])
+def test_run_oneshot_short_write_fails_nonzero_without_fallback_duplicate(
+    monkeypatch,
+    capsys,
+    short_phase,
+):
+    class ShortWriteStream(io.StringIO):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def write(self, value):
+            self.calls += 1
+            if short_phase == "content" and self.calls == 1:
+                super().write(value[:2])
+                return 2
+            if short_phase == "newline" and value == "\n":
+                return 0
+            return super().write(value)
+
+    stream = ShortWriteStream()
+    monkeypatch.setattr(sys, "stdout", stream)
+    monkeypatch.setattr(
+        oneshot,
+        "_run_agent",
+        lambda *_args, **_kwargs: ("private answer", {}),
+    )
+    monkeypatch.setattr(oneshot._OneshotResources, "close", lambda *_args, **_kwargs: None)
+
+    try:
+        assert oneshot.run_oneshot("prompt") == 1
+    finally:
+        logging.disable(logging.NOTSET)
+
+    assert stream.calls == (1 if short_phase == "content" else 2)
+    assert stream.getvalue() in {"pr", "private answer"}
+    assert "private answer" not in capsys.readouterr().err
+
+
 def test_delivery_swallows_ordinary_callback_failure_after_flush(caplog):
     stream = RecordingStdout([])
 
@@ -151,6 +241,7 @@ def test_transient_hook_is_first_and_removes_only_it_in_place(monkeypatch, raise
     events: list[tuple[str, object]] = []
     stream = RecordingStdout(events)
     resources = oneshot._OneshotResources()
+    resources.task_id = "task-current"
     delivery = oneshot._FinalDelivery(stream, lambda: events.append(("delivered", None)))
 
     def existing(**_kwargs):
@@ -165,7 +256,10 @@ def test_transient_hook_is_first_and_removes_only_it_in_place(monkeypatch, raise
             assert manager._hooks["post_llm_call"] is callbacks
             assert callbacks[0] is not existing
             for callback in list(callbacks):
-                callback(assistant_response="transformed final")
+                callback(
+                    assistant_response="transformed final",
+                    task_id="task-current",
+                )
             if raised is not None:
                 raise raised
 
@@ -179,6 +273,74 @@ def test_transient_hook_is_first_and_removes_only_it_in_place(monkeypatch, raise
     assert manager._hooks["post_llm_call"] is callbacks
     assert callbacks == [existing]
     assert events.index(("flush", None)) < events.index(("existing", None))
+
+
+def test_overlapping_transient_hooks_route_only_matching_task_and_leave_no_residue(monkeypatch):
+    callbacks = [lambda **_kwargs: None]
+    original_callbacks = callbacks
+    manager = types.SimpleNamespace(_hooks={"post_llm_call": callbacks})
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+    events_a: list[tuple[str, object]] = []
+    events_b: list[tuple[str, object]] = []
+    delivery_a = oneshot._FinalDelivery(RecordingStdout(events_a), lambda: None)
+    delivery_b = oneshot._FinalDelivery(RecordingStdout(events_b), lambda: None)
+    resources_a = oneshot._OneshotResources()
+    resources_b = oneshot._OneshotResources()
+    resources_a.task_id = "task-a"
+    resources_b.task_id = "task-b"
+
+    with oneshot._install_final_delivery_hook(delivery_a, resources_a):
+        dispatcher = callbacks[0]
+        with oneshot._install_final_delivery_hook(delivery_b, resources_b):
+            assert callbacks[0] is dispatcher
+            assert callbacks.count(dispatcher) == 1
+            dispatcher(task_id="task-a", assistant_response="answer-a")
+            assert delivery_a.delivered is True
+            assert delivery_b.delivered is False
+            dispatcher(task_id="unknown", assistant_response="wrong")
+            dispatcher(task_id="task-b", assistant_response="answer-b")
+            assert delivery_b.delivered is True
+        assert callbacks[0] is dispatcher
+
+    assert manager._hooks["post_llm_call"] is original_callbacks
+    assert len(callbacks) == 1
+    assert events_a[0] == ("write", "answer-a")
+    assert events_b[0] == ("write", "answer-b")
+
+
+def test_dispatcher_snapshot_survives_matching_context_removal_during_invocation(monkeypatch):
+    callbacks = []
+    manager = types.SimpleNamespace(_hooks={"post_llm_call": callbacks})
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+    resources = oneshot._OneshotResources()
+    resources.task_id = "task-a"
+    entered = threading.Event()
+    release = threading.Event()
+    stream = RecordingStdout([])
+
+    class BlockingDelivery(oneshot._FinalDelivery):
+        def deliver(self, text):
+            entered.set()
+            assert release.wait(timeout=2)
+            return super().deliver(text)
+
+    delivery = BlockingDelivery(stream, lambda: None)
+
+    with oneshot._install_final_delivery_hook(delivery, resources):
+        dispatcher = callbacks[0]
+        worker = threading.Thread(
+            target=dispatcher,
+            kwargs={"task_id": "task-a", "assistant_response": "answer"},
+        )
+        worker.start()
+        assert entered.wait(timeout=2)
+    assert callbacks == []
+    release.set()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert delivery.delivered is True
+    assert stream.getvalue() == "answer\n"
 
 
 def _install_cleanup_modules(monkeypatch, events):
@@ -305,6 +467,52 @@ def test_resources_primary_failure_wins_over_cleanup_control_flow(monkeypatch):
     assert "aux" in events
 
 
+def test_watchdog_failed_delivery_arm_is_retried_by_cleanup(monkeypatch):
+    events: list[str] = []
+    _install_cleanup_modules(monkeypatch, events)
+    attempts = Mock(side_effect=[RuntimeError("unavailable"), None])
+    monkeypatch.setattr("hermes_cli.exit_watchdog.arm_exit_watchdog", attempts)
+    resources = oneshot._OneshotResources()
+    resources.task_id = str(uuid.uuid4())
+
+    resources.mark_final_delivered()
+    resources.close()
+
+    assert attempts.call_args_list == [call(exit_code=70), call(exit_code=70)]
+
+
+@pytest.mark.parametrize("failure", [KeyboardInterrupt(), SystemExit(70)])
+def test_watchdog_baseexception_does_not_poison_retry(monkeypatch, failure):
+    attempts = Mock(side_effect=[failure, None])
+    monkeypatch.setattr("hermes_cli.exit_watchdog.arm_exit_watchdog", attempts)
+    resources = oneshot._OneshotResources()
+
+    with pytest.raises(type(failure)):
+        resources._arm_watchdog_once()
+    resources._arm_watchdog_once()
+    resources._arm_watchdog_once()
+
+    assert attempts.call_count == 2
+
+
+def test_watchdog_concurrent_success_arms_exactly_once(monkeypatch):
+    entered = threading.Event()
+    release = threading.Event()
+    attempts = Mock(side_effect=lambda **_kwargs: (entered.set(), release.wait(timeout=2)))
+    monkeypatch.setattr("hermes_cli.exit_watchdog.arm_exit_watchdog", attempts)
+    resources = oneshot._OneshotResources()
+    threads = [threading.Thread(target=resources._arm_watchdog_once) for _ in range(6)]
+
+    for thread in threads:
+        thread.start()
+    assert entered.wait(timeout=2)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert attempts.call_count == 1
+
+
 def test_mark_final_delivered_arms_then_ends_current_session_once(monkeypatch):
     events: list[str] = []
     resources = oneshot._OneshotResources()
@@ -381,6 +589,60 @@ def test_resources_without_task_id_never_issue_global_process_cleanup(monkeypatc
     cleanup.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("flush_result", "expect_success_log"),
+    [(False, False), (None, True), (True, True)],
+)
+def test_memory_flush_false_is_cleanup_failure_but_none_and_true_succeed(
+    monkeypatch,
+    flush_result,
+    expect_success_log,
+):
+    events: list[str] = []
+    _install_cleanup_modules(monkeypatch, events)
+    monkeypatch.setattr(oneshot._OneshotResources, "_arm_watchdog_once", Mock())
+    info = Mock()
+    warning = Mock()
+    monkeypatch.setattr(oneshot.logger, "info", info)
+    monkeypatch.setattr(oneshot.logger, "warning", warning)
+    resources = oneshot._OneshotResources()
+    resources.task_id = str(uuid.uuid4())
+    resources.agent = types.SimpleNamespace(
+        session_id="session",
+        _session_messages=[],
+        _memory_manager=types.SimpleNamespace(
+            flush_pending=Mock(return_value=flush_result)
+        ),
+        shutdown_memory_provider=Mock(side_effect=lambda _messages: events.append("memory_stop")),
+        _cleanup_task_resources=Mock(side_effect=lambda _task_id: events.append("task_resources")),
+        close=Mock(side_effect=lambda: events.append("agent")),
+    )
+    resources.session_db = types.SimpleNamespace(
+        close=Mock(side_effect=lambda: events.append("db"))
+    )
+
+    resources.close()
+
+    assert "memory_stop" in events
+    assert "agent" in events
+    assert "mcp" in events
+    assert "aux" in events
+    assert "db" in events
+    success_calls = [
+        item for item in info.call_args_list if item.args and item.args[0].startswith("oneshot cleanup completed")
+    ]
+    assert bool(success_calls) is expect_success_log
+    if flush_result is False:
+        assert any(
+            item.args == (
+                "oneshot lifecycle operation failed operation=%s exception_type=%s",
+                "memory_flush",
+                "_IncompleteCleanupError",
+            )
+            for item in warning.call_args_list
+        )
+
+
 def test_mark_final_delivered_leaves_agent_fallback_when_db_end_fails(monkeypatch):
     resources = oneshot._OneshotResources()
     agent = types.SimpleNamespace(session_id="current-child", _end_session_on_close=True)
@@ -412,7 +674,10 @@ def test_run_agent_passes_explicit_uuid_task_id_and_installs_hook(monkeypatch):
             captured["prompt"] = prompt
             captured["task_id"] = task_id
             captured["hook_present"] = bool(manager._hooks["post_llm_call"])
-            manager._hooks["post_llm_call"][0](assistant_response="transformed")
+            manager._hooks["post_llm_call"][0](
+                assistant_response="transformed",
+                task_id=task_id,
+            )
             return {"final_response": "transformed", "failed": False}
 
     def mod(name, **attrs):

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -1337,6 +1337,40 @@ def test_logging_terminal_handler_suppression_overlaps_and_restores_once_in_reve
             added_file_handler.close()
 
 
+def test_logging_stale_add_handler_wrapper_race_delegates_once_without_mutation():
+    logger = logging.getLogger("hermes.tests.oneshot.task4.add-handler-race")
+    context = oneshot._suppress_terminal_log_handlers()
+    context.__enter__()
+    captured = threading.Event()
+    release = threading.Event()
+    errors = []
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setLevel(logging.ERROR)
+
+    def add_from_stale_bound_wrapper():
+        stale_add_handler = logger.addHandler
+        captured.set()
+        release.wait()
+        try:
+            stale_add_handler(handler)
+        except BaseException as exc:
+            errors.append(exc)
+
+    worker = threading.Thread(target=add_from_stale_bound_wrapper)
+    worker.start()
+    assert captured.wait(timeout=2)
+    context.__exit__(None, None, None)
+    release.set()
+    worker.join(timeout=2)
+    try:
+        assert not worker.is_alive()
+        assert errors == []
+        assert handler.level == logging.ERROR
+        assert sum(existing is handler for existing in logger.handlers) == 1
+    finally:
+        logger.removeHandler(handler)
+
+
 def _run_watchdog_subprocess(
     mode: str,
     usage_path: Path | None = None,
@@ -1495,6 +1529,50 @@ def test_watchdog_during_atomic_usage_preserves_exact_previous_bytes(tmp_path):
     assert completed.stderr == ""
     assert completed.elapsed < 3
     assert usage_path.read_bytes() == original
+
+
+def test_usage_write_cleans_only_safe_stale_owned_temp_siblings(
+    monkeypatch,
+    tmp_path,
+):
+    usage_path = tmp_path / "usage.json"
+    stale = tmp_path / (".usage.json.tmp-424242-" + "a" * 32)
+    stale.write_text("stale private usage", encoding="utf-8")
+    os.utime(stale, (0, 0))
+    target = tmp_path / "must-survive"
+    target.write_text("target", encoding="utf-8")
+    symlink = tmp_path / (".usage.json.tmp-424243-" + "b" * 32)
+    symlink.symlink_to(target)
+    arbitrary = tmp_path / ".usage.json.tmp-not-owned"
+    arbitrary.write_text("arbitrary", encoding="utf-8")
+    monkeypatch.setattr(oneshot, "_usage_temp_pid_is_running", lambda _pid: False)
+
+    oneshot._write_usage_file(str(usage_path), {"completed": True})
+
+    assert usage_path.exists()
+    assert not stale.exists()
+    assert symlink.is_symlink()
+    assert target.read_text(encoding="utf-8") == "target"
+    assert arbitrary.read_text(encoding="utf-8") == "arbitrary"
+
+
+def test_atomic_usage_replace_error_removes_current_temp_and_preserves_target(
+    monkeypatch,
+    tmp_path,
+):
+    usage_path = tmp_path / "usage.json"
+    original = b'{"earlier":true}\n'
+    usage_path.write_bytes(original)
+    monkeypatch.setattr(
+        oneshot.os,
+        "replace",
+        Mock(side_effect=OSError("replace failed")),
+    )
+
+    oneshot._write_usage_file(str(usage_path), {"completed": True})
+
+    assert usage_path.read_bytes() == original
+    assert list(tmp_path.glob(".usage.json.tmp-*")) == []
 
 
 def test_normal_cleanup_releases_non_daemon_mcp_like_thread():

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -4,8 +4,10 @@ import io
 import json
 import logging
 import os
+import subprocess
 import sys
 import threading
+import time
 import types
 import uuid
 from pathlib import Path
@@ -1063,13 +1065,27 @@ def test_cleanup_terminal_chatter_stays_inside_redirected_streams(monkeypatch):
 def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
     tmp_path: Path,
     monkeypatch,
+    request,
 ):
+    from agent.turn_finalizer import finalize_turn
     from hermes_state import SessionDB
     from run_agent import AIAgent
+    from tools import browser_tool, process_registry as process_registry_module
+    from tools import terminal_tool
+    from tools.process_registry import ProcessRegistry, ProcessSession
 
+    task_id = str(uuid.uuid4())
     db = SessionDB(db_path=tmp_path / "state.db")
     parent = "oneshot-parent"
     db.create_session(parent, source="cli", model="test/model")
+    end_calls: list[tuple[str, str]] = []
+    real_end_session = db.end_session
+
+    def tracked_end_session(session_id, reason):
+        end_calls.append((session_id, reason))
+        return real_end_session(session_id, reason)
+
+    monkeypatch.setattr(db, "end_session", tracked_end_session)
     with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
         agent = AIAgent(
             api_key="test-key",
@@ -1105,24 +1121,93 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
     agent._compress_context(messages, "sys", approx_tokens=120_000)
     child = agent.session_id
     assert child != parent
-    task_id = str(uuid.uuid4())
-    events: list[str] = []
-    _, kill_all, _, _ = _install_cleanup_modules(monkeypatch, events)
+
+    registry = ProcessRegistry()
+    monkeypatch.setattr(process_registry_module, "process_registry", registry)
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    def reap_fixture_process():
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=5)
+
+    request.addfinalizer(reap_fixture_process)
+    process_session = ProcessSession(
+        id=f"proc_{uuid.uuid4().hex[:12]}",
+        command="python sleep fixture",
+        task_id=task_id,
+        pid=process.pid,
+        process=process,
+        cwd=str(tmp_path),
+        started_at=time.time(),
+        host_start_time=registry._safe_host_start_time(process.pid),
+    )
+    registry._running[process_session.id] = process_session
+
+    terminal_cleaned: list[str] = []
+
+    class FixtureEnvironment:
+        _persistent = False
+
+        def cleanup(self):
+            terminal_cleaned.append(task_id)
+
+    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FixtureEnvironment()})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {task_id: time.time()})
+    monkeypatch.setattr(terminal_tool, "_creation_locks", {task_id: threading.Lock()})
+
+    monkeypatch.setattr(
+        browser_tool,
+        "_active_sessions",
+        {task_id: {"session_name": "oneshot-fixture", "bb_session_id": None}},
+    )
+    monkeypatch.setattr(browser_tool, "_session_last_activity", {task_id: time.time()})
+    monkeypatch.setattr(browser_tool, "_last_active_session_key", {task_id: task_id})
+    monkeypatch.setattr(browser_tool, "_run_browser_command", lambda *_a, **_kw: {"success": True})
+    monkeypatch.setattr(browser_tool, "_maybe_stop_recording", lambda *_a, **_kw: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+
+    manager = types.SimpleNamespace(_hooks={})
+    hook_task_ids: list[str] = []
+
+    def invoke_hook(name, **kwargs):
+        if name in {"post_llm_call", "on_session_end"}:
+            hook_task_ids.append(kwargs["task_id"])
+        return [callback(**kwargs) for callback in list(manager._hooks.get(name, []))]
+
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke_hook)
+    monkeypatch.setattr("tools.async_delegation.interrupt_all", lambda **_kwargs: None)
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
+    monkeypatch.setattr("agent.auxiliary_client.shutdown_cached_clients", lambda: None)
+
     resources = oneshot._OneshotResources()
     resources.agent = agent
     resources.session_db = db
     resources.task_id = task_id
     monkeypatch.setattr(resources, "_arm_watchdog_once", Mock())
+    delivery = oneshot._FinalDelivery(io.StringIO(), resources.mark_final_delivered)
 
-    close_fallback = Mock(
-        side_effect=lambda: db.end_session(agent.session_id, "agent_close")
-        if agent._end_session_on_close
-        else None
-    )
-    monkeypatch.setattr(agent, "close", close_fallback)
-    resources.mark_final_delivered()
-
-    result = {"session_id": agent.session_id, "failed": False}
+    with oneshot._install_final_delivery_hook(delivery, resources):
+        result = finalize_turn(
+            agent,
+            final_response="compressed final",
+            api_call_count=1,
+            interrupted=False,
+            failed=False,
+            messages=messages,
+            conversation_history=[],
+            effective_task_id=task_id,
+            turn_id="oneshot-turn",
+            user_message="prompt",
+            original_user_message="prompt",
+            _should_review_memory=False,
+            _turn_exit_reason="text_response(finish_reason=stop)",
+        )
     usage_path = tmp_path / "usage.json"
     oneshot._write_usage_file(str(usage_path), result)
     resources.close()
@@ -1132,9 +1217,21 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
     child_row = reopened.get_session(child)
     assert parent_row["end_reason"] == "compression"
     assert child_row["end_reason"] == "oneshot_complete"
+    assert reopened.get_conversation_root(child) == parent
+    assert reopened.get_compression_lineage(child) == [parent, child]
     assert result["session_id"] == child
     assert json.loads(usage_path.read_text())["session_id"] == child
-    assert kill_all.call_args_list == [call(task_id=task_id)]
-    assert close_fallback.call_count == 1
+    assert end_calls == [
+        (parent, "compression"),
+        (child, "oneshot_complete"),
+    ]
+    assert hook_task_ids == [task_id, task_id]
+    assert resources.task_id == task_id
+    assert registry.has_active_processes(task_id) is False
+    assert process_session.id not in registry._running
+    assert process.poll() is not None
+    assert task_id not in terminal_tool._active_environments
+    assert task_id not in browser_tool._active_sessions
+    assert terminal_cleaned == [task_id]
     assert agent._end_session_on_close is False
     reopened.close()

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -32,6 +32,67 @@ class RecordingStdout(io.StringIO):
         return super().flush()
 
 
+def _cleanup_real_oneshot_fixture(state: dict) -> None:
+    """Best-effort teardown for every real resource seeded by integration tests."""
+
+    def attempt(callback):
+        try:
+            callback()
+        except BaseException:
+            pass
+
+    resources = state.get("resources")
+    if resources is not None:
+        attempt(resources.close)
+
+    agent = state.get("agent")
+    if agent is not None:
+        attempt(agent.close)
+
+    task_id = state.get("task_id")
+    terminal_tool = state.get("terminal_tool")
+    if terminal_tool is not None and task_id:
+        def cleanup_terminal():
+            try:
+                terminal_tool.cleanup_vm(task_id)
+            finally:
+                terminal_tool._active_environments.pop(task_id, None)
+                terminal_tool._last_activity.pop(task_id, None)
+                terminal_tool._creation_locks.pop(task_id, None)
+
+        attempt(cleanup_terminal)
+
+    browser_tool = state.get("browser_tool")
+    if browser_tool is not None and task_id:
+        def cleanup_browser():
+            try:
+                browser_tool.cleanup_browser(task_id)
+            finally:
+                browser_tool._active_sessions.pop(task_id, None)
+                browser_tool._session_last_activity.pop(task_id, None)
+                browser_tool._last_active_session_key.pop(task_id, None)
+
+        attempt(cleanup_browser)
+
+    db = state.get("db")
+    if db is not None:
+        attempt(db.close)
+
+    process = state.get("process")
+    if process is not None:
+        def reap_process():
+            if process.poll() is not None:
+                return
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
+        attempt(reap_process)
+
+
 def test_delivery_orders_write_flush_and_callback_and_is_idempotent():
     events: list[tuple[str, object]] = []
     delivery = oneshot._FinalDelivery(
@@ -1062,6 +1123,73 @@ def test_cleanup_terminal_chatter_stays_inside_redirected_streams(monkeypatch):
     assert stderr.getvalue() == ""
 
 
+def test_real_fixture_cleanup_survives_failures_and_force_kills_stuck_process():
+    events: list[str] = []
+
+    class StuckProcess:
+        def __init__(self):
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            events.append("terminate")
+
+        def wait(self, timeout):
+            self.wait_calls += 1
+            events.append(("wait", timeout))
+            if self.wait_calls == 1:
+                raise subprocess.TimeoutExpired("fixture", timeout)
+            return -9
+
+        def kill(self):
+            events.append("kill")
+
+    task_id = str(uuid.uuid4())
+    terminal = types.SimpleNamespace(
+        _active_environments={task_id: object()},
+        _last_activity={task_id: 1.0},
+        _creation_locks={task_id: object()},
+        cleanup_vm=Mock(side_effect=RuntimeError("early terminal failure")),
+    )
+    browser = types.SimpleNamespace(
+        _active_sessions={task_id: object()},
+        _session_last_activity={task_id: 1.0},
+        _last_active_session_key={task_id: task_id},
+        cleanup_browser=Mock(side_effect=RuntimeError("early browser failure")),
+    )
+    resources = types.SimpleNamespace(
+        close=Mock(side_effect=RuntimeError("primary cleanup failure"))
+    )
+    agent = types.SimpleNamespace(close=Mock(side_effect=lambda: events.append("agent")))
+    db = types.SimpleNamespace(close=Mock(side_effect=lambda: events.append("db")))
+    process = StuckProcess()
+
+    _cleanup_real_oneshot_fixture(
+        {
+            "task_id": task_id,
+            "resources": resources,
+            "agent": agent,
+            "db": db,
+            "process": process,
+            "terminal_tool": terminal,
+            "browser_tool": browser,
+        }
+    )
+
+    resources.close.assert_called_once_with()
+    agent.close.assert_called_once_with()
+    db.close.assert_called_once_with()
+    assert task_id not in terminal._active_environments
+    assert task_id not in terminal._last_activity
+    assert task_id not in terminal._creation_locks
+    assert task_id not in browser._active_sessions
+    assert task_id not in browser._session_last_activity
+    assert task_id not in browser._last_active_session_key
+    assert events == ["agent", "db", "terminate", ("wait", 5), "kill", ("wait", 5)]
+
+
 def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
     tmp_path: Path,
     monkeypatch,
@@ -1075,7 +1203,10 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
     from tools.process_registry import ProcessRegistry, ProcessSession
 
     task_id = str(uuid.uuid4())
+    cleanup_state = {"task_id": task_id}
+    request.addfinalizer(lambda: _cleanup_real_oneshot_fixture(cleanup_state))
     db = SessionDB(db_path=tmp_path / "state.db")
+    cleanup_state["db"] = db
     parent = "oneshot-parent"
     db.create_session(parent, source="cli", model="test/model")
     end_calls: list[tuple[str, str]] = []
@@ -1098,6 +1229,7 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
             skip_context_files=True,
             skip_memory=True,
         )
+    cleanup_state["agent"] = agent
     compressor = MagicMock()
     compressor.compress.return_value = [
         {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
@@ -1117,10 +1249,21 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
         {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}
         for i in range(20)
     ]
+    compression_task_ids: list[str] = []
+    monkeypatch.setattr(
+        "tools.file_tools.reset_file_dedup",
+        lambda compression_task_id: compression_task_ids.append(compression_task_id),
+    )
 
-    agent._compress_context(messages, "sys", approx_tokens=120_000)
+    agent._compress_context(
+        messages,
+        "sys",
+        approx_tokens=120_000,
+        task_id=task_id,
+    )
     child = agent.session_id
     assert child != parent
+    assert compression_task_ids == [task_id]
 
     registry = ProcessRegistry()
     monkeypatch.setattr(process_registry_module, "process_registry", registry)
@@ -1129,13 +1272,7 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-
-    def reap_fixture_process():
-        if process.poll() is None:
-            process.terminate()
-            process.wait(timeout=5)
-
-    request.addfinalizer(reap_fixture_process)
+    cleanup_state["process"] = process
     process_session = ProcessSession(
         id=f"proc_{uuid.uuid4().hex[:12]}",
         command="python sleep fixture",
@@ -1159,17 +1296,20 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
     monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FixtureEnvironment()})
     monkeypatch.setattr(terminal_tool, "_last_activity", {task_id: time.time()})
     monkeypatch.setattr(terminal_tool, "_creation_locks", {task_id: threading.Lock()})
+    cleanup_state["terminal_tool"] = terminal_tool
 
+    browser_session_name = f"oneshot-{task_id}"
     monkeypatch.setattr(
         browser_tool,
         "_active_sessions",
-        {task_id: {"session_name": "oneshot-fixture", "bb_session_id": None}},
+        {task_id: {"session_name": browser_session_name, "bb_session_id": None}},
     )
     monkeypatch.setattr(browser_tool, "_session_last_activity", {task_id: time.time()})
     monkeypatch.setattr(browser_tool, "_last_active_session_key", {task_id: task_id})
     monkeypatch.setattr(browser_tool, "_run_browser_command", lambda *_a, **_kw: {"success": True})
     monkeypatch.setattr(browser_tool, "_maybe_stop_recording", lambda *_a, **_kw: None)
     monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    cleanup_state["browser_tool"] = browser_tool
 
     manager = types.SimpleNamespace(_hooks={})
     hook_task_ids: list[str] = []
@@ -1189,6 +1329,7 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
     resources.agent = agent
     resources.session_db = db
     resources.task_id = task_id
+    cleanup_state["resources"] = resources
     monkeypatch.setattr(resources, "_arm_watchdog_once", Mock())
     delivery = oneshot._FinalDelivery(io.StringIO(), resources.mark_final_delivered)
 
@@ -1210,7 +1351,7 @@ def test_real_sessiondb_compression_child_is_the_only_oneshot_terminal_session(
         )
     usage_path = tmp_path / "usage.json"
     oneshot._write_usage_file(str(usage_path), result)
-    resources.close()
+    _cleanup_real_oneshot_fixture(cleanup_state)
 
     reopened = SessionDB(db_path=tmp_path / "state.db")
     parent_row = reopened.get_session(parent)

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -1637,6 +1637,107 @@ def test_atomic_usage_replace_error_removes_current_temp_and_preserves_target(
     assert list(tmp_path.glob(".usage.json.tmp-*")) == []
 
 
+@pytest.mark.parametrize("failure_stage", ["write", "flush", "fsync"])
+def test_atomic_usage_owned_handle_failure_never_raw_closes_reused_descriptor(
+    monkeypatch,
+    tmp_path,
+    failure_stage,
+):
+    usage_path = tmp_path / "usage.json"
+    original = b'{"earlier":true}\n'
+    usage_path.write_bytes(original)
+    real_fdopen = oneshot.os.fdopen
+    real_fsync = oneshot.os.fsync
+    real_close = oneshot.os.close
+    state = {"handle_closed": False, "raw_close_calls": []}
+
+    class FailingOwnedHandle:
+        def __init__(self, descriptor, *args, **kwargs):
+            self._handle = real_fdopen(descriptor, *args, **kwargs)
+
+        def __enter__(self):
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            try:
+                return self._handle.__exit__(exc_type, exc, traceback)
+            finally:
+                # The descriptor number can now be reused by unrelated code.
+                state["handle_closed"] = True
+
+        def write(self, value):
+            if failure_stage == "write":
+                raise OSError("body write failed")
+            return self._handle.write(value)
+
+        def flush(self):
+            if failure_stage == "flush":
+                raise OSError("body flush failed")
+            return self._handle.flush()
+
+        def fileno(self):
+            return self._handle.fileno()
+
+    def close_spy(descriptor):
+        state["raw_close_calls"].append((descriptor, state["handle_closed"]))
+        if not state["handle_closed"]:
+            real_close(descriptor)
+
+    def fsync_spy(descriptor):
+        if failure_stage == "fsync":
+            raise OSError("body fsync failed")
+        return real_fsync(descriptor)
+
+    monkeypatch.setattr(oneshot.os, "fdopen", FailingOwnedHandle)
+    monkeypatch.setattr(oneshot.os, "close", close_spy)
+    monkeypatch.setattr(oneshot.os, "fsync", fsync_spy)
+
+    oneshot._write_usage_file(str(usage_path), {"completed": True})
+
+    assert state["handle_closed"] is True
+    assert state["raw_close_calls"] == []
+    assert usage_path.read_bytes() == original
+    assert list(tmp_path.glob(".usage.json.tmp-*")) == []
+
+
+def test_atomic_usage_fdopen_construction_failure_closes_raw_descriptor_once(
+    monkeypatch,
+    tmp_path,
+):
+    usage_path = tmp_path / "usage.json"
+    original = b'{"earlier":true}\n'
+    usage_path.write_bytes(original)
+    real_open = oneshot.os.open
+    real_close = oneshot.os.close
+    opened = []
+    close_calls = []
+
+    def open_spy(*args, **kwargs):
+        descriptor = real_open(*args, **kwargs)
+        opened.append(descriptor)
+        return descriptor
+
+    def close_spy(descriptor):
+        close_calls.append(descriptor)
+        real_close(descriptor)
+
+    monkeypatch.setattr(oneshot.os, "open", open_spy)
+    monkeypatch.setattr(
+        oneshot.os,
+        "fdopen",
+        Mock(side_effect=OSError("fdopen construction failed")),
+    )
+    monkeypatch.setattr(oneshot.os, "close", close_spy)
+
+    oneshot._write_usage_file(str(usage_path), {"completed": True})
+
+    assert len(opened) == 1
+    assert close_calls == opened
+    assert usage_path.read_bytes() == original
+    assert list(tmp_path.glob(".usage.json.tmp-*")) == []
+
+
 def test_normal_cleanup_releases_non_daemon_mcp_like_thread():
     completed = _run_watchdog_subprocess("mcp_release")
 

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+import io
+import sys
+import threading
+import types
+import uuid
+from unittest.mock import Mock, call
+
+import pytest
+
+import hermes_cli.oneshot as oneshot
+
+
+class RecordingStdout(io.StringIO):
+    def __init__(self, events: list[tuple[str, object]]) -> None:
+        super().__init__()
+        self.events = events
+
+    def write(self, value: str) -> int:
+        self.events.append(("write", value))
+        return super().write(value)
+
+    def flush(self) -> None:
+        self.events.append(("flush", None))
+        return super().flush()
+
+
+def test_delivery_orders_write_flush_and_callback_and_is_idempotent():
+    events: list[tuple[str, object]] = []
+    delivery = oneshot._FinalDelivery(
+        RecordingStdout(events),
+        on_delivered=lambda: events.append(("on_delivered", None)),
+    )
+
+    assert delivery.deliver("final answer") is True
+    assert delivery.deliver("duplicate") is False
+    assert delivery.delivered is True
+    assert events == [
+        ("write", "final answer"),
+        ("write", "\n"),
+        ("flush", None),
+        ("on_delivered", None),
+    ]
+
+
+def test_delivery_preserves_existing_newline_and_rejects_blank_without_claiming():
+    events: list[tuple[str, object]] = []
+    stream = RecordingStdout(events)
+    delivery = oneshot._FinalDelivery(stream, lambda: events.append(("delivered", None)))
+
+    assert delivery.deliver(" \n\t") is False
+    assert delivery.deliver("ready\n") is True
+    assert stream.getvalue() == "ready\n"
+    assert events == [("write", "ready\n"), ("flush", None), ("delivered", None)]
+
+
+def test_delivery_concurrent_calls_print_exactly_once():
+    events: list[tuple[str, object]] = []
+    stream = RecordingStdout(events)
+    delivery = oneshot._FinalDelivery(stream, lambda: None)
+    barrier = threading.Barrier(8)
+    results: list[bool] = []
+
+    def worker(index: int) -> None:
+        barrier.wait()
+        results.append(delivery.deliver(f"answer-{index}"))
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert results.count(True) == 1
+    assert results.count(False) == 7
+    assert sum(1 for event, _ in events if event == "flush") == 1
+    assert stream.getvalue().count("answer-") == 1
+
+
+@pytest.mark.parametrize("failure_point", ["write", "flush"])
+def test_delivery_io_failure_is_retained_and_never_retried(failure_point):
+    failure = OSError(failure_point)
+
+    class BrokenStream(RecordingStdout):
+        def __init__(self):
+            super().__init__([])
+            self.write_calls = 0
+            self.flush_calls = 0
+
+        def write(self, value):
+            self.write_calls += 1
+            if failure_point == "write":
+                raise failure
+            return super().write(value)
+
+        def flush(self):
+            self.flush_calls += 1
+            if failure_point == "flush":
+                raise failure
+            return super().flush()
+
+    stream = BrokenStream()
+    delivery = oneshot._FinalDelivery(stream, lambda: None)
+
+    with pytest.raises(OSError) as first:
+        delivery.deliver("answer\n")
+    first_counts = (stream.write_calls, stream.flush_calls)
+    with pytest.raises(OSError) as second:
+        delivery.deliver("fallback")
+
+    assert first.value is failure
+    assert second.value is failure
+    assert (stream.write_calls, stream.flush_calls) == first_counts
+    assert delivery.delivered is False
+
+
+def test_delivery_swallows_ordinary_callback_failure_after_flush(caplog):
+    stream = RecordingStdout([])
+
+    def fail():
+        raise RuntimeError("private detail")
+
+    delivery = oneshot._FinalDelivery(stream, fail)
+    assert delivery.deliver("answer") is True
+    assert delivery.delivered is True
+    assert stream.getvalue() == "answer\n"
+    assert "completion callback failed" in caplog.text
+
+
+@pytest.mark.parametrize("failure", [KeyboardInterrupt(), SystemExit(19)])
+def test_delivery_propagates_control_flow_callback_after_flush_without_retry(failure):
+    events: list[tuple[str, object]] = []
+    stream = RecordingStdout(events)
+
+    def fail():
+        raise failure
+
+    delivery = oneshot._FinalDelivery(stream, fail)
+    with pytest.raises(type(failure)) as raised:
+        delivery.deliver("answer")
+    assert raised.value is failure
+    assert delivery.delivered is True
+    assert stream.getvalue() == "answer\n"
+    assert delivery.deliver("fallback") is False
+    assert sum(1 for event, _ in events if event == "flush") == 1
+
+
+@pytest.mark.parametrize("raised", [None, RuntimeError("boom"), KeyboardInterrupt(), SystemExit(4)])
+def test_transient_hook_is_first_and_removes_only_it_in_place(monkeypatch, raised):
+    events: list[tuple[str, object]] = []
+    stream = RecordingStdout(events)
+    resources = oneshot._OneshotResources()
+    delivery = oneshot._FinalDelivery(stream, lambda: events.append(("delivered", None)))
+
+    def existing(**_kwargs):
+        events.append(("existing", None))
+
+    callbacks = [existing]
+    manager = types.SimpleNamespace(_hooks={"post_llm_call": callbacks})
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+    def execute_body():
+        with oneshot._install_final_delivery_hook(delivery, resources):
+            assert manager._hooks["post_llm_call"] is callbacks
+            assert callbacks[0] is not existing
+            for callback in list(callbacks):
+                callback(assistant_response="transformed final")
+            if raised is not None:
+                raise raised
+
+    if raised is None:
+        execute_body()
+    else:
+        with pytest.raises(type(raised)) as caught:
+            execute_body()
+        assert caught.value is raised
+
+    assert manager._hooks["post_llm_call"] is callbacks
+    assert callbacks == [existing]
+    assert events.index(("flush", None)) < events.index(("existing", None))
+
+
+def _install_cleanup_modules(monkeypatch, events):
+    def module(name, **attrs):
+        value = types.ModuleType(name)
+        for key, item in attrs.items():
+            setattr(value, key, item)
+        monkeypatch.setitem(sys.modules, name, value)
+        return value
+
+    interrupt_all = Mock(side_effect=lambda **_kwargs: events.append("interrupt"))
+    kill_all = Mock(side_effect=lambda **_kwargs: events.append("processes"))
+    shutdown_mcp = Mock(side_effect=lambda: events.append("mcp"))
+    shutdown_aux = Mock(side_effect=lambda: events.append("aux"))
+    module("tools.async_delegation", interrupt_all=interrupt_all)
+    module("tools.process_registry", process_registry=types.SimpleNamespace(kill_all=kill_all))
+    module("tools.mcp_tool", shutdown_mcp_servers=shutdown_mcp)
+    module("agent.auxiliary_client", shutdown_cached_clients=shutdown_aux)
+    return interrupt_all, kill_all, shutdown_mcp, shutdown_aux
+
+
+def test_resources_use_explicit_task_id_and_close_in_exact_order_once(monkeypatch):
+    events: list[str] = []
+    task_id = str(uuid.uuid4())
+    interrupt_all, kill_all, shutdown_mcp, shutdown_aux = _install_cleanup_modules(
+        monkeypatch, events
+    )
+    monkeypatch.setattr(
+        oneshot._OneshotResources,
+        "_arm_watchdog_once",
+        lambda self, exit_code=70: events.append("watchdog"),
+    )
+
+    memory = types.SimpleNamespace(
+        flush_pending=Mock(side_effect=lambda **_kwargs: events.append("memory_flush"))
+    )
+    agent = types.SimpleNamespace(
+        session_id="compression-child",
+        _session_messages=[{"role": "user", "content": "hello"}],
+        _memory_manager=memory,
+        shutdown_memory_provider=Mock(side_effect=lambda _messages: events.append("memory_stop")),
+        _cleanup_task_resources=Mock(side_effect=lambda _task_id: events.append("task_resources")),
+        close=Mock(side_effect=lambda: events.append("agent")),
+    )
+    db = types.SimpleNamespace(close=Mock(side_effect=lambda: events.append("db")))
+    resources = oneshot._OneshotResources()
+    resources.agent = agent
+    resources.session_db = db
+    resources.task_id = task_id
+
+    resources.close()
+    resources.close()
+
+    assert events == [
+        "watchdog",
+        "interrupt",
+        "memory_flush",
+        "memory_stop",
+        "processes",
+        "task_resources",
+        "agent",
+        "mcp",
+        "aux",
+        "db",
+    ]
+    assert interrupt_all.call_args_list == [call(reason="oneshot shutdown")]
+    assert memory.flush_pending.call_args_list == [call(timeout=10)]
+    assert kill_all.call_args_list == [call(task_id=task_id)]
+    assert agent._cleanup_task_resources.call_args_list == [call(task_id)]
+    assert agent.shutdown_memory_provider.call_args_list == [
+        call([{"role": "user", "content": "hello"}])
+    ]
+    assert agent.close.call_count == shutdown_mcp.call_count == shutdown_aux.call_count == 1
+    assert db.close.call_count == 1
+
+
+def test_resources_continue_after_failures_and_preserve_control_flow(monkeypatch):
+    events: list[str] = []
+    _install_cleanup_modules(monkeypatch, events)
+    monkeypatch.setattr(
+        oneshot._OneshotResources,
+        "_arm_watchdog_once",
+        lambda self, exit_code=70: events.append("watchdog"),
+    )
+    agent = types.SimpleNamespace(
+        session_id="child",
+        _session_messages=[],
+        _memory_manager=types.SimpleNamespace(
+            flush_pending=Mock(side_effect=KeyboardInterrupt())
+        ),
+        shutdown_memory_provider=Mock(side_effect=lambda _messages: events.append("memory_stop")),
+        _cleanup_task_resources=Mock(side_effect=RuntimeError("secret")),
+        close=Mock(side_effect=lambda: events.append("agent")),
+    )
+    resources = oneshot._OneshotResources()
+    resources.agent = agent
+    resources.session_db = types.SimpleNamespace(close=Mock(side_effect=lambda: events.append("db")))
+    resources.task_id = str(uuid.uuid4())
+
+    with pytest.raises(KeyboardInterrupt):
+        resources.close()
+    assert "memory_stop" in events
+    assert "agent" in events
+    assert "mcp" in events
+    assert "aux" in events
+    assert "db" in events
+
+
+def test_resources_primary_failure_wins_over_cleanup_control_flow(monkeypatch):
+    events: list[str] = []
+    _install_cleanup_modules(monkeypatch, events)
+    monkeypatch.setattr(
+        oneshot._OneshotResources,
+        "_arm_watchdog_once",
+        Mock(side_effect=SystemExit(70)),
+    )
+    resources = oneshot._OneshotResources()
+    resources.task_id = str(uuid.uuid4())
+    primary = RuntimeError("primary")
+
+    resources.close(primary_failure=primary)
+    assert "interrupt" in events
+    assert "mcp" in events
+    assert "aux" in events
+
+
+def test_mark_final_delivered_arms_then_ends_current_session_once(monkeypatch):
+    events: list[str] = []
+    resources = oneshot._OneshotResources()
+    agent = types.SimpleNamespace(session_id="compression-child", _end_session_on_close=True)
+    db = types.SimpleNamespace(
+        end_session=Mock(side_effect=lambda *_args: events.append("session"))
+    )
+    resources.agent = agent
+    resources.session_db = db
+    resources.task_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        resources,
+        "_arm_watchdog_once",
+        lambda exit_code=70: events.append("watchdog"),
+    )
+
+    resources.mark_final_delivered()
+    resources.mark_final_delivered()
+
+    assert events == ["watchdog", "session"]
+    assert db.end_session.call_args_list == [call("compression-child", "oneshot_complete")]
+    assert agent._end_session_on_close is False
+
+
+def test_mark_final_delivered_ends_session_even_when_watchdog_fails(monkeypatch):
+    resources = oneshot._OneshotResources()
+    agent = types.SimpleNamespace(session_id="current-child", _end_session_on_close=True)
+    db = types.SimpleNamespace(end_session=Mock())
+    resources.agent = agent
+    resources.session_db = db
+    monkeypatch.setattr(resources, "_arm_watchdog_once", Mock(side_effect=RuntimeError("boom")))
+
+    resources.mark_final_delivered()
+
+    db.end_session.assert_called_once_with("current-child", "oneshot_complete")
+    assert agent._end_session_on_close is False
+
+
+def test_mark_final_delivered_ends_session_before_propagating_control_flow(monkeypatch):
+    resources = oneshot._OneshotResources()
+    agent = types.SimpleNamespace(session_id="current-child", _end_session_on_close=True)
+    db = types.SimpleNamespace(end_session=Mock())
+    resources.agent = agent
+    resources.session_db = db
+    failure = KeyboardInterrupt()
+    monkeypatch.setattr(resources, "_arm_watchdog_once", Mock(side_effect=failure))
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        resources.mark_final_delivered()
+
+    assert raised.value is failure
+    db.end_session.assert_called_once_with("current-child", "oneshot_complete")
+    assert agent._end_session_on_close is False
+
+
+def test_resources_without_task_id_never_issue_global_process_cleanup(monkeypatch):
+    events: list[str] = []
+    _, kill_all, _, _ = _install_cleanup_modules(monkeypatch, events)
+    monkeypatch.setattr(oneshot._OneshotResources, "_arm_watchdog_once", Mock())
+    cleanup = Mock()
+    resources = oneshot._OneshotResources()
+    resources.agent = types.SimpleNamespace(
+        _memory_manager=None,
+        _session_messages=[],
+        shutdown_memory_provider=Mock(),
+        _cleanup_task_resources=cleanup,
+        close=Mock(),
+        session_id="session",
+    )
+
+    resources.close()
+
+    kill_all.assert_not_called()
+    cleanup.assert_not_called()
+
+
+def test_mark_final_delivered_leaves_agent_fallback_when_db_end_fails(monkeypatch):
+    resources = oneshot._OneshotResources()
+    agent = types.SimpleNamespace(session_id="current-child", _end_session_on_close=True)
+    resources.agent = agent
+    resources.session_db = types.SimpleNamespace(
+        end_session=Mock(side_effect=RuntimeError("db unavailable"))
+    )
+    monkeypatch.setattr(resources, "_arm_watchdog_once", Mock())
+
+    resources.mark_final_delivered()
+
+    assert agent._end_session_on_close is True
+
+
+def test_run_agent_passes_explicit_uuid_task_id_and_installs_hook(monkeypatch):
+    captured = {}
+    sentinel_db = types.SimpleNamespace()
+    manager = types.SimpleNamespace(_hooks={"post_llm_call": []})
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.session_id = "session"
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def run_conversation(self, prompt, task_id):
+            captured["prompt"] = prompt
+            captured["task_id"] = task_id
+            captured["hook_present"] = bool(manager._hooks["post_llm_call"])
+            manager._hooks["post_llm_call"][0](assistant_response="transformed")
+            return {"final_response": "transformed", "failed": False}
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        monkeypatch.setitem(sys.modules, name, module)
+
+    mod("run_agent", AIAgent=FakeAgent)
+    mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}})
+    mod("hermes_cli.models", detect_provider_for_model=lambda *_a, **_k: None)
+    mod(
+        "hermes_cli.runtime_provider",
+        resolve_runtime_provider=lambda **_k: {
+            "api_key": "k",
+            "base_url": "u",
+            "provider": "p",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    mod("hermes_cli.tools_config", _get_platform_tools=lambda *_a, **_k: set())
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: sentinel_db)
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+    resources = oneshot._OneshotResources()
+    delivery = oneshot._FinalDelivery(io.StringIO(), lambda: None)
+    text, result = oneshot._run_agent(
+        "prompt",
+        None,
+        None,
+        None,
+        True,
+        delivery,
+        resources,
+    )
+
+    assert text == "transformed"
+    assert result["failed"] is False
+    assert resources.agent is not None
+    assert resources.session_db is sentinel_db
+    assert resources.task_id == captured["task_id"]
+    uuid.UUID(resources.task_id)
+    assert captured["prompt"] == "prompt"
+    assert captured["hook_present"] is True
+    assert manager._hooks["post_llm_call"] == []

--- a/tests/hermes_cli/test_oneshot_final_delivery.py
+++ b/tests/hermes_cli/test_oneshot_final_delivery.py
@@ -6,6 +6,7 @@ import logging
 import os
 import subprocess
 import sys
+import textwrap
 import threading
 import time
 import types
@@ -721,6 +722,69 @@ def test_memory_flush_false_is_cleanup_failure_but_none_and_true_succeed(
         )
 
 
+def test_lifecycle_logs_are_exact_sanitized_and_cleanup_marker_is_success_only(
+    monkeypatch,
+):
+    events: list[str] = []
+    _install_cleanup_modules(monkeypatch, events)
+    monkeypatch.setattr(oneshot._OneshotResources, "_arm_watchdog_once", Mock())
+    info = Mock()
+    warning = Mock()
+    monkeypatch.setattr(oneshot.logger, "info", info)
+    monkeypatch.setattr(oneshot.logger, "warning", warning)
+
+    def resources_with(flush_pending):
+        value = oneshot._OneshotResources()
+        value.task_id = "00000000-0000-4000-8000-000000000004"
+        value.agent = types.SimpleNamespace(
+            session_id="opaque-session",
+            _end_session_on_close=True,
+            _session_messages=[],
+            _memory_manager=types.SimpleNamespace(flush_pending=flush_pending),
+            shutdown_memory_provider=Mock(),
+            _cleanup_task_resources=Mock(),
+            close=Mock(),
+        )
+        value.session_db = types.SimpleNamespace(end_session=Mock(), close=Mock())
+        return value
+
+    healthy = resources_with(Mock(return_value=True))
+    healthy.mark_final_delivered()
+    healthy.close()
+
+    assert info.call_args_list == [
+        call(
+            "oneshot final delivered session_id=%s task_id=%s",
+            "opaque-session",
+            "00000000-0000-4000-8000-000000000004",
+        ),
+        call(
+            "oneshot cleanup completed session_id=%s task_id=%s",
+            "opaque-session",
+            "00000000-0000-4000-8000-000000000004",
+        ),
+    ]
+
+    info.reset_mock()
+    failed = resources_with(
+        Mock(side_effect=RuntimeError("private prompt response tool-output payload"))
+    )
+    failed.close()
+
+    assert not any(
+        item.args and item.args[0] == "oneshot cleanup completed session_id=%s task_id=%s"
+        for item in info.call_args_list
+    )
+    assert warning.call_args_list[-1].args == (
+        "oneshot lifecycle operation failed operation=%s exception_type=%s",
+        "memory_flush",
+        "RuntimeError",
+    )
+    rendered = repr(info.call_args_list) + repr(warning.call_args_list)
+    for secret in ("private prompt", "response", "tool-output", "payload"):
+        assert secret not in rendered
+
+
 def test_mark_final_delivered_leaves_agent_fallback_when_db_end_fails(monkeypatch):
     resources = oneshot._OneshotResources()
     agent = types.SimpleNamespace(session_id="current-child", _end_session_on_close=True)
@@ -1133,6 +1197,185 @@ def test_cleanup_terminal_chatter_stays_inside_redirected_streams(monkeypatch):
 
     assert stdout.getvalue() == "final\n"
     assert stderr.getvalue() == ""
+
+
+def test_oneshot_logging_preserves_file_logs_and_suppresses_preexisting_terminal_handler(
+    monkeypatch,
+    tmp_path,
+):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    path = tmp_path / "agent.log"
+    file_handler = logging.FileHandler(path, encoding="utf-8")
+    terminal_handler = logging.StreamHandler(stderr)
+    file_handler.setLevel(logging.INFO)
+    terminal_handler.setLevel(logging.INFO)
+    test_logger = logging.getLogger("hermes.tests.oneshot.task4")
+    old_level = test_logger.level
+    old_propagate = test_logger.propagate
+    test_logger.setLevel(logging.INFO)
+    test_logger.propagate = False
+    test_logger.addHandler(file_handler)
+    test_logger.addHandler(terminal_handler)
+
+    def run(*_args, delivery, **_kwargs):
+        test_logger.info("agent-call-record")
+        delivery.deliver("final")
+        return "final", {"failed": False}
+
+    def close(*_args, **_kwargs):
+        test_logger.info("cleanup-record")
+
+    monkeypatch.setattr(oneshot, "_run_agent", run)
+    monkeypatch.setattr(oneshot._OneshotResources, "close", close)
+    try:
+        assert oneshot.run_oneshot("private prompt") == 0
+    finally:
+        test_logger.removeHandler(file_handler)
+        test_logger.removeHandler(terminal_handler)
+        test_logger.setLevel(old_level)
+        test_logger.propagate = old_propagate
+        file_handler.close()
+        terminal_handler.close()
+
+    assert stdout.getvalue() == "final\n"
+    assert stderr.getvalue() == ""
+    assert path.read_text(encoding="utf-8").splitlines() == [
+        "agent-call-record",
+        "cleanup-record",
+    ]
+    assert file_handler.level == logging.INFO
+    assert terminal_handler.level == logging.INFO
+
+
+def _run_watchdog_subprocess(
+    mode: str,
+    usage_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    usage_literal = repr(str(usage_path)) if usage_path is not None else "None"
+    script = textwrap.dedent(
+        f"""
+        import os
+        import sys
+        import threading
+        import types
+
+        os.environ.pop("PYTEST_CURRENT_TEST", None)
+        os.environ["HERMES_EXIT_WATCHDOG_S"] = "0.2"
+
+        import hermes_cli.oneshot as oneshot
+
+        mode = {mode!r}
+        stop = threading.Event()
+
+        def module(name, **attrs):
+            value = types.ModuleType(name)
+            for key, item in attrs.items():
+                setattr(value, key, item)
+            sys.modules[name] = value
+
+        def interrupt_all(reason):
+            if mode in {{"cleanup_after_final", "cleanup_without_final"}}:
+                threading.Event().wait()
+
+        module("tools.async_delegation", interrupt_all=interrupt_all)
+        module(
+            "tools.process_registry",
+            process_registry=types.SimpleNamespace(kill_all=lambda task_id: None),
+        )
+
+        def shutdown_mcp_servers():
+            if mode == "mcp_release":
+                stop.set()
+
+        module("tools.mcp_tool", shutdown_mcp_servers=shutdown_mcp_servers)
+        module("agent.auxiliary_client", shutdown_cached_clients=lambda: None)
+
+        def run(*_args, delivery, resources, **_kwargs):
+            resources.task_id = "00000000-0000-4000-8000-000000000004"
+            resources.agent = types.SimpleNamespace(
+                session_id="session-opaque",
+                _end_session_on_close=True,
+                _session_messages=[],
+                _memory_manager=None,
+                shutdown_memory_provider=lambda messages: None,
+                _cleanup_task_resources=lambda task_id: None,
+                close=lambda: None,
+            )
+            resources.session_db = types.SimpleNamespace(
+                end_session=lambda session_id, reason: None,
+                close=lambda: None,
+            )
+            if mode == "mcp_release":
+                worker = threading.Thread(target=stop.wait, daemon=False)
+                worker.start()
+            if mode != "cleanup_without_final":
+                delivery.deliver("final")
+            if mode == "late_hook_after_final":
+                threading.Event().wait()
+            return ("final" if mode != "cleanup_without_final" else "", {{"failed": False}})
+
+        oneshot._run_agent = run
+        raise SystemExit(
+            oneshot.run_oneshot("private prompt", usage_file={usage_literal})
+        )
+        """
+    )
+    env = os.environ.copy()
+    env.pop("PYTEST_CURRENT_TEST", None)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    started = time.monotonic()
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=4,
+    )
+    completed.elapsed = time.monotonic() - started
+    return completed
+
+
+@pytest.mark.parametrize("mode", ["late_hook_after_final", "cleanup_after_final"])
+def test_watchdog_forces_bounded_exit_after_delivered_final(mode):
+    completed = _run_watchdog_subprocess(mode)
+
+    assert completed.returncode == 70
+    assert completed.stdout == "final\n"
+    assert completed.stderr == ""
+    assert completed.elapsed < 3
+
+
+@pytest.mark.parametrize("preexisting_usage", [False, True])
+def test_watchdog_forces_bounded_exit_during_cleanup_without_final(
+    tmp_path,
+    preexisting_usage,
+):
+    usage_path = tmp_path / "usage.json"
+    if preexisting_usage:
+        usage_path.write_text('{"sentinel":"earlier-valid"}\n', encoding="utf-8")
+    completed = _run_watchdog_subprocess("cleanup_without_final", usage_path)
+
+    assert completed.returncode == 70
+    assert completed.stdout == ""
+    assert completed.stderr == ""
+    assert completed.elapsed < 3
+    if preexisting_usage:
+        assert json.loads(usage_path.read_text()) == {"sentinel": "earlier-valid"}
+    else:
+        assert not usage_path.exists()
+
+
+def test_normal_cleanup_releases_non_daemon_mcp_like_thread():
+    completed = _run_watchdog_subprocess("mcp_release")
+
+    assert completed.returncode == 0
+    assert completed.stdout == "final\n"
+    assert completed.stderr == ""
+    assert completed.elapsed < 3
 
 
 def test_real_fixture_cleanup_survives_failures_and_force_kills_stuck_process():

--- a/tests/hermes_cli/test_oneshot_usage_file.py
+++ b/tests/hermes_cli/test_oneshot_usage_file.py
@@ -1,7 +1,12 @@
 """Tests for hermes -z --usage-file (per-run JSON usage report)."""
 
+import io
 import json
+import sys
 
+import pytest
+
+import hermes_cli.oneshot as oneshot
 from hermes_cli.oneshot import _write_usage_file
 
 
@@ -67,3 +72,81 @@ class TestWriteUsageFile:
         path = tmp_path / "usage.json"
         _write_usage_file(str(path), _result(failed=True))
         assert json.loads(path.read_text())["failed"] is True
+
+
+@pytest.mark.parametrize(
+    ("run_failure", "expected"),
+    [
+        (None, 0),
+        (RuntimeError("private run detail"), 1),
+        (KeyboardInterrupt(), KeyboardInterrupt),
+        (SystemExit(23), SystemExit),
+    ],
+)
+def test_oneshot_usage_is_written_for_normal_success_error_and_interruption(
+    monkeypatch,
+    tmp_path,
+    run_failure,
+    expected,
+):
+    usage_path = tmp_path / "usage.json"
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    result = _result()
+
+    def run(*_args, delivery, **_kwargs):
+        if run_failure is None:
+            delivery.deliver("final")
+            return "final", result
+        raise run_failure
+
+    monkeypatch.setattr(oneshot, "_run_agent", run)
+    monkeypatch.setattr(oneshot._OneshotResources, "close", lambda *_a, **_kw: None)
+    if isinstance(expected, type) and issubclass(expected, BaseException):
+        with pytest.raises(expected) as raised:
+            oneshot.run_oneshot("private prompt", usage_file=str(usage_path))
+        assert raised.value is run_failure
+    else:
+        assert oneshot.run_oneshot("private prompt", usage_file=str(usage_path)) == expected
+
+    report = json.loads(usage_path.read_text())
+    if run_failure is None:
+        assert report["failed"] is False
+        assert report["estimated_cost_usd"] == result["estimated_cost_usd"]
+        assert report["total_tokens"] == result["total_tokens"]
+    else:
+        assert report["failed"] is True
+
+
+def test_cleanup_failure_does_not_overwrite_primary_usage_result(monkeypatch, tmp_path):
+    usage_path = tmp_path / "usage.json"
+    result = _result(estimated_cost_usd=9.75, total_tokens=9876)
+
+    class CleanupFailureResources:
+        def __init__(self):
+            self.cleanup_failed = False
+
+        def mark_final_delivered(self):
+            return None
+
+        def close(self, primary_failure=None):
+            self.cleanup_failed = True
+
+    monkeypatch.setattr(oneshot, "_OneshotResources", CleanupFailureResources)
+    monkeypatch.setattr(
+        oneshot,
+        "_run_agent",
+        lambda *_args, delivery, **_kwargs: (
+            delivery.deliver("final") and "final",
+            result,
+        ),
+    )
+
+    assert oneshot.run_oneshot("private prompt", usage_file=str(usage_path)) == 1
+    report = json.loads(usage_path.read_text())
+    assert report["failed"] is True
+    assert report["estimated_cost_usd"] == 9.75
+    assert report["total_tokens"] == 9876
+    assert report["session_id"] == result["session_id"]

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+import io
 import os
 from pathlib import Path
 import sys
@@ -832,8 +833,9 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
             self.stream_delta_callback = object()
             self.tool_gen_callback = object()
 
-        def run_conversation(self, prompt, **_kwargs):
+        def run_conversation(self, prompt, **kwargs):
             captured["prompt"] = prompt
+            captured.update(kwargs)
             return {"final_response": "ok", "failed": False, "partial": False}
 
     class FakeSessionDB:
@@ -878,12 +880,24 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
         mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: {"session_search"}),
     )
 
-    text, result = _run_agent("recall this")
+    from hermes_cli.oneshot import _FinalDelivery, _OneshotResources
+
+    resources = _OneshotResources()
+    text, result = _run_agent(
+        "recall this",
+        model=None,
+        provider=None,
+        toolsets=None,
+        use_config_toolsets=True,
+        delivery=_FinalDelivery(io.StringIO(), lambda: None),
+        resources=resources,
+    )
     assert text == "ok"
     assert not result.get("failed")
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
     assert captured["prompt"] == "recall this"
+    assert captured["task_id"] == resources.task_id
 
 
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):


### PR DESCRIPTION
## Summary

- flush the transformed one-shot final response at the first `post_llm_call` hook before later hooks or teardown can stall
- terminate the current compressed child session while keeping the explicit turn task UUID for process, terminal, and browser cleanup
- centralize the exit watchdog with one-shot exit 70 and normal CLI exit 0
- preserve file logging, silence terminal chatter, atomically write usage reports, and make cleanup bounded and exact-once

## Confirmed failure

Before this change, a late `post_llm_call` hook could block after the final response was already transformed and persisted but before `hermes -z` wrote stdout. The controlled baseline reproduction observed trajectory save, task cleanup, session persistence, and transformed final, while stdout remained empty until the later hook was released.

## Verification

- focused lifecycle gate after final rebase: 184/184 passed
- final one-shot focused gate after review fix: 42/42 passed
- one-shot final-delivery file in full suite: 72/72 passed
- full canonical `scripts/run_tests.sh`: 38,528 passed; all 39 failures reproduced on clean origin/main problem files; one branch-only Telegram timing flake passed 14/14 on immediate rerun
- clean-origin replay of all 29 problematic files: 4,302 passed with the same 39 baseline/platform failures and one reproduced timeout
- ruff, py_compile, and git diff --check passed
- consolidated independent Claude Code review: no remaining findings; READY TO MERGE yes
- Ponytail review: no further safe simplification; the optional stale-temp scanner was removed

## Ordering contract

The transformed final is written and flushed before the watchdog is armed, before the current session is ended, and before later hooks, memory shutdown, MCP/client shutdown, and process cleanup. Delivery is claim-before-I/O and never retries a partial or failed write.

## Production

This PR does not modify a deployed checkout. Rollout must use the official Hermes update path after upstream merge/release, followed by the short one-shot smoke and long compression/tool replay.

Events & Logs: not applicable in this upstream repository — existing Hermes runtime/stall observability remains the owner; no marketing-specific event is introduced.