### PR TITLE
fix(honcho): timeout staleness check must resolve from the same sources as the build path

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -860,6 +860,8 @@ _cached_timeout: float | None = None
 # the staleness check on every get_honcho_client() call costs one stat()
 # instead of a full YAML load. (None, None) = not yet populated.
 _config_timeout_memo: tuple[int | None, float | None] = (None, None)
+# Same memoization for the honcho.json-derived timeout; mtime -1 = file absent.
+_honcho_json_timeout_memo: tuple[int | None, float | None] = (None, None)
 
 
 def _config_yaml_timeout() -> float | None:
@@ -891,11 +893,50 @@ def _config_yaml_timeout() -> float | None:
         return None
 
 
+def _honcho_json_timeout() -> float | None:
+    """Read timeout/requestTimeout from honcho.json (host block wins), memoized on mtime."""
+    global _honcho_json_timeout_memo
+    try:
+        path = resolve_config_path()
+        try:
+            mtime_ns: int = path.stat().st_mtime_ns
+        except OSError:
+            mtime_ns = -1
+        if _honcho_json_timeout_memo[0] == mtime_ns:
+            return _honcho_json_timeout_memo[1]
+
+        timeout = None
+        if mtime_ns != -1:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            host_block = _host_block(raw, resolve_active_host())
+            timeout = _resolve_optional_float(
+                host_block.get("timeout"),
+                host_block.get("requestTimeout"),
+                raw.get("timeout"),
+                raw.get("requestTimeout"),
+            )
+        _honcho_json_timeout_memo = (mtime_ns, timeout)
+        return timeout
+    except Exception:
+        return None
+
+
 def _resolve_timeout_from_sources(config: HonchoClientConfig | None) -> float:
-    """Resolve the effective timeout from env, config.yaml, and the explicit config."""
-    timeout = config.timeout if config is not None else None
-    if timeout is None:
-        timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
+    """Mirror the build path's timeout resolution so the staleness check agrees with it.
+
+    With an explicit config this matches ``_build`` (config.timeout, then
+    config.yaml, then default).  With no config it matches what
+    ``from_global_config`` + ``_build`` would produce: honcho.json host
+    block/root keys, then HONCHO_TIMEOUT, then config.yaml, then default.
+    Any source skew here makes the check disagree with the built client
+    forever and rebuild it on every call.
+    """
+    if config is not None:
+        timeout = config.timeout
+    else:
+        timeout = _honcho_json_timeout()
+        if timeout is None:
+            timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
     if timeout is None:
         timeout = _config_yaml_timeout()
     return timeout if timeout is not None else _DEFAULT_HTTP_TIMEOUT
@@ -1077,7 +1118,8 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
 
 def reset_honcho_client() -> None:
     """Reset the Honcho client singleton (useful for testing)."""
-    global _cached_timeout, _config_timeout_memo
+    global _cached_timeout, _config_timeout_memo, _honcho_json_timeout_memo
     _honcho_client_slot.reset()
     _cached_timeout = None
     _config_timeout_memo = (None, None)
+    _honcho_json_timeout_memo = (None, None)

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -856,39 +856,27 @@ class HonchoClientConfig:
 
 _honcho_client_slot: SingletonSlot = SingletonSlot()
 _cached_timeout: float | None = None
-# Memo for the config.yaml-derived timeout, keyed on the file's mtime_ns so
+# Memo for the honcho.json-derived timeout, keyed on the file's mtime_ns so
 # the staleness check on every get_honcho_client() call costs one stat()
-# instead of a full YAML load. (None, None) = not yet populated.
-_config_timeout_memo: tuple[int | None, float | None] = (None, None)
-# Same memoization for the honcho.json-derived timeout; mtime -1 = file absent.
+# instead of a JSON parse. mtime -1 = file absent; (None, None) = not yet
+# populated. config.yaml needs no such memo: load_config_readonly() is
+# internally cached on both the user and managed files' signatures, and a
+# bespoke key here would have to duplicate that invalidation logic.
 _honcho_json_timeout_memo: tuple[int | None, float | None] = (None, None)
 
 
 def _config_yaml_timeout() -> float | None:
-    """Read honcho.timeout / honcho.request_timeout from config.yaml, memoized on mtime."""
-    global _config_timeout_memo
+    """Read honcho.timeout / honcho.request_timeout via the cached config loader."""
     try:
-        from hermes_constants import get_hermes_home
+        from hermes_cli.config import load_config_readonly
 
-        cfg_path = get_hermes_home() / "config.yaml"
-        try:
-            mtime_ns: int | None = cfg_path.stat().st_mtime_ns
-        except OSError:
-            mtime_ns = None
-        if _config_timeout_memo[0] is not None and _config_timeout_memo[0] == mtime_ns:
-            return _config_timeout_memo[1]
-
-        from hermes_cli.config import load_config
-
-        honcho_cfg = load_config().get("honcho", {})
-        timeout = None
+        honcho_cfg = load_config_readonly().get("honcho", {})
         if isinstance(honcho_cfg, dict):
-            timeout = _resolve_optional_float(
+            return _resolve_optional_float(
                 honcho_cfg.get("timeout"),
                 honcho_cfg.get("request_timeout"),
             )
-        _config_timeout_memo = (mtime_ns, timeout)
-        return timeout
+        return None
     except Exception:
         return None
 
@@ -1118,8 +1106,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
 
 def reset_honcho_client() -> None:
     """Reset the Honcho client singleton (useful for testing)."""
-    global _cached_timeout, _config_timeout_memo, _honcho_json_timeout_memo
+    global _cached_timeout, _honcho_json_timeout_memo
     _honcho_client_slot.reset()
     _cached_timeout = None
-    _config_timeout_memo = (None, None)
     _honcho_json_timeout_memo = (None, None)

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -773,6 +773,57 @@ class TestGetHonchoClient:
         mock_h3.assert_called_once()
         assert mock_h3.call_args.kwargs["timeout"] == 300.0
 
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("honcho"),
+        reason="honcho SDK not installed"
+    )
+    def test_honcho_json_timeout_does_not_thrash_singleton(self, tmp_path):
+        """Regression: a timeout configured in honcho.json must not rebuild the
+        client on every no-config call. The staleness check used to resolve the
+        timeout without reading honcho.json, so it permanently disagreed with
+        the built client and reset the singleton on each access."""
+        config_file = tmp_path / "honcho.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "cloud-key",
+            "hosts": {"hermes": {"workspace": "ws", "requestTimeout": 120}},
+        }))
+
+        fake_honcho_1 = MagicMock(name="Honcho_v1")
+        fake_honcho_2 = MagicMock(name="Honcho_v2")
+
+        with patch("plugins.memory.honcho.client.resolve_config_path", return_value=config_file), \
+             patch("hermes_cli.profiles.get_active_profile_name", return_value="default"):
+            with patch("honcho.Honcho", return_value=fake_honcho_1) as mock_h1:
+                client1 = get_honcho_client()
+
+            assert client1 is fake_honcho_1
+            assert mock_h1.call_args.kwargs["timeout"] == 120.0
+
+            # Repeated no-config calls (the session manager hot path) must
+            # return the cached client, not rebuild.
+            with patch("honcho.Honcho", return_value=fake_honcho_2) as mock_h2:
+                client2 = get_honcho_client()
+                client3 = get_honcho_client()
+
+            assert client2 is fake_honcho_1
+            assert client3 is fake_honcho_1
+            mock_h2.assert_not_called()
+
+            # A real honcho.json timeout change is still detected.
+            config_file.write_text(json.dumps({
+                "apiKey": "cloud-key",
+                "hosts": {"hermes": {"workspace": "ws", "requestTimeout": 240}},
+            }))
+            st = config_file.stat()
+            os.utime(config_file, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+            with patch("honcho.Honcho", return_value=fake_honcho_2) as mock_h3:
+                client4 = get_honcho_client()
+
+            assert client4 is fake_honcho_2
+            mock_h3.assert_called_once()
+            assert mock_h3.call_args.kwargs["timeout"] == 240.0
+
 
 class TestResolveSessionNameGatewayKey:
     """Regression tests for gateway_session_key priority in resolve_session_name.

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -741,6 +741,11 @@ class TestGetHonchoClient:
     )
     def test_timeout_change_triggers_client_rebuild(self):
         """Changing timeout config must rebuild the cached client."""
+        from hermes_constants import get_hermes_home
+
+        cfg_yaml = get_hermes_home() / "config.yaml"
+        cfg_yaml.write_text("honcho:\n  timeout: 30\n")
+
         fake_honcho_1 = MagicMock(name="Honcho_v1")
         fake_honcho_2 = MagicMock(name="Honcho_v2")
         cfg = HonchoClientConfig(
@@ -749,29 +754,73 @@ class TestGetHonchoClient:
             environment="production",
         )
 
-        with patch("honcho.Honcho", return_value=fake_honcho_1) as mock_h1, \
-             patch("hermes_cli.config.load_config", return_value={"honcho": {"timeout": 30}}):
+        with patch("honcho.Honcho", return_value=fake_honcho_1) as mock_h1:
             client1 = get_honcho_client(cfg)
 
         assert client1 is fake_honcho_1
         assert mock_h1.call_args.kwargs["timeout"] == 30.0
 
         # Same config — should return cached client (no rebuild)
-        with patch("honcho.Honcho", return_value=fake_honcho_2) as mock_h2, \
-             patch("hermes_cli.config.load_config", return_value={"honcho": {"timeout": 30}}):
+        with patch("honcho.Honcho", return_value=fake_honcho_2) as mock_h2:
             client2 = get_honcho_client(cfg)
 
         assert client2 is fake_honcho_1  # still cached
         mock_h2.assert_not_called()
 
         # Changed timeout — must rebuild
-        with patch("honcho.Honcho", return_value=fake_honcho_2) as mock_h3, \
-             patch("hermes_cli.config.load_config", return_value={"honcho": {"timeout": 300}}):
+        cfg_yaml.write_text("honcho:\n  timeout: 300\n")
+        st = cfg_yaml.stat()
+        os.utime(cfg_yaml, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+        with patch("honcho.Honcho", return_value=fake_honcho_2) as mock_h3:
             client3 = get_honcho_client(cfg)
 
         assert client3 is fake_honcho_2  # rebuilt
         mock_h3.assert_called_once()
         assert mock_h3.call_args.kwargs["timeout"] == 300.0
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("honcho"),
+        reason="honcho SDK not installed"
+    )
+    def test_managed_config_timeout_does_not_thrash_singleton(self, tmp_path, monkeypatch):
+        """A managed-scope honcho.timeout with no user config.yaml must be seen
+        by the staleness check (stable reuse), and a managed edit must trigger
+        a rebuild. Regression for a memo that keyed only on the user file."""
+        managed_dir = tmp_path / "managed"
+        managed_dir.mkdir()
+        managed_cfg = managed_dir / "config.yaml"
+        managed_cfg.write_text("honcho:\n  timeout: 88\n")
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+
+        fake_honcho_1 = MagicMock(name="Honcho_v1")
+        fake_honcho_2 = MagicMock(name="Honcho_v2")
+        cfg = HonchoClientConfig(
+            api_key="test-key",
+            workspace_id="hermes",
+            environment="production",
+        )
+
+        with patch("honcho.Honcho", return_value=fake_honcho_1) as mock_h1:
+            client1 = get_honcho_client(cfg)
+            client2 = get_honcho_client(cfg)
+
+        assert client1 is fake_honcho_1
+        assert client2 is fake_honcho_1
+        assert mock_h1.call_count == 1
+        assert mock_h1.call_args.kwargs["timeout"] == 88.0
+
+        # A managed-timeout edit is detected (same-size write, so bump mtime).
+        managed_cfg.write_text("honcho:\n  timeout: 99\n")
+        st = managed_cfg.stat()
+        os.utime(managed_cfg, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+        with patch("honcho.Honcho", return_value=fake_honcho_2) as mock_h2:
+            client3 = get_honcho_client(cfg)
+
+        assert client3 is fake_honcho_2
+        mock_h2.assert_called_once()
+        assert mock_h2.call_args.kwargs["timeout"] == 99.0
 
     @pytest.mark.skipif(
         not importlib.util.find_spec("honcho"),


### PR DESCRIPTION
# Summary

Follow-up to #66052. The timeout staleness check added there resolves the timeout from different config sources than the build path does, and when the timeout is configured in `honcho.json` the two permanently disagree — which the check interprets as a config change on every call, tearing down and rebuilding the client singleton each time.

## The bug

- `_resolve_timeout_from_sources` checked: explicit config → `HONCHO_TIMEOUT` env → `config.yaml` → 30.0 default. It never read `honcho.json`.
- The build path (`from_global_config`) resolves the timeout from the `honcho.json` host block (`timeout`/`requestTimeout`) and root-level keys — a supported surface (`test_hermes_request_timeout_alias_used` asserts it).
- `HonchoSessionManager.honcho` calls `get_honcho_client()` with **no config on every property access**.

So with e.g. `"hosts": {"hermes": {"requestTimeout": 120}}`: the client is built with `_cached_timeout = 120`, the checker resolves 30.0, sees a "change", resets the singleton, and the rebuild lands back on 120 — forever. Every Honcho operation in a long-lived gateway pays a full client rebuild (config re-read, OAuth pre-refresh, new connection pool), which is exactly the hot path the mtime memo in #66052 was added to keep cheap.

## The fix

- `_resolve_timeout_from_sources` now mirrors the build path exactly: with an explicit config it matches `_build` (config → config.yaml → default); with no config it matches `from_global_config` + `_build` (honcho.json host block/root → env → config.yaml → default). The honcho.json read is memoized on the file's `st_mtime_ns` so the per-call cost stays one `stat()`. A genuine honcho.json timeout change is now also *detected*, extending #57437 to that config surface.
- The `config.yaml` read now goes through `load_config_readonly()` instead of a bespoke user-file-mtime memo. The bespoke memo keyed only on the user `config.yaml`, but `load_config()` merges the managed-scope config (`HERMES_MANAGED_DIR/config.yaml`, `/etc/hermes`) whose leaf keys win — so a managed `honcho.timeout` with no user file produced the same perpetual-rebuild mismatch, and a managed timeout edit was invisible while the user file's mtime stayed put. `load_config_readonly()` is already cached on both files' signatures plus the env-ref snapshot, and skips the defensive deepcopy the old memo existed to avoid — no invalidation logic to duplicate.

## Validation

| Check | Result |
|---|---|
| New regression test (`test_honcho_json_timeout_does_not_thrash_singleton`) fails on pre-fix client.py, passes with fix | verified both directions |
| New regression test (`test_managed_config_timeout_does_not_thrash_singleton`, real `HERMES_MANAGED_DIR`): stable reuse with managed-only timeout + rebuild on managed edit | verified both directions |
| `test_timeout_change_triggers_client_rebuild` rewritten to drive a real `config.yaml` (write → rewrite + mtime bump) instead of patching `load_config` | pass |
| `tests/honcho_plugin/` + `tests/test_honcho_client_config.py` + memory provider suites | 550/550 |
