### PR TITLE
fix(cron): report execution and work status truthfully

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -18,6 +18,7 @@ import time
 import os
 import re
 import uuid
+import unicodedata
 
 # Cross-process advisory file locking for jobs.json critical sections.
 # fcntl is Unix-only; on Windows fall back to msvcrt. Either may be absent,
@@ -1509,27 +1510,204 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
-def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
-    """
-    Mark a job as having been run.
-    
-    Updates last_run_at, last_status, increments completed count,
-    computes next_run_at, and auto-deletes if repeat limit reached.
+def _safe_status_metadata(value: Any) -> Optional[str]:
+    """Return bounded control-safe status metadata, otherwise ``None``."""
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned or len(cleaned) > 512:
+        return None
+    if any(
+        not char.isprintable() or unicodedata.category(char).startswith("C")
+        for char in cleaned
+    ):
+        return None
+    return cleaned
 
-    ``delivery_error`` is tracked separately from the agent error — a job
-    can succeed (agent produced output) but fail delivery (platform down).
+
+def effective_job_status(job: Dict[str, Any]) -> Dict[str, Any]:
+    """Project a newer execution-ledger attempt over stale job summary fields."""
+    result = {
+        "last_run_at": job.get("last_run_at"),
+        "last_status": job.get("last_status"),
+        "last_run_status": job.get("last_run_status"),
+        "last_error": job.get("last_error"),
+        "last_delivery_status": job.get("last_delivery_status"),
+        "last_delivery_error": job.get("last_delivery_error"),
+        "last_work_status": job.get("last_work_status"),
+        "last_work_status_source": job.get("last_work_status_source"),
+        "last_evidence_id": job.get("last_evidence_id"),
+        "last_evidence_verified": job.get("last_evidence_verified", False),
+        "last_executor_handle": job.get("last_executor_handle"),
+    }
+    execution = job.get("latest_execution")
+    if not isinstance(execution, dict):
+        return result
+    latest_text = execution.get("started_at") or execution.get("claimed_at")
+    prior_text = job.get("last_run_at")
+    if not latest_text:
+        return result
+    try:
+        latest = _ensure_aware(datetime.fromisoformat(str(latest_text).replace("Z", "+00:00")))
+        prior = (
+            _ensure_aware(datetime.fromisoformat(str(prior_text).replace("Z", "+00:00")))
+            if prior_text
+            else None
+        )
+        is_newer = prior is None or latest > prior
+    except (TypeError, ValueError):
+        is_newer = not prior_text or str(latest_text) > str(prior_text)
+    if not is_newer:
+        return result
+
+    execution_status = str(execution.get("status") or "unknown")
+    run_status = {
+        "completed": "ok",
+        "failed": "error",
+        "running": "running",
+        "claimed": "pending",
+    }.get(execution_status, "unknown")
+    result.update(
+        {
+            "last_run_at": latest_text,
+            "last_status": run_status,
+            "last_run_status": run_status,
+            "last_error": execution.get("error"),
+            "last_delivery_status": "unknown",
+            "last_delivery_error": None,
+            "last_work_status": "unknown",
+            "last_work_status_source": "none",
+            "last_evidence_id": None,
+            "last_evidence_verified": False,
+            "last_executor_handle": None,
+        }
+    )
+    return result
+
+
+def mark_job_run(
+    job_id: str,
+    success: bool,
+    error: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+    *,
+    delivery_status: Optional[str] = None,
+    work_status: Optional[str] = None,
+    work_status_source: Optional[str] = None,
+    evidence_id: Optional[str] = None,
+    evidence_verified: bool = False,
+    executor_handle: Optional[str] = None,
+):
+    """Mark a job run while keeping run, delivery, and work status separate.
+
+    ``last_status`` remains the backward-compatible run status.  The explicit
+    ``last_run_status`` alias plus independent delivery/work fields prevent a
+    successful scheduler invocation or delivery from being mistaken for
+    substantive project progress.
+
+    Legacy callers may omit the new keyword-only fields; those dimensions are
+    then recorded as ``unknown`` rather than inferred from run success.
     """
     with _jobs_lock():
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
+                was_paused = job.get("state") == "paused"
                 now = _hermes_now().isoformat()
+                run_status = "ok" if success else "error"
+                allowed_delivery_statuses = {
+                    "unknown", "pending", "ok", "error", "suppressed", "not_requested"
+                }
+                allowed_work_statuses = {
+                    "unknown", "progress", "no_progress", "blocked", "waiting_external"
+                }
+                resolved_delivery_status = delivery_status
+                if resolved_delivery_status is None:
+                    resolved_delivery_status = "error" if delivery_error else "unknown"
+                if resolved_delivery_status not in allowed_delivery_statuses:
+                    resolved_delivery_status = "unknown"
+                resolved_work_status = work_status or "unknown"
+                if resolved_work_status not in allowed_work_statuses:
+                    resolved_work_status = "unknown"
+                allowed_work_status_sources = {"none", "agent_marker", "external_verifier"}
+                resolved_work_status_source = work_status_source or "none"
+                if resolved_work_status_source not in allowed_work_status_sources:
+                    resolved_work_status_source = "none"
+                resolved_evidence_id = _safe_status_metadata(evidence_id)
+                resolved_executor_handle = _safe_status_metadata(executor_handle)
+                evidence_history = []
+                for item in job.get("work_evidence_ids") or []:
+                    normalized_item = _safe_status_metadata(item)
+                    if normalized_item:
+                        evidence_history.append(normalized_item)
+                seen_evidence_ids = set(evidence_history)
+                previous_evidence_id = job.get("last_progress_evidence_id") or job.get("last_evidence_id")
+                normalized_previous_evidence = _safe_status_metadata(previous_evidence_id)
+                if normalized_previous_evidence:
+                    seen_evidence_ids.add(normalized_previous_evidence)
+                if (
+                    resolved_work_status == "progress"
+                    and resolved_evidence_id
+                    and resolved_evidence_id in seen_evidence_ids
+                ):
+                    resolved_work_status = "no_progress"
+                    resolved_evidence_id = None
+                    resolved_executor_handle = None
+                elif (
+                    resolved_work_status == "progress"
+                    and resolved_evidence_id
+                    and len(evidence_history) >= 256
+                ):
+                    resolved_work_status = "unknown"
+                    resolved_work_status_source = "none"
+                    resolved_evidence_id = None
+                    resolved_executor_handle = None
+                if (
+                    resolved_work_status == "progress" and not resolved_evidence_id
+                ) or (
+                    resolved_work_status == "waiting_external" and not resolved_executor_handle
+                ):
+                    resolved_work_status = "unknown"
+                    resolved_work_status_source = "none"
+                    resolved_evidence_id = None
+                    resolved_executor_handle = None
+                resolved_evidence_verified = bool(
+                    evidence_verified
+                    and resolved_evidence_id
+                    and resolved_work_status_source == "external_verifier"
+                )
+                new_progress_evidence_id = (
+                    resolved_evidence_id if resolved_work_status == "progress" else None
+                )
+                if resolved_work_status == "progress" and not resolved_evidence_verified:
+                    resolved_work_status = "reported_progress"
+                elif (
+                    resolved_work_status == "waiting_external"
+                    and resolved_work_status_source != "external_verifier"
+                ):
+                    resolved_work_status = "reported_waiting_external"
+                elif (
+                    resolved_work_status == "blocked"
+                    and resolved_work_status_source == "agent_marker"
+                ):
+                    resolved_work_status = "reported_blocked"
+
                 job["last_run_at"] = now
-                job["last_status"] = "ok" if success else "error"
+                job["last_status"] = run_status
+                job["last_run_status"] = run_status
                 job["last_error"] = error if not success else None
-                # Track delivery failures separately — cleared on successful delivery
+                job["last_delivery_status"] = resolved_delivery_status
                 job["last_delivery_error"] = delivery_error
+                job["last_work_status"] = resolved_work_status
+                job["last_work_status_source"] = resolved_work_status_source
+                job["last_evidence_id"] = resolved_evidence_id
+                if new_progress_evidence_id:
+                    job["last_progress_evidence_id"] = new_progress_evidence_id
+                    if new_progress_evidence_id not in evidence_history:
+                        evidence_history.append(new_progress_evidence_id)
+                    job["work_evidence_ids"] = evidence_history
+                job["last_evidence_verified"] = resolved_evidence_verified
+                job["last_executor_handle"] = resolved_executor_handle
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None
@@ -1559,10 +1737,15 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         completed += 1
                         repeat["completed"] = completed
 
-                    # Check if we've hit the repeat limit
+                    # Retain terminal jobs so their final run/delivery/work
+                    # dimensions remain inspectable. A late completion may
+                    # update history, but it must never delete or resume a job
+                    # the operator paused while it was running.
                     if times is not None and times > 0 and completed >= times:
-                        # Remove the job (limit reached)
-                        jobs.pop(i)
+                        job["next_run_at"] = None
+                        if not was_paused:
+                            job["enabled"] = False
+                            job["state"] = "completed"
                         save_jobs(jobs)
                         return
                 
@@ -1577,7 +1760,9 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 # schedule quietly goes off. See issue #16265.
                 if job["next_run_at"] is None:
                     kind = job.get("schedule", {}).get("kind")
-                    if kind in {"cron", "interval"}:
+                    if was_paused:
+                        pass
+                    elif kind in {"cron", "interval"}:
                         job["state"] = "error"
                         if not job.get("last_error"):
                             job["last_error"] = (
@@ -1604,6 +1789,25 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
 
 
+def _retire_unknown_oneshot(job: Dict[str, Any], reason: str) -> None:
+    """Retain an at-most-once terminal record when run outcome is unknowable."""
+    job["enabled"] = False
+    job["state"] = "completed"
+    job["next_run_at"] = None
+    job["run_claim"] = None
+    job["fire_claim"] = None
+    job["last_status"] = "unknown"
+    job["last_run_status"] = "unknown"
+    job["last_error"] = reason
+    job["last_delivery_status"] = "unknown"
+    job["last_delivery_error"] = None
+    job["last_work_status"] = "unknown"
+    job["last_work_status_source"] = "none"
+    job["last_evidence_id"] = None
+    job["last_evidence_verified"] = False
+    job["last_executor_handle"] = None
+
+
 def claim_dispatch(job_id: str) -> bool:
     """Atomically claim a finite one-shot job dispatch BEFORE execution.
 
@@ -1615,7 +1819,8 @@ def claim_dispatch(job_id: str) -> bool:
     instead of infinitely (issue #38758).
 
     Returns ``True`` if the caller may proceed to run the job, ``False`` if the
-    dispatch limit is already reached (in which case the stale job is removed).
+    dispatch limit is already reached. A maxed preclaim is retained as a
+    disabled terminal record with an explicit unknown run outcome.
 
     Only claims jobs with ``schedule.kind == "once"`` and ``repeat.times > 0``.
     Recurring jobs (they use ``advance_next_run``) and infinite-repeat / no-repeat
@@ -1636,13 +1841,17 @@ def claim_dispatch(job_id: str) -> bool:
                 return True  # infinite — always dispatch
             completed = repeat.get("completed", 0)
             if completed >= times:
-                # Already dispatched the max number of times (e.g. a prior
-                # tick claimed then died before mark_job_run could remove it).
-                # Clean up so it stops appearing as due on every tick.
-                jobs.pop(i)
+                # A prior tick consumed the at-most-once dispatch and died
+                # before persisting a terminal result. Never re-fire it, but
+                # retain an explicit unknown-outcome record for inspection.
+                reason = (
+                    "One-shot dispatch was preclaimed, but no terminal run result "
+                    "was persisted; side effects are unknown and the job will not re-fire."
+                )
+                _retire_unknown_oneshot(job, reason)
                 save_jobs(jobs)
                 logger.info(
-                    "Job '%s': dispatch limit reached (%d/%d) — removing",
+                    "Job '%s': dispatch limit reached (%d/%d) — retaining unknown outcome",
                     job.get("name", job.get("id", "?")),
                     completed,
                     times,
@@ -2073,9 +2282,9 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
 
                 # One-shot dispatch-limit guard (issue #38758): a finite one-shot
                 # claimed via claim_dispatch() but whose tick died before
-                # mark_job_run could remove it will have completed >= times while
-                # still looking due (last_run_at was never written, so the
-                # recovery helper re-armed it). Remove it instead of re-firing.
+                # mark_job_run could persist a result will have completed >= times
+                # while still looking due. Retire it with an unknown outcome
+                # instead of re-firing or deleting its status pointer.
                 if kind == "once":
                     repeat = job.get("repeat")
                     if repeat:
@@ -2103,14 +2312,19 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                                 continue
                             logger.info(
                                 "Job '%s': one-shot dispatch limit reached (%d/%d) "
-                                "— removing stale due entry",
+                                "— retaining stale due entry with unknown outcome",
                                 job.get("name", job.get("id", "?")),
                                 completed,
                                 times,
                             )
+                            reason = (
+                                "One-shot dispatch was preclaimed, but its executor is no "
+                                "longer live and no terminal result was persisted; side "
+                                "effects are unknown and the job will not re-fire."
+                            )
                             for rj in raw_jobs:
                                 if rj["id"] == job["id"]:
-                                    raw_jobs.remove(rj)
+                                    _retire_unknown_oneshot(rj, reason)
                                     needs_save = True
                                     break
                             continue

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import threading
 import time
+import unicodedata
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -328,6 +329,103 @@ def _is_cron_silence_response(text: str) -> bool:
     if upper.startswith("[SILENT]"):
         return True
     return False
+
+
+_WORK_RESULT_MARKER = "[HERMES_WORK_RESULT]"
+_WORK_STATUSES = frozenset({"progress", "no_progress", "blocked", "waiting_external"})
+
+
+def _safe_work_metadata(value: Any) -> tuple[bool, Optional[str]]:
+    """Validate untrusted marker metadata without coercion or control bytes."""
+    if value is None:
+        return True, None
+    if not isinstance(value, str):
+        return False, None
+    cleaned = value.strip()
+    if not cleaned:
+        return True, None
+    if len(cleaned) > 512:
+        return False, None
+    if any(
+        not char.isprintable() or unicodedata.category(char).startswith("C")
+        for char in cleaned
+    ):
+        return False, None
+    return True, cleaned
+
+
+def _extract_work_result(text: str) -> tuple[str, dict[str, Any]]:
+    """Strip and parse the final machine-readable work-result marker.
+
+    Missing, malformed, or internally inconsistent metadata fails closed to
+    ``unknown``.  In particular, ``progress`` requires a concrete evidence ID
+    and ``waiting_external`` requires an executor handle.
+    """
+    unknown = {
+        "work_status": "unknown",
+        "work_status_source": "none",
+        "evidence_id": None,
+        "evidence_verified": False,
+        "executor_handle": None,
+    }
+    if not isinstance(text, str) or not text:
+        return text or "", unknown
+
+    lines = text.splitlines()
+    marker_indexes = [
+        index
+        for index, line in enumerate(lines)
+        if line.strip().startswith(_WORK_RESULT_MARKER)
+    ]
+    if not marker_indexes:
+        return text, unknown
+
+    cleaned = "\n".join(
+        line for index, line in enumerate(lines) if index not in marker_indexes
+    ).strip()
+    nonblank_indexes = [index for index, line in enumerate(lines) if line.strip()]
+    marker_index = marker_indexes[0]
+    if (
+        len(marker_indexes) != 1
+        or not nonblank_indexes
+        or marker_index != nonblank_indexes[-1]
+    ):
+        return cleaned, unknown
+
+    marker_line = lines[marker_index].strip()
+    raw_payload = marker_line[len(_WORK_RESULT_MARKER) :].strip()
+    try:
+        payload = json.loads(raw_payload)
+    except (json.JSONDecodeError, TypeError):
+        return cleaned, unknown
+    if not isinstance(payload, dict):
+        return cleaned, unknown
+
+    raw_work_status = payload.get("workStatus")
+    evidence_valid, evidence_id = _safe_work_metadata(payload.get("evidenceId"))
+    executor_valid, executor_handle = _safe_work_metadata(payload.get("executorHandle"))
+    if not isinstance(raw_work_status, str):
+        return cleaned, unknown
+    if not evidence_valid or not executor_valid:
+        return cleaned, unknown
+    if _is_cron_silence_response(cleaned):
+        return cleaned, unknown
+
+    work_status = raw_work_status.strip().lower()
+    if work_status not in _WORK_STATUSES:
+        return cleaned, unknown
+    if work_status == "progress" and evidence_id is None:
+        return cleaned, unknown
+    if work_status == "waiting_external" and executor_handle is None:
+        return cleaned, unknown
+    return cleaned, {
+        "work_status": work_status,
+        "work_status_source": "agent_marker",
+        "evidence_id": evidence_id,
+        "evidence_verified": False,
+        "executor_handle": executor_handle,
+    }
+
 
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
@@ -2052,7 +2150,9 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(
+    script_path: str, *, preserve_stdout: bool = False
+) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -2082,6 +2182,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     Returns:
         (success, output) — on failure *output* contains the error message so the
         LLM can report the problem to the user.
+
+    ``preserve_stdout`` keeps successful stdout text exact for ``no_agent``
+    delivery. Redaction still applies before the text leaves this boundary.
     """
     scripts_dir = _get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
@@ -2147,8 +2250,16 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             env=_sanitize_subprocess_env(os.environ.copy()),
             **popen_kwargs,
         )
-        stdout = (result.stdout or "").strip()
+        stdout = result.stdout or ""
         stderr = (result.stderr or "").strip()
+
+        # Successful no_agent jobs have a direct-output contract: their text
+        # reaches delivery exactly as written, including leading/trailing
+        # whitespace and final newlines. Other script consumers retain the
+        # historical normalized output, and failures stay normalized for the
+        # structured error wrapper below.
+        if not preserve_stdout or result.returncode != 0:
+            stdout = stdout.strip()
 
         # Redact secrets from both stdout and stderr before any return path.
         try:
@@ -2177,7 +2288,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
 
 def _run_job_script_with_claim_heartbeat(
-    job: dict, script_path: str
+    job: dict, script_path: str, *, preserve_stdout: bool = False
 ) -> tuple[bool, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
@@ -2191,6 +2302,12 @@ def _run_job_script_with_claim_heartbeat(
     storage.  ``heartbeat_run_claim`` compares that stable owner before every
     refresh, so a stale runner cannot extend a replacement owner's claim.
     """
+
+    def _execute_script() -> tuple[bool, str]:
+        if preserve_stdout:
+            return _run_job_script(script_path, preserve_stdout=True)
+        return _run_job_script(script_path)
+
     schedule = job.get("schedule")
     claim = job.get("run_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
@@ -2199,7 +2316,7 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path)
+        return _execute_script()
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -2230,10 +2347,10 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path)
+        return _execute_script()
 
     try:
-        return _run_job_script(script_path)
+        return _execute_script()
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -2377,7 +2494,16 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         "SILENT: If there is genuinely nothing new to report, respond "
         "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
         "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        "findings normally, or say [SILENT] and nothing more. "
+        "WORK STATUS: Unless the entire response is [SILENT], append one final "
+        "machine-readable line exactly in this form: "
+        "[HERMES_WORK_RESULT] {\"workStatus\":\"no_progress\",\"evidenceId\":null,\"executorHandle\":null}. "
+        "workStatus must be progress, no_progress, blocked, or waiting_external. "
+        "Progress requires a concrete evidenceId; waiting_external requires a concrete "
+        "executorHandle. The system strips this marker before delivery and records the "
+        "three status dimensions independently. Marker metadata is self-reported: it is "
+        "stored with source=agent_marker and evidenceVerified=false until an external "
+        "verifier independently confirms the evidence.]\n\n"
     )
     prompt = cron_hint + prompt
     if skills is None:
@@ -2648,7 +2774,9 @@ def run_job(
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script_with_claim_heartbeat(job, script_path)
+            ok, output = _run_job_script_with_claim_heartbeat(
+                job, script_path, preserve_stdout=True
+            )
         finally:
             if _prior_cwd is not None:
                 try:
@@ -2690,7 +2818,7 @@ def run_job(
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (wakeAgent=false)\n"
             )
-            return True, silent_doc, SILENT_MARKER, None
+            return True, silent_doc, "", None
 
         if not output.strip():
             logger.info("Job '%s' (no_agent): empty stdout — silent run", job_id)
@@ -2701,7 +2829,7 @@ def run_job(
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (empty output)\n"
             )
-            return True, silent_doc, SILENT_MARKER, None
+            return True, silent_doc, "", None
 
         doc = (
             f"# Cron Job: {job_name}\n\n"
@@ -3691,6 +3819,16 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             success, output, final_response, error = run_job(
                 job, defer_agent_teardown=_deferred_agents
             )
+            if job.get("no_agent"):
+                work_result = {
+                    "work_status": "unknown",
+                    "work_status_source": "none",
+                    "evidence_id": None,
+                    "evidence_verified": False,
+                    "executor_handle": None,
+                }
+            else:
+                final_response, work_result = _extract_work_result(final_response)
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
             # it down here so a failed run never leaks its async resources
@@ -3710,6 +3848,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # deferred agent is still torn down. Otherwise the outer `except` would
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         delivery_error = None
+        delivery_status = "unknown"
         try:
             output_file = save_job_output(job["id"], output)
             if verbose:
@@ -3733,6 +3872,9 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             # If the agent responded with [SILENT], skip delivery (but
             # output is already saved above).  Failed jobs always deliver.
             deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+            delivery_targets = _resolve_delivery_targets(job)
+            deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
+            delivery_is_requested = bool(delivery_targets)
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
@@ -3743,7 +3885,12 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
             # #46917).  Keeps the intentional bracketed-prefix / trailing-line
             # tolerance the cron contract relies on.
-            if should_deliver and success and _is_cron_silence_response(deliver_content):
+            if (
+                should_deliver
+                and success
+                and not job.get("no_agent")
+                and _is_cron_silence_response(deliver_content)
+            ):
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
 
@@ -3753,6 +3900,12 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
+                if not delivery_is_requested and deliver_value in {"local", "origin"}:
+                    delivery_status = "not_requested"
+                else:
+                    delivery_status = "error" if delivery_error else "ok"
+            else:
+                delivery_status = "suppressed"
         finally:
             # Tear down the deferred agent(s) now that save + delivery have run
             # (or raised). Must happen on every path so cron agents never leak
@@ -3763,12 +3916,31 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # Treat empty final_response as a soft failure so last_status
         # is not "ok" — the agent ran but produced nothing useful.
         # (issue #8585)
-        if success and not final_response.strip():
+        if success and not job.get("no_agent") and not final_response.strip():
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
+        if not success:
+            work_result = {
+                "work_status": "unknown",
+                "work_status_source": "none",
+                "evidence_id": None,
+                "evidence_verified": False,
+                "executor_handle": None,
+            }
         if not _consume_interrupted_flag(job["id"]):
-            mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+            mark_job_run(
+                job["id"],
+                success,
+                error,
+                delivery_error=delivery_error,
+                delivery_status=delivery_status,
+                work_status=work_result["work_status"],
+                work_status_source=work_result["work_status_source"],
+                evidence_id=work_result["evidence_id"],
+                evidence_verified=work_result["evidence_verified"],
+                executor_handle=work_result["executor_handle"],
+            )
         finish_execution(execution_id, success=success, error=error)
         return True
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1318,6 +1318,20 @@ class CLICommandsMixin:
                 print(f"  Prompt: {job.get('prompt_preview', '')}")
                 if job.get("last_run_at"):
                     print(f"  Last run: {job['last_run_at']} ({job.get('last_status', '?')})")
+                    run_status = job.get("last_run_status") or job.get("last_status") or "unknown"
+                    delivery_status = job.get("last_delivery_status") or (
+                        "error" if job.get("last_delivery_error") else "unknown"
+                    )
+                    work_status = job.get("last_work_status") or "unknown"
+                    work_source = job.get("last_work_status_source") or "none"
+                    evidence_id = job.get("last_evidence_id") or "none"
+                    evidence_verified = "yes" if job.get("last_evidence_verified", False) else "no"
+                    executor_handle = job.get("last_executor_handle") or "none"
+                    print(f"  Run status: {run_status}")
+                    print(f"  Delivery:   {delivery_status}")
+                    print(f"  Work status: {work_status} (source={work_source})")
+                    print(f"  Evidence:   {evidence_id} (verified={evidence_verified})")
+                    print(f"  Executor:   {executor_handle}")
                 print()
             return
 
@@ -1416,8 +1430,18 @@ class CLICommandsMixin:
                 print(f"(^_^)b Resumed job: {result['job']['name']} ({job_id})")
                 print(f"  Next run: {result['job'].get('next_run_at')}")
             elif action == "run":
-                print(f"(^_^)b Triggered job: {result['job']['name']} ({job_id})")
-                print("  It will run on the next scheduler tick.")
+                job = result["job"]
+                print(f"(^_^)b Triggered job: {job['name']} ({job_id})")
+                if job.get("executed"):
+                    outcome = "succeeded" if job.get("execution_success") else "failed"
+                    print(f"  Scheduler run: {outcome}.")
+                    from .cron import _print_status_dimensions
+
+                    _print_status_dimensions(job)
+                elif job.get("execution_skipped"):
+                    print(f"  {job['execution_skipped']}")
+                else:
+                    print("  Scheduler run status is unknown.")
             else:
                 removed = result.get("removed_job", {})
                 print(f"(^_^)b Removed job: {removed.get('name', job_id)} ({job_id})")

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -7,6 +7,7 @@ pause/resume/run/remove, status, and tick.
 
 import json
 import sys
+import unicodedata
 from pathlib import Path
 from typing import Iterable, List, Optional
 
@@ -24,6 +25,33 @@ from hermes_cli.colors import Colors, color
 from cron.lifecycle_guard import (  # noqa: F401  (re-exported for terminal_tool)
     contains_gateway_lifecycle_command as _contains_gateway_lifecycle_command,
 )
+
+
+def _surface_safe(value) -> str:
+    text = str(value) if value is not None else "none"
+    return "".join(
+        char
+        if char.isprintable() and not unicodedata.category(char).startswith("C")
+        else f"\\u{ord(char):04x}"
+        for char in text
+    )
+
+
+def _print_status_dimensions(job: dict, indent: str = "  ") -> None:
+    run_status = job.get("last_run_status") or job.get("last_status") or "unknown"
+    delivery_status = job.get("last_delivery_status") or (
+        "error" if job.get("last_delivery_error") else "unknown"
+    )
+    work_status = job.get("last_work_status") or "unknown"
+    work_source = job.get("last_work_status_source") or "none"
+    evidence_id = _surface_safe(job.get("last_evidence_id"))
+    evidence_verified = "yes" if job.get("last_evidence_verified", False) else "no"
+    executor_handle = _surface_safe(job.get("last_executor_handle"))
+    print(f"{indent}Run status: {run_status}")
+    print(f"{indent}Delivery:   {delivery_status}")
+    print(f"{indent}Work status: {work_status} (source={work_source})")
+    print(f"{indent}Evidence:   {evidence_id} (verified={evidence_verified})")
+    print(f"{indent}Executor:   {executor_handle}")
 
 
 def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None) -> Optional[List[str]]:
@@ -98,7 +126,7 @@ def _warn_if_gateway_not_running() -> None:
 
 def cron_list(show_all: bool = False):
     """List all scheduled jobs."""
-    from cron.jobs import list_jobs
+    from cron.jobs import effective_job_status, list_jobs
 
     jobs = list_jobs(include_disabled=show_all)
 
@@ -114,8 +142,9 @@ def cron_list(show_all: bool = False):
     print()
 
     for job in jobs:
-        job_id = job.get("id", "?")
-        name = job.get("name", "(unnamed)")
+        status_job = effective_job_status(job)
+        job_id = _surface_safe(job.get("id", "?"))
+        name = _surface_safe(job.get("name", "(unnamed)"))
         schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
         next_run = job.get("next_run_at", "?")
@@ -165,14 +194,21 @@ def cron_list(show_all: bool = False):
             print(f"    Workdir:   {workdir}")
 
         # Execution history
-        last_status = job.get("last_status")
-        if last_status:
-            last_run = job.get("last_run_at", "?")
+        last_status = status_job.get("last_status")
+        if last_status or status_job.get("last_run_status") or status_job.get("last_run_at"):
+            last_run = status_job.get("last_run_at", "?")
             if last_status == "ok":
                 status_display = color("ok", Colors.GREEN)
+            elif last_status:
+                status_display = color(
+                    f"{last_status}: {_surface_safe(status_job.get('last_error', '?'))}",
+                    Colors.RED,
+                )
             else:
-                status_display = color(f"{last_status}: {job.get('last_error', '?')}", Colors.RED)
+                status_display = color("unknown", Colors.YELLOW)
             print(f"    Last run:  {last_run}  {status_display}")
+
+            _print_status_dimensions(status_job, indent="    ")
 
         latest_execution = job.get("latest_execution")
         if latest_execution:
@@ -181,9 +217,9 @@ def cron_list(show_all: bool = False):
                 f"{latest_execution.get('id', '?')}"
             )
 
-        delivery_err = job.get("last_delivery_error")
+        delivery_err = status_job.get("last_delivery_error")
         if delivery_err:
-            print(f"    {color('⚠ Delivery failed:', Colors.YELLOW)} {delivery_err}")
+            print(f"    {color('⚠ Delivery failed:', Colors.YELLOW)} {_surface_safe(delivery_err)}")
 
         print()
 
@@ -433,11 +469,12 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
         job = result.get("job", {})
         if job.get("executed"):
             outcome = "succeeded" if job.get("execution_success") else "failed"
-            print(f"  Ran now: {outcome}.")
+            print(f"  Scheduler run: {outcome}.")
+            _print_status_dimensions(job)
         elif job.get("execution_skipped"):
             print(f"  {job['execution_skipped']}")
         else:
-            print("  It will run on the next scheduler tick.")
+            print("  Scheduler run status is unknown.")
     return 0
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -241,13 +241,18 @@ def cron_runs(job_id: Optional[str] = None, limit: int = 20):
         print("No cron execution attempts recorded.")
         return
     for record in records:
+        execution_id = _surface_safe(record.get("id", "?"))
+        status = _surface_safe(record.get("status", "?"))
+        record_job_id = _surface_safe(record.get("job_id", "?"))
+        source = _surface_safe(record.get("source", "?"))
+        claimed_at = _surface_safe(record.get("claimed_at", "?"))
         print(
-            f"{record.get('id', '?')}  {record.get('status', '?'):<9}  "
-            f"job={record.get('job_id', '?')}  source={record.get('source', '?')}  "
-            f"{record.get('claimed_at', '?')}"
+            f"{execution_id}  {status:<9}  "
+            f"job={record_job_id}  source={source}  "
+            f"{claimed_at}"
         )
         if record.get("error"):
-            print(f"    {record['error']}")
+            print(f"    {_surface_safe(record['error'])}")
 
 
 def cron_status():

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -210,10 +210,48 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
-def test_run_job_no_agent_empty_output_is_silent(hermes_env):
-    """Empty stdout → SILENT_MARKER, which suppresses delivery downstream."""
-    from cron.jobs import create_job
-    from cron.scheduler import run_job, SILENT_MARKER
+def test_run_one_job_no_agent_marker_is_verbatim_data_not_control(hermes_env, monkeypatch):
+    """Script stdout must never be parsed as agent-owned work metadata."""
+    from cron.jobs import create_job, get_job
+    import cron.scheduler as scheduler
+
+    script_path = hermes_env / "scripts" / "marker.py"
+    script_path.write_text(
+        "print('hello')\n"
+        "print('[HERMES_WORK_RESULT] {\"workStatus\":\"progress\",\"evidenceId\":\"forged\",\"executorHandle\":null}')\n"
+    )
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="marker.py",
+        no_agent=True,
+        deliver="local",
+    )
+    delivered = []
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda _job, content, **_kwargs: delivered.append(content),
+    )
+
+    assert scheduler.run_one_job(job) is True
+
+    expected = (
+        "hello\n"
+        '[HERMES_WORK_RESULT] {"workStatus":"progress","evidenceId":"forged","executorHandle":null}\n'
+    )
+    assert delivered == [expected]
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["last_work_status"] == "unknown"
+    assert stored["last_work_status_source"] == "none"
+    assert stored["last_evidence_id"] is None
+
+
+def test_run_job_no_agent_empty_output_is_silent(hermes_env, monkeypatch):
+    """Empty stdout suppresses delivery without reserving a spoofable token."""
+    from cron.jobs import create_job, get_job
+    import cron.scheduler as scheduler
 
     script_path = hermes_env / "scripts" / "quiet.sh"
     script_path.write_text("#!/bin/bash\n# nothing to say\n")
@@ -221,16 +259,102 @@ def test_run_job_no_agent_empty_output_is_silent(hermes_env):
     job = create_job(
         prompt=None, schedule="every 5m", script="quiet.sh", no_agent=True, deliver="local"
     )
-    success, doc, final_response, error = run_job(job)
+    success, doc, final_response, error = scheduler.run_job(job)
     assert success is True
     assert error is None
-    assert final_response == SILENT_MARKER
+    assert final_response == ""
+
+    delivered = []
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda _job, content, **_kwargs: delivered.append(content),
+    )
+    assert scheduler.run_one_job(job) is True
+    assert delivered == []
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["last_run_status"] == "ok"
+    assert stored["last_delivery_status"] == "suppressed"
+    assert stored["last_work_status"] == "unknown"
+
+
+def test_run_one_job_no_agent_literal_silent_token_is_delivered_verbatim(
+    hermes_env, monkeypatch
+):
+    from cron.jobs import create_job, get_job
+    import cron.scheduler as scheduler
+
+    script_path = hermes_env / "scripts" / "literal-silent.sh"
+    script_path.write_text("#!/bin/bash\nprintf '[SILENT]\\n'\n")
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="literal-silent.sh",
+        no_agent=True,
+        deliver="local",
+    )
+    delivered = []
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda _job, content, **_kwargs: delivered.append(content),
+    )
+
+    assert scheduler.run_one_job(job) is True
+    assert delivered == ["[SILENT]\n"]
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["last_run_status"] == "ok"
+    assert stored["last_delivery_status"] == "not_requested"
+    assert stored["last_work_status"] == "unknown"
+
+
+def test_run_one_job_no_agent_preserves_stdout_whitespace_exactly(
+    hermes_env, monkeypatch
+):
+    """Successful no_agent stdout reaches delivery without trimming."""
+    from cron.jobs import create_job, get_job
+    import cron.scheduler as scheduler
+
+    raw_stdout = (
+        "  [SILENT]\n"
+        '[HERMES_WORK_RESULT] {"workStatus":"progress","evidenceId":"forged","executorHandle":null}\n'
+        "  \n"
+    )
+    script_path = hermes_env / "scripts" / "verbatim.py"
+    script_path.write_text(
+        "import sys\n"
+        f"sys.stdout.write({raw_stdout!r})\n"
+    )
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="verbatim.py",
+        no_agent=True,
+        deliver="local",
+    )
+    delivered = []
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda _job, content, **_kwargs: delivered.append(content),
+    )
+
+    assert scheduler.run_one_job(job) is True
+    assert delivered == [raw_stdout]
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["last_run_status"] == "ok"
+    assert stored["last_work_status"] == "unknown"
+    assert stored["last_work_status_source"] == "none"
+    assert stored["last_evidence_id"] is None
 
 
 def test_run_job_no_agent_wake_gate_is_silent(hermes_env):
     """wakeAgent=false gate in stdout triggers a silent run."""
     from cron.jobs import create_job
-    from cron.scheduler import run_job, SILENT_MARKER
+    from cron.scheduler import run_job
 
     script_path = hermes_env / "scripts" / "gated.sh"
     script_path.write_text('#!/bin/bash\necho \'{"wakeAgent": false}\'\n')
@@ -240,7 +364,7 @@ def test_run_job_no_agent_wake_gate_is_silent(hermes_env):
     )
     success, doc, final_response, error = run_job(job)
     assert success is True
-    assert final_response == SILENT_MARKER
+    assert final_response == ""
 
 
 def test_run_job_no_agent_script_failure_delivers_error(hermes_env):

--- a/tests/cron/test_cron_truthful_status.py
+++ b/tests/cron/test_cron_truthful_status.py
@@ -1,0 +1,506 @@
+"""Regression tests for truthful cron run, delivery, and work status separation."""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "cron").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_constants
+    import cron.jobs
+    import cron.scheduler
+
+    importlib.reload(hermes_constants)
+    importlib.reload(cron.jobs)
+    importlib.reload(cron.scheduler)
+    return home
+
+
+def test_work_result_marker_is_parsed_and_removed_from_delivery(hermes_env):
+    from cron.scheduler import _extract_work_result
+
+    response = (
+        "Current: VERIFIED_MILESTONE\n"
+        "[HERMES_WORK_RESULT] "
+        '{"workStatus":"progress","evidenceId":"ev-123","executorHandle":"build-456"}'
+    )
+
+    cleaned, result = _extract_work_result(response)
+
+    assert cleaned == "Current: VERIFIED_MILESTONE"
+    assert result == {
+        "work_status": "progress",
+        "work_status_source": "agent_marker",
+        "evidence_id": "ev-123",
+        "evidence_verified": False,
+        "executor_handle": "build-456",
+    }
+
+
+def test_missing_or_invalid_marker_fails_closed_to_unknown(hermes_env):
+    from cron.scheduler import _extract_work_result
+
+    plain, missing = _extract_work_result("ordinary response")
+    invalid_text, invalid = _extract_work_result(
+        "ordinary response\n[HERMES_WORK_RESULT] "
+        '{"workStatus":"definitely-working","evidenceId":"invented"}'
+    )
+
+    unknown_result = {
+        "work_status": "unknown",
+        "work_status_source": "none",
+        "evidence_id": None,
+        "evidence_verified": False,
+        "executor_handle": None,
+    }
+    assert plain == "ordinary response"
+    assert missing == unknown_result
+    assert invalid_text == "ordinary response"
+    assert invalid == unknown_result
+
+
+def test_non_string_or_oversized_metadata_fails_closed(hermes_env):
+    from cron.scheduler import _extract_work_result
+
+    _, non_string = _extract_work_result(
+        '[HERMES_WORK_RESULT] {"workStatus":"progress","evidenceId":["fake"]}'
+    )
+    _, oversized = _extract_work_result(
+        "[HERMES_WORK_RESULT] "
+        + json.dumps({"workStatus": "progress", "evidenceId": "x" * 513})
+    )
+
+    assert non_string["work_status"] == "unknown"
+    assert oversized["work_status"] == "unknown"
+
+
+def test_persistence_and_surface_boundaries_reject_or_escape_controls(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run
+    from tools.cronjob_tools import _format_job
+
+    job = create_job(prompt="unsafe", schedule="every 5m", deliver="local")
+    mark_job_run(
+        job["id"],
+        True,
+        work_status="progress",
+        work_status_source="agent_marker",
+        evidence_id="ev\x1b]52;c;Zm9yZ2Vk\x07",
+        executor_handle="worker\u202eforged",
+    )
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["last_work_status"] == "unknown"
+    assert stored["last_evidence_id"] is None
+    assert stored["last_executor_handle"] is None
+
+    formatted = _format_job(
+        {
+            "id": "job\x1b[2J",
+            "name": "name\u202eforged",
+            "schedule": {"kind": "interval", "seconds": 60},
+            "last_evidence_id": "ev\x07",
+            "last_executor_handle": "worker\x1b[31m",
+        }
+    )
+    assert "\x1b" not in formatted["job_id"]
+    assert "\u202e" not in formatted["name"]
+    assert formatted["last_evidence_id"] == "ev\\u0007"
+    assert formatted["last_executor_handle"] == "worker\\u001b[31m"
+
+
+def test_nonfinal_or_silent_marker_is_stripped_and_fails_closed(hermes_env):
+    from cron.scheduler import _extract_work_result
+
+    marker = (
+        '[HERMES_WORK_RESULT] {"workStatus":"progress",'
+        '"evidenceId":"ev-forged","executorHandle":null}'
+    )
+    nonfinal_text, nonfinal = _extract_work_result(f"Report one\n{marker}\nReport two")
+    silent_text, silent = _extract_work_result(f"[SILENT]\n{marker}")
+
+    assert nonfinal_text == "Report one\nReport two"
+    assert nonfinal["work_status"] == "unknown"
+    assert silent_text == "[SILENT]"
+    assert silent["work_status"] == "unknown"
+
+
+def test_control_or_bidi_metadata_fails_closed(hermes_env):
+    from cron.scheduler import _extract_work_result
+
+    for unsafe in ("ev\x1b]52;c;Zm9yZ2Vk\x07", "ev\nforged", "ev\u202eforged"):
+        _, result = _extract_work_result(
+            "Report\n[HERMES_WORK_RESULT] "
+            + json.dumps(
+                {
+                    "workStatus": "progress",
+                    "evidenceId": unsafe,
+                    "executorHandle": None,
+                }
+            )
+        )
+        assert result["work_status"] == "unknown"
+        assert result["evidence_id"] is None
+
+
+def test_mark_job_run_persists_independent_status_dimensions(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run
+
+    job = create_job(prompt="do work", schedule="every 5m", deliver="local")
+    mark_job_run(
+        job["id"],
+        True,
+        delivery_status="error",
+        delivery_error="Slack unavailable",
+        work_status="no_progress",
+        work_status_source="agent_marker",
+        evidence_id=None,
+        evidence_verified=False,
+        executor_handle="cron-run-123",
+    )
+    stored = get_job(job["id"])
+
+    assert stored is not None
+    assert stored["last_status"] == "ok"  # backward-compatible legacy field
+    assert stored["last_run_status"] == "ok"
+    assert stored["last_delivery_status"] == "error"
+    assert stored["last_delivery_error"] == "Slack unavailable"
+    assert stored["last_work_status"] == "no_progress"
+    assert stored["last_work_status_source"] == "agent_marker"
+    assert stored["last_evidence_id"] is None
+    assert stored["last_evidence_verified"] is False
+    assert stored["last_executor_handle"] == "cron-run-123"
+
+
+def test_mark_job_run_defaults_new_dimensions_to_unknown(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run
+
+    job = create_job(prompt="legacy caller", schedule="every 5m", deliver="local")
+    mark_job_run(job["id"], True)
+    stored = get_job(job["id"])
+
+    assert stored is not None
+    assert stored["last_run_status"] == "ok"
+    assert stored["last_delivery_status"] == "unknown"
+    assert stored["last_work_status"] == "unknown"
+    assert stored["last_work_status_source"] == "none"
+    assert stored["last_evidence_id"] is None
+    assert stored["last_evidence_verified"] is False
+    assert stored["last_executor_handle"] is None
+
+
+def test_mark_job_run_rejects_unsubstantiated_active_work(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run
+
+    progress_job = create_job(prompt="claim progress", schedule="every 5m", deliver="local")
+    mark_job_run(
+        progress_job["id"],
+        True,
+        work_status="progress",
+        work_status_source="agent_marker",
+        evidence_id=None,
+        executor_handle="worker-1",
+    )
+    waiting_job = create_job(prompt="claim waiting", schedule="every 5m", deliver="local")
+    mark_job_run(
+        waiting_job["id"],
+        True,
+        work_status="waiting_external",
+        work_status_source="agent_marker",
+        evidence_id="ev-1",
+        executor_handle=None,
+    )
+
+    stored_progress = get_job(progress_job["id"])
+    stored_waiting = get_job(waiting_job["id"])
+    assert stored_progress is not None
+    assert stored_waiting is not None
+    assert stored_progress["last_work_status"] == "unknown"
+    assert stored_progress["last_work_status_source"] == "none"
+    assert stored_waiting["last_work_status"] == "unknown"
+    assert stored_waiting["last_work_status_source"] == "none"
+
+
+def test_duplicate_evidence_cannot_be_reported_as_new_progress(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run
+
+    job = create_job(prompt="repeat old artifact", schedule="every 5m", deliver="local")
+    for _ in range(3):
+        mark_job_run(
+            job["id"],
+            True,
+            work_status="progress",
+            work_status_source="agent_marker",
+            evidence_id="same-evidence",
+            executor_handle="worker-1",
+        )
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["last_work_status"] == "no_progress"
+    assert stored["last_evidence_id"] is None
+    assert stored["last_evidence_verified"] is False
+
+
+def test_nonconsecutive_duplicate_evidence_cannot_be_reported_as_progress(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run
+
+    job = create_job(prompt="cycle old artifacts", schedule="every 5m", deliver="local")
+    for evidence_id in ("evidence-a", "evidence-b", "evidence-a"):
+        mark_job_run(
+            job["id"],
+            True,
+            work_status="progress",
+            work_status_source="agent_marker",
+            evidence_id=evidence_id,
+            executor_handle="worker-1",
+        )
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["last_work_status"] == "no_progress"
+    assert stored["last_evidence_id"] is None
+
+
+def test_evidence_registry_fails_closed_at_capacity_without_eviction(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run
+
+    job = create_job(prompt="many artifacts", schedule="every 5m", deliver="local")
+    for index in range(256):
+        mark_job_run(
+            job["id"],
+            True,
+            work_status="progress",
+            work_status_source="agent_marker",
+            evidence_id=f"ev-{index}",
+            executor_handle="worker-1",
+        )
+    mark_job_run(
+        job["id"],
+        True,
+        work_status="progress",
+        work_status_source="agent_marker",
+        evidence_id="ev-over-capacity",
+        executor_handle="worker-1",
+    )
+    at_capacity = get_job(job["id"])
+    assert at_capacity is not None
+    assert at_capacity["last_work_status"] == "unknown"
+    assert at_capacity["last_evidence_id"] is None
+    assert len(at_capacity["work_evidence_ids"]) == 256
+
+    mark_job_run(
+        job["id"],
+        True,
+        work_status="progress",
+        work_status_source="agent_marker",
+        evidence_id="ev-0",
+        executor_handle="worker-1",
+    )
+    replay = get_job(job["id"])
+    assert replay is not None
+    assert replay["last_work_status"] == "no_progress"
+    assert replay["last_evidence_id"] is None
+
+
+def test_pause_survives_late_run_completion(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run, pause_job
+
+    job = create_job(prompt="do work", schedule="every 5m", deliver="local")
+    pause_job(job["id"], reason="operator pause during run")
+    mark_job_run(job["id"], True, delivery_status="ok", work_status="no_progress")
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["enabled"] is False
+    assert stored["state"] == "paused"
+    assert stored["paused_reason"] == "operator pause during run"
+
+
+def test_pause_survives_late_completion_for_finite_and_oneshot_jobs(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run, pause_job
+
+    finite = create_job(
+        prompt="finite", schedule="every 5m", repeat=1, deliver="local"
+    )
+    oneshot = create_job(
+        prompt="once", schedule="2026-07-18T12:00:00Z", deliver="local"
+    )
+    for job in (finite, oneshot):
+        pause_job(job["id"], reason="operator pause during run")
+        mark_job_run(job["id"], True, delivery_status="ok", work_status="no_progress")
+        stored = get_job(job["id"])
+        assert stored is not None
+        assert stored["enabled"] is False
+        assert stored["state"] == "paused"
+        assert stored["paused_reason"] == "operator pause during run"
+
+
+def test_completed_oneshot_retains_truthful_status_for_inspection(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run
+
+    job = create_job(
+        prompt="once", schedule="2026-07-18T12:00:00Z", deliver="local"
+    )
+    mark_job_run(
+        job["id"],
+        True,
+        delivery_status="error",
+        delivery_error="Slack unavailable",
+        work_status="progress",
+        work_status_source="agent_marker",
+        evidence_id="ev-once",
+        executor_handle="worker-once",
+    )
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["enabled"] is False
+    assert stored["state"] == "completed"
+    assert stored["last_run_status"] == "ok"
+    assert stored["last_delivery_status"] == "error"
+    assert stored["last_work_status"] == "reported_progress"
+    assert stored["last_evidence_id"] == "ev-once"
+
+
+def test_run_one_job_strips_marker_and_records_all_statuses(hermes_env, monkeypatch):
+    import cron.scheduler as scheduler
+    import agent.secret_scope as secret_scope
+
+    delivered = []
+    marked = []
+    response = (
+        "Verified artifact created\n"
+        "[HERMES_WORK_RESULT] "
+        '{"workStatus":"progress","evidenceId":"ev-789","executorHandle":"worker-1"}'
+    )
+    monkeypatch.setattr(scheduler, "create_execution", lambda *a, **k: {"id": "exec-1"})
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda *a, **k: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda *a, **k: None)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *a, **k: (True, "audit output", response, None),
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *a, **k: "/tmp/output")
+    monkeypatch.setattr(scheduler, "_resolve_delivery_targets", lambda *a, **k: [])
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda job, content, **kwargs: delivered.append(content),
+    )
+    monkeypatch.setattr(scheduler, "_is_interrupted", lambda *a, **k: False)
+    monkeypatch.setattr(scheduler, "_consume_interrupted_flag", lambda *a, **k: False)
+    monkeypatch.setattr(
+        scheduler,
+        "mark_job_run",
+        lambda *args, **kwargs: marked.append((args, kwargs)),
+    )
+    monkeypatch.setattr(scheduler, "finish_execution", lambda *a, **k: None)
+    monkeypatch.setattr(secret_scope, "build_profile_secret_scope", lambda *a, **k: object())
+    monkeypatch.setattr(secret_scope, "set_secret_scope", lambda *a, **k: object())
+    monkeypatch.setattr(secret_scope, "reset_secret_scope", lambda *a, **k: None)
+
+    processed = scheduler.run_one_job(
+        {"id": "job-1", "name": "status integration", "deliver": "local"}
+    )
+
+    assert processed is True
+    assert delivered == ["Verified artifact created"]
+    assert len(marked) == 1
+    args, kwargs = marked[0]
+    assert args[:3] == ("job-1", True, None)
+    assert kwargs == {
+        "delivery_error": None,
+        "delivery_status": "not_requested",
+        "work_status": "progress",
+        "work_status_source": "agent_marker",
+        "evidence_id": "ev-789",
+        "evidence_verified": False,
+        "executor_handle": "worker-1",
+    }
+
+
+def test_cron_prompt_requires_explicit_work_result_metadata(hermes_env):
+    from cron.scheduler import _build_job_prompt
+
+    prompt = _build_job_prompt(
+        {"id": "job-1", "name": "status contract", "prompt": "perform one bounded slice"}
+    )
+
+    assert prompt is not None
+    assert "[HERMES_WORK_RESULT]" in prompt
+    assert '"workStatus":"no_progress"' in prompt
+    assert "Progress requires a concrete evidenceId" in prompt
+
+
+def test_latest_recovered_execution_overrides_stale_progress_in_surfaces(hermes_env):
+    from tools.cronjob_tools import _format_job
+
+    formatted = _format_job(
+        {
+            "id": "job-crashed",
+            "name": "crashed worker",
+            "schedule": {"kind": "interval", "seconds": 60},
+            "last_run_at": "2026-07-17T16:00:00Z",
+            "last_status": "ok",
+            "last_run_status": "ok",
+            "last_delivery_status": "ok",
+            "last_work_status": "reported_progress",
+            "last_work_status_source": "agent_marker",
+            "last_evidence_id": "stale-evidence",
+            "last_evidence_verified": False,
+            "last_executor_handle": "stale-worker",
+            "latest_execution": {
+                "id": "exec-crashed",
+                "job_id": "job-crashed",
+                "status": "unknown",
+                "claimed_at": "2026-07-17T16:05:00Z",
+                "started_at": "2026-07-17T16:05:01Z",
+                "finished_at": "2026-07-17T16:06:00Z",
+                "error": "scheduler process exited before completion",
+            },
+        }
+    )
+
+    assert formatted["last_run_status"] == "unknown"
+    assert formatted["last_delivery_status"] == "unknown"
+    assert formatted["last_work_status"] == "unknown"
+    assert formatted["last_work_status_source"] == "none"
+    assert formatted["last_evidence_id"] is None
+    assert formatted["last_executor_handle"] is None
+
+
+def test_cron_tool_format_surfaces_separate_status_dimensions(hermes_env):
+    from tools.cronjob_tools import _format_job
+
+    formatted = _format_job(
+        {
+            "id": "job-1",
+            "name": "truthful status",
+            "schedule": {"kind": "interval", "seconds": 60},
+            "last_status": "ok",
+            "last_run_status": "ok",
+            "last_delivery_status": "error",
+            "last_work_status": "no_progress",
+            "last_work_status_source": "agent_marker",
+            "last_evidence_id": None,
+            "last_evidence_verified": False,
+            "last_executor_handle": None,
+        }
+    )
+
+    assert formatted["last_status"] == "ok"
+    assert formatted["last_run_status"] == "ok"
+    assert formatted["last_delivery_status"] == "error"
+    assert formatted["last_work_status"] == "no_progress"
+    assert formatted["last_work_status_source"] == "agent_marker"
+    assert formatted["last_evidence_id"] is None
+    assert formatted["last_evidence_verified"] is False
+    assert formatted["last_executor_handle"] is None

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -570,11 +570,16 @@ class TestMarkJobRun:
         assert updated["repeat"]["completed"] == 1
         assert updated["last_status"] == "ok"
 
-    def test_repeat_limit_removes_job(self, tmp_cron_dir):
+    def test_repeat_limit_retires_job_with_status_retained(self, tmp_cron_dir):
         job = create_job(prompt="Once", schedule="30m", repeat=1)
         mark_job_run(job["id"], success=True)
-        # Job should be removed after hitting repeat limit
-        assert get_job(job["id"]) is None
+        # Terminal jobs remain inspectable but can never fire again.
+        stored = get_job(job["id"])
+        assert stored is not None
+        assert stored["enabled"] is False
+        assert stored["state"] == "completed"
+        assert stored["next_run_at"] is None
+        assert stored["repeat"]["completed"] == 1
 
     def test_repeat_negative_one_is_infinite(self, tmp_cron_dir):
         # LLMs often pass repeat=-1 to mean "infinite/forever".
@@ -1113,8 +1118,9 @@ class TestGetDueJobs:
         asleep mid-run) satisfies the same completed >= times + expired-claim
         condition as a dead tick. When the scheduler in this process still has
         the job in its running set, the stale-entry recovery must keep the
-        record so the in-flight run's mark_job_run() can land its outcome —
-        and remove it only once the run is actually gone.
+        record so the in-flight run's mark_job_run() can land its outcome.
+        Once the run is provably gone, retain a disabled unknown-outcome record
+        instead of erasing the only durable status pointer.
         """
         import cron.scheduler as scheduler_mod
         from cron.jobs import _hermes_now, _oneshot_run_claim_ttl_seconds
@@ -1140,12 +1146,21 @@ class TestGetDueJobs:
         assert get_due_jobs() == []
         assert get_job("inflight") is not None  # still visible to list/run
 
-        # The claiming tick really died (running set empty) → recovered as before.
+        # The claiming tick really died (running set empty) → retire it with an
+        # explicit unknown outcome, preserving inspectability without re-firing.
         monkeypatch.setattr(
             scheduler_mod, "get_running_job_ids", lambda: frozenset()
         )
         assert get_due_jobs() == []
-        assert get_job("inflight") is None  # stale entry cleaned up
+        recovered = get_job("inflight")
+        assert recovered is not None
+        assert recovered["enabled"] is False
+        assert recovered["state"] == "completed"
+        assert recovered["next_run_at"] is None
+        assert recovered["run_claim"] is None
+        assert recovered["last_run_status"] == "unknown"
+        assert recovered["last_delivery_status"] == "unknown"
+        assert recovered["last_work_status"] == "unknown"
 
     def test_stale_maxed_oneshot_kept_when_running_check_errors(
         self, tmp_cron_dir, monkeypatch
@@ -1216,10 +1231,13 @@ class TestGetDueJobs:
         assert get_due_jobs() == []
         assert get_job("slowrun") is not None
 
-        # Run completes → outcome lands on a record that still exists
-        # (times=1 reached, so mark_job_run retires the job normally).
+        # Run completes → outcome lands on a retained, disabled tombstone so
+        # its final status remains inspectable without allowing another fire.
         mark_job_run("slowrun", True)
-        assert get_job("slowrun") is None
+        completed = get_job("slowrun")
+        assert completed is not None
+        assert completed["enabled"] is False
+        assert completed["state"] == "completed"
 
     def test_heartbeat_run_claim_noop_without_claim(self, tmp_cron_dir):
         """heartbeat_run_claim is a safe no-op when there is nothing to refresh
@@ -1835,12 +1853,20 @@ class TestClaimDispatch:
         # Persisted BEFORE any side effect — survives a crash.
         assert load_jobs()[0]["repeat"]["completed"] == 1
 
-    def test_already_dispatched_oneshot_is_removed(self, tmp_cron_dir):
+    def test_already_dispatched_oneshot_is_retained_unknown(self, tmp_cron_dir):
         # A prior tick claimed (completed==times) then died before mark_job_run
-        # could remove the job.  The next claim must refuse AND clean up.
+        # could persist a result. Refuse another fire but keep an inspectable
+        # unknown-outcome tombstone.
         save_jobs([self._oneshot(times=1, completed=1)])
         assert claim_dispatch("os1") is False
-        assert load_jobs() == []  # removed, will not re-fire
+        stored = load_jobs()
+        assert len(stored) == 1
+        assert stored[0]["enabled"] is False
+        assert stored[0]["state"] == "completed"
+        assert stored[0]["next_run_at"] is None
+        assert stored[0]["last_run_status"] == "unknown"
+        assert stored[0]["last_delivery_status"] == "unknown"
+        assert stored[0]["last_work_status"] == "unknown"
 
     def test_recurring_job_is_not_claimed(self, tmp_cron_dir):
         job = {
@@ -1873,12 +1899,16 @@ class TestClaimDispatch:
 
     def test_mark_job_run_does_not_double_count_preclaimed_oneshot(self, tmp_cron_dir):
         # Full lifecycle: claim bumps completed to times, then mark_job_run must
-        # NOT increment again — it recognizes the pre-claim and removes the job.
+        # NOT increment again — it recognizes the pre-claim and retires the job.
         save_jobs([self._oneshot(times=1, completed=0)])
         assert claim_dispatch("os1") is True
         assert load_jobs()[0]["repeat"]["completed"] == 1
         mark_job_run("os1", success=True)
-        assert load_jobs() == []  # completed once, removed — not fired twice
+        stored = load_jobs()
+        assert len(stored) == 1
+        assert stored[0]["repeat"]["completed"] == 1
+        assert stored[0]["enabled"] is False
+        assert stored[0]["state"] == "completed"
 
     def test_mark_job_run_still_increments_recurring(self, tmp_cron_dir):
         # The double-count guard is one-shot-specific; recurring jobs keep the
@@ -1892,10 +1922,11 @@ class TestClaimDispatch:
         mark_job_run("rec", success=True)
         assert load_jobs()[0]["repeat"]["completed"] == 2
 
-    def test_get_due_jobs_removes_stale_maxed_oneshot(self, tmp_cron_dir):
+    def test_get_due_jobs_retires_stale_maxed_oneshot_unknown(self, tmp_cron_dir):
         # A claimed one-shot whose tick died leaves completed>=times with
         # last_run_at still unset, so the recovery helper re-arms it as due.
-        # get_due_jobs must drop it instead of returning it for another fire.
+        # get_due_jobs must not re-fire or erase it: retain a disabled unknown
+        # outcome for inspection.
         past = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat()
         save_jobs([{
             "id": "os1",
@@ -1907,7 +1938,13 @@ class TestClaimDispatch:
         }])
         due = get_due_jobs()
         assert due == []
-        assert load_jobs() == []  # cleaned up
+        stored = load_jobs()
+        assert len(stored) == 1
+        assert stored[0]["enabled"] is False
+        assert stored[0]["state"] == "completed"
+        assert stored[0]["last_run_status"] == "unknown"
+        assert stored[0]["last_delivery_status"] == "unknown"
+        assert stored[0]["last_work_status"] == "unknown"
 
     def test_bad_schedule_does_not_crash_or_block_sibling_jobs(self, tmp_cron_dir):
         """Regression for a job with non-dict 'schedule' (null / string / etc.

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -31,7 +31,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("deliver", job["id"]))
         return None
 
-    def fake_mark(jid, ok, err=None, delivery_error=None):
+    def fake_mark(jid, ok, err=None, delivery_error=None, **status_dimensions):
         calls.append(("mark", jid, ok))
 
     monkeypatch.setattr(s, "run_job", fake_run_job)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2700,6 +2700,12 @@ class TestSilentDelivery:
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
+            delivery_status="suppressed",
+            work_status="unknown",
+            work_status_source="none",
+            evidence_id=None,
+            evidence_verified=False,
+            executor_handle=None,
         )
 
 

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -84,10 +84,13 @@ def test_long_running_script_refreshes_owned_claim_in_profile_store(
         heartbeat_seen.set()
         return updated
 
-    def _blocking_script(_script_path: str) -> tuple[bool, str]:
+    def _blocking_script(
+        _script_path: str, *, preserve_stdout: bool = False
+    ) -> tuple[bool, str]:
         assert heartbeat_seen.wait(timeout=2), (
             "claim was not refreshed while script blocked"
         )
+        assert preserve_stdout is no_agent
         return True, script_output
 
     monkeypatch.setattr(scheduler, "heartbeat_run_claim", _observed_heartbeat)

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -263,6 +263,30 @@ class TestCronCommandLifecycle:
         assert "Work status: unknown (source=none)" in out
         assert "stale\x1b[2J" not in out
 
+    def test_runs_sanitizes_terminal_controls_from_persisted_fields(
+        self, capsys, monkeypatch
+    ):
+        hostile = "failure\x1b[2J"
+        monkeypatch.setattr(
+            "cron.executions.list_executions",
+            lambda job_id=None, limit=20: [
+                {
+                    "id": hostile,
+                    "status": hostile,
+                    "job_id": hostile,
+                    "source": hostile,
+                    "claimed_at": hostile,
+                    "error": hostile,
+                }
+            ],
+        )
+
+        cron_cli.cron_runs("job-1", limit=1)
+
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert "failure\\u001b[2J" in out
+
     def test_manual_run_labels_scheduler_and_work_status_separately(
         self, capsys, monkeypatch
     ):

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.cron command handling."""
 
 from argparse import Namespace
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -153,6 +154,178 @@ class TestCronCommandLifecycle:
 
         out = capsys.readouterr().out
         assert "Deliver:   local" in out
+
+    def test_list_displays_run_delivery_and_work_status_separately(
+        self, tmp_cron_dir, capsys, monkeypatch
+    ):
+        """A successful scheduler run must not be presented as work progress."""
+        from cron.jobs import mark_job_run
+
+        job = create_job(prompt="Truthful report", schedule="every 1h")
+        mark_job_run(
+            job["id"],
+            True,
+            delivery_error="Slack unavailable",
+            delivery_status="error",
+            work_status="no_progress",
+            work_status_source="agent_marker",
+            evidence_id=None,
+            evidence_verified=False,
+            executor_handle=None,
+        )
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+        cron_cli.cron_list()
+
+        out = capsys.readouterr().out
+        assert "Run status: ok" in out
+        assert "Delivery:   error" in out
+        assert "Work status: no_progress" in out
+        assert "Evidence:   none (verified=no)" in out
+        assert "Executor:   none" in out
+
+    def test_slash_list_displays_run_delivery_and_work_status_separately(
+        self, capsys, monkeypatch
+    ):
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        monkeypatch.setattr(
+            "tools.cronjob_tools.cronjob",
+            lambda **kwargs: json.dumps(
+                {
+                    "success": True,
+                    "jobs": [
+                        {
+                            "job_id": "job-1",
+                            "name": "Truthful report",
+                            "state": "scheduled",
+                            "schedule": "every 1h",
+                            "repeat": "∞",
+                            "next_run_at": "2026-07-17T17:00:00Z",
+                            "prompt_preview": "do one slice",
+                            "last_run_at": "2026-07-17T16:00:00Z",
+                            "last_status": "ok",
+                            "last_run_status": "ok",
+                            "last_delivery_status": "error",
+                            "last_work_status": "no_progress",
+                            "last_work_status_source": "agent_marker",
+                            "last_evidence_id": None,
+                            "last_evidence_verified": False,
+                            "last_executor_handle": None,
+                        }
+                    ],
+                }
+            ),
+        )
+
+        CLICommandsMixin()._handle_cron_command("/cron list")
+
+        out = capsys.readouterr().out
+        assert "Run status: ok" in out
+        assert "Delivery:   error" in out
+        assert "Work status: no_progress" in out
+        assert "Evidence:   none (verified=no)" in out
+        assert "Executor:   none" in out
+
+    def test_list_projects_newer_recovered_execution_over_stale_progress(
+        self, capsys, monkeypatch
+    ):
+        stale = {
+            "id": "job-crashed",
+            "name": "crashed",
+            "schedule": {"kind": "interval", "seconds": 60},
+            "schedule_display": "every 1m",
+            "enabled": True,
+            "state": "scheduled",
+            "last_run_at": "2026-07-17T16:00:00Z",
+            "last_status": "ok",
+            "last_run_status": "ok",
+            "last_delivery_status": "ok",
+            "last_work_status": "reported_progress",
+            "last_work_status_source": "agent_marker",
+            "last_evidence_id": "stale\x1b[2J",
+            "latest_execution": {
+                "id": "exec-crashed",
+                "status": "unknown",
+                "claimed_at": "2026-07-17T16:05:00Z",
+                "started_at": "2026-07-17T16:05:01Z",
+                "error": "scheduler exited",
+            },
+        }
+        monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [stale])
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+        cron_cli.cron_list(show_all=True)
+
+        out = capsys.readouterr().out
+        assert "Run status: unknown" in out
+        assert "Delivery:   unknown" in out
+        assert "Work status: unknown (source=none)" in out
+        assert "stale\x1b[2J" not in out
+
+    def test_manual_run_labels_scheduler_and_work_status_separately(
+        self, capsys, monkeypatch
+    ):
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **_kwargs: {
+                "success": True,
+                "job": {
+                    "name": "Truthful report",
+                    "executed": True,
+                    "execution_success": True,
+                    "last_run_status": "ok",
+                    "last_delivery_status": "ok",
+                    "last_work_status": "no_progress",
+                    "last_work_status_source": "agent_marker",
+                    "last_evidence_id": None,
+                    "last_evidence_verified": False,
+                    "last_executor_handle": None,
+                },
+            },
+        )
+
+        assert cron_cli._job_action("run", "job-1", "Triggered") == 0
+
+        out = capsys.readouterr().out
+        assert "Scheduler run: succeeded" in out
+        assert "Work status: no_progress" in out
+        assert "Delivery:   ok" in out
+        assert "Ran now: succeeded" not in out
+
+    def test_slash_manual_run_reports_inline_dimensions(self, capsys, monkeypatch):
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        monkeypatch.setattr(
+            "tools.cronjob_tools.cronjob",
+            lambda **_kwargs: json.dumps(
+                {
+                    "success": True,
+                    "job": {
+                        "job_id": "job-1",
+                        "name": "Truthful report",
+                        "executed": True,
+                        "execution_success": True,
+                        "last_run_status": "ok",
+                        "last_delivery_status": "ok",
+                        "last_work_status": "no_progress",
+                        "last_work_status_source": "agent_marker",
+                        "last_evidence_id": None,
+                        "last_evidence_verified": False,
+                        "last_executor_handle": None,
+                    },
+                }
+            ),
+        )
+
+        CLICommandsMixin()._handle_cron_command("/cron run job-1")
+
+        out = capsys.readouterr().out
+        assert "Scheduler run: succeeded" in out
+        assert "Work status: no_progress" in out
+        assert "Delivery:   ok" in out
+        assert "next scheduler tick" not in out
 
 
 class TestGatewayNotRunningWarning:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -9,6 +9,7 @@ import json
 import logging
 import re
 import sys
+import unicodedata
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -23,6 +24,7 @@ from cron.jobs import (
     AmbiguousJobReference,
     claim_job_for_fire,
     create_job,
+    effective_job_status,
     get_job,
     list_jobs,
     mark_job_run,
@@ -564,11 +566,36 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     return None
 
 
+def _surface_safe(value: Any) -> Any:
+    """Escape control/format code points before values reach terminal surfaces."""
+    if not isinstance(value, str):
+        return value
+    return "".join(
+        char
+        if char.isprintable() and not unicodedata.category(char).startswith("C")
+        else f"\\u{ord(char):04x}"
+        for char in value
+    )
+
+
 def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
-    job_id = str(job.get("id") or "unknown")
-    name = str(job.get("name") or prompt[:50] or (skills[0] if skills else "") or job_id or "cron job")
+    job_id = _surface_safe(str(job.get("id") or "unknown"))
+    name = _surface_safe(
+        str(job.get("name") or prompt[:50] or (skills[0] if skills else "") or job_id or "cron job")
+    )
+    status = effective_job_status(job)
+    last_run_at = status["last_run_at"]
+    last_status = _surface_safe(status["last_status"])
+    last_run_status = _surface_safe(status["last_run_status"])
+    last_delivery_status = _surface_safe(status["last_delivery_status"])
+    last_delivery_error = _surface_safe(status["last_delivery_error"])
+    last_work_status = _surface_safe(status["last_work_status"])
+    last_work_status_source = _surface_safe(status["last_work_status_source"])
+    last_evidence_id = _surface_safe(status["last_evidence_id"])
+    last_evidence_verified = status["last_evidence_verified"]
+    last_executor_handle = _surface_safe(status["last_executor_handle"])
     result = {
         "job_id": job_id,
         "name": name,
@@ -582,9 +609,16 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
         "next_run_at": job.get("next_run_at"),
-        "last_run_at": job.get("last_run_at"),
-        "last_status": job.get("last_status"),
-        "last_delivery_error": job.get("last_delivery_error"),
+        "last_run_at": last_run_at,
+        "last_status": last_status,
+        "last_run_status": last_run_status,
+        "last_delivery_status": last_delivery_status,
+        "last_delivery_error": last_delivery_error,
+        "last_work_status": last_work_status,
+        "last_work_status_source": last_work_status_source,
+        "last_evidence_id": last_evidence_id,
+        "last_evidence_verified": last_evidence_verified,
+        "last_executor_handle": last_executor_handle,
         "enabled": job.get("enabled", True),
         "state": job.get("state", "scheduled" if job.get("enabled", True) else "paused"),
         "paused_at": job.get("paused_at"),


### PR DESCRIPTION
## Summary

- add durable cron execution records and separate scheduler run, delivery, and substantive-work status across scheduler, tool, CLI, and manual-run surfaces
- treat agent work markers as unverified reports unless backed by durable evidence; reject malformed, duplicate, stale, control-character, and bidi metadata fail-closed
- retain paused, completed, and crash-interrupted one-shot records for inspection without re-firing unknown side effects
- keep `no_agent` script stdout as data only and preserve successful stdout text exactly, including leading/trailing whitespace and final newlines; genuinely empty output and `wakeAgent=false` remain successful suppressed runs
- add regression coverage for marker placement, evidence replay bounds, crash projection, pause races, no-agent spoof attempts, exact stdout delivery, and status rendering

## Verification

- `970 passed, 0 failed` — post-rebase cron + tool + CLI + gateway + plugin gate (50 test files)
- independent read-only review: **GO**, no blocker or major issue
- independent active `/opt/hermes/.venv` overlay preserved exact leading/trailing whitespace, final newlines, literal `[SILENT]`, and literal marker-looking text
- independent 27-writer concurrent pause race: all 27 records remained paused after late completion
- local active-environment one-shot probe verified heartbeat, exact output, terminal retention, and no re-fire
- reviewer SHA-256 manifest matched all 12 committed files before and after rebase
- Ruff passed
- `python -m py_compile` passed
- `git diff --check` passed

## Rollout safety

- all First Person and truthful-status rollout cron jobs remain paused; 14 unrelated jobs remain enabled per the user's explicit correction not to pause all cron globally
- live gateway remains the existing `/opt/hermes` runtime until this reviewed commit is canaried
- rollback target is the existing `/opt/hermes/.venv/bin/hermes` gateway runtime
