### PR TITLE
fix(curator): enforce fail-closed skill-only tool surface

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -826,6 +826,11 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+            # The plugin whitelist is thread-local and therefore cannot protect
+            # concurrent tool worker threads on its own. Mirror the same policy
+            # onto the agent so both executor paths enforce it before dispatch.
+            setattr(review_agent, "_runtime_tool_allowlist", frozenset(review_whitelist))
+            setattr(review_agent, "_runtime_tool_scope_name", "background review")
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -77,6 +77,12 @@ DEFAULT_ARCHIVE_AFTER_DAYS = 90
 # consolidation pass is opt-in.
 DEFAULT_CONSOLIDATE = False
 
+# The autonomous curator may only inspect and mutate skills through the
+# provenance-aware skill tools. Generic file/shell/code/plugin tools would
+# bypass pin, bundled, read-before-write, consolidation and dry-run guards.
+_CURATOR_READ_TOOLS = frozenset({"skills_list", "skill_view"})
+_CURATOR_WRITE_TOOLS = frozenset({*_CURATOR_READ_TOOLS, "skill_manage"})
+
 
 # ---------------------------------------------------------------------------
 # .curator_state — persistent scheduler + status
@@ -1674,7 +1680,11 @@ def run_curator_review(
                     )
                 else:
                     prompt = f"{CURATOR_REVIEW_PROMPT}{builtins_note}\n\n{candidate_list}"
-                llm_meta = _run_llm_review(prompt)
+                llm_meta = (
+                    _run_llm_review(prompt, allow_mutation=False)
+                    if dry_run
+                    else _run_llm_review(prompt)
+                )
                 final_summary = (
                     f"{prefix}{auto_summary}; llm: {llm_meta.get('summary', 'no change')}"
                 )
@@ -1822,7 +1832,7 @@ def _resolve_review_model(cfg: Dict[str, Any]) -> tuple[str, str]:
     return b.provider, b.model
 
 
-def _run_llm_review(prompt: str) -> Dict[str, Any]:
+def _run_llm_review(prompt: str, *, allow_mutation: bool = True) -> Dict[str, Any]:
     """Spawn an AIAgent fork to run the curator review prompt.
 
     Returns a dict with:
@@ -1929,6 +1939,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             max_iterations=9999,
             quiet_mode=True,
             platform="curator",
+            enabled_toolsets=["skills"],
             skip_context_files=True,
             skip_memory=True,
         )
@@ -1942,7 +1953,54 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # trigger during the curation pass they exist to protect against.
         # turn_context.py binds this onto the write-origin ContextVar at turn
         # start (see agent/turn_context.py).
-        review_agent._memory_write_origin = "background_review"
+        from tools.skill_provenance import CURATOR_DRY_RUN
+
+        review_agent._memory_write_origin = (
+            "background_review" if allow_mutation else CURATOR_DRY_RUN
+        )
+
+        # Keep the curated schema stable across turns. A late MCP refresh could
+        # otherwise reintroduce tools filtered below (notably skill_manage in
+        # dry-run), even though the runtime allowlist would still deny them.
+        review_agent._skip_mcp_refresh = True
+
+        # Close the write surface at both schema and dispatch layers. The
+        # explicit name set is intentionally narrower than trusting future
+        # membership changes to the generic ``skills`` toolset. In dry-run,
+        # skill_manage is absent from the model schema and denied at runtime.
+        _allowed_tools = (
+            _CURATOR_WRITE_TOOLS if allow_mutation else _CURATOR_READ_TOOLS
+        )
+        _filtered_tools = [
+            tool for tool in (getattr(review_agent, "tools", []) or [])
+            if isinstance(tool, dict)
+            and (tool.get("function") or {}).get("name") in _allowed_tools
+        ]
+        _valid_tool_names = frozenset(
+            tool.get("function", {}).get("name")
+            for tool in _filtered_tools
+            if isinstance(tool, dict) and tool.get("function", {}).get("name")
+        )
+        # Exact membership is an intentional fail-closed dependency on the
+        # skills toolset contract. A missing expected tool aborts the review
+        # rather than silently weakening the curator's declared capability.
+        if _valid_tool_names != set(_allowed_tools):
+            missing = sorted(set(_allowed_tools) - _valid_tool_names)
+            schema_error = (
+                "Curator tool schema initialization failed closed: "
+                f"missing={missing}"
+            )
+            result_meta["error"] = f"error: {schema_error}"
+            result_meta["summary"] = result_meta["error"]
+            return result_meta
+        setattr(review_agent, "tools", _filtered_tools)
+        # Preserve AIAgent's normal mutable-set contract for this general
+        # bookkeeping attribute; only the dispatch policy below must be immutable.
+        setattr(review_agent, "valid_tool_names", set(_valid_tool_names))
+        setattr(review_agent, "_runtime_tool_allowlist", frozenset(_allowed_tools))
+        setattr(review_agent, "_runtime_tool_scope_name", (
+            "curator" if allow_mutation else "curator dry-run"
+        ))
 
         # Redirect the forked agent's stdout/stderr to /dev/null while it
         # runs so its tool-call chatter doesn't pollute the foreground

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -95,6 +95,32 @@ def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
     )
 
 
+def _runtime_tool_scope_block(agent, function_name: str) -> Optional[str]:
+    """Return a denial when an agent-scoped runtime allowlist excludes a tool.
+
+    The policy lives on the agent object rather than in thread-local state, so
+    it is preserved across the concurrent executor's worker threads. ``None``
+    means that the agent did not opt into an extra runtime scope; an empty
+    allowlist intentionally denies every tool.
+    """
+    allowlist = getattr(agent, "_runtime_tool_allowlist", None)
+    if allowlist is None:
+        return None
+    # The policy is deliberately immutable. Accepting a list/set here would
+    # let another reference widen an autonomous agent's surface after setup.
+    if isinstance(allowlist, frozenset) and function_name in allowlist:
+        return None
+    scope_name = getattr(agent, "_runtime_tool_scope_name", None) or "restricted agent"
+    denial = f"Tool '{function_name}' is not allowed in the {scope_name} runtime scope."
+    logger.warning(
+        "Runtime tool scope denied tool=%r scope=%r session_id=%r",
+        function_name,
+        scope_name,
+        getattr(agent, "session_id", "") or "",
+    )
+    return denial
+
+
 def _resolve_concurrent_tool_timeout() -> float | None:
     raw = os.getenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "").strip()
     if not raw:
@@ -156,6 +182,11 @@ def _emit_terminal_post_tool_call(
     error_message: str | None = None,
     middleware_trace: Optional[list[dict[str, Any]]] = None,
 ) -> None:
+    """Emit a post-tool event with serialized ``result`` and plain-text errors.
+
+    ``error_message`` is human-readable metadata, not a second serialized copy
+    of ``result``. This matches cancellation and ordinary tool-failure events.
+    """
     try:
         from model_tools import _emit_post_tool_call_hook
         _emit_post_tool_call_hook(
@@ -412,31 +443,38 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         function_name = _underlying
                         function_args = _underlying_args
                     else:
-                        _ts_scope_block = json.dumps({
-                            "error": (
-                                f"'{_underlying}' is not available in this session. "
-                                "Use tool_search to find tools you can call."
-                            ),
-                        }, ensure_ascii=False)
+                        _ts_scope_block = (
+                            f"'{_underlying}' is not available in this session. "
+                            "Use tool_search to find tools you can call."
+                        )
         except Exception:
             pass
 
-        function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
-            agent,
-            function_name=function_name,
-            function_args=function_args,
-            effective_task_id=effective_task_id,
-            tool_call_id=getattr(tool_call, "id", "") or "",
-        )
+        _runtime_scope_message = _runtime_tool_scope_block(agent, function_name)
+        _scope_block_message = _runtime_scope_message or _ts_scope_block
+        if _scope_block_message is None:
+            function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+            )
+        else:
+            # Runtime scope is a security boundary: denied payloads must not
+            # reach middleware or plugin hooks before being rejected.
+            middleware_trace = []
 
         # ── Block evaluation (BEFORE checkpoint preflight) ───────────
         # We must know whether the tool will execute before touching
         # checkpoint state (dedup slot, real snapshots).
         block_result = None
         blocked_by_guardrail = False
-        if _ts_scope_block is not None:
+        if _scope_block_message is not None:
             # Out-of-scope tool_call: reject before hooks/guardrails/dispatch.
-            block_result = _ts_scope_block
+            block_result = json.dumps(
+                {"error": _scope_block_message}, ensure_ascii=False
+            )
             _emit_terminal_post_tool_call(
                 agent,
                 function_name=function_name,
@@ -446,7 +484,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 tool_call_id=getattr(tool_call, "id", "") or "",
                 status="blocked",
                 error_type="tool_scope_block",
-                error_message=_ts_scope_block,
+                error_message=_scope_block_message,
                 middleware_trace=list(middleware_trace),
             )
         else:
@@ -1098,19 +1136,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         except Exception:
             pass
 
-        function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
-            agent,
-            function_name=function_name,
-            function_args=function_args,
-            effective_task_id=effective_task_id,
-            tool_call_id=getattr(tool_call, "id", "") or "",
-        )
+        _runtime_scope_message = _runtime_tool_scope_block(agent, function_name)
+        _scope_block_message = _runtime_scope_message or _ts_scope_block
+        if _scope_block_message is None:
+            function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+            )
+        else:
+            middleware_trace = []
 
         # Check plugin hooks for a block directive before executing.
         _block_msg: Optional[str] = None
         _block_error_type = "plugin_block"
-        if _ts_scope_block is not None:
-            _block_msg = _ts_scope_block
+        if _scope_block_message is not None:
+            _block_msg = _scope_block_message
             _block_error_type = "tool_scope_block"
         else:
             try:

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,11 @@
+# Backlog
+
+## Open
+
+_None._
+
+## Completed
+
+- **Source:** Windows canonical skill-tool suite · **Severity:** medium / cross-platform API contract · **Description:** on Windows, the `skill_view` JSON `path` and collision `matches` fields used native `\\` separators even though categorized skill identifiers and the tested tool contract use `/`. · **Status:** DONE — all user/model-facing skill paths now use `Path.as_posix()` normalization; the complete `test_skills_tool.py` wrapper gate verifies the behavior.
+- **Source:** Windows canonical test-wrapper gate · **Severity:** medium / developer infrastructure · **Description:** when invoked from MSYS, `scripts/run_tests.sh` recognized only the POSIX `venv/bin/python` layout, then `env -i` discarded the home, system, temp, and UTF-8 variables required by native Windows Python. As a result, the mandatory wrapper could not find the venv, failed before collection with `Path.home()`/CP1250 errors, or created a relative `%SystemDrive%/ProgramData` cache tree in the worktree. · **Status:** DONE — the wrapper recognizes the `Scripts/python.exe` layout, forwards the required non-secret Windows environment variables, and runs with `PYTHONUTF8=1`; verified through the real wrapper and a clean-worktree readback.
+- **Source:** Curator write-surface pytest gate · **Severity:** low / test portability · **Description:** `TestDeleteSkillRmtreeGuard.test_symlinked_skill_dir_refused` failed with `WinError 1314` before reaching the guard under test when the Windows process lacked symlink privileges. · **Status:** DONE — following the repository's existing capability-gate pattern, the test runs only in symlink-capable environments; where supported, the original refusal and external-target integrity assertions remain unchanged.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -42,15 +42,22 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # (HERMES_PYTHON is exported by the devShell hook and ships [dev] extras:
 # pytest, pytest-asyncio, pytest-timeout, ruff, ty).
 VENV=""
+VENV_PYTHON=""
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
   if [ -f "$candidate/bin/activate" ]; then
     VENV="$candidate"
+    VENV_PYTHON="$candidate/bin/python"
+    break
+  elif [ -x "$candidate/Scripts/python.exe" ]; then
+    # Native Windows uv/venv layout when this bash script runs under MSYS.
+    VENV="$candidate"
+    VENV_PYTHON="$candidate/Scripts/python.exe"
     break
   fi
 done
 
 if [ -n "$VENV" ]; then
-  PYTHON="$VENV/bin/python"
+  PYTHON="$VENV_PYTHON"
 elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
     && "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
   # Guard with an import check: HERMES_PYTHON may point at the RELEASE
@@ -94,9 +101,22 @@ echo "▶ launching test runner"
 exec env -i \
   PATH="$PATH" \
   HOME="$HOME" \
+  ${USERPROFILE:+USERPROFILE="$USERPROFILE"} \
+  ${HOMEDRIVE:+HOMEDRIVE="$HOMEDRIVE"} \
+  ${HOMEPATH:+HOMEPATH="$HOMEPATH"} \
+  ${APPDATA:+APPDATA="$APPDATA"} \
+  ${LOCALAPPDATA:+LOCALAPPDATA="$LOCALAPPDATA"} \
+  ${PROGRAMDATA:+PROGRAMDATA="$PROGRAMDATA"} \
+  ${ALLUSERSPROFILE:+ALLUSERSPROFILE="$ALLUSERSPROFILE"} \
+  ${SYSTEMDRIVE:+SYSTEMDRIVE="$SYSTEMDRIVE"} \
+  ${SYSTEMROOT:+SYSTEMROOT="$SYSTEMROOT"} \
+  ${WINDIR:+WINDIR="$WINDIR"} \
+  ${TEMP:+TEMP="$TEMP"} \
+  ${TMP:+TMP="$TMP"} \
   TZ=UTC \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
+  PYTHONUTF8=1 \
   PYTHONHASHSEED=0 \
   ${HERMES_RUN_SLOW_PET_TESTS:+HERMES_RUN_SLOW_PET_TESTS="$HERMES_RUN_SLOW_PET_TESTS"} \
   ${EXTRA_PYTHONPATH:+PYTHONPATH="$EXTRA_PYTHONPATH"} \

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -14,6 +14,15 @@ from pathlib import Path
 import pytest
 
 
+def _seed_stub_skill_tools(agent):
+    names = {"skills_list", "skill_view", "skill_manage"}
+    agent.tools = [
+        {"type": "function", "function": {"name": name}}
+        for name in sorted(names)
+    ]
+    agent.valid_tool_names = set(names)
+
+
 @pytest.fixture
 def curator_env(tmp_path, monkeypatch):
     """Isolated HERMES_HOME + freshly reloaded curator + skill_usage modules."""
@@ -607,9 +616,9 @@ def test_dry_run_does_not_advance_state(curator_env, monkeypatch):
 
 def test_dry_run_injects_report_only_banner(curator_env, monkeypatch):
     """The dry-run prompt must carry a banner instructing the LLM not to
-    call any mutating tool. This is defense in depth — the caller also
-    skips automatic transitions — but the LLM prompt is the only guard
-    against the model calling skill_manage directly."""
+    call any mutating tool. This is defense in depth: the caller also skips
+    automatic transitions and passes allow_mutation=False so skill_manage is
+    absent from both the model schema and runtime dispatch allowlist."""
     c = curator_env["curator"]
     u = curator_env["usage"]
     skills_dir = curator_env["home"] / "skills"
@@ -617,8 +626,9 @@ def test_dry_run_injects_report_only_banner(curator_env, monkeypatch):
     u.mark_agent_created("a")
 
     captured = {}
-    def _stub(prompt):
+    def _stub(prompt, *, allow_mutation):
         captured["prompt"] = prompt
+        captured["allow_mutation"] = allow_mutation
         return {"final": "", "summary": "s", "model": "", "provider": "",
                 "tool_calls": [], "error": None}
     monkeypatch.setattr(c, "_run_llm_review", _stub)
@@ -626,6 +636,7 @@ def test_dry_run_injects_report_only_banner(curator_env, monkeypatch):
     c.run_curator_review(synchronous=True, dry_run=True, consolidate=True)
     assert "DRY-RUN" in captured["prompt"]
     assert "DO NOT" in captured["prompt"]
+    assert captured["allow_mutation"] is False
 
 
 def test_dry_run_skips_automatic_transitions(curator_env, monkeypatch):
@@ -1275,6 +1286,7 @@ def test_review_fork_runs_under_background_review_origin(curator_env, monkeypatc
             self._skill_nudge_interval = 10
             self.platform = kwargs.get("platform")
             self._session_messages = []
+            _seed_stub_skill_tools(self)
 
         def run_conversation(self, user_message=None, **kwargs):
             # Capture the origin AT RUN TIME — i.e. after _run_llm_review has
@@ -1321,6 +1333,7 @@ def test_review_fork_forwards_runtime_pool_and_overrides(curator_env, monkeypatc
             self._memory_nudge_interval = 0
             self._skill_nudge_interval = 0
             self._session_messages = []
+            _seed_stub_skill_tools(self)
 
         def run_conversation(self, user_message=None, **kwargs):
             return {"final_response": "ok"}
@@ -1371,6 +1384,7 @@ def test_review_fork_uses_runtime_model_and_output_cap(curator_env, monkeypatch)
         def __init__(self, **kwargs):
             captured.update(kwargs)
             self._session_messages = []
+            _seed_stub_skill_tools(self)
 
         def run_conversation(self, **_kwargs):
             return {"final_response": "ok"}
@@ -1422,6 +1436,7 @@ def test_review_fork_merges_slot_extra_body_over_runtime(curator_env, monkeypatc
         def __init__(self, **kwargs):
             captured.update(kwargs)
             self._session_messages = []
+            _seed_stub_skill_tools(self)
 
         def run_conversation(self, **_kwargs):
             return {"final_response": "ok"}
@@ -1442,3 +1457,127 @@ def test_review_fork_merges_slot_extra_body_over_runtime(curator_env, monkeypatc
         },
         "service_tier": "priority",
     }
+
+
+@pytest.mark.parametrize(
+    ("allow_mutation", "expected_tools", "scope_name", "write_origin"),
+    [
+        (
+            True,
+            {"skills_list", "skill_view", "skill_manage"},
+            "curator",
+            "background_review",
+        ),
+        (
+            False,
+            {"skills_list", "skill_view"},
+            "curator dry-run",
+            "curator_dry_run",
+        ),
+    ],
+)
+def test_review_fork_has_closed_skill_only_tool_surface(
+    curator_env,
+    monkeypatch,
+    allow_mutation,
+    expected_tools,
+    scope_name,
+    write_origin,
+):
+    """Curator schemas and dispatch policy must exclude generic writers."""
+    # curator_env replaces _run_llm_review with an offline lambda for the
+    # orchestrator tests. Reload so this test exercises the real fork builder;
+    # HERMES_HOME remains isolated by the fixture.
+    curator = importlib.reload(curator_env["curator"])
+    captured = {}
+
+    class _StubAgent:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+            names = {"skills_list", "skill_view", "skill_manage"}
+            self.tools = [
+                {"type": "function", "function": {"name": name}}
+                for name in sorted(names)
+            ]
+            self.valid_tool_names = set(names)
+            self._session_messages = []
+
+        def run_conversation(self, **_kwargs):
+            captured["tools"] = {
+                tool["function"]["name"] for tool in self.tools
+            }
+            captured["valid_tool_names"] = self.valid_tool_names
+            captured["runtime_allowlist"] = self._runtime_tool_allowlist
+            captured["scope_name"] = self._runtime_tool_scope_name
+            captured["write_origin"] = self._memory_write_origin
+            captured["skip_mcp_refresh"] = getattr(
+                self, "_skip_mcp_refresh", None
+            )
+            return {"final_response": "ok"}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", _StubAgent)
+
+    result = curator._run_llm_review("review", allow_mutation=allow_mutation)
+
+    assert result["error"] is None
+    assert captured["kwargs"]["enabled_toolsets"] == ["skills"]
+    assert captured["tools"] == expected_tools
+    assert captured["valid_tool_names"] == expected_tools
+    assert isinstance(captured["valid_tool_names"], set)
+    assert captured["runtime_allowlist"] == frozenset(expected_tools)
+    assert captured["scope_name"] == scope_name
+    assert captured["write_origin"] == write_origin
+    for bypass in {"terminal", "write_file", "patch", "execute_code"}:
+        assert bypass not in captured["runtime_allowlist"]
+
+    # Between-turn MCP refresh must not widen the curated schema.
+    assert captured["skip_mcp_refresh"] is True, (
+        "Curator review fork must set _skip_mcp_refresh=True to prevent "
+        "between-turn MCP refresh from widening the tool schema on turn 2+"
+    )
+
+
+def test_review_fork_fails_closed_when_expected_schema_is_missing(
+    curator_env, monkeypatch
+):
+    curator = importlib.reload(curator_env["curator"])
+
+    class _IncompleteAgent:
+        def __init__(self, **_kwargs):
+            self.tools = [
+                {"type": "function", "function": {"name": "skills_list"}},
+                "malformed-tool-schema",
+            ]
+            self.valid_tool_names = {"skills_list"}
+            self._session_messages = []
+
+        def run_conversation(self, **_kwargs):
+            raise AssertionError("conversation must not run with an incomplete schema")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", _IncompleteAgent)
+
+    result = curator._run_llm_review("review", allow_mutation=False)
+
+    assert "failed closed" in result["error"]
+    assert "skill_view" in result["error"]
+    assert "AttributeError" not in result["error"]
+
+
+def test_real_skills_toolset_matches_curator_schema_contract():
+    from model_tools import get_tool_definitions
+
+    tools = get_tool_definitions(
+        enabled_toolsets=["skills"],
+        disabled_toolsets=[],
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    names = {tool["function"]["name"] for tool in tools}
+
+    assert names == {"skills_list", "skill_view", "skill_manage"}

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -40,6 +40,13 @@ def _write_skill(skills_dir: Path, name: str, body: str = "body") -> Path:
     return d
 
 
+def _mark_agent_created(usage, name: str) -> None:
+    data = usage.load_usage()
+    data[name] = usage._empty_record()
+    data[name]["created_by"] = "agent"
+    usage.save_usage(data)
+
+
 # ---------------------------------------------------------------------------
 # snapshot_skills
 # ---------------------------------------------------------------------------
@@ -270,23 +277,32 @@ def test_real_run_takes_pre_snapshot(backup_env, monkeypatch):
     skills = backup_env["skills"]
     _write_skill(skills, "alpha")
 
-    # Reload curator module against the freshly-env'd hermes_constants
+    # Reload usage before curator so the candidate scan uses this test's HOME.
+    import tools.skill_usage as usage
+    importlib.reload(usage)
+    _mark_agent_created(usage, "alpha")
+
+    # Reload curator module against the freshly-env'd hermes_constants.
     from agent import curator
     importlib.reload(curator)
 
     # Stub out LLM review and auto transitions — we only care about the
     # snapshot side-effect.
-    monkeypatch.setattr(
-        curator, "_run_llm_review",
-        lambda p: {"final": "", "summary": "s", "model": "", "provider": "",
-                   "tool_calls": [], "error": None},
-    )
+    review_modes = []
+
+    def _review_stub(_prompt, *, allow_mutation=True):
+        review_modes.append(allow_mutation)
+        return {"final": "", "summary": "s", "model": "", "provider": "",
+                "tool_calls": [], "error": None}
+
+    monkeypatch.setattr(curator, "_run_llm_review", _review_stub)
     monkeypatch.setattr(
         curator, "apply_automatic_transitions",
         lambda now=None: {"checked": 1, "marked_stale": 0, "archived": 0, "reactivated": 0},
     )
 
-    curator.run_curator_review(synchronous=True)
+    curator.run_curator_review(synchronous=True, consolidate=True)
+    assert review_modes == [True]
     # Pre-run snapshot should exist
     rows = cb.list_backups()
     assert any(r.get("reason") == "pre-curator-run" for r in rows), (
@@ -301,15 +317,23 @@ def test_dry_run_skips_snapshot(backup_env, monkeypatch):
     skills = backup_env["skills"]
     _write_skill(skills, "alpha")
 
+    import tools.skill_usage as usage
+    importlib.reload(usage)
+    _mark_agent_created(usage, "alpha")
+
     from agent import curator
     importlib.reload(curator)
-    monkeypatch.setattr(
-        curator, "_run_llm_review",
-        lambda p: {"final": "", "summary": "s", "model": "", "provider": "",
-                   "tool_calls": [], "error": None},
-    )
+    review_modes = []
 
-    curator.run_curator_review(synchronous=True, dry_run=True)
+    def _review_stub(_prompt, *, allow_mutation=True):
+        review_modes.append(allow_mutation)
+        return {"final": "", "summary": "s", "model": "", "provider": "",
+                "tool_calls": [], "error": None}
+
+    monkeypatch.setattr(curator, "_run_llm_review", _review_stub)
+
+    curator.run_curator_review(synchronous=True, dry_run=True, consolidate=True)
+    assert review_modes == [False]
     rows = cb.list_backups()
     assert not any(r.get("reason") == "pre-curator-run" for r in rows), (
         "dry-run must not create a pre-run snapshot"

--- a/tests/agent/test_runtime_tool_allowlist.py
+++ b/tests/agent/test_runtime_tool_allowlist.py
@@ -1,0 +1,66 @@
+"""Security regressions for agent-scoped runtime tool allowlists."""
+
+import logging
+from types import SimpleNamespace
+
+from agent.tool_executor import _runtime_tool_scope_block
+
+
+def test_runtime_tool_allowlist_is_opt_in():
+    agent = SimpleNamespace()
+
+    assert _runtime_tool_scope_block(agent, "terminal") is None
+
+
+def test_runtime_tool_allowlist_allows_only_named_tools():
+    agent = SimpleNamespace(
+        _runtime_tool_allowlist=frozenset({"skills_list", "skill_view"}),
+        _runtime_tool_scope_name="curator dry-run",
+    )
+
+    assert _runtime_tool_scope_block(agent, "skill_view") is None
+    denied = _runtime_tool_scope_block(agent, "terminal")
+
+    assert denied is not None
+    assert "terminal" in denied
+    assert "curator dry-run" in denied
+    assert "not allowed" in denied
+
+
+def test_runtime_tool_allowlist_empty_set_denies_everything():
+    agent = SimpleNamespace(
+        _runtime_tool_allowlist=frozenset(),
+        _runtime_tool_scope_name="locked agent",
+    )
+
+    assert _runtime_tool_scope_block(agent, "skill_view") is not None
+
+
+def test_runtime_tool_allowlist_fails_closed_for_mutable_policy():
+    agent = SimpleNamespace(
+        _runtime_tool_allowlist=["skill_view"],
+        _runtime_tool_scope_name="curator",
+    )
+
+    denied = _runtime_tool_scope_block(agent, "skill_view")
+
+    assert denied is not None
+    assert "curator runtime scope" in denied
+
+
+def test_runtime_tool_scope_denial_emits_security_audit_log(caplog):
+    agent = SimpleNamespace(
+        _runtime_tool_allowlist=frozenset({"skill_view"}),
+        _runtime_tool_scope_name="curator dry-run",
+        session_id="curator-session",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="agent.tool_executor"):
+        denied = _runtime_tool_scope_block(agent, "terminal")
+
+    assert denied is not None
+    record = caplog.records[-1]
+    assert record.levelno == logging.WARNING
+    assert "tool='terminal'" in record.getMessage()
+    assert "scope='curator dry-run'" in record.getMessage()
+    assert "session_id='curator-session'" in record.getMessage()

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -179,6 +179,17 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.active_system_prompt == "SYSTEM"
 
 
+def test_binds_arbitrary_agent_write_origin_without_filtering():
+    """Curator dry-run origins must reach the provenance ContextVar verbatim."""
+    agent = _FakeAgent()
+    agent._memory_write_origin = "curator_dry_run"
+    observed = []
+
+    _build(agent, set_current_write_origin=observed.append)
+
+    assert observed == ["curator_dry_run"]
+
+
 def test_applies_agent_side_effects():
     agent = _FakeAgent()
     _build(agent)

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -109,6 +109,7 @@ def test_background_review_installs_thread_local_whitelist():
     def _no_init(self, *args, **kwargs):
         # Don't crash AIAgent.__init__; let execution flow reach
         # set_thread_tool_whitelist.
+        captured["review_agent"] = self
         return None
 
     with patch.object(run_agent.AIAgent, "__init__", _no_init), \
@@ -122,6 +123,13 @@ def test_background_review_installs_thread_local_whitelist():
 
     assert "whitelist" in captured, "set_thread_tool_whitelist was not called"
     whitelist = captured["whitelist"]
+    review_agent = captured["review_agent"]
+    assert review_agent._runtime_tool_allowlist == frozenset(whitelist)
+    assert review_agent._runtime_tool_scope_name == "background review"
+    from agent.tool_executor import _runtime_tool_scope_block
+
+    assert _runtime_tool_scope_block(review_agent, "skill_view") is None
+    assert _runtime_tool_scope_block(review_agent, "terminal") is not None
     # memory + skills tools must be allowed
     assert "memory" in whitelist
     assert "skill_manage" in whitelist

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3052,6 +3052,182 @@ class TestConcurrentToolExecution:
             )
             assert result == "result"
 
+    def test_runtime_allowlist_blocks_sequential_dispatch_before_middleware(self, agent):
+        """A restricted autonomous agent cannot reach a denied handler."""
+        agent._runtime_tool_allowlist = frozenset({"skill_view"})
+        agent._runtime_tool_scope_name = "curator"
+        tool_call = _mock_tool_call(
+            name="web_search", arguments='{"query":"bypass"}', call_id="c-denied"
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        with patch("hermes_cli.middleware.apply_tool_request_middleware") as middleware, \
+             patch("run_agent.handle_function_call") as handler:
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        middleware.assert_not_called()
+        handler.assert_not_called()
+        assert len(messages) == 1
+        assert "not allowed in the curator runtime scope" in messages[0]["content"]
+
+    def test_runtime_allowlist_blocks_concurrent_dispatch_before_workers(self, agent):
+        """Parallel calls cannot escape an agent-scoped runtime allowlist."""
+        agent._runtime_tool_allowlist = frozenset({"skill_view"})
+        agent._runtime_tool_scope_name = "curator"
+        tool_calls = [
+            _mock_tool_call(
+                name="web_search",
+                arguments=json.dumps({"query": query}),
+                call_id=f"c-{query}",
+            )
+            for query in ("one", "two")
+        ]
+        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
+        messages = []
+
+        with patch("hermes_cli.middleware.apply_tool_request_middleware") as middleware, \
+             patch("run_agent.handle_function_call") as handler:
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        middleware.assert_not_called()
+        handler.assert_not_called()
+        assert len(messages) == 2
+        assert all(
+            "not allowed in the curator runtime scope" in message["content"]
+            for message in messages
+        )
+
+    def test_runtime_scope_denial_format_matches_between_executors(self, agent):
+        agent._runtime_tool_allowlist = frozenset({"skill_view"})
+        agent._runtime_tool_scope_name = "curator"
+        sequential_messages = []
+        concurrent_messages = []
+
+        sequential_call = _mock_tool_call(
+            name="web_search", arguments='{"query":"one"}', call_id="seq"
+        )
+        with patch("agent.tool_executor._emit_terminal_post_tool_call") as emitted:
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[sequential_call]),
+                sequential_messages,
+                "task-1",
+            )
+
+            concurrent_calls = [
+                _mock_tool_call(
+                    name="web_search",
+                    arguments=json.dumps({"query": query}),
+                    call_id=f"con-{query}",
+                )
+                for query in ("one", "two")
+            ]
+            agent._execute_tool_calls_concurrent(
+                _mock_assistant_msg(content="", tool_calls=concurrent_calls),
+                concurrent_messages,
+                "task-1",
+            )
+
+        expected = sequential_messages[0]["content"]
+        assert '"error"' in expected
+        assert all(
+            message["content"] == expected
+            for message in concurrent_messages
+        )
+        assert len(emitted.call_args_list) == 3
+        for emitted_call in emitted.call_args_list:
+            payload = json.loads(emitted_call.kwargs["result"])
+            assert set(payload) == {"error"}
+            assert payload["error"] == emitted_call.kwargs["error_message"]
+            assert emitted_call.kwargs["error_type"] == "tool_scope_block"
+
+    def test_api_kwargs_use_current_filtered_tool_schema(self, agent):
+        """Post-init schema filtering must reach the actual model request."""
+        agent.tools = _make_tool_defs("skills_list", "skill_view")
+        agent.valid_tool_names = frozenset({"skills_list", "skill_view"})
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "review"}])
+
+        assert {
+            tool["function"]["name"] for tool in kwargs["tools"]
+        } == {"skills_list", "skill_view"}
+
+    def test_concurrent_executor_propagates_curator_dry_run_origin(self, agent):
+        from tools.skill_provenance import (
+            CURATOR_DRY_RUN,
+            is_curator_dry_run,
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        observed = []
+        agent._invoke_tool = MagicMock(
+            side_effect=lambda *_args, **_kwargs: (
+                observed.append(is_curator_dry_run()) or "{}"
+            )
+        )
+        calls = [
+            _mock_tool_call(
+                name="web_search",
+                arguments=json.dumps({"query": query}),
+                call_id=f"dry-run-{query}",
+            )
+            for query in ("one", "two")
+        ]
+        token = set_current_write_origin(CURATOR_DRY_RUN)
+        try:
+            agent._execute_tool_calls_concurrent(
+                _mock_assistant_msg(content="", tool_calls=calls),
+                [],
+                "task-1",
+            )
+        finally:
+            reset_current_write_origin(token)
+
+        assert observed == [True, True]
+
+    def test_tool_search_scope_block_skips_middleware_in_both_executors(self, agent):
+        from tools import tool_search
+
+        def call(call_id):
+            return _mock_tool_call(
+                name=tool_search.TOOL_CALL_NAME,
+                arguments='{"name":"terminal","arguments":{}}',
+                call_id=call_id,
+            )
+
+        sequential_messages = []
+        concurrent_messages = []
+        with patch(
+            "tools.tool_search.resolve_underlying_call",
+            return_value=("terminal", {"command": "blocked"}, None),
+        ), patch(
+            "agent.tool_executor._tool_search_scoped_names",
+            return_value={"web_search"},
+        ), patch(
+            "hermes_cli.middleware.apply_tool_request_middleware"
+        ) as middleware, patch("run_agent.handle_function_call") as handler:
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[call("seq")]),
+                sequential_messages,
+                "task-1",
+            )
+            agent._execute_tool_calls_concurrent(
+                _mock_assistant_msg(
+                    content="", tool_calls=[call("con-1"), call("con-2")]
+                ),
+                concurrent_messages,
+                "task-1",
+            )
+
+        middleware.assert_not_called()
+        handler.assert_not_called()
+        assert "not available in this session" in sequential_messages[0]["content"]
+        assert all(
+            "not available in this session" in message["content"]
+            for message in concurrent_messages
+        )
+
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1114,7 +1114,10 @@ class TestDeleteSkillRmtreeGuard:
         skills = tmp_path / "skills"
         skills.mkdir()
         evil = skills / "evil-skill"
-        evil.symlink_to(victim, target_is_directory=True)
+        try:
+            evil.symlink_to(victim, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
         try:
             with patch("tools.skill_manager_tool.SKILLS_DIR", skills), \
                  patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills]), \

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -3,7 +3,7 @@
 import json
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -375,6 +375,39 @@ class TestSkillsList:
 
 
 class TestSkillView:
+    def test_curator_dry_run_does_not_write_usage_telemetry(self, monkeypatch):
+        """Dry-run inspection must not mutate the skill usage sidecar."""
+        from tools import skills_tool
+        from tools.skill_provenance import (
+            CURATOR_DRY_RUN,
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        monkeypatch.setattr(
+            skills_tool,
+            "skill_view",
+            lambda *args, **kwargs: json.dumps(
+                {"success": True, "name": "inspected-skill", "content": "body"}
+            ),
+        )
+        bump_view = Mock()
+        bump_use = Mock()
+        monkeypatch.setattr("tools.skill_usage.bump_view", bump_view)
+        monkeypatch.setattr("tools.skill_usage.bump_use", bump_use)
+
+        token = set_current_write_origin(CURATOR_DRY_RUN)
+        try:
+            result = json.loads(
+                skills_tool._skill_view_with_bump({"name": "inspected-skill"})
+            )
+        finally:
+            reset_current_write_origin(token)
+
+        assert result["success"] is True
+        bump_view.assert_not_called()
+        bump_use.assert_not_called()
+
     def test_view_existing_skill(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "my-skill")

--- a/tools/skill_provenance.py
+++ b/tools/skill_provenance.py
@@ -43,6 +43,9 @@ _write_origin: contextvars.ContextVar[str] = contextvars.ContextVar(
 # run_agent.py's AIAgent._memory_write_origin override in
 # _spawn_background_review().
 BACKGROUND_REVIEW = "background_review"
+# Read-only curator reviews use a distinct origin so inspection can suppress
+# usage telemetry without weakening normal background-review provenance.
+CURATOR_DRY_RUN = "curator_dry_run"
 
 
 def set_current_write_origin(origin: str) -> contextvars.Token[str]:
@@ -76,3 +79,8 @@ def is_background_review() -> bool:
     """Convenience: True iff the current write origin is the background
     review fork."""
     return get_current_write_origin() == BACKGROUND_REVIEW
+
+
+def is_curator_dry_run() -> bool:
+    """Return True while a read-only curator fork is inspecting skills."""
+    return get_current_write_origin() == CURATOR_DRY_RUN

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -78,6 +78,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, Any, List, Optional, Set, Tuple
 
 from tools.registry import registry, tool_error
+from tools.skill_provenance import is_curator_dry_run
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled
 from agent.skill_utils import (
@@ -1180,7 +1181,10 @@ def skill_view(
                     _record(None, found_md)
 
         if len(candidates) > 1:
-            paths = [str(smd) for _, smd in candidates]
+            # Tool payloads use portable POSIX separators on every host. This
+            # keeps categorized-path hints machine-independent and matches the
+            # convention used throughout skill manifests.
+            paths = [smd.as_posix() for _, smd in candidates]
             logging.getLogger(__name__).warning(
                 "Skill name collision for '%s': %d candidates — %s",
                 name, len(candidates), "; ".join(paths),
@@ -1473,10 +1477,14 @@ def skill_view(
             linked_files["scripts"] = script_files
 
         try:
-            rel_path = str(skill_md.relative_to(active_skills_dir))
+            rel_path = skill_md.relative_to(active_skills_dir).as_posix()
         except ValueError:
             # External skill — use path relative to the skill's own parent dir
-            rel_path = str(skill_md.relative_to(skill_md.parent.parent)) if skill_md.parent.parent else skill_md.name
+            rel_path = (
+                skill_md.relative_to(skill_md.parent.parent).as_posix()
+                if skill_md.parent.parent
+                else skill_md.name
+            )
         skill_name = frontmatter.get(
             "name", skill_md.stem if not skill_dir else skill_dir.name
         )
@@ -1733,6 +1741,10 @@ def _skill_view_with_bump(args, **kw):
         name, file_path=args.get("file_path"), task_id=kw.get("task_id")
     )
     try:
+        # A dry-run may inspect skill content, but must not change the usage
+        # sidecar (view/use counts and timestamps are writes too).
+        if is_curator_dry_run():
+            return result
         parsed = json.loads(result)
         if isinstance(parsed, dict) and parsed.get("success"):
             # Use the resolved skill name from the payload when present —


### PR DESCRIPTION
## Summary
- restrict Curator model schemas to the three skill tools (two in dry-run) and fail closed when the expected schema is incomplete
- enforce an immutable agent-level runtime allowlist before middleware, hooks, or handlers in both executor paths, including background review
- suppress dry-run skill usage telemetry and cover worker-thread ContextVar propagation
- normalize Windows skill paths and make the canonical test wrapper preserve required non-secret Windows environment state

## Security invariants
- normal Curator: `skills_list`, `skill_view`, `skill_manage`
- dry-run Curator: `skills_list`, `skill_view`
- generic terminal/file/code execution cannot reach the skill tree
- denied calls emit one structured tool result and one blocked post-tool event
- provenance, pin, read-before-write, and target-containment guards remain intact

## Verification
- `scripts/run_tests.sh` relevant suite: 764 passed
- `uv run ruff check .`
- `scripts/check-windows-footguns.py --all`
- `ty` changed-file baseline diff: 0 new diagnostics
- independent dual review is being revalidated on commit `4da6add2fcb6870490462fbb6b0e1de265da8c0e`
