### PR TITLE
fix(docs): correct tab.position docs — plugins render in separate section

### DIFF
--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -380,11 +380,10 @@ Write the manifest:
   "version": "1.0.0",
   "tab": {
     "path": "/my-plugin",
-    "position": "after:skills"
+    "position": "end"
   },
   "entry": "dist/index.js"
 }
-```
 
 Write the JS bundle (a plain IIFE — no build step needed):
 
@@ -414,7 +413,7 @@ Write the JS bundle (a plain IIFE — no build step needed):
 })();
 ```
 
-Refresh the dashboard — your tab appears in the nav bar, after **Skills**.
+Refresh the dashboard — your tab appears in the **Plugins** section at the bottom of the sidebar nav.
 
 :::tip Skip React.createElement
 If you prefer JSX, use any bundler (esbuild, Vite, rollup) with React as an external and IIFE output. The only hard requirement is that the final file is a single JS file loadable via `<script>`. React is never bundled; it comes from `SDK.React`.
@@ -472,7 +471,7 @@ None of them are required; include only the layers you need.
 | `icon` | No | Lucide icon name. Defaults to `Puzzle`. Unknown names fall back to `Puzzle`. |
 | `version` | No | Semver string. Defaults to `0.0.0`. |
 | `tab.path` | Yes | URL path for the tab (e.g. `/my-plugin`). |
-| `tab.position` | No | Where to insert the tab. `"end"` (default), `"after:<path>"`, or `"before:<path>"` — value after the colon is the **path segment** of the target tab (no leading slash). Examples: `"after:skills"`, `"before:config"`. |
+| `tab.position` | No | Where to place the tab within the **Plugins** section of the sidebar. `"end"` (default) appends it at the end; `"after:<path>"` inserts after another plugin tab; `"before:<path>"` inserts before another plugin tab — value after the colon is the **path segment** of the target tab (no leading slash). Plugin tabs are always rendered in a separate "Plugins" group below all built-in sidebar items, so `before:`/`after:` targets must be other plugin paths (referencing a built-in path like `"after:skills"` has no visible effect relative to that built-in item).|
 | `tab.override` | No | Set to a built-in route path (`"/"`, `"/sessions"`, `"/config"`, ...) to **replace** that page instead of adding a new tab. See [Replacing built-in pages](#replacing-built-in-pages-taboverride). |
 | `tab.hidden` | No | When true, register the component and any slots without adding a tab to the nav. Used by slot-only plugins. See [Slot-only plugins](#slot-only-plugins-tabhidden). |
 | `slots` | No | Named shell slots this plugin populates. **Documentation aid only** — actual registration happens from the JS bundle via `registerSlot()`. Listing slots here makes discovery surfaces more informative. |


### PR DESCRIPTION
## Description

Fixes #66442 — Dashboard plugin `tab.position` documentation mismatch.

### Problem

The documentation claimed that `before:<path>` and `after:<path>` position plugin tabs relative to built-in sidebar items (e.g. `"after:skills"` would place the tab after the **Skills** nav link).

In reality, `buildNavItems()` correctly inserts the plugin into the merged list, but `partitionSidebarNav()` then **splits** built-in and plugin items — plugin tabs are always rendered in a separate **"Plugins"** section below all built-in items. The `before:`/`after:` values only affect ordering among plugin tabs within that section; referencing a built-in path has no visible effect relative to that item.

### Changes

1. **Quick-start example**: Changed `"position": "after:skills"` to `"position": "end"` in the getting-started manifest — a beginner should see a working example without misleading cross-section positioning.

2. **Quick-start description**: Changed from *"your tab appears in the nav bar, after **Skills**"* to *"your tab appears in the **Plugins** section at the bottom of the sidebar nav"*.

3. **`tab.position` field description**: Rewrote to accurately explain that plugin tabs are in a separate "Plugins" group, and `before:`/`after:` targets must be other plugin paths.

### Why docs fix instead of code fix

The separate "Plugins" section is an intentional UI design choice — it has a labeled heading, a visual separator, and distinct UX. Changing the sidebar to interleave plugin items among core items would require a major refactor of the sidebar rendering, mobile behavior, and accessibility. Updating the documentation to match the actual (and intentionally designed) behavior is the correct fix for this P3 bug.

### Verification

- `git diff --stat`: 1 file changed, 3 insertions(+), 4 deletions(-)
- All changes are in `website/docs/user-guide/features/extending-the-dashboard.md`
