### PR TITLE
fix(desktop): relay CLI --profile to Electron backend via HERMES_DESKTOP_PROFILE (#66397)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6796,7 +6796,7 @@ async function startHermes() {
     // resolves HERMES_HOME the same way `hermes -p <name>` does on the CLI. An
     // unset preference keeps the legacy launch so existing installs are
     // unaffected.
-    const activeProfile = readActiveDesktopProfile()
+    const activeProfile = readActiveDesktopProfile() || process.env.HERMES_DESKTOP_PROFILE || null
 
     if (activeProfile) {
       backendArgs.unshift('--profile', activeProfile)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5666,6 +5666,15 @@ def cmd_gui(args: argparse.Namespace):
 
     # with_hermes_node_path() copies os.environ when called with no arg.
     env = with_hermes_node_path()
+    # If HERMES_HOME was pinned to a profile directory (via -p / --profile),
+    # relay the profile name to the Electron app so startHermes() can pass
+    # `--profile <name>` when spawning the backend (the desktop's own
+    # active-profile.json is not written by the CLI invocation).
+    _gui_hermes_home = os.environ.get("HERMES_HOME", "")
+    if _gui_hermes_home:
+        _gui_home_path = Path(_gui_hermes_home)
+        if _gui_home_path.parent.name == "profiles":
+            env["HERMES_DESKTOP_PROFILE"] = _gui_home_path.name
     if getattr(args, "fake_boot", False):
         env["HERMES_DESKTOP_BOOT_FAKE"] = "1"
     if getattr(args, "ignore_existing", False):


### PR DESCRIPTION
## Problem

`hermes -p <profile> desktop` always launches the desktop app with the default profile, ignoring the user-specified profile. The `-p` flag is correctly intercepted by `_apply_profile_override()` which sets `HERMES_HOME` to the profile directory, but the Electron app's backend spawn reads its `active-profile.json` (which is never written by the CLI invocation) and omits the `--profile` flag from the backend args.

## Fix

1. **Python side** (`cmd_gui` in `hermes_cli/main.py`): Detect when `HERMES_HOME` points into a `profiles/` directory (set by `-p` / `--profile`) and relay the profile name to the Electron app via a new `HERMES_DESKTOP_PROFILE` env var.

2. **Electron side** (`startHermes()` in `apps/desktop/electron/main.ts`): Fall back to `process.env.HERMES_DESKTOP_PROFILE` when `readActiveDesktopProfile()` returns null, so the CLI-provided profile is used for the backend spawn.

This is a minimal change — the existing profile-persistence path (`active-profile.json`) is unchanged and still takes precedence for in-app profile switching.