### PR TITLE
fix(model): check auth.json credential pool when wizard probes for existing key (#65977)

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2628,6 +2628,25 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         if existing_key:
             break
 
+    # Fallback: check credential pool (auth.json) — a key added via
+    # `hermes auth` is invisible to get_env_value/os.getenv but is live
+    # and working (see #65977).  Same fallback pattern as resolve_provider
+    # in hermes_cli/auth.py.
+    if not existing_key:
+        try:
+            from agent.credential_pool import load_pool as _load_pool
+            _pool = _load_pool(provider_id)
+            if _pool and _pool.has_credentials():
+                _entry = _pool.peek()
+                if _entry:
+                    existing_key = (
+                        getattr(_entry, "access_token", "")
+                        or getattr(_entry, "runtime_api_key", "")
+                        or ""
+                    )
+        except Exception:
+            pass
+
     existing_key, abort = _prompt_api_key(
         pconfig, existing_key, provider_id=provider_id
     )


### PR DESCRIPTION
## Problem

`hermes model` wizard only checks `.env` and shell environment variables to decide if a provider has a configured API key. Providers whose key was added via `hermes auth` (which stores it in `auth.json`'s `credential_pool`) appear as "No X API key configured" and the wizard prompts for a new key, even though the existing key works fine.

## Fix

In `_model_flow_api_key_provider`, after the existing env-var loop, add a fallback check of the credential pool via `agent.credential_pool.load_pool()` — the same pattern `resolve_provider()` in `hermes_cli/auth.py` already uses.

This ensures `hermes model` recognizes keys stored in `auth.json` via `hermes auth add`, matching the runtime behaviour where those keys are fully functional.