### PR TITLE
fix(agent): fall back from an unenterable configured cwd in resolve_agent_cwd

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -57,19 +57,40 @@ def _session_cwd_override() -> str:
     return str(value).strip()
 
 
+def _cwd_usable(p: Path) -> bool:
+    """True only when ``p`` is a directory a process can actually enter.
+
+    Existence alone is a trap: ``Path('/root').is_dir()`` is True for a
+    non-root user (stat only needs search permission on the parent), yet
+    ``os.scandir`` / ``subprocess(cwd=...)`` there die with
+    ``PermissionError: [Errno 13]``. Requiring ``X_OK`` lets an inaccessible
+    configured cwd fall through to a usable one instead of poisoning every
+    downstream consumer (the coding-context git/scandir probes, the codex
+    app-server workspace, the system-prompt cwd line). Same guard as
+    ``tools.environments.local._cwd_usable`` (#66306 / #65583). On Windows
+    ``X_OK`` on a directory is always satisfied, so this is a no-op there.
+    """
+    try:
+        return p.is_dir() and os.access(p, os.X_OK)
+    except OSError:
+        return False
+
+
 def resolve_agent_cwd() -> Path:
     override = _session_cwd_override()
     if override:
         p = Path(override).expanduser()
-        if p.is_dir():
+        if _cwd_usable(p):
             return p
-        logger.warning("configured working directory does not exist: %s", override)
+        logger.warning(
+            "configured working directory is missing or not enterable: %s", override
+        )
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
-        if p.is_dir():
+        if _cwd_usable(p):
             return p
-        logger.warning("TERMINAL_CWD does not exist: %s", raw)
+        logger.warning("TERMINAL_CWD is missing or not enterable: %s", raw)
     return Path(os.getcwd())
 
 
@@ -85,16 +106,18 @@ def resolve_context_cwd() -> Path | None:
     override = _session_cwd_override()
     if override:
         p = Path(override).expanduser()
-        if not p.is_dir():
-            logger.warning("configured working directory does not exist: %s", override)
+        if not _cwd_usable(p):
+            logger.warning(
+                "configured working directory is missing or not enterable: %s", override
+            )
         else:
             return p
         return None
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
-        if not p.is_dir():
-            logger.warning("TERMINAL_CWD does not exist: %s", raw)
+        if not _cwd_usable(p):
+            logger.warning("TERMINAL_CWD is missing or not enterable: %s", raw)
         else:
             return p
     return None

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -136,3 +136,77 @@ class TestSessionCwdOverride:
             assert resolve_agent_cwd() == tmp_path
         finally:
             rt._SESSION_CWD.reset(token)
+
+
+needs_posix_perms = pytest.mark.skipif(
+    os.name != "posix" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="chmod-based access denial needs POSIX + non-root",
+)
+
+
+@pytest.fixture
+def denied_dir(tmp_path):
+    """A directory that exists but cannot be entered (simulates a leaked /root)."""
+    d = tmp_path / "rootlike"
+    d.mkdir()
+    d.chmod(0)
+    yield d
+    d.chmod(0o755)  # so pytest can clean it up
+
+
+@needs_posix_perms
+class TestInaccessibleCwdFallback:
+    """A configured cwd that exists but is not enterable must fall through.
+
+    ``Path('/root').is_dir()`` is True for a non-root user, so the old
+    existence-only checks returned an inaccessible directory that then poisoned
+    every consumer with ``PermissionError`` (coding-context scandir/git, the
+    codex workspace). Mirrors the tools/environments/local fix (#66306).
+    """
+
+    def test_cwd_usable_rejects_unenterable_directory(self, denied_dir):
+        assert denied_dir.is_dir()  # the trap: stat/isdir succeeds
+        assert rt._cwd_usable(denied_dir) is False
+
+    def test_resolve_agent_cwd_falls_back_from_unenterable_terminal_cwd(
+        self, monkeypatch, denied_dir, tmp_path
+    ):
+        monkeypatch.setenv("TERMINAL_CWD", str(denied_dir))
+        monkeypatch.chdir(tmp_path)
+        resolved = resolve_agent_cwd()
+        assert resolved != denied_dir
+        assert os.access(resolved, os.X_OK)
+        assert resolved == tmp_path  # nearest usable = the launch dir
+
+    def test_resolve_context_cwd_skips_unenterable_terminal_cwd(
+        self, monkeypatch, denied_dir
+    ):
+        monkeypatch.setenv("TERMINAL_CWD", str(denied_dir))
+        # An unenterable configured cwd is treated like a missing one → None,
+        # so build_context_files_prompt falls back to the launch dir.
+        assert resolve_context_cwd() is None
+
+
+def test_resolve_agent_cwd_falls_back_when_dir_not_enterable(monkeypatch, tmp_path):
+    """Platform-independent regression: a configured cwd that is a directory
+    but not enterable (``os.access(..., X_OK)`` False, e.g. a leaked /root on a
+    non-root process) must fall through to the launch dir, not be returned."""
+    denied = tmp_path / "rootlike"
+    denied.mkdir()
+    launch = tmp_path / "launch"
+    launch.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(denied))
+    monkeypatch.chdir(launch)
+
+    real_access = os.access
+
+    def _deny_x_ok(path, mode, *a, **k):
+        if os.path.realpath(str(path)) == os.path.realpath(str(denied)) and mode == os.X_OK:
+            return False
+        return real_access(path, mode, *a, **k)
+
+    monkeypatch.setattr(rt.os, "access", _deny_x_ok)
+
+    resolved = resolve_agent_cwd()
+    assert resolved != denied
+    assert resolved == launch


### PR DESCRIPTION
## What does this PR do?

#66306 fixed `tools/environments/local._resolve_safe_cwd` to require `X_OK` so a
leaked, existing-but-inaccessible directory (e.g. `/root` on a non-root
gateway/cron process) can't reach `subprocess.Popen(cwd=…)` and kill every
command with `PermissionError: [Errno 13]`. `agent/runtime_cwd.py`'s own
resolvers — `resolve_agent_cwd` and `resolve_context_cwd` — had the **identical
existence-only trap**: `Path('/root').is_dir()` is True for a non-root user
(stat only needs search permission on the parent), so a leaked `TERMINAL_CWD` /
session cwd was returned verbatim.

That poisons the consumers that DON'T re-validate through `_resolve_safe_cwd`:
`resolve_agent_cwd` feeds the coding-context git/`os.scandir` probes and the
codex app-server workspace, and both resolvers feed the system-prompt cwd line.
A resolver should return a *usable* directory, not an inaccessible one.

Adds a shared `_cwd_usable(p)` helper (`is_dir` + `os.access(p, os.X_OK)`,
mirroring the `tools/environments/local` guard) and gates both resolvers on it:
an unenterable configured cwd now warns and falls through to the launch dir /
`None` exactly like a missing one. On Windows `X_OK` on a directory is always
satisfied, so the common path is unchanged.

## Related Issue

Extends #66306 / #65583 (the `/root`-leak `PermissionError` class) to the
`runtime_cwd` resolvers that the local-environment fix didn't cover.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/runtime_cwd.py` — add `_cwd_usable(p)` and use it in `resolve_agent_cwd`
  and `resolve_context_cwd` in place of the existence-only `is_dir()` checks.
- `tests/agent/test_runtime_cwd.py` — add `TestInaccessibleCwdFallback`
  (POSIX-gated chmod-0 cases, matching #66306) plus a platform-independent
  `os.access`-mocked regression.

## How to Test

1. `pytest tests/agent/test_runtime_cwd.py -q` → **17 passed, 3 skipped** (the
   chmod-based cases are POSIX+non-root only, like #66306; the mocked case runs
   everywhere).
2. Proof the fix works — revert only the `runtime_cwd.py` change and re-run
   `test_resolve_agent_cwd_falls_back_when_dir_not_enterable`: it fails because
   the old code returns the inaccessible directory (`is_dir()` is True). With the
   fix it falls through to the launch dir. On Linux CI the chmod-0 cases also
   exercise the real `PermissionError` path.
3. `pytest tests/agent/test_coding_context.py -q` → 55 passed (a consumer of
   `resolve_agent_cwd`, unaffected).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suite (`pytest tests/agent/test_runtime_cwd.py -q`) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation — inline rationale added; no external docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `X_OK` on a directory is always satisfied on Windows, so the common path is unchanged there; the enterability guard only bites on POSIX