### PR TITLE
fix(update): keep passive checks from locking shallow clones

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -143,15 +143,8 @@ def _canonical_github_remote(url: str | None) -> str:
     return value.lower()
 
 
-def _is_ssh_remote(url: str | None) -> bool:
-    if not url:
-        return False
-    value = url.strip().lower()
-    return value.startswith("git@") or value.startswith("ssh://")
-
-
-def _is_official_ssh_remote(url: str | None) -> bool:
-    return _is_ssh_remote(url) and _canonical_github_remote(url) == _OFFICIAL_REPO_CANONICAL
+def _is_official_remote(url: str | None) -> bool:
+    return _canonical_github_remote(url) == _OFFICIAL_REPO_CANONICAL
 
 
 def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str]:
@@ -194,7 +187,13 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
-    if _is_official_ssh_remote(origin_url):
+    # Passive checks must not mutate an official installer checkout. In
+    # particular, a shallow ``git fetch --depth 1`` writes ``shallow.lock``;
+    # if the short passive-check timeout kills Git, that lock survives and
+    # blocks the real ``hermes update``. Comparing HEAD with the official
+    # remote tip via ls-remote is read-only and works for both HTTPS and SSH
+    # origins (the probe itself always uses the public HTTPS URL).
+    if _is_official_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
         checked = _check_via_rev(head_rev) if head_rev else None
         if checked == UPDATE_AVAILABLE_NO_COUNT:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -97,8 +97,17 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
     assert mock_run.call_count == 4
 
 
-def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
-    """Passive update checks must not trigger SSH auth for official installs."""
+@pytest.mark.parametrize(
+    "origin_url",
+    [
+        "git@github.com:NousResearch/hermes-agent.git",
+        "https://github.com/NousResearch/hermes-agent.git",
+    ],
+)
+def test_check_for_updates_official_origin_uses_read_only_https_probe(
+    tmp_path, origin_url
+):
+    """Official passive checks must neither trigger SSH auth nor mutate Git."""
     import hermes_cli.banner as banner
 
     repo_dir = tmp_path / "hermes-agent"
@@ -110,7 +119,7 @@ def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
         if cmd == ["git", "remote", "get-url", "origin"]:
-            return MagicMock(returncode=0, stdout="git@github.com:NousResearch/hermes-agent.git\n")
+            return MagicMock(returncode=0, stdout=f"{origin_url}\n")
         if cmd == ["git", "rev-parse", "HEAD"]:
             return MagicMock(returncode=0, stdout="local-sha\n")
         if cmd == [
@@ -127,10 +136,11 @@ def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
 
     assert result == 1
     assert ["git", "fetch", "origin", "--quiet"] not in calls
+    assert not any(cmd[:2] == ["git", "fetch"] for cmd in calls)
 
 
-def test_check_via_local_git_shallow_clone_behind_reports_no_count(tmp_path):
-    """Shallow installer clones must report presence-only, never a bogus count.
+def test_check_via_local_git_shallow_fork_behind_reports_no_count(tmp_path):
+    """Shallow fork clones must report presence-only, never a bogus count.
 
     On a ``git clone --depth 1`` checkout the history stops at one commit, so
     counting ``HEAD..origin/main`` across the shallow boundary yields a huge
@@ -149,7 +159,7 @@ def test_check_via_local_git_shallow_clone_behind_reports_no_count(tmp_path):
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
         if cmd == ["git", "remote", "get-url", "origin"]:
-            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+            return MagicMock(returncode=0, stdout="https://github.com/example/hermes-agent.git\n")
         if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
             return MagicMock(returncode=0, stdout="true\n")
         if cmd[:2] == ["git", "fetch"]:
@@ -170,8 +180,8 @@ def test_check_via_local_git_shallow_clone_behind_reports_no_count(tmp_path):
     assert ["git", "fetch", "origin", "--depth", "1", "--quiet"] in calls
 
 
-def test_check_via_local_git_shallow_clone_up_to_date(tmp_path):
-    """Shallow clone whose tip matches upstream reports up-to-date (0)."""
+def test_check_via_local_git_shallow_fork_up_to_date(tmp_path):
+    """Shallow fork whose tip matches its origin reports up-to-date (0)."""
     import hermes_cli.banner as banner
 
     repo_dir = tmp_path / "hermes-agent"
@@ -180,7 +190,7 @@ def test_check_via_local_git_shallow_clone_up_to_date(tmp_path):
 
     def fake_run(cmd, **kwargs):
         if cmd == ["git", "remote", "get-url", "origin"]:
-            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+            return MagicMock(returncode=0, stdout="https://github.com/example/hermes-agent.git\n")
         if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
             return MagicMock(returncode=0, stdout="true\n")
         if cmd[:2] == ["git", "fetch"]:
@@ -197,8 +207,8 @@ def test_check_via_local_git_shallow_clone_up_to_date(tmp_path):
     assert result == 0
 
 
-def test_check_via_local_git_full_clone_keeps_exact_count(tmp_path):
-    """Full (non-shallow) clones keep the exact rev-list count path."""
+def test_check_via_local_git_full_fork_keeps_exact_count(tmp_path):
+    """Full (non-shallow) fork clones keep the exact rev-list count path."""
     import hermes_cli.banner as banner
 
     repo_dir = tmp_path / "hermes-agent"
@@ -207,7 +217,7 @@ def test_check_via_local_git_full_clone_keeps_exact_count(tmp_path):
 
     def fake_run(cmd, **kwargs):
         if cmd == ["git", "remote", "get-url", "origin"]:
-            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+            return MagicMock(returncode=0, stdout="https://github.com/example/hermes-agent.git\n")
         if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
             return MagicMock(returncode=0, stdout="false\n")
         if cmd[:2] == ["git", "fetch"]:


### PR DESCRIPTION
## What

Official-checkout passive update checks now compare local `HEAD` with the public upstream tip through the existing read-only `git ls-remote` path for both HTTPS and SSH origins. They no longer run a mutating `git fetch`.

Fork checkouts keep the existing origin-fetch behavior, including exact counts for full clones and presence-only reporting for shallow clones.

## Why

On a shallow installer checkout, `git fetch --depth 1` creates `.git/shallow.lock`. The passive checker has a 10-second timeout; when that timeout kills Git, the lock can survive and block the real update path:

```text
fatal: Unable to create .../.git/shallow.lock: File exists.
```

This was observed with a nine-day-old orphaned lock on an ARM64 git install and reproduced again by running `hermes --version`: the passive fetch reached its timeout, left `shallow.lock`, and the immediately following `hermes update --check` failed. No Git process held either lock afterward.

A public `ls-remote` can still time out or fail offline, but it never mutates or locks the checkout, so a passive freshness check cannot strand a future update.

Related to #3523 and complementary to #63041, which covers `index.lock` preflight on the mutating updater path.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_update_check.py -q` — 16 passed
- All 10 update-check/version/banner integration files — 186 passed
- `uv run ruff check hermes_cli/banner.py tests/hermes_cli/test_update_check.py`
- `git diff --check`

The regression test covers both official HTTPS and SSH origin forms and asserts that neither emits any `git fetch` command.