### PR TITLE
fix(model): send alias-declared key instead of no-key-required placeholder

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -238,6 +238,11 @@ class DirectAlias(NamedTuple):
     model: str
     provider: str
     base_url: str
+    # Optional per-alias credentials. A custom ``base_url`` (e.g. a proxy) may
+    # require auth; ``api_key`` inlines it, ``key_env`` names an env var to read
+    # it from. Both default empty so existing aliases are unaffected.
+    api_key: str = ""
+    key_env: str = ""
 
 
 # Built-in direct aliases (can be extended via config.yaml model_aliases:)
@@ -281,9 +286,12 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                 model = entry.get("model", "")
                 provider = entry.get("provider", "custom")
                 base_url = entry.get("base_url", "")
+                api_key = entry.get("api_key", "")
+                key_env = entry.get("key_env", "") or entry.get("api_key_env", "")
                 if model:
                     merged[name.strip().lower()] = DirectAlias(
                         model=model, provider=provider, base_url=base_url,
+                        api_key=api_key, key_env=key_env,
                     )
 
         # --- model.aliases (string-based format, from config set) ---
@@ -1253,7 +1261,16 @@ def switch_model(
             base_url = _da.base_url
             api_mode = ""  # clear so determine_api_mode re-detects from URL
             if not api_key:
-                api_key = "no-key-required"
+                # A custom base_url (e.g. a LiteLLM proxy) usually DOES require a
+                # key. Prefer one the alias declares — inline ``api_key:`` or a
+                # ``key_env:`` naming an env var — before the no-auth placeholder,
+                # which otherwise 401s on attempt-1. Mirrors the named-custom-
+                # provider key resolution in auxiliary_client.resolve_provider_client.
+                import os
+                alias_key = _da.api_key.strip() or (
+                    os.environ.get(_da.key_env, "").strip() if _da.key_env else ""
+                )
+                api_key = alias_key or "no-key-required"
 
     # --- Normalize model name for target provider ---
     new_model = normalize_model_for_provider(new_model, target_provider)

--- a/tests/hermes_cli/test_model_switch_alias_key_resolution.py
+++ b/tests/hermes_cli/test_model_switch_alias_key_resolution.py
@@ -1,0 +1,94 @@
+"""Regression tests: a main model switched to a ``model_aliases:`` entry
+(``DirectAlias``) with a custom ``base_url`` must send the alias's own API key,
+not the ``no-key-required`` placeholder.
+
+Repro: switching the main model to an alias whose ``base_url`` points at an
+auth-required proxy (e.g. a LiteLLM gateway) stamped ``api_key`` with the
+hard-coded ``no-key-required`` placeholder because ``DirectAlias`` carried no
+credential field — so the very first request 401'd. The fix gives
+``DirectAlias`` optional ``api_key`` / ``key_env`` fields and resolves them in
+``switch_model`` before falling back to the placeholder, mirroring the
+named-custom-provider key resolution in
+``auxiliary_client.resolve_provider_client``.
+
+Hermetic: the resolution chain is fully mocked (no network), mirroring
+``tests/hermes_cli/test_model_switch_configured_provider_routing.py``.
+"""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import DirectAlias, switch_model
+
+_ACCEPTED = {"accepted": True, "persist": True, "recognized": True, "message": None}
+
+_PROXY_URL = "https://litellm.proxy.example/v1"
+
+
+def _switch_to_alias(alias, *, env=None):
+    """Drive ``switch_model`` for a raw input that resolves to *alias*
+    (a ``custom``-provider ``DirectAlias`` registered under ``"proxyalias"``).
+
+    The raw input resolves to the ``custom`` provider with a current base_url
+    set and an empty current api_key, so credential resolution takes the
+    ``custom`` + current-base_url branch (no network/runtime lookup) and leaves
+    ``api_key`` empty — making the DirectAlias key-resolution branch the only
+    thing that can supply a key.
+    """
+    aliases = {"proxyalias": alias}
+    with patch("hermes_cli.model_switch.resolve_alias",
+               return_value=(alias.provider, alias.model, "proxyalias")), \
+         patch("hermes_cli.model_switch._ensure_direct_aliases"), \
+         patch.dict("hermes_cli.model_switch.DIRECT_ALIASES", aliases, clear=True), \
+         patch("hermes_cli.model_switch.list_provider_models", return_value=[]), \
+         patch("hermes_cli.model_switch.normalize_model_for_provider",
+               side_effect=lambda model, provider: model), \
+         patch("hermes_cli.model_switch.determine_api_mode", return_value=""), \
+         patch("hermes_cli.models.validate_requested_model", return_value=_ACCEPTED), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
+         patch.dict(os.environ, env or {}, clear=False):
+        return switch_model(
+            raw_input="proxyalias",
+            current_provider="openai",
+            current_model="gpt-4o",
+            current_base_url="http://previous-endpoint.example/v1",
+            current_api_key="",
+            user_providers={},
+            custom_providers=[],
+        )
+
+
+def test_alias_key_env_is_resolved_not_placeholder():
+    """``key_env:`` on the alias → read the env var, not ``no-key-required``."""
+    alias = DirectAlias(
+        model="qwen3.5:397b", provider="custom",
+        base_url=_PROXY_URL, key_env="LITELLM_KEY",
+    )
+    result = _switch_to_alias(alias, env={"LITELLM_KEY": "sk-secret-123"})
+    assert result.success is True, result.error_message
+    assert result.base_url == _PROXY_URL
+    assert result.api_key == "sk-secret-123"
+
+
+def test_alias_inline_api_key_is_used():
+    """Inline ``api_key:`` on the alias is used verbatim."""
+    alias = DirectAlias(
+        model="qwen3.5:397b", provider="custom",
+        base_url=_PROXY_URL, api_key="sk-inline-456",
+    )
+    result = _switch_to_alias(alias)
+    assert result.success is True, result.error_message
+    assert result.api_key == "sk-inline-456"
+
+
+def test_alias_without_key_still_falls_back_to_placeholder():
+    """No key anywhere → the no-auth placeholder is preserved (local servers)."""
+    alias = DirectAlias(
+        model="llama3.4", provider="custom",
+        base_url="http://localhost:11434/v1",
+    )
+    result = _switch_to_alias(alias)
+    assert result.success is True, result.error_message
+    assert result.api_key == "no-key-required"


### PR DESCRIPTION
## Summary

Fixes the model switch logic to send the key that was declared in the alias configuration instead of the 'no-key-required' placeholder string.

## Context

When a model alias was configured with a declared API key, the model switch was sending the placeholder 'no-key-required' literal string as the key value rather than the actual key from the alias config.

## Changes

- `hermes_cli/model_switch.py`: Resolve the alias-declared key before sending
- `tests/hermes_cli/test_model_switch_alias_key_resolution.py`: New test coverage

Closes CLA-160