### PR TITLE
fix: resolve git binary path in hermes update (#66416)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8710,6 +8710,24 @@ def _resolve_git_cmd() -> list[str]:
             "/opt/homebrew/bin/git",  # Apple Silicon Homebrew
             "/usr/local/opt/git/bin/git",  # Intel Homebrew (legacy cellar)
         ]
+
+        # Windows Git-for-Windows fallback paths (same pattern as plugins_cmd._resolve_git_executable)
+        if sys.platform == "win32":
+            _prog = _os.environ.get("ProgramFiles", r"C:\Program Files")
+            _prog_x86 = _os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+            _local = _os.environ.get("LOCALAPPDATA", "")
+            _common_locations.extend([
+                _os.path.join(_prog, "Git", "cmd", "git.exe"),
+                _os.path.join(_prog, "Git", "bin", "git.exe"),
+                _os.path.join(_prog_x86, "Git", "cmd", "git.exe"),
+                _os.path.join(_prog_x86, "Git", "bin", "git.exe"),
+            ])
+            if _local:
+                _common_locations.extend([
+                    _os.path.join(_local, "Programs", "Git", "cmd", "git.exe"),
+                    _os.path.join(_local, "Programs", "Git", "bin", "git.exe"),
+                ])
+
         for candidate in _common_locations:
             if _os.path.isfile(candidate) and _os.access(candidate, _os.X_OK):
                 git_path = candidate

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8672,6 +8672,67 @@ def _finalize_update_output(state):
             pass
 
 
+def _resolve_git_cmd() -> list[str]:
+    """Resolve the git binary and return a ready-to-use command list.
+
+    Uses ``shutil.which("git")`` to find git on PATH first.  If that fails,
+    falls back to common install locations (``/usr/bin/git``,
+    ``/usr/local/bin/git``, ``~/.local/bin/git``) so the update path works
+    even when git is not on the default PATH (e.g. Homebrew on macOS,
+    custom PATH environments).
+
+    On Windows, appends ``-c windows.appendAtomically=false`` as a
+    workaround for filesystem atomicity issues.
+
+    Returns
+    -------
+    list[str]
+        A command list suitable for ``subprocess.run``, e.g. ``["/usr/bin/git"]``
+        or ``["/usr/bin/git", "-c", "windows.appendAtomically=false"]``.
+
+    Raises
+    ------
+    SystemExit
+        If git cannot be resolved at all.  Prints a helpful diagnostic
+        message before exiting.
+    """
+    import shutil
+
+    git_path = shutil.which("git")
+    if not git_path:
+        # Fall back to common locations not always on PATH
+        import os as _os
+
+        _common_locations = [
+            "/usr/bin/git",
+            "/usr/local/bin/git",
+            _os.path.expanduser("~/.local/bin/git"),
+            "/opt/homebrew/bin/git",  # Apple Silicon Homebrew
+            "/usr/local/opt/git/bin/git",  # Intel Homebrew (legacy cellar)
+        ]
+        for candidate in _common_locations:
+            if _os.path.isfile(candidate) and _os.access(candidate, _os.X_OK):
+                git_path = candidate
+                break
+
+    if not git_path:
+        print(
+            "✗ Git is required for hermes update, but no git executable was found.\n"
+            "  Install git:\n"
+            "    • macOS:  brew install git\n"
+            "    • Debian: sudo apt install git\n"
+            "    • Fedora: sudo dnf install git\n"
+            "    • Windows: https://git-scm.com/download/win\n"
+            "  Or add git to your PATH and try again."
+        )
+        sys.exit(1)
+
+    cmd = [git_path]
+    if sys.platform == "win32":
+        cmd.extend(["-c", "windows.appendAtomically=false"])
+    return cmd
+
+
 def _resolve_update_branch(args) -> str:
     """Normalize ``args.branch`` into a non-empty branch name.
 
@@ -8732,9 +8793,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         print("✗ Not a git repository — cannot check for updates.")
         sys.exit(1)
 
-    git_cmd = ["git"]
-    if sys.platform == "win32":
-        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+    git_cmd = _resolve_git_cmd()
 
     # Fetch only the branch we compare against; prefer upstream as the canonical
     # reference. A bare `git fetch <remote>` pulls every ref, and this repo has
@@ -9873,9 +9932,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # On Windows, git can fail with "unable to write loose object file: Invalid argument"
     # due to filesystem atomicity issues. Set the recommended workaround.
     if sys.platform == "win32" and git_dir.exists():
+        _win_git_cmd = _resolve_git_cmd()
         subprocess.run(
-            [
-                "git",
+            _win_git_cmd
+            + [
                 "-c",
                 "windows.appendAtomically=false",
                 "config",
@@ -9888,9 +9948,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         )
 
     # Build git command once — reused for fork detection and the update itself.
-    git_cmd = ["git"]
-    if sys.platform == "win32":
-        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+    git_cmd = _resolve_git_cmd()
 
     # Discard npm lockfile churn before any stash/branch logic. npm rewrites
     # tracked package-lock.json files non-deterministically at install/build

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -410,8 +410,9 @@ class TestCmdUpdateBranchFallback:
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
+    @patch("hermes_cli.main._resolve_git_cmd", return_value=["git"])
     def test_update_on_fork_checks_upstream_when_origin_up_to_date(
-        self, mock_run, _mock_which, mock_args, capsys
+        self, mock_resolve_git, mock_run, _mock_which, mock_args, capsys
     ):
         """Regression for issue #26172: forks whose local HEAD already matches
         origin/main must still consult upstream/main before printing

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -399,6 +399,7 @@ def _setup_update_mocks(monkeypatch, tmp_path):
 def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypatch, tmp_path, capsys):
     """When .[all] fails, update should keep base deps and retry extras individually."""
     _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_resolve_git_cmd", lambda: ["git"])
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
     monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
     monkeypatch.setattr(hermes_main, "_load_installable_optional_extras", lambda group="all": ["matrix", "mcp"])
@@ -449,6 +450,7 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
 def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     """When .[all] succeeds, no fallback should be attempted."""
     _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_resolve_git_cmd", lambda: ["git"])
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
     monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
 
@@ -571,6 +573,7 @@ def _make_update_side_effect(
 def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path, capsys):
     """When --ff-only fails (diverged history), update resets to origin/{branch}."""
     _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_resolve_git_cmd", lambda: ["git"])
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
     side_effect, recorded = _make_update_side_effect(ff_only_fails=True)
@@ -692,6 +695,7 @@ def test_cmd_update_fetch_is_scoped_to_target_branch(monkeypatch, tmp_path):
     pulls every ref, and this repo has thousands of auto-generated branches, so
     an unscoped fetch can stall for minutes on a non-single-branch checkout."""
     _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_resolve_git_cmd", lambda: ["git"])
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
     side_effect, recorded = _make_update_side_effect()


### PR DESCRIPTION
## Summary

`hermes update` calls `"git"` as a bare command, which fails when git is not on the default PATH (e.g., Homebrew on macOS, custom PATH environments). This PR replaces all bare `["git"]` references in the update code with `_resolve_git_cmd()`, a new helper that:

1. Uses `shutil.which("git")` to find git on PATH (the primary mechanism)
2. Falls back to common install locations when `which` fails:
   - `/usr/bin/git`
   - `/usr/local/bin/git`
   - `~/.local/bin/git`
   - `/opt/homebrew/bin/git` (Apple Silicon Homebrew)
   - `/usr/local/opt/git/bin/git` (Intel Homebrew legacy cellar)
3. Prints a helpful error with platform-specific install instructions if git is not found anywhere

## Changes

- **`hermes_cli/main.py`**: Added `_resolve_git_cmd()` helper function
- **`_cmd_update_check`**: Replaced `git_cmd = ["git"]` with `git_cmd = _resolve_git_cmd()`
- **`_cmd_update_impl`**: Replaced both `git_cmd = ["git"]` and the Windows `subprocess.run(["git", ...])` config fixup with resolved paths
- Windows `-c windows.appendAtomically=false` handling is preserved inside `_resolve_git_cmd()`

Closes #66416