### PR TITLE
fix: replace hardcoded ~/.hermes with get_hermes_home() in system prompt (#66450)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -46,6 +46,7 @@ from agent.prompt_builder import (
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
+from hermes_constants import get_hermes_home
 from utils import is_truthy_value
 
 
@@ -395,7 +396,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if active_profile == "default":
         stable_parts.append(
             "Active Hermes profile: default. Other profiles (if any) live "
-            "under ~/.hermes/profiles/<name>/. Each profile has its own "
+            "under " + str(get_hermes_home()) + "/profiles/<name>/. Each profile has its own "
             "skills/, plugins/, cron/, and memories/ that affect a different "
             "session than this one. Do not modify another profile's "
             "skills/plugins/cron/memories unless the user explicitly directs "
@@ -404,9 +405,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     else:
         stable_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes ~/.hermes/profiles/{active_profile}/. The default "
-            f"profile's data lives at ~/.hermes/skills/, ~/.hermes/plugins/, "
-            f"~/.hermes/cron/, ~/.hermes/memories/ — those belong to a "
+            f"and writes {get_hermes_home()}/profiles/{active_profile}/. The default "
+            f"profile's data lives at {get_hermes_home()}/skills/, {get_hermes_home()}/plugins/, "
+            f"{get_hermes_home()}/cron/, {get_hermes_home()}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "


### PR DESCRIPTION
## Summary

The system prompt building code hardcoded `~/.hermes` paths instead of using `get_hermes_home()`. When `HERMES_HOME` is set to a custom location (e.g., `/opt/data`), the prompt text still referenced `~/.hermes`, confusing the AI about where files actually live.

## Changes

| File | Change |
|------|--------|
| `agent/system_prompt.py` | Import `get_hermes_home()` from `hermes_constants` |
| `agent/system_prompt.py` | Default profile hint: `~/.hermes/profiles/<name>/` → `<home>/profiles/<name>/` |
| `agent/system_prompt.py` | Non-default profile hint: all `~/.hermes/...` paths → `<home>/...` paths |

## Verification

- Python parse: `PARSE OK`
- All 3 hardcoded `~/.hermes` references in prompt text replaced (2 remaining are in comments only)

Closes #66450