### PR TITLE
catalog: add Tigris object storage MCP entry + object storage guide

### DIFF
--- a/optional-mcps/tigris/manifest.yaml
+++ b/optional-mcps/tigris/manifest.yaml
@@ -1,0 +1,42 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: tigris
+description: List, read, write, and share objects in Tigris buckets from Hermes.
+source: https://www.tigrisdata.com/docs/mcp/remote/
+
+# Why object storage for an agent: Hermes runs on laptops, VPSes, and
+# serverless infra, and artifacts it produces need to outlive the box. Tigris
+# is S3-compatible object storage with a single global endpoint
+# (t3.storage.dev): objects are served from the region nearest the caller, so
+# the same bucket works unchanged wherever Hermes runs, with no region
+# configuration. Data transfer (egress) is not billed, which matters for
+# agents that repeatedly re-read their own artifacts and state.
+
+# Tigris ships a remote MCP server with native OAuth 2.1 over Streamable HTTP
+# at mcp.storage.dev. Hermes's MCP client + mcp_oauth_manager handle discovery,
+# PKCE, token exchange, and refresh — nothing to install locally.
+transport:
+  type: http
+  url: https://mcp.storage.dev/mcp
+
+auth:
+  type: oauth
+  # No `provider:` — this is native MCP OAuth (case 1), not a third-party
+  # provider like Google. The MCP client triggers the browser flow on the
+  # first probe / first connect.
+
+# Tool selection at install time:
+# The Tigris MCP server exposes bucket management (list / create / delete),
+# object operations (upload, download, list, delete, create folders and text
+# files), and presigned share links. We leave `default_enabled` unset so the
+# install-time checklist starts with everything pre-checked — users prune what
+# they don't want.
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with Tigris.
+  After auth, restart your Hermes session so the Tigris tools are loaded.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure tigris

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,6 +334,7 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/tigris" = ["optional-mcps/tigris/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]

--- a/website/docs/guides/use-object-storage-with-hermes.md
+++ b/website/docs/guides/use-object-storage-with-hermes.md
@@ -91,9 +91,9 @@ A dedicated bucket per agent keeps the blast radius small: a confused agent
 can only rearrange the bucket it works in.
 
 Tigris adds two operator-side controls that extend this. Bucket
-[snapshots](https://www.tigrisdata.com/docs/buckets/snapshots/) capture the
-bucket at a point in time, so an agent mistake is a rollback rather than a
-loss. [Forks](https://www.tigrisdata.com/docs/buckets/forking/) create a
+[snapshots](https://www.tigrisdata.com/docs/snapshots/) capture the bucket at
+a point in time, so an agent mistake is a rollback rather than a loss.
+[Forks](https://www.tigrisdata.com/docs/forks/) create a
 zero-copy branch of a bucket, so you can point an experimental agent, or a
 new version of your prompts, at a fork of the real artifact history and throw
 it away afterwards — testing against real accumulated state instead of

--- a/website/docs/guides/use-object-storage-with-hermes.md
+++ b/website/docs/guides/use-object-storage-with-hermes.md
@@ -1,0 +1,136 @@
+---
+sidebar_position: 7
+title: "Use Object Storage with Hermes"
+description: "Give Hermes Agent durable file storage through an MCP server: setup, tool scoping, and patterns for artifacts that outlive the sandbox"
+---
+
+# Use Object Storage with Hermes
+
+Hermes runs on laptops, VPSes, containers, and serverless infrastructure — and
+several of those are ephemeral by design. Anything the agent writes to its
+working directory disappears with the sandbox. Object storage gives the agent
+a durable place for the files it produces: reports, generated assets,
+downloads, data it should find again next session, and files it wants to hand
+to you as a link.
+
+This guide connects Hermes to [Tigris](https://www.tigrisdata.com/), an
+S3-compatible object storage service with a hosted MCP server, so the setup
+is config-only. The same pattern applies to any storage provider that ships
+an MCP server.
+
+## When should you use this?
+
+Use object storage when:
+
+- Hermes runs on ephemeral or remote compute and its output needs to survive
+- you talk to Hermes from Telegram or another chat surface and want files
+  handed back as links rather than trapped on the host
+- multiple Hermes deployments (or you and the agent) need to see the same
+  files
+- the agent produces artifacts on a schedule (see
+  [Automate with Cron](./automate-with-cron.md)) that something else consumes
+
+Do not use it when:
+
+- everything the agent touches is local and the host is durable — the
+  filesystem MCP server or built-in tools are simpler
+- you're tempted to put Hermes's own home directory in a bucket. Session
+  state lives in SQLite under `~/.hermes`, and SQLite on remote storage
+  corrupts. Buckets are for the agent's files, not its internals.
+
+## Step 1: connect the Tigris MCP server
+
+If your Hermes includes the `tigris` catalog entry, install it from the
+catalog:
+
+```bash
+hermes mcp install tigris
+```
+
+Otherwise, add it to `~/.hermes/config.yaml` yourself:
+
+```yaml
+mcp_servers:
+  tigris:
+    url: "https://mcp.storage.dev/mcp"
+    auth: oauth
+```
+
+It's a hosted MCP server with OAuth 2.1, so there is nothing to run locally.
+On first connect, Hermes opens the browser authorization flow and caches the
+token under `~/.hermes/mcp-tokens/`. If Hermes runs on a remote or headless
+host, complete the flow with the paste-back prompt or a port forward — see
+[OAuth over SSH / Remote Hosts](./oauth-over-ssh.md#mcp-servers).
+
+Tigris uses a single global endpoint, so there is no region to configure;
+the same config works wherever the agent runs.
+
+## Step 2: scope the tool surface
+
+The server exposes bucket management (list, create, delete), object
+operations (upload, download, list, delete, create folders and text files),
+and presigned share links. As with any MCP server, connect the smallest
+useful surface. For an agent that should file artifacts and share them — but
+never delete anything or touch other buckets — filter at install time (the
+catalog checklist) or in config:
+
+```yaml
+mcp_servers:
+  tigris:
+    url: "https://mcp.storage.dev/mcp"
+    auth: oauth
+    tools:
+      include:
+        - list_objects
+        - get_object
+        - put_object
+        - create_presigned_url
+```
+
+A dedicated bucket per agent keeps the blast radius small: a confused agent
+can only rearrange the bucket it works in.
+
+Tigris adds two operator-side controls that extend this. Bucket
+[snapshots](https://www.tigrisdata.com/docs/buckets/snapshots/) capture the
+bucket at a point in time, so an agent mistake is a rollback rather than a
+loss. [Forks](https://www.tigrisdata.com/docs/buckets/forking/) create a
+zero-copy branch of a bucket, so you can point an experimental agent, or a
+new version of your prompts, at a fork of the real artifact history and throw
+it away afterwards — testing against real accumulated state instead of
+fixtures. Both are managed from the Tigris CLI or console, not by the agent
+itself. If you use a different storage provider, check what versioning
+features it offers.
+
+## Step 3: put it to work
+
+Tell Hermes once where its files go — it persists knowledge across sessions,
+so this tends to stick:
+
+```text
+Store everything you produce in the bucket hermes-artifacts. When you finish
+a deliverable, give me a presigned link to it.
+```
+
+Then use it like any other capability:
+
+```text
+Summarize this week's monitoring reports, write the summary to
+hermes-artifacts as reports/week-29.md, and send me a share link.
+```
+
+The share link is a presigned URL — it works from your phone, expires on its
+own, and requires no account on the receiving end. Paired with a
+[cron job](./automate-with-cron.md), this is the standard shape for a nightly
+report bot: generate, upload, drop the link in chat.
+
+## Verify
+
+Ask Hermes to list the bucket, or check directly:
+
+```bash
+aws s3 ls s3://hermes-artifacts/ --endpoint-url https://t3.storage.dev
+```
+
+If the tools don't appear in the session, confirm the `mcp_servers` block is
+present, restart the session, and check that the OAuth flow completed —
+`hermes mcp login tigris` re-runs it.

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -64,6 +64,7 @@ The picker shows each entry with its current status:
 ```
 n8n          available              Manage and inspect n8n workflows from Hermes
 linear       enabled                Linear issue/project management (remote OAuth)
+tigris       available              Tigris object storage: buckets, objects, share links
 github       installed (disabled)   GitHub repo + PR tools
 ```
 
@@ -211,7 +212,7 @@ Use HTTP servers when:
 
 ### OAuth-authenticated HTTP servers
 
-Most hosted MCP servers (Linear, Sentry, Atlassian, Asana, Figma, Stripe, …) require OAuth 2.1 instead of a static bearer token. Set `auth: oauth` and Hermes handles discovery, dynamic client registration, PKCE, token exchange, refresh, and step-up auth via the MCP Python SDK.
+Most hosted MCP servers (Linear, Sentry, Atlassian, Asana, Figma, Stripe, Tigris, …) require OAuth 2.1 instead of a static bearer token. Set `auth: oauth` and Hermes handles discovery, dynamic client registration, PKCE, token exchange, refresh, and step-up auth via the MCP Python SDK.
 
 ```yaml
 mcp_servers:


### PR DESCRIPTION
## What does this PR do?

Hermes is built to run on disposable compute — a $5 VPS, a container, serverless
that scales to zero. The gap that creates: anything the agent writes dies with
the box. Object storage is the natural fix, and there's currently no storage
entry in the MCP catalog.

This adds Tigris to `optional-mcps/`. It's the same shape as the Linear entry —
a hosted remote MCP server with OAuth 2.1 over Streamable HTTP — so there's
nothing to install, no pinned dependency, and no code in this repo to maintain.
The server is run and maintained by Tigris. One practical reason Tigris works
well for this particular catalog: it has a single global endpoint, so the same
manifest works for every user regardless of where their Hermes runs — no
region config to document or get wrong.

I'm aware of the "third-party products ship as standalone plugins" rule in
CONTRIBUTING — this deliberately isn't a plugin. It's a catalog manifest
pointing at an external server, the mechanism the catalog exists for.

Also adds a guide, `use-object-storage-with-hermes.md`, written to your guides
format ("when should you use this", tool scoping, cron + oauth-over-ssh
cross-links). It covers the setup, scoping the tool surface down for
artifact-only agents, and a warning we'd rather your users read before they
learn it the hard way: don't put `~/.hermes` in a bucket (SQLite on remote
storage corrupts) — buckets are for the agent's files, not its internals.

## Related Issue

N/A — happy to open one first if you'd prefer that flow.

## Type of Change

- [x] 📝 Documentation update
- [x] ✨ New feature (catalog entry)

## Changes Made

- `optional-mcps/tigris/manifest.yaml` — catalog entry (remote HTTP + `auth: oauth`, modeled on `optional-mcps/linear/`)
- `website/docs/guides/use-object-storage-with-hermes.md` — new guide
- `website/docs/user-guide/features/mcp.md` — Tigris added to the OAuth-server
  examples list; `tigris` row added to the catalog picker example

## How to Test

1. Add to `~/.hermes/config.yaml`:
   `mcp_servers: { tigris: { url: "https://mcp.storage.dev/mcp", auth: oauth } }`
   (or `hermes mcp install tigris` from this branch)
2. Start a session — the browser OAuth flow should complete and the Tigris
   tools appear.
3. Ask Hermes: "Create a file notes/hello.txt in bucket <your-bucket> and give
   me a share link." The presigned URL should open from any device.