### PR TITLE
fix(desktop): swap sidebar toggle mappings when panes are flipped (#66357)

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -504,11 +504,33 @@ $panesFlipped.listen(flipped => {
   }
 })
 
-// POSITIONAL side toggles (titlebar buttons, ⌘B / ⌘J): $sidebarOpen ≙ the
-// LEFT side of the main zone, $fileBrowserOpen ≙ the RIGHT — everything on
-// that side hides together, whatever panes have been rearranged there.
-bindTreeSideVisibility('left', $sidebarOpen, setSidebarOpen)
-bindTreeSideVisibility('right', $fileBrowserOpen, setFileBrowserOpen)
+// ── Flip-aware side visibility bindings ──────────────────────────────
+// When panes are flipped (⌘\ / Swap Sidebar Sides), the sessions sidebar
+// moves to the RIGHT side and the file browser moves to the LEFT.
+// $sidebarOpen always tracks the sessions pane, so its tree-side binding
+// must swap with the flip state — likewise for $fileBrowserOpen.
+let _unsubSidebar: (() => void) | null = null
+let _unsubFileBrowser: (() => void) | null = null
+
+function _rebindSideVisibility() {
+  _unsubSidebar?.()
+  _unsubFileBrowser?.()
+  const flipped = $panesFlipped.get()
+  _unsubSidebar = bindTreeSideVisibility(
+    flipped ? 'right' : 'left',
+    $sidebarOpen,
+    setSidebarOpen,
+  )
+  _unsubFileBrowser = bindTreeSideVisibility(
+    flipped ? 'left' : 'right',
+    $fileBrowserOpen,
+    setFileBrowserOpen,
+  )
+}
+
+_rebindSideVisibility()
+$panesFlipped.listen(_rebindSideVisibility)
+// ── End flip-aware side visibility ────────────────────────────────────
 
 // Workspace-scoped surfaces: the file tree and git diff only mean something
 // inside a project. A detached chat (no cwd) hides them — their zones

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils'
 import { $hapticsMuted, toggleHapticsMuted } from '@/store/haptics'
 import {
   $fileBrowserOpen,
+  $panesFlipped,
   $sidebarOpen,
   toggleFileBrowserOpen,
   togglePanesFlipped,
@@ -101,6 +102,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const modHeld = useModifierHeld()
   const hapticsMuted = useStore($hapticsMuted)
   const fileBrowserOpen = useStore($fileBrowserOpen)
+  const panesFlipped = useStore($panesFlipped)
   const sidebarOpen = useStore($sidebarOpen)
 
   const toggleHaptics = () => {
@@ -117,11 +119,15 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   // POSITIONAL toggles: each button shows/hides everything on its physical
   // side of the main zone (the layout tree collapses the whole side), so they
-  // stay correct through flips and rearranges. $sidebarOpen ≙ left side,
-  // $fileBrowserOpen ≙ right side. Never an active highlight — plain
-  // show/hide affordances.
-  const leftEdge = { open: sidebarOpen, toggle: toggleSidebarOpen }
-  const rightEdge = { open: fileBrowserOpen, toggle: toggleFileBrowserOpen }
+  // stay correct through flips and rearranges. When panes are flipped (⌘\)
+  // the sessions sidebar moves to the right and the file browser to the left,
+  // so the left/right edge mappings swap to match the physical arrangement.
+  const leftEdge = panesFlipped
+    ? { open: fileBrowserOpen, toggle: toggleFileBrowserOpen }
+    : { open: sidebarOpen, toggle: toggleSidebarOpen }
+  const rightEdge = panesFlipped
+    ? { open: sidebarOpen, toggle: toggleSidebarOpen }
+    : { open: fileBrowserOpen, toggle: toggleFileBrowserOpen }
 
   const leftToolbarTools: TitlebarTool[] = [
     {

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -541,10 +541,10 @@ export function bindTreeSideVisibility(
   side: TreeSide,
   $open: { get(): boolean; listen(fn: (open: boolean) => void): void },
   setOpen: (open: boolean) => void
-) {
+): () => void {
   sideOpeners[side] = setOpen
   setTreeSideCollapsed(side, !$open.get())
-  $open.listen(open => setTreeSideCollapsed(side, !open))
+  return $open.listen(open => setTreeSideCollapsed(side, !open))
 }
 
 /** The chrome toggle owning `paneId`'s root-row column — SEMANTIC, matching


### PR DESCRIPTION
Fixes #66357

## Problem

After clicking "Swap Sidebar Sides" (⌘\\):
- The left Hide/Show button controls the sessions pane (now on the right) instead of the file browser (now on the left).
- The right Hide/Show button controls the file browser (now on the left) instead of the sessions (now on the right).

## Root cause

The titlebar button mapping and tree-side collapse bindings were hard-coded to the default left=sessions / right=files layout and did not account for the panes-flipped state.

## Changes

- **store.ts**: `bindTreeSideVisibility` now returns the `listen()` unsubscribe function so callers can clean up old listeners before re-binding.
- **controller.tsx**: `` and `` dynamically bind to the tree side where their respective pane actually lives, and re-bind when `` changes.
- **titlebar-controls.tsx**: The left/right titlebar toggle buttons and their labels follow the physical side content after a flip.