### PR TITLE
fix(tui-gateway): relay Codex app-server tool events to serve WebSocket clients (#66360)

### DIFF
--- a/tests/tui_gateway/test_codex_ws_tool_progress.py
+++ b/tests/tui_gateway/test_codex_ws_tool_progress.py
@@ -1,0 +1,140 @@
+"""Tests for the hermes serve WebSocket relaying Codex app-server tool events.
+
+On the Codex app-server route, native tools execute *inside* Codex, so the
+authoritative ``tool_start_callback`` / ``tool_complete_callback`` never fire.
+The only tool signal that reaches ``_on_tool_progress`` is the
+``tool.started`` / ``tool.completed`` progress events bridged from the Codex
+event stream. These must be relayed to WS clients (tool.start / tool.complete)
+on that route, while remaining suppressed/ignored on the normal route (where
+the authoritative emitters already fire and would otherwise be duplicated).
+
+Covers issue #66360 Layers 1+2 (Layer 3, webSearch bridging, is already fixed
+on main).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(
+                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_codex_ws")
+            ),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
+        import importlib
+
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+
+
+@pytest.fixture()
+def emits(server, monkeypatch):
+    captured: list = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: captured.append((event, sid, payload)),
+    )
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda sid: True)
+    return captured
+
+
+def _seed_session(server, sid: str, api_mode: str) -> None:
+    """Register a session whose agent reports the given ``api_mode``."""
+    agent = MagicMock()
+    agent.api_mode = api_mode
+    server._sessions[sid] = {"agent": agent, "tool_started_at": {}}
+
+
+# ── Layer 2: tool.started is relayed on the Codex route ───────────────
+
+def test_codex_route_tool_started_emits_tool_start(server, emits):
+    _seed_session(server, "sid-cx", "codex_app_server")
+    server._on_tool_progress(
+        "sid-cx", "tool.started", "web_search", "searching the web", {"query": "x"}
+    )
+    assert len(emits) == 1
+    event, sid, payload = emits[0]
+    assert event == "tool.start"
+    assert sid == "sid-cx"
+    assert payload["name"] == "web_search"
+
+
+def test_normal_route_tool_started_still_suppressed(server, emits):
+    """Guard: the normal route must not duplicate the authoritative tool.start."""
+    _seed_session(server, "sid-norm", "")
+    server._on_tool_progress(
+        "sid-norm", "tool.started", "terminal", "running cmd", {"command": "ls"}
+    )
+    assert emits == []
+
+
+# ── Layer 1: tool.completed is relayed on the Codex route ─────────────
+
+def test_codex_route_tool_completed_emits_tool_complete_with_result(server, emits):
+    _seed_session(server, "sid-cx", "codex_app_server")
+    server._on_tool_progress(
+        "sid-cx", "tool.completed", "web_search", None, None,
+        result=json.dumps({"urls": ["https://example.com"]}),
+        duration=1.25, is_error=False,
+    )
+    assert len(emits) == 1
+    event, sid, payload = emits[0]
+    assert event == "tool.complete"
+    assert sid == "sid-cx"
+    assert payload["name"] == "web_search"
+    # JSON-string result is parsed, mirroring _on_tool_complete.
+    assert payload["result"] == {"urls": ["https://example.com"]}
+    assert payload["duration_s"] == 1.25
+
+
+def test_codex_route_tool_completed_error_flag_forwarded(server, emits):
+    _seed_session(server, "sid-cx", "codex_app_server")
+    server._on_tool_progress(
+        "sid-cx", "tool.completed", "commandExecution", None, None,
+        result="[error] boom", is_error=True,
+    )
+    assert len(emits) == 1
+    event, _sid, payload = emits[0]
+    assert event == "tool.complete"
+    assert payload["is_error"] is True
+    # Non-JSON result string is preserved verbatim.
+    assert payload["result"] == "[error] boom"
+
+
+def test_normal_route_tool_completed_still_ignored(server, emits):
+    """Guard: the normal route already emits the authoritative tool.complete."""
+    _seed_session(server, "sid-norm", "")
+    server._on_tool_progress(
+        "sid-norm", "tool.completed", "terminal", None, None, result="ok"
+    )
+    assert emits == []
+
+
+# ── Robustness: unknown api_mode / missing session do not crash ────────
+
+def test_no_session_tool_started_does_not_crash(server, emits):
+    server._on_tool_progress(
+        "orphan-sid", "tool.started", "web_search", "p", {}
+    )
+    assert emits == []
+
+
+def test_no_session_tool_completed_does_not_crash(server, emits):
+    server._on_tool_progress(
+        "orphan-sid", "tool.completed", "web_search", None, None, result="ok"
+    )
+    assert emits == []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3947,6 +3947,22 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
         _emit("tool.complete", sid, payload)
 
 
+def _session_is_codex_app_server(sid: str) -> bool:
+    """Whether the serve session's agent runs on the Codex app-server route.
+
+    On that route native tools execute *inside* Codex, so the authoritative
+    ``tool_start_callback`` / ``tool_complete_callback`` never fire and the
+    only tool signal is the progress callback. ``_on_tool_progress`` must
+    therefore relay ``tool.started`` / ``tool.completed`` on this route
+    instead of suppressing them (as it does for every other route, where the
+    authoritative emitters would otherwise be duplicated).
+    """
+    session = _sessions.get(sid)
+    if session is None:
+        return False
+    return getattr(session.get("agent"), "api_mode", "") == "codex_app_server"
+
+
 def _on_tool_progress(
     sid: str,
     event_type: str,
@@ -3960,7 +3976,42 @@ def _on_tool_progress(
     if event_type == "tool.started" and name:
         # `_on_tool_start` already emits the authoritative `tool.start` with
         # the stable tool id and args. Emitting another id-less progress row
-        # here makes the desktop live view diverge from hydrated history.
+        # here makes the desktop live view diverge from hydrated history — so
+        # suppress it. The codex app-server route is the exception: tools run
+        # inside Codex and `_on_tool_start` never fires, so this progress event
+        # is the *only* start signal and must be relayed (#66360).
+        if _session_is_codex_app_server(sid):
+            payload: dict[str, object] = {
+                "tool_id": "",
+                "name": str(name),
+                "context": _tool_ctx(str(name), _args or {}),
+            }
+            _emit("tool.start", sid, payload)
+        return
+    if event_type == "tool.completed" and name:
+        # Same rationale as tool.started: the normal route's authoritative
+        # `_on_tool_complete` emits `tool.complete` (and the tool executor also
+        # pushes a tool.completed progress event), so relay only on the codex
+        # app-server route to avoid a duplicate on normal routes (#66360).
+        if _session_is_codex_app_server(sid):
+            payload: dict[str, object] = {
+                "tool_id": str(_kwargs.get("tool_call_id") or ""),
+                "name": str(name),
+            }
+            result = _kwargs.get("result")
+            if result is not None:
+                try:
+                    payload["result"] = json.loads(result)
+                except (TypeError, ValueError):
+                    payload["result"] = result
+            if _kwargs.get("duration") is not None:
+                try:
+                    payload["duration_s"] = float(_kwargs["duration"])
+                except (TypeError, ValueError):
+                    pass
+            if _kwargs.get("is_error"):
+                payload["is_error"] = True
+            _emit("tool.complete", sid, payload)
         return
     if event_type == "tool.output_risk" and name:
         metadata = _kwargs.get("risk_metadata")


### PR DESCRIPTION
## What

On the Codex app-server route (`agent.api_mode == "codex_app_server"`), native tools execute *inside* Codex, so the authoritative `tool_start_callback` / `tool_complete_callback` never fire. The Codex event bridge (`make_codex_app_server_event_bridge`) forwards tool activity into `tool_progress_callback("tool.started"/"tool.completed", ...)`, but `tui_gateway/server.py::_on_tool_progress` dropped both:

1. **`tool.completed`** had no branch at all → fell through silently, so tool results never reached serve WebSocket clients.
2. **`tool.started`** is deliberately suppressed (it duplicates the authoritative `tool.start` that `_on_tool_start` emits) → but on the Codex route that authoritative event never fires, so the suppression dropped the *only* start signal the route produces.

Net effect: a serve WS client driving a Codex-route session received only `session.info` / `message.*` lifecycle events — zero tool activity — while the same session's JSONL export showed extensive native tool use. This defeated observability/audit for Codex-route turns. (#66360)

Layer 3 from the issue (webSearch not in `_CODEX_TOOL_ITEM_TYPES`) is already fixed on `main`.

## How

Added a `_session_is_codex_app_server(sid)` helper that detects the Codex route via `agent.api_mode`. Then in `_on_tool_progress`:

- **`tool.started`**: on the Codex route, emit `tool.start` (name + context) instead of suppressing; every other route is unchanged.
- **`tool.completed`**: new branch — on the Codex route only, emit `tool.complete` with `name`, parsed `result` (`json.loads` with raw-string fallback, mirroring `_on_tool_complete`), `duration_s`, and `is_error`.

The gating is the critical safety property: the normal route also pushes `tool.started`/`tool.completed` through the progress callback, but its authoritative emitters (`_on_tool_start`/`_on_tool_complete`) already fire there — relaying on the normal route would produce duplicate `tool.start`/`tool.complete` events that make the desktop live view diverge from hydrated history. Guard tests confirm the normal route is unchanged.

## Verification

Built on `upstream/main` `ef9e0c98f` (rebuilt after an upstream force-push rewrote the base the original artifact used).

**New tests** — `tests/tui_gateway/test_codex_ws_tool_progress.py` (7 tests):
- RED on upstream/main: 3 Codex-route tests fail (no emit). 4 guard/robustness tests pass.
- GREEN with fix: **7/7 pass**.

Covers: Codex route emits `tool.start` / `tool.complete`; result parsing (JSON + non-JSON fallback); `is_error` forwarded; `duration_s` forwarded; normal route unchanged (no duplicate emit); missing session does not crash.

**Nearby suites (no regressions):**
- `tests/agent/test_codex_app_server_event_bridge.py` — **46 passed**
- `tests/tui_gateway/test_moa_reference_emit.py` — **3 passed**

**Quality:**
- `ruff check` — clean
- `git diff --check` — clean
- One focused commit, exactly `0 1` ahead of `upstream/main`

## Competitor note

PR #66366 (webtecnica) touches `gateway/run.py` (chat-platform display path) rather than `tui_gateway/server.py` (the serve WS bridge this issue is about). It covers 0/3 serve-WS layers and has no tests. These are complementary surfaces, not duplicates.

Auto-published by Moonsong via Path B automated pipeline.
