### PR TITLE
fix(desktop): quiet headless token probe

### DIFF
--- a/apps/desktop/electron/dashboard-token.test.ts
+++ b/apps/desktop/electron/dashboard-token.test.ts
@@ -130,6 +130,23 @@ test('adoptServedDashboardToken refuses a foreign token when our child is dead',
   )
 })
 
+test('adoptServedDashboardToken silently falls back for headless serve', async () => {
+  const logs = []
+
+  const token = await adoptServedDashboardToken('http://127.0.0.1:9120', 'spawn-token', {
+    childAlive: () => true,
+    fetchText: async () => {
+      throw new Error(
+        '404: {"error":"Headless backend (hermes serve): web UI disabled — use `hermes dashboard` for the browser UI."}'
+      )
+    },
+    rememberLog: line => logs.push(line)
+  })
+
+  assert.equal(token, 'spawn-token')
+  assert.deepEqual(logs, [])
+})
+
 test('adoptServedDashboardToken falls back to the spawn token when the fetch fails', async () => {
   const logs = []
 

--- a/apps/desktop/electron/dashboard-token.ts
+++ b/apps/desktop/electron/dashboard-token.ts
@@ -8,6 +8,7 @@
  */
 
 const DEFAULT_TOKEN_FETCH_TIMEOUT_MS = 3_000
+const HEADLESS_SERVE_TOKEN_UNAVAILABLE = 'Headless backend (hermes serve): web UI disabled'
 
 async function fetchPublicText(url, options: any = {}) {
   const { protocol } = new URL(url)
@@ -80,6 +81,10 @@ function isForeignBackendToken({ servedToken, spawnToken, childAlive }) {
   return Boolean(servedToken) && servedToken !== spawnToken && !childAlive
 }
 
+function isExpectedHeadlessServeTokenError(error) {
+  return error instanceof Error && error.message.includes(HEADLESS_SERVE_TOKEN_UNAVAILABLE)
+}
+
 /**
  * Resolve the token the backend actually serves, adopting benign drift and
  * failing loudly on a foreign backend. `childAlive` is a thunk so liveness is
@@ -87,7 +92,9 @@ function isForeignBackendToken({ servedToken, spawnToken, childAlive }) {
  */
 async function adoptServedDashboardToken(baseUrl, spawnToken, { childAlive, label = 'Hermes backend', ...options }) {
   const servedToken = await resolveServedDashboardToken(baseUrl, spawnToken, options).catch(error => {
-    options.rememberLog?.(`[boot] could not read served dashboard token (${label}): ${error.message}`)
+    if (!isExpectedHeadlessServeTokenError(error)) {
+      options.rememberLog?.(`[boot] could not read served dashboard token (${label}): ${error.message}`)
+    }
 
     return spawnToken
   })


### PR DESCRIPTION
## Current change

Current head: `0c4089c` — rebased on `NousResearch/main` `e598cef`.

Desktop treats the intentional root-route 404 from headless `hermes serve` as an expected token-probe outcome: it retains the spawn token without a misleading boot warning. Other token-probe failures remain logged and retain the existing fallback behavior.

## Scope

This branch contains only the headless token-probe fix. The unrelated CSS cleanup from the earlier branch was deliberately dropped.

## Validation

Node 22:

- focused Electron contract: 1 file, 14 passed;
- full Electron project: 45 files, 459 passed, 1 skipped;
- typecheck;
- lint: 9 existing warnings, no errors;
- Prettier and build.

## Review focus

Please review that the suppression matches only the explicit headless-serve UI-disabled response and does not hide genuine token-probe failures.
