### PR TITLE
fix(kanban): bind auto-subscriptions to active profile

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -2100,6 +2100,7 @@ def _sub_index(subs):
                 "chat_id": getattr(s, "chat_id", None),
                 "thread_id": getattr(s, "thread_id", None),
                 "user_id": getattr(s, "user_id", None),
+                "notifier_profile": getattr(s, "notifier_profile", None),
             })
     return out
 
@@ -2130,6 +2131,26 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     assert s["chat_id"] == "chat-42"
     assert s["thread_id"] == "thread-7"
     assert s["user_id"] == "user-9"
+
+
+def test_create_subscription_falls_back_to_active_profile(monkeypatch, worker_env):
+    """A gateway subscription must never be left ownerless in a fleet."""
+    from hermes_cli import profiles
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
+    monkeypatch.delenv("HERMES_SESSION_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "spanorama")
+
+    payload = json.loads(kt._handle_create({
+        "title": "owned subscription",
+        "assignee": "peer",
+    }))
+
+    subs = _sub_index(_list_subs_for_task(payload["task_id"]))
+    assert subs[0]["notifier_profile"] == "spanorama"
 
 
 def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1257,6 +1257,9 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             get_session_env("HERMES_SESSION_PROFILE", "")
             or os.environ.get("HERMES_PROFILE")
         )
+        if not notifier_profile:
+            from hermes_cli.profiles import get_active_profile_name
+            notifier_profile = get_active_profile_name()
 
         # Lazy-import to keep the module-level dependency light
         from hermes_cli import kanban_db as _kb


### PR DESCRIPTION
## Summary

Fixes #57993.

Kanban auto-subscriptions could be stored with `notifier_profile=NULL` whenever gateway session metadata and `HERMES_PROFILE` were absent. In a multi-profile fleet, any gateway sharing the platform/chat could then claim and deliver that terminal event through the wrong bot.

When explicit session/environment ownership is unavailable, `_maybe_auto_subscribe()` now resolves the active Hermes profile through the canonical profile resolver before writing the subscription. Existing explicit ownership precedence is unchanged.

## Tests

- `python -m pytest -q tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_notify.py tests/gateway/test_kanban_notifier.py`
- 133 passed
- `git diff --check`