### PR TITLE
fix(kanban): bound decomposed child runtimes

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -181,6 +181,11 @@ DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 # effect of normal API traffic.
 DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS = 60 * 60
 
+# Auto-decomposed work must have an execution bound even when the triage root
+# omitted one. Ten minutes is long enough for a normal worker turn while still
+# letting the dispatcher recover a healthy-but-stuck child deterministically.
+DECOMPOSE_DEFAULT_MAX_RUNTIME_SECONDS = 10 * 60
+
 # Grace added to a claim when a reclaim is deferred because the previous
 # host-local worker is still alive after a termination attempt. Releasing the
 # claim in that state would spawn a duplicate alongside the surviving worker —
@@ -2015,6 +2020,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_events_run "
         "ON task_events(run_id, id)"
     )
+    # Batch ``recompute_ready`` and diagnostics both filter task_events
+    # by kind. Without this index, ``WHERE kind IN ('blocked', 'unblocked')
+    # GROUP BY task_id`` scans every event row.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_events_kind "
+        "ON task_events(kind)"
+    )
 
     notify_table_exists = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
@@ -2123,6 +2135,7 @@ _REBUILD_SPECS = {
         (
             "CREATE INDEX idx_events_task ON task_events(task_id, created_at)",
             "CREATE INDEX idx_events_run ON task_events(run_id, id)",
+            "CREATE INDEX idx_events_kind ON task_events(kind)",
         ),
     ),
     "task_comments": (
@@ -5409,7 +5422,8 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, workspace_kind, workspace_path, "
+            "max_runtime_seconds "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -5424,6 +5438,11 @@ def decompose_triage_task(
         # override with its own 'workspace_kind' / 'workspace_path'.
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
+        child_max_runtime_seconds = (
+            root_row["max_runtime_seconds"]
+            if root_row["max_runtime_seconds"] is not None
+            else DECOMPOSE_DEFAULT_MAX_RUNTIME_SECONDS
+        )
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -5449,8 +5468,8 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, max_runtime_seconds, created_at, created_by) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -5459,6 +5478,7 @@ def decompose_triage_task(
                     child_ws_kind,
                     child_ws_path,
                     tenant,
+                    child_max_runtime_seconds,
                     now,
                     (author or "decomposer"),
                 ),

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -21,7 +21,10 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
-def _create_triage(conn, title="rough idea", body=None, assignee=None, tenant=None):
+def _create_triage(
+    conn, title="rough idea", body=None, assignee=None, tenant=None,
+    max_runtime_seconds=None,
+):
     return kb.create_task(
         conn,
         title=title,
@@ -29,6 +32,7 @@ def _create_triage(conn, title="rough idea", body=None, assignee=None, tenant=No
         assignee=assignee,
         tenant=tenant,
         triage=True,
+        max_runtime_seconds=max_runtime_seconds,
     )
 
 
@@ -66,6 +70,28 @@ def test_decompose_creates_children_and_promotes_root(kanban_home):
     # Second child has parents=[0] → stays in todo until c0 completes.
     assert c1.status == "todo"
     assert c1.assignee == "engineer"
+
+
+@pytest.mark.parametrize(
+    ("root_limit", "expected_child_limit"),
+    [(240, 240), (None, 600)],
+)
+def test_decompose_bounds_child_runtime(
+    kanban_home, root_limit, expected_child_limit,
+):
+    with kb.connect() as conn:
+        tid = _create_triage(conn, max_runtime_seconds=root_limit)
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[{"title": "research"}, {"title": "build"}],
+        )
+        assert child_ids is not None
+        assert {
+            kb.get_task(conn, child_id).max_runtime_seconds
+            for child_id in child_ids
+        } == {expected_child_limit}
 
 
 def test_decompose_returns_none_when_task_missing(kanban_home):


### PR DESCRIPTION
## Summary

Fixes #54089.

`decompose_triage_task()` inserted children directly and omitted `max_runtime_seconds`, so every child became unbounded even when the triage root had an explicit deadline. Healthy-but-stuck workers were therefore excluded from runtime enforcement indefinitely.

This patch:

- inherits an explicit root runtime cap for every decomposed child
- applies a conservative 10-minute bound when the root is unbounded
- preserves the existing atomic fan-out, workspace inheritance, and dependency topology

## Tests

- `python -m pytest -q tests/hermes_cli/test_kanban_decompose_db.py tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_core_functionality.py`
- 194 passed, 1 skipped
- `git diff --check`