### PR TITLE
perf(sessions): add guarded external-content FTS migration

### DIFF
--- a/docs/benchmarks/2026-07-17-external-content-fts.md
+++ b/docs/benchmarks/2026-07-17-external-content-fts.md
@@ -1,0 +1,76 @@
+# External-Content FTS Snapshot Benchmark — 2026-07-17
+
+## Scope
+
+This benchmark exercised the external-content FTS migration on a checksum-verified disposable copy of an archived Hermes production snapshot. It did **not** modify the live database, live checkout, gateway unit, or deployed code.
+
+> **Code-version note:** The measured run preceded the independent-review remediation that made startup trigger repair mode-aware, prevented no-trigram repeat rebuilds, randomized staging names, persisted the layout marker, and moved schema discovery behind `BEGIN IMMEDIATE`. The external table definitions, canonical search document, rebuild commands, final triggers, and integrity checks measured here are unchanged. The exact post-review diff passes the repository's 524-test relevant state/repair/session-search gate, but the multi-GiB benchmark itself was not repeated.
+
+- Source snapshot: `/home/ubuntu/.hermes/state-snapshots/20260614-122344-pre-update/state.db`
+- Disposable copy: `/tmp/hermes-fts-benchmark-inline-v2.db`
+- Source/copy SHA-256: `9fc2ca0a45a3cc23101ede2fbc220333ceda22dd38a46d78bfe4cccea479a9fc`
+- Benchmark report: `/tmp/hermes-fts-benchmark-report-v2.json`
+- SQLite used by the benchmark venv: `3.50.4`
+- Separate compatibility spike passed on the VM system SQLite `3.37.2`.
+
+## Dataset
+
+- Sessions: `5,927`
+- Messages: `187,949`
+- Initial FTS mode: inline/contentful for base and trigram indexes
+- Initial file size: `3,222,536,192` bytes
+
+The harness sampled:
+
+- 50 standard/tool-oriented FTS queries from the real vocabulary
+- 14 real CJK/trigram queries from message content
+- Public `SessionDB.search_messages()` projections
+- Direct rowid/snippet results for both FTS tables
+
+## Migration and integrity
+
+- Transactional migration: `861.896 s` (`14.365 min`)
+- Final FTS mode: external
+- External-content `integrity-check rank=1`: passed for both tables
+- Final compact clone `PRAGMA quick_check`: `ok` (`65.486 s`)
+- Base rowid/snippet mismatches: `0`
+- Trigram rowid/snippet mismatches: `0`
+- Public API result mismatches: `0`
+- Post-VACUUM base mismatches: `0`
+- Post-VACUUM trigram mismatches: `0`
+
+## Storage
+
+| Metric | Before | After migration, before VACUUM | After VACUUM |
+|---|---:|---:|---:|
+| Main file | 3,222,536,192 B | 4,527,972,352 B | 2,093,027,328 B |
+| Freelist | 0 B | 2,431,594,496 B | 0 B |
+| Base FTS content shadow | 557,199,360 B | 0 B | 0 B |
+| Trigram FTS content shadow | 557,199,360 B | 0 B | 0 B |
+| Base FTS total | 717,815,808 B | 160,968,704 B | 160,841,728 B |
+| Trigram FTS total | 1,712,324,608 B | 1,141,075,968 B | 1,140,678,656 B |
+
+Physical file savings after VACUUM:
+
+- `1,129,508,864` bytes
+- `1.051937 GiB`
+- `35.0503%`
+
+The migration temporarily increased the main file by `1,305,436,160` bytes while staged indexes coexisted with old indexes. After the swap, dropped pages became `2,431,594,496` bytes of reusable freelist space. `VACUUM` took `115.493 s` (`1.925 min`) and returned that space to the filesystem.
+
+## Warm sampled query timing
+
+| Workload | Before median | After median | Before p95 | After p95 |
+|---|---:|---:|---:|---:|
+| Base FTS, 50 queries | 55.7700 ms | 19.8077 ms | 88.0409 ms | 26.1953 ms |
+| Trigram FTS, 14 queries | 1.3623 ms | 0.5842 ms | 46.9513 ms | 10.5274 ms |
+
+These latency changes combine external-content retrieval with a freshly rebuilt and defragmented FTS index and warm-cache effects. They are useful end-to-end observations, not proof that external content alone causes the speedup.
+
+## Operational conclusions
+
+1. The migration preserves sampled search IDs, snippets, public API results, and CJK/trigram behavior.
+2. Actual reclaimed size on this snapshot is 35.05%; the current 8.69 GB live database still needs its own verified clone benchmark before claiming the earlier ~2.84 GiB projection as measured fact.
+3. The operation requires a maintenance window. The dual-index rebuild held one write transaction for 14.4 minutes and produced substantial staged/WAL I/O.
+4. Production execution should require the gateway and other writers to be stopped, explicit free-space preflight, an online backup, post-migration FTS integrity checks, and a separate approval for `VACUUM`.
+5. Migration and `VACUUM` must remain separate operations so search/integrity can be validated before the compact rewrite.

--- a/docs/plans/2026-07-17-external-content-fts.md
+++ b/docs/plans/2026-07-17-external-content-fts.md
@@ -89,10 +89,23 @@ Expected RED: FTS SQL lacks `content=` and physical `_content` shadow tables exi
 
 **Objective:** Expose a maintenance path only after the core migration is proven safe.
 
+**Implemented command:**
+
+```bash
+# Logical read-only preflight: mode, revision, backup/staging estimate, free space
+hermes sessions migrate-fts --check-only
+
+# After explicitly stopping the gateway and every other state.db writer
+hermes sessions migrate-fts --writers-stopped
+```
+
+`--check-only` makes no logical database/schema/content changes and creates no backup. SQLite may still create or update its normal `state.db-shm` coordination sidecar when inspecting a WAL-mode database. The mutating command opens the database through a maintenance-only path that skips startup WAL/schema initialization, acquires `BEGIN IMMEDIATE`, revalidates schema and free space under that reserved writer lock, then creates and verifies a timestamped SQLite online backup beside `state.db` through a separate read connection while retaining the lock. This prevents a writer commit from falling into the migration but outside its rollback backup. The backup receives owner-only permissions on POSIX systems and the command fsyncs the file and parent directory where supported, then rechecks free space before migration. `--yes` skips only the final CLI prompt; it does not bypass writer attestation, backup, or free-space checks. Backup suppression requires the deliberately explicit `--unsafe-no-backup`. The whole-database staging figure and reserve are conservative planning estimates, not proven upper bounds; operators must retain additional headroom for repeated WAL frames and SQLite temp files. Temp-filesystem assessment honors a valid writable `SQLITE_TMPDIR` before Python's platform temp directory. The command refuses to mutate from inside a gateway process, structurally validates both canonical FTS5 tables and the `messages_fts_source` view, rejects missing, partial, or unsupported FTS schemas (including an ordinary/malformed object at the source-view name), rejects base-only schemas when the runtime supports trigram, permits valid base-only operation when trigram is unavailable, exits nonzero on safety failures, and never stops a gateway automatically. The local Hermes Console applies its own centralized confirmation before invoking the handler; the command is not exposed in hosted Console context. `VACUUM` remains a separate operation.
+
 **Files:**
-- Prefer create: `hermes_cli/subcommands/sessions_fts.py` if command extraction is warranted.
-- Otherwise modify narrowly: `hermes_cli/main.py`, `hermes_cli/console_engine.py`.
-- Test: focused CLI parser/handler tests.
+- `hermes_cli/session_fts.py`
+- `hermes_cli/main.py`
+- `hermes_cli/console_engine.py`
+- `tests/hermes_cli/test_session_fts_migration.py`
 
 **Safety requirements:**
 - Never migrate during `SessionDB.__init__`.

--- a/docs/plans/2026-07-17-external-content-fts.md
+++ b/docs/plans/2026-07-17-external-content-fts.md
@@ -1,0 +1,133 @@
+# External-Content Session FTS Implementation Plan
+
+**Status:** Implemented and validated in `perf/session-fts-external-content`; not deployed. See [`../benchmarks/2026-07-17-external-content-fts.md`](../benchmarks/2026-07-17-external-content-fts.md) for the checksum-verified snapshot benchmark.
+
+> **For Hermes:** Use strict test-driven development and review each migration safety boundary before implementation.
+
+**Goal:** Remove duplicated message text from the `messages_fts*_content` shadow tables while preserving standard, tool-field, CJK/trigram, ranking, and snippet behavior.
+
+**Architecture:** Expose the existing canonical search document (`content || ' ' || tool_name || ' ' || tool_calls`) through a zero-storage SQL view named `messages_fts_source`. The non-obvious name is required: `messages_fts_content` is reserved by FTS5 as the legacy inline table's physical content-shadow name and cannot safely be reused as a migration view. New FTS5 tables reference the source view with `content='messages_fts_source'` and `content_rowid='id'`. Existing inline FTS tables remain supported and are migrated only by an explicit transactional maintenance method; startup never performs the large rebuild automatically.
+
+**Tech Stack:** Python 3.11, SQLite/FTS5 3.37+, pytest.
+
+---
+
+### Task 1: Specify external-content behavior
+
+**Objective:** Prove the desired new-database schema and search behavior before implementation.
+
+**Files:**
+- Create: `tests/test_fts_external_content_migration.py`
+- Modify later: `hermes_state.py`
+
+**Steps:**
+1. Create a new `SessionDB` in `tmp_path`.
+2. Assert both FTS virtual-table SQL definitions include `content='messages_fts_source'` and `content_rowid='id'`.
+3. Assert `messages_fts_source` is a view and neither `messages_fts_source` nor `messages_fts_trigram_content` exists as a physical FTS shadow table.
+4. Insert messages whose search terms occur in message content, `tool_name`, `tool_calls`, and CJK text.
+5. Assert result rowids and snippets preserve current behavior.
+6. Run the focused test and observe the expected RED failure against inline FTS.
+
+Run: `venv/bin/python -m pytest tests/test_fts_external_content_migration.py::test_new_database_uses_external_content_fts -v`
+Expected RED: FTS SQL lacks `content=` and physical `_content` shadow tables exist.
+
+### Task 2: Make new databases external-content by default
+
+**Objective:** Add the content view and correct FTS5 trigger semantics without migrating existing databases.
+
+**Files:**
+- Modify: `hermes_state.py` near `FTS_SQL`, `FTS_TRIGRAM_SQL`, and `_ensure_fts_schema()`.
+- Test: `tests/test_fts_external_content_migration.py`
+
+**Steps:**
+1. Define one canonical SQL expression for the indexed document.
+2. Add `CREATE VIEW IF NOT EXISTS messages_fts_source AS SELECT id, <expression> AS content FROM messages`.
+3. Define external-content base and trigram FTS DDL using the view.
+4. Change delete/update triggers to FTS5's special `INSERT ... VALUES('delete', old.id, <old expression>)` form.
+5. Keep existing inline tables and triggers untouched when they already exist (`IF NOT EXISTS` compatibility).
+6. Run the focused test until GREEN.
+
+### Task 3: Preserve legacy inline compatibility and repair behavior
+
+**Objective:** Ensure upgraded code opens and repairs legacy inline databases without silently changing storage mode.
+
+**Files:**
+- Modify: `hermes_state.py` around `_rebuild_fts_indexes()` and FTS schema inspection.
+- Test: `tests/test_fts_external_content_migration.py`
+- Regression: `tests/test_hermes_state.py`, `tests/test_state_db_malformed_repair.py`
+
+**Steps:**
+1. Add a schema-inspection helper returning `inline`, `external`, `missing`, or `mixed`.
+2. For external tables, rebuild with `INSERT INTO <table>(<table>) VALUES('rebuild')`.
+3. For legacy inline tables, retain the existing delete/backfill rebuild path.
+4. Build a legacy inline fixture and assert opening it does not auto-migrate it.
+5. Drop triggers, reopen, and verify trigger repair plus search backfill for both storage modes.
+6. Run focused and repair regression tests.
+
+### Task 4: Implement explicit transactional migration
+
+**Objective:** Rebuild and atomically swap the FTS indexes while preserving the old schema on any failure.
+
+**Files:**
+- Modify: `hermes_state.py`
+- Test: `tests/test_fts_external_content_migration.py`
+
+**Steps:**
+1. Add `SessionDB.migrate_fts_to_external_content()`; reject read-only connections.
+2. Acquire `BEGIN IMMEDIATE` so canonical messages cannot change during rebuild.
+3. Create uniquely named staging FTS tables referencing `messages_fts_source`.
+4. Rebuild each staging table from the view.
+5. Run `integrity-check` with `rank=1` so SQLite compares each staged index against the external content view.
+6. Drop old FTS triggers/tables only after staged validation.
+7. Rename staged tables to canonical names and create external-content triggers.
+8. Re-run `integrity-check` with `rank=1`, then commit.
+9. On any error, roll back the entire transaction; the legacy tables/triggers remain operational.
+10. Return a report containing previous mode, final mode, migrated tables, and whether the call was a no-op.
+11. Test successful dual-inline migration, idempotence, rollback after destructive swap/final-validation failure, subprocess kill recovery after staged validation, and write/search behavior after migration.
+
+### Task 5: Keep migration opt-in operationally
+
+**Objective:** Expose a maintenance path only after the core migration is proven safe.
+
+**Files:**
+- Prefer create: `hermes_cli/subcommands/sessions_fts.py` if command extraction is warranted.
+- Otherwise modify narrowly: `hermes_cli/main.py`, `hermes_cli/console_engine.py`.
+- Test: focused CLI parser/handler tests.
+
+**Safety requirements:**
+- Never migrate during `SessionDB.__init__`.
+- Require an explicit flag/command and confirmation.
+- State that a gateway stop/maintenance window is required.
+- Create a verified SQLite online backup by default; allow backup suppression only with an explicit unsafe flag.
+- Refuse before taking the write lock unless filesystem free space is at least `backup_bytes + current_fts_used_bytes + max(2 GiB, 25% of database_bytes)`. Re-check after the backup. This reserves coexistence space for old/staged indexes plus WAL/transaction overhead; report every term to the operator.
+- Persist and verify `state_meta.fts_storage_revision=external-content-v1`; state that downgrading to a Hermes release without external-content-aware repair paths is unsupported.
+- Do not run `VACUUM` implicitly as part of the core migration. Reclamation is a separate, explicit step because it needs additional free disk and an exclusive rewrite; perform a second free-space preflight sized for a complete replacement database.
+
+### Task 6: Verify equivalence and storage savings
+
+**Objective:** Quantify correctness and savings without touching production.
+
+**Files:**
+- Create if useful: `scripts/benchmark_fts_external_content.py`
+
+**Steps:**
+1. Run all focused state/FTS/repair tests plus Ruff and `py_compile`.
+2. Generate a representative disposable database containing content, tool fields, updates, deletes, and CJK rows.
+3. Capture ordered search results and snippets before migration.
+4. Migrate, then assert byte-for-byte result/snippet equivalence for the query corpus.
+5. Compare `dbstat` used bytes by FTS shadow object before/after.
+6. Run `VACUUM` only on the disposable copy and compare file sizes.
+7. If a verified production snapshot is available locally with adequate free space, repeat there; never benchmark the live production file.
+
+### Task 7: Independent review
+
+**Objective:** Catch corruption, compatibility, and operational hazards before any deployment proposal.
+
+**Review checklist:**
+- Transactional DDL rollback on injected failures.
+- Correct old-value delete commands in update/delete triggers.
+- `rank=1` external-content integrity checks.
+- Compatibility with SQLite 3.37.2 and builds lacking trigram.
+- Legacy inline repair path remains green.
+- No startup migration or implicit production `VACUUM`.
+- No secrets, snapshots, or generated databases in git.

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -898,6 +898,15 @@ class HermesConsoleEngine:
             mutating=True,
             confirmation="Repair the session database?",
         )
+        self.register(
+            ("sessions", "migrate-fts"),
+            "sessions migrate-fts [--check-only] [--writers-stopped] "
+            "[--unsafe-no-backup] [--yes]",
+            "Migrate session FTS indexes to external-content storage.",
+            _sessions_migrate_fts,
+            mutating=True,
+            confirmation="Run guarded FTS storage migration or preflight?",
+        )
 
         self.register(
             ("profile",),
@@ -1504,6 +1513,29 @@ def _sessions_repair(_engine: HermesConsoleEngine, args: list[str]) -> str:
             print("Repaired session database.")
             return
         raise ConsoleCommandError(f"Repair failed: {report.get('error')}")
+
+    return _capture_output(_run)
+
+
+def _sessions_migrate_fts(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    parser = _ArgumentParser(prog="sessions migrate-fts", add_help=False)
+    from hermes_cli.session_fts import (
+        SessionFtsMaintenanceError,
+        configure_migrate_fts_parser,
+        run_external_fts_migration,
+    )
+
+    configure_migrate_fts_parser(parser)
+    ns = parser.parse_args(args)
+    # The console engine invokes mutating handlers only after its own explicit
+    # confirmation. Avoid a second stdin prompt inside the console process.
+    ns.yes = True
+
+    def _run() -> None:
+        try:
+            run_external_fts_migration(ns)
+        except SessionFtsMaintenanceError as exc:
+            raise ConsoleCommandError(str(exc)) from exc
 
     return _capture_output(_run)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14138,6 +14138,19 @@ def main():
         help="Skip the timestamped backup copy (not recommended)",
     )
 
+    sessions_migrate_fts = sessions_subparsers.add_parser(
+        "migrate-fts",
+        help="Migrate session FTS indexes to external-content storage",
+        description=(
+            "Maintenance-window migration for the session search indexes. "
+            "Requires stopped writers, conservative free-space headroom, and "
+            "a verified online backup by default. VACUUM is never implicit."
+        ),
+    )
+    from hermes_cli.session_fts import configure_migrate_fts_parser
+
+    configure_migrate_fts_parser(sessions_migrate_fts)
+
     sessions_subparsers.add_parser("stats", help="Show session store statistics")
 
     sessions_rename = sessions_subparsers.add_parser(
@@ -14212,6 +14225,19 @@ def main():
                 if report.get("backup_path"):
                     print(f"  A backup is preserved at: {report['backup_path']}")
                 print("  Keep state.db and the backup; do not delete them.")
+            return
+
+        if action == "migrate-fts":
+            from hermes_cli.session_fts import (
+                SessionFtsMaintenanceError,
+                run_external_fts_migration,
+            )
+
+            try:
+                run_external_fts_migration(args)
+            except SessionFtsMaintenanceError as exc:
+                print(f"Error: {exc}")
+                raise SystemExit(1) from exc
             return
 
         try:

--- a/hermes_cli/session_fts.py
+++ b/hermes_cli/session_fts.py
@@ -1,0 +1,497 @@
+"""Guarded operator workflow for external-content FTS migration."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from hermes_state import (
+    DEFAULT_DB_PATH,
+    FTS_STORAGE_REVISION_EXTERNAL_V1,
+    FTS_STORAGE_REVISION_KEY,
+    SessionDB,
+)
+
+_GIB = 1024**3
+_MIN_RESERVE_BYTES = 2 * _GIB
+
+
+class SessionFtsMaintenanceError(RuntimeError):
+    """Raised when an external-content FTS maintenance guard fails."""
+
+
+def configure_migrate_fts_parser(parser) -> None:
+    """Add the guarded migration flags to an argparse parser."""
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help=(
+            "Report mode and space without logical DB changes or a backup "
+            "(SQLite may maintain a WAL -shm sidecar)"
+        ),
+    )
+    parser.add_argument(
+        "--writers-stopped",
+        action="store_true",
+        help="Attest that gateway and all other state.db writers are stopped",
+    )
+    parser.add_argument(
+        "--unsafe-no-backup",
+        action="store_true",
+        help="Skip the verified online backup (unsafe; not recommended)",
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip the final interactive confirmation",
+    )
+
+
+def _format_bytes(value: int) -> str:
+    amount = float(value)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if amount < 1024 or unit == "TiB":
+            return f"{amount:.2f} {unit}"
+        amount /= 1024
+    return f"{amount:.2f} TiB"
+
+
+def _read_database_layout(db_path: Path) -> dict[str, Any]:
+    if not db_path.exists():
+        raise SessionFtsMaintenanceError(f"session database does not exist: {db_path}")
+
+    conn = sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True)
+    try:
+        quick_check = str(conn.execute("PRAGMA quick_check").fetchone()[0])
+        if quick_check != "ok":
+            raise SessionFtsMaintenanceError(
+                f"database quick_check failed before migration: {quick_check}"
+            )
+        page_count = int(conn.execute("PRAGMA page_count").fetchone()[0])
+        page_size = int(conn.execute("PRAGMA page_size").fetchone()[0])
+        rows = conn.execute(
+            "SELECT name, sql FROM sqlite_master "
+            "WHERE type = 'table' AND name IN (?, ?) ORDER BY name",
+            ("messages_fts", "messages_fts_trigram"),
+        ).fetchall()
+        source_row = conn.execute(
+            "SELECT type, sql FROM sqlite_master "
+            "WHERE name = ? ORDER BY type LIMIT 1",
+            ("messages_fts_source",),
+        ).fetchone()
+        try:
+            revision_row = conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (FTS_STORAGE_REVISION_KEY,),
+            ).fetchone()
+        except sqlite3.OperationalError:
+            revision_row = None
+    finally:
+        conn.close()
+
+    table_modes = {}
+    for name, sql in rows:
+        table_name = str(name)
+        table_modes[table_name] = SessionDB._classify_fts_table_sql(
+            table_name,
+            str(sql) if sql is not None else None,
+        )
+    source_mode = SessionDB._classify_fts_source_sql(
+        str(source_row[0]) if source_row is not None else None,
+        str(source_row[1])
+        if source_row is not None and source_row[1] is not None
+        else None,
+    )
+
+    expected_tables = {"messages_fts", "messages_fts_trigram"}
+    external_present = "external" in table_modes.values()
+    if source_mode == "unsupported" or (
+        external_present and source_mode != "canonical"
+    ):
+        mode = "unsupported"
+    elif not table_modes:
+        mode = "missing"
+    elif "unsupported" in table_modes.values():
+        mode = "unsupported"
+    elif set(table_modes) == expected_tables:
+        values = set(table_modes.values())
+        mode = values.pop() if len(values) == 1 else "mixed"
+    elif set(table_modes) == {"messages_fts"}:
+        mode = f"base-only-{table_modes['messages_fts']}"
+    else:
+        mode = "partial"
+
+    logical_bytes = page_count * page_size
+    database_bytes = max(db_path.stat().st_size, logical_bytes)
+    wal_path = db_path.with_name(f"{db_path.name}-wal")
+    return {
+        "storage_mode": mode,
+        "source_view_mode": source_mode,
+        "storage_revision": str(revision_row[0]) if revision_row else None,
+        "database_bytes": database_bytes,
+        "wal_bytes": wal_path.stat().st_size if wal_path.exists() else 0,
+        "quick_check": quick_check,
+    }
+
+
+def _runtime_supports_trigram() -> bool:
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute(
+            "CREATE VIRTUAL TABLE temp._hermes_trigram_probe "
+            "USING fts5(x, tokenize='trigram')"
+        )
+        return True
+    except sqlite3.OperationalError as exc:
+        message = str(exc).lower()
+        if "no such tokenizer: trigram" in message or (
+            "no such module" in message and "fts5" in message
+        ):
+            return False
+        raise
+    finally:
+        conn.close()
+
+
+def _sqlite_temp_path() -> Path:
+    configured = os.environ.get("SQLITE_TMPDIR")
+    if configured:
+        candidate = Path(configured).expanduser()
+        if candidate.is_dir() and os.access(candidate, os.W_OK | os.X_OK):
+            return candidate.resolve()
+    return Path(tempfile.gettempdir()).resolve()
+
+
+def _space_plan(
+    db_path: Path,
+    *,
+    database_bytes: int,
+    backup_enabled: bool,
+    disk_usage_fn: Callable[[Path], Any],
+) -> dict[str, Any]:
+    # A whole-database staging estimate is deliberately conservative relative
+    # to observed benchmarks and much faster to determine than scanning
+    # multi-GiB dbstat output. It is a heuristic, not a proven upper bound;
+    # repeated WAL frames and SQLite temp files can require additional space.
+    staging_bytes = database_bytes
+    backup_bytes = database_bytes if backup_enabled else 0
+    reserve_bytes = max(_MIN_RESERVE_BYTES, (database_bytes + 3) // 4)
+    required_free_bytes = backup_bytes + staging_bytes + reserve_bytes
+    free_bytes = int(disk_usage_fn(db_path.parent).free)
+    temp_path = _sqlite_temp_path()
+    separate_temp_filesystem = (
+        os.stat(db_path.parent).st_dev != os.stat(temp_path).st_dev
+    )
+    temp_required_bytes = staging_bytes + reserve_bytes if separate_temp_filesystem else 0
+    temp_free_bytes = (
+        int(disk_usage_fn(temp_path).free) if separate_temp_filesystem else free_bytes
+    )
+    temp_space_ok = temp_free_bytes >= temp_required_bytes
+    return {
+        "backup_bytes": backup_bytes,
+        "staging_bytes": staging_bytes,
+        "reserve_bytes": reserve_bytes,
+        "required_free_bytes": required_free_bytes,
+        "free_bytes": free_bytes,
+        "space_ok": free_bytes >= required_free_bytes and temp_space_ok,
+        "temp_path": str(temp_path),
+        "separate_temp_filesystem": separate_temp_filesystem,
+        "temp_required_bytes": temp_required_bytes,
+        "temp_free_bytes": temp_free_bytes,
+        "temp_space_ok": temp_space_ok,
+    }
+
+
+def _backup_path(db_path: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%fZ")
+    return db_path.with_name(f"{db_path.name}.pre-fts-external-{stamp}.bak")
+
+
+def _create_verified_backup(db_path: Path, destination: Path) -> None:
+    try:
+        destination_fd = os.open(
+            destination,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+    except FileExistsError as exc:
+        raise SessionFtsMaintenanceError(
+            f"refusing to overwrite existing backup: {destination}"
+        ) from exc
+    else:
+        os.close(destination_fd)
+
+    source = None
+    backup = None
+    try:
+        source = sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True)
+        backup = sqlite3.connect(str(destination))
+        if os.name != "nt":
+            os.chmod(destination, 0o600)
+        source.backup(backup)
+        result = str(backup.execute("PRAGMA quick_check").fetchone()[0])
+        if result != "ok":
+            raise SessionFtsMaintenanceError(
+                f"backup quick_check failed: {result}"
+            )
+        backup.close()
+        backup = None
+        if os.name != "nt":
+            os.chmod(destination, 0o600)
+        fd = os.open(destination, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        if os.name != "nt":
+            directory_fd = os.open(destination.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+    except BaseException:
+        try:
+            if backup is not None:
+                backup.close()
+        except Exception:
+            pass
+        try:
+            destination.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    finally:
+        if source is not None:
+            try:
+                source.close()
+            except Exception:
+                pass
+
+
+def _print_plan(db_path: Path, layout: dict[str, Any], plan: dict[str, Any]) -> None:
+    print(f"Session database: {db_path}")
+    print(f"FTS storage mode: {layout['storage_mode']}")
+    print(f"FTS storage revision: {layout['storage_revision'] or '(unset)'}")
+    print(f"Runtime trigram support: {'yes' if layout['trigram_available'] else 'no'}")
+    print(f"Database size allowance: {_format_bytes(layout['database_bytes'])}")
+    print(f"Current WAL size: {_format_bytes(layout['wal_bytes'])}")
+    print(f"Backup allowance: {_format_bytes(plan['backup_bytes'])}")
+    print(f"Staging estimate: {_format_bytes(plan['staging_bytes'])}")
+    print(f"Safety reserve: {_format_bytes(plan['reserve_bytes'])}")
+    print(f"Required free space: {_format_bytes(plan['required_free_bytes'])}")
+    print(f"Available free space: {_format_bytes(plan['free_bytes'])}")
+    if plan["separate_temp_filesystem"]:
+        print(f"SQLite temp filesystem: {plan['temp_path']}")
+        print(
+            "Temp-space estimate: "
+            f"{_format_bytes(plan['temp_required_bytes'])} required, "
+            f"{_format_bytes(plan['temp_free_bytes'])} available"
+        )
+
+
+def run_external_fts_migration(
+    args,
+    *,
+    db_path: Path | None = None,
+    input_fn: Callable[[str], str] = input,
+    disk_usage_fn: Callable[[Path], Any] = shutil.disk_usage,
+) -> dict[str, Any]:
+    """Run or preflight the guarded external-content FTS migration."""
+    path = Path(db_path or DEFAULT_DB_PATH).expanduser().resolve()
+    backup_enabled = not bool(args.unsafe_no_backup)
+    try:
+        layout = _read_database_layout(path)
+        layout["trigram_available"] = _runtime_supports_trigram()
+        plan = _space_plan(
+            path,
+            database_bytes=int(layout["database_bytes"]),
+            backup_enabled=backup_enabled,
+            disk_usage_fn=disk_usage_fn,
+        )
+    except SessionFtsMaintenanceError:
+        raise
+    except Exception as exc:
+        raise SessionFtsMaintenanceError(f"FTS preflight failed: {exc}") from exc
+    _print_plan(path, layout, plan)
+
+    base_report = {
+        **layout,
+        **plan,
+        "check_only": bool(args.check_only),
+        "backup_path": None,
+    }
+    if args.check_only:
+        return base_report
+
+    invalid_mode = layout["storage_mode"] in {"missing", "partial", "unsupported"}
+    invalid_base_only = (
+        layout["storage_mode"] in {"base-only-inline", "base-only-external"}
+        and layout["trigram_available"]
+    )
+    if invalid_mode or invalid_base_only:
+        raise SessionFtsMaintenanceError(
+            "both FTS5 tables (messages_fts and messages_fts_trigram) must be "
+            "present when this SQLite runtime supports trigram; "
+            f"detected {layout['storage_mode']}"
+        )
+    if os.environ.get("_HERMES_GATEWAY") == "1":
+        raise SessionFtsMaintenanceError(
+            "run this maintenance command outside the gateway process"
+        )
+    if not args.writers_stopped:
+        raise SessionFtsMaintenanceError(
+            "refusing migration without --writers-stopped; stop the gateway and "
+            "all other state.db writers first"
+        )
+    if not plan["temp_space_ok"]:
+        raise SessionFtsMaintenanceError(
+            "insufficient free space on SQLite temp filesystem "
+            f"{plan['temp_path']}: need "
+            f"{_format_bytes(plan['temp_required_bytes'])}, have "
+            f"{_format_bytes(plan['temp_free_bytes'])}"
+        )
+    if plan["free_bytes"] < plan["required_free_bytes"]:
+        raise SessionFtsMaintenanceError(
+            "insufficient free space: "
+            f"need {_format_bytes(plan['required_free_bytes'])}, "
+            f"have {_format_bytes(plan['free_bytes'])}"
+        )
+
+    if not args.yes:
+        try:
+            answer = input_fn(
+                "Create the verified backup and migrate available FTS indexes now? [y/N] "
+            )
+        except (EOFError, KeyboardInterrupt):
+            answer = ""
+        if answer.strip().lower() not in {"y", "yes"}:
+            print("Migration cancelled; no changes made.")
+            return {**base_report, "cancelled": True}
+
+    destination = None
+    backup_verified = False
+    db = None
+    try:
+        db = SessionDB.open_for_fts_maintenance(path)
+        db.begin_fts_maintenance_transaction()
+
+        # Re-read mode and sizing after acquiring the cross-process writer lock.
+        # No writer can commit between this snapshot, the backup, and migration.
+        locked_layout = _read_database_layout(path)
+        locked_layout["trigram_available"] = layout["trigram_available"]
+        locked_invalid_mode = locked_layout["storage_mode"] in {
+            "missing",
+            "partial",
+            "unsupported",
+        }
+        locked_invalid_base_only = (
+            locked_layout["storage_mode"]
+            in {"base-only-inline", "base-only-external"}
+            and locked_layout["trigram_available"]
+        )
+        if locked_invalid_mode or locked_invalid_base_only:
+            raise SessionFtsMaintenanceError(
+                "FTS schema changed before the maintenance lock was acquired; "
+                f"detected {locked_layout['storage_mode']}"
+            )
+        locked_plan = _space_plan(
+            path,
+            database_bytes=int(locked_layout["database_bytes"]),
+            backup_enabled=backup_enabled,
+            disk_usage_fn=disk_usage_fn,
+        )
+        if not locked_plan["temp_space_ok"] or (
+            locked_plan["free_bytes"] < locked_plan["required_free_bytes"]
+        ):
+            raise SessionFtsMaintenanceError(
+                "free space fell below the locked maintenance requirement"
+            )
+        base_report.update(locked_layout)
+        base_report.update(locked_plan)
+
+        if backup_enabled:
+            destination = _backup_path(path)
+            try:
+                _create_verified_backup(path, destination)
+            except SessionFtsMaintenanceError:
+                raise
+            except Exception as exc:
+                raise SessionFtsMaintenanceError(
+                    f"verified backup failed; migration was not attempted: {exc}"
+                ) from exc
+            backup_verified = True
+            print(f"Verified backup: {destination}")
+
+            try:
+                remaining = _space_plan(
+                    path,
+                    database_bytes=int(locked_layout["database_bytes"]),
+                    backup_enabled=False,
+                    disk_usage_fn=disk_usage_fn,
+                )
+            except Exception as exc:
+                raise SessionFtsMaintenanceError(
+                    "post-backup free-space check failed; "
+                    f"backup preserved at {destination}: {exc}"
+                ) from exc
+            if not remaining["space_ok"]:
+                raise SessionFtsMaintenanceError(
+                    "free space fell below the post-backup migration requirement; "
+                    f"backup preserved at {destination}"
+                )
+
+        migration = db.migrate_fts_to_external_content()
+        final_mode = db.fts_storage_mode()
+        conn = db._conn
+        if conn is None:
+            raise SessionFtsMaintenanceError("session database connection closed unexpectedly")
+        quick_check = str(conn.execute("PRAGMA quick_check").fetchone()[0])
+        revision_row = conn.execute(
+            "SELECT value FROM state_meta WHERE key = ?",
+            (FTS_STORAGE_REVISION_KEY,),
+        ).fetchone()
+        final_revision = str(revision_row[0]) if revision_row else None
+        if (
+            final_mode != "external"
+            or quick_check != "ok"
+            or final_revision != FTS_STORAGE_REVISION_EXTERNAL_V1
+        ):
+            raise SessionFtsMaintenanceError(
+                "post-migration validation failed: "
+                f"mode={final_mode}, revision={final_revision}, "
+                f"quick_check={quick_check}"
+            )
+    except Exception as exc:
+        if isinstance(exc, SessionFtsMaintenanceError) and "backup preserved at" in str(exc):
+            raise
+        if backup_verified:
+            backup_context = f"backup preserved at {destination}"
+        elif backup_enabled:
+            backup_context = "no verified backup was created"
+        else:
+            backup_context = "no backup was requested"
+        raise SessionFtsMaintenanceError(
+            f"FTS migration failed; {backup_context}: {exc}"
+        ) from exc
+    finally:
+        if db is not None:
+            conn = db._conn
+            if conn is not None and conn.in_transaction:
+                conn.rollback()
+            db.close()
+
+    print("FTS migration completed and validated.")
+    print("VACUUM was not run; disk reclamation remains a separate operation.")
+    return {
+        **base_report,
+        **migration,
+        "storage_revision": final_revision,
+        "backup_path": str(destination) if destination else None,
+        "post_migration_quick_check": quick_check,
+    }

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -23,6 +23,7 @@ import sqlite3
 import sys
 import threading
 import time
+import uuid
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -141,6 +142,8 @@ T = TypeVar("T")
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
 SCHEMA_VERSION = 22
+FTS_STORAGE_REVISION_KEY = "fts_storage_revision"
+FTS_STORAGE_REVISION_EXTERNAL_V1 = "external-content-v1"
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
 # Search queries do not need to be arbitrarily large, and bounding them keeps
@@ -603,6 +606,41 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         conn.close()
 
 
+def _rebuild_fts_table_for_repair(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> bool:
+    """Rebuild one existing FTS table using its actual storage protocol."""
+    if table_name not in {"messages_fts", "messages_fts_trigram"}:
+        raise ValueError(f"unsupported FTS table: {table_name}")
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    if row is None:
+        return False
+    normalized = "".join(str(row[0]).lower().split())
+    external = (
+        "content='messages_fts_source'" in normalized
+        or 'content="messages_fts_source"' in normalized
+    )
+    if external:
+        conn.execute(
+            f"INSERT INTO {table_name}({table_name}) VALUES('rebuild')"
+        )
+    else:
+        conn.execute(f"DELETE FROM {table_name}")
+        conn.execute(
+            f"INSERT INTO {table_name}(rowid, content) "
+            "SELECT id, "
+            "COALESCE(content, '') || ' ' || "
+            "COALESCE(tool_name, '') || ' ' || "
+            "COALESCE(tool_calls, '') "
+            "FROM messages"
+        )
+    return True
+
+
 def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, Any]:
     """Repair a state.db whose ``sqlite_master`` schema is malformed or whose
     FTS indexes reject writes.
@@ -613,10 +651,10 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     ``integrity_check`` passes but writes fail through the ``messages_fts*``
     triggers. Tries least-destructive recovery first and escalates:
 
-      1. **Rebuild FTS indexes in place** via the FTS5 ``'rebuild'`` command,
-         which rewrites the internal b-tree segments from the canonical
-         ``messages`` rows without dropping or recreating anything. Fixes the
-         FTS write-corruption class while preserving the schema intact.
+      1. **Rebuild FTS indexes in place** using the mode-correct protocol:
+         FTS5 ``'rebuild'`` for external-content tables, transactional
+         delete/backfill for legacy inline tables. This rewrites internal b-tree
+         segments from canonical ``messages`` rows without changing schema.
       2. **De-duplicate** ``sqlite_master`` (keep the lowest rowid per
          ``type``/``name``). Fixes the canonical "table X already exists"
          case and PRESERVES the existing FTS index intact.
@@ -652,20 +690,29 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
         report["backup_path"] = str(bpath) if bpath else None
 
     # ── Strategy 0: rebuild FTS indexes in place (FTS write-corruption) ──
-    # The FTS5 'rebuild' command rewrites the internal index from the canonical
-    # content table. This is the recommended, least-destructive recovery for a
-    # corrupt FTS index that rejects message writes while reads still succeed.
+    # External-content tables use FTS5's 'rebuild' command; legacy inline
+    # tables require an ordinary delete/backfill. Keep both in one transaction
+    # so a failure in either table leaves both original indexes intact.
     try:
         conn = sqlite3.connect(str(db_path), isolation_level=None)
         try:
+            conn.execute("BEGIN IMMEDIATE")
             for table_name in ("messages_fts", "messages_fts_trigram"):
                 try:
-                    conn.execute(
-                        f"INSERT INTO {table_name}({table_name}) VALUES('rebuild')"
-                    )
-                except sqlite3.OperationalError:
-                    # Table absent (FTS disabled / trigram off) — skip it.
-                    continue
+                    _rebuild_fts_table_for_repair(conn, table_name)
+                except sqlite3.OperationalError as exc:
+                    msg = str(exc).lower()
+                    if (
+                        "no such table" in msg
+                        or "no such module" in msg
+                        or "no such tokenizer: trigram" in msg
+                    ):
+                        continue
+                    raise
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
         finally:
             conn.close()
         if _db_opens_cleanly(db_path) is None:
@@ -912,9 +959,25 @@ CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
     ON sessions(handoff_state, started_at);
 """
 
-FTS_SQL = """
+# FTS5 indexes the same canonical document for ordinary text, tool names, and
+# serialized tool calls.  A zero-storage view lets external-content FTS retrieve
+# that exact document for snippet()/rebuild without duplicating it in each
+# FTS ``*_content`` shadow table.
+FTS_CONTENT_VIEW_SQL = """
+CREATE VIEW IF NOT EXISTS messages_fts_source AS
+SELECT
+    id,
+    COALESCE(content, '') || ' ' ||
+    COALESCE(tool_name, '') || ' ' ||
+    COALESCE(tool_calls, '') AS content
+FROM messages;
+"""
+
+FTS_SQL = FTS_CONTENT_VIEW_SQL + """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-    content
+    content,
+    content='messages_fts_source',
+    content_rowid='id'
 );
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_insert AFTER INSERT ON messages BEGIN
@@ -925,11 +988,20 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_insert AFTER INSERT ON messages BEGIN
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_delete AFTER DELETE ON messages BEGIN
-    DELETE FROM messages_fts WHERE rowid = old.id;
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES (
+        'delete',
+        old.id,
+        COALESCE(old.content, '') || ' ' || COALESCE(old.tool_name, '') || ' ' || COALESCE(old.tool_calls, '')
+    );
 END;
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
-    DELETE FROM messages_fts WHERE rowid = old.id;
+CREATE TRIGGER IF NOT EXISTS messages_fts_update
+AFTER UPDATE OF id, content, tool_name, tool_calls ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES (
+        'delete',
+        old.id,
+        COALESCE(old.content, '') || ' ' || COALESCE(old.tool_name, '') || ' ' || COALESCE(old.tool_calls, '')
+    );
     INSERT INTO messages_fts(rowid, content) VALUES (
         new.id,
         COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
@@ -941,9 +1013,11 @@ END;
 # tokenizer splits CJK characters into individual tokens, breaking phrase
 # matching.  The trigram tokenizer creates overlapping 3-byte sequences so
 # substring queries work natively for any script (CJK, Thai, etc.).
-FTS_TRIGRAM_SQL = """
+FTS_TRIGRAM_SQL = FTS_CONTENT_VIEW_SQL + """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
     content,
+    content='messages_fts_source',
+    content_rowid='id',
     tokenize='trigram'
 );
 
@@ -955,16 +1029,45 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_insert AFTER INSERT ON message
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON messages BEGIN
-    DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content) VALUES (
+        'delete',
+        old.id,
+        COALESCE(old.content, '') || ' ' || COALESCE(old.tool_name, '') || ' ' || COALESCE(old.tool_calls, '')
+    );
 END;
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON messages BEGIN
-    DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update
+AFTER UPDATE OF id, content, tool_name, tool_calls ON messages BEGIN
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content) VALUES (
+        'delete',
+        old.id,
+        COALESCE(old.content, '') || ' ' || COALESCE(old.tool_name, '') || ' ' || COALESCE(old.tool_calls, '')
+    );
     INSERT INTO messages_fts_trigram(rowid, content) VALUES (
         new.id,
         COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
     );
 END;
+"""
+
+# Startup uses table-only DDL and installs triggers separately after inspecting
+# the existing table's storage mode.  The full FTS_SQL constants above remain
+# for historical migrations that explicitly drop/recreate their FTS schema.
+FTS_TABLE_ONLY_SQL = FTS_CONTENT_VIEW_SQL + """
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+    content,
+    content='messages_fts_source',
+    content_rowid='id'
+);
+"""
+
+FTS_TRIGRAM_TABLE_ONLY_SQL = FTS_CONTENT_VIEW_SQL + """
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
+    content,
+    content='messages_fts_source',
+    content_rowid='id',
+    tokenize='trigram'
+);
 """
 
 
@@ -1178,31 +1281,144 @@ class SessionDB:
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
 
     @staticmethod
+    def _fts_trigger_names(table_name: str) -> Tuple[str, str, str]:
+        if table_name not in {"messages_fts", "messages_fts_trigram"}:
+            raise ValueError(f"unsupported FTS table: {table_name}")
+        return (
+            f"{table_name}_insert",
+            f"{table_name}_delete",
+            f"{table_name}_update",
+        )
+
+    @classmethod
+    def _missing_fts_triggers(
+        cls,
+        cursor: sqlite3.Cursor,
+        table_name: str,
+    ) -> List[str]:
+        names = cls._fts_trigger_names(table_name)
+        placeholders = ",".join("?" for _ in names)
+        rows = cursor.execute(
+            f"SELECT name FROM sqlite_master "
+            f"WHERE type = 'trigger' AND name IN ({placeholders})",
+            names,
+        ).fetchall()
+        present = {str(row[0]) for row in rows}
+        return [name for name in names if name not in present]
+
+    @classmethod
+    def _create_fts_triggers(
+        cls,
+        cursor: sqlite3.Cursor,
+        table_name: str,
+        *,
+        external: bool,
+    ) -> None:
+        """Install mode-correct write triggers for one FTS table."""
+        cls._fts_trigger_names(table_name)  # Validate interpolated identifier.
+        document_new = (
+            "COALESCE(new.content, '') || ' ' || "
+            "COALESCE(new.tool_name, '') || ' ' || "
+            "COALESCE(new.tool_calls, '')"
+        )
+        document_old = (
+            "COALESCE(old.content, '') || ' ' || "
+            "COALESCE(old.tool_name, '') || ' ' || "
+            "COALESCE(old.tool_calls, '')"
+        )
+        cursor.execute(
+            f"CREATE TRIGGER IF NOT EXISTS {table_name}_insert "
+            "AFTER INSERT ON messages BEGIN "
+            f"INSERT INTO {table_name}(rowid, content) "
+            f"VALUES (new.id, {document_new}); END"
+        )
+        if external:
+            delete_old = (
+                f"INSERT INTO {table_name}({table_name}, rowid, content) "
+                f"VALUES ('delete', old.id, {document_old})"
+            )
+        else:
+            delete_old = f"DELETE FROM {table_name} WHERE rowid = old.id"
+        cursor.execute(
+            f"CREATE TRIGGER IF NOT EXISTS {table_name}_delete "
+            "AFTER DELETE ON messages BEGIN "
+            f"{delete_old}; END"
+        )
+        cursor.execute(
+            f"CREATE TRIGGER IF NOT EXISTS {table_name}_update "
+            "AFTER UPDATE OF id, content, tool_name, tool_calls ON messages BEGIN "
+            f"{delete_old}; "
+            f"INSERT INTO {table_name}(rowid, content) "
+            f"VALUES (new.id, {document_new}); END"
+        )
+
+    @classmethod
+    def _repair_fts_triggers(
+        cls,
+        cursor: sqlite3.Cursor,
+        table_name: str,
+    ) -> bool:
+        """Create missing triggers in the table's mode; return whether repaired."""
+        missing = cls._missing_fts_triggers(cursor, table_name)
+        if not missing:
+            return False
+        cls._create_fts_triggers(
+            cursor,
+            table_name,
+            external=cls._fts_table_uses_external_content(cursor, table_name),
+        )
+        return True
+
+    @staticmethod
+    def _fts_table_uses_external_content(
+        cursor: sqlite3.Cursor,
+        table_name: str,
+    ) -> bool:
+        """Return whether *table_name* references the canonical content view."""
+        row = cursor.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        ).fetchone()
+        if row is None:
+            return False
+        sql = str(row[0] if not isinstance(row, sqlite3.Row) else row["sql"])
+        normalized = "".join(sql.lower().split())
+        return (
+            "content='messages_fts_source'" in normalized
+            or 'content="messages_fts_source"' in normalized
+        )
+
+    @classmethod
+    def _rebuild_fts_table(
+        cls,
+        cursor: sqlite3.Cursor,
+        table_name: str,
+    ) -> None:
+        if cls._fts_table_uses_external_content(cursor, table_name):
+            cursor.execute(
+                f"INSERT INTO {table_name}({table_name}) VALUES('rebuild')"
+            )
+            return
+        cursor.execute(f"DELETE FROM {table_name}")
+        cursor.execute(
+            f"INSERT INTO {table_name}(rowid, content) "
+            "SELECT id, "
+            "COALESCE(content, '') || ' ' || "
+            "COALESCE(tool_name, '') || ' ' || "
+            "COALESCE(tool_calls, '') "
+            "FROM messages"
+        )
+
+    @classmethod
     def _rebuild_fts_indexes(
+        cls,
         cursor: sqlite3.Cursor,
         *,
         include_trigram: bool = True,
     ) -> None:
-        cursor.execute("DELETE FROM messages_fts")
-        cursor.execute(
-            "INSERT INTO messages_fts(rowid, content) "
-            "SELECT id, "
-            "COALESCE(content, '') || ' ' || "
-            "COALESCE(tool_name, '') || ' ' || "
-            "COALESCE(tool_calls, '') "
-            "FROM messages"
-        )
-        if not include_trigram:
-            return
-        cursor.execute("DELETE FROM messages_fts_trigram")
-        cursor.execute(
-            "INSERT INTO messages_fts_trigram(rowid, content) "
-            "SELECT id, "
-            "COALESCE(content, '') || ' ' || "
-            "COALESCE(tool_name, '') || ' ' || "
-            "COALESCE(tool_calls, '') "
-            "FROM messages"
-        )
+        cls._rebuild_fts_table(cursor, "messages_fts")
+        if include_trigram:
+            cls._rebuild_fts_table(cursor, "messages_fts_trigram")
 
     def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
         try:
@@ -1814,24 +2030,71 @@ class SessionDB:
             pass  # Index already exists
 
         if fts5_available:
-            # FTS5 setup. Run the DDL even when the virtual table exists so
-            # CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation from
-            # an earlier no-FTS5 runtime.
-            triggers_need_repair = self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
-            self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
+            # Create/probe each FTS table independently, then repair only that
+            # table's missing triggers using its actual storage mode.  Inline
+            # tables require ordinary DELETE statements; external-content tables
+            # require FTS5's special 'delete' command.
+            self._fts_enabled = self._ensure_fts_schema(
+                cursor,
+                "messages_fts",
+                FTS_TABLE_ONLY_SQL,
+            )
 
             # Trigram FTS5 for CJK/substring search. This is optional relative
             # to the main FTS table; if it cannot be created, CJK search falls
             # back to LIKE.
             if self._fts_enabled:
+                base_triggers_repaired = self._repair_fts_triggers(
+                    cursor,
+                    "messages_fts",
+                )
                 trigram_enabled = self._ensure_fts_schema(
-                    cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+                    cursor,
+                    "messages_fts_trigram",
+                    FTS_TRIGRAM_TABLE_ONLY_SQL,
                 )
                 self._trigram_available = trigram_enabled
-                if triggers_need_repair:
-                    self._rebuild_fts_indexes(
+                trigram_triggers_repaired = False
+                if trigram_enabled:
+                    trigram_triggers_repaired = self._repair_fts_triggers(
                         cursor,
-                        include_trigram=trigram_enabled,
+                        "messages_fts_trigram",
+                    )
+
+                # A missing trigger means writes may have occurred while that
+                # table was stale. Rebuild only the affected table; absence of
+                # optional trigram triggers must never force a base-index rebuild.
+                if base_triggers_repaired:
+                    self._rebuild_fts_table(cursor, "messages_fts")
+                if trigram_triggers_repaired:
+                    self._rebuild_fts_table(cursor, "messages_fts_trigram")
+
+                fts_names = [
+                    str(row[0])
+                    for row in cursor.execute(
+                        "SELECT name FROM sqlite_master "
+                        "WHERE type = 'table' AND name IN (?, ?)",
+                        self._FTS_TABLES,
+                    ).fetchall()
+                ]
+                all_external = bool(fts_names) and all(
+                    self._fts_table_uses_external_content(cursor, name)
+                    for name in fts_names
+                )
+                if all_external:
+                    cursor.execute(
+                        "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                        "ON CONFLICT(key) DO UPDATE SET value = excluded.value "
+                        "WHERE state_meta.value IS NOT excluded.value",
+                        (
+                            FTS_STORAGE_REVISION_KEY,
+                            FTS_STORAGE_REVISION_EXTERNAL_V1,
+                        ),
+                    )
+                else:
+                    cursor.execute(
+                        "DELETE FROM state_meta WHERE key = ?",
+                        (FTS_STORAGE_REVISION_KEY,),
                     )
 
         self._conn.commit()
@@ -7225,6 +7488,168 @@ class SessionDB:
     # trigram table is created lazily / may be disabled, so we probe before
     # touching it (see optimize_fts).
     _FTS_TABLES = ("messages_fts", "messages_fts_trigram")
+
+    def fts_storage_mode(self) -> str:
+        """Return ``external``, ``inline``, ``mixed``, or ``missing``."""
+        with self._lock:
+            cursor = self._conn.cursor()
+            rows = cursor.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type = 'table' AND name IN (?, ?) ORDER BY name",
+                self._FTS_TABLES,
+            ).fetchall()
+            names = [str(row[0]) for row in rows]
+            if not names:
+                return "missing"
+            modes = {
+                self._fts_table_uses_external_content(cursor, name)
+                for name in names
+            }
+            if modes == {True}:
+                return "external"
+            if modes == {False}:
+                return "inline"
+            return "mixed"
+
+    @classmethod
+    def _create_external_fts_triggers(
+        cls,
+        cursor: sqlite3.Cursor,
+        table_name: str,
+    ) -> None:
+        """Create INSERT/DELETE/UPDATE triggers for one external FTS table."""
+        cls._create_fts_triggers(cursor, table_name, external=True)
+
+    @staticmethod
+    def _validate_external_fts_table(
+        cursor: sqlite3.Cursor,
+        table_name: str,
+    ) -> None:
+        # rank=1 compares the index against its external content source, not
+        # merely the internal FTS b-tree structure.
+        cursor.execute(
+            f"INSERT INTO {table_name}({table_name}, rank) "
+            "VALUES('integrity-check', 1)"
+        )
+
+    def migrate_fts_to_external_content(self) -> Dict[str, Any]:
+        """Explicitly migrate inline FTS indexes to external-content storage.
+
+        This operation is deliberately never called by :meth:`_init_schema`:
+        rebuilding a multi-GiB index belongs in a maintenance window.  The
+        staged rebuild, integrity checks, trigger swap, and table renames run in
+        one ``BEGIN IMMEDIATE`` transaction so any failure restores the original
+        inline tables and triggers.
+        """
+        if self.read_only:
+            raise sqlite3.OperationalError(
+                "external-content FTS migration requires a writable SessionDB"
+            )
+        if not self._fts_enabled:
+            raise sqlite3.OperationalError(
+                "external-content FTS migration requires SQLite FTS5"
+            )
+
+        with self._lock:
+            cursor = self._conn.cursor()
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                # Discover storage mode only after acquiring the cross-process
+                # SQLite write lock. Concurrent migrators therefore observe the
+                # latest committed schema instead of acting on stale mode data.
+                rows = cursor.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type = 'table' AND name IN (?, ?) ORDER BY name",
+                    self._FTS_TABLES,
+                ).fetchall()
+                existing = [str(row[0]) for row in rows]
+                if not existing:
+                    raise sqlite3.OperationalError("no FTS5 tables are present")
+                external = [
+                    name
+                    for name in existing
+                    if self._fts_table_uses_external_content(cursor, name)
+                ]
+                if len(external) == len(existing):
+                    previous_mode = "external"
+                elif not external:
+                    previous_mode = "inline"
+                else:
+                    previous_mode = "mixed"
+                to_migrate = [name for name in existing if name not in external]
+                if not to_migrate:
+                    self._conn.commit()
+                    return {
+                        "previous_mode": previous_mode,
+                        "final_mode": "external",
+                        "migrated_tables": [],
+                        "noop": True,
+                    }
+
+                if (
+                    "messages_fts_trigram" in to_migrate
+                    and not self._trigram_available
+                ):
+                    raise sqlite3.OperationalError(
+                        "cannot migrate trigram FTS with this SQLite build"
+                    )
+
+                suffix = uuid.uuid4().hex
+                staging = {
+                    name: f"{name}__external_new_{suffix}"
+                    for name in to_migrate
+                }
+                cursor.execute(FTS_CONTENT_VIEW_SQL)
+                for name in to_migrate:
+                    stage = staging[name]
+                    collision = cursor.execute(
+                        "SELECT 1 FROM sqlite_master WHERE name = ?",
+                        (stage,),
+                    ).fetchone()
+                    if collision is not None:
+                        raise sqlite3.OperationalError(
+                            f"refusing to overwrite existing staging object: {stage}"
+                        )
+                    tokenize = ", tokenize='trigram'" if name.endswith("_trigram") else ""
+                    cursor.execute(
+                        f"CREATE VIRTUAL TABLE {stage} USING fts5("
+                        "content, content='messages_fts_source', "
+                        f"content_rowid='id'{tokenize})"
+                    )
+                    cursor.execute(
+                        f"INSERT INTO {stage}({stage}) VALUES('rebuild')"
+                    )
+                    self._validate_external_fts_table(cursor, stage)
+
+                self._drop_fts_triggers(cursor)
+                for name in to_migrate:
+                    stage = staging[name]
+                    cursor.execute(f"DROP TABLE {name}")
+                    cursor.execute(f"ALTER TABLE {stage} RENAME TO {name}")
+
+                for name in existing:
+                    self._create_external_fts_triggers(cursor, name)
+                    self._validate_external_fts_table(cursor, name)
+                cursor.execute(
+                    "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value "
+                    "WHERE state_meta.value IS NOT excluded.value",
+                    (
+                        FTS_STORAGE_REVISION_KEY,
+                        FTS_STORAGE_REVISION_EXTERNAL_V1,
+                    ),
+                )
+                self._conn.commit()
+            except BaseException:
+                self._conn.rollback()
+                raise
+
+            return {
+                "previous_mode": previous_mode,
+                "final_mode": "external",
+                "migrated_tables": to_migrate,
+                "noop": False,
+            }
 
     def _fts_table_exists(self, name: str) -> bool:
         """True if an FTS5 virtual table is queryable in this DB."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1113,7 +1113,13 @@ class SessionDB:
     _IMPORT_MAX_SESSION_BYTES = 5 * 1024 * 1024
     _IMPORT_MAX_TOTAL_BYTES = 25 * 1024 * 1024
 
-    def __init__(self, db_path: Path = None, read_only: bool = False):
+    def __init__(
+        self,
+        db_path: Path = None,
+        read_only: bool = False,
+        *,
+        _maintenance_open: bool = False,
+    ):
         self.db_path = db_path or DEFAULT_DB_PATH
         self.read_only = read_only
 
@@ -1123,7 +1129,29 @@ class SessionDB:
         self._trigram_available = False
         self._fts_unavailable_warned = False
         self._conn = None
+        self._checkpoint_on_close = not _maintenance_open
+        self._fts_maintenance_transaction = False
         try:
+            if _maintenance_open:
+                if read_only:
+                    raise ValueError("maintenance-open SessionDB must be writable")
+                maintenance_uri = (
+                    f"{Path(self.db_path).expanduser().resolve().as_uri()}?mode=rw"
+                )
+                self._conn = sqlite3.connect(
+                    maintenance_uri,
+                    uri=True,
+                    check_same_thread=False,
+                    timeout=1.0,
+                    isolation_level=None,
+                )
+                self._conn.row_factory = sqlite3.Row
+                cursor = self._conn.cursor()
+                self._fts_enabled = self._sqlite_supports_fts5(cursor)
+                self._trigram_available = (
+                    self._fts_enabled and self._sqlite_supports_trigram(cursor)
+                )
+                return
             if read_only:
                 # Read-only attach for cross-profile aggregation: SELECT-only,
                 # so we skip schema init entirely (no DDL, no FTS probe, no
@@ -1204,6 +1232,16 @@ class SessionDB:
             _set_last_init_error(f"{type(exc).__name__}: {exc}")
             raise
 
+    @classmethod
+    def open_for_fts_maintenance(cls, db_path: Path) -> "SessionDB":
+        """Open an existing state DB without startup schema writes or repair.
+
+        Capability probes use only the connection's temporary schema. The
+        migration method can therefore acquire ``BEGIN IMMEDIATE`` before its
+        first target-database write.
+        """
+        return cls(db_path=db_path, _maintenance_open=True)
+
     # ── Core write helper ──
 
     @staticmethod
@@ -1262,6 +1300,19 @@ class SessionDB:
             self._warn_fts5_unavailable(exc)
             return False
 
+    def _sqlite_supports_trigram(self, cursor: sqlite3.Cursor) -> bool:
+        try:
+            cursor.execute(
+                "CREATE VIRTUAL TABLE temp._hermes_trigram_probe "
+                "USING fts5(x, tokenize='trigram')"
+            )
+            cursor.execute("DROP TABLE temp._hermes_trigram_probe")
+            return True
+        except sqlite3.OperationalError as exc:
+            if not self._is_fts5_unavailable_error(exc):
+                raise
+            return False
+
     @staticmethod
     def _drop_fts_triggers(cursor: sqlite3.Cursor) -> None:
         for trigger in _FTS_TRIGGERS:
@@ -1307,14 +1358,13 @@ class SessionDB:
         return [name for name in names if name not in present]
 
     @classmethod
-    def _create_fts_triggers(
+    def _fts_trigger_sql(
         cls,
-        cursor: sqlite3.Cursor,
         table_name: str,
         *,
         external: bool,
-    ) -> None:
-        """Install mode-correct write triggers for one FTS table."""
+    ) -> Dict[str, str]:
+        """Return canonical mode-correct write-trigger SQL for one FTS table."""
         cls._fts_trigger_names(table_name)  # Validate interpolated identifier.
         document_new = (
             "COALESCE(new.content, '') || ' ' || "
@@ -1326,12 +1376,14 @@ class SessionDB:
             "COALESCE(old.tool_name, '') || ' ' || "
             "COALESCE(old.tool_calls, '')"
         )
-        cursor.execute(
-            f"CREATE TRIGGER IF NOT EXISTS {table_name}_insert "
+        statements = {
+            f"{table_name}_insert": (
+                f"CREATE TRIGGER IF NOT EXISTS {table_name}_insert "
             "AFTER INSERT ON messages BEGIN "
             f"INSERT INTO {table_name}(rowid, content) "
             f"VALUES (new.id, {document_new}); END"
-        )
+            )
+        }
         if external:
             delete_old = (
                 f"INSERT INTO {table_name}({table_name}, rowid, content) "
@@ -1339,18 +1391,74 @@ class SessionDB:
             )
         else:
             delete_old = f"DELETE FROM {table_name} WHERE rowid = old.id"
-        cursor.execute(
+        statements[f"{table_name}_delete"] = (
             f"CREATE TRIGGER IF NOT EXISTS {table_name}_delete "
-            "AFTER DELETE ON messages BEGIN "
-            f"{delete_old}; END"
+            f"AFTER DELETE ON messages BEGIN {delete_old}; END"
         )
-        cursor.execute(
+        statements[f"{table_name}_update"] = (
             f"CREATE TRIGGER IF NOT EXISTS {table_name}_update "
             "AFTER UPDATE OF id, content, tool_name, tool_calls ON messages BEGIN "
             f"{delete_old}; "
             f"INSERT INTO {table_name}(rowid, content) "
             f"VALUES (new.id, {document_new}); END"
         )
+        return statements
+
+    @classmethod
+    def _create_fts_triggers(
+        cls,
+        cursor: sqlite3.Cursor,
+        table_name: str,
+        *,
+        external: bool,
+    ) -> None:
+        """Install mode-correct write triggers for one FTS table."""
+        for statement in cls._fts_trigger_sql(
+            table_name,
+            external=external,
+        ).values():
+            cursor.execute(statement)
+
+    @staticmethod
+    def _normalize_trigger_sql(sql: str) -> str:
+        parts = re.split(r"('(?:''|[^'])*')", sql)
+        normalized = "".join(
+            part
+            if index % 2
+            else re.sub(r"\s+", "", part.lower())
+            for index, part in enumerate(parts)
+        ).rstrip(";")
+        return normalized.replace("createtriggerifnotexists", "createtrigger", 1)
+
+    @classmethod
+    def _repair_fts_trigger_definitions(
+        cls,
+        cursor: sqlite3.Cursor,
+        table_name: str,
+    ) -> bool:
+        """Replace missing or noncanonical triggers; return whether repaired."""
+        external = cls._fts_table_uses_external_content(cursor, table_name)
+        expected = cls._fts_trigger_sql(table_name, external=external)
+        names = tuple(expected)
+        placeholders = ",".join("?" for _ in names)
+        rows = cursor.execute(
+            f"SELECT name, sql FROM sqlite_master "
+            f"WHERE type = 'trigger' AND name IN ({placeholders})",
+            names,
+        ).fetchall()
+        actual = {str(row[0]): str(row[1] or "") for row in rows}
+        current = all(
+            name in actual
+            and cls._normalize_trigger_sql(actual[name])
+            == cls._normalize_trigger_sql(statement)
+            for name, statement in expected.items()
+        )
+        if current:
+            return False
+        for name in names:
+            cursor.execute(f"DROP TRIGGER IF EXISTS {name}")
+        cls._create_fts_triggers(cursor, table_name, external=external)
+        return True
 
     @classmethod
     def _repair_fts_triggers(
@@ -1370,6 +1478,85 @@ class SessionDB:
         return True
 
     @staticmethod
+    def _classify_fts_table_sql(table_name: str, sql: Optional[str]) -> str:
+        """Classify an exact supported canonical FTS5 table definition."""
+        if table_name not in {"messages_fts", "messages_fts_trigram"}:
+            raise ValueError(f"unsupported FTS table: {table_name}")
+        if not sql:
+            return "unsupported"
+
+        quoted_name = (
+            rf'(?:{re.escape(table_name)}|"{re.escape(table_name)}"|'
+            rf"`{re.escape(table_name)}`|\[{re.escape(table_name)}\])"
+        )
+        match = re.fullmatch(
+            rf"\s*CREATE\s+VIRTUAL\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+            rf"{quoted_name}\s+USING\s+fts5\s*\((.*)\)\s*;?\s*",
+            str(sql),
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        if match is None:
+            return "unsupported"
+
+        body = re.sub(r"\s+", "", match.group(1).lower()).replace('"', "'")
+        tokens = body.split(",") if body else []
+        expected_inline = ["content"]
+        expected_external = [
+            "content",
+            "content='messages_fts_source'",
+            "content_rowid='id'",
+        ]
+        if table_name == "messages_fts_trigram":
+            expected_inline.append("tokenize='trigram'")
+            expected_external.append("tokenize='trigram'")
+
+        if len(tokens) == len(expected_inline) and set(tokens) == set(expected_inline):
+            return "inline"
+        if len(tokens) == len(expected_external) and set(tokens) == set(
+            expected_external
+        ):
+            return "external"
+        return "unsupported"
+
+    @staticmethod
+    def _classify_fts_source_sql(
+        object_type: Optional[str],
+        sql: Optional[str],
+    ) -> str:
+        """Classify the canonical external-content source view definition."""
+        if object_type is None and sql is None:
+            return "missing"
+        if object_type != "view" or not sql:
+            return "unsupported"
+        match = re.fullmatch(
+            r"\s*create\s+view\s+(?:if\s+not\s+exists\s+)?"
+            r"(?:messages_fts_source|\"messages_fts_source\"|"
+            r"`messages_fts_source`|\[messages_fts_source\])\s+as\s+"
+            r"(.+?)\s*;?\s*",
+            sql,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        if match is None:
+            return "unsupported"
+        body_parts = re.split(r"('(?:''|[^'])*')", match.group(1).lower())
+        body = "".join(
+            part
+            if index % 2
+            else re.sub(
+                r"\s+",
+                "",
+                part.translate(str.maketrans("", "", '"`[]')),
+            )
+            for index, part in enumerate(body_parts)
+        ).rstrip(";")
+        expected = (
+            "selectid,coalesce(content,'')||' '||"
+            "coalesce(tool_name,'')||' '||"
+            "coalesce(tool_calls,'')ascontentfrommessages"
+        )
+        return "canonical" if body == expected else "unsupported"
+
+    @staticmethod
     def _fts_table_uses_external_content(
         cursor: sqlite3.Cursor,
         table_name: str,
@@ -1382,11 +1569,7 @@ class SessionDB:
         if row is None:
             return False
         sql = str(row[0] if not isinstance(row, sqlite3.Row) else row["sql"])
-        normalized = "".join(sql.lower().split())
-        return (
-            "content='messages_fts_source'" in normalized
-            or 'content="messages_fts_source"' in normalized
-        )
+        return SessionDB._classify_fts_table_sql(table_name, sql) == "external"
 
     @classmethod
     def _rebuild_fts_table(
@@ -1572,10 +1755,13 @@ class SessionDB:
         """
         with self._lock:
             if self._conn:
-                try:
-                    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-                except Exception as exc:
-                    logger.debug("WAL checkpoint (TRUNCATE) at close failed: %s", exc)
+                if self._checkpoint_on_close:
+                    try:
+                        self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                    except Exception as exc:
+                        logger.debug(
+                            "WAL checkpoint (TRUNCATE) at close failed: %s", exc
+                        )
                 self._conn.close()
                 self._conn = None
 
@@ -7532,6 +7718,20 @@ class SessionDB:
             "VALUES('integrity-check', 1)"
         )
 
+    def begin_fts_maintenance_transaction(self) -> None:
+        """Acquire the reserved writer lock used by guarded FTS maintenance."""
+        if self.read_only or self._conn is None:
+            raise sqlite3.OperationalError(
+                "FTS maintenance transaction requires a writable SessionDB"
+            )
+        with self._lock:
+            if self._conn.in_transaction:
+                raise sqlite3.OperationalError(
+                    "FTS maintenance transaction is already active"
+                )
+            self._conn.execute("BEGIN IMMEDIATE")
+            self._fts_maintenance_transaction = True
+
     def migrate_fts_to_external_content(self) -> Dict[str, Any]:
         """Explicitly migrate inline FTS indexes to external-content storage.
 
@@ -7552,24 +7752,58 @@ class SessionDB:
 
         with self._lock:
             cursor = self._conn.cursor()
-            self._conn.execute("BEGIN IMMEDIATE")
+            if self._conn.in_transaction and not self._fts_maintenance_transaction:
+                raise sqlite3.OperationalError(
+                    "refusing FTS migration inside an unrelated transaction"
+                )
+            if not self._conn.in_transaction:
+                self._conn.execute("BEGIN IMMEDIATE")
             try:
                 # Discover storage mode only after acquiring the cross-process
                 # SQLite write lock. Concurrent migrators therefore observe the
                 # latest committed schema instead of acting on stale mode data.
                 rows = cursor.execute(
-                    "SELECT name FROM sqlite_master "
+                    "SELECT name, sql FROM sqlite_master "
                     "WHERE type = 'table' AND name IN (?, ?) ORDER BY name",
                     self._FTS_TABLES,
                 ).fetchall()
                 existing = [str(row[0]) for row in rows]
                 if not existing:
                     raise sqlite3.OperationalError("no FTS5 tables are present")
-                external = [
-                    name
-                    for name in existing
-                    if self._fts_table_uses_external_content(cursor, name)
+                storage_kinds = {
+                    str(row[0]): self._classify_fts_table_sql(
+                        str(row[0]),
+                        str(row[1]) if row[1] is not None else None,
+                    )
+                    for row in rows
+                }
+                unsupported = [
+                    name for name, kind in storage_kinds.items() if kind == "unsupported"
                 ]
+                if unsupported:
+                    raise sqlite3.OperationalError(
+                        "unsupported canonical FTS schema: " + ", ".join(unsupported)
+                    )
+                external = [
+                    name for name, kind in storage_kinds.items() if kind == "external"
+                ]
+                source_row = cursor.execute(
+                    "SELECT type, sql FROM sqlite_master WHERE name = ? "
+                    "ORDER BY type LIMIT 1",
+                    ("messages_fts_source",),
+                ).fetchone()
+                source_kind = self._classify_fts_source_sql(
+                    str(source_row[0]) if source_row is not None else None,
+                    str(source_row[1])
+                    if source_row is not None and source_row[1] is not None
+                    else None,
+                )
+                if source_kind == "unsupported" or (
+                    external and source_kind != "canonical"
+                ):
+                    raise sqlite3.OperationalError(
+                        "unsupported messages_fts_source definition: " + source_kind
+                    )
                 if len(external) == len(existing):
                     previous_mode = "external"
                 elif not external:
@@ -7578,12 +7812,41 @@ class SessionDB:
                     previous_mode = "mixed"
                 to_migrate = [name for name in existing if name not in external]
                 if not to_migrate:
+                    revision_row = cursor.execute(
+                        "SELECT value FROM state_meta WHERE key = ?",
+                        (FTS_STORAGE_REVISION_KEY,),
+                    ).fetchone()
+                    revision_current = bool(
+                        revision_row
+                        and str(revision_row[0])
+                        == FTS_STORAGE_REVISION_EXTERNAL_V1
+                    )
+                    triggers_repaired = False
+                    for name in existing:
+                        triggers_repaired = (
+                            self._repair_fts_trigger_definitions(cursor, name)
+                            or triggers_repaired
+                        )
+                        self._validate_external_fts_table(cursor, name)
+                    cursor.execute(
+                        "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                        "ON CONFLICT(key) DO UPDATE SET value = excluded.value "
+                        "WHERE state_meta.value IS NOT excluded.value",
+                        (
+                            FTS_STORAGE_REVISION_KEY,
+                            FTS_STORAGE_REVISION_EXTERNAL_V1,
+                        ),
+                    )
                     self._conn.commit()
+                    self._fts_maintenance_transaction = False
+                    changed = triggers_repaired or not revision_current
                     return {
                         "previous_mode": previous_mode,
                         "final_mode": "external",
                         "migrated_tables": [],
-                        "noop": True,
+                        "noop": not changed,
+                        "schema_changed": triggers_repaired,
+                        "metadata_changed": not revision_current,
                     }
 
                 if (
@@ -7640,8 +7903,10 @@ class SessionDB:
                     ),
                 )
                 self._conn.commit()
+                self._fts_maintenance_transaction = False
             except BaseException:
                 self._conn.rollback()
+                self._fts_maintenance_transaction = False
                 raise
 
             return {

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -37,6 +37,7 @@ EXPECTED_CONSOLE_COMMANDS = {
     ("sessions", "rename"),
     ("sessions", "optimize"),
     ("sessions", "repair"),
+    ("sessions", "migrate-fts"),
     ("cron", "list"),
     ("cron", "status"),
     ("cron", "create"),

--- a/tests/hermes_cli/test_session_fts_migration.py
+++ b/tests/hermes_cli/test_session_fts_migration.py
@@ -1,0 +1,863 @@
+import os
+import shutil
+import sqlite3
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_cli.session_fts import (
+    SessionFtsMaintenanceError,
+    configure_migrate_fts_parser,
+    run_external_fts_migration,
+)
+
+
+LEGACY_INLINE_BOTH_SQL = """
+DROP TRIGGER IF EXISTS messages_fts_insert;
+DROP TRIGGER IF EXISTS messages_fts_delete;
+DROP TRIGGER IF EXISTS messages_fts_update;
+DROP TRIGGER IF EXISTS messages_fts_trigram_insert;
+DROP TRIGGER IF EXISTS messages_fts_trigram_delete;
+DROP TRIGGER IF EXISTS messages_fts_trigram_update;
+DROP TABLE IF EXISTS messages_fts;
+DROP TABLE IF EXISTS messages_fts_trigram;
+DROP VIEW IF EXISTS messages_fts_source;
+
+CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content, tokenize='trigram');
+
+CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+  INSERT INTO messages_fts(rowid, content)
+  VALUES (new.id, COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, ''));
+END;
+CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+  DELETE FROM messages_fts WHERE rowid = old.id;
+END;
+CREATE TRIGGER messages_fts_update AFTER UPDATE OF id, content, tool_name, tool_calls ON messages BEGIN
+  DELETE FROM messages_fts WHERE rowid = old.id;
+  INSERT INTO messages_fts(rowid, content)
+  VALUES (new.id, COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, ''));
+END;
+
+CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages BEGIN
+  INSERT INTO messages_fts_trigram(rowid, content)
+  VALUES (new.id, COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, ''));
+END;
+CREATE TRIGGER messages_fts_trigram_delete AFTER DELETE ON messages BEGIN
+  DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+END;
+CREATE TRIGGER messages_fts_trigram_update AFTER UPDATE OF id, content, tool_name, tool_calls ON messages BEGIN
+  DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+  INSERT INTO messages_fts_trigram(rowid, content)
+  VALUES (new.id, COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, ''));
+END;
+
+INSERT INTO messages_fts(rowid, content)
+SELECT id, COALESCE(content, '') || ' ' || COALESCE(tool_name, '') || ' ' || COALESCE(tool_calls, '') FROM messages;
+INSERT INTO messages_fts_trigram(rowid, content)
+SELECT id, COALESCE(content, '') || ' ' || COALESCE(tool_name, '') || ' ' || COALESCE(tool_calls, '') FROM messages;
+"""
+
+
+def _options(**overrides):
+    values = {
+        "check_only": False,
+        "writers_stopped": False,
+        "unsafe_no_backup": False,
+        "yes": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _disk_usage(free=100 * 1024**3):
+    return shutil._ntuple_diskusage(total=200 * 1024**3, used=0, free=free)
+
+
+@pytest.fixture
+def legacy_inline_db(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        if not db._fts_enabled or not db._trigram_available:
+            pytest.skip("SQLite build lacks FTS5 trigram support")
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="maintenance migration sentinel")
+    finally:
+        db.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(LEGACY_INLINE_BOTH_SQL)
+        raw.commit()
+    finally:
+        raw.close()
+    return db_path
+
+
+def test_parser_exposes_explicit_safety_flags():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    configure_migrate_fts_parser(parser)
+    args = parser.parse_args(
+        ["--check-only", "--writers-stopped", "--unsafe-no-backup", "--yes"]
+    )
+    assert args.check_only is True
+    assert args.writers_stopped is True
+    assert args.unsafe_no_backup is True
+    assert args.yes is True
+
+
+@pytest.mark.parametrize(
+    ("table_name", "sql", "expected"),
+    [
+        (
+            "messages_fts",
+            'CREATE VIRTUAL TABLE "messages_fts" USING fts5( content, '
+            'content = "messages_fts_source", content_rowid = "id" )',
+            "external",
+        ),
+        (
+            "messages_fts",
+            "CREATE VIRTUAL TABLE messages_fts USING fts5("
+            "content, content='messages', content_rowid='id')",
+            "unsupported",
+        ),
+        (
+            "messages_fts",
+            "CREATE VIRTUAL TABLE messages_fts USING fts5("
+            "content, content='messages_fts_source', content_rowid='rowid')",
+            "unsupported",
+        ),
+        (
+            "messages_fts_trigram",
+            "CREATE VIRTUAL TABLE messages_fts_trigram USING fts5("
+            "content, content='messages_fts_source', content_rowid='id', "
+            "tokenize='unicode61')",
+            "unsupported",
+        ),
+        (
+            "messages_fts",
+            "CREATE TABLE messages_fts(content TEXT)",
+            "unsupported",
+        ),
+    ],
+)
+def test_canonical_fts_schema_classifier_is_structural(table_name, sql, expected):
+    assert SessionDB._classify_fts_table_sql(table_name, sql) == expected
+
+
+@pytest.mark.parametrize(
+    ("object_type", "sql", "expected"),
+    [
+        (None, None, "missing"),
+        ("table", "CREATE TABLE messages_fts_source(id, content)", "unsupported"),
+        (
+            "view",
+            'CREATE VIEW "messages_fts_source" AS SELECT "id", '
+            "COALESCE(\"content\", '') || ' ' || "
+            "COALESCE(\"tool_name\", '') || ' ' || "
+            "COALESCE(\"tool_calls\", '') AS \"content\" FROM \"messages\";",
+            "canonical",
+        ),
+        (
+            "view",
+            "CREATE VIEW messages_fts_source AS "
+            "SELECT id, 'WRONG' AS content FROM messages",
+            "unsupported",
+        ),
+    ],
+)
+def test_fts_source_schema_classifier_is_structural(object_type, sql, expected):
+    assert SessionDB._classify_fts_source_sql(object_type, sql) == expected
+
+
+@pytest.mark.parametrize(
+    "source_sql",
+    [
+        "CREATE VIEW messages_fts_source AS "
+        "SELECT id, 'WRONG' AS content FROM messages",
+        "CREATE TABLE messages_fts_source(id INTEGER, content TEXT)",
+    ],
+)
+def test_unsupported_fts_source_objects_are_preserved_and_refused(
+    legacy_inline_db, source_sql
+):
+    raw = sqlite3.connect(legacy_inline_db)
+    try:
+        raw.execute(source_sql)
+        raw.commit()
+        original = raw.execute(
+            "SELECT type, sql FROM sqlite_master WHERE name = 'messages_fts_source'"
+        ).fetchone()
+    finally:
+        raw.close()
+
+    report = run_external_fts_migration(
+        _options(check_only=True),
+        db_path=legacy_inline_db,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert report["storage_mode"] == "unsupported"
+    with pytest.raises(SessionFtsMaintenanceError, match="unsupported"):
+        run_external_fts_migration(
+            _options(writers_stopped=True),
+            db_path=legacy_inline_db,
+            disk_usage_fn=lambda _path: _disk_usage(),
+        )
+    assert not list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak"))
+
+    maintenance = SessionDB.open_for_fts_maintenance(legacy_inline_db)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="messages_fts_source"):
+            maintenance.migrate_fts_to_external_content()
+    finally:
+        maintenance.close()
+
+    raw = sqlite3.connect(legacy_inline_db)
+    try:
+        assert raw.execute(
+            "SELECT type, sql FROM sqlite_master WHERE name = 'messages_fts_source'"
+        ).fetchone() == original
+    finally:
+        raw.close()
+
+
+def test_canonical_quoted_source_view_is_accepted_and_retained(legacy_inline_db):
+    raw = sqlite3.connect(legacy_inline_db)
+    try:
+        raw.execute(
+            'CREATE VIEW "messages_fts_source" AS SELECT "id", '
+            "COALESCE(\"content\", '') || ' ' || "
+            "COALESCE(\"tool_name\", '') || ' ' || "
+            "COALESCE(\"tool_calls\", '') AS \"content\" FROM \"messages\""
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+    check = run_external_fts_migration(
+        _options(check_only=True),
+        db_path=legacy_inline_db,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert check["storage_mode"] == "inline"
+    migrated = run_external_fts_migration(
+        _options(writers_stopped=True),
+        db_path=legacy_inline_db,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert migrated["final_mode"] == "external"
+
+
+def test_external_tables_require_canonical_source_view(tmp_path):
+    db_path = tmp_path / "external-missing-source.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled:
+            pytest.skip("SQLite build lacks FTS5")
+    finally:
+        seeded.close()
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.execute("DROP VIEW messages_fts_source")
+        raw.commit()
+    finally:
+        raw.close()
+
+    report = run_external_fts_migration(
+        _options(check_only=True),
+        db_path=db_path,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert report["storage_mode"] == "unsupported"
+    maintenance = SessionDB.open_for_fts_maintenance(db_path)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="messages_fts_source"):
+            maintenance.migrate_fts_to_external_content()
+    finally:
+        maintenance.close()
+
+
+def test_check_only_uses_encoded_uri_for_special_paths(tmp_path):
+    special_parent = tmp_path / "parent?#"
+    special_parent.mkdir()
+    db_path = special_parent / "state?#.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        if not db._fts_enabled:
+            pytest.skip("SQLite build lacks FTS5")
+    finally:
+        db.close()
+
+    report = run_external_fts_migration(
+        _options(check_only=True),
+        db_path=db_path,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+
+    assert report["storage_mode"] in {"external", "base-only-external"}
+    assert not (special_parent / "state").exists()
+
+
+def test_ordinary_canonical_tables_are_refused_by_command_and_core(tmp_path):
+    db_path = tmp_path / "ordinary-canonical.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled:
+            pytest.skip("SQLite build lacks FTS5")
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(
+            """
+            DROP TRIGGER IF EXISTS messages_fts_insert;
+            DROP TRIGGER IF EXISTS messages_fts_delete;
+            DROP TRIGGER IF EXISTS messages_fts_update;
+            DROP TRIGGER IF EXISTS messages_fts_trigram_insert;
+            DROP TRIGGER IF EXISTS messages_fts_trigram_delete;
+            DROP TRIGGER IF EXISTS messages_fts_trigram_update;
+            DROP TABLE IF EXISTS messages_fts;
+            DROP TABLE IF EXISTS messages_fts_trigram;
+            DROP VIEW IF EXISTS messages_fts_source;
+            CREATE TABLE messages_fts(content TEXT);
+            CREATE TABLE messages_fts_trigram(content TEXT);
+            INSERT INTO messages_fts VALUES('preserve me');
+            """
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+    report = run_external_fts_migration(
+        _options(check_only=True),
+        db_path=db_path,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert report["storage_mode"] == "unsupported"
+
+    with pytest.raises(SessionFtsMaintenanceError, match="unsupported"):
+        run_external_fts_migration(
+            _options(writers_stopped=True, unsafe_no_backup=True),
+            db_path=db_path,
+            disk_usage_fn=lambda _path: _disk_usage(),
+        )
+
+    maintenance = SessionDB.open_for_fts_maintenance(db_path)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="unsupported canonical"):
+            maintenance.migrate_fts_to_external_content()
+    finally:
+        maintenance.close()
+
+    verify = sqlite3.connect(db_path)
+    try:
+        assert verify.execute("SELECT content FROM messages_fts").fetchone()[0] == (
+            "preserve me"
+        )
+    finally:
+        verify.close()
+
+
+def test_check_only_reports_requirements_without_mutation_or_backup(legacy_inline_db):
+    report = run_external_fts_migration(
+        _options(check_only=True),
+        db_path=legacy_inline_db,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+
+    assert report["check_only"] is True
+    assert report["storage_mode"] == "inline"
+    assert report["space_ok"] is True
+    assert report["backup_path"] is None
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+    db = SessionDB(db_path=legacy_inline_db, read_only=True)
+    try:
+        assert db.fts_storage_mode() == "inline"
+    finally:
+        db.close()
+
+
+def test_check_only_wal_preserves_logical_database(legacy_inline_db):
+    writer = sqlite3.connect(legacy_inline_db, isolation_level=None)
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        writer.execute("BEGIN IMMEDIATE")
+        writer.execute(
+            "INSERT INTO state_meta(key, value) VALUES('wal_preflight_sentinel', 'kept') "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+        )
+        writer.commit()
+        before_schema = writer.execute("PRAGMA schema_version").fetchone()[0]
+        before_value = writer.execute(
+            "SELECT value FROM state_meta WHERE key = 'wal_preflight_sentinel'"
+        ).fetchone()[0]
+
+        report = run_external_fts_migration(
+            _options(check_only=True),
+            db_path=legacy_inline_db,
+            disk_usage_fn=lambda _path: _disk_usage(),
+        )
+
+        assert report["check_only"] is True
+        assert writer.execute("PRAGMA schema_version").fetchone()[0] == before_schema
+        assert writer.execute(
+            "SELECT value FROM state_meta WHERE key = 'wal_preflight_sentinel'"
+        ).fetchone()[0] == before_value
+    finally:
+        writer.close()
+
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+
+def test_partial_fts_schema_is_reported_and_refused(legacy_inline_db):
+    raw = sqlite3.connect(legacy_inline_db)
+    try:
+        raw.executescript(
+            """
+            DROP TRIGGER messages_fts_trigram_insert;
+            DROP TRIGGER messages_fts_trigram_delete;
+            DROP TRIGGER messages_fts_trigram_update;
+            DROP TABLE messages_fts_trigram;
+            """
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+    report = run_external_fts_migration(
+        _options(check_only=True),
+        db_path=legacy_inline_db,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert report["storage_mode"] == "base-only-inline"
+
+    with pytest.raises(SessionFtsMaintenanceError, match="both FTS5 tables"):
+        run_external_fts_migration(
+            _options(writers_stopped=True),
+            db_path=legacy_inline_db,
+            disk_usage_fn=lambda _path: _disk_usage(),
+        )
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+
+def test_base_only_migrates_and_noops_when_trigram_is_unavailable(
+    legacy_inline_db, monkeypatch
+):
+    import hermes_cli.session_fts as session_fts
+
+    raw = sqlite3.connect(legacy_inline_db)
+    try:
+        raw.executescript(
+            """
+            DROP TRIGGER messages_fts_trigram_insert;
+            DROP TRIGGER messages_fts_trigram_delete;
+            DROP TRIGGER messages_fts_trigram_update;
+            DROP TABLE messages_fts_trigram;
+            """
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+    monkeypatch.setattr(session_fts, "_runtime_supports_trigram", lambda: False)
+    monkeypatch.setattr(
+        SessionDB,
+        "_sqlite_supports_trigram",
+        lambda _self, _cursor: False,
+    )
+
+    first = run_external_fts_migration(
+        _options(writers_stopped=True, unsafe_no_backup=True),
+        db_path=legacy_inline_db,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert first["noop"] is False
+    assert first["migrated_tables"] == ["messages_fts"]
+
+    second = run_external_fts_migration(
+        _options(writers_stopped=True, unsafe_no_backup=True),
+        db_path=legacy_inline_db,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert second["noop"] is True
+    assert second["storage_revision"] == "external-content-v1"
+
+
+def test_actual_migration_requires_writer_stop_attestation(legacy_inline_db):
+    with pytest.raises(SessionFtsMaintenanceError, match="--writers-stopped"):
+        run_external_fts_migration(
+            _options(),
+            db_path=legacy_inline_db,
+            disk_usage_fn=lambda _path: _disk_usage(),
+        )
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+
+def test_cli_refusal_exits_nonzero(legacy_inline_db):
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(legacy_inline_db.parent)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "sessions",
+            "migrate-fts",
+            "--yes",
+        ],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "--writers-stopped" in result.stdout + result.stderr
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+
+def test_cli_successfully_migrates_isolated_database(legacy_inline_db):
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(legacy_inline_db.parent)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "sessions",
+            "migrate-fts",
+            "--writers-stopped",
+            "--unsafe-no-backup",
+            "--yes",
+        ],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "FTS migration completed and validated" in result.stdout
+    migrated = SessionDB(db_path=legacy_inline_db, read_only=True)
+    try:
+        assert migrated.fts_storage_mode() == "external"
+    finally:
+        migrated.close()
+
+
+def test_lock_contention_is_reported_cleanly(legacy_inline_db):
+    blocker = sqlite3.connect(legacy_inline_db, isolation_level=None)
+    blocker.execute("BEGIN IMMEDIATE")
+    try:
+        with pytest.raises(SessionFtsMaintenanceError, match="database is locked"):
+            run_external_fts_migration(
+                _options(writers_stopped=True, unsafe_no_backup=True),
+                db_path=legacy_inline_db,
+                disk_usage_fn=lambda _path: _disk_usage(),
+            )
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+
+def test_disk_usage_failure_is_normalized(legacy_inline_db):
+    def fail_disk_usage(_path):
+        raise OSError("injected disk usage failure")
+
+    with pytest.raises(SessionFtsMaintenanceError, match="FTS preflight failed"):
+        run_external_fts_migration(
+            _options(writers_stopped=True),
+            db_path=legacy_inline_db,
+            disk_usage_fn=fail_disk_usage,
+        )
+
+
+def test_verified_backup_runs_while_migration_writer_lock_is_held(
+    legacy_inline_db, monkeypatch
+):
+    import hermes_cli.session_fts as session_fts
+
+    real_backup = session_fts._create_verified_backup
+    observed = []
+
+    def verify_lock_then_backup(source, destination):
+        contender = sqlite3.connect(source, timeout=0, isolation_level=None)
+        try:
+            try:
+                contender.execute("BEGIN IMMEDIATE")
+            except sqlite3.OperationalError as exc:
+                observed.append("locked" in str(exc).lower())
+            else:
+                observed.append(False)
+                contender.rollback()
+        finally:
+            contender.close()
+        real_backup(source, destination)
+
+    monkeypatch.setattr(session_fts, "_create_verified_backup", verify_lock_then_backup)
+    run_external_fts_migration(
+        _options(writers_stopped=True),
+        db_path=legacy_inline_db,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert observed == [True]
+
+
+def test_sqlite_tmpdir_overrides_python_tempdir(tmp_path, monkeypatch):
+    import hermes_cli.session_fts as session_fts
+
+    sqlite_tmp = tmp_path / "sqlite-tmp"
+    python_tmp = tmp_path / "python-tmp"
+    sqlite_tmp.mkdir()
+    python_tmp.mkdir()
+    monkeypatch.setenv("SQLITE_TMPDIR", str(sqlite_tmp))
+    monkeypatch.setattr(session_fts.tempfile, "gettempdir", lambda: str(python_tmp))
+
+    assert session_fts._sqlite_temp_path() == sqlite_tmp.resolve()
+
+
+def test_eof_confirmation_cancels_without_changes(legacy_inline_db):
+    def eof(_prompt):
+        raise EOFError
+
+    report = run_external_fts_migration(
+        _options(writers_stopped=True, yes=False),
+        db_path=legacy_inline_db,
+        input_fn=eof,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert report["cancelled"] is True
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+
+def test_insufficient_space_refuses_before_backup(legacy_inline_db):
+    with pytest.raises(SessionFtsMaintenanceError, match="free space"):
+        run_external_fts_migration(
+            _options(writers_stopped=True),
+            db_path=legacy_inline_db,
+            disk_usage_fn=lambda _path: _disk_usage(free=1),
+        )
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+
+def test_post_backup_space_drop_preserves_backup_and_refuses_migration(
+    legacy_inline_db,
+):
+    def disk_usage_after_backup(_path):
+        backup_exists = bool(
+            list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak"))
+        )
+        return _disk_usage(free=1 if backup_exists else 100 * 1024**3)
+
+    with pytest.raises(
+        SessionFtsMaintenanceError,
+        match="post-backup migration requirement",
+    ):
+        run_external_fts_migration(
+            _options(writers_stopped=True),
+            db_path=legacy_inline_db,
+            disk_usage_fn=disk_usage_after_backup,
+        )
+
+    backups = list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak"))
+    assert len(backups) == 1
+    untouched = SessionDB(db_path=legacy_inline_db, read_only=True)
+    try:
+        assert untouched.fts_storage_mode() == "inline"
+    finally:
+        untouched.close()
+
+
+def test_verified_backup_then_migration_preserves_search(legacy_inline_db):
+    report = run_external_fts_migration(
+        _options(writers_stopped=True),
+        db_path=legacy_inline_db,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+
+    backup_path = Path(report["backup_path"])
+    assert backup_path.exists()
+    assert stat.S_IMODE(backup_path.stat().st_mode) == 0o600
+    backup = sqlite3.connect(backup_path)
+    try:
+        assert backup.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+        backup_sql = backup.execute(
+            "SELECT sql FROM sqlite_master WHERE name='messages_fts'"
+        ).fetchone()[0]
+        assert "content='messages_fts_source'" not in backup_sql
+    finally:
+        backup.close()
+
+    db = SessionDB(db_path=legacy_inline_db)
+    try:
+        assert db.fts_storage_mode() == "external"
+        hits = db.search_messages("sentinel")
+        assert [row["session_id"] for row in hits] == ["s1"]
+        assert db._conn.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+    finally:
+        db.close()
+
+
+def test_backup_fsync_failure_removes_partial_file(legacy_inline_db, monkeypatch):
+    import hermes_cli.session_fts as session_fts
+
+    destination = legacy_inline_db.with_name("forced-fsync-failure.bak")
+
+    def fail_fsync(_fd):
+        raise OSError("injected fsync failure")
+
+    monkeypatch.setattr(session_fts.os, "fsync", fail_fsync)
+    with pytest.raises(OSError, match="injected fsync failure"):
+        session_fts._create_verified_backup(legacy_inline_db, destination)
+    assert destination.exists() is False
+
+
+def test_backup_fsyncs_file_and_parent_directory(legacy_inline_db, monkeypatch):
+    import hermes_cli.session_fts as session_fts
+
+    destination = legacy_inline_db.with_name("durable-backup.bak")
+    calls = []
+    monkeypatch.setattr(session_fts.os, "fsync", lambda fd: calls.append(fd))
+
+    session_fts._create_verified_backup(legacy_inline_db, destination)
+
+    assert destination.exists()
+    expected_calls = 1 if os.name == "nt" else 2
+    assert len(calls) == expected_calls
+
+
+def test_backup_refuses_to_overwrite_existing_destination(legacy_inline_db):
+    import hermes_cli.session_fts as session_fts
+
+    destination = legacy_inline_db.with_name("existing-backup.bak")
+    destination.write_bytes(b"do not overwrite")
+
+    with pytest.raises(SessionFtsMaintenanceError, match="refusing to overwrite"):
+        session_fts._create_verified_backup(legacy_inline_db, destination)
+    assert destination.read_bytes() == b"do not overwrite"
+
+
+def test_backup_io_failure_is_clean_and_does_not_migrate(
+    legacy_inline_db, monkeypatch
+):
+    import hermes_cli.session_fts as session_fts
+
+    def fail_backup(_source, _destination):
+        raise OSError("injected backup failure")
+
+    monkeypatch.setattr(session_fts, "_create_verified_backup", fail_backup)
+    with pytest.raises(SessionFtsMaintenanceError, match="verified backup failed"):
+        run_external_fts_migration(
+            _options(writers_stopped=True),
+            db_path=legacy_inline_db,
+            disk_usage_fn=lambda _path: _disk_usage(),
+        )
+
+    db = SessionDB(db_path=legacy_inline_db, read_only=True)
+    try:
+        assert db.fts_storage_mode() == "inline"
+    finally:
+        db.close()
+
+    writer = sqlite3.connect(legacy_inline_db, timeout=0, isolation_level=None)
+    try:
+        writer.execute("BEGIN IMMEDIATE")
+        writer.rollback()
+    finally:
+        writer.close()
+
+
+def test_migration_failure_preserves_verified_backup(
+    legacy_inline_db, monkeypatch
+):
+    def fail_migration(_db):
+        raise sqlite3.OperationalError("injected migration failure")
+
+    monkeypatch.setattr(SessionDB, "migrate_fts_to_external_content", fail_migration)
+
+    with pytest.raises(
+        SessionFtsMaintenanceError,
+        match="backup preserved at",
+    ):
+        run_external_fts_migration(
+            _options(writers_stopped=True),
+            db_path=legacy_inline_db,
+            disk_usage_fn=lambda _path: _disk_usage(),
+        )
+
+    backups = list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak"))
+    assert len(backups) == 1
+    backup = sqlite3.connect(backups[0])
+    try:
+        assert backup.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+    finally:
+        backup.close()
+
+
+def test_unsafe_no_backup_is_explicit_and_skips_backup(legacy_inline_db):
+    report = run_external_fts_migration(
+        _options(writers_stopped=True, unsafe_no_backup=True),
+        db_path=legacy_inline_db,
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert report["backup_path"] is None
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+
+def test_declined_confirmation_leaves_inline_database_untouched(legacy_inline_db):
+    report = run_external_fts_migration(
+        _options(writers_stopped=True, yes=False),
+        db_path=legacy_inline_db,
+        input_fn=lambda _prompt: "no",
+        disk_usage_fn=lambda _path: _disk_usage(),
+    )
+    assert report["cancelled"] is True
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+    db = SessionDB(db_path=legacy_inline_db, read_only=True)
+    try:
+        assert db.fts_storage_mode() == "inline"
+    finally:
+        db.close()
+
+
+def test_console_check_only_uses_guarded_maintenance_api(
+    legacy_inline_db, monkeypatch
+):
+    import hermes_cli.session_fts as session_fts
+    from hermes_cli.console_engine import HermesConsoleEngine
+
+    monkeypatch.setattr(session_fts, "DEFAULT_DB_PATH", legacy_inline_db)
+    engine = HermesConsoleEngine()
+    pending = engine.execute("sessions migrate-fts --check-only")
+    assert pending.status == "confirm_required"
+
+    result = engine.execute("sessions migrate-fts --check-only", confirmed=True)
+    assert result.status == "ok"
+    assert "FTS storage mode: inline" in result.output
+    assert list(legacy_inline_db.parent.glob("*.pre-fts-external-*.bak")) == []
+
+
+def test_gateway_process_cannot_run_mutating_migration(legacy_inline_db, monkeypatch):
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+    with pytest.raises(SessionFtsMaintenanceError, match="outside the gateway"):
+        run_external_fts_migration(
+            _options(writers_stopped=True),
+            db_path=legacy_inline_db,
+            disk_usage_fn=lambda _path: _disk_usage(),
+        )

--- a/tests/test_fts_external_content_migration.py
+++ b/tests/test_fts_external_content_migration.py
@@ -1,0 +1,611 @@
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB, _rebuild_fts_table_for_repair
+
+
+def _schema_sql(db: SessionDB, name: str) -> str:
+    row = db._conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = ?",
+        (name,),
+    ).fetchone()
+    assert row is not None
+    return str(row[0])
+
+
+def test_new_database_uses_external_content_fts_and_preserves_search_documents(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        if not db._fts_enabled:
+            pytest.skip("SQLite build has no FTS5")
+
+        base_sql = _schema_sql(db, "messages_fts")
+        assert "content='messages_fts_source'" in base_sql
+        assert "content_rowid='id'" in base_sql
+        assert db.get_meta("fts_storage_revision") == "external-content-v1"
+
+        view = db._conn.execute(
+            "SELECT type, sql FROM sqlite_master WHERE name = 'messages_fts_source'"
+        ).fetchone()
+        assert view is not None
+        assert view[0] == "view"
+        assert "COALESCE(content, '')" in view[1]
+        assert "COALESCE(tool_name, '')" in view[1]
+        assert "COALESCE(tool_calls, '')" in view[1]
+
+        # External-content FTS keeps only its index/docsize/config data. The
+        # canonical document text is supplied by the zero-storage view.
+        shadow_tables = {
+            row[0]
+            for row in db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "messages_fts_source" not in shadow_tables
+        assert "messages_fts_content" not in shadow_tables
+        if db._trigram_available:
+            trigram_sql = _schema_sql(db, "messages_fts_trigram")
+            assert "content='messages_fts_source'" in trigram_sql
+            assert "content_rowid='id'" in trigram_sql
+            assert "messages_fts_trigram_content" not in shadow_tables
+
+        db.create_session(session_id="s1", source="cli")
+        content_id = db.append_message(
+            "s1", role="user", content="alpha content needle"
+        )
+        tool_id = db.append_message(
+            "s1",
+            role="assistant",
+            content="tool result body",
+            tool_name="beta_tool_needle",
+            tool_calls=[{"name": "gamma_call_needle"}],
+        )
+
+        content_hit = db.search_messages("alpha")
+        assert [row["id"] for row in content_hit] == [content_id]
+        assert ">>>alpha<<<" in content_hit[0]["snippet"]
+
+        tool_hit = db.search_messages("beta_tool_needle")
+        assert [row["id"] for row in tool_hit] == [tool_id]
+        assert ">>>beta_tool_needle<<<" in tool_hit[0]["snippet"]
+
+        call_hit = db.search_messages("gamma_call_needle")
+        assert [row["id"] for row in call_hit] == [tool_id]
+        assert ">>>gamma_call_needle<<<" in call_hit[0]["snippet"]
+
+        if db._trigram_available:
+            cjk_id = db.append_message(
+                "s1", role="user", content="中文迁移测试内容"
+            )
+            cjk_hit = db.search_messages("迁移测试")
+            assert [row["id"] for row in cjk_hit] == [cjk_id]
+
+        # rank=1 makes FTS5 compare the inverted index with the external view.
+        db._conn.execute(
+            "INSERT INTO messages_fts(messages_fts, rank) "
+            "VALUES('integrity-check', 1)"
+        )
+        if db._trigram_available:
+            db._conn.execute(
+                "INSERT INTO messages_fts_trigram(messages_fts_trigram, rank) "
+                "VALUES('integrity-check', 1)"
+            )
+    finally:
+        db.close()
+
+
+LEGACY_INLINE_BASE_SQL = """
+DROP TRIGGER IF EXISTS messages_fts_insert;
+DROP TRIGGER IF EXISTS messages_fts_delete;
+DROP TRIGGER IF EXISTS messages_fts_update;
+DROP TRIGGER IF EXISTS messages_fts_trigram_insert;
+DROP TRIGGER IF EXISTS messages_fts_trigram_delete;
+DROP TRIGGER IF EXISTS messages_fts_trigram_update;
+DROP TABLE IF EXISTS messages_fts;
+DROP TABLE IF EXISTS messages_fts_trigram;
+DROP VIEW IF EXISTS messages_fts_source;
+CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, content) VALUES (
+        new.id,
+        COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
+    );
+END;
+CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+    DELETE FROM messages_fts WHERE rowid = old.id;
+END;
+CREATE TRIGGER messages_fts_update AFTER UPDATE ON messages BEGIN
+    DELETE FROM messages_fts WHERE rowid = old.id;
+    INSERT INTO messages_fts(rowid, content) VALUES (
+        new.id,
+        COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
+    );
+END;
+INSERT INTO messages_fts(rowid, content)
+SELECT id,
+       COALESCE(content, '') || ' ' || COALESCE(tool_name, '') || ' ' || COALESCE(tool_calls, '')
+FROM messages;
+"""
+
+LEGACY_INLINE_TRIGRAM_SQL = """
+CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content, tokenize='trigram');
+CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts_trigram(rowid, content) VALUES (
+        new.id,
+        COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
+    );
+END;
+CREATE TRIGGER messages_fts_trigram_delete AFTER DELETE ON messages BEGIN
+    DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+END;
+CREATE TRIGGER messages_fts_trigram_update AFTER UPDATE ON messages BEGIN
+    DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+    INSERT INTO messages_fts_trigram(rowid, content) VALUES (
+        new.id,
+        COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
+    );
+END;
+INSERT INTO messages_fts_trigram(rowid, content)
+SELECT id,
+       COALESCE(content, '') || ' ' || COALESCE(tool_name, '') || ' ' || COALESCE(tool_calls, '')
+FROM messages;
+"""
+
+LEGACY_INLINE_BOTH_SQL = LEGACY_INLINE_BASE_SQL + LEGACY_INLINE_TRIGRAM_SQL
+
+
+@pytest.mark.parametrize(
+    "missing_trigger",
+    (
+        "messages_fts_insert",
+        "messages_fts_delete",
+        "messages_fts_update",
+        "messages_fts_trigram_insert",
+        "messages_fts_trigram_delete",
+        "messages_fts_trigram_update",
+    ),
+)
+def test_startup_repairs_inline_triggers_with_inline_protocol(tmp_path, missing_trigger):
+    db_path = tmp_path / f"inline-trigger-{missing_trigger}.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled or not seeded._trigram_available:
+            pytest.skip("SQLite build lacks FTS5 trigram support")
+        seeded.create_session(session_id="s1", source="cli")
+        seeded.append_message("s1", role="user", content="existing repair sentinel")
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(LEGACY_INLINE_BOTH_SQL)
+        raw.execute(f"DROP TRIGGER {missing_trigger}")
+        raw.commit()
+    finally:
+        raw.close()
+
+    repaired = SessionDB(db_path=db_path)
+    try:
+        assert repaired.fts_storage_mode() == "inline"
+        inserted = repaired.append_message(
+            "s1", role="assistant", content="insert repair needle"
+        )
+        repaired._conn.execute(
+            "UPDATE messages SET content = ? WHERE id = ?",
+            ("updated repair needle", inserted),
+        )
+        repaired._conn.commit()
+        assert _search_projection(repaired, "insert") == []
+        assert _search_projection(repaired, "updated")[0][0] == inserted
+
+        repaired._conn.execute("DELETE FROM messages WHERE id = ?", (inserted,))
+        repaired._conn.commit()
+        assert _search_projection(repaired, "updated") == []
+    finally:
+        repaired.close()
+
+
+def test_standalone_repair_rebuilds_inline_base_and_trigram(tmp_path):
+    db_path = tmp_path / "inline-repair.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled or not seeded._trigram_available:
+            pytest.skip("SQLite build lacks FTS5 trigram support")
+        seeded.create_session(session_id="s1", source="cli")
+        message_id = seeded.append_message(
+            "s1",
+            role="assistant",
+            content="repair canonical body",
+            tool_name="repair_tool_needle",
+        )
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        raw.executescript(LEGACY_INLINE_BOTH_SQL)
+        raw.execute("DELETE FROM messages_fts")
+        raw.execute("DELETE FROM messages_fts_trigram")
+        assert raw.execute(
+            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'repair'"
+        ).fetchone()[0] == 0
+
+        raw.execute("BEGIN IMMEDIATE")
+        assert _rebuild_fts_table_for_repair(raw, "messages_fts") is True
+        assert _rebuild_fts_table_for_repair(raw, "messages_fts_trigram") is True
+        raw.commit()
+
+        base_ids = raw.execute(
+            "SELECT rowid FROM messages_fts WHERE messages_fts MATCH 'repair_tool_needle'"
+        ).fetchall()
+        trigram_ids = raw.execute(
+            "SELECT rowid FROM messages_fts_trigram "
+            "WHERE messages_fts_trigram MATCH 'canonical'"
+        ).fetchall()
+        assert base_ids == [(message_id,)]
+        assert trigram_ids == [(message_id,)]
+    finally:
+        raw.close()
+
+
+def _search_projection(db: SessionDB, query: str):
+    return [
+        (row["id"], row["snippet"], row["tool_name"], row["role"])
+        for row in db.search_messages(query, include_inactive=True)
+    ]
+
+
+def test_explicit_migration_preserves_legacy_search_and_write_semantics(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled or not seeded._trigram_available:
+            pytest.skip("SQLite build lacks FTS5 trigram support")
+        seeded.create_session(session_id="s1", source="cli")
+        body_id = seeded.append_message(
+            "s1", role="user", content="legacy alpha phrase 中文迁移测试"
+        )
+        tool_id = seeded.append_message(
+            "s1",
+            role="assistant",
+            content="legacy tool body",
+            tool_name="legacy_beta_tool",
+            tool_calls=[{"name": "legacy_gamma_call"}],
+        )
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(LEGACY_INLINE_BOTH_SQL)
+        raw.commit()
+    finally:
+        raw.close()
+
+    db = SessionDB(db_path=db_path)
+    try:
+        # Startup remains bounded: opening a legacy database does not perform
+        # the potentially multi-GiB rebuild automatically.
+        assert "content='messages_fts_source'" not in _schema_sql(db, "messages_fts")
+        assert db.get_meta("fts_storage_revision") is None
+
+        queries = (
+            "legacy",
+            "alpha",
+            "legacy_beta_tool",
+            "legacy_gamma_call",
+            "迁移测试",
+        )
+        before = {query: _search_projection(db, query) for query in queries}
+        assert before["alpha"][0][0] == body_id
+        assert before["legacy_beta_tool"][0][0] == tool_id
+
+        report = db.migrate_fts_to_external_content()
+        assert report["previous_mode"] == "inline"
+        assert report["final_mode"] == "external"
+        assert report["migrated_tables"] == [
+            "messages_fts",
+            "messages_fts_trigram",
+        ]
+        assert report["noop"] is False
+        assert "content='messages_fts_source'" in _schema_sql(db, "messages_fts")
+        assert db.get_meta("fts_storage_revision") == "external-content-v1"
+
+        after = {query: _search_projection(db, query) for query in queries}
+        assert after == before
+
+        # Validate index/content consistency and the external-content trigger
+        # delete protocol after ordinary message UPDATE and DELETE operations.
+        db._conn.execute(
+            "INSERT INTO messages_fts(messages_fts, rank) "
+            "VALUES('integrity-check', 1)"
+        )
+        db._conn.execute(
+            "UPDATE messages SET content = ? WHERE id = ?",
+            ("replacement delta phrase", body_id),
+        )
+        db._conn.commit()
+        assert _search_projection(db, "alpha") == []
+        assert _search_projection(db, "delta")[0][0] == body_id
+
+        db._conn.execute("DELETE FROM messages WHERE id = ?", (tool_id,))
+        db._conn.commit()
+        assert _search_projection(db, "legacy_beta_tool") == []
+        db._conn.execute(
+            "INSERT INTO messages_fts(messages_fts, rank) "
+            "VALUES('integrity-check', 1)"
+        )
+
+        second = db.migrate_fts_to_external_content()
+        assert second["noop"] is True
+        assert second["migrated_tables"] == []
+    finally:
+        db.close()
+
+
+def test_concurrent_migrators_serialize_schema_discovery_after_write_lock(tmp_path):
+    db_path = tmp_path / "concurrent-migration.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled or not seeded._trigram_available:
+            pytest.skip("SQLite build lacks FTS5 trigram support")
+        seeded.create_session(session_id="s1", source="cli")
+        seeded.append_message("s1", role="user", content="concurrent migration sentinel")
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(LEGACY_INLINE_BOTH_SQL)
+        raw.commit()
+    finally:
+        raw.close()
+
+    connections = [SessionDB(db_path=db_path), SessionDB(db_path=db_path)]
+    barrier = threading.Barrier(3)
+    results = []
+    errors = []
+    result_lock = threading.Lock()
+
+    def migrate(db):
+        barrier.wait()
+        try:
+            report = db.migrate_fts_to_external_content()
+            with result_lock:
+                results.append(report)
+        except Exception as exc:
+            with result_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=migrate, args=(db,)) for db in connections]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    try:
+        assert all(not thread.is_alive() for thread in threads)
+        assert errors == []
+        assert sorted(report["noop"] for report in results) == [False, True]
+        migrated = next(report for report in results if not report["noop"])
+        noop = next(report for report in results if report["noop"])
+        assert migrated["previous_mode"] == "inline"
+        assert noop["previous_mode"] == "external"
+        assert connections[0].fts_storage_mode() == "external"
+        assert _search_projection(connections[0], "sentinel")
+    finally:
+        for db in connections:
+            db.close()
+
+
+def test_migration_failure_after_swap_rolls_back_both_inline_indexes(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "rollback.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled or not seeded._trigram_available:
+            pytest.skip("SQLite build lacks FTS5 trigram support")
+        seeded.create_session(session_id="s1", source="cli")
+        message_id = seeded.append_message(
+            "s1", role="user", content="rollback sentinel needle"
+        )
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(LEGACY_INLINE_BOTH_SQL)
+        raw.commit()
+    finally:
+        raw.close()
+
+    db = SessionDB(db_path=db_path)
+    original_validate = SessionDB._validate_external_fts_table
+
+    def fail_after_swap(cursor, table_name):
+        if table_name == "messages_fts":
+            raise RuntimeError("injected final validation failure")
+        return original_validate(cursor, table_name)
+
+    monkeypatch.setattr(
+        SessionDB,
+        "_validate_external_fts_table",
+        staticmethod(fail_after_swap),
+    )
+    try:
+        before_base_sql = _schema_sql(db, "messages_fts")
+        before_trigram_sql = _schema_sql(db, "messages_fts_trigram")
+        with pytest.raises(RuntimeError, match="injected final validation failure"):
+            db.migrate_fts_to_external_content()
+
+        assert _schema_sql(db, "messages_fts") == before_base_sql
+        assert _schema_sql(db, "messages_fts_trigram") == before_trigram_sql
+        assert "content='messages_fts_source'" not in before_base_sql
+        assert "content='messages_fts_source'" not in before_trigram_sql
+        assert db.get_meta("fts_storage_revision") is None
+        assert _search_projection(db, "sentinel")[0][0] == message_id
+        leaked = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE name LIKE '%__external_new%'"
+        ).fetchall()
+        assert leaked == []
+
+        # The original triggers remain writable after rollback.
+        appended = db.append_message(
+            "s1", role="assistant", content="rollback survivor term"
+        )
+        assert _search_projection(db, "survivor")[0][0] == appended
+    finally:
+        db.close()
+
+
+def test_read_only_connection_rejects_external_fts_migration(tmp_path):
+    db_path = tmp_path / "read-only.db"
+    writable = SessionDB(db_path=db_path)
+    writable.close()
+
+    read_only = SessionDB(db_path=db_path, read_only=True)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="requires a writable"):
+            read_only.migrate_fts_to_external_content()
+    finally:
+        read_only.close()
+
+
+def test_external_fts_ignores_non_searchable_message_updates(tmp_path):
+    db = SessionDB(db_path=tmp_path / "metadata-update.db")
+    try:
+        if not db._fts_enabled:
+            pytest.skip("SQLite build has no FTS5")
+        db.create_session(session_id="s1", source="cli")
+        message_id = db.append_message(
+            "s1", role="user", content="metadata update sentinel"
+        )
+
+        before = db._conn.total_changes
+        db._conn.execute(
+            "UPDATE messages SET active = 0, compacted = 1 WHERE id = ?",
+            (message_id,),
+        )
+        metadata_delta = db._conn.total_changes - before
+
+        # Only the messages row changes. External FTS triggers are scoped to
+        # id/content/tool fields and therefore do not rewrite either index.
+        assert metadata_delta == 1
+        db._conn.execute(
+            "INSERT INTO messages_fts(messages_fts, rank) "
+            "VALUES('integrity-check', 1)"
+        )
+        if db._trigram_available:
+            db._conn.execute(
+                "INSERT INTO messages_fts_trigram(messages_fts_trigram, rank) "
+                "VALUES('integrity-check', 1)"
+            )
+        assert _search_projection(db, "sentinel")[0][0] == message_id
+    finally:
+        db.close()
+
+
+@pytest.mark.live_system_guard_bypass
+def test_process_kill_rolls_back_staged_fts_migration(tmp_path):
+    db_path = tmp_path / "crash-recovery.db"
+    marker_path = tmp_path / "staged-index-validated"
+
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled or not seeded._trigram_available:
+            pytest.skip("SQLite build lacks FTS5 trigram support")
+        seeded.create_session(session_id="s1", source="cli")
+        message_id = seeded.append_message(
+            "s1", role="user", content="crash rollback sentinel"
+        )
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(LEGACY_INLINE_BOTH_SQL)
+        raw.commit()
+    finally:
+        raw.close()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    child_code = f"""
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, {str(repo_root)!r})
+from hermes_state import SessionDB
+
+marker = Path({str(marker_path)!r})
+original_validate = SessionDB._validate_external_fts_table
+
+def pause_after_staged_validation(cursor, table_name):
+    original_validate(cursor, table_name)
+    if '__external_new_' in table_name:
+        marker.write_text(table_name)
+        time.sleep(60)
+
+SessionDB._validate_external_fts_table = staticmethod(pause_after_staged_validation)
+db = SessionDB(db_path=Path({str(db_path)!r}))
+db.migrate_fts_to_external_content()
+"""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", child_code],
+        cwd=str(tmp_path),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while (
+            not marker_path.exists()
+            and proc.poll() is None
+            and time.monotonic() < deadline
+        ):
+            time.sleep(0.02)
+
+        if not marker_path.exists():
+            stdout, stderr = proc.communicate(timeout=5)
+            pytest.fail(
+                "child did not reach staged-index validation before exiting: "
+                f"returncode={proc.returncode}, stdout={stdout!r}, stderr={stderr!r}"
+            )
+
+        proc.kill()
+        proc.wait(timeout=5)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    recovered = sqlite3.connect(db_path)
+    try:
+        assert recovered.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+        base_sql = recovered.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'messages_fts'"
+        ).fetchone()[0]
+        assert "content='messages_fts_source'" not in base_sql
+        assert recovered.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE '%__external_new%'"
+        ).fetchone()[0] == 0
+    finally:
+        recovered.close()
+
+    reopened = SessionDB(db_path=db_path)
+    try:
+        assert reopened.get_meta("fts_storage_revision") is None
+        assert _search_projection(reopened, "sentinel")[0][0] == message_id
+        assert reopened._conn is not None
+        assert reopened._fts_trigger_count(reopened._conn.cursor()) == 6
+    finally:
+        reopened.close()

--- a/tests/test_fts_external_content_migration.py
+++ b/tests/test_fts_external_content_migration.py
@@ -609,3 +609,268 @@ db.migrate_fts_to_external_content()
         assert reopened._fts_trigger_count(reopened._conn.cursor()) == 6
     finally:
         reopened.close()
+
+
+def test_mixed_mode_migrates_only_inline_trigram(tmp_path):
+    db_path = tmp_path / "mixed-mode.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled or not seeded._trigram_available:
+            pytest.skip("SQLite build lacks FTS5 trigram support")
+        seeded.create_session(session_id="s1", source="cli")
+        seeded.append_message("s1", role="user", content="mixed mode sentinel")
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(
+            """
+            DROP TRIGGER messages_fts_trigram_insert;
+            DROP TRIGGER messages_fts_trigram_delete;
+            DROP TRIGGER messages_fts_trigram_update;
+            DROP TABLE messages_fts_trigram;
+            CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content, tokenize='trigram');
+            CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages BEGIN
+              INSERT INTO messages_fts_trigram(rowid, content)
+              VALUES (new.id, COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, ''));
+            END;
+            CREATE TRIGGER messages_fts_trigram_delete AFTER DELETE ON messages BEGIN
+              DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+            END;
+            CREATE TRIGGER messages_fts_trigram_update AFTER UPDATE OF id, content, tool_name, tool_calls ON messages BEGIN
+              DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+              INSERT INTO messages_fts_trigram(rowid, content)
+              VALUES (new.id, COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, ''));
+            END;
+            INSERT INTO messages_fts_trigram(rowid, content)
+            SELECT id, COALESCE(content, '') || ' ' || COALESCE(tool_name, '') || ' ' || COALESCE(tool_calls, '') FROM messages;
+            """
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+    maintenance = SessionDB.open_for_fts_maintenance(db_path)
+    try:
+        assert maintenance.fts_storage_mode() == "mixed"
+        report = maintenance.migrate_fts_to_external_content()
+        assert report["previous_mode"] == "mixed"
+        assert report["migrated_tables"] == ["messages_fts_trigram"]
+        assert maintenance.fts_storage_mode() == "external"
+        maintenance._conn.execute(
+            "INSERT INTO messages_fts(messages_fts, rank) VALUES('integrity-check', 1)"
+        )
+        maintenance._conn.execute(
+            "INSERT INTO messages_fts_trigram(messages_fts_trigram, rank) "
+            "VALUES('integrity-check', 1)"
+        )
+    finally:
+        maintenance.close()
+
+
+def test_maintenance_open_skips_schema_and_metadata_repair(tmp_path):
+    db_path = tmp_path / "maintenance-open.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled or not seeded._trigram_available:
+            pytest.skip("SQLite build lacks FTS5 trigram support")
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(LEGACY_INLINE_BOTH_SQL)
+        raw.execute("DROP TRIGGER messages_fts_delete")
+        raw.execute("DELETE FROM state_meta WHERE key = 'fts_storage_revision'")
+        raw.commit()
+    finally:
+        raw.close()
+
+    maintenance = SessionDB.open_for_fts_maintenance(db_path)
+    try:
+        missing = maintenance._conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = 'messages_fts_delete'"
+        ).fetchone()
+        revision = maintenance._conn.execute(
+            "SELECT value FROM state_meta WHERE key = 'fts_storage_revision'"
+        ).fetchone()
+        assert missing is None
+        assert revision is None
+    finally:
+        maintenance.close()
+
+
+def test_external_noop_validates_and_restores_storage_revision(tmp_path):
+    db_path = tmp_path / "external-noop-revision.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled:
+            pytest.skip("SQLite build lacks FTS5")
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.execute("DELETE FROM state_meta WHERE key = 'fts_storage_revision'")
+        raw.commit()
+    finally:
+        raw.close()
+
+    maintenance = SessionDB.open_for_fts_maintenance(db_path)
+    try:
+        report = maintenance.migrate_fts_to_external_content()
+        assert report["noop"] is False
+        assert report["schema_changed"] is False
+        assert report["metadata_changed"] is True
+        revision = maintenance._conn.execute(
+            "SELECT value FROM state_meta WHERE key = 'fts_storage_revision'"
+        ).fetchone()
+        assert revision[0] == "external-content-v1"
+    finally:
+        maintenance.close()
+
+
+def test_external_maintenance_repairs_missing_trigger_and_reports_change(tmp_path):
+    db_path = tmp_path / "external-missing-trigger.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled:
+            pytest.skip("SQLite build lacks FTS5")
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.execute("DROP TRIGGER messages_fts_insert")
+        raw.commit()
+    finally:
+        raw.close()
+
+    maintenance = SessionDB.open_for_fts_maintenance(db_path)
+    try:
+        report = maintenance.migrate_fts_to_external_content()
+        assert report["noop"] is False
+        assert report["schema_changed"] is True
+        assert report["metadata_changed"] is False
+        assert maintenance._conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = 'messages_fts_insert'"
+        ).fetchone()
+    finally:
+        maintenance.close()
+
+
+def test_external_maintenance_repairs_wrong_present_trigger_definitions(tmp_path):
+    db_path = tmp_path / "external-wrong-triggers.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled:
+            pytest.skip("SQLite build lacks FTS5")
+        seeded.create_session(session_id="s1", source="cli")
+        message_id = seeded.append_message(
+            "s1", role="user", content="before trigger repair"
+        )
+    finally:
+        seeded.close()
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(
+            """
+            DROP TRIGGER messages_fts_delete;
+            DROP TRIGGER messages_fts_update;
+            CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+              DELETE FROM messages_fts WHERE rowid = old.id;
+            END;
+            CREATE TRIGGER messages_fts_update AFTER UPDATE ON messages BEGIN
+              DELETE FROM messages_fts WHERE rowid = old.id;
+              INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
+            END;
+            """
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+    maintenance = SessionDB.open_for_fts_maintenance(db_path)
+    try:
+        report = maintenance.migrate_fts_to_external_content()
+        assert report["noop"] is False
+        assert report["schema_changed"] is True
+        maintenance._conn.execute(
+            "UPDATE messages SET content = ? WHERE id = ?",
+            ("after trigger repair", message_id),
+        )
+        maintenance._conn.commit()
+        maintenance._conn.execute(
+            "INSERT INTO messages_fts(messages_fts, rank) "
+            "VALUES('integrity-check', 1)"
+        )
+    finally:
+        maintenance.close()
+
+
+def test_migration_refuses_unrelated_caller_transaction(tmp_path):
+    db = SessionDB(db_path=tmp_path / "unrelated-transaction.db")
+    try:
+        if not db._fts_enabled:
+            pytest.skip("SQLite build lacks FTS5")
+        db._conn.execute("BEGIN IMMEDIATE")
+        with pytest.raises(sqlite3.OperationalError, match="unrelated transaction"):
+            db.migrate_fts_to_external_content()
+        assert db._conn.in_transaction is True
+        db._conn.rollback()
+    finally:
+        db.close()
+
+
+def test_external_maintenance_repairs_trigger_with_changed_literal(tmp_path):
+    db_path = tmp_path / "external-wrong-literal-trigger.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        if not seeded._fts_enabled:
+            pytest.skip("SQLite build lacks FTS5")
+        seeded.create_session(session_id="s1", source="cli")
+    finally:
+        seeded.close()
+
+    canonical = SessionDB._fts_trigger_sql(
+        "messages_fts", external=True
+    )["messages_fts_insert"]
+    wrong = canonical.replace(" || ' ' || ", " || '' || ")
+    assert wrong != canonical
+    assert SessionDB._normalize_trigger_sql(wrong) != SessionDB._normalize_trigger_sql(
+        canonical
+    )
+
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.execute("DROP TRIGGER messages_fts_insert")
+        raw.execute(wrong)
+        raw.commit()
+    finally:
+        raw.close()
+
+    maintenance = SessionDB.open_for_fts_maintenance(db_path)
+    try:
+        report = maintenance.migrate_fts_to_external_content()
+        assert report["noop"] is False
+        assert report["schema_changed"] is True
+    finally:
+        maintenance.close()
+
+    verified = SessionDB(db_path=db_path)
+    try:
+        message_id = verified.append_message(
+            "s1",
+            role="assistant",
+            content="alpha",
+            tool_name="beta",
+        )
+        assert any(hit["id"] == message_id for hit in verified.search_messages("alpha"))
+        assert any(hit["id"] == message_id for hit in verified.search_messages("beta"))
+        assert not verified.search_messages("alphabeta")
+    finally:
+        verified.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -594,6 +594,11 @@ class TestSessionLifecycle:
             assert len(messages) == 1
             assert messages[0]["content"] == "hello from sqlite without fts"
             assert db.search_messages("hello") == []
+            with pytest.raises(
+                sqlite3.OperationalError,
+                match="requires SQLite FTS5",
+            ):
+                db.migrate_fts_to_external_content()
         finally:
             db.close()
 
@@ -735,6 +740,27 @@ class TestSessionLifecycle:
             assert len(restored.search_messages("needle")) == 1
         finally:
             restored.close()
+
+        rebuild_calls = []
+        original_rebuild = SessionDB._rebuild_fts_table.__func__
+
+        def track_rebuild(cls, cursor, table_name):
+            rebuild_calls.append(table_name)
+            return original_rebuild(cls, cursor, table_name)
+
+        monkeypatch.setattr(
+            SessionDB,
+            "_rebuild_fts_table",
+            classmethod(track_rebuild),
+        )
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_enabled is True
+            assert reopened._trigram_available is False
+            assert len(reopened.search_messages("needle")) == 1
+            assert rebuild_calls == []
+        finally:
+            reopened.close()
 
     def test_is_fts5_unavailable_error_catches_trigram_tokenizer(self):
         """Unit test: _is_fts5_unavailable_error matches 'no such tokenizer: trigram'."""


### PR DESCRIPTION
## What does this PR do?

Migrates Hermes session full-text indexes from inline-content FTS5 tables to external-content FTS5 tables backed by a canonical `messages_fts_source` view. This removes duplicate message payload storage from the FTS shadow tables while preserving search behavior.

The migration is deliberately explicit rather than automatic at startup. A guarded `hermes sessions migrate-fts` maintenance command performs read-only preflight checks, requires writer-shutdown attestation, acquires `BEGIN IMMEDIATE`, creates and verifies a rollback backup while retaining the writer lock, migrates atomically, validates both FTS indexes, and does not run `VACUUM`.

A production-shaped benchmark documented in this PR reclaimed 1,129,508,864 bytes (about 35%) after the separate VACUUM step.

## Related Issue

No linked issue. I searched open and closed upstream PRs/issues for external-content FTS, `migrate-fts`, and `messages_fts_source`; no duplicate work was found.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add external-content FTS schema and atomic migration support in `hermes_state.py`.
- Add strict structural validation for canonical FTS tables, the source view, and write triggers.
- Add `hermes sessions migrate-fts` with check-only mode, free-space planning, verified exclusive backup creation, writer-lock ordering, no-trigram support, and explicit unsafe no-backup gating.
- Integrate the maintenance command with local Console confirmation while keeping it unavailable in hosted Console mode.
- Add regression coverage for WAL/read-only behavior, URI-sensitive paths, malformed schemas, lock contention, rollback, backup failures, mixed/idempotent modes, trigger repair, source-view validation, and no-trigram SQLite builds.
- Document the measured storage benchmark, operator workflow, and the separate VACUUM requirement.

## How to Test

1. Run focused migration and command tests:
   ```bash
   python -m pytest tests/test_fts_external_content_migration.py tests/hermes_cli/test_session_fts_migration.py -q
   ```
2. Run expanded state/search/Console coverage:
   ```bash
   python -m pytest tests/hermes_state tests/test_state_db_malformed_repair.py tests/test_hermes_state.py tests/test_fts_external_content_migration.py tests/tools/test_session_search.py tests/hermes_cli/test_web_server_session_search.py tests/hermes_cli/test_session_fts_migration.py -q
   python -m pytest tests/hermes_cli/test_console_engine.py -q
   ```
3. Run the complete test suite:
   ```bash
   python -m pytest tests/ -q
   ```
4. On a disposable session database, inspect without mutation:
   ```bash
   hermes sessions migrate-fts --check-only
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: no config keys added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A: no contributor workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — URI-safe paths and POSIX-only permission/fsync behavior are platform-gated
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A: no model tool schema changed

## Screenshots / Logs

Current-upstream verification before PR creation:

- Focused migration/CLI tests: `61 passed`
- Expanded session/state/search tests: `569 passed`
- Console tests: `74 passed`
- Ruff: passed
- `py_compile`: passed
- `git diff --check`: passed
- PR diff secret-pattern scan: 0 findings
- Full-suite fail-fast status: both this branch and clean `origin/main` stop at the same unrelated order-dependent failure, `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`; that test passes individually on both branches
- Independent exact-diff review: **APPROVE** — no HIGH or MEDIUM findings
