### PR TITLE
fix: fallback to active profile name when profile not provided in model set (#66406)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5851,7 +5851,14 @@ async def set_model_assignment(body: ModelAssignment, profile: Optional[str] = N
                 }
 
         def _apply_assignment():
-            with _profile_scope(body.profile or profile):
+            effective_profile = body.profile or profile
+            if not effective_profile:
+                try:
+                    from hermes_cli.profiles import get_active_profile_name
+                    effective_profile = get_active_profile_name()
+                except Exception:
+                    effective_profile = None
+            with _profile_scope(effective_profile):
                 return _apply_model_assignment_sync(
                     scope, provider, model, task, base_url, api_key
                 )


### PR DESCRIPTION
**Bug:** Dashboard with `--open-profile <name>` could write model changes to the default profile's config when the profile parameter wasn't propagated to `POST /api/model/set`.

**Fix:** Added fallback in `set_model_assignment()` that calls `get_active_profile_name()` when both `body.profile` and the query param `profile` are None/empty.

Closes #66406