### PR TITLE
feat(hindsight): add enable_retain_tool config to gate hindsight_retain exposure

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -683,6 +683,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # Retain controls
         self._auto_retain = True
+        self._enable_retain_tool = True  # expose hindsight_retain to the agent
         self._retain_every_n_turns = 1
         self._retain_async = True
         self._retain_context = "conversation between Hermes Agent and the User"
@@ -998,6 +999,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_types", "description": "Fact types to surface on recall — applies to both auto-recall and the hindsight_recall tool (comma-separated or list). Defaults to observation-only — observations are Hindsight's consolidated, deduplicated, evidence-grounded knowledge layer; raw world/experience facts are the supporting evidence observations already summarize. Set to e.g. 'observation,world,experience' to also include raw facts.", "default": "observation"},
             {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
             {"key": "auto_retain", "description": "Automatically retain conversation turns", "default": True},
+            {"key": "enable_retain_tool", "description": "Expose hindsight_retain as an agent-callable tool. When disabled, auto_retain continues to work internally but the model cannot manually write memories — preventing accidental overwrite of session documents (retain is a full-overwrite, not an append). Disable this if you rely only on automatic memory and want to eliminate the risk of destructive manual writes.", "default": True},
             {"key": "retain_every_n_turns", "description": "Retain every N turns (1 = every turn)", "default": 1},
             {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
@@ -1332,6 +1334,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # Retain controls
         self._auto_retain = self._config.get("auto_retain", True)
+        self._enable_retain_tool = self._config.get("enable_retain_tool", True)
         self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 1)))
         self._retain_context = self._config.get("retain_context", "conversation between Hermes Agent and the User")
 
@@ -1698,7 +1701,10 @@ class HindsightMemoryProvider(MemoryProvider):
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
             return []
-        return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA]
+        tools = [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA]
+        if not getattr(self, "_enable_retain_tool", True):
+            tools = [s for s in tools if s["name"] != "hindsight_retain"]
+        return tools
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if tool_name == "hindsight_retain":


### PR DESCRIPTION
## Summary

Add `enable_retain_tool` config option to the Hindsight memory plugin, giving users control over whether the `hindsight_retain` tool is exposed to the agent.

Follow-up to #55819 (closed as `implemented_on_main`), which identified the destructive risk of `hindsight_retain` but was resolved upstream by isolating background review forks (`skip_memory=True`).  That fix prevents background review from calling memory tools, but the main conversation agent still has access to `hindsight_retain` — and if the model calls it without understanding the tool's semantics, it will **overwrite the entire session document**, silently destroying all auto-retained memories.

## Problem

`hindsight_retain` is a **full-overwrite operation**, not an incremental append.  When the agent calls it:

1. The existing session document in Hindsight is **completely replaced** with whatever content the model provides.
2. All previous auto-retained turns are **irretrievably lost**.
3. The tool description (`RETAIN_SCHEMA`) reads "Store important information" — it does NOT disclose the destructive nature.

Most users rely on `auto_retain` + `auto_recall` for memory — these work internally without the model ever touching the `hindsight_retain` tool.  Exposing a destructive manual write tool to the agent is an **unnecessary risk vector** for those users.

## Changes

Single file: `plugins/memory/hindsight/__init__.py` (+7 / −1 lines)

1. **Schema** — new config key `enable_retain_tool` (default: `true`, backward-compatible)
2. **Config parsing** — reads `enable_retain_tool` from config, falling back to `True`
3. **`get_tool_schemas()`** — filters out `hindsight_retain` when `enable_retain_tool` is `false`

Config in `hindsight/config.json`:

```json
{
  "enable_retain_tool": false
}
```

When disabled:
- The agent **cannot see or call** `hindsight_retain` — it's removed from the tool list
- `auto_retain` continues to work internally and is completely unaffected
- `hindsight_recall` and `hindsight_reflect` (read-only tools) remain exposed

## Why this matters

Background review isolation (#27190) is a good fix for one call path, but it doesn't address the broader risk: any agent turn can invoke `hindsight_retain`.  This PR gives users a simple config toggle to eliminate that risk entirely, without sacrificing the automatic memory functionality they already rely on.