### PR TITLE
fix(desktop): harden link title transport

### DIFF
--- a/apps/desktop/electron/link-title-curl.test.ts
+++ b/apps/desktop/electron/link-title-curl.test.ts
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import fs from 'node:fs/promises'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+import { test, vi } from 'vitest'
+
+import {
+  createLinkTitleCurlFetcher,
+  linkTitleCurlRequestArgs,
+  parseLinkTitleCurlHeaders
+} from './link-title-curl'
+import { startLinkTitleSocksGateway } from './link-title-socks'
+
+const execFileAsync = promisify(execFile)
+
+function admitPublicUrl(value: string): null | string {
+  const url = new URL(value)
+
+  if (url.hostname === '127.0.0.1') {
+    return null
+  }
+
+  return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null
+}
+
+test('curl request arguments never enable automatic redirect following', () => {
+  const args = linkTitleCurlRequestArgs('https://example.com/', {
+    connectTimeoutSeconds: 4,
+    headerPath: 'C:\\Temp\\hermes-link-title.headers',
+    maxBytes: 98_304,
+    proxyUrl: 'socks5://127.0.0.1:48123',
+    timeoutSeconds: 5,
+    userAgent: 'Hermes test'
+  })
+
+  assert.equal(args[0], '--disable')
+  assert.equal(args.includes('--no-location'), true)
+  assert.equal(args.includes('--location'), false)
+  assert.equal(args.includes('--max-redirs'), false)
+  assert.deepEqual(args.slice(args.indexOf('--proxy'), args.indexOf('--proxy') + 2), [
+    '--proxy',
+    'socks5h://127.0.0.1:48123'
+  ])
+  assert.deepEqual(args.slice(args.indexOf('--noproxy'), args.indexOf('--noproxy') + 2), ['--noproxy', ''])
+  assert.deepEqual(args.slice(args.indexOf('--max-filesize'), args.indexOf('--max-filesize') + 2), [
+    '--max-filesize',
+    '98304'
+  ])
+  assert.deepEqual(args.slice(args.indexOf('--dump-header'), args.indexOf('--dump-header') + 2), [
+    '--dump-header',
+    'C:\\Temp\\hermes-link-title.headers'
+  ])
+})
+
+test('curl ignores a default config that enables automatic redirects', async () => {
+  const curlHome = await fs.mkdtemp(path.join(os.tmpdir(), 'hermes-link-title-curlrc-'))
+  const headerPath = path.join(curlHome, 'headers')
+  let redirectedRequests = 0
+  let gateway
+
+  const server = http.createServer((request, response) => {
+    if (request.url === '/start') {
+      response.writeHead(302, { Location: '/redirected' })
+      response.end()
+
+      return
+    }
+
+    redirectedRequests += 1
+    response.end('redirected')
+  })
+
+  try {
+    await Promise.all([
+      fs.writeFile(path.join(curlHome, '.curlrc'), 'location\n'),
+      fs.writeFile(path.join(curlHome, '_curlrc'), 'location\n')
+    ])
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address()
+
+    assert.ok(address && typeof address !== 'string')
+    gateway = await startLinkTitleSocksGateway({
+      connectTimeoutMs: 1_000,
+      resolve: async () => [{ address: '127.0.0.1', family: 4 }]
+    })
+
+    const args = linkTitleCurlRequestArgs(`http://127.0.0.1:${address.port}/start`, {
+      connectTimeoutSeconds: 2,
+      headerPath,
+      maxBytes: 98_304,
+      proxyUrl: gateway.proxyUrl,
+      timeoutSeconds: 2,
+      userAgent: 'Hermes test'
+    })
+
+    await execFileAsync('curl', args, {
+      encoding: 'utf8',
+      env: { ...process.env, CURL_HOME: curlHome },
+      timeout: 5_000
+    })
+    assert.equal(redirectedRequests, 0)
+  } finally {
+    await gateway?.close()
+    await new Promise<void>(resolve => server.close(() => resolve()))
+    await fs.rm(curlHome, { force: true, recursive: true })
+  }
+})
+
+test('public redirects to loopback stop before a second request', async () => {
+  const request = vi.fn().mockResolvedValue({ body: '', location: 'http://127.0.0.1/private', statusCode: 302 })
+
+  const fetchTitle = createLinkTitleCurlFetcher({
+    admitUrl: admitPublicUrl,
+    maxRedirects: 3,
+    now: () => 0,
+    readTitle: vi.fn(() => ''),
+    request,
+    timeoutMs: 5_000
+  })
+
+  assert.equal(await fetchTitle('https://example.com/start'), '')
+  assert.deepEqual(request.mock.calls, [['https://example.com/start', 5_000]])
+})
+
+test('public redirects resolve with WHATWG URL semantics and retain title fetching', async () => {
+  const request = vi
+    .fn()
+    .mockResolvedValueOnce({ body: '', location: '../next', statusCode: 302 })
+    .mockResolvedValueOnce({ body: '<title>Public destination</title>', location: null, statusCode: 200 })
+
+  const readTitle = vi.fn(() => 'Public destination')
+
+  const fetchTitle = createLinkTitleCurlFetcher({
+    admitUrl: admitPublicUrl,
+    maxRedirects: 3,
+    now: () => 0,
+    readTitle,
+    request,
+    timeoutMs: 5_000
+  })
+
+  assert.equal(await fetchTitle('https://example.com/path/start'), 'Public destination')
+  assert.deepEqual(request.mock.calls, [
+    ['https://example.com/path/start', 5_000],
+    ['https://example.com/next', 5_000]
+  ])
+  assert.deepEqual(readTitle.mock.calls, [['<title>Public destination</title>']])
+})
+
+test('curl header parsing retains the raw Location header for WHATWG resolution', () => {
+  const parsed = parseLinkTitleCurlHeaders(
+    'HTTP/1.1 200 Connection established\r\n\r\nHTTP/2 302\r\nlocation: ../next\r\ncontent-length: 0\r\n\r\n'
+  )
+
+  assert.deepEqual(parsed, { location: '../next', statusCode: 302 })
+})

--- a/apps/desktop/electron/link-title-curl.ts
+++ b/apps/desktop/electron/link-title-curl.ts
@@ -1,0 +1,143 @@
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308])
+
+export interface LinkTitleCurlHop {
+  body: string
+  location: null | string
+  statusCode: number
+}
+
+export interface LinkTitleCurlDependencies {
+  admitUrl(value: string): null | string
+  maxRedirects: number
+  now?: () => number
+  readTitle(body: string): string
+  request(url: string, timeoutMs: number): Promise<LinkTitleCurlHop>
+  timeoutMs: number
+}
+
+export interface LinkTitleCurlRequestOptions {
+  connectTimeoutSeconds: number
+  headerPath: string
+  maxBytes: number
+  proxyUrl: string
+  timeoutSeconds: number
+  userAgent: string
+}
+
+function curlSocksProxyUrl(proxyUrl: string): string {
+  return proxyUrl.replace(/^socks5:/, 'socks5h:')
+}
+
+export function linkTitleCurlRequestArgs(url: string, options: LinkTitleCurlRequestOptions): string[] {
+  return [
+    '--disable',
+    '--no-location',
+    '--proxy',
+    curlSocksProxyUrl(options.proxyUrl),
+    '--noproxy',
+    '',
+    '--silent',
+    '--show-error',
+    '--max-time',
+    String(options.timeoutSeconds),
+    '--connect-timeout',
+    String(options.connectTimeoutSeconds),
+    '--user-agent',
+    options.userAgent,
+    '--header',
+    'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.5',
+    '--header',
+    'Accept-Language: en-US,en;q=0.7',
+    '--header',
+    'Accept-Encoding: identity',
+    '--proto',
+    '=http,https',
+    '--max-filesize',
+    String(options.maxBytes),
+    '--dump-header',
+    options.headerPath,
+    '--raw',
+    url
+  ]
+}
+
+export function parseLinkTitleCurlHeaders(value: string): Pick<LinkTitleCurlHop, 'location' | 'statusCode'> {
+  let location: null | string = null
+  let statusCode = 0
+
+  for (const block of value.split(/\r?\n\r?\n/)) {
+    const lines = block.split(/\r?\n/)
+    const status = /^HTTP\/\S+\s+(\d{3})\b/i.exec(lines[0] ?? '')
+
+    if (!status) {
+      continue
+    }
+
+    statusCode = Number.parseInt(status[1], 10)
+    location = null
+
+    for (const line of lines.slice(1)) {
+      const match = /^location\s*:\s*(.*)$/i.exec(line)
+
+      if (match) {
+        location = match[1].trim() || null
+      }
+    }
+  }
+
+  return { location, statusCode }
+}
+
+export function createLinkTitleCurlFetcher(deps: LinkTitleCurlDependencies): (rawUrl: string) => Promise<string> {
+  return async rawUrl => {
+    const now = deps.now ?? Date.now
+    const deadline = now() + deps.timeoutMs
+    let redirects = 0
+    let url = deps.admitUrl(rawUrl)
+
+    if (!url) {
+      return ''
+    }
+
+    while (true) {
+      const remainingMs = deadline - now()
+
+      if (remainingMs <= 0) {
+        return ''
+      }
+
+      let response: LinkTitleCurlHop
+
+      try {
+        response = await deps.request(url, remainingMs)
+      } catch {
+        return ''
+      }
+
+      if (!REDIRECT_STATUS_CODES.has(response.statusCode) || !response.location) {
+        return deps.readTitle(response.body)
+      }
+
+      if (redirects >= deps.maxRedirects) {
+        return ''
+      }
+
+      let resolved: string
+
+      try {
+        resolved = new URL(response.location, url).href
+      } catch {
+        return ''
+      }
+
+      const nextUrl = deps.admitUrl(resolved)
+
+      if (!nextUrl) {
+        return ''
+      }
+
+      url = nextUrl
+      redirects += 1
+    }
+  }
+}

--- a/apps/desktop/electron/link-title-deadline.ts
+++ b/apps/desktop/electron/link-title-deadline.ts
@@ -1,0 +1,34 @@
+export function remainingLinkTitleMs(deadline: number, now: () => number = Date.now): number {
+  return Math.max(0, deadline - now())
+}
+
+export function withLinkTitleTimeout<T>(operation: PromiseLike<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      reject(new Error('Link title operation timed out'))
+
+      return
+    }
+
+    let settled = false
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      clearTimeout(timer)
+      callback()
+    }
+
+    const timer = setTimeout(() => {
+      finish(() => reject(new Error('Link title operation timed out')))
+    }, timeoutMs)
+
+    Promise.resolve(operation).then(
+      value => finish(() => resolve(value)),
+      error => finish(() => reject(error))
+    )
+  })
+}

--- a/apps/desktop/electron/link-title-dns.test.ts
+++ b/apps/desktop/electron/link-title-dns.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { createLinkTitlePinnedResolver, type LinkTitleAddress } from './link-title-dns'
+
+const PUBLIC_V4 = '93.184.216.34'
+const PUBLIC_V6 = '2606:4700:4700::1111'
+const PRIVATE_V4 = '10.0.0.8'
+
+function address(address: string, family: 4 | 6): LinkTitleAddress {
+  return { address, family }
+}
+
+function isPublicAddress(value: string): boolean {
+  return value === PUBLIC_V4 || value === PUBLIC_V6
+}
+
+test('normalizes hostname cache keys and reuses the immutable approved answer set inside the TTL', async () => {
+  const lookup = vi.fn(async () => [address(PUBLIC_V4, 4), address(PUBLIC_V6, 6), address(PUBLIC_V4, 4)])
+  const resolver = createLinkTitlePinnedResolver({ isPublicAddress, lookup, now: () => 1_000, ttlMs: 30_000 })
+
+  const first = await resolver.resolve('ExAmPlE.COM.')
+  const second = await resolver.resolve('example.com')
+
+  assert.equal(first, second)
+  assert.deepEqual(first, [address(PUBLIC_V4, 4), address(PUBLIC_V6, 6)])
+  assert.equal(Object.isFrozen(first), true)
+  assert.equal(Object.isFrozen(first[0]), true)
+  assert.deepEqual(lookup.mock.calls, [['example.com']])
+})
+
+test('public IP literals are normalized without DNS and private literals are rejected', async () => {
+  const lookup = vi.fn<() => Promise<readonly LinkTitleAddress[]>>()
+  const resolver = createLinkTitlePinnedResolver({ isPublicAddress, lookup, ttlMs: 30_000 })
+
+  assert.deepEqual(await resolver.resolve(`[${PUBLIC_V6}]`), [address(PUBLIC_V6, 6)])
+  assert.deepEqual(await resolver.resolve(PUBLIC_V4), [address(PUBLIC_V4, 4)])
+  await assert.rejects(resolver.resolve(PRIVATE_V4), /non-public/i)
+  assert.equal(lookup.mock.calls.length, 0)
+})
+
+test('rejects empty, private-only, and mixed DNS answers without caching them', async () => {
+  const lookup = vi
+    .fn<(hostname: string) => Promise<readonly LinkTitleAddress[]>>()
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([address(PRIVATE_V4, 4)])
+    .mockResolvedValueOnce([address(PUBLIC_V4, 4), address(PRIVATE_V4, 4)])
+    .mockResolvedValueOnce([address(PUBLIC_V4, 4)])
+
+  const resolver = createLinkTitlePinnedResolver({ isPublicAddress, lookup, now: () => 0, ttlMs: 30_000 })
+
+  await assert.rejects(resolver.resolve('empty.example'), /empty/i)
+  await assert.rejects(resolver.resolve('private.example'), /non-public/i)
+  await assert.rejects(resolver.resolve('mixed.example'), /non-public/i)
+  assert.deepEqual(await resolver.resolve('mixed.example'), [address(PUBLIC_V4, 4)])
+  assert.deepEqual(lookup.mock.calls, [
+    ['empty.example'],
+    ['private.example'],
+    ['mixed.example'],
+    ['mixed.example']
+  ])
+})
+
+test('renews an active pin for a full TTL so a near-expiry fetch cannot rebind mid-flight', async () => {
+  let now = 100
+  let finishFirstLookup: ((value: readonly LinkTitleAddress[]) => void) | undefined
+
+  const firstLookup = new Promise<readonly LinkTitleAddress[]>(resolve => {
+    finishFirstLookup = resolve
+  })
+
+  const lookup = vi
+    .fn<(hostname: string) => Promise<readonly LinkTitleAddress[]>>()
+    .mockReturnValueOnce(firstLookup)
+    .mockResolvedValueOnce([address(PRIVATE_V4, 4)])
+    .mockResolvedValueOnce([address(PUBLIC_V6, 6)])
+
+  const resolver = createLinkTitlePinnedResolver({ isPublicAddress, lookup, now: () => now, ttlMs: 30_000 })
+
+  const first = resolver.resolve('rebind.example')
+  const concurrent = resolver.resolve('REBIND.EXAMPLE.')
+  assert.equal(lookup.mock.calls.length, 1)
+  finishFirstLookup?.([address(PUBLIC_V4, 4)])
+  assert.equal(await first, await concurrent)
+
+  now += 29_999
+  assert.deepEqual(await resolver.resolve('rebind.example'), [address(PUBLIC_V4, 4)])
+  assert.equal(lookup.mock.calls.length, 1)
+
+  now += 20_000
+  assert.deepEqual(await resolver.resolve('rebind.example'), [address(PUBLIC_V4, 4)])
+  assert.equal(lookup.mock.calls.length, 1)
+
+  now += 30_001
+  await assert.rejects(resolver.resolve('rebind.example'), /non-public/i)
+  assert.equal(lookup.mock.calls.length, 2)
+
+  assert.deepEqual(await resolver.resolve('rebind.example'), [address(PUBLIC_V6, 6)])
+  assert.equal(lookup.mock.calls.length, 3)
+})
+
+test('bounds one-shot hostname pins and evicts the least recently used entry', async () => {
+  let now = 0
+  const lookup = vi.fn(async () => [address(PUBLIC_V4, 4)])
+
+  const resolver = createLinkTitlePinnedResolver({
+    isPublicAddress,
+    lookup,
+    maxEntries: 2,
+    now: () => now,
+    ttlMs: 30_000
+  })
+
+  await resolver.resolve('one.example')
+  now += 1
+  await resolver.resolve('two.example')
+  now += 1
+  await resolver.resolve('one.example')
+  now += 1
+  await resolver.resolve('three.example')
+  now += 1
+  await resolver.resolve('two.example')
+
+  assert.deepEqual(lookup.mock.calls, [
+    ['one.example'],
+    ['two.example'],
+    ['three.example'],
+    ['two.example']
+  ])
+})
+
+test('prunes expired one-shot pins before admitting new hostnames', async () => {
+  let now = 0
+  const lookup = vi.fn(async () => [address(PUBLIC_V4, 4)])
+
+  const resolver = createLinkTitlePinnedResolver({
+    isPublicAddress,
+    lookup,
+    maxEntries: 2,
+    now: () => now,
+    ttlMs: 10
+  })
+
+  await resolver.resolve('expired.example')
+  now = 11
+  await resolver.resolve('fresh.example')
+  await resolver.resolve('expired.example')
+
+  assert.deepEqual(lookup.mock.calls, [['expired.example'], ['fresh.example'], ['expired.example']])
+})
+
+test('clear invalidates approved pins immediately', async () => {
+  const lookup = vi
+    .fn<(hostname: string) => Promise<readonly LinkTitleAddress[]>>()
+    .mockResolvedValueOnce([address(PUBLIC_V4, 4)])
+    .mockResolvedValueOnce([address(PUBLIC_V6, 6)])
+
+  const resolver = createLinkTitlePinnedResolver({ isPublicAddress, lookup, now: () => 0, ttlMs: 30_000 })
+
+  assert.deepEqual(await resolver.resolve('example.com'), [address(PUBLIC_V4, 4)])
+  resolver.clear()
+  assert.deepEqual(await resolver.resolve('example.com'), [address(PUBLIC_V6, 6)])
+  assert.equal(lookup.mock.calls.length, 2)
+})

--- a/apps/desktop/electron/link-title-dns.ts
+++ b/apps/desktop/electron/link-title-dns.ts
@@ -1,0 +1,192 @@
+import { lookup as dnsLookup } from 'node:dns'
+import { isIP } from 'node:net'
+
+export type LinkTitleAddress = { address: string; family: 4 | 6 }
+
+export interface LinkTitlePinnedResolver {
+  clear(): void
+  resolve(hostname: string): Promise<readonly LinkTitleAddress[]>
+}
+
+interface CachedAddresses {
+  addresses: readonly LinkTitleAddress[]
+  expiresAt: number
+}
+
+type LinkTitleLookup = (hostname: string) => Promise<readonly LinkTitleAddress[]>
+
+function lookupAll(hostname: string): Promise<readonly LinkTitleAddress[]> {
+  return new Promise((resolve, reject) => {
+    dnsLookup(hostname, { all: true, verbatim: true }, (error, addresses) => {
+      if (error) {
+        reject(error)
+
+        return
+      }
+
+      resolve(
+        addresses.map(value => ({
+          address: value.address,
+          family: value.family as 4 | 6
+        }))
+      )
+    })
+  })
+}
+
+function normalizeHostname(hostname: string): string {
+  let normalized = hostname.trim().toLowerCase()
+
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    normalized = normalized.slice(1, -1)
+  }
+
+  if (normalized.endsWith('.')) {
+    normalized = normalized.slice(0, -1)
+  }
+
+  if (!normalized) {
+    throw new Error('Link title DNS hostname is empty')
+  }
+
+  return normalized
+}
+
+function immutableAddresses(addresses: readonly LinkTitleAddress[]): readonly LinkTitleAddress[] {
+  return Object.freeze(addresses.map(value => Object.freeze({ ...value })))
+}
+
+function approveAnswers(
+  answers: readonly LinkTitleAddress[],
+  isPublicAddress: (value: string) => boolean
+): readonly LinkTitleAddress[] {
+  if (answers.length === 0) {
+    throw new Error('Link title DNS returned an empty answer set')
+  }
+
+  if (answers.some(answer => !isPublicAddress(answer.address))) {
+    throw new Error('Link title DNS returned a non-public address')
+  }
+
+  const approved: LinkTitleAddress[] = []
+  const seen = new Set<string>()
+
+  for (const answer of answers) {
+    const key = `${answer.family}:${answer.address}`
+
+    if (!seen.has(key)) {
+      seen.add(key)
+      approved.push(answer)
+    }
+  }
+
+  return immutableAddresses(approved)
+}
+
+export function createLinkTitlePinnedResolver(options: {
+  isPublicAddress(value: string): boolean
+  lookup?: LinkTitleLookup
+  maxEntries?: number
+  now?: () => number
+  ttlMs: number
+}): LinkTitlePinnedResolver {
+  const cache = new Map<string, CachedAddresses>()
+  const inflight = new Map<string, Promise<readonly LinkTitleAddress[]>>()
+  const lookup = options.lookup ?? lookupAll
+  const maxEntries = Math.max(1, Math.floor(options.maxEntries ?? 512))
+  const now = options.now ?? Date.now
+  let generation = 0
+
+  const pruneCache = (currentTime: number) => {
+    for (const [hostname, cached] of cache) {
+      if (currentTime >= cached.expiresAt) {
+        cache.delete(hostname)
+      }
+    }
+
+    while (cache.size > maxEntries) {
+      const oldest = cache.keys().next().value
+
+      if (oldest === undefined) {
+        break
+      }
+
+      cache.delete(oldest)
+    }
+  }
+
+  return {
+    clear() {
+      generation += 1
+      cache.clear()
+      inflight.clear()
+    },
+    async resolve(hostname) {
+      const normalized = normalizeHostname(hostname)
+      const family = isIP(normalized)
+
+      if (family !== 0) {
+        if (!options.isPublicAddress(normalized)) {
+          throw new Error('Link title DNS literal is a non-public address')
+        }
+
+        return immutableAddresses([{ address: normalized, family: family === 4 ? 4 : 6 }])
+      }
+
+      const currentTime = now()
+      pruneCache(currentTime)
+      const cached = cache.get(normalized)
+
+      if (cached) {
+        cache.delete(normalized)
+        cache.set(normalized, {
+          addresses: cached.addresses,
+          expiresAt: currentTime + options.ttlMs
+        })
+
+        return cached.addresses
+      }
+
+      const pending = inflight.get(normalized)
+
+      if (pending) {
+        return pending
+      }
+
+      const startedGeneration = generation
+
+      const resolution = (async () => {
+        const approved = approveAnswers(await lookup(normalized), options.isPublicAddress)
+
+        if (generation === startedGeneration) {
+          const resolvedAt = now()
+          pruneCache(resolvedAt)
+
+          while (cache.size >= maxEntries) {
+            const oldest = cache.keys().next().value
+
+            if (oldest === undefined) {
+              break
+            }
+
+            cache.delete(oldest)
+          }
+
+          cache.set(normalized, { addresses: approved, expiresAt: resolvedAt + options.ttlMs })
+        }
+
+        return approved
+      })()
+
+      inflight.set(normalized, resolution)
+
+      try {
+        return await resolution
+      } finally {
+        if (inflight.get(normalized) === resolution) {
+          inflight.delete(normalized)
+        }
+      }
+    }
+  }
+}

--- a/apps/desktop/electron/link-title-fetch.test.ts
+++ b/apps/desktop/electron/link-title-fetch.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { createLinkTitleFetcher } from './link-title-fetch'
+
+function makeDependencies() {
+  return {
+    admitUrl: vi.fn((value: string) => new URL(value).href),
+    cache: {
+      get: vi.fn(() => undefined),
+      has: vi.fn(() => false)
+    },
+    cacheKey: vi.fn(() => 'example.com/'),
+    fetchWithCurl: vi.fn(async () => ''),
+    fetchWithRenderer: vi.fn(async () => 'Rendered title'),
+    inflight: {
+      delete: vi.fn(() => true),
+      get: vi.fn(() => undefined),
+      set: vi.fn()
+    },
+    normalizeTitle: vi.fn((value: string) => value.trim()),
+    storeCachedTitle: vi.fn()
+  }
+}
+
+test('blocked URLs return before cache or network title resolution', async () => {
+  const deps = makeDependencies()
+  deps.admitUrl.mockReturnValue(null)
+  const fetchLinkTitle = createLinkTitleFetcher(deps)
+
+  assert.equal(await fetchLinkTitle(' http://127 '), '')
+  assert.deepEqual(deps.admitUrl.mock.calls, [['http://127']])
+  assert.equal(deps.cacheKey.mock.calls.length, 0)
+  assert.equal(deps.cache.has.mock.calls.length, 0)
+  assert.equal(deps.cache.get.mock.calls.length, 0)
+  assert.equal(deps.inflight.get.mock.calls.length, 0)
+  assert.equal(deps.fetchWithCurl.mock.calls.length, 0)
+  assert.equal(deps.fetchWithRenderer.mock.calls.length, 0)
+  assert.equal(deps.storeCachedTitle.mock.calls.length, 0)
+})
+
+test('public URLs use the curl result before falling back to the renderer', async () => {
+  const deps = makeDependencies()
+  const fetchLinkTitle = createLinkTitleFetcher(deps)
+  const pending = fetchLinkTitle(' https://example.com ')
+
+  assert.equal(await pending, 'Rendered title')
+  assert.deepEqual(deps.cacheKey.mock.calls, [['https://example.com/']])
+  assert.deepEqual(deps.fetchWithCurl.mock.calls, [['https://example.com/']])
+  assert.deepEqual(deps.fetchWithRenderer.mock.calls, [['https://example.com/']])
+  assert.ok(deps.fetchWithCurl.mock.invocationCallOrder[0] < deps.fetchWithRenderer.mock.invocationCallOrder[0])
+  assert.deepEqual(deps.storeCachedTitle.mock.calls, [['example.com/', 'Rendered title']])
+  assert.equal(deps.inflight.set.mock.calls.length, 1)
+  assert.equal(deps.inflight.set.mock.calls[0][0], 'example.com/')
+  assert.equal(deps.inflight.set.mock.calls[0][1], pending)
+  assert.deepEqual(deps.inflight.delete.mock.calls, [['example.com/']])
+})
+
+test('uses the admitted canonical URL instead of the caller representation', async () => {
+  const deps = makeDependencies()
+  const canonical = 'http://example.com/@127.0.0.1/'
+  deps.admitUrl.mockReturnValue(canonical)
+  deps.fetchWithCurl.mockResolvedValue('Curl title')
+  const fetchLinkTitle = createLinkTitleFetcher(deps)
+
+  assert.equal(await fetchLinkTitle('http://example.com\\@127.0.0.1/'), 'Curl title')
+  assert.deepEqual(deps.cacheKey.mock.calls, [[canonical]])
+  assert.deepEqual(deps.fetchWithCurl.mock.calls, [[canonical]])
+  assert.equal(deps.fetchWithRenderer.mock.calls.length, 0)
+})

--- a/apps/desktop/electron/link-title-fetch.ts
+++ b/apps/desktop/electron/link-title-fetch.ts
@@ -1,0 +1,68 @@
+export interface LinkTitleFetchDependencies {
+  admitUrl(value: string): null | string
+  cache: {
+    get(key: string): string | undefined
+    has(key: string): boolean
+  }
+  cacheKey(value: string): string
+  fetchWithCurl(url: string): Promise<string>
+  fetchWithRenderer(url: string): Promise<string>
+  inflight: {
+    delete(key: string): unknown
+    get(key: string): Promise<string> | undefined
+    set(key: string, value: Promise<string>): unknown
+  }
+  normalizeTitle(value: string): string
+  storeCachedTitle(key: string, value: string): void
+}
+
+export function createLinkTitleFetcher(deps: LinkTitleFetchDependencies): (rawUrl: unknown) => Promise<string> {
+  return rawUrl => {
+    const raw = String(rawUrl || '').trim()
+    const url = deps.admitUrl(raw)
+
+    if (!url) {
+      return Promise.resolve('')
+    }
+
+    const key = deps.cacheKey(url)
+
+    if (!key) {
+      return Promise.resolve('')
+    }
+
+    if (deps.cache.has(key)) {
+      return Promise.resolve(deps.cache.get(key) ?? '')
+    }
+
+    const inflight = deps.inflight.get(key)
+
+    if (inflight) {
+      return inflight
+    }
+
+    const pending = deps
+      .fetchWithCurl(url)
+      .catch(() => '')
+      .then(value => deps.normalizeTitle((value || '').slice(0, 240)))
+      .then(async value => {
+        if (value) {
+          return value
+        }
+
+        const rendered = await deps.fetchWithRenderer(url).catch(() => '')
+
+        return deps.normalizeTitle((rendered || '').slice(0, 240))
+      })
+      .then(clean => {
+        deps.storeCachedTitle(key, clean)
+        deps.inflight.delete(key)
+
+        return clean
+      })
+
+    deps.inflight.set(key, pending)
+
+    return pending
+  }
+}

--- a/apps/desktop/electron/link-title-render-queue.test.ts
+++ b/apps/desktop/electron/link-title-render-queue.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { createLinkTitleRenderQueue } from './link-title-render-queue'
+
+test('renderer queue wait consumes the absolute renderer deadline', async () => {
+  let finishFirst: ((value: string) => void) | undefined
+
+  const run = vi.fn(
+    () =>
+      new Promise<string>(resolve => {
+        finishFirst = resolve
+      })
+  )
+
+  const queue = createLinkTitleRenderQueue({ concurrency: 1, run, timeoutMs: 25 })
+
+  const first = queue.enqueue('https://first.example/')
+  const second = queue.enqueue('https://second.example/')
+
+  assert.equal(await second, '')
+  assert.equal(run.mock.calls.length, 1)
+
+  finishFirst?.('First title')
+  assert.equal(await first, 'First title')
+  assert.equal(run.mock.calls.length, 1)
+})
+
+test('closing the renderer queue settles queued and future work without starting it', async () => {
+  let finishFirst: ((value: string) => void) | undefined
+
+  const run = vi.fn(
+    () =>
+      new Promise<string>(resolve => {
+        finishFirst = resolve
+      })
+  )
+
+  const queue = createLinkTitleRenderQueue({ concurrency: 1, run, timeoutMs: 1_000 })
+
+  const first = queue.enqueue('https://first.example/')
+  const queued = queue.enqueue('https://queued.example/')
+
+  queue.close()
+
+  assert.equal(await queued, '')
+  assert.equal(await queue.enqueue('https://future.example/'), '')
+  assert.equal(run.mock.calls.length, 1)
+
+  finishFirst?.('First title')
+  assert.equal(await first, 'First title')
+})

--- a/apps/desktop/electron/link-title-render-queue.ts
+++ b/apps/desktop/electron/link-title-render-queue.ts
@@ -1,0 +1,96 @@
+export interface LinkTitleRenderQueue {
+  close(): void
+  enqueue(url: string): Promise<string>
+}
+
+interface QueueItem {
+  deadline: number
+  resolve(value: string): void
+  settled: boolean
+  timer: ReturnType<typeof setTimeout>
+  url: string
+}
+
+export function createLinkTitleRenderQueue(options: {
+  concurrency: number
+  now?: () => number
+  run(url: string, deadline: number): Promise<string>
+  timeoutMs: number
+}): LinkTitleRenderQueue {
+  const concurrency = Math.max(1, Math.floor(options.concurrency))
+  const now = options.now ?? Date.now
+  const pending: QueueItem[] = []
+  let active = 0
+  let closed = false
+
+  const settle = (item: QueueItem, value: string) => {
+    if (item.settled) {
+      return
+    }
+
+    item.settled = true
+    clearTimeout(item.timer)
+    item.resolve(value)
+  }
+
+  const dequeue = () => {
+    while (!closed && active < concurrency && pending.length) {
+      const item = pending.shift()
+
+      if (!item || item.settled) {
+        continue
+      }
+
+      if (now() >= item.deadline) {
+        settle(item, '')
+
+        continue
+      }
+
+      clearTimeout(item.timer)
+      active += 1
+      void options
+        .run(item.url, item.deadline)
+        .catch(() => '')
+        .then(value => settle(item, value))
+        .finally(() => {
+          active -= 1
+          dequeue()
+        })
+    }
+  }
+
+  return {
+    close() {
+      if (closed) {
+        return
+      }
+
+      closed = true
+
+      for (const item of pending.splice(0)) {
+        settle(item, '')
+      }
+    },
+    enqueue(url) {
+      if (closed) {
+        return Promise.resolve('')
+      }
+
+      return new Promise(resolve => {
+        const deadline = now() + options.timeoutMs
+
+        const item: QueueItem = {
+          deadline,
+          resolve,
+          settled: false,
+          timer: setTimeout(() => settle(item, ''), Math.max(0, deadline - now())),
+          url
+        }
+
+        pending.push(item)
+        dequeue()
+      })
+    }
+  }
+}

--- a/apps/desktop/electron/link-title-socks.test.ts
+++ b/apps/desktop/electron/link-title-socks.test.ts
@@ -1,0 +1,338 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { once } from 'node:events'
+import http from 'node:http'
+import net from 'node:net'
+import { promisify } from 'node:util'
+
+import { test, vi } from 'vitest'
+
+import { createLinkTitlePinnedResolver } from './link-title-dns'
+import { createLinkTitleSocksGatewayController, startLinkTitleSocksGateway } from './link-title-socks'
+
+const execFileAsync = promisify(execFile)
+
+async function connectToGateway(proxyUrl: string): Promise<net.Socket> {
+  const url = new URL(proxyUrl)
+  const socket = net.createConnection({ host: url.hostname, port: Number(url.port) })
+  await once(socket, 'connect')
+
+  return socket
+}
+
+async function readAtLeast(socket: net.Socket, byteCount: number): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  let bytes = 0
+
+  while (bytes < byteCount) {
+    const [chunk] = (await once(socket, 'data')) as [Buffer]
+    chunks.push(chunk)
+    bytes += chunk.length
+  }
+
+  return Buffer.concat(chunks)
+}
+
+async function negotiateNoAuth(socket: net.Socket): Promise<void> {
+  socket.write(Buffer.from([0x05, 0x01, 0x00]))
+  assert.deepEqual(await readAtLeast(socket, 2), Buffer.from([0x05, 0x00]))
+}
+
+function domainRequest(command: number, hostname: string, port = 80): Buffer {
+  const domain = Buffer.from(hostname, 'ascii')
+
+  return Buffer.from([0x05, command, 0x00, 0x03, domain.length, ...domain, port >> 8, port & 0xff])
+}
+
+test('gateway binds to loopback and rejects unsupported SOCKS commands before resolving', async () => {
+  const resolve = vi.fn(async () => [{ address: '93.184.216.34', family: 4 as const }])
+  const createConnection = vi.fn()
+
+  const gateway = await startLinkTitleSocksGateway({
+    connectTimeoutMs: 250,
+    createConnection: createConnection as unknown as typeof net.createConnection,
+    resolve
+  })
+
+  try {
+    const url = new URL(gateway.proxyUrl)
+    assert.equal(url.protocol, 'socks5:')
+    assert.equal(url.hostname, '127.0.0.1')
+    assert.ok(Number(url.port) > 0)
+
+    const socket = await connectToGateway(gateway.proxyUrl)
+    await negotiateNoAuth(socket)
+    socket.write(domainRequest(0x02, 'example.com'))
+
+    const reply = await readAtLeast(socket, 10)
+    assert.equal(reply[0], 0x05)
+    assert.equal(reply[1], 0x07)
+    assert.equal(resolve.mock.calls.length, 0)
+    assert.equal(createConnection.mock.calls.length, 0)
+    socket.destroy()
+  } finally {
+    await gateway.close()
+  }
+})
+
+test('gateway rejects unknown address types and oversized handshakes', async () => {
+  const resolve = vi.fn(async () => [{ address: '93.184.216.34', family: 4 as const }])
+  const gateway = await startLinkTitleSocksGateway({ connectTimeoutMs: 250, resolve })
+
+  try {
+    const unknown = await connectToGateway(gateway.proxyUrl)
+    await negotiateNoAuth(unknown)
+    unknown.write(Buffer.from([0x05, 0x01, 0x00, 0x09, 0x00, 0x50]))
+    const reply = await readAtLeast(unknown, 10)
+    assert.equal(reply[1], 0x08)
+    unknown.destroy()
+
+    const oversized = await connectToGateway(gateway.proxyUrl)
+    oversized.write(Buffer.concat([Buffer.from([0x05, 0xff]), Buffer.alloc(1_100)]))
+    await once(oversized, 'close')
+    assert.equal(resolve.mock.calls.length, 0)
+  } finally {
+    await gateway.close()
+  }
+})
+
+test('gateway returns the SOCKS greeting rejection shape when no supported auth method is offered', async () => {
+  const resolve = vi.fn(async () => [{ address: '93.184.216.34', family: 4 as const }])
+  const gateway = await startLinkTitleSocksGateway({ connectTimeoutMs: 250, resolve })
+
+  try {
+    const socket = await connectToGateway(gateway.proxyUrl)
+    socket.write(Buffer.from([0x05, 0x01, 0x02]))
+    assert.deepEqual(await readAtLeast(socket, 2), Buffer.from([0x05, 0xff]))
+    assert.equal(resolve.mock.calls.length, 0)
+    socket.destroy()
+  } finally {
+    await gateway.close()
+  }
+})
+
+test('resolver rejection never reaches the upstream connector', async () => {
+  const resolve = vi.fn(async () => {
+    throw new Error('mixed or private DNS answer')
+  })
+
+  const createConnection = vi.fn()
+
+  const gateway = await startLinkTitleSocksGateway({
+    connectTimeoutMs: 250,
+    createConnection: createConnection as unknown as typeof net.createConnection,
+    resolve
+  })
+
+  try {
+    const socket = await connectToGateway(gateway.proxyUrl)
+    await negotiateNoAuth(socket)
+    socket.write(domainRequest(0x01, 'mixed.example'))
+    const reply = await readAtLeast(socket, 10)
+
+    assert.equal(reply[1], 0x04)
+    assert.deepEqual(resolve.mock.calls, [['mixed.example']])
+    assert.equal(createConnection.mock.calls.length, 0)
+    socket.destroy()
+  } finally {
+    await gateway.close()
+  }
+})
+
+test('a timed-out client cannot start an upstream connection after slow DNS eventually resolves', async () => {
+  let finishResolve: ((value: readonly { address: string; family: 4 }[]) => void) | undefined
+
+  const pendingResolve = new Promise<readonly { address: string; family: 4 }[]>(resolve => {
+    finishResolve = resolve
+  })
+
+  const createConnection = vi.fn()
+
+  const gateway = await startLinkTitleSocksGateway({
+    connectTimeoutMs: 40,
+    createConnection: createConnection as unknown as typeof net.createConnection,
+    resolve: () => pendingResolve
+  })
+
+  try {
+    const socket = await connectToGateway(gateway.proxyUrl)
+    await negotiateNoAuth(socket)
+    socket.write(domainRequest(0x01, 'slow.example'))
+    await once(socket, 'close')
+
+    finishResolve?.([{ address: '93.184.216.34', family: 4 }])
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    assert.equal(createConnection.mock.calls.length, 0)
+  } finally {
+    await gateway.close()
+  }
+})
+
+test('gateway close destroys an upstream socket that is still connecting', async () => {
+  const stalled = new net.Socket()
+  const createConnection = vi.fn(() => stalled)
+
+  const gateway = await startLinkTitleSocksGateway({
+    connectTimeoutMs: 5_000,
+    createConnection: createConnection as unknown as typeof net.createConnection,
+    resolve: async () => [{ address: '93.184.216.34', family: 4 }]
+  })
+
+  const client = await connectToGateway(gateway.proxyUrl)
+  await negotiateNoAuth(client)
+  client.write(domainRequest(0x01, 'pending.example'))
+
+  for (let attempt = 0; attempt < 20 && createConnection.mock.calls.length === 0; attempt += 1) {
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }
+
+  assert.equal(createConnection.mock.calls.length, 1)
+  await gateway.close()
+  assert.equal(stalled.destroyed, true)
+  client.destroy()
+})
+
+test('all approved addresses share one absolute connection deadline', async () => {
+  const sockets: net.Socket[] = []
+
+  const createConnection = vi.fn(() => {
+    const socket = new net.Socket()
+    sockets.push(socket)
+
+    return socket
+  })
+
+  const gateway = await startLinkTitleSocksGateway({
+    connectTimeoutMs: 40,
+    createConnection: createConnection as unknown as typeof net.createConnection,
+    resolve: async () => [
+      { address: '93.184.216.34', family: 4 },
+      { address: '2606:4700:4700::1111', family: 6 }
+    ]
+  })
+
+  try {
+    const client = await connectToGateway(gateway.proxyUrl)
+    await negotiateNoAuth(client)
+    client.write(domainRequest(0x01, 'deadline.example'))
+    await once(client, 'close')
+
+    assert.equal(createConnection.mock.calls.length, 1)
+    assert.equal(sockets.every(socket => socket.destroyed), true)
+  } finally {
+    await gateway.close()
+  }
+})
+
+test('real curl traffic preserves Host and reuses the pinned answer inside the TTL', async () => {
+  let observedHost = ''
+  let requests = 0
+
+  const server = http.createServer((request, response) => {
+    observedHost = request.headers.host ?? ''
+    requests += 1
+    response.end('<title>Pinned title</title>')
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  assert.ok(address && typeof address !== 'string')
+
+  let lookupCount = 0
+
+  const resolver = createLinkTitlePinnedResolver({
+    isPublicAddress: value => value === '127.0.0.1',
+    lookup: async () => {
+      lookupCount += 1
+
+      return lookupCount === 1
+        ? [{ address: '127.0.0.1', family: 4 }]
+        : [{ address: '10.0.0.1', family: 4 }]
+    },
+    now: () => 0,
+    ttlMs: 30_000
+  })
+
+  const gateway = await startLinkTitleSocksGateway({ connectTimeoutMs: 1_000, resolve: resolver.resolve })
+  const curlProxy = gateway.proxyUrl.replace(/^socks5:/, 'socks5h:')
+  const target = `http://public-title.invalid:${address.port}/title`
+
+  try {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const { stdout } = await execFileAsync(
+        'curl',
+        ['--disable', '--silent', '--show-error', '--proxy', curlProxy, '--noproxy', '', target],
+        { encoding: 'utf8', timeout: 5_000 }
+      )
+
+      assert.equal(stdout, '<title>Pinned title</title>')
+    }
+
+    assert.equal(requests, 2)
+    assert.equal(observedHost, `public-title.invalid:${address.port}`)
+    assert.equal(lookupCount, 1)
+  } finally {
+    await gateway.close()
+    await new Promise<void>(resolve => server.close(() => resolve()))
+  }
+})
+
+test('gateway controller starts one lazy gateway and closes it with its DNS pins', async () => {
+  const close = vi.fn(async () => undefined)
+  const start = vi.fn(async () => ({ close, proxyUrl: 'socks5://127.0.0.1:48123' }))
+  const clearPins = vi.fn()
+  const controller = createLinkTitleSocksGatewayController({ clearPins, start })
+
+  const [first, second] = await Promise.all([controller.get(), controller.get()])
+
+  assert.equal(first, second)
+  assert.equal(start.mock.calls.length, 1)
+
+  await controller.close()
+  assert.equal(close.mock.calls.length, 1)
+  assert.equal(clearPins.mock.calls.length, 1)
+})
+
+test('gateway controller never returns a direct fallback and permits a later pinned retry', async () => {
+  const gateway = { close: vi.fn(async () => undefined), proxyUrl: 'socks5://127.0.0.1:48123' }
+  const start = vi.fn().mockRejectedValueOnce(new Error('bind failed')).mockResolvedValueOnce(gateway)
+  const controller = createLinkTitleSocksGatewayController({ clearPins: vi.fn(), start })
+
+  await assert.rejects(controller.get(), /bind failed/)
+  assert.equal(await controller.get(), gateway)
+  assert.equal(start.mock.calls.length, 2)
+  await controller.close()
+})
+
+test('gateway controller close is terminal during an in-progress gateway shutdown', async () => {
+  let finishClose: (() => void) | undefined
+
+  const close = vi.fn(
+    () =>
+      new Promise<void>(resolve => {
+        finishClose = resolve
+      })
+  )
+
+  const start = vi.fn(async () => ({ close, proxyUrl: 'socks5://127.0.0.1:48123' }))
+  const clearPins = vi.fn()
+  const controller = createLinkTitleSocksGatewayController({ clearPins, start })
+
+  await controller.get()
+  const closing = controller.close()
+
+  await assert.rejects(controller.get(), /closed/i)
+  assert.equal(start.mock.calls.length, 1)
+
+  finishClose?.()
+  await closing
+  await controller.close()
+
+  assert.equal(close.mock.calls.length, 1)
+  assert.equal(clearPins.mock.calls.length, 1)
+  await assert.rejects(controller.get(), /closed/i)
+})

--- a/apps/desktop/electron/link-title-socks.ts
+++ b/apps/desktop/electron/link-title-socks.ts
@@ -1,0 +1,583 @@
+import net, { type Socket } from 'node:net'
+
+import type { LinkTitleAddress } from './link-title-dns'
+
+export interface LinkTitleSocksGateway {
+  proxyUrl: string
+  close(): Promise<void>
+}
+
+export interface LinkTitleSocksGatewayController {
+  close(): Promise<void>
+  get(): Promise<LinkTitleSocksGateway>
+}
+
+export function createLinkTitleSocksGatewayController(options: {
+  clearPins(): void
+  start(): Promise<LinkTitleSocksGateway>
+}): LinkTitleSocksGatewayController {
+  let closed = false
+  let closePromise: Promise<void> | null = null
+  let pending: Promise<LinkTitleSocksGateway> | null = null
+
+  return {
+    close() {
+      if (!closePromise) {
+        closed = true
+        const current = pending
+        pending = null
+
+        closePromise = (async () => {
+          try {
+            await (await current?.catch(() => null))?.close()
+          } finally {
+            options.clearPins()
+          }
+        })()
+      }
+
+      return closePromise
+    },
+    get() {
+      if (closed) {
+        return Promise.reject(new Error('Link title SOCKS gateway controller is closed'))
+      }
+
+      if (!pending) {
+        const attempt = options.start()
+
+        const guarded = attempt.catch(error => {
+          if (pending === guarded) {
+            pending = null
+          }
+
+          throw error
+        })
+
+        pending = guarded
+      }
+
+      return pending
+    }
+  }
+}
+
+const MAX_HANDSHAKE_BYTES = 1_024
+
+function reply(code: number): Buffer {
+  return Buffer.from([0x05, code, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+}
+
+function ipv6FromBytes(value: Buffer): string {
+  const words: string[] = []
+
+  for (let offset = 0; offset < value.length; offset += 2) {
+    words.push(value.readUInt16BE(offset).toString(16))
+  }
+
+  return words.join(':')
+}
+
+class LinkTitleSocksAbortError extends Error {
+  constructor() {
+    super('Link title SOCKS operation was aborted')
+  }
+}
+
+class LinkTitleSocksTimeoutError extends Error {
+  constructor() {
+    super('Link title SOCKS operation timed out')
+  }
+}
+
+function abortError(): LinkTitleSocksAbortError {
+  return new LinkTitleSocksAbortError()
+}
+
+function timeoutError(): LinkTitleSocksTimeoutError {
+  return new LinkTitleSocksTimeoutError()
+}
+
+function awaitWithin<T>(operation: PromiseLike<T>, signal: AbortSignal, deadline: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(abortError())
+
+      return
+    }
+
+    const remainingMs = deadline - Date.now()
+
+    if (remainingMs <= 0) {
+      reject(timeoutError())
+
+      return
+    }
+
+    let settled = false
+
+    const cleanup = () => {
+      clearTimeout(timer)
+      signal.removeEventListener('abort', onAbort)
+    }
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      cleanup()
+      callback()
+    }
+
+    const onAbort = () => finish(() => reject(abortError()))
+    const timer = setTimeout(() => finish(() => reject(timeoutError())), remainingMs)
+
+    signal.addEventListener('abort', onAbort, { once: true })
+    Promise.resolve(operation).then(
+      value => finish(() => resolve(value)),
+      error => finish(() => reject(error))
+    )
+  })
+}
+
+async function connectToApprovedAddress(
+  addresses: readonly LinkTitleAddress[],
+  port: number,
+  deadline: number,
+  signal: AbortSignal,
+  createConnection: typeof net.createConnection,
+  peers: Set<Socket>
+): Promise<Socket> {
+  let lastError: unknown = new Error('Link title SOCKS resolver returned no approved addresses')
+
+  for (const target of addresses) {
+    if (signal.aborted || Date.now() >= deadline) {
+      throw signal.aborted ? abortError() : timeoutError()
+    }
+
+    let upstream: Socket
+
+    try {
+      upstream = createConnection({ family: target.family, host: target.address, port })
+    } catch (error) {
+      lastError = error
+
+      continue
+    }
+
+    peers.add(upstream)
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const remainingMs = deadline - Date.now()
+
+        if (remainingMs <= 0) {
+          peers.delete(upstream)
+          upstream.destroy()
+          reject(timeoutError())
+
+          return
+        }
+
+        let settled = false
+
+        const cleanup = () => {
+          clearTimeout(timer)
+          signal.removeEventListener('abort', onAbort)
+          upstream.off('close', onClose)
+          upstream.off('connect', onConnect)
+          upstream.off('error', onError)
+        }
+
+        const fail = (error: Error) => {
+          if (settled) {
+            return
+          }
+
+          settled = true
+          cleanup()
+          peers.delete(upstream)
+          upstream.destroy()
+          reject(error)
+        }
+
+        const onAbort = () => fail(abortError())
+        const onClose = () => fail(new Error('Link title SOCKS upstream closed before connecting'))
+
+        const onConnect = () => {
+          if (settled) {
+            return
+          }
+
+          settled = true
+          cleanup()
+          resolve()
+        }
+
+        const onError = (error: Error) => fail(error)
+        const timer = setTimeout(() => fail(timeoutError()), remainingMs)
+
+        signal.addEventListener('abort', onAbort, { once: true })
+        upstream.once('close', onClose)
+        upstream.once('connect', onConnect)
+        upstream.once('error', onError)
+      })
+
+      return upstream
+    } catch (error) {
+      lastError = error
+
+      if (error instanceof LinkTitleSocksAbortError || error instanceof LinkTitleSocksTimeoutError) {
+        throw error
+      }
+    }
+  }
+
+  throw lastError
+}
+
+function handleClient(
+  client: Socket,
+  options: {
+    resolve(hostname: string): Promise<readonly LinkTitleAddress[]>
+    connectTimeoutMs: number
+    createConnection: typeof net.createConnection
+  },
+  peers: Set<Socket>,
+  controllers: Set<AbortController>,
+  tasks: Set<Promise<void>>
+): void {
+  const controller = new AbortController()
+  const deadline = Date.now() + options.connectTimeoutMs
+  let buffer = Buffer.alloc(0)
+  let phase: 'greeting' | 'request' | 'connecting' | 'relay' | 'closed' = 'greeting'
+  let processing = false
+  let upstream: Socket | null = null
+
+  peers.add(client)
+  controllers.add(controller)
+
+  const handshakeTimer = setTimeout(() => {
+    if (phase !== 'relay' && phase !== 'closed') {
+      controller.abort()
+      phase = 'closed'
+      client.destroy()
+    }
+  }, options.connectTimeoutMs)
+
+  const closeWithReply = (code: number) => {
+    if (phase === 'closed') {
+      return
+    }
+
+    controller.abort()
+    phase = 'closed'
+    clearTimeout(handshakeTimer)
+    client.end(reply(code))
+  }
+
+  const beginRelay = async (hostname: string, port: number, pending: Buffer) => {
+    try {
+      const addresses = await awaitWithin(options.resolve(hostname), controller.signal, deadline)
+      upstream = await connectToApprovedAddress(
+        addresses,
+        port,
+        deadline,
+        controller.signal,
+        options.createConnection,
+        peers
+      )
+    } catch {
+      if (!controller.signal.aborted && phase !== 'closed' && !client.destroyed) {
+        closeWithReply(0x04)
+      } else {
+        client.destroy()
+      }
+
+      return
+    }
+
+    if (controller.signal.aborted || phase === 'closed' || client.destroyed) {
+      upstream.destroy()
+
+      return
+    }
+
+    phase = 'relay'
+    clearTimeout(handshakeTimer)
+
+    upstream.once('close', () => {
+      peers.delete(upstream as Socket)
+      client.destroy()
+    })
+    upstream.once('error', () => client.destroy())
+    client.once('error', () => upstream?.destroy())
+
+    client.write(reply(0x00))
+
+    if (pending.length) {
+      upstream.write(pending)
+    }
+
+    client.pipe(upstream)
+    upstream.pipe(client)
+    client.resume()
+  }
+
+  const startRelay = (hostname: string, port: number, pending: Buffer) => {
+    const task = beginRelay(hostname, port, pending).finally(() => tasks.delete(task))
+    tasks.add(task)
+  }
+
+  const processBuffer = () => {
+    if (processing || phase === 'connecting' || phase === 'relay' || phase === 'closed') {
+      return
+    }
+
+    processing = true
+
+    try {
+      while (phase === 'greeting' || phase === 'request') {
+        if (phase === 'greeting') {
+          if (buffer.length < 2) {
+            return
+          }
+
+          const methodCount = buffer[1]
+          const greetingLength = 2 + methodCount
+
+          if (buffer[0] !== 0x05 || methodCount === 0 || greetingLength > MAX_HANDSHAKE_BYTES) {
+            controller.abort()
+            phase = 'closed'
+            clearTimeout(handshakeTimer)
+            client.destroy()
+
+            return
+          }
+
+          if (buffer.length < greetingLength) {
+            return
+          }
+
+          const methods = buffer.subarray(2, greetingLength)
+          buffer = buffer.subarray(greetingLength)
+
+          if (!methods.includes(0x00)) {
+            controller.abort()
+            phase = 'closed'
+            clearTimeout(handshakeTimer)
+            client.end(Buffer.from([0x05, 0xff]))
+
+            return
+          }
+
+          client.write(Buffer.from([0x05, 0x00]))
+          phase = 'request'
+        }
+
+        if (phase !== 'request' || buffer.length < 4) {
+          return
+        }
+
+        if (buffer[0] !== 0x05 || buffer[2] !== 0x00) {
+          closeWithReply(0x01)
+
+          return
+        }
+
+        if (buffer[1] !== 0x01) {
+          closeWithReply(0x07)
+
+          return
+        }
+
+        const addressType = buffer[3]
+        let addressLength: number
+        let addressOffset: number
+
+        if (addressType === 0x01) {
+          addressOffset = 4
+          addressLength = 4
+        } else if (addressType === 0x04) {
+          addressOffset = 4
+          addressLength = 16
+        } else if (addressType === 0x03) {
+          if (buffer.length < 5) {
+            return
+          }
+
+          addressOffset = 5
+          addressLength = buffer[4]
+
+          if (addressLength === 0) {
+            closeWithReply(0x08)
+
+            return
+          }
+        } else {
+          closeWithReply(0x08)
+
+          return
+        }
+
+        const requestLength = addressOffset + addressLength + 2
+
+        if (requestLength > MAX_HANDSHAKE_BYTES) {
+          controller.abort()
+          phase = 'closed'
+          clearTimeout(handshakeTimer)
+          client.destroy()
+
+          return
+        }
+
+        if (buffer.length < requestLength) {
+          return
+        }
+
+        const rawAddress = buffer.subarray(addressOffset, addressOffset + addressLength)
+
+        const hostname =
+          addressType === 0x01
+            ? [...rawAddress].join('.')
+            : addressType === 0x04
+              ? ipv6FromBytes(rawAddress)
+              : rawAddress.toString('ascii')
+
+        const port = buffer.readUInt16BE(addressOffset + addressLength)
+        const pending = buffer.subarray(requestLength)
+        buffer = Buffer.alloc(0)
+        phase = 'connecting'
+        client.pause()
+        startRelay(hostname, port, pending)
+
+        return
+      }
+    } finally {
+      processing = false
+    }
+  }
+
+  client.on('data', chunk => {
+    if (phase !== 'greeting' && phase !== 'request') {
+      return
+    }
+
+    const next = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+
+    if (buffer.length + next.length > MAX_HANDSHAKE_BYTES) {
+      controller.abort()
+      phase = 'closed'
+      clearTimeout(handshakeTimer)
+      client.destroy()
+
+      return
+    }
+
+    buffer = Buffer.concat([buffer, next])
+    processBuffer()
+  })
+  client.once('close', () => {
+    phase = 'closed'
+    controller.abort()
+    controllers.delete(controller)
+    clearTimeout(handshakeTimer)
+    peers.delete(client)
+    upstream?.destroy()
+  })
+  client.once('error', () => undefined)
+}
+
+export async function startLinkTitleSocksGateway(options: {
+  resolve(hostname: string): Promise<readonly LinkTitleAddress[]>
+  connectTimeoutMs: number
+  createConnection?: typeof net.createConnection
+}): Promise<LinkTitleSocksGateway> {
+  const controllers = new Set<AbortController>()
+  const peers = new Set<Socket>()
+  const tasks = new Set<Promise<void>>()
+  const createConnection = options.createConnection ?? net.createConnection
+
+  const server = net.createServer(client =>
+    handleClient(client, { ...options, createConnection }, peers, controllers, tasks)
+  )
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false
+
+    const cleanup = () => {
+      clearTimeout(timer)
+      server.off('error', onError)
+      server.off('listening', onListening)
+    }
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      cleanup()
+      callback()
+    }
+
+    const onError = (error: Error) => finish(() => reject(error))
+    const onListening = () => finish(resolve)
+
+    const timer = setTimeout(() => {
+      server.close()
+      finish(() => reject(new Error('Link title SOCKS gateway startup timed out')))
+    }, options.connectTimeoutMs)
+
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(0, '127.0.0.1')
+  })
+
+  const address = server.address()
+
+  if (!address || typeof address === 'string') {
+    server.close()
+    throw new Error('Link title SOCKS gateway did not bind a TCP port')
+  }
+
+  server.on('error', () => undefined)
+  let closePromise: Promise<void> | null = null
+
+  return {
+    async close() {
+      if (!closePromise) {
+        closePromise = (async () => {
+          for (const controller of controllers) {
+            controller.abort()
+          }
+
+          controllers.clear()
+
+          for (const peer of peers) {
+            peer.destroy()
+          }
+
+          peers.clear()
+
+          await new Promise<void>((resolve, reject) => {
+            server.close(error => {
+              if (error) {
+                reject(error)
+              } else {
+                resolve()
+              }
+            })
+          })
+
+          await Promise.allSettled([...tasks])
+        })()
+      }
+
+      return closePromise
+    },
+    proxyUrl: `socks5://127.0.0.1:${address.port}`
+  }
+}

--- a/apps/desktop/electron/link-title-window.e2e.ts
+++ b/apps/desktop/electron/link-title-window.e2e.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs'
+import http from 'node:http'
+import type net from 'node:net'
+
+import { app, BrowserWindow, session } from 'electron'
+
+import { startLinkTitleSocksGateway } from './link-title-socks'
+import { configureLinkTitleSession, createLinkTitleWindow, readLinkTitleWindowTitle } from './link-title-window'
+
+const receiptPath = process.env.HERMES_LINK_TITLE_E2E_RECEIPT
+
+if (!receiptPath) {
+  throw new Error('HERMES_LINK_TITLE_E2E_RECEIPT is required')
+}
+
+function listen(server: net.Server | http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+
+      if (!address || typeof address === 'string') {
+        reject(new Error('server did not bind a TCP port'))
+
+        return
+      }
+
+      resolve(address.port)
+    })
+  })
+}
+
+function close(server: net.Server | http.Server): Promise<void> {
+  return new Promise(resolve => server.close(() => resolve()))
+}
+
+async function loadTitle(window: BrowserWindow, url: string): Promise<string> {
+  await window.loadURL(url)
+  await new Promise(resolve => setTimeout(resolve, 25))
+
+  return readLinkTitleWindowTitle(window)
+}
+
+async function run(): Promise<void> {
+  await app.whenReady()
+
+  let requestCount = 0
+
+  const target = http.createServer((request, response) => {
+    requestCount += 1
+    response.setHeader('content-type', 'text/html')
+    response.end('<title>Pinned BrowserWindow title</title>')
+  })
+
+  const port = await listen(target)
+
+  const gateway = await startLinkTitleSocksGateway({
+    connectTimeoutMs: 1_000,
+    resolve: async hostname => {
+      if (hostname !== 'public-title.invalid') {
+        throw new Error(`unexpected hostname: ${hostname}`)
+      }
+
+      return [{ address: '127.0.0.1', family: 4 }]
+    }
+  })
+
+  const partition = `link-title-e2e-${process.pid}-${Date.now()}`
+  const partitionSession = session.fromPartition(partition, { cache: false })
+  const window = createLinkTitleWindow(BrowserWindow, partitionSession)
+
+  try {
+    await configureLinkTitleSession(partitionSession, value => value, gateway.proxyUrl, 1_000)
+    const title = await loadTitle(window, `http://public-title.invalid:${port}/title`)
+
+    if (title !== 'Pinned BrowserWindow title' || requestCount !== 1) {
+      throw new Error(`proxied BrowserWindow request failed: title=${JSON.stringify(title)}, requests=${requestCount}`)
+    }
+
+    const failedSession = session.fromPartition(`${partition}-failed`, { cache: false })
+    const failedWindow = createLinkTitleWindow(BrowserWindow, failedSession)
+
+    try {
+      await configureLinkTitleSession(failedSession, value => value, 'socks5://127.0.0.1:1', 1_000)
+      requestCount = 0
+
+      const loadFailed = await failedWindow.loadURL(`http://127.0.0.1:${port}/title`).then(
+        () => false,
+        () => true
+      )
+
+      if (!loadFailed || requestCount !== 0) {
+        throw new Error(`proxy failure did not fail closed: failed=${loadFailed}, requests=${requestCount}`)
+      }
+    } finally {
+      if (!failedWindow.isDestroyed()) {
+        failedWindow.destroy()
+      }
+    }
+
+    fs.writeFileSync(
+      receiptPath,
+      JSON.stringify({
+        port,
+        proxied: { host: `public-title.invalid:${port}`, title },
+        proxyFailure: { failed: true, requestCount }
+      })
+    )
+  } finally {
+    if (!window.isDestroyed()) {
+      window.destroy()
+    }
+
+    await gateway.close()
+    await close(target)
+    app.exit(0)
+  }
+}
+
+run().catch(error => {
+  fs.writeFileSync(receiptPath, JSON.stringify({ error: error instanceof Error ? error.stack || error.message : String(error) }))
+  app.exit(1)
+})

--- a/apps/desktop/electron/link-title-window.test.ts
+++ b/apps/desktop/electron/link-title-window.test.ts
@@ -1,22 +1,70 @@
 import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
+import { build } from 'esbuild'
 import { test } from 'vitest'
 
 import {
+  configureLinkTitleSession,
   createLinkTitleWindow,
   guardLinkTitleSession,
   linkTitleWindowOptions,
   readLinkTitleWindowTitle
 } from './link-title-window'
 
+const require = createRequire(import.meta.url)
+const ELECTRON_BINARY = require('electron') as string
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url))
+
+async function waitForFile(filePath: string, timeoutMs: number): Promise<string> {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    try {
+      return await readFile(filePath, 'utf8')
+    } catch {
+      await new Promise(resolve => setTimeout(resolve, 25))
+    }
+  }
+
+  throw new Error(`Timed out waiting for Electron receipt: ${filePath}`)
+}
+
+async function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+
+  await Promise.race([
+    new Promise<void>(resolve => child.once('exit', () => resolve())),
+    new Promise<void>(resolve => setTimeout(resolve, timeoutMs))
+  ])
+}
+
 function makeFakeBrowserWindow() {
-  const calls = { audioMuted: [] }
+  const calls = { audioMuted: [], destroyed: 0, webRtcPolicies: [], windowOpenHandlers: [] }
 
   const FakeBrowserWindow = function (options) {
     this.options = options
+
+    this.destroy = () => {
+      calls.destroyed += 1
+    }
+
     this.webContents = {
       setAudioMuted(value) {
         calls.audioMuted.push(value)
+      },
+      setWindowOpenHandler(handler) {
+        calls.windowOpenHandlers.push(handler)
+      },
+      setWebRTCIPHandlingPolicy(value) {
+        calls.webRtcPolicies.push(value)
       }
     }
   }
@@ -45,6 +93,9 @@ test('createLinkTitleWindow mutes audio so historical links never autoplay sound
 
   assert.ok(window instanceof FakeBrowserWindow)
   assert.deepEqual(calls.audioMuted, [true])
+  assert.deepEqual(calls.webRtcPolicies, ['disable_non_proxied_udp'])
+  assert.equal(calls.windowOpenHandlers.length, 1)
+  assert.deepEqual(calls.windowOpenHandlers[0](), { action: 'deny' })
 })
 
 test('createLinkTitleWindow still returns the window if muting throws', () => {
@@ -53,7 +104,9 @@ test('createLinkTitleWindow still returns the window if muting throws', () => {
     this.webContents = {
       setAudioMuted() {
         throw new Error('webContents unavailable')
-      }
+      },
+      setWindowOpenHandler() {},
+      setWebRTCIPHandlingPolicy() {}
     }
   }
 
@@ -62,14 +115,70 @@ test('createLinkTitleWindow still returns the window if muting throws', () => {
   assert.ok(window instanceof ThrowingBrowserWindow)
 })
 
+test('createLinkTitleWindow fails closed when non-proxied WebRTC cannot be disabled', () => {
+  let destroyed = false
+
+  const ThrowingBrowserWindow = function (options) {
+    this.options = options
+
+    this.destroy = () => {
+      destroyed = true
+    }
+
+    this.webContents = {
+      setAudioMuted() {},
+      setWindowOpenHandler() {},
+      setWebRTCIPHandlingPolicy() {
+        throw new Error('WebRTC policy unavailable')
+      }
+    }
+  }
+
+  assert.throws(
+    () => createLinkTitleWindow(ThrowingBrowserWindow, { id: 'link-titles' }),
+    /WebRTC policy unavailable/
+  )
+  assert.equal(destroyed, true)
+})
+
+test('createLinkTitleWindow fails closed when popup creation cannot be denied', () => {
+  let destroyed = false
+
+  const ThrowingBrowserWindow = function (options) {
+    this.options = options
+
+    this.destroy = () => {
+      destroyed = true
+    }
+
+    this.webContents = {
+      setAudioMuted() {},
+      setWindowOpenHandler() {
+        throw new Error('window-open policy unavailable')
+      },
+      setWebRTCIPHandlingPolicy() {}
+    }
+  }
+
+  assert.throws(
+    () => createLinkTitleWindow(ThrowingBrowserWindow, { id: 'link-titles' }),
+    /window-open policy unavailable/
+  )
+  assert.equal(destroyed, true)
+})
+
 test('guardLinkTitleSession cancels downloads triggered by the title-fetch window', () => {
   let cancelled = false
   const handlers = {}
-  guardLinkTitleSession({
-    on: (e, h) => {
-      handlers[e] = h
-    }
-  })
+  guardLinkTitleSession(
+    {
+      on: (e, h) => {
+        handlers[e] = h
+      },
+      webRequest: { onBeforeRequest() {} }
+    },
+    value => value
+  )
   handlers['will-download'](null, {
     cancel: () => {
       cancelled = true
@@ -78,13 +187,126 @@ test('guardLinkTitleSession cancels downloads triggered by the title-fetch windo
   assert.ok(cancelled)
 })
 
+test('configureLinkTitleSession installs the fixed SOCKS proxy before request guards', async () => {
+  const calls = []
+
+  const partitionSession = {
+    on: () => calls.push('download-guard'),
+    setProxy: async config => calls.push(['setProxy', config]),
+    webRequest: { onBeforeRequest: () => calls.push('request-guard') }
+  }
+
+  await configureLinkTitleSession(partitionSession, value => value, 'socks5://127.0.0.1:48123')
+
+  assert.deepEqual(calls, [
+    [
+      'setProxy',
+      {
+        mode: 'fixed_servers',
+        proxyBypassRules: '<-loopback>',
+        proxyRules: 'socks5://127.0.0.1:48123'
+      }
+    ],
+    'request-guard',
+    'download-guard'
+  ])
+})
+
+test('configureLinkTitleSession fails before installing guards when proxy setup fails', async () => {
+  let guarded = false
+
+  const partitionSession = {
+    on: () => {
+      guarded = true
+    },
+    setProxy: async () => {
+      throw new Error('proxy unavailable')
+    },
+    webRequest: {
+      onBeforeRequest: () => {
+        guarded = true
+      }
+    }
+  }
+
+  await assert.rejects(
+    configureLinkTitleSession(partitionSession, value => value, 'socks5://127.0.0.1:48123'),
+    /proxy unavailable/
+  )
+  assert.equal(guarded, false)
+})
+
+test('configureLinkTitleSession times out instead of holding a renderer queue slot forever', async () => {
+  const partitionSession = {
+    on() {},
+    setProxy: () => new Promise(() => undefined),
+    webRequest: { onBeforeRequest() {} }
+  }
+
+  const result = await Promise.race([
+    configureLinkTitleSession(partitionSession, value => value, 'socks5://127.0.0.1:48123', 20).then(
+      () => 'resolved',
+      error => String(error?.message || error)
+    ),
+    new Promise<string>(resolve => setTimeout(() => resolve('still pending'), 200))
+  ])
+
+  assert.match(result, /timed out/i)
+})
+
+test('guardLinkTitleSession blocks rejected redirects and subrequests while allowing public HTTP(S)', () => {
+  let beforeRequest
+
+  const admitUrl = value => {
+    const url = new URL(value)
+
+    if (!['http:', 'https:'].includes(url.protocol) || ['10.0.0.1', '127.0.0.1'].includes(url.hostname)) {
+      return null
+    }
+
+    return url.href
+  }
+
+  guardLinkTitleSession(
+    {
+      on() {},
+      webRequest: {
+        onBeforeRequest(handler) {
+          beforeRequest = handler
+        }
+      }
+    },
+    admitUrl
+  )
+
+  const cancelled = (url, resourceType) => {
+    let result
+    beforeRequest({ resourceType, url }, value => {
+      result = value.cancel
+    })
+
+    return result
+  }
+
+  assert.equal(cancelled('http://127.0.0.1/redirect', 'mainFrame'), true)
+  assert.equal(cancelled('http://10.0.0.1/data', 'xhr'), true)
+  assert.equal(cancelled('file:///tmp/private', 'mainFrame'), true)
+  assert.equal(cancelled('https://example.com/', 'mainFrame'), false)
+  assert.equal(cancelled('http://cdn.example.com/app.js', 'script'), false)
+  assert.equal(cancelled('https://example.com/site.css', 'stylesheet'), true)
+})
+
 test('guardLinkTitleSession is a no-op when session.on throws', () => {
   assert.doesNotThrow(() =>
-    guardLinkTitleSession({
-      on() {
-        throw new Error()
-      }
-    })
+    guardLinkTitleSession(
+      {
+        on() {
+          throw new Error()
+        },
+        webRequest: { onBeforeRequest() {} }
+      },
+      value => value
+    )
   )
 })
 
@@ -116,6 +338,52 @@ test('readLinkTitleWindowTitle swallows getTitle throws after teardown', () => {
 
   assert.equal(readLinkTitleWindowTitle(window), '')
 })
+
+test('real Electron hidden BrowserWindow routes through SOCKS and fails closed when proxy establishment fails', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'hermes-link-title-electron-e2e-'))
+  const bundlePath = path.join(tempRoot, 'link-title-window.e2e.mjs')
+  const receiptPath = path.join(tempRoot, 'receipt.json')
+  const userDataPath = path.join(tempRoot, 'user-data')
+  let child: ReturnType<typeof spawn> | null = null
+  let stderr = ''
+
+  try {
+    await build({
+      bundle: true,
+      entryPoints: [path.join(TEST_DIR, 'link-title-window.e2e.ts')],
+      external: ['electron'],
+      format: 'esm',
+      outfile: bundlePath,
+      platform: 'node',
+      target: 'node20'
+    })
+
+    child = spawn(ELECTRON_BINARY, ['--no-sandbox', `--user-data-dir=${userDataPath}`, bundlePath], {
+      env: { ...process.env, HERMES_LINK_TITLE_E2E_RECEIPT: receiptPath },
+      stdio: ['ignore', 'ignore', 'pipe']
+    })
+    child.stderr?.on('data', chunk => {
+      stderr += String(chunk)
+    })
+
+    const receipt = JSON.parse(await waitForFile(receiptPath, 10_000))
+
+    assert.deepEqual(receipt.proxied, {
+      host: `public-title.invalid:${receipt.port}`,
+      title: 'Pinned BrowserWindow title'
+    })
+    assert.deepEqual(receipt.proxyFailure, { failed: true, requestCount: 0 })
+  } catch (error) {
+    throw new Error(`${error instanceof Error ? error.message : String(error)}\nElectron stderr:\n${stderr}`)
+  } finally {
+    if (child && child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGTERM')
+      await waitForExit(child, 2_000)
+    }
+
+    await rm(tempRoot, { force: true, recursive: true })
+  }
+}, 15_000)
 
 test('readLinkTitleWindowTitle returns trimmed page title', () => {
   const window = {

--- a/apps/desktop/electron/link-title-window.ts
+++ b/apps/desktop/electron/link-title-window.ts
@@ -3,6 +3,10 @@
 // in an offscreen window and read its title. That window loads arbitrary
 // user-linked pages, so it must never emit sound or trigger real downloads.
 
+import { withLinkTitleTimeout } from './link-title-deadline'
+
+const BLOCKED_RESOURCE_TYPES = new Set(['cspReport', 'font', 'imageset', 'media', 'object', 'ping', 'stylesheet'])
+
 export function linkTitleWindowOptions(partitionSession) {
   return {
     show: false,
@@ -27,6 +31,19 @@ export function createLinkTitleWindow(BrowserWindow, partitionSession) {
   const window = new BrowserWindow(linkTitleWindowOptions(partitionSession))
 
   try {
+    window.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+    window.webContents.setWebRTCIPHandlingPolicy('disable_non_proxied_udp')
+  } catch (error) {
+    try {
+      window.destroy()
+    } catch {
+      // The security boundary failed before navigation; teardown is best-effort.
+    }
+
+    throw error
+  }
+
+  try {
     window.webContents.setAudioMuted(true)
   } catch {
     // webContents may be unavailable in degraded/headless environments; muting
@@ -36,15 +53,39 @@ export function createLinkTitleWindow(BrowserWindow, partitionSession) {
   return window
 }
 
-// Cancel any download the title-fetch window triggers. Without this, a link
-// artifact URL served with Content-Disposition: attachment auto-downloads every
-// time the Artifacts page renders and fetchLinkTitle loads it.
-export function guardLinkTitleSession(partitionSession) {
+// Reject disallowed navigation/subresource requests and cancel any download
+// the title-fetch window triggers. The request listener is intentionally owned
+// here because Electron sessions keep one onBeforeRequest handler per event.
+export function guardLinkTitleSession(partitionSession, admitUrl) {
+  partitionSession.webRequest.onBeforeRequest((details, callback) => {
+    let admittedUrl = null
+
+    try {
+      admittedUrl = admitUrl(details.url)
+    } catch {
+      // Admission errors fail closed for this isolated title-fetch session.
+    }
+
+    callback({ cancel: BLOCKED_RESOURCE_TYPES.has(details.resourceType) || !admittedUrl })
+  })
+
   try {
     partitionSession.on('will-download', (_event, item) => item.cancel())
   } catch {
     // best-effort; worst case is a spurious download
   }
+}
+
+export async function configureLinkTitleSession(partitionSession, admitUrl, proxyUrl, timeoutMs = 4_000) {
+  await withLinkTitleTimeout(
+    partitionSession.setProxy({
+      mode: 'fixed_servers',
+      proxyBypassRules: '<-loopback>',
+      proxyRules: proxyUrl
+    }),
+    timeoutMs
+  )
+  guardLinkTitleSession(partitionSession, admitUrl)
 }
 
 // Read the page title from a title-fetch window. Callers schedule this from

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -101,7 +101,25 @@ import {
   resolveTimeoutMs,
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
-import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
+import {
+  createLinkTitleCurlFetcher,
+  type LinkTitleCurlHop,
+  linkTitleCurlRequestArgs,
+  parseLinkTitleCurlHeaders
+} from './link-title-curl'
+import { remainingLinkTitleMs, withLinkTitleTimeout } from './link-title-deadline'
+import { createLinkTitlePinnedResolver } from './link-title-dns'
+import { createLinkTitleFetcher } from './link-title-fetch'
+import { createLinkTitleRenderQueue } from './link-title-render-queue'
+import {
+  createLinkTitleSocksGatewayController,
+  startLinkTitleSocksGateway
+} from './link-title-socks'
+import {
+  configureLinkTitleSession,
+  createLinkTitleWindow,
+  readLinkTitleWindowTitle
+} from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
@@ -3858,12 +3876,21 @@ function filenameFromUrl(rawUrl, fallback = 'image') {
 }
 
 // Link title resolution — curl (tier 1) → hidden BrowserWindow (tier 2).
+// Use bundle-time require here so the Electron composite project does not pull
+// the shared workspace's source tree under its own rootDir.
+const { admitLinkTitleUrl, isPublicLinkTitleAddress } = require('@hermes/shared') as {
+  admitLinkTitleUrl: (value: string) => null | string
+  isPublicLinkTitleAddress: (value: string) => boolean
+}
+
 const titleCache = new Map()
 const titleInflight = new Map()
 const TITLE_CACHE_LIMIT = 500
 const TITLE_BYTE_BUDGET = 96 * 1024
 const TITLE_TIMEOUT_MS = 5000
 const TITLE_MAX_REDIRECTS = 3
+const TITLE_DNS_PIN_TTL_MS = 30_000
+const TITLE_CONNECT_TIMEOUT_MS = 4_000
 
 // Browser-shaped UA — many bot-walled sites (GetYourGuide, Cloudflare-protected
 // pages) refuse anything that doesn't look like a real Chrome.
@@ -3881,22 +3908,27 @@ const RENDER_TITLE_MAX_CONCURRENT = 2
 const RENDER_TITLE_TIMEOUT_MS = 8000
 const RENDER_TITLE_GRACE_MS = 700
 
-// Resource types we cancel before the network even fires — keeps the hidden
-// renderer fast and cuts third-party tracking noise.
-const RENDER_TITLE_BLOCKED_RESOURCES = new Set([
-  'cspReport',
-  'font',
-  'imageset',
-  'media',
-  'object',
-  'ping',
-  'stylesheet'
-])
-
 let linkTitleSession = null
+let linkTitleSessionPending = null
+let linkTitleQuitting = false
+let linkTitleQuitCleanupStarted = false
+let linkTitleGatewayClosed = false
+let linkTitleGatewayClosePromise: Promise<void> | null = null
 let oauthSession = null
-let renderTitleInFlight = 0
-const renderTitleQueue = []
+
+const linkTitleResolver = createLinkTitlePinnedResolver({
+  isPublicAddress: isPublicLinkTitleAddress,
+  ttlMs: TITLE_DNS_PIN_TTL_MS
+})
+
+const linkTitleGatewayController = createLinkTitleSocksGatewayController({
+  clearPins: linkTitleResolver.clear,
+  start: () =>
+    startLinkTitleSocksGateway({
+      connectTimeoutMs: TITLE_CONNECT_TIMEOUT_MS,
+      resolve: linkTitleResolver.resolve
+    })
+})
 
 function canonicalTitleCacheKey(rawUrl) {
   const value = String(rawUrl || '').trim()
@@ -3937,39 +3969,64 @@ function parseHtmlTitle(html) {
   return raw ? decodeHtmlEntities(raw).replace(/\s+/g, ' ').trim() : ''
 }
 
-function fetchHtmlTitleWithCurl(rawUrl: string): Promise<string> {
+async function requestHtmlTitleWithCurl(url: string, timeoutMs: number): Promise<LinkTitleCurlHop> {
+  if (linkTitleQuitting) {
+    return { body: '', location: null, statusCode: 0 }
+  }
+
+  const deadline = Date.now() + timeoutMs
+  let gateway
+
+  try {
+    gateway = await withLinkTitleTimeout(linkTitleGatewayController.get(), remainingLinkTitleMs(deadline))
+  } catch {
+    // The pinned transport is mandatory. Networks that require a system proxy
+    // may return no preview rather than delegating DNS or connecting directly.
+    return { body: '', location: null, statusCode: 0 }
+  }
+
+  const requestTimeoutMs = remainingLinkTitleMs(deadline)
+
+  if (requestTimeoutMs <= 0) {
+    return { body: '', location: null, statusCode: 0 }
+  }
+
   return new Promise(resolve => {
-    const url = String(rawUrl || '').trim()
+    const timeoutSeconds = Math.max(0.1, requestTimeoutMs / 1000)
 
-    if (!url) {
-      return resolve('')
-    }
+    const headerPath = path.join(
+      os.tmpdir(),
+      `hermes-link-title-${process.pid}-${crypto.randomBytes(6).toString('hex')}.headers`
+    )
 
-    const args = [
-      '--silent',
-      '--show-error',
-      '--location',
-      '--max-redirs',
-      String(TITLE_MAX_REDIRECTS),
-      '--max-time',
-      String(Math.max(2, Math.ceil(TITLE_TIMEOUT_MS / 1000))),
-      '--connect-timeout',
-      '4',
-      '--user-agent',
-      TITLE_USER_AGENT,
-      '--header',
-      'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.5',
-      '--header',
-      'Accept-Language: en-US,en;q=0.7',
-      '--header',
-      'Accept-Encoding: identity',
-      '--raw',
-      url
-    ]
+    const args = linkTitleCurlRequestArgs(url, {
+      connectTimeoutSeconds: Math.min(4, timeoutSeconds),
+      headerPath,
+      maxBytes: TITLE_BYTE_BUDGET,
+      proxyUrl: gateway.proxyUrl,
+      timeoutSeconds,
+      userAgent: TITLE_USER_AGENT
+    })
 
     const child = spawn('curl', args, hiddenWindowsChildOptions({ stdio: ['ignore', 'pipe', 'ignore'] }))
     const chunks = []
     let bytes = 0
+    let settled = false
+
+    const finish = async () => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      const headers = await fs.promises.readFile(headerPath, 'utf8').catch(() => '')
+      await fs.promises.unlink(headerPath).catch(() => undefined)
+
+      resolve({
+        body: chunks.length ? Buffer.concat(chunks).toString('utf8') : '',
+        ...parseLinkTitleCurlHeaders(headers)
+      })
+    }
 
     child.stdout.on('data', chunk => {
       if (bytes >= TITLE_BYTE_BUDGET) {
@@ -3983,54 +4040,83 @@ function fetchHtmlTitleWithCurl(rawUrl: string): Promise<string> {
       bytes += next.length
     })
 
-    child.on('error', () => resolve(''))
-    child.on('close', () => {
-      if (!chunks.length) {
-        return resolve('')
-      }
-
-      resolve(parseHtmlTitle(Buffer.concat(chunks).toString('utf8')))
-    })
+    child.on('error', () => void finish())
+    child.on('close', () => void finish())
   })
 }
 
-function getLinkTitleSession() {
-  if (linkTitleSession || !app.isReady()) {
+const fetchHtmlTitleWithCurl = createLinkTitleCurlFetcher({
+  admitUrl: admitLinkTitleUrl,
+  maxRedirects: TITLE_MAX_REDIRECTS,
+  readTitle: parseHtmlTitle,
+  request: requestHtmlTitleWithCurl,
+  timeoutMs: TITLE_TIMEOUT_MS
+})
+
+async function getLinkTitleSession(timeoutMs: number) {
+  if (linkTitleQuitting || !app.isReady()) {
+    return null
+  }
+
+  if (linkTitleSession) {
     return linkTitleSession
   }
 
-  linkTitleSession = session.fromPartition('hermes:link-titles', { cache: false })
-  linkTitleSession.webRequest.onBeforeRequest((details, callback) => {
-    callback({ cancel: RENDER_TITLE_BLOCKED_RESOURCES.has(details.resourceType) })
-  })
-  guardLinkTitleSession(linkTitleSession)
-
-  return linkTitleSession
-}
-
-function dequeueRenderTitle() {
-  while (renderTitleInFlight < RENDER_TITLE_MAX_CONCURRENT && renderTitleQueue.length) {
-    const item = renderTitleQueue.shift()
-    renderTitleInFlight += 1
-    runRenderTitleJob(item.url).then(title => {
-      renderTitleInFlight -= 1
-      item.resolve(title)
-      dequeueRenderTitle()
-    })
+  if (linkTitleSessionPending) {
+    return withLinkTitleTimeout(linkTitleSessionPending, timeoutMs).catch(() => null)
   }
+
+  const deadline = Date.now() + timeoutMs
+
+  const pending = (async () => {
+    const gateway = await withLinkTitleTimeout(linkTitleGatewayController.get(), remainingLinkTitleMs(deadline))
+    const candidate = session.fromPartition('hermes:link-titles', { cache: false })
+    await configureLinkTitleSession(
+      candidate,
+      admitLinkTitleUrl,
+      gateway.proxyUrl,
+      remainingLinkTitleMs(deadline)
+    )
+    linkTitleSession = candidate
+
+    return candidate
+  })()
+    .catch(() => null)
+    .finally(() => {
+      if (linkTitleSessionPending === pending) {
+        linkTitleSessionPending = null
+      }
+    })
+
+  linkTitleSessionPending = pending
+
+  return pending
 }
 
-function runRenderTitleJob(rawUrl) {
-  return new Promise(resolve => {
-    if (!app.isReady()) {
-      return resolve('')
-    }
+async function runRenderTitleJob(rawUrl: string, deadline: number): Promise<string> {
+  const url = admitLinkTitleUrl(rawUrl)
 
-    const partitionSession = getLinkTitleSession()
+  if (!url || linkTitleQuitting) {
+    return ''
+  }
 
-    if (!partitionSession) {
-      return resolve('')
-    }
+  if (!app.isReady()) {
+    return ''
+  }
+
+  const partitionSession = await getLinkTitleSession(remainingLinkTitleMs(deadline))
+
+  if (!partitionSession || linkTitleQuitting) {
+    return ''
+  }
+
+  const remainingMs = remainingLinkTitleMs(deadline)
+
+  if (remainingMs <= 0) {
+    return ''
+  }
+
+  return new Promise<string>(resolve => {
 
     let settled = false
     let window = null
@@ -4081,7 +4167,7 @@ function runRenderTitleJob(rawUrl) {
       graceTimer = setTimeout(finishWithTitle, RENDER_TITLE_GRACE_MS)
     }
 
-    hardTimer = setTimeout(finishWithTitle, RENDER_TITLE_TIMEOUT_MS)
+    hardTimer = setTimeout(finishWithTitle, remainingMs)
 
     window.webContents.setUserAgent(TITLE_USER_AGENT)
     window.webContents.on('page-title-updated', scheduleGrace)
@@ -4093,7 +4179,7 @@ function runRenderTitleJob(rawUrl) {
     })
 
     window
-      .loadURL(rawUrl, {
+      .loadURL(url, {
         httpReferrer: 'https://www.google.com/',
         userAgent: TITLE_USER_AGENT
       })
@@ -4101,11 +4187,20 @@ function runRenderTitleJob(rawUrl) {
   })
 }
 
+const linkTitleRenderQueue = createLinkTitleRenderQueue({
+  concurrency: RENDER_TITLE_MAX_CONCURRENT,
+  run: runRenderTitleJob,
+  timeoutMs: RENDER_TITLE_TIMEOUT_MS
+})
+
 function fetchHtmlTitleWithRenderer(rawUrl: string): Promise<string> {
-  return new Promise(resolve => {
-    renderTitleQueue.push({ resolve, url: rawUrl })
-    dequeueRenderTitle()
-  })
+  const url = admitLinkTitleUrl(rawUrl)
+
+  if (!url || linkTitleQuitting) {
+    return Promise.resolve('')
+  }
+
+  return linkTitleRenderQueue.enqueue(url)
 }
 
 // Strips known error/captcha titles (e.g. "GetYourGuide – Error", "Just a
@@ -4114,39 +4209,16 @@ function usableTitle(value: string): string {
   return value && !TITLE_ERROR_RE.test(value) ? value : ''
 }
 
-function fetchLinkTitle(rawUrl) {
-  const url = String(rawUrl || '').trim()
-  const key = canonicalTitleCacheKey(url)
-
-  if (!key) {
-    return Promise.resolve('')
-  }
-
-  if (titleCache.has(key)) {
-    return Promise.resolve(titleCache.get(key))
-  }
-
-  if (titleInflight.has(key)) {
-    return titleInflight.get(key)
-  }
-
-  const pending = fetchHtmlTitleWithCurl(url)
-    .catch(() => '')
-    .then(value => usableTitle((value || '').slice(0, 240)))
-    .then(
-      async value => value || usableTitle(((await fetchHtmlTitleWithRenderer(url).catch(() => '')) || '').slice(0, 240))
-    )
-    .then(clean => {
-      cacheTitle(key, clean)
-      titleInflight.delete(key)
-
-      return clean
-    })
-
-  titleInflight.set(key, pending)
-
-  return pending
-}
+const fetchLinkTitle = createLinkTitleFetcher({
+  admitUrl: admitLinkTitleUrl,
+  cache: titleCache,
+  cacheKey: canonicalTitleCacheKey,
+  fetchWithCurl: fetchHtmlTitleWithCurl,
+  fetchWithRenderer: fetchHtmlTitleWithRenderer,
+  inflight: titleInflight,
+  normalizeTitle: usableTitle,
+  storeCachedTitle: cacheTitle
+})
 
 async function resourceBufferFromUrl(rawUrl) {
   if (!rawUrl) {
@@ -9207,6 +9279,20 @@ function configureSpellChecker() {
 }
 
 app.on('before-quit', () => {
+  if (linkTitleQuitCleanupStarted) {
+    return
+  }
+
+  linkTitleQuitCleanupStarted = true
+  linkTitleQuitting = true
+  linkTitleRenderQueue.close()
+  linkTitleSession = null
+  linkTitleSessionPending = null
+  linkTitleGatewayClosePromise = linkTitleGatewayController.close().catch(() => undefined)
+  void linkTitleGatewayClosePromise.finally(() => {
+    linkTitleGatewayClosed = true
+  })
+
   // The always-on-top overlay isn't a "real" app window; close it so a stray
   // pet can't keep the process alive or float over a quit app.
   closePetOverlay()
@@ -9236,6 +9322,15 @@ app.on('before-quit', () => {
 
   stopBackendChild(backendConnectionState.getProcess())
   stopAllPoolBackends()
+})
+
+app.on('will-quit', event => {
+  if (!linkTitleGatewayClosePromise || linkTitleGatewayClosed) {
+    return
+  }
+
+  event.preventDefault()
+  void linkTitleGatewayClosePromise.finally(() => app.quit())
 })
 
 app.on('window-all-closed', () => {

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -1,3 +1,4 @@
+import { admitLinkTitleUrl, isPublicLinkTitleAddress } from '@hermes/shared'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -36,6 +37,39 @@ afterEach(() => {
 })
 
 describe('external link helpers', () => {
+  it('accepts public bracketed or unbracketed IPv4 and IPv6 title addresses', () => {
+    expect(isPublicLinkTitleAddress('8.8.8.8')).toBe(true)
+    expect(isPublicLinkTitleAddress('[8.8.8.8]')).toBe(true)
+    expect(isPublicLinkTitleAddress('2606:4700:4700::1111')).toBe(true)
+    expect(isPublicLinkTitleAddress('[2606:4700:4700::1111]')).toBe(true)
+  })
+
+  it('preserves narrow public address exceptions', () => {
+    expect(isPublicLinkTitleAddress('192.0.0.9')).toBe(true)
+    expect(isPublicLinkTitleAddress('192.0.0.10')).toBe(true)
+    expect(isPublicLinkTitleAddress('2001:3::1')).toBe(true)
+  })
+
+  it.each([
+    ['IPv4 loopback', '127.0.0.1'],
+    ['IPv6 loopback', '::1'],
+    ['RFC1918 10/8', '10.0.0.1'],
+    ['RFC1918 172.16/12', '172.16.0.1'],
+    ['RFC1918 192.168/16', '192.168.0.1'],
+    ['IPv4 link-local', '169.254.0.1'],
+    ['IPv6 link-local', 'fe80::1'],
+    ['carrier-grade NAT', '100.64.0.1'],
+    ['IPv4 multicast', '224.0.0.1'],
+    ['IPv6 multicast', 'ff02::1'],
+    ['IPv4 documentation', '192.0.2.1'],
+    ['IPv6 documentation', '2001:db8::1'],
+    ['deprecated IPv6 site-local', 'fec0::1'],
+    ['IPv4-mapped private IPv6', '::ffff:7f00:1'],
+    ['NAT64-mapped private IPv6', '64:ff9b::7f00:1']
+  ])('rejects %s title addresses', (_label, address) => {
+    expect(isPublicLinkTitleAddress(address)).toBe(false)
+  })
+
   it('formats URL fallbacks as host + path', () => {
     expect(
       hostPathLabel(
@@ -55,8 +89,55 @@ describe('external link helpers', () => {
   it('filters out local/non-http targets for title fetches', () => {
     expect(isTitleFetchable('https://www.expedia.com/things-to-do/foo')).toBe(true)
     expect(isTitleFetchable('http://localhost:5174')).toBe(false)
+    expect(isTitleFetchable('http://127')).toBe(false)
+    expect(isTitleFetchable('http://0.0.0.127/')).toBe(false)
+    expect(isTitleFetchable('http://127.1')).toBe(false)
+    expect(isTitleFetchable('http://2130706433')).toBe(false)
+    expect(isTitleFetchable('http://10.0.0.1')).toBe(false)
+    expect(isTitleFetchable('http://192.168.1.1')).toBe(false)
+    expect(isTitleFetchable('https://192.0.0.9')).toBe(true)
+    expect(isTitleFetchable('https://192.0.0.10')).toBe(true)
+    expect(isTitleFetchable('http://[::1]')).toBe(false)
+    expect(isTitleFetchable('http://[fc00::1]')).toBe(false)
+    expect(isTitleFetchable('https://[::ffff:8.8.8.8]')).toBe(true)
+    expect(isTitleFetchable('http://[::ffff:127.0.0.1]')).toBe(false)
+    expect(isTitleFetchable('https://[64:ff9b::808:808]')).toBe(true)
+    expect(isTitleFetchable('http://[64:ff9b::7f00:1]')).toBe(false)
+    // IANA's globally reachable AMT assignment inside 2001::/23.
+    expect(isTitleFetchable('https://[2001:3::1]')).toBe(true)
+    expect(isTitleFetchable('https://[100:0:0:1::1]')).toBe(false)
+    expect(isTitleFetchable('https://[2001:5::1]')).toBe(false)
+    expect(isTitleFetchable('https://[5f00::1]')).toBe(false)
+    expect(isTitleFetchable('https://8.8.8.8')).toBe(true)
     expect(isTitleFetchable('file:///tmp/demo.html')).toBe(false)
     expect(isTitleFetchable('mailto:hello@example.com')).toBe(false)
+  })
+
+  it.each([
+    'https://github.com/NousResearch/hermes-agent.git\\ncd',
+    'https://github.com/NousResearch/hermes-agent.git%5Cncd'
+  ])('rejects title URLs that carry an escaped shell continuation: %s', value => {
+    expect(admitLinkTitleUrl(value)).toBeNull()
+    expect(isTitleFetchable(value)).toBe(false)
+  })
+
+  it('does not ask Electron to fetch titles for blocked local targets', async () => {
+    const bridge = vi.fn().mockResolvedValue('unexpected')
+    installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+
+    await expect(fetchLinkTitle('http://127')).resolves.toBe('')
+    expect(bridge).not.toHaveBeenCalled()
+  })
+
+  it('forwards the exact WHATWG-canonical admitted URL to Electron', async () => {
+    const bridge = vi.fn().mockResolvedValue('Canonical title')
+    installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+    const raw = 'http://example.com\\@127.0.0.1/'
+    const canonical = 'http://example.com/@127.0.0.1/'
+
+    expect(admitLinkTitleUrl(raw)).toBe(canonical)
+    await expect(fetchLinkTitle(raw)).resolves.toBe('Canonical title')
+    expect(bridge).toHaveBeenCalledWith(canonical)
   })
 
   it('deduplicates in-flight title fetches and caches results', async () => {

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -1,3 +1,4 @@
+import { admitLinkTitleUrl } from '@hermes/shared'
 import type { ComponentProps, ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 
@@ -19,8 +20,6 @@ const URL_RE =
 const EXPLICIT_URL_RE = /(?:https?:\/\/|www\.)[^\s<>"'`]+[^\s<>"'`.,;:!?)]/gi
 
 const DOMAIN_RE = /^(?:www\.)?[a-z0-9](?:[a-z0-9-]*\.)+[a-z]{2,}(?::\d+)?(?:[/?#][^\s]*)?$/i
-const SKIP_PROTO_RE = /^(?:file|data|mailto|javascript|blob|chrome|about|hermes):/i
-const LOCAL_HOST_RE = /^(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?$/i
 
 const ERROR_TITLE_RE =
   /\b(?:access denied|attention required|captcha|error|forbidden|just a moment|request blocked|too many requests)\b/i
@@ -112,22 +111,17 @@ export function urlSlugTitleLabel(value: string): string {
 }
 
 export function isTitleFetchable(value: string): boolean {
-  if (!value || SKIP_PROTO_RE.test(value)) {
-    return false
-  }
-
-  const url = parseUrl(value)
-
-  return Boolean(url && /^https?:$/.test(url.protocol) && !LOCAL_HOST_RE.test(url.host))
+  return admitLinkTitleUrl(normalizeExternalUrl(value)) !== null
 }
 
 export function fetchLinkTitle(url: string): Promise<string> {
-  const normalizedUrl = normalizeExternalUrl(url)
-  const key = titleCacheKey(normalizedUrl)
+  const canonicalUrl = admitLinkTitleUrl(normalizeExternalUrl(url))
 
-  if (!isTitleFetchable(normalizedUrl)) {
+  if (!canonicalUrl) {
     return Promise.resolve('')
   }
+
+  const key = titleCacheKey(canonicalUrl)
 
   if (titleCache.has(key)) {
     return Promise.resolve(titleCache.get(key) ?? '')
@@ -147,7 +141,7 @@ export function fetchLinkTitle(url: string): Promise<string> {
     return Promise.resolve('')
   }
 
-  const promise = bridge(normalizedUrl)
+  const promise = bridge(canonicalUrl)
     .then(value => (value || '').replace(/\s+/g, ' ').trim())
     .then(clean => (clean && !ERROR_TITLE_RE.test(clean) ? clean : ''))
     .catch(() => '')
@@ -165,14 +159,14 @@ export function fetchLinkTitle(url: string): Promise<string> {
 }
 
 export function useLinkTitle(url?: null | string): string {
-  const normalizedUrl = useMemo(() => (url ? normalizeExternalUrl(url) : ''), [url])
-  const key = useMemo(() => (normalizedUrl ? titleCacheKey(normalizedUrl) : ''), [normalizedUrl])
+  const canonicalUrl = useMemo(() => (url ? (admitLinkTitleUrl(normalizeExternalUrl(url)) ?? '') : ''), [url])
+  const key = useMemo(() => (canonicalUrl ? titleCacheKey(canonicalUrl) : ''), [canonicalUrl])
   const [title, setTitle] = useState(() => (key ? (titleCache.get(key) ?? '') : ''))
 
   useEffect(() => {
     setTitle(key ? (titleCache.get(key) ?? '') : '')
 
-    if (!key || !isTitleFetchable(normalizedUrl)) {
+    if (!key) {
       return
     }
 
@@ -180,7 +174,7 @@ export function useLinkTitle(url?: null | string): string {
 
     subs.add(setTitle)
     titleSubs.set(key, subs)
-    void fetchLinkTitle(normalizedUrl)
+    void fetchLinkTitle(canonicalUrl)
 
     return () => {
       subs.delete(setTitle)
@@ -189,7 +183,7 @@ export function useLinkTitle(url?: null | string): string {
         titleSubs.delete(key)
       }
     }
-  }, [key, normalizedUrl])
+  }, [canonicalUrl, key])
 
   return title
 }

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -8,6 +8,7 @@ export {
   JsonRpcGatewayClient,
   type WebSocketLike
 } from './json-rpc-gateway'
+export { admitLinkTitleUrl, isLinkTitleFetchableUrl, isPublicLinkTitleAddress } from './link-title-url'
 export {
   buildHermesWebSocketUrl,
   type GatewayAuthMode,

--- a/apps/shared/src/link-title-url.ts
+++ b/apps/shared/src/link-title-url.ts
@@ -1,0 +1,246 @@
+const LOCAL_ONLY_HOST_SUFFIXES = ['home.arpa', 'internal', 'lan', 'local', 'localdomain', 'localhost']
+const PUBLIC_IPV4_EXCEPTIONS = new Set([0xc0000009, 0xc000000a])
+
+const NON_PUBLIC_IPV4_RANGES: ReadonlyArray<readonly [network: number, prefixLength: number]> = [
+  [0x00000000, 8],
+  [0x0a000000, 8],
+  [0x64400000, 10],
+  [0x7f000000, 8],
+  [0xa9fe0000, 16],
+  [0xac100000, 12],
+  [0xc0000000, 24],
+  [0xc0000200, 24],
+  [0xc0586300, 24],
+  [0xc0a80000, 16],
+  [0xc6120000, 15],
+  [0xc6336400, 24],
+  [0xcb007100, 24],
+  [0xe0000000, 4],
+  [0xf0000000, 4]
+]
+
+const PUBLIC_IETF_IPV6_RANGES: ReadonlyArray<readonly [network: readonly number[], prefixLength: number]> = [
+  [[0x2001, 0x0001, 0, 0, 0, 0, 0, 1], 128],
+  [[0x2001, 0x0001, 0, 0, 0, 0, 0, 2], 128],
+  [[0x2001, 0x0001, 0, 0, 0, 0, 0, 3], 128],
+  [[0x2001, 0x0003], 32],
+  [[0x2001, 0x0004, 0x0112], 48],
+  [[0x2001, 0x0020], 28],
+  [[0x2001, 0x0030], 28]
+]
+
+const NON_PUBLIC_GLOBAL_UNICAST_IPV6_RANGES: ReadonlyArray<
+  readonly [network: readonly number[], prefixLength: number]
+> = [
+  [[0x2001, 0x0db8], 32],
+  [[0x2002], 16],
+  [[0x3fff, 0], 20]
+]
+
+function canonicalIpv4Value(hostname: string): null | number {
+  const octets = hostname.split('.')
+
+  if (octets.length !== 4 || octets.some(octet => !/^\d+$/.test(octet))) {
+    return null
+  }
+
+  const values = octets.map(Number)
+
+  if (values.some(value => value < 0 || value > 255)) {
+    return null
+  }
+
+  return (((values[0] * 256 + values[1]) * 256 + values[2]) * 256 + values[3]) >>> 0
+}
+
+function isInIpv4Range(value: number, network: number, prefixLength: number): boolean {
+  const mask = prefixLength === 0 ? 0 : (0xffffffff << (32 - prefixLength)) >>> 0
+
+  return (value & mask) >>> 0 === (network & mask) >>> 0
+}
+
+function isNonPublicIpv4(value: number): boolean {
+  if (PUBLIC_IPV4_EXCEPTIONS.has(value)) {
+    return false
+  }
+
+  return NON_PUBLIC_IPV4_RANGES.some(([network, prefixLength]) => isInIpv4Range(value, network, prefixLength))
+}
+
+function parseIpv6Section(section: string): null | number[] {
+  if (!section) {
+    return []
+  }
+
+  const words = section.split(':')
+
+  if (words.some(word => !/^[0-9a-f]{1,4}$/i.test(word))) {
+    return null
+  }
+
+  return words.map(word => Number.parseInt(word, 16))
+}
+
+function canonicalIpv6Words(hostname: string): null | number[] {
+  if (!hostname.startsWith('[') || !hostname.endsWith(']')) {
+    return null
+  }
+
+  const address = hostname.slice(1, -1)
+  const halves = address.split('::')
+
+  if (halves.length > 2) {
+    return null
+  }
+
+  const left = parseIpv6Section(halves[0])
+  const right = parseIpv6Section(halves[1] ?? '')
+
+  if (!left || !right) {
+    return null
+  }
+
+  const omitted = 8 - left.length - right.length
+
+  if ((halves.length === 1 && omitted !== 0) || (halves.length === 2 && omitted < 1)) {
+    return null
+  }
+
+  return [...left, ...Array.from({ length: omitted }, () => 0), ...right]
+}
+
+function isInIpv6Range(words: number[], network: readonly number[], prefixLength: number): boolean {
+  const wholeWords = Math.floor(prefixLength / 16)
+
+  for (let index = 0; index < wholeWords; index += 1) {
+    if (words[index] !== (network[index] ?? 0)) {
+      return false
+    }
+  }
+
+  const remainingBits = prefixLength % 16
+
+  if (!remainingBits) {
+    return true
+  }
+
+  const mask = (0xffff << (16 - remainingBits)) & 0xffff
+
+  return (words[wholeWords] & mask) === ((network[wholeWords] ?? 0) & mask)
+}
+
+function embeddedIpv4(words: number[]): null | number {
+  const isMapped = words.slice(0, 5).every(word => word === 0) && words[5] === 0xffff
+  const isNat64Wkp =
+    words[0] === 0x0064 && words[1] === 0xff9b && words.slice(2, 6).every(word => word === 0)
+
+  if (!isMapped && !isNat64Wkp) {
+    return null
+  }
+
+  return ((words[6] << 16) | words[7]) >>> 0
+}
+
+function isPublicIpv6(words: number[]): boolean {
+  const ipv4 = embeddedIpv4(words)
+
+  if (ipv4 !== null) {
+    return !isNonPublicIpv4(ipv4)
+  }
+
+  if (!isInIpv6Range(words, [0x2000], 3)) {
+    return false
+  }
+
+  if (isInIpv6Range(words, [0x2001], 23)) {
+    return PUBLIC_IETF_IPV6_RANGES.some(([network, prefixLength]) => isInIpv6Range(words, network, prefixLength))
+  }
+
+  return !NON_PUBLIC_GLOBAL_UNICAST_IPV6_RANGES.some(([network, prefixLength]) =>
+    isInIpv6Range(words, network, prefixLength)
+  )
+}
+
+function isLocalOnlyHostname(hostname: string): boolean {
+  if (!hostname.includes('.')) {
+    return true
+  }
+
+  return LOCAL_ONLY_HOST_SUFFIXES.some(suffix => hostname === suffix || hostname.endsWith(`.${suffix}`))
+}
+
+function unbracketAddress(value: string): null | string {
+  const startsWithBracket = value.startsWith('[')
+  const endsWithBracket = value.endsWith(']')
+
+  if (startsWithBracket !== endsWithBracket) {
+    return null
+  }
+
+  return startsWithBracket ? value.slice(1, -1) : value
+}
+
+export function isPublicLinkTitleAddress(value: string): boolean {
+  const address = unbracketAddress(value)
+
+  if (address === null) {
+    return false
+  }
+
+  const ipv4 = canonicalIpv4Value(address)
+
+  if (ipv4 !== null) {
+    return !isNonPublicIpv4(ipv4)
+  }
+
+  const ipv6 = canonicalIpv6Words(`[${address}]`)
+
+  return ipv6 !== null && isPublicIpv6(ipv6)
+}
+
+const URL_CONTROL_CHARACTER_RE = /[\u0000-\u001f\u007f]/
+const ENCODED_URL_CONTROL_CHARACTER_RE = /%(?:0[0-9a-f]|1[0-9a-f]|7f)/i
+// A pasted shell snippet such as `https://example.test/repo\\ncd repo` must
+// not become a title-preview navigation. WHATWG URL canonicalization otherwise
+// turns the backslash into a path separator before this function can inspect it.
+const ESCAPED_SHELL_CONTROL_RE = /(?:\\|%5c)[nrt]/i
+
+export function admitLinkTitleUrl(value: string): null | string {
+  if (
+    URL_CONTROL_CHARACTER_RE.test(value) ||
+    ENCODED_URL_CONTROL_CHARACTER_RE.test(value) ||
+    ESCAPED_SHELL_CONTROL_RE.test(value)
+  ) {
+    return null
+  }
+
+  let url: URL
+
+  try {
+    url = new URL(value)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return null
+  }
+
+  const hostname = url.hostname.toLowerCase().replace(/\.$/, '')
+  const ipv4 = canonicalIpv4Value(hostname)
+  const ipv6 = canonicalIpv6Words(hostname)
+
+  if ((ipv4 !== null || ipv6) && !isPublicLinkTitleAddress(hostname)) {
+    return null
+  }
+
+  if (ipv4 === null && !ipv6 && isLocalOnlyHostname(hostname)) {
+    return null
+  }
+
+  return url.href
+}
+
+export function isLinkTitleFetchableUrl(value: string): boolean {
+  return admitLinkTitleUrl(value) !== null
+}


### PR DESCRIPTION
## Summary
- Gate title URLs and redirects against public-address admission.
- Pin DNS answers through a loopback SOCKS gateway to resist rebinding and direct fallback.
- Fail closed for renderer proxy setup and WebRTC/popup policy failures.
- Add a real Electron hidden BrowserWindow test proving SOCKS routing and an unreachable proxy does not direct-connect.

## Verification
- Electron link-title suites: 44 passed.
- UI URL-admission suite: 34 passed.
- `npm run typecheck` and targeted ESLint passed.

## Note
The full Electron project suite has a pre-existing timeout in `electron/git-review-ops.test.ts`, reproduced unchanged on the untouched local main checkout; it is not included in this PR scope.