### PR TITLE
feat: add provider fallback lifecycle hooks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1523,6 +1523,7 @@ def restore_primary_runtime(agent) -> bool:
         # ── Reset fallback chain for the new turn ──
         agent._fallback_activated = False
         agent._fallback_index = 0
+        agent._fallback_exhaustion_notified = False
 
         # Reset the stale-call circuit breaker (#58962): the streak measured
         # the FALLBACK provider we're leaving; the restored primary deserves
@@ -1539,6 +1540,20 @@ def restore_primary_runtime(agent) -> bool:
             "Primary runtime restored for new turn: %s (%s)",
             agent.model, agent.provider,
         )
+        # Observer-only hook for metrics / telemetry plugins.  Fail-open.
+        try:
+            from hermes_cli.plugins import has_hook, invoke_hook
+
+            if has_hook("on_primary_restored"):
+                invoke_hook(
+                    "on_primary_restored",
+                    provider=agent.provider,
+                    model=agent.model,
+                    session_id=getattr(agent, "session_id", None) or "",
+                    platform=getattr(agent, "platform", None) or "",
+                )
+        except Exception:
+            pass
         return True
     except Exception as e:
         logger.warning("Failed to restore primary runtime: %s", e)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1361,7 +1361,8 @@ def restore_primary_runtime(agent) -> bool:
         # _fallback_activated stays False.  The next turn skips this block
         # entirely, stranding the index and silently blocking all future
         # fallback attempts for the session.  Fixes #20465.
-        agent._fallback_index = 0
+        from agent.chat_completion_helpers import _reset_fallback_episode
+        _reset_fallback_episode(agent)
         return False
 
     if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
@@ -1521,9 +1522,8 @@ def restore_primary_runtime(agent) -> bool:
             agent.reasoning_config = dict(saved_reasoning)
 
         # ── Reset fallback chain for the new turn ──
-        agent._fallback_activated = False
-        agent._fallback_index = 0
-        agent._fallback_exhaustion_notified = False
+        from agent.chat_completion_helpers import _reset_fallback_episode
+        _reset_fallback_episode(agent)
 
         # Reset the stale-call circuit breaker (#58962): the streak measured
         # the FALLBACK provider we're leaving; the restored primary deserves
@@ -2355,8 +2355,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         })
 
     # ── Reset fallback state ──
-    agent._fallback_activated = False
-    agent._fallback_index = 0
+    from agent.chat_completion_helpers import _reset_fallback_episode
+    _reset_fallback_episode(agent)
 
     # When the user deliberately swaps primary providers (e.g. openrouter
     # → anthropic), drop any fallback entries that target the OLD primary

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1556,6 +1556,32 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if (not fallback_already_active) or (primary_provider and current_provider == primary_provider):
             agent._rate_limited_until = time.monotonic() + 60
     if agent._fallback_index >= len(agent._fallback_chain):
+        # Emit one structured terminal event per fallback episode.  This is an
+        # observer-only seam for metrics/alerting; it must not affect routing.
+        if (
+            agent._fallback_chain
+            and not getattr(agent, "_fallback_exhaustion_notified", False)
+        ):
+            agent._fallback_exhaustion_notified = True
+            try:
+                from hermes_cli.plugins import has_hook, invoke_hook
+
+                if has_hook("on_fallback_chain_exhausted"):
+                    primary = getattr(agent, "_primary_runtime", None) or {}
+                    reason_value = getattr(reason, "value", reason) if reason is not None else None
+                    invoke_hook(
+                        "on_fallback_chain_exhausted",
+                        provider=getattr(agent, "provider", "") or "",
+                        model=getattr(agent, "model", "") or "",
+                        primary_provider=primary.get("provider") or "",
+                        primary_model=primary.get("model") or "",
+                        reason=reason_value,
+                        chain_length=len(agent._fallback_chain),
+                        session_id=getattr(agent, "session_id", None) or "",
+                        platform=getattr(agent, "platform", None) or "",
+                    )
+            except Exception:
+                pass
         # Chain exhausted.  If we actually walked a non-empty chain and the
         # failure was NOT a rate-limit/billing event (those already armed
         # their own 60s cooldown above), arm a short cooldown so the next
@@ -1887,6 +1913,27 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             "Fallback activated: %s → %s (%s)",
             old_model, fb_model, fb_provider,
         )
+        # Observer-only hook for metrics / telemetry plugins.  Must never
+        # affect activation success — fail-open and ignore return values.
+        try:
+            from hermes_cli.plugins import has_hook, invoke_hook
+
+            if has_hook("on_fallback_activated"):
+                reason_value = None
+                if reason is not None:
+                    reason_value = getattr(reason, "value", reason)
+                invoke_hook(
+                    "on_fallback_activated",
+                    from_provider=old_provider,
+                    from_model=old_model,
+                    to_provider=fb_provider,
+                    to_model=fb_model,
+                    reason=reason_value,
+                    session_id=getattr(agent, "session_id", None) or "",
+                    platform=getattr(agent, "platform", None) or "",
+                )
+        except Exception:
+            pass
         # Reset the stale-call circuit breaker (#58962): the streak measured
         # the OLD provider's unresponsiveness.  Carrying it over would
         # short-circuit the freshly activated fallback before it gets a

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1533,6 +1533,13 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
     return None
 
 
+def _reset_fallback_episode(agent) -> None:
+    """Reset all state scoped to one fallback-chain episode."""
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_exhaustion_notified = False
+
+
 
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4419,8 +4419,8 @@ def run_conversation(
                         # still activate fallback_providers after stale
                         # pre-recovery fallback/credential-pool bookkeeping.
                         _retry.has_retried_429 = False
-                        agent._fallback_index = 0
-                        agent._fallback_activated = False
+                        from agent.chat_completion_helpers import _reset_fallback_episode
+                        _reset_fallback_episode(agent)
                         continue
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5664,7 +5664,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent._fallback_chain = new_chain
         agent._fallback_model = new_chain[0] if new_chain else None
         if not getattr(agent, "_fallback_activated", False):
-            agent._fallback_index = 0
+            from agent.chat_completion_helpers import _reset_fallback_episode
+            _reset_fallback_episode(agent)
         # A config edit signals the user changed something — drop the
         # session-scoped unavailability memo so re-configured entries
         # (e.g. credentials added mid-uptime for a previously-failing

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -157,6 +157,12 @@ VALID_HOOKS: Set[str] = {
     "pre_api_request",
     "post_api_request",
     "api_request_error",
+    # Provider-routing observers. Fired after a successful fallback activation
+    # / primary restoration so plugins can emit metrics without parsing logs.
+    # Return values are ignored.
+    "on_fallback_activated",
+    "on_fallback_chain_exhausted",
+    "on_primary_restored",
     "on_session_start",
     "on_session_end",
     "on_session_finalize",

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -627,6 +627,9 @@ class TestPluginHooks:
         assert "pre_api_request" in VALID_HOOKS
         assert "post_api_request" in VALID_HOOKS
         assert "api_request_error" in VALID_HOOKS
+        assert "on_fallback_activated" in VALID_HOOKS
+        assert "on_fallback_chain_exhausted" in VALID_HOOKS
+        assert "on_primary_restored" in VALID_HOOKS
         assert "subagent_start" in VALID_HOOKS
         assert "transform_terminal_output" in VALID_HOOKS
         assert "transform_tool_result" in VALID_HOOKS

--- a/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
+++ b/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
@@ -47,6 +47,45 @@ def _mock_client(base_url="https://openrouter.ai/api/v1", api_key="fb-key"):
 
 
 class TestExhaustionArmsCooldown:
+    def test_nonempty_chain_exhaustion_fires_observer_once(self):
+        """Operators get one structured exhaustion event, not log parsing or spam."""
+        agent = _make_agent(
+            fallback_model=[{"provider": "kimi-coding", "model": "kimi-k2.7-code"}]
+        )
+        agent.provider = "kimi-coding"
+        agent.model = "kimi-k2.7-code"
+        agent._fallback_index = len(agent._fallback_chain)
+
+        with (
+            patch("hermes_cli.plugins.has_hook", return_value=True),
+            patch("hermes_cli.plugins.invoke_hook") as invoke,
+        ):
+            assert agent._try_activate_fallback(reason=FailoverReason.timeout) is False
+            # A repeated terminal call in the same fallback episode must not
+            # emit duplicate exhaustion events.
+            assert agent._try_activate_fallback(reason=FailoverReason.timeout) is False
+
+        invoke.assert_called_once_with(
+            "on_fallback_chain_exhausted",
+            provider="kimi-coding",
+            model="kimi-k2.7-code",
+            primary_provider=agent._primary_runtime["provider"],
+            primary_model=agent._primary_runtime["model"],
+            reason="timeout",
+            chain_length=1,
+            session_id=agent.session_id or "",
+            platform=agent.platform or "",
+        )
+
+    def test_empty_chain_does_not_fire_exhaustion_observer(self):
+        agent = _make_agent(fallback_model=None)
+        with (
+            patch("hermes_cli.plugins.has_hook", return_value=True),
+            patch("hermes_cli.plugins.invoke_hook") as invoke,
+        ):
+            assert agent._try_activate_fallback(reason=FailoverReason.timeout) is False
+        invoke.assert_not_called()
+
     def test_non_retryable_exhaustion_arms_cooldown(self):
         """Walking a non-empty chain to exhaustion on a non-rate-limit
         failure arms a short ``_rate_limited_until`` cooldown.

--- a/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
+++ b/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
@@ -86,6 +86,27 @@ class TestExhaustionArmsCooldown:
             assert agent._try_activate_fallback(reason=FailoverReason.timeout) is False
         invoke.assert_not_called()
 
+    def test_second_fallback_episode_fires_a_second_exhaustion_observer(self):
+        agent = _make_agent(
+            fallback_model=[{"provider": "kimi-coding", "model": "kimi-k2.7-code"}]
+        )
+        agent._fallback_index = len(agent._fallback_chain)
+
+        with (
+            patch("hermes_cli.plugins.has_hook", return_value=True),
+            patch("hermes_cli.plugins.invoke_hook") as invoke,
+        ):
+            assert agent._try_activate_fallback(reason=FailoverReason.timeout) is False
+
+            # Start a new episode through the normal new-turn reset path.
+            agent._rate_limited_until = 0
+            assert agent._restore_primary_runtime() is False
+            agent._fallback_index = len(agent._fallback_chain)
+
+            assert agent._try_activate_fallback(reason=FailoverReason.timeout) is False
+
+        assert invoke.call_count == 2
+
     def test_non_retryable_exhaustion_arms_cooldown(self):
         """Walking a non-empty chain to exhaustion on a non-rate-limit
         failure arms a short ``_rate_limited_until`` cooldown.

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -607,11 +607,14 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
+| [`on_fallback_activated`](/user-guide/features/hooks#provider-fallback-lifecycle-hooks) | Fallback provider/model activation succeeds | `from_provider: str, from_model: str, to_provider: str, to_model: str, reason: str \| None, session_id: str, platform: str` | ignored |
+| [`on_fallback_chain_exhausted`](/user-guide/features/hooks#provider-fallback-lifecycle-hooks) | A non-empty fallback episode has no remaining route | `provider: str, model: str, primary_provider: str, primary_model: str, reason: str \| None, chain_length: int, session_id: str, platform: str` | ignored |
+| [`on_primary_restored`](/user-guide/features/hooks#provider-fallback-lifecycle-hooks) | Primary provider/model restoration succeeds | `provider: str, model: str, session_id: str, platform: str` | ignored |
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation.
+Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation. Provider fallback lifecycle hooks are strictly observer-only: their callbacks cannot alter routing or recovery behavior.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -387,6 +387,9 @@ def register(ctx):
 | [`on_session_end`](#on_session_end) | Session ends | ignored |
 | [`on_session_finalize`](#on_session_finalize) | CLI/gateway tears down an active session (flush, save, stats) | ignored |
 | [`on_session_reset`](#on_session_reset) | Gateway swaps in a fresh session key (e.g. `/new`, `/reset`) | ignored |
+| [`on_fallback_activated`](#provider-fallback-lifecycle-hooks) | Hermes switches to the next configured fallback provider/model | ignored |
+| [`on_fallback_chain_exhausted`](#provider-fallback-lifecycle-hooks) | A non-empty fallback chain has no remaining route | ignored |
+| [`on_primary_restored`](#provider-fallback-lifecycle-hooks) | Hermes restores the primary provider/model for a later turn | ignored |
 | [`subagent_start`](#subagent_start) | A `delegate_task` child has been constructed and is about to run | ignored |
 | [`subagent_stop`](#subagent_stop) | A `delegate_task` child has exited | ignored |
 | [`pre_gateway_dispatch`](#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch | `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow |
@@ -395,6 +398,62 @@ def register(ctx):
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
 | [`transform_terminal_output`](#transform_terminal_output) | Inside the `terminal` tool, before truncation/ANSI-strip/redact | `str` to replace the raw output, `None` to leave unchanged |
 | [`transform_llm_output`](#transform_llm_output) | After the tool-calling loop completes, before the final response is delivered | `str` to replace the response text, `None`/empty to leave unchanged |
+
+---
+
+### Provider fallback lifecycle hooks
+
+These three hooks expose provider-routing transitions to observability plugins.
+They are **observer-only**: callback return values are ignored, and callback
+failures cannot change fallback selection, restoration, or exhaustion.
+
+#### `on_fallback_activated`
+
+Fires after Hermes successfully switches to one fallback route.
+
+```python
+def callback(from_provider: str, from_model: str,
+             to_provider: str, to_model: str,
+             reason: str | None, session_id: str,
+             platform: str, **kwargs):
+```
+
+#### `on_fallback_chain_exhausted`
+
+Fires once per fallback episode when a non-empty chain has no remaining route.
+A later episode can emit another event after Hermes resets fallback state.
+
+```python
+def callback(provider: str, model: str,
+             primary_provider: str, primary_model: str,
+             reason: str | None, chain_length: int,
+             session_id: str, platform: str, **kwargs):
+```
+
+#### `on_primary_restored`
+
+Fires after Hermes successfully restores the primary runtime for a later turn.
+
+```python
+def callback(provider: str, model: str,
+             session_id: str, platform: str, **kwargs):
+```
+
+Common payload fields:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `provider`, `model` | `str` | Current route at exhaustion or the restored primary route. |
+| `from_provider`, `from_model` | `str` | Route that failed before fallback activation. |
+| `to_provider`, `to_model` | `str` | Newly activated fallback route. |
+| `primary_provider`, `primary_model` | `str` | Original primary route for the exhausted episode. |
+| `reason` | `str \| None` | Classified failover reason when available. |
+| `chain_length` | `int` | Number of configured fallback entries in the exhausted chain. |
+| `session_id` | `str` | Current session identifier, or an empty string when unavailable. |
+| `platform` | `str` | Current surface, or an empty string when unavailable. |
+
+As with every plugin hook, accept `**kwargs` for forward compatibility. All
+three hooks also receive the standard correlation metadata described above.
 
 ---
 


### PR DESCRIPTION
## Summary
- add fail-open observer hooks for successful fallback activation and primary restoration
- add one terminal `on_fallback_chain_exhausted` event per fallback episode
- centralize fallback-episode reset state so exhaustion notification resets with index/activation on every runtime reset path
- document all three public events, payloads, and observer-only return semantics

## Motivation
A real external plugin needs structured provider-routing outcomes. Existing `api_request_error` can observe individual failures but cannot distinguish fallback activation, successful primary restoration, or terminal chain exhaustion without parsing logs.

## Scope
This PR only widens the generic plugin lifecycle surface. Prometheus/Grafana integration remains an external plugin under `~/.hermes/plugins/` and is intentionally excluded.

## Review follow-up
- rebased onto current upstream `main`
- centralized `_reset_fallback_episode()` now resets `_fallback_activated`, `_fallback_index`, and `_fallback_exhaustion_notified` together
- added a second-episode regression proving a later exhaustion emits another event while repeated terminal calls in one episode remain deduplicated
- documented event timing, exact payload fields, forward-compatible `**kwargs`, and ignored return values

## Verification
- 147 focused fallback/plugin/gateway tests passed across six files
- repeated terminal calls emit one exhaustion event per fallback episode
- a second fallback episode emits a second exhaustion event
- empty fallback chains do not emit exhaustion
- observer exceptions are swallowed and cannot alter routing
- all production fallback-index reset sites now flow through the centralized reset helper, except initial construction
- `git diff --check`
