### PR TITLE
fix(mcp): drain list_* pagination in the server capability probe

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -297,6 +297,7 @@ def _probe_single_server(
         _connect_server,
         _stop_mcp_loop_if_idle,
         _parse_boolish,
+        _paginate_full_list,
     )
 
     config = _resolve_mcp_server_config(config)
@@ -352,17 +353,27 @@ def _probe_single_server(
                     return getattr(advertised_caps, cap_attr, None) is not None
 
                 # Capability probes are best-effort: servers without the
-                # capability raise, which just means "0".
+                # capability raise, which just means "0". Drain nextCursor
+                # pagination so the reported counts match what the agent will
+                # actually see — the tool count above already comes from the
+                # paginated discovery (server._tools), so a page-1-only prompt/
+                # resource count here would understate a paginated server.
                 if prompts_enabled and _advertises("prompts"):
                     try:
-                        result = await server.session.list_prompts()
-                        details["prompts"] = len(result.prompts)
+                        async with server._rpc_lock:
+                            all_prompts = await _paginate_full_list(
+                                server.session.list_prompts, "prompts", name
+                            )
+                        details["prompts"] = len(all_prompts)
                     except Exception:
                         pass
                 if resources_enabled and _advertises("resources"):
                     try:
-                        result = await server.session.list_resources()
-                        details["resources"] = len(result.resources)
+                        async with server._rpc_lock:
+                            all_resources = await _paginate_full_list(
+                                server.session.list_resources, "resources", name
+                            )
+                        details["resources"] = len(all_resources)
                     except Exception:
                         pass
         finally:

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -6,8 +6,10 @@ any actual MCP servers or API keys.
 """
 
 import argparse
+import asyncio
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -682,6 +684,12 @@ class TestProbeCapabilityGating:
             session = _Session()
             initialize_result = outer._InitResult(caps)
 
+            def __init__(self_inner):
+                # The probe now drains list_* pagination under the server's
+                # _rpc_lock (parity with the tool discovery path); the lock is
+                # created here on the MCP loop thread so it binds to that loop.
+                self_inner._rpc_lock = asyncio.Lock()
+
             async def shutdown(self_inner):
                 return None
 
@@ -724,6 +732,66 @@ class TestProbeCapabilityGating:
         # No initialize_result captured → preserve legacy always-try behaviour.
         called, _ = self._run_probe(monkeypatch, {"url": "http://x/mcp"}, None)
         assert set(called) == {"prompts", "resources"}
+
+    def _make_paginated_server(self, prompt_pages, resource_pages, caps):
+        outer = self
+
+        class _Session:
+            async def list_prompts(self_inner, cursor=None):
+                return prompt_pages[cursor]
+
+            async def list_resources(self_inner, cursor=None):
+                return resource_pages[cursor]
+
+        class _FakeServer:
+            _tools = [outer._FakeTool()]
+            session = _Session()
+            initialize_result = outer._InitResult(caps)
+
+            def __init__(self_inner):
+                self_inner._rpc_lock = asyncio.Lock()
+
+            async def shutdown(self_inner):
+                return None
+
+        return _FakeServer()
+
+    def test_probe_counts_drain_pagination(self, monkeypatch):
+        """Prompt/resource counts must follow ``nextCursor`` so a paginated
+        server is not undercounted at page 1.
+
+        The tool count in the same probe already comes from the paginated
+        discovery (``server._tools``), so leaving prompts/resources on page 1
+        reported an inconsistent, understated capability count for any server
+        that paginates ``prompts/list`` / ``resources/list``. Mirrors the
+        nextCursor draining applied to the tools/resources/prompts discovery
+        sites in ``tools/mcp_tool.py``.
+        """
+        import hermes_cli.mcp_config as mc
+
+        caps = self._Caps(prompts=object(), resources=object())
+        # 2 prompts on page 1 (+cursor) then 1 on page 2 (no cursor) → 3 total.
+        prompt_pages = {
+            None: SimpleNamespace(prompts=[object(), object()], nextCursor="p2"),
+            "p2": SimpleNamespace(prompts=[object()], nextCursor=None),
+        }
+        # 1 resource on page 1 (+cursor) then 2 on page 2 → 3 total.
+        resource_pages = {
+            None: SimpleNamespace(resources=[object()], nextCursor="r2"),
+            "r2": SimpleNamespace(resources=[object(), object()], nextCursor=None),
+        }
+        server = self._make_paginated_server(prompt_pages, resource_pages, caps)
+
+        async def _fake_connect(name, cfg):
+            return server
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", _fake_connect)
+        details: dict = {}
+        mc._probe_single_server("srv", {"url": "http://x/mcp"}, details=details)
+
+        # Before the fix these were len(page-1) == 2 and 1 respectively.
+        assert details["prompts"] == 3
+        assert details["resources"] == 3
 
 
 class TestStripBearerPrefix:


### PR DESCRIPTION
## What does this PR do?

The `hermes mcp` **Test server** probe reported prompt/resource **counts** from a single `list_prompts()` / `list_resources()` call. The MCP spec lets servers paginate `prompts/list` and `resources/list` via an opaque `nextCursor`, and the Python SDK's `ClientSession.list_*` returns exactly one page per call — so on a paginated server the probe stopped at page 1 and understated the server's real capabilities.

This is the same nextCursor-draining invariant already applied to the tools / resources / prompts **discovery** sites in `tools/mcp_tool.py` (the `_paginate_full_list()` sweep). The capability probe was a remaining `list_*` site that still fetched only page 1. The gap was visible *within a single probe*: the tool count in the same result already comes from the paginated discovery (`server._tools`), while the prompt/resource counts did not follow the cursor — so a paginated server rendered as, say, "42 tools, 2 prompts" when it actually exposes many more.

The fix reuses the existing `_paginate_full_list()` helper (opaque-string cursor validation + 50-page runaway cap) under the server's `_rpc_lock`, exactly matching the discovery handlers. The probes stay best-effort: a server that doesn't advertise/allow the capability still just yields `0`, and the existing capability-gating (`tools.prompts` / `tools.resources` config + advertised-capability check) is untouched.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/mcp_config.py` — in `_probe_single_server`, drain `list_prompts` / `list_resources` through `_paginate_full_list()` (held under `server._rpc_lock`) instead of reading a single page, and import the helper. Counts now reflect every page.
- `tests/hermes_cli/test_mcp_config.py` — add `test_probe_counts_drain_pagination` (a mocked server paginating prompts 2+1 and resources 1+2 reports 3 and 3); give the capability-gating test doubles an `_rpc_lock` so they exercise the drained path.

## How to Test

1. Configure an MCP server that paginates `prompts/list` / `resources/list` (returns a `nextCursor`), e.g. one exposing >1 page of prompts.
2. Run the `hermes mcp` **Test server** action (or the web dashboard test endpoint) against it.
3. Before this change the reported prompt/resource counts stop at the first page; after it they reflect the full catalog — matching the tool count, which was already paginated.

Automated:

```
pytest tests/hermes_cli/test_mcp_config.py tests/tools/test_mcp_list_pagination.py tests/tools/test_mcp_probe.py -q
# 74 passed
```

The new test fails without the source change (`assert 2 == 3`) and passes with it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — or N/A
- [x] cli-config.yaml.example — N/A (no config keys changed)
- [x] CONTRIBUTING.md / AGENTS.md — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — N/A (pure async/list logic, no platform-specific code)