### PR TITLE
perf: fast model picker + dialogs — config-load hot path, model.options off the reader thread, off-screen turns skip rendering

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -43,11 +43,19 @@ logger = logging.getLogger(__name__)
 
 
 def _load_config_safe() -> Optional[dict]:
-    """Load config.yaml, returning None on any error."""
-    try:
-        from hermes_cli.config import load_config
+    """Load config.yaml read-only, returning None on any error.
 
-        return load_config()
+    Uses ``load_config_readonly()``: every consumer in this module only reads
+    (``get_pool_strategy``, ``_iter_custom_providers``, the model-config seed),
+    and the deepcopy that ``load_config()`` pays per call is what made
+    credential-pool checks the dominant cost of ``model.options`` — the picker
+    calls ``load_pool()`` once per provider row, each of which loaded (and
+    deep-copied) the full config again.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        return load_config_readonly()
     except Exception:
         return None
 

--- a/apps/desktop/scripts/profile-session-switch.mjs
+++ b/apps/desktop/scripts/profile-session-switch.mjs
@@ -10,7 +10,7 @@
 
 import { writeFileSync } from 'node:fs'
 
-const CDP_HTTP = 'http://127.0.0.1:9222'
+const CDP_HTTP = process.env.CDP_HTTP || 'http://127.0.0.1:9222'
 const A = process.argv[2]
 const B = process.argv[3]
 const ROUNDS = Number(process.argv[4] || 2)

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -360,8 +360,18 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
               </button>
             )}
             {visibleGroups.map(group => (
+              // content-visibility:auto — off-screen turns skip style recalc,
+              // layout, and paint. On a long transcript this is what keeps
+              // UNRELATED UI fast: any dialog/popover mount (Radix Presence
+              // reads getComputedStyle) forces a whole-document style recalc,
+              // measured ~650-730ms per open on a 1300-message session and
+              // ~100-200ms with this on. contain-intrinsic-size keeps a
+              // placeholder height for never-rendered turns (auto: remembered
+              // real size once rendered), so scrollbar/anchoring stay stable.
+              // Sticky human bubbles are unaffected — their turn is rendered
+              // whenever any part of it intersects the viewport.
               <div
-                className="flex min-w-0 flex-col gap-(--conversation-turn-gap) pb-(--conversation-turn-gap)"
+                className="flex min-w-0 flex-col gap-(--conversation-turn-gap) pb-(--conversation-turn-gap) [contain-intrinsic-size:auto_37.5rem] [content-visibility:auto]"
                 key={group.id}
               >
                 <MessageRenderBoundary resetKey={messageSignature}>

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -913,14 +913,32 @@ def _ensure_default_soul_md(home: Path) -> None:
     _secure_file(soul_path)
 
 
+# Home paths whose directory skeleton has been created this process — see
+# ensure_hermes_home(). Only successful passes are recorded, so a raised
+# managed-mode/missing-profile error keeps re-checking on later loads.
+_HERMES_HOME_ENSURED: set = set()
+
+
 def ensure_hermes_home():
     """Ensure ~/.hermes directory structure exists with secure permissions.
 
     In managed mode (NixOS), dirs are created by the activation script with
     setgid + group-writable (2770). We skip mkdir and set umask(0o007) so
     any files created (e.g. SOUL.md) are group-writable (0660).
+
+    Memoized per home path: this runs on EVERY ``load_config()`` (inside the
+    config lock), and the ~14 mkdir/chmod syscalls per call made repeated
+    config loads the dominant cost of hot read paths like ``model.options``.
+    After the first successful pass for a given ``HERMES_HOME`` we only re-run
+    the full walk if the home directory itself has vanished (a deleted home is
+    recreated on the next load, as before). Profile switches change
+    ``get_hermes_home()`` and therefore re-run for the new path.
     """
     home = get_hermes_home()
+    key = str(home)
+
+    if key in _HERMES_HOME_ENSURED and home.is_dir():
+        return
     # Named profiles must be created explicitly (e.g. ``hermes profile create``).
     # If a stale process keeps running after the profile was renamed/deleted,
     # silently mkdir-ing the old HERMES_HOME would resurrect an empty skeleton
@@ -947,6 +965,8 @@ def ensure_hermes_home():
             d.mkdir(parents=True, exist_ok=True)
             _secure_dir(d)
         _ensure_default_soul_md(home)
+
+    _HERMES_HOME_ENSURED.add(key)
 
 
 def _ensure_hermes_home_managed(home: Path):

--- a/tests/hermes_cli/test_ensure_hermes_home_memo.py
+++ b/tests/hermes_cli/test_ensure_hermes_home_memo.py
@@ -1,0 +1,40 @@
+"""ensure_hermes_home is memoized per home path (perf: it runs on every
+load_config), but a deleted home must still be recreated on the next call."""
+
+import shutil
+
+from hermes_cli import config as cfg
+
+
+def test_repeat_calls_are_memoized_but_deleted_home_is_recreated(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    cfg.ensure_hermes_home()
+    assert (home / "sessions").is_dir()
+
+    # Memoized: a second call must not recreate a removed SUBDIR (the fast
+    # path only re-checks the home root)…
+    shutil.rmtree(home / "sessions")
+    cfg.ensure_hermes_home()
+    assert not (home / "sessions").exists()
+
+    # …but a vanished HOME re-runs the full walk and restores the skeleton.
+    shutil.rmtree(home)
+    cfg.ensure_hermes_home()
+    assert (home / "sessions").is_dir()
+
+
+def test_distinct_home_paths_each_get_the_skeleton(tmp_path, monkeypatch):
+    first = tmp_path / "a" / ".hermes"
+    second = tmp_path / "b" / ".hermes"
+
+    monkeypatch.setenv("HERMES_HOME", str(first))
+    cfg.ensure_hermes_home()
+
+    # Profile switch: HERMES_HOME moves → the new path is ensured too.
+    monkeypatch.setenv("HERMES_HOME", str(second))
+    cfg.ensure_hermes_home()
+
+    assert (first / "logs").is_dir()
+    assert (second / "logs").is_dir()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -191,6 +191,12 @@ _LONG_HANDLERS = frozenset(
         "complete.path",
         "complete.slash",
         "llm.oneshot",
+        # model.options builds the full picker payload — per-provider credential
+        # pool checks, pricing fetch, Nous tier check, optional custom-provider
+        # probe — measured seconds inline. While it runs on the reader thread,
+        # prompt.submit / session.interrupt sit unread (same class as #21123),
+        # and the Desktop model pill / picker block on it every open.
+        "model.options",
         # Pet RPCs hit the network (manifest fetch / spritesheet download) or do
         # per-frame PNG decode/encode (pet.cells): inline they serialize on the
         # reader thread, so picker previews trickle in one at a time and the


### PR DESCRIPTION
## Summary

Third profiling round (after #66033, #66347), targeting the **composer model picker** and **dialog opens** (worktree dialog, and every other Radix dialog/popover), measured over CDP against real 1000+-message sessions.

| surface | before | after |
|---|---|---|
| `model.options` RPC (drives the model pill dropdown + picker on every open) | 4.8 s cold / 1.8 s warm | **0.43 s / 0.23 s** |
| `build_models_payload` in isolation (python) | 6.2 s cold / 1.8 s warm | **0.97 s / 0.27 s** |
| worktree dialog (⌘⇧B) open on a 1300-message session | 656–730 ms **every** open | **~200 ms** |
| WS reader thread during `model.options` | blocked (prompt.submit/interrupt unread) | free (pool) |

## Backend: why the model picker was slow

CPU-profiling `build_models_payload` showed the cost wasn't models or pricing — it was **config loading**: `list_authenticated_providers` checks the credential pool per provider row, each `load_pool()` calls `get_pool_strategy()` → `load_config()`, and each of those paid (a) a defensive deepcopy of the full config and (b) `ensure_hermes_home()`'s ~14 mkdir/chmod syscalls **inside the config lock** — 72 pool loads / 85 config loads per picker payload.

- **`agent/credential_pool.py`** — `_load_config_safe` now uses `load_config_readonly()`. Audited every consumer in the module (`get_pool_strategy`, `_iter_custom_providers`, the model-config seed): all reads, no mutation of the returned dict.
- **`hermes_cli/config.py`** — `ensure_hermes_home()` is memoized per home path. The fast path still re-checks the home dir exists, so a deleted `~/.hermes` is recreated on the next load exactly as before, and profile switches (new `HERMES_HOME`) re-run the full walk. New tests cover both properties.
- **`tui_gateway/server.py`** — `model.options` joins `_LONG_HANDLERS`. It measured seconds inline on the WS reader thread; while it ran, `prompt.submit` / `session.interrupt` sat unread in the pipe — the same starvation class as #21123 (`complete.path`).

## Desktop: why every dialog was slow on long transcripts

CPU profile of a worktree-dialog open showed 483 ms of self time in Radix Presence's `getAnimationName` — i.e. `getComputedStyle` on mount forcing a **whole-document style recalc** over the ~10k-node transcript. Every Radix dialog/popover pays this on a long session, every open.

- **`thread/list.tsx`** — `content-visibility: auto` + `contain-intrinsic-size: auto 37.5rem` on the per-turn group wrappers. Off-screen turns skip style recalc, layout, and paint; never-rendered turns hold a placeholder height (`auto` = remembered real size once rendered) so the scrollbar and anchoring stay stable. This also trims the session-switch backfill commit (it's the same off-screen content).

Verified over CDP on the live app: dialog opens ~200 ms on the same monster session; stick-to-bottom pin intact, scroll-to-top renders the top turns correctly, sticky human bubbles unaffected (a turn is rendered whenever any part of it intersects the viewport).

## Verification

- [x] `scripts/run_tests.sh` — config, credential-pool, inventory, model-switch routing, tui_gateway protocol, profiles suites green (406+ tests; `test_profiles.py` has one pre-existing failure on clean main, unrelated — verified by stash/run/pop)
- [x] New `tests/hermes_cli/test_ensure_hermes_home_memo.py` — memo fast path + deleted-home recreation + per-profile-path behavior
- [x] `apps/desktop` — `tsc --noEmit` clean, eslint + prettier clean, thread/session suites green (326 tests)
- [x] E2E over CDP — before/after numbers above, measured on the live desktop backend