### PR TITLE
fix(matrix): drop duplicate infinity-emoji keys in _approval_reaction_map

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -960,8 +960,6 @@ class MatrixAdapter(BasePlatformAdapter):
             "✅": "once",
             "♾️": "always",
             "♾": "always",
-            "\u267e\ufe0f": "always",
-            "\u267e": "always",
             "❌": "deny",
             "❎": "deny",
         }


### PR DESCRIPTION
### Problem

`_approval_reaction_map` in `plugins/platforms/matrix/adapter.py` declares **7 entries but only 5 distinct keys**:

```python
self._approval_reaction_map = {
    "✅": "once",
    "♾️": "always",              # U+267E U+FE0F  (literal, with variation selector)
    "♾": "always",               # U+267E         (literal, without VS)
    "♾️": "always",    # <-- same key as line above, \u-escaped
    "♾": "always",          # <-- same key as line above, \u-escaped
    "❌": "deny",
    "❎": "deny",
}
```

The `♾` "always" reaction is intentionally mapped **twice** — with and without the `U+FE0F` variation selector — so Matrix clients that send either form are matched. But the next two entries re-add those *exact same keys* (`U+267E U+FE0F` and `U+267E`) in `\u`-escaped notation. Python parses `"♾️"` and `"♾️"` to the identical string, so these are duplicate dict keys with the identical value `"always"` — dead re-declarations (likely a rebase artifact from `4717989c`, where one side used literals and the other escapes).

### Fix

Remove the two redundant `\u`-escaped entries, keeping the human-readable literal forms as canonical.

```diff
         self._approval_reaction_map = {
             "✅": "once",
             "♾️": "always",
             "♾": "always",
-            "♾️": "always",
-            "♾": "always",
             "❌": "deny",
             "❎": "deny",
         }
```

### Why this is behavior-preserving

Duplicate keys with identical values collapse to the same dict on construction, so the map is byte-for-byte equivalent before and after. Both variation-selector forms (`♾️` and `♾`) are retained, so client-side matching is unchanged. No logic, control flow, or public surface is touched.

Provable by reading — the removed keys are the same two codepoints already present two lines above.
