### PR TITLE
perf(kanban): batch ready-state dependency reads

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3352,43 +3352,6 @@ def _synthesize_ended_run(
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
 
-def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return True when ``task_id`` is sticky-blocked by an explicit
-    worker/operator ``kanban_block`` call (#28712).
-
-    A ``blocked`` status can come from two very different sources:
-
-    * **Worker- or operator-initiated** — a worker called
-      ``kanban_block(reason="review-required: ...")`` (or somebody ran
-      ``hermes kanban block <id>``).  This is a deliberate handoff that
-      should stay blocked until an operator unblocks it.  The block tool
-      emits a ``"blocked"`` event row in ``task_events``.
-
-    * **Circuit-breaker** — ``_record_task_failure`` tripped after
-      repeated crashes / spawn failures / timeouts.  This emits
-      ``"gave_up"``, *not* ``"blocked"``, and is meant to recover
-      automatically once the underlying conditions change (e.g. parents
-      finish, transient infra error clears).
-
-    The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
-
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
-    """
-    row = conn.execute(
-        "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
-        "ORDER BY id DESC LIMIT 1",
-        (task_id,),
-    ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
-
 
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
@@ -3429,22 +3392,37 @@ def recompute_ready(
             "SELECT id, status, consecutive_failures, max_retries "
             "FROM tasks WHERE status IN ('todo', 'blocked')"
         ).fetchall()
+        parent_statuses: dict[str, list[str]] = {}
+        for parent in conn.execute(
+            "SELECT l.child_id, p.status FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "JOIN tasks c ON c.id = l.child_id "
+            "WHERE c.status IN ('todo', 'blocked')"
+        ).fetchall():
+            parent_statuses.setdefault(parent["child_id"], []).append(parent["status"])
+        latest_block_events = {
+            event["task_id"]: event["kind"]
+            for event in conn.execute(
+                "SELECT e.task_id, e.kind FROM task_events e "
+                "JOIN ("
+                "  SELECT task_id, MAX(id) AS event_id FROM task_events "
+                "  WHERE kind IN ('blocked', 'unblocked') GROUP BY task_id"
+                ") latest ON latest.event_id = e.id "
+                "JOIN tasks t ON t.id = e.task_id "
+                "WHERE t.status = 'blocked'"
+            ).fetchall()
+        }
         for row in todo_rows:
             task_id = row["id"]
             cur_status = row["status"]
-            if cur_status == "blocked" and _has_sticky_block(conn, task_id):
+            if cur_status == "blocked" and latest_block_events.get(task_id) == "blocked":
                 # Worker / operator asked for human review — do not
                 # silently auto-recover.  ``unblock_task`` is the only
                 # legitimate exit (it emits ``"unblocked"`` which flips
                 # this predicate back).
                 continue
-            parents = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            parents = parent_statuses.get(task_id, ())
+            if all(status in ("done", "archived") for status in parents):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
                     # circuit-breaker failure limit.  Without this

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -324,6 +324,27 @@ def test_recompute_ready_cascades_through_chain(kanban_home):
         assert kb.get_task(conn, c).status == "ready"
 
 
+def test_recompute_ready_batches_dependency_and_sticky_block_reads(kanban_home):
+    """Dispatcher ticks must not issue one dependency/event query per task."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="unfinished parent")
+        for i in range(25):
+            kb.create_task(conn, title=f"waiting {i}", parents=[parent])
+        for i in range(25):
+            task_id = kb.create_task(conn, title=f"sticky {i}")
+            kb.block_task(conn, task_id, reason="needs review")
+
+        statements = []
+        conn.set_trace_callback(statements.append)
+        try:
+            assert kb.recompute_ready(conn) == 0
+        finally:
+            conn.set_trace_callback(None)
+
+        selects = [sql for sql in statements if sql.lstrip().upper().startswith("SELECT")]
+        assert len(selects) <= 3
+
+
 def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
     """blocked tasks with all parents done should be promoted to ready,
     unless the circuit-breaker failure limit has been reached."""


### PR DESCRIPTION
## Summary

`recompute_ready()` runs on every dispatcher tick and previously issued one parent-status query per pending task plus one latest-block-event query per blocked task. This replaces both N+1 loops with two set-based reads while preserving sticky-block, dependency, and circuit-breaker semantics.

On the regression fixture with 25 dependency-blocked and 25 explicitly blocked tasks, the dispatcher path drops from 51 SELECTs to at most 3. No dependency or schema change.

## Tests

- `python -m pytest -q tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_block_kinds.py`
- 408 passed
- `git diff --check`

The regression test asserts the query count remains bounded as task count grows.