### PR TITLE
fix(kanban): ignore stale failure accounting

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7086,6 +7086,11 @@ def _record_task_failure(
             return False
         failures = int(row["consecutive_failures"]) + 1
         cur_status = row["status"]
+        if cur_status not in ("ready", "running"):
+            # Another writer won the race after the detector/spawner chose
+            # this task. Never stamp stale failure state or emit gave_up on a
+            # task that has since completed, blocked, or been re-claimed.
+            return False
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1200,6 +1200,35 @@ def test_unblock_resets_failure_counters(kanban_home):
         assert task.last_failure_error is None
 
 
+@pytest.mark.parametrize("failure_limit", [1, 2])
+def test_stale_failure_record_does_not_mutate_completed_task(
+    kanban_home, failure_limit,
+):
+    """Late crash accounting must be a no-op after another writer completes."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="completed elsewhere", assignee="a")
+        kb.claim_task(conn, task_id)
+        kb.complete_task(conn, task_id, result="done")
+        events_before = len(kb.list_events(conn, task_id))
+
+        tripped = kb._record_task_failure(
+            conn,
+            task_id,
+            error="stale crash detector",
+            outcome="crashed",
+            release_claim=False,
+            end_run=False,
+            failure_limit=failure_limit,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert tripped is False
+        assert task.status == "done"
+        assert task.consecutive_failures == 0
+        assert task.last_failure_error is None
+        assert len(kb.list_events(conn, task_id)) == events_before
+
+
 def test_recompute_ready_skips_tasks_at_failure_limit(kanban_home):
     """recompute_ready must not auto-recover tasks whose consecutive_failures
     has reached the circuit-breaker limit (#35072).


### PR DESCRIPTION
## Summary

Crash and timeout detection deliberately release their transaction before calling `_record_task_failure()`. Another writer can complete or block the task in that window. The failure recorder previously trusted the stale detection result: below the breaker threshold it stamped `consecutive_failures` and `last_failure_error` on terminal tasks; at the threshold it could emit a false `gave_up` event and report the task auto-blocked even though the guarded status update did nothing.

Failure accounting now proceeds only while the task is still dispatchable (`ready` or `running`). A concurrent lifecycle transition wins cleanly without stale counters or events.

The regression covers both below-threshold and breaker-trip races against a completed task.

## Tests

- `python -m pytest -q tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_diagnostics.py`
- 452 passed, 1 skipped
- `git diff --check`