### PR TITLE
fix(agent): load root SOUL.md when profile home has only the seeded default (#66396)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from pathlib import Path
 
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
-from typing import Optional
+from typing import List, Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.skill_utils import (
@@ -1830,12 +1830,62 @@ def _truncate_content(
     return head + marker + tail
 
 
+def _soul_md_candidates() -> List[Path]:
+    """Ordered SOUL.md dirs to try: active HERMES_HOME, then the profile root.
+
+    The active home wins so a genuinely-customized per-profile persona stays
+    authoritative. When the active home is a *profile* (``<root>/profiles/
+    <name>``) whose SOUL.md is only the auto-seeded default (see
+    :func:`_soul_is_uncustomized`), fall back to the root ``SOUL.md`` — the
+    persona the user configured at ``~/.hermes/SOUL.md`` and confirmed with
+    ``hermes doctor``. Without this a gateway whose systemd unit pins
+    ``HERMES_HOME=<root>/profiles/<name>`` silently serves the hardcoded
+    default identity even though the root SOUL.md exists (#66396):
+    ``ensure_hermes_home()`` seeds ``DEFAULT_SOUL_MD`` into the profile home,
+    which then shadows the root persona.
+
+    The fallback is scoped to profile homes only: for a Docker/custom
+    deployment ``get_default_hermes_root()`` equals ``get_hermes_home()`` so no
+    second candidate is added, and a bare ``/opt/data`` home never borrows an
+    unrelated ``~/.hermes/SOUL.md``.
+    """
+    candidates = [get_hermes_home()]
+    try:
+        from hermes_constants import get_default_hermes_root
+        root = get_default_hermes_root()
+        if root.resolve() != candidates[0].resolve():
+            candidates.append(root)
+    except Exception as e:
+        logger.debug("Could not resolve profile root for SOUL.md fallback: %s", e)
+    return candidates
+
+
+def _soul_is_uncustomized(content: str) -> bool:
+    """True when SOUL.md content carries zero user intent.
+
+    Matches the runtime default (``DEFAULT_SOUL_MD``, auto-seeded by
+    ``ensure_hermes_home()``) or a legacy comment-only scaffold. Such content
+    is safe to skip in favour of a root persona because the user demonstrably
+    never customized it — the same safety guarantee ``is_legacy_template_soul``
+    relies on.
+    """
+    try:
+        from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul
+    except Exception:
+        return False
+    return content.strip() == DEFAULT_SOUL_MD.strip() or is_legacy_template_soul(content)
+
+
 def load_soul_md(context_length: Optional[int] = None) -> Optional[str]:
-    """Load SOUL.md from HERMES_HOME and return its content, or None.
+    """Load SOUL.md and return its content, or None.
 
     Used as the agent identity (slot #1 in the system prompt).  When this
     returns content, ``build_context_files_prompt`` should be called with
     ``skip_soul=True`` so SOUL.md isn't injected twice.
+
+    Reads from the active HERMES_HOME, falling back to the profile root's
+    SOUL.md when the active home is a profile whose SOUL.md is only the
+    auto-seeded default (see :func:`_soul_md_candidates`).
     """
     try:
         from hermes_cli.config import ensure_hermes_home
@@ -1843,22 +1893,41 @@ def load_soul_md(context_length: Optional[int] = None) -> Optional[str]:
     except Exception as e:
         logger.debug("Could not ensure HERMES_HOME before loading SOUL.md: %s", e)
 
-    soul_path = get_hermes_home() / "SOUL.md"
-    if not soul_path.exists():
-        return None
-    try:
-        content = soul_path.read_text(encoding="utf-8").strip()
+    # First readable persona, even if it is only the seeded default — used as
+    # the fallback when no candidate is customized (preserves prior behavior).
+    default_hit: Optional[str] = None
+    for soul_dir in _soul_md_candidates():
+        soul_path = soul_dir / "SOUL.md"
+        if not soul_path.exists():
+            continue
+        try:
+            content = soul_path.read_text(encoding="utf-8").strip()
+        except Exception as e:
+            logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
+            continue
         if not content:
-            return None
-        content = _scan_context_content(content, "SOUL.md")
-        content = _truncate_content(
-            content, "SOUL.md", context_length=context_length,
-            read_path=str(soul_path),
-        )
-        return content
-    except Exception as e:
-        logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
-        return None
+            continue
+        if _soul_is_uncustomized(content):
+            # Keep looking for a customized persona (e.g. the root SOUL.md a
+            # profile-home gateway would otherwise shadow); remember this as a
+            # fallback if none is found.
+            if default_hit is None:
+                default_hit = content
+            continue
+        return _finalize_soul(content, soul_path, context_length)
+
+    if default_hit is not None:
+        return _finalize_soul(default_hit, get_hermes_home() / "SOUL.md", context_length)
+    return None
+
+
+def _finalize_soul(content: str, read_path: Path, context_length: Optional[int]) -> str:
+    """Scan + truncate SOUL.md content for injection/size before use."""
+    content = _scan_context_content(content, "SOUL.md")
+    return _truncate_content(
+        content, "SOUL.md", context_length=context_length,
+        read_path=str(read_path),
+    )
 
 
 def _load_hermes_md(cwd_path: Path, context_length: Optional[int] = None) -> str:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1188,10 +1188,22 @@ def run_doctor(args):
         content = soul_path.read_text(encoding="utf-8").strip()
         # Check if it's just the template comments (no real content)
         lines = [l for l in content.splitlines() if l.strip() and not l.strip().startswith(("<!--", "-->", "#"))]
-        if lines:
-            check_ok(f"{_DHH}/SOUL.md exists (persona configured)")
-        else:
+        # A SOUL.md that still holds the auto-seeded DEFAULT_SOUL_MD (or a legacy
+        # comment-only scaffold) is NOT a configured persona — reporting it as
+        # one gives false confidence that a custom identity is active when the
+        # runtime is really serving the hardcoded default (#66396). Detect it
+        # with the same helper the prompt builder uses so doctor and runtime agree.
+        try:
+            from agent.prompt_builder import _soul_is_uncustomized
+            uncustomized = _soul_is_uncustomized(content)
+        except Exception:
+            uncustomized = False
+        if not lines:
             check_info(f"{_DHH}/SOUL.md exists but is empty — edit it to customize personality")
+        elif uncustomized:
+            check_info(f"{_DHH}/SOUL.md exists but is the default persona — edit it to customize personality")
+        else:
+            check_ok(f"{_DHH}/SOUL.md exists (persona configured)")
     else:
         check_warn(f"{_DHH}/SOUL.md not found", "(create it to give Hermes a custom personality)")
         if should_fix:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -18,6 +18,8 @@ from agent.prompt_builder import (
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
+    load_soul_md,
+    _soul_is_uncustomized,
     CONTEXT_FILE_MAX_CHARS,
     _dynamic_context_file_max_chars,
     _get_context_file_max_chars,
@@ -1684,6 +1686,106 @@ class TestParallelToolCallGuidance:
         # steer. The Google-only block must NOT carry its own copy, otherwise
         # Gemini/Gemma would receive the instruction twice in one prompt.
         assert "parallel tool call" not in GOOGLE_MODEL_OPERATIONAL_GUIDANCE.lower()
+
+
+# =========================================================================
+# SOUL.md loading — profile-home fallback (#66396)
+# =========================================================================
+
+
+class TestLoadSoulMdProfileFallback:
+    """A profile-home gateway must not shadow the root persona with the
+    auto-seeded default SOUL.md (#66396)."""
+
+    def _profile_layout(self, tmp_path, monkeypatch, root_soul, profile_soul):
+        """Wire a <root>/profiles/jarvis layout and point HERMES_HOME at it."""
+        import hermes_constants
+
+        root = tmp_path / "hermes_root"
+        root.mkdir()
+        monkeypatch.setattr(
+            hermes_constants, "_get_platform_default_hermes_home", lambda: root
+        )
+        if root_soul is not None:
+            (root / "SOUL.md").write_text(root_soul, encoding="utf-8")
+        profile = root / "profiles" / "jarvis"
+        profile.mkdir(parents=True)
+        if profile_soul is not None:
+            (profile / "SOUL.md").write_text(profile_soul, encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        return root, profile
+
+    def test_seeded_default_profile_falls_back_to_root_persona(self, tmp_path, monkeypatch):
+        from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+        self._profile_layout(
+            tmp_path, monkeypatch,
+            root_soul="# Putri\n\nSaya Putri, asisten pribadi.",
+            profile_soul=DEFAULT_SOUL_MD,
+        )
+        result = load_soul_md()
+        assert "Putri" in result
+        assert result != DEFAULT_SOUL_MD
+
+    def test_customized_profile_persona_wins_over_root(self, tmp_path, monkeypatch):
+        self._profile_layout(
+            tmp_path, monkeypatch,
+            root_soul="# Root persona",
+            profile_soul="# Jarvis, the profile persona",
+        )
+        result = load_soul_md()
+        assert "Jarvis" in result
+        assert "Root persona" not in result
+
+    def test_missing_profile_soul_falls_back_to_root(self, tmp_path, monkeypatch):
+        self._profile_layout(
+            tmp_path, monkeypatch,
+            root_soul="# Root persona lives here",
+            profile_soul=None,
+        )
+        # ensure_hermes_home seeds the profile with DEFAULT_SOUL_MD, which the
+        # loader then treats as uncustomized and skips.
+        result = load_soul_md()
+        assert "Root persona lives here" in result
+
+    def test_both_default_returns_default(self, tmp_path, monkeypatch):
+        from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+        self._profile_layout(
+            tmp_path, monkeypatch,
+            root_soul=DEFAULT_SOUL_MD,
+            profile_soul=DEFAULT_SOUL_MD,
+        )
+        assert load_soul_md() == DEFAULT_SOUL_MD
+
+    def test_custom_default_home_not_overridden(self, tmp_path, monkeypatch):
+        # A non-profile custom home (HERMES_HOME == root, e.g. Docker /opt/data)
+        # must load its own SOUL.md with no second candidate.
+        import hermes_constants
+
+        home = tmp_path / "opt_data"
+        home.mkdir()
+        monkeypatch.setattr(
+            hermes_constants, "_get_platform_default_hermes_home", lambda: home
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "SOUL.md").write_text("# Custom home persona", encoding="utf-8")
+        assert "Custom home persona" in load_soul_md()
+
+
+class TestSoulIsUncustomized:
+    def test_default_soul_is_uncustomized(self):
+        from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+        assert _soul_is_uncustomized(DEFAULT_SOUL_MD) is True
+
+    def test_legacy_scaffold_is_uncustomized(self):
+        from hermes_cli.default_soul import _LEGACY_TEMPLATE_SOULS
+
+        assert _soul_is_uncustomized(_LEGACY_TEMPLATE_SOULS[0]) is True
+
+    def test_real_persona_is_customized(self):
+        assert _soul_is_uncustomized("# Putri\n\nSaya Putri.") is False
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Fixes SOUL.md being ignored by the Telegram (and any) gateway when the gateway
runs under a **profile** HERMES_HOME.

Root cause: a gateway whose systemd unit pins `HERMES_HOME=<root>/profiles/<name>`
served the hardcoded default identity even though the user configured a persona
at `~/.hermes/SOUL.md` and `hermes doctor` confirmed it. On startup
`ensure_hermes_home()` auto-seeds `DEFAULT_SOUL_MD` into the *profile* home, and
`load_soul_md()` then returned that seeded default from prompt slot #1 — shadowing
the user's root persona. `hermes doctor`, meanwhile, ran under the default home,
checked `~/.hermes/SOUL.md`, and reported "persona configured", so nothing in the
UX revealed the mismatch (the reporter's "silent failure" hypothesis).

`load_soul_md()` now treats an **uncustomized** SOUL.md — content matching
`DEFAULT_SOUL_MD` or a legacy comment-only scaffold, i.e. carrying zero user
intent — as "not configured" and falls back to the profile root's `SOUL.md`. A
genuinely customized profile persona still wins. A Docker/custom home
(`HERMES_HOME == get_default_hermes_root()`) adds no second candidate and never
borrows an unrelated `~/.hermes/SOUL.md`.

`hermes doctor` now reports a still-default SOUL.md as *"the default persona"*
rather than *"persona configured"*, using the same detection helper, so runtime
and doctor agree and users get accurate feedback.

## Related Issue

Fixes #66396

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`:
  - `load_soul_md()` now iterates candidate homes (active HERMES_HOME → profile
    root) and skips an auto-seeded/legacy default in favour of a customized
    persona, falling back to the default only when no candidate is customized.
  - New helpers `_soul_md_candidates()`, `_soul_is_uncustomized()`, `_finalize_soul()`.
- `hermes_cli/doctor.py`: SOUL.md check reports an uncustomized default honestly
  instead of "persona configured".
- `tests/agent/test_prompt_builder.py`: `TestLoadSoulMdProfileFallback` (profile
  shadowing, customized-profile-wins, missing-profile-soul, both-default,
  custom-home-no-override) and `TestSoulIsUncustomized`.

## How to Test

```
scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/hermes_cli/test_doctor.py -q
```
Result locally: **179 passed, 1 skipped** (prompt_builder + system_prompt);
affected-test gate green via the contributor preflight (windows-footguns, ruff,
tests all PASS).

Manual reproduction:
1. `hermes profile create jarvis`; install/run the gateway pinned to that profile
   (`HERMES_HOME=~/.hermes/profiles/jarvis`).
2. Put a custom persona in `~/.hermes/SOUL.md` (root). `hermes doctor` shows it.
3. Before: gateway replies with the default Hermes identity. After: gateway loads
   the root persona (profile SOUL.md is only the auto-seeded default).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact — resolution logic is path-based and
      reuses existing `get_default_hermes_root()` (handles Windows/Docker layouts)
- [x] N/A — no tool behavior changed
