### PR TITLE
feat(gateway): expose continuation checkpoints on turn limits

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1778,7 +1778,17 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     summary_request = (
         "You've reached the maximum number of tool-calling iterations allowed. "
         "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
+        "without calling any more tools.\n\n"
+        "If the work is NOT finished, end your response with a fenced markdown code block whose "
+        "first line is exactly `CONTINUATION CHECKPOINT` so an automated runner can resume the "
+        "workflow in a later turn. Keep the block under ~40 lines, using short bullet lists:\n"
+        "- Goal: the user's original goal, one line\n"
+        "- Where: the current task / worktree or directory path\n"
+        "- Verified: verification steps already completed\n"
+        "- Pending: the ordered remaining steps, in order\n"
+        "- Artifacts: branch names, PR URLs, task ids, files already created\n"
+        "- Unknown side effects: any side-effecting call (git push, deploy, external API write) "
+        "that was issued but whose completion you could not confirm"
     )
     messages.append({"role": "user", "content": summary_request})
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3836,6 +3836,22 @@ class TestHandleMaxIterations:
         assert len(result) > 0
         assert "summary" in result.lower()
 
+    def test_summary_requests_continuation_checkpoint_for_unfinished_work(self, agent):
+        resp = _mock_response(content="Work remains.")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Work remains."
+        sent_msgs = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        summary_request = sent_msgs[-1]
+        assert summary_request["role"] == "user"
+        assert "CONTINUATION CHECKPOINT" in summary_request["content"]
+        assert "Unknown side effects" in summary_request["content"]
+        assert "under ~40 lines" in summary_request["content"]
+
     def test_api_failure_returns_error(self, agent):
         agent.client.chat.completions.create.side_effect = Exception("API down")
         agent._cached_system_prompt = "You are helpful."

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10292,3 +10292,53 @@ def test_get_usage_clamps_post_compression_sentinel():
     usage = server._get_usage(agent)
     assert "context_used" not in usage
     assert "context_percent" not in usage
+
+
+# -- message.complete turn-exit signal (issue #902 -- Foxy auto-continuation) --
+
+
+class _IterAgent:
+    max_iterations = 25
+
+
+def test_completion_payload_carries_turn_exit_reason_on_iteration_limit():
+    payload = {"text": "summary", "status": "complete"}
+    result = {
+        "final_response": "summary",
+        "turn_exit_reason": "max_iterations_reached(25/25)",
+        "api_calls": 25,
+    }
+    out = server._augment_completion_payload(payload, result, _IterAgent())
+    assert out["turn_exit_reason"] == "max_iterations_reached(25/25)"
+    assert out["iterations_used"] == 25
+    assert out["iterations_max"] == 25
+    # Status semantics untouched -- lenient consumers key off it.
+    assert out["status"] == "complete"
+
+
+def test_completion_payload_carries_turn_exit_reason_on_budget_exhausted():
+    payload = {"text": "summary", "status": "complete"}
+    result = {"final_response": "summary", "turn_exit_reason": "budget_exhausted"}
+    out = server._augment_completion_payload(payload, result, _IterAgent())
+    assert out["turn_exit_reason"] == "budget_exhausted"
+    # api_calls absent -> no iterations_used key fabricated.
+    assert "iterations_used" not in out
+
+
+def test_completion_payload_unchanged_on_normal_text_response_exit():
+    payload = {"text": "answer", "status": "complete"}
+    result = {
+        "final_response": "answer",
+        "turn_exit_reason": "text_response(finish_reason=stop)",
+        "api_calls": 3,
+    }
+    out = server._augment_completion_payload(payload, result, _IterAgent())
+    assert "turn_exit_reason" not in out
+    assert "iterations_used" not in out
+    assert "iterations_max" not in out
+
+
+def test_completion_payload_unchanged_on_non_dict_result():
+    payload = {"text": "answer", "status": "complete"}
+    out = server._augment_completion_payload(payload, "plain string result", _IterAgent())
+    assert out == {"text": "answer", "status": "complete"}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3465,6 +3465,35 @@ def _sync_session_key_after_compress(
             pass
 
 
+def _augment_completion_payload(payload: dict, result, agent) -> dict:
+    """Additively fold the structured turn-exit signal into a message.complete
+    payload (issue #902 — Foxy auto-continuation).
+
+    The runtime knows exactly why a turn ended (``run_conversation`` returns
+    ``turn_exit_reason``: ``max_iterations_reached(N/M)``, ``budget_exhausted``,
+    …) but the gateway used to drop it, so an iteration-limit exit surfaced to
+    consumers as a normal completed turn. Emit the reason — plus the iteration
+    counters — whenever the turn ended for a NON-text_response reason. Never
+    touches ``status`` (lenient consumers elsewhere key off it).
+    """
+    if not isinstance(result, dict):
+        return payload
+    exit_reason = result.get("turn_exit_reason")
+    if (
+        isinstance(exit_reason, str)
+        and exit_reason
+        and not exit_reason.startswith("text_response")
+    ):
+        payload["turn_exit_reason"] = exit_reason
+        api_calls = result.get("api_calls")
+        if isinstance(api_calls, int):
+            payload["iterations_used"] = api_calls
+        max_iter = getattr(agent, "max_iterations", None)
+        if isinstance(max_iter, int):
+            payload["iterations_max"] = max_iter
+    return payload
+
+
 def _get_usage(agent) -> dict:
     g = lambda k, fb=None: getattr(agent, k, 0) or (getattr(agent, fb, 0) if fb else 0)
     usage = {
@@ -9604,6 +9633,10 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 payload["reasoning"] = last_reasoning
             if status_note:
                 payload["warning"] = status_note
+            # Structured turn-exit signal (additive; status semantics untouched).
+            # An iteration-limit exit must not surface as a normal completed turn
+            # — the Foxy dashboard auto-continuation (issue #902) keys off this.
+            _augment_completion_payload(payload, result, agent)
             rendered = render_message(raw, cols)
             if rendered:
                 payload["rendered"] = rendered


### PR DESCRIPTION
## Summary
- preserve the structured `turn_exit_reason` and iteration counters in gateway `message.complete` payloads for non-normal exits
- request a bounded `CONTINUATION CHECKPOINT` from the existing max-iteration grace response when work remains
- keep normal `text_response` and existing `status` semantics unchanged

## Why
A dashboard consumer needs to distinguish a genuinely completed turn from `max_iterations_reached(...)` / `budget_exhausted` so it can durably auto-resume instead of silently presenting partial work as completion. The consumer side is tracked by AdHacksHQ/refurbapp#902.

## Verification (exact head c189bdaab)
- focused new tests: 5 passed
- target suites: 783 passed, 3 unrelated pre-existing/environment-sensitive failures (browser-connect Darwin fixture and 2 browser callback tests)
- `ruff check` on all changed files: PASS
- `compileall` on changed production modules: PASS
- `git diff --check`: PASS

No new tool or prompt-cache mutation is introduced; this extends the existing gateway payload and existing max-iteration grace prompt.