### PR TITLE
fix(tui): keep exit summary on durable session

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1212,6 +1212,7 @@ def test_session_branch_persists_branched_from_marker(server, monkeypatch):
     assert len(create_calls) == 1
     new_key, kwargs = create_calls[0]
     assert new_key == "20260101_000001_child0"
+    assert resp["result"]["stored_session_id"] == new_key
     assert kwargs["parent_session_id"] == parent_key
     # The marker — without it the branch is invisible in /resume and /sessions.
     assert kwargs["model_config"] == {"_branched_from": parent_key}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8499,7 +8499,15 @@ def _(rid, params: dict) -> dict:
         if lease is not None:
             lease.release()
         return _err(rid, 5000, f"agent init failed on branch: {e}")
-    return _ok(rid, {"session_id": new_sid, "title": title, "parent": old_key})
+    return _ok(
+        rid,
+        {
+            "session_id": new_sid,
+            "stored_session_id": new_key,
+            "title": title,
+            "parent": old_key,
+        },
+    )
 
 
 @method("session.interrupt")

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
@@ -64,6 +68,39 @@ describe('createGatewayEventHandler', () => {
     resetTurnState()
     turnController.fullReset()
     patchUiState({ showReasoning: true })
+  })
+
+  it('refreshes the exit breadcrumb when session.info reports a compression continuation key', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hermes-tui-compress-'))
+    const path = join(dir, 'active.json')
+    const previousFile = process.env.HERMES_TUI_ACTIVE_SESSION_FILE
+    process.env.HERMES_TUI_ACTIVE_SESSION_FILE = path
+    patchUiState({ sid: 'runtime-sid' })
+
+    try {
+      writeFileSync(path, JSON.stringify({ session_id: 'durable-parent' }))
+      createGatewayEventHandler(buildCtx([]))({
+        payload: {
+          model: 'test-model',
+          skills: {},
+          stored_session_id: 'durable-continuation',
+          tools: {}
+        },
+        session_id: 'runtime-sid',
+        type: 'session.info'
+      } as any)
+
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ session_id: 'durable-continuation' })
+      expect(getUiState().sid).toBe('runtime-sid')
+    } finally {
+      rmSync(dir, { force: true, recursive: true })
+
+      if (previousFile === undefined) {
+        delete process.env.HERMES_TUI_ACTIVE_SESSION_FILE
+      } else {
+        process.env.HERMES_TUI_ACTIVE_SESSION_FILE = previousFile
+      }
+    }
   })
 
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createSlashHandler } from '../app/createSlashHandler.js'
@@ -387,18 +391,74 @@ describe('createSlashHandler', () => {
   })
 
   it('keeps visible scrollback when branching a TUI session', async () => {
-    patchUiState({ sid: 'sid-parent' })
-    const rpc = vi.fn(() => Promise.resolve({ session_id: 'sid-branch', title: 'branch title' }))
-    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+    const dir = mkdtempSync(join(tmpdir(), 'hermes-tui-branch-'))
+    const path = join(dir, 'active.json')
+    const previousFile = process.env.HERMES_TUI_ACTIVE_SESSION_FILE
+    process.env.HERMES_TUI_ACTIVE_SESSION_FILE = path
 
-    expect(createSlashHandler(ctx)('/branch branch title')).toBe(true)
+    try {
+      patchUiState({ sid: 'sid-parent' })
 
-    expect(rpc).toHaveBeenCalledWith('session.branch', { name: 'branch title', session_id: 'sid-parent' })
-    await vi.waitFor(() => {
-      expect(getUiState().sid).toBe('sid-branch')
-      expect(ctx.transcript.sys).toHaveBeenCalledWith('branched → branch title')
-    })
-    expect(ctx.transcript.setHistoryItems).not.toHaveBeenCalled()
+      const rpc = vi.fn(() =>
+        Promise.resolve({
+          session_id: 'sid-branch',
+          stored_session_id: 'durable-branch',
+          title: 'branch title'
+        })
+      )
+
+      const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+      expect(createSlashHandler(ctx)('/branch branch title')).toBe(true)
+
+      expect(rpc).toHaveBeenCalledWith('session.branch', { name: 'branch title', session_id: 'sid-parent' })
+      await vi.waitFor(() => {
+        expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ session_id: 'durable-branch' })
+        expect(getUiState().sid).toBe('sid-branch')
+        expect(ctx.transcript.sys).toHaveBeenCalledWith('branched → branch title')
+      })
+      expect(ctx.transcript.setHistoryItems).not.toHaveBeenCalled()
+    } finally {
+      if (previousFile === undefined) {
+        delete process.env.HERMES_TUI_ACTIVE_SESSION_FILE
+      } else {
+        process.env.HERMES_TUI_ACTIVE_SESSION_FILE = previousFile
+      }
+
+      rmSync(dir, { force: true, recursive: true })
+    }
+  })
+
+  it('keeps the parent active when a branch response omits its durable session id', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hermes-tui-branch-'))
+    const path = join(dir, 'active.json')
+    const previousFile = process.env.HERMES_TUI_ACTIVE_SESSION_FILE
+    process.env.HERMES_TUI_ACTIVE_SESSION_FILE = path
+
+    try {
+      patchUiState({ sid: 'sid-parent' })
+
+      const response = Promise.resolve({ session_id: 'sid-branch', title: 'branch title' })
+      const rpc = vi.fn(() => response)
+      const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+      expect(createSlashHandler(ctx)('/branch branch title')).toBe(true)
+      await response
+
+      expect(ctx.session.closeSession).not.toHaveBeenCalled()
+      expect(ctx.session.setSessionStartedAt).not.toHaveBeenCalled()
+      expect(getUiState().sid).toBe('sid-parent')
+      expect(() => readFileSync(path, 'utf8')).toThrow()
+      expect(ctx.transcript.sys).not.toHaveBeenCalledWith('branched → branch title')
+    } finally {
+      if (previousFile === undefined) {
+        delete process.env.HERMES_TUI_ACTIVE_SESSION_FILE
+      } else {
+        process.env.HERMES_TUI_ACTIVE_SESSION_FILE = previousFile
+      }
+
+      rmSync(dir, { force: true, recursive: true })
+    }
   })
 
   it('reloads skills in the live gateway and refreshes the catalog', async () => {

--- a/ui-tui/src/__tests__/useSessionLifecycle.test.ts
+++ b/ui-tui/src/__tests__/useSessionLifecycle.test.ts
@@ -1,19 +1,71 @@
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
 
+import { renderSync } from '@hermes/ink'
+import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
-import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import {
   hydrateLiveSessionInflight,
   liveSessionInflightMessages,
   scheduleResumeScrollToBottom,
   signalFreshSessionBoundary,
+  useSessionLifecycle,
   writeActiveSessionFile
 } from '../app/useSessionLifecycle.js'
+
+const makeStreams = () => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', () => {})
+
+  return { stderr, stdin, stdout }
+}
+
+const mountSessionLifecycle = (rpc: ReturnType<typeof vi.fn>, request: ReturnType<typeof vi.fn>) => {
+  const expose = { current: null as null | ReturnType<typeof useSessionLifecycle> }
+
+  function Harness() {
+    expose.current = useSessionLifecycle({
+      colsRef: { current: 80 },
+      composerActions: { setPasteSnips: vi.fn() } as any,
+      gw: { request } as any,
+      panel: vi.fn(),
+      rpc: rpc as any,
+      scrollRef: { current: null },
+      setHistoryItems: vi.fn(),
+      setLastUserMsg: vi.fn(),
+      setSessionStartedAt: vi.fn(),
+      setStickyPrompt: vi.fn(),
+      setVoiceProcessing: vi.fn(),
+      setVoiceRecording: vi.fn(),
+      sys: vi.fn()
+    })
+
+    return null
+  }
+
+  const streams = makeStreams()
+
+  const instance = renderSync(React.createElement(Harness), {
+    patchConsole: false,
+    stderr: streams.stderr as NodeJS.WriteStream,
+    stdin: streams.stdin as NodeJS.ReadStream,
+    stdout: streams.stdout as NodeJS.WriteStream
+  })
+
+  return { expose, instance }
+}
 
 describe('fresh session boundary', () => {
   it('signals only when a live session is replaced by a different session', () => {
@@ -46,6 +98,69 @@ describe('writeActiveSessionFile', () => {
     writeActiveSessionFile('actual_session', path)
 
     expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ session_id: 'actual_session' })
+  })
+
+  it('tracks durable keys for create, resume, and live activation without replacing the runtime sid', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'hermes-tui-active-'))
+    const path = join(dir, 'active.json')
+    const previousFile = process.env.HERMES_TUI_ACTIVE_SESSION_FILE
+    process.env.HERMES_TUI_ACTIVE_SESSION_FILE = path
+
+    const rpc = vi.fn(async (method: string) => {
+      if (method === 'setup.status') {
+        return { provider_configured: true }
+      }
+
+      if (method === 'session.create') {
+        return { info: null, session_id: 'runtime-create', stored_session_id: 'durable-create' }
+      }
+
+      return null
+    })
+
+    const request = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return {
+          info: null,
+          messages: [],
+          resumed: 'durable-resume',
+          session_id: 'runtime-resume',
+          session_key: 'durable-resume'
+        }
+      }
+
+      return {
+        info: null,
+        messages: [],
+        session_id: 'runtime-activate',
+        session_key: 'durable-activate'
+      }
+    })
+
+    const { expose, instance } = mountSessionLifecycle(rpc, request)
+
+    try {
+      await expose.current!.newSession()
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ session_id: 'durable-create' })
+      expect(getUiState().sid).toBe('runtime-create')
+
+      expose.current!.resumeById('durable-resume')
+      await vi.waitFor(() => expect(getUiState().sid).toBe('runtime-resume'))
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ session_id: 'durable-resume' })
+
+      expose.current!.activateLiveSession('runtime-activate')
+      await vi.waitFor(() => expect(getUiState().sid).toBe('runtime-activate'))
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ session_id: 'durable-activate' })
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+
+      if (previousFile === undefined) {
+        delete process.env.HERMES_TUI_ACTIVE_SESSION_FILE
+      } else {
+        process.env.HERMES_TUI_ACTIVE_SESSION_FILE = previousFile
+      }
+    }
   })
 })
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -24,6 +24,7 @@ import { flashGoodVibes, flashPet } from './petFlashStore.js'
 import { turnController } from './turnController.js'
 import { getTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
+import { writeActiveSessionFile } from './useSessionLifecycle.js'
 
 const NO_PROVIDER_RE = /\bNo (?:LLM|inference) provider configured\b/i
 
@@ -423,6 +424,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'session.info': {
         const info = ev.payload
 
+        writeActiveSessionFile(info.stored_session_id ?? null)
         patchUiState(state => ({
           ...state,
           info,

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -17,6 +17,7 @@ import type { PanelSection } from '../../../types.js'
 import { DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES, type IndicatorStyle } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
 import { patchUiState } from '../../uiStore.js'
+import { writeActiveSessionFile } from '../../useSessionLifecycle.js'
 import type { SlashCommand } from '../types.js'
 
 const TUI_SESSION_MODEL_RE = new RegExp(`(?:^|\\s)${TUI_SESSION_MODEL_FLAG}(?:\\s|$)`)
@@ -246,11 +247,12 @@ export const sessionCommands: SlashCommand[] = [
 
       ctx.gateway.rpc<SessionBranchResponse>('session.branch', { name: arg, session_id: ctx.sid }).then(
         ctx.guarded<SessionBranchResponse>(r => {
-          if (!r.session_id) {
+          if (!r.session_id || !r.stored_session_id) {
             return
           }
 
           void ctx.session.closeSession(prevSid)
+          writeActiveSessionFile(r.stored_session_id)
           patchUiState({ sid: r.session_id })
           ctx.session.setSessionStartedAt(Date.now())
           ctx.transcript.sys(`branched → ${r.title ?? ''}`)

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -240,7 +240,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       resetSession()
       setSessionStartedAt(Date.now())
 
-      writeActiveSessionFile(r.session_id)
+      writeActiveSessionFile(r.stored_session_id)
       patchUiState({
         info,
         sid: r.session_id,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -225,6 +225,7 @@ export interface SetupStatusResponse {
 export interface SessionCreateResponse {
   info?: SessionInfo & { config_warning?: string; credential_warning?: string }
   session_id: string
+  stored_session_id: string
 }
 
 export interface SessionResumeResponse {

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -356,6 +356,7 @@ export interface SessionCompressResponse {
 
 export interface SessionBranchResponse {
   session_id?: string
+  stored_session_id?: string
   title?: string
 }
 

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -161,6 +161,7 @@ export interface SessionInfo {
   release_date?: string
   service_tier?: string
   skills: Record<string, string[]>
+  stored_session_id?: string
   system_prompt?: string
   tools: Record<string, string[]>
   update_behind?: number | null


### PR DESCRIPTION
## Rationale

The TUI shell exit summary can print an older parent session ID than `/status` after context compression rotates the durable session to a continuation. The exit breadcrumb was initialized with the ephemeral runtime SID and was not refreshed when `session.info` reported the new durable key.

## Summary

- write `stored_session_id` to the exit breadcrumb when creating a session
- refresh the breadcrumb from matching `session.info` events so compression continuations stay current
- keep the runtime `session_id` unchanged for TUI event routing
- cover create, resume, live activation, and compression continuation behavior

## Test Plan

- [x] `npm --prefix ui-tui test -- --run src/__tests__/useSessionLifecycle.test.ts src/__tests__/createGatewayEventHandler.test.ts` (88 passed)
- [x] `npm --prefix ui-tui run typecheck`
- [x] ESLint on the six changed TypeScript files
- [x] `npm --prefix ui-tui run build`
- [x] `scripts/run_tests.sh tests/test_tui_gateway_server.py -k 'session_resume_follows_compression_tip or session_compress_syncs_session_key_after_rotation'` (2 passed)
- [x] `git diff --check`
