### PR TITLE
fix(desktop): repair invalid active runtime

### DIFF
--- a/apps/desktop/electron/active-runtime-state.test.ts
+++ b/apps/desktop/electron/active-runtime-state.test.ts
@@ -35,9 +35,17 @@ test('classifyActiveRuntime uses a healthy active runtime even when the marker i
   })
 })
 
-test('classifyActiveRuntime refuses an unusable runtime even if a valid marker exists', () => {
+test('a valid marker plus an unusable active runtime requires managed repair before external fallback', () => {
   assert.deepEqual(classifyActiveRuntime(VALID_MARKER, 1, false), {
     hasValidMarker: true,
+    shouldUseActiveRuntime: false,
+    usabilityReason: 'repair'
+  })
+})
+
+test('an unusable unmarked runtime remains eligible for ordinary external fallback', () => {
+  assert.deepEqual(classifyActiveRuntime(null, 1, false), {
+    hasValidMarker: false,
     shouldUseActiveRuntime: false,
     usabilityReason: 'unusable'
   })

--- a/apps/desktop/electron/active-runtime-state.ts
+++ b/apps/desktop/electron/active-runtime-state.ts
@@ -6,7 +6,7 @@ export interface BootstrapMarkerLike {
 export interface ActiveRuntimeState {
   hasValidMarker: boolean
   shouldUseActiveRuntime: boolean
-  usabilityReason: 'usable' | 'unusable'
+  usabilityReason: 'usable' | 'unusable' | 'repair'
 }
 
 export function hasValidBootstrapMarker(
@@ -46,7 +46,12 @@ export function classifyActiveRuntime(
     return {
       hasValidMarker,
       shouldUseActiveRuntime: false,
-      usabilityReason: 'unusable'
+      // A valid marker says Desktop owns this canonical install. If its
+      // preflight fails, repair that install before any PATH/system-Python
+      // fallback can silently change the user's backend. Without a valid
+      // marker, this is an unowned/incomplete location and normal external
+      // candidate resolution remains appropriate.
+      usabilityReason: hasValidMarker ? 'repair' : 'unusable'
     }
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3824,6 +3824,24 @@ function resolveHermesBackend(backendArgs) {
     return createActiveBackend(backendArgs)
   }
 
+  if (activeRuntime.usabilityReason === 'repair') {
+    rememberLog('[bootstrap] desktop-managed active runtime failed preflight; repairing the active install before external fallback')
+
+    return {
+      kind: 'bootstrap-needed',
+      label: 'Hermes Agent runtime needs repair; bootstrap required',
+      command: null,
+      args: backendArgs,
+      bootstrap: true,
+      env: {},
+      shell: false,
+      activeRoot: ACTIVE_HERMES_ROOT,
+      installStamp: INSTALL_STAMP,
+      isPackaged: IS_PACKAGED,
+      platform: process.platform
+    }
+  }
+
   if (bootstrapRepairRequested) {
     rememberLog('[bootstrap] repair requested; bypassing the usable active runtime to re-run the installer')
   }


### PR DESCRIPTION
## Current change

Current head: `28da6bf` — rebased on `NousResearch/main` `e598cef`.

Desktop now distinguishes a valid managed-runtime marker whose active runtime fails startup preflight from an ordinary unavailable runtime. That state selects repair before unrelated external backend candidates.

## Root cause

The resolver previously collapsed “marker valid, active runtime probe failed” to false and could continue into an external candidate rung. This could bypass the managed-runtime repair path.

## Review disposition

The generated-Python source-text assertion was removed. The regression now uses a real interpreter/process-bound fixture: shallow configuration imports succeed, the dashboard web-server startup import deliberately fails, and `canImportHermesCli()` must reject that runtime before the resolver selects `repair`.

## Validation

Node 22:

- Electron platform suite: 46 files, 461 passed, 1 skipped;
- typecheck passed.

## Review focus

Please review the preflight boundary: a marker-backed active runtime must be proven through the actual startup-import contract before the resolver can keep it active; a failed proof must choose repair rather than an unrelated candidate.
