### PR TITLE
fix(mcp): skip watchdog wrapping for launcher commands (uvx, npx, etc.) (#66423)

### DIFF
--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -120,18 +119,13 @@ def test_run_stdio_uses_resolved_command_and_prepended_path(tmp_path):
             server = MCPServerTask("srv")
             await server.start({"command": "npx", "args": ["-y", "pkg"], "env": {"PATH": "/usr/bin"}})
 
-            # The real (resolved) command no longer reaches StdioServerParameters
-            # directly -- it's now wrapped in the parent-death watchdog
-            # supervisor (tools/mcp_stdio_watchdog.py) so an ungraceful exit of
-            # this process can't orphan it. Assert the resolved npx path and
-            # its args still flow through correctly as the watchdog's target
-            # command, preserving this test's original path-resolution intent.
+            # npx is a launcher command (like uvx, bunx) — it manages its own
+            # child process lifecycle, so the parent-death watchdog is skipped
+            # to avoid breaking the pipe relay during slow startup resolution.
+            # The resolved npx path and its args still flow through correctly.
             call_kwargs = mock_params.call_args.kwargs
-            assert call_kwargs["command"] == sys.executable
-            assert call_kwargs["args"][0].endswith("mcp_stdio_watchdog.py")
-            assert "--" in call_kwargs["args"]
-            sep = call_kwargs["args"].index("--")
-            assert call_kwargs["args"][sep + 1:] == [str(npx_path), "-y", "pkg"]
+            assert call_kwargs["command"] == str(npx_path)
+            assert call_kwargs["args"] == ["-y", "pkg"]
             assert call_kwargs["env"]["PATH"].split(os.pathsep)[0] == str(node_bin)
 
             await server.shutdown()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -669,6 +669,16 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     return resolved_command, resolved_env
 
 
+# Launcher commands that manage their own child process lifecycle.
+# These tools (uvx, npx, bunx, deno) already isolate their subprocesses
+# and the watchdog's intermediate pipe relay can break their startup,
+# especially for slow-starting tools like uvx resolving @latest over the
+# network.  The watchdog's orphan-prevention is redundant here.
+_LAUNCHER_COMMANDS: frozenset[str] = frozenset({
+    "uvx", "uv", "npx", "bunx", "deno", "yarn", "pnpm",
+})
+
+
 def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
     """Wrap a stdio MCP server command in the parent-death watchdog supervisor.
 
@@ -676,6 +686,10 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
     rationale. Returns the (command, args) unchanged on any platform/failure
     where the wrap can't safely apply, so this can never be the reason a
     previously-working MCP server stops starting.
+
+    Launcher commands (uvx, npx, bunx, deno, etc.) are returned unwrapped
+    because they already manage their own subprocess lifecycle and the
+    watchdog's intermediate pipe relay can break their startup sequence.
     """
     if os.name != "posix":
         # Relies on process groups (os.getpgid/os.killpg); no POSIX
@@ -683,6 +697,12 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
         # orphan cleanup's platform scope (Windows falls back to plain
         # os.kill there too).
         return command, args
+
+    # Extract the base command name (without path) for launcher detection.
+    base_command = os.path.basename(command)
+    if base_command in _LAUNCHER_COMMANDS:
+        return command, args
+
     try:
         my_pid = os.getpid()
         try:


### PR DESCRIPTION
**Bug:** The `mcp_stdio_watchdog` breaks uvx/npx-based MCP servers by wrapping them in an intermediate pipe relay that interferes with their startup sequence.

**Fix:** Added `_LAUNCHER_COMMANDS` set (uvx, uv, npx, bunx, deno, yarn, pnpm) and early return in `_wrap_command_with_watchdog()` — launcher commands are returned unwrapped since they already manage their own subprocess lifecycle.

Closes #66423