### PR TITLE
fix(gateway): reliability hardening — Bedrock stream liveness, supervised watchers, launchd respawn throttle

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -789,6 +789,7 @@ def stream_converse_with_callbacks(
     on_tool_start=None,
     on_reasoning_delta=None,
     on_interrupt_check=None,
+    on_event=None,
 ) -> SimpleNamespace:
     """Process a Bedrock ConverseStream event stream with real-time callbacks.
 
@@ -808,6 +809,12 @@ def stream_converse_with_callbacks(
             on supported models (Claude 4.6+).
         on_interrupt_check: Called on each event. Should return True if the
             agent has been interrupted and streaming should stop.
+        on_event: Called once at the top of the loop body for EVERY yielded
+            Bedrock event (text/tool-input/reasoning/metadata deltas alike),
+            before any branching. Provides a wire-level liveness signal so an
+            external watchdog can distinguish "still receiving events" from
+            "stream wedged with no data". Errors raised by the callback are
+            swallowed so a liveness hook can never abort the stream.
 
     Returns:
         An OpenAI-compatible SimpleNamespace response, identical in shape to
@@ -823,6 +830,15 @@ def stream_converse_with_callbacks(
     usage_data: Dict[str, int] = {}
 
     for event in event_stream.get("stream", []):
+        # Wire-level liveness signal: fire on EVERY yielded event (text, tool
+        # input, reasoning, metadata) before branching so an external watchdog
+        # can tell a still-flowing stream from a wedged one. Best-effort — a
+        # liveness callback must never be able to abort the stream.
+        if on_event is not None:
+            try:
+                on_event()
+            except Exception:
+                pass
         # Check for interrupt
         if on_interrupt_check and on_interrupt_check():
             break

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -264,6 +264,35 @@ def _check_stale_giveup(agent) -> None:
         )
 
 
+def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
+    """Stale-stream patience for a provider that is never a local endpoint.
+
+    Mirrors the main streaming path's derivation — provider config → env base
+    → context-size scaling → reasoning-model floor — minus the local-endpoint
+    ``float('inf')``/900s disable branch, which cannot apply to Bedrock (its
+    endpoint is always the AWS cloud). Factored so the Bedrock streaming
+    watchdog shares the exact same patience budget as the OpenAI/Anthropic
+    stale-stream detector below.
+    """
+    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
+    if _cfg_stale is not None:
+        _base = _cfg_stale
+    else:
+        _base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+    _est_tokens = estimate_request_context_tokens(api_kwargs)
+    if _est_tokens > 100_000:
+        _timeout = max(_base, 300.0)
+    elif _est_tokens > 50_000:
+        _timeout = max(_base, 240.0)
+    else:
+        _timeout = _base
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+    if _reasoning_floor is not None:
+        _timeout = max(_timeout, _reasoning_floor)
+    return _timeout
+
+
 def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     """Run one non-streaming LLM request for the active api_mode and return it.
 
@@ -2091,6 +2120,24 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         result = {"response": None, "error": None}
         first_delta_fired = {"done": False}
         deltas_were_sent = {"yes": False}
+        # Wire-level liveness for the boto3 converse_stream worker: the worker
+        # thread blocks inside ``for event in event_stream`` with NO read
+        # timeout, so a provider that opens the stream then stops yielding
+        # events wedges the thread forever. on_event stamps this on EVERY
+        # yielded Bedrock event (text/tool/metadata) — the poll loop below
+        # trips a watchdog when the gap exceeds the stale timeout.
+        _bedrock_last_event = {"t": time.time()}
+        # Region captured for the poll-loop client eviction below.  Read
+        # (not popped) here so the worker's own pop inside _bedrock_call still
+        # resolves the same value.
+        _bedrock_region = api_kwargs.get("__bedrock_region__", "us-east-1")
+        # Same patience budget as the OpenAI/Anthropic stale detector.
+        _bedrock_stale_timeout = _derive_stream_stale_timeout(agent, api_kwargs)
+
+        # Cross-turn stale-stream circuit breaker (#58962): a pre-elevated
+        # streak from prior wedged turns aborts before we even start — mirrors
+        # the entry check on the OpenAI/Anthropic path below.
+        _check_stale_giveup(agent)
 
         def _fire_first():
             if not first_delta_fired["done"] and on_first_delta:
@@ -2168,6 +2215,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     on_tool_start=_on_tool,
                     on_reasoning_delta=_on_reasoning if agent.reasoning_callback or agent.stream_delta_callback else None,
                     on_interrupt_check=lambda: agent._interrupt_requested,
+                    on_event=lambda: _bedrock_last_event.__setitem__("t", time.time()),
                 )
             except Exception as e:
                 result["error"] = e
@@ -2178,6 +2226,56 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             t.join(timeout=0.3)
             if agent._interrupt_requested:
                 raise InterruptedError("Agent interrupted during Bedrock API call")
+            # Liveness watchdog: no Bedrock event for longer than the stale
+            # timeout means the stream has wedged (open socket, keep-alives but
+            # no data, or a silently hung provider).  Without this the worker
+            # blocks in ``for event in event_stream`` indefinitely.
+            _stale_elapsed = time.time() - _bedrock_last_event["t"]
+            if _stale_elapsed > _bedrock_stale_timeout:
+                logger.warning(
+                    "Bedrock stream stale for %.0fs (threshold %.0fs) — no events "
+                    "received. region=%s model=%s. Aborting call.",
+                    _stale_elapsed, _bedrock_stale_timeout,
+                    _bedrock_region, api_kwargs.get("modelId", "unknown"),
+                )
+                agent._buffer_status(
+                    f"⚠️ No events from Bedrock for {int(_stale_elapsed)}s "
+                    f"(model: {api_kwargs.get('modelId', 'unknown')}). Aborting..."
+                )
+                # Count the stale kill in the SAME cross-turn breaker as the
+                # OpenAI/Anthropic path (#58962).
+                _bump_stale_streak(agent)
+                # Best-effort: evict the region's cached bedrock-runtime client
+                # so the NEXT call reconnects with a fresh pool.  NOTE: this does
+                # NOT abort the in-flight botocore EventStream the worker thread
+                # is blocked on — botocore exposes no external cancellation for
+                # it — so the daemon worker keeps reading until its socket read
+                # ultimately errors.  We therefore end THIS call by raising
+                # below and let the streak+give-up breaker escalate across turns.
+                try:
+                    from agent.bedrock_adapter import invalidate_runtime_client
+                    invalidate_runtime_client(_bedrock_region)
+                except Exception as _inval_exc:
+                    logger.debug(
+                        "bedrock: stale client eviction failed: %s", _inval_exc
+                    )
+                # Reset the timer so a repeated trip (should the worker somehow
+                # survive) waits a fresh interval rather than re-firing instantly.
+                _bedrock_last_event["t"] = time.time()
+                # Escalate across turns: raises RuntimeError once the streak
+                # crosses HERMES_STREAM_STALE_GIVEUP, so a persistently wedged
+                # Bedrock provider aborts fast instead of re-waiting the timeout.
+                _check_stale_giveup(agent)
+                # Streak still under the give-up threshold: end THIS call with a
+                # TimeoutError so the outer retry loop / next turn re-evaluates
+                # and the streak carries forward.  Break rather than keep polling
+                # a worker we cannot abort.
+                result["error"] = TimeoutError(
+                    f"Bedrock stream produced no events for {int(_stale_elapsed)}s "
+                    f"(threshold {int(_bedrock_stale_timeout)}s) — aborting stalled "
+                    f"stream so the retry/fallback path can recover."
+                )
+                break
         # Worker exited before the poll loop observed the interrupt flag. The
         # Bedrock stream callback breaks out and returns a PARTIAL response
         # without raising on interrupt (see bedrock_adapter.py
@@ -2190,6 +2288,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             raise InterruptedError("Agent interrupted during Bedrock API call (post-worker)")
         if result["error"] is not None:
             raise result["error"]
+        # Success — clear the cross-turn breaker (#58962): Bedrock proved
+        # responsive.  Mirrors the OpenAI/Anthropic success reset below so a
+        # recovered provider doesn't carry a stale streak into later turns.
+        if result["response"] is not None:
+            _reset_stale_streak(agent)
         return result["response"]
 
     result = {"response": None, "error": None, "partial_tool_names": []}
@@ -3196,11 +3299,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     else:
         _stream_stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-    # for prefill on large contexts.  Disable the stale detector unless
-    # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
+    # for prefill on large contexts, so tolerate far longer silence than
+    # the cloud default — but a wedged local server must EVENTUALLY trip the
+    # detector rather than hang forever (an infinite timeout meant a crashed
+    # or deadlocked local endpoint stalled the session indefinitely).  900s
+    # tolerates slow prefill while still bounding a hung endpoint.  Applies
+    # unless the user explicitly set HERMES_STREAM_STALE_TIMEOUT; override the
+    # local ceiling with HERMES_LOCAL_STREAM_STALE_TIMEOUT.
     if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        _stream_stale_timeout = float("inf")
-        logger.debug("Local provider detected (%s) — stale stream timeout disabled", agent.base_url)
+        _stream_stale_timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", 900.0)
+        logger.debug(
+            "Local provider detected (%s) — stale stream timeout set to %.0fs",
+            agent.base_url, _stream_stale_timeout,
+        )
     else:
         # Scale the stale timeout for large contexts: slow models (like Opus)
         # can legitimately think for minutes before producing the first token

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -323,10 +323,16 @@ def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
     trailing date-stamp / ``-v1:0`` version suffix, so no suffix stripping is
     needed. First non-None wins; returns None for unknown models.
 
-    Known limitation: floor keys that embed a dotted version (e.g.
-    ``claude-sonnet-4.5``) will NOT match the Bedrock dashed form
-    (``claude-sonnet-4-5-...``); only floor keys with dashed/base slugs
-    (``claude-opus-4``, ``deepseek-r1``) match the Bedrock id shape.
+    The floor table mixes version-separator conventions: some keys are
+    keyed with a dashed version (``claude-opus-4``) while others embed a
+    dotted version (``claude-sonnet-4.5``, ``claude-sonnet-4.6``). Bedrock
+    always dashes the version (``claude-sonnet-4-5-v1:0``), so for every
+    candidate slug we also try the alternate version-separator form —
+    digit-dash-digit rewritten to digit-dot-digit and vice-versa — so a
+    dashed Bedrock id matches a dotted floor key (and the reverse). The
+    rewrite only touches version-number separators (a dash/dot flanked by
+    digits), never other dashes in the slug, so ``claude-sonnet`` is left
+    intact while ``4-5`` becomes ``4.5``.
     """
     from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
 
@@ -337,10 +343,20 @@ def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
         if name.startswith(prefix):
             name = name[len(prefix):]
             break
-    candidates = [name]
+    base_candidates = [name]
     if "." in name:
-        candidates.append(name.rsplit(".", 1)[1])   # claude-opus-4-6-v1:0
-        candidates.append(name.replace(".", "-", 1))  # deepseek-r1-v1:0
+        base_candidates.append(name.rsplit(".", 1)[1])   # claude-opus-4-6-v1:0
+        base_candidates.append(name.replace(".", "-", 1))  # deepseek-r1-v1:0
+    candidates: list[str] = []
+    for cand in base_candidates:
+        # Try the slug as-is plus both alternate version-separator forms.
+        # ``4-5`` <-> ``4.5`` only; a dash/dot not flanked by digits is
+        # left alone (e.g. ``claude-sonnet`` stays dashed).
+        dashed_to_dotted = re.sub(r"(?<=\d)-(?=\d)", ".", cand)
+        dotted_to_dashed = re.sub(r"(?<=\d)\.(?=\d)", "-", cand)
+        for form in (cand, dashed_to_dotted, dotted_to_dashed):
+            if form not in candidates:
+                candidates.append(form)
     for cand in candidates:
         floor = get_reasoning_stale_timeout_floor(cand)
         if floor is not None:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -287,10 +287,65 @@ def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
     else:
         _timeout = _base
     from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
-    _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+    # Resolve the model id from BOTH the OpenAI/Anthropic key (``model``) and
+    # the Bedrock key (``modelId``). OpenAI/Anthropic wins first via the ``or``
+    # chain, so those paths are unchanged. Bedrock carries the model as a
+    # dotted, region-prefixed inference-profile id (e.g.
+    # ``us.anthropic.claude-opus-4-6-v1:0``) that the floor's start-of-slug
+    # regex cannot match directly — normalize it to a canonical slug first.
+    _model_id = api_kwargs.get("model") or api_kwargs.get("modelId") or ""
+    _reasoning_floor = get_reasoning_stale_timeout_floor(_model_id)
+    if _reasoning_floor is None and api_kwargs.get("modelId"):
+        _reasoning_floor = _bedrock_reasoning_stale_floor(api_kwargs["modelId"])
     if _reasoning_floor is not None:
         _timeout = max(_timeout, _reasoning_floor)
     return _timeout
+
+
+def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
+    """Map a Bedrock inference-profile id to its reasoning stale-timeout floor.
+
+    Bedrock carries the model as a dotted, region-prefixed id such as
+    ``us.anthropic.claude-opus-4-6-v1:0``, whereas
+    :func:`get_reasoning_stale_timeout_floor` anchors its slug patterns at the
+    start of a bare slug (``claude-opus-4``). Strip the region prefix
+    (``us.``/``eu.``/``apac.``/...) and try two candidate slugs against the
+    floor:
+
+    * the segment after the provider namespace (``claude-opus-4-6-v1:0``) —
+      matches Anthropic-style slugs whose floor key excludes the provider
+      (``claude-opus-4``); and
+    * the region-stripped id with the provider dot rewritten to a dash
+      (``deepseek-r1-v1:0``) — matches provider-qualified floor keys
+      (``deepseek-r1``).
+
+    The floor's right-anchor (``$`` or ``-``/``.``/``_``) tolerates the
+    trailing date-stamp / ``-v1:0`` version suffix, so no suffix stripping is
+    needed. First non-None wins; returns None for unknown models.
+
+    Known limitation: floor keys that embed a dotted version (e.g.
+    ``claude-sonnet-4.5``) will NOT match the Bedrock dashed form
+    (``claude-sonnet-4-5-...``); only floor keys with dashed/base slugs
+    (``claude-opus-4``, ``deepseek-r1``) match the Bedrock id shape.
+    """
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+    if not model_id or not isinstance(model_id, str):
+        return None
+    name = model_id.strip().lower()
+    for prefix in ("us.", "eu.", "apac.", "ap.", "global.", "jp."):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            break
+    candidates = [name]
+    if "." in name:
+        candidates.append(name.rsplit(".", 1)[1])   # claude-opus-4-6-v1:0
+        candidates.append(name.replace(".", "-", 1))  # deepseek-r1-v1:0
+    for cand in candidates:
+        floor = get_reasoning_stale_timeout_floor(cand)
+        if floor is not None:
+            return floor
+    return None
 
 
 def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7617,7 +7617,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Process in batches of 100 with event-loop yield points to avoid
             # O(n^2) event-loop blocking when recovering thousands of watchers.
             for i, watcher in enumerate(watchers):
-                asyncio.create_task(self._run_process_watcher(watcher))
+                self._spawn_supervised(
+                    lambda w=watcher: self._run_process_watcher(w),
+                    f"process_watcher:{watcher.get('session_id')}",
+                    restart=False,
+                )
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
                 if i % 100 == 99:
                     await asyncio.sleep(0)
@@ -7625,18 +7629,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.error("Recovered watcher setup error: %s", e)
 
         # Start background session expiry watcher to finalize expired sessions
-        asyncio.create_task(self._session_expiry_watcher())
+        self._spawn_supervised(self._session_expiry_watcher, "session_expiry_watcher")
 
         # Start background kanban notifier — delivers `completed`, `blocked`,
         # `spawn_auto_blocked`, and `crashed` events to gateway subscribers
         # so human-in-the-loop workflows hear back without polling.
-        asyncio.create_task(self._kanban_notifier_watcher())
+        self._spawn_supervised(self._kanban_notifier_watcher, "kanban_notifier_watcher")
 
         # Start background kanban dispatcher — spawns workers for ready
         # tasks. Gated by `kanban.dispatch_in_gateway` (default True).
         # When false, users run `hermes kanban daemon` externally or
         # simply don't use kanban; this loop becomes a no-op.
-        asyncio.create_task(self._kanban_dispatcher_watcher())
+        self._spawn_supervised(self._kanban_dispatcher_watcher, "kanban_dispatcher_watcher")
 
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:
@@ -7645,19 +7649,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 len(self._failed_platforms),
                 ", ".join(p.value for p in self._failed_platforms),
             )
-        asyncio.create_task(self._platform_reconnect_watcher())
+        self._spawn_supervised(self._platform_reconnect_watcher, "platform_reconnect_watcher")
 
         # Start background handoff watcher — picks up CLI sessions marked
         # handoff_state='pending' in state.db and re-binds them to the
         # destination platform's home channel, then forges a synthetic user
         # turn so the agent kicks off the new chat.
-        asyncio.create_task(self._handoff_watcher())
+        self._spawn_supervised(self._handoff_watcher, "handoff_watcher")
 
         # Start background async-delegation watcher — drains completion events
         # from delegate_task(background=true) subagents and injects each
         # result back into its originating session as a new turn, covering the
         # idle case where the subagent finishes with no agent turn running.
-        asyncio.create_task(self._async_delegation_watcher())
+        self._spawn_supervised(self._async_delegation_watcher, "async_delegation_watcher")
 
         # Start the scale-to-zero idle watcher ONLY when this instance is opted
         # in (the NAS "Labs" HERMES_SCALE_TO_ZERO stamp), messaging is
@@ -7671,7 +7675,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "scale-to-zero: armed (idle timeout %.0fs) — watching for idle",
                     self._scale_to_zero_idle_timeout_seconds(),
                 )
-                asyncio.create_task(self._scale_to_zero_watcher())
+                self._spawn_supervised(self._scale_to_zero_watcher, "scale_to_zero_watcher")
             else:
                 # Surface WHY an OPTED-IN instance didn't arm (a non-opted instance
                 # not arming is normal — stay silent there). Without this, a failed
@@ -7686,11 +7690,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # left behind by a prior instantiation (durable-volume restart, NS-570)
         # is ignored via its instantiation epoch; only a current-epoch marker
         # engages drain on the first tick.
-        asyncio.create_task(self._drain_control_watcher())
+        self._spawn_supervised(self._drain_control_watcher, "drain_control_watcher")
 
         logger.info("Press Ctrl+C to stop")
         
         return True
+
+    _MAX_SUPERVISED_RESTARTS = 5
+
+    def _spawn_supervised(self, coro_factory, name, *, restart=True, _attempt=0):
+        """Launch a long-lived background task with task-level supervision.
+
+        Complements upstream's per-iteration inner-loop try/except (which only
+        guards a single loop-body) by covering what that CANNOT: an exception
+        raised in the watcher's OUTER ``while self._running:`` loop or its
+        pre-try setup region, plus task-level death generally. A bare
+        ``asyncio.create_task`` drops such an exception on the floor — no log,
+        no restart, the watcher silently gone. This retains the handle in
+        ``self._background_tasks``, logs any crash, and restarts with capped
+        exponential backoff up to ``_MAX_SUPERVISED_RESTARTS`` consecutive
+        failures.
+        """
+        if getattr(self, "_background_tasks", None) is None:
+            self._background_tasks = set()
+
+        # Deliberately do NOT pass name= to create_task — some test doubles mock
+        # create_task with a signature that rejects the name kwarg.
+        task = asyncio.create_task(coro_factory())
+        self._background_tasks.add(task)
+
+        def _done(t):
+            self._background_tasks.discard(t)
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is None:
+                # Clean return == deliberate shutdown or a self-disabling watcher
+                # (e.g. a gated no-op that returns synchronously). Respawning here
+                # would busy-spin such a watcher — so NEVER restart on clean exit.
+                return
+            logger.error("Supervised task %s died: %r", name, exc, exc_info=exc)
+            if restart and self._running:
+                if _attempt >= self._MAX_SUPERVISED_RESTARTS:
+                    logger.error(
+                        "Supervised task %s died %d times consecutively — giving up restarts",
+                        name,
+                        _attempt,
+                    )
+                    return
+                backoff = min(60, 2 ** min(_attempt, 6))
+
+                async def _respawn():
+                    await asyncio.sleep(backoff)
+                    if self._running:
+                        self._spawn_supervised(
+                            coro_factory, name, restart=restart, _attempt=_attempt + 1
+                        )
+
+                respawn_task = asyncio.create_task(_respawn())
+                self._background_tasks.add(respawn_task)
+                respawn_task.add_done_callback(self._background_tasks.discard)
+
+        task.add_done_callback(_done)
+        return task
 
     async def _handoff_watcher(self, interval: float = 2.0) -> None:
         """Background task that processes pending CLI→gateway session handoffs.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7697,6 +7697,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return True
 
     _MAX_SUPERVISED_RESTARTS = 5
+    # A task that ran at least this long before crashing is treated as having
+    # been HEALTHY — its crash is a fresh, isolated failure rather than part of
+    # a rapid crash-loop, so the consecutive-restart counter resets to 0. Only
+    # crashes that happen within this window of a (re)spawn accumulate toward
+    # ``_MAX_SUPERVISED_RESTARTS``. Without this, a long-lived launchd daemon
+    # whose watcher crashes a handful of times over days would hit the cap and
+    # be permanently abandoned (NS: silent loss of platform-reconnect / kanban /
+    # handoff for the rest of the process life).
+    _SUPERVISED_HEALTHY_SECS = 300
 
     def _spawn_supervised(self, coro_factory, name, *, restart=True, _attempt=0):
         """Launch a long-lived background task with task-level supervision.
@@ -7708,11 +7717,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``asyncio.create_task`` drops such an exception on the floor — no log,
         no restart, the watcher silently gone. This retains the handle in
         ``self._background_tasks``, logs any crash, and restarts with capped
-        exponential backoff up to ``_MAX_SUPERVISED_RESTARTS`` consecutive
-        failures.
+        exponential backoff up to ``_MAX_SUPERVISED_RESTARTS`` failures in rapid
+        succession (each within ``_SUPERVISED_HEALTHY_SECS`` of its restart).
+        The counter resets after any run that stayed healthy for at least
+        ``_SUPERVISED_HEALTHY_SECS`` — so a long-lived daemon that crashes
+        occasionally over days is never permanently abandoned.
         """
         if getattr(self, "_background_tasks", None) is None:
             self._background_tasks = set()
+
+        # Monotonic spawn timestamp captured per spawn: the ``_done`` callback
+        # uses it to distinguish a rapid crash-loop from a healthy-run-then-crash.
+        _started = time.monotonic()
 
         # Deliberately do NOT pass name= to create_task — some test doubles mock
         # create_task with a signature that rejects the name kwarg.
@@ -7731,20 +7747,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
             logger.error("Supervised task %s died: %r", name, exc, exc_info=exc)
             if restart and self._running:
-                if _attempt >= self._MAX_SUPERVISED_RESTARTS:
+                ran_for = time.monotonic() - _started
+                if ran_for >= self._SUPERVISED_HEALTHY_SECS:
+                    # Ran healthily for a while before crashing — this is a
+                    # FRESH failure, not part of a rapid crash-loop. Reset the
+                    # consecutive counter so a daemon that crashes a handful of
+                    # times over days is never permanently abandoned.
+                    effective_attempt = 0
+                else:
+                    effective_attempt = _attempt
+                if effective_attempt >= self._MAX_SUPERVISED_RESTARTS:
                     logger.error(
-                        "Supervised task %s died %d times consecutively — giving up restarts",
+                        "Supervised task %s died %d times in rapid succession "
+                        "(each within %ds of restart) — giving up restarts",
                         name,
-                        _attempt,
+                        effective_attempt,
+                        self._SUPERVISED_HEALTHY_SECS,
                     )
                     return
-                backoff = min(60, 2 ** min(_attempt, 6))
+                backoff = min(60, 2 ** min(effective_attempt, 6))
 
                 async def _respawn():
                     await asyncio.sleep(backoff)
                     if self._running:
                         self._spawn_supervised(
-                            coro_factory, name, restart=restart, _attempt=_attempt + 1
+                            coro_factory,
+                            name,
+                            restart=restart,
+                            _attempt=effective_attempt + 1,
                         )
 
                 respawn_task = asyncio.create_task(_respawn())

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -13,6 +13,7 @@ concurrently under distinct configurations).
 
 import hashlib
 import json
+import logging
 import os
 import shlex
 import signal
@@ -23,7 +24,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home, _get_platform_default_hermes_home
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 from utils import atomic_json_write
 
 if sys.platform == "win32":
@@ -45,6 +46,84 @@ _WINDOWS_LOCK_OFFSET = 1024 * 1024
 _GATEWAY_RUNNING_PID_CACHE_TTL_SECONDS = 1.0
 _gateway_running_pid_cache_lock = threading.Lock()
 _gateway_running_pid_cache: dict[tuple[str, bool, bool], tuple[float, tuple[Any, ...], Optional[int]]] = {}
+
+logger = logging.getLogger(__name__)
+
+
+class StormInfo(NamedTuple):
+    """Result of a respawn-storm check: how many starts, over what window, and
+    the backoff the caller should sleep to break the storm."""
+
+    count: int
+    window_s: float
+    backoff_s: float
+
+
+def _get_starts_log_path() -> Path:
+    """Path to the append-only gateway-start ledger used by the respawn-storm
+    breaker. Distinct from ``restart_loop.json`` (the auto-resume guard) — no
+    collision."""
+    return get_hermes_home() / "gateway-starts.log"
+
+
+def record_start_and_check_storm(
+    max_starts: int = 5, window_s: float = 120.0, *, backoff_cap_s: float = 300.0
+) -> Optional[StormInfo]:
+    """Record this gateway start and report whether a respawn storm is underway.
+
+    Appends the current UTC timestamp to the starts-log, prunes entries older
+    than ``window_s``, and ring-buffers the file so it can't grow unbounded.
+    Returns a :class:`StormInfo` when more than ``max_starts`` starts landed in
+    the window (with an exponential backoff capped at ``backoff_cap_s``), else
+    ``None``.
+
+    Best-effort: any bookkeeping failure is logged and swallowed so a broken
+    ledger can never crash gateway startup.
+    """
+    try:
+        path = _get_starts_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        now = datetime.now(timezone.utc).timestamp()
+
+        existing: list[float] = []
+        if path.exists():
+            for line in path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    existing.append(float(line))
+                except ValueError:
+                    continue
+
+        existing.append(now)
+
+        # Keep only starts within the sliding window for the storm decision.
+        recent = [ts for ts in existing if now - ts <= window_s]
+
+        # Ring-buffer what we persist so the file stays bounded even if the
+        # window is wide or starts are frequent.
+        keep = max(max_starts * 4, 40)
+        to_write = existing[-keep:]
+
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            "\n".join(repr(ts) for ts in to_write) + "\n", encoding="utf-8"
+        )
+        os.replace(tmp, path)
+
+        if len(recent) > max_starts:
+            backoff = min(
+                backoff_cap_s, 5.0 * (2 ** min(len(recent) - max_starts, 6))
+            )
+            return StormInfo(count=len(recent), window_s=window_s, backoff_s=backoff)
+        return None
+    except Exception as _e:
+        logger.debug(
+            "respawn-storm breaker bookkeeping failed (non-fatal): %s", _e
+        )
+        return None
 
 
 def _get_process_hermes_home() -> Path:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3982,7 +3982,17 @@ def generate_launchd_plist() -> str:
     
     <key>KeepAlive</key>
     <true/>
-    
+
+    <!-- ThrottleInterval raises launchd's default 10s minimum respawn interval
+         to 30s so a crash-looping gateway can't hammer launchd into a rapid
+         respawn storm; ExitTimeOut gives the gateway 25s of graceful-drain
+         headroom before launchd escalates from SIGTERM to SIGKILL on stop. -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>ExitTimeOut</key>
+    <integer>25</integer>
+
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     
@@ -4855,6 +4865,39 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
         _exit_diag("atexit.hook", sys_exc=repr(sys.exc_info()))
 
     _atexit.register(_atexit_hook)
+
+    # Portable, app-level respawn-storm circuit breaker. launchd/systemd have
+    # their own throttles, but this backstop works on every platform (and covers
+    # supervisors that lack a respawn floor). Set HERMES_GATEWAY_MAX_STARTS<=0 to
+    # disable. Kept best-effort: a bookkeeping failure must never block startup.
+    try:
+        import time as _time
+
+        from gateway.status import record_start_and_check_storm
+
+        try:
+            _max_starts = int(os.getenv("HERMES_GATEWAY_MAX_STARTS", "5"))
+        except ValueError:
+            _max_starts = 5
+        try:
+            _win = float(os.getenv("HERMES_GATEWAY_START_WINDOW_S", "120"))
+        except ValueError:
+            _win = 120.0
+        _storm = (
+            record_start_and_check_storm(max_starts=_max_starts, window_s=_win)
+            if _max_starts > 0
+            else None
+        )
+        if _storm is not None:
+            logger.warning(
+                "Gateway (re)started %d times in %.0fs — backing off %.0fs to break a respawn storm.",
+                _storm.count,
+                _storm.window_s,
+                _storm.backoff_s,
+            )
+            _time.sleep(_storm.backoff_s)
+    except Exception as _be:
+        logger.debug("respawn-storm breaker check failed (non-fatal): %s", _be)
 
     success = False
     try:

--- a/tests/agent/test_bedrock_interrupt_post_worker.py
+++ b/tests/agent/test_bedrock_interrupt_post_worker.py
@@ -22,9 +22,17 @@ class _FakeAgent:
     _disable_streaming = False
     reasoning_callback = None
     stream_delta_callback = None
+    # Real AIAgent always carries these; the streaming stale-timeout derivation
+    # (chat_completion_helpers._derive_stream_stale_timeout) reads them.
+    provider = "bedrock"
+    model = "anthropic.claude-3-sonnet-20240229-v1:0"
+    _consecutive_stale_streams = 0
 
     def _has_stream_consumers(self):
         return False
+
+    def _buffer_status(self, *a, **k):
+        pass
 
     def _claim_stream_writer(self):
         return 1

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -840,3 +840,64 @@ class TestPlatformSlashCommand:
         runner = _make_runner()
         out = await runner._handle_platform_command(self._make_event("/platform"))
         assert "Gateway platforms" in out
+
+
+# --- Supervised task wrapper (_spawn_supervised) ---
+
+class TestSpawnSupervised:
+    """Verify the task-level supervision wrapper around watcher launches."""
+
+    @pytest.mark.asyncio
+    async def test_clean_synchronous_return_is_not_respawned(self):
+        # A supervised coro that returns immediately (clean exit) must be
+        # invoked EXACTLY ONCE — a clean return means deliberate shutdown or a
+        # gated no-op watcher; respawning it would busy-spin the event loop.
+        runner = _make_runner()
+        calls = {"n": 0}
+
+        async def _coro():
+            calls["n"] += 1
+            return
+
+        runner._spawn_supervised(lambda: _coro(), "clean_watcher")
+
+        # Drive the loop so the done-callback fires; if it (wrongly) respawned,
+        # the count would keep climbing across these ticks.
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+        assert calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_exception_restart_bounded_by_ceiling(self, monkeypatch):
+        # A coro that always raises is restarted with backoff, but the restart
+        # chain is capped: initial launch + _MAX_SUPERVISED_RESTARTS respawns.
+        runner = _make_runner()
+        calls = {"n": 0}
+
+        # Collapse the backoff sleeps to a single loop-yield so the restart
+        # chain converges fast. Bind the real sleep BEFORE patching so the
+        # replacement still yields control (and doesn't recurse into itself).
+        real_sleep = asyncio.sleep
+
+        async def _instant_sleep(_delay):
+            await real_sleep(0)
+
+        monkeypatch.setattr("gateway.run.asyncio.sleep", _instant_sleep)
+
+        async def _coro():
+            calls["n"] += 1
+            raise RuntimeError("boom")
+
+        runner._spawn_supervised(lambda: _coro(), "always_raises")
+
+        expected = runner._MAX_SUPERVISED_RESTARTS + 1
+        for _ in range(500):
+            await real_sleep(0)
+            if calls["n"] >= expected:
+                break
+        # A few extra ticks to prove the chain has stopped (no over-restart).
+        for _ in range(20):
+            await real_sleep(0)
+
+        assert calls["n"] == expected

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -901,3 +901,51 @@ class TestSpawnSupervised:
             await real_sleep(0)
 
         assert calls["n"] == expected
+
+    @pytest.mark.asyncio
+    async def test_healthy_run_then_crash_resets_restart_counter(self, monkeypatch):
+        # A watcher that runs HEALTHILY (>= _SUPERVISED_HEALTHY_SECS) before
+        # each crash must NOT be abandoned at the ceiling: every healthy run
+        # resets the consecutive-failure counter, so the daemon keeps
+        # restarting it well past _MAX_SUPERVISED_RESTARTS. This is the
+        # long-lived-launchd-daemon guarantee — a watcher that crashes a
+        # handful of times over days is never permanently dropped.
+        runner = _make_runner()
+
+        # Treat every run as "healthy": with the floor at 0s, any positive
+        # real elapsed (ran_for >= 0.0) counts as a fresh, isolated failure,
+        # so the effective attempt resets to 0 on each crash.
+        monkeypatch.setattr(runner, "_SUPERVISED_HEALTHY_SECS", 0.0)
+
+        real_sleep = asyncio.sleep
+
+        async def _instant_sleep(_delay):
+            await real_sleep(0)
+
+        monkeypatch.setattr("gateway.run.asyncio.sleep", _instant_sleep)
+
+        # Crash more times than the cumulative cap would ever allow, then
+        # return cleanly to terminate the chain.
+        crash_budget = runner._MAX_SUPERVISED_RESTARTS + 3
+        calls = {"n": 0}
+
+        async def _coro():
+            calls["n"] += 1
+            if calls["n"] <= crash_budget:
+                raise RuntimeError("boom")
+            return
+
+        runner._spawn_supervised(lambda: _coro(), "healthy_then_crash")
+
+        target = crash_budget + 1  # crash_budget failures + one final clean run
+        for _ in range(2000):
+            await real_sleep(0)
+            if calls["n"] >= target:
+                break
+        for _ in range(20):
+            await real_sleep(0)
+
+        # Under the OLD cumulative cap this would have stopped at
+        # _MAX_SUPERVISED_RESTARTS + 1; the reset lets it run to completion.
+        assert calls["n"] == target
+        assert calls["n"] > runner._MAX_SUPERVISED_RESTARTS + 1

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1660,3 +1661,63 @@ class TestGatewayBusyDerivation:
             assert status.derive_gateway_drainable(
                 gateway_running=True, gateway_state=state
             ) is False, state
+
+
+class TestRespawnStormBreaker:
+    def test_no_storm_under_threshold(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for _ in range(5):
+            result = status.record_start_and_check_storm(
+                max_starts=5, window_s=120.0
+            )
+            assert result is None
+
+    def test_storm_detected_over_threshold(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        results = [
+            status.record_start_and_check_storm(max_starts=5, window_s=120.0)
+            for _ in range(7)
+        ]
+        last = results[-1]
+        assert last is not None
+        assert last.count >= 6
+        assert last.backoff_s > 0
+
+    def test_old_starts_pruned_outside_window(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        log_path = status._get_starts_log_path()
+        old = time.time() - 10000
+        log_path.write_text(
+            "\n".join(repr(old) for _ in range(10)) + "\n", encoding="utf-8"
+        )
+        # All seeded entries are far outside the window, so a single new start
+        # cannot exceed the threshold.
+        result = status.record_start_and_check_storm(max_starts=5, window_s=120.0)
+        assert result is None
+
+    def test_starts_log_written_atomically(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for _ in range(6):
+            status.record_start_and_check_storm(max_starts=5, window_s=120.0)
+
+        # No leftover temp file from the atomic write.
+        assert not list(tmp_path.glob("*.tmp"))
+
+        log_path = status._get_starts_log_path()
+        assert log_path.exists()
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            float(line)  # every persisted line must parse as a float
+
+
+class TestLaunchdPlistRespawnGovernance:
+    def test_plist_has_throttle_interval(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.gateway import generate_launchd_plist
+
+        plist = generate_launchd_plist()
+        assert "<key>ThrottleInterval</key>" in plist
+        assert "<key>ExitTimeOut</key>" in plist
+        assert "<key>KeepAlive</key>" in plist

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1966,3 +1966,171 @@ class TestBedrockIamStreamingFallback:
 
         client.converse.assert_not_called()
         assert getattr(agent, "_disable_streaming", False) is False
+
+
+class _BlockingEventStream:
+    """Mock boto3 ``converse_stream()`` response whose event iterator blocks
+    forever — simulates a provider that opens the stream then stops yielding
+    events. The worker thread sits inside ``for event in event_stream`` exactly
+    as a wedged Bedrock stream would, giving the liveness watchdog something to
+    trip on."""
+
+    def __init__(self, release):
+        self._release = release
+
+    def get(self, key, default=None):
+        if key == "stream":
+            return self
+        return default
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        # Never yields — blocks until the test releases it (teardown) so the
+        # daemon worker can exit instead of leaking a truly-hung thread.
+        self._release.wait(timeout=30)
+        raise StopIteration
+
+
+def test_on_event_fires_per_bedrock_event():
+    """FIX 1: on_event fires once for EVERY yielded Bedrock event — text,
+    tool-input delta, messageStop, and metadata alike — providing wire-level
+    liveness (not just text deltas)."""
+    from agent.bedrock_adapter import stream_converse_with_callbacks
+
+    events = [
+        {"contentBlockDelta": {"delta": {"text": "a"}}},
+        {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "t1", "name": "x"}}}},
+        {"contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 1}}},
+    ]
+    calls = {"n": 0}
+
+    stream_converse_with_callbacks(
+        {"stream": iter(events)},
+        on_event=lambda: calls.__setitem__("n", calls["n"] + 1),
+    )
+
+    assert calls["n"] == len(events)
+
+
+def test_on_event_exception_is_swallowed():
+    """FIX 1: a raising on_event callback must never abort the stream."""
+    from agent.bedrock_adapter import stream_converse_with_callbacks
+
+    events = [{"messageStop": {"stopReason": "end_turn"}}]
+
+    def _boom():
+        raise ValueError("liveness hook blew up")
+
+    resp = stream_converse_with_callbacks({"stream": iter(events)}, on_event=_boom)
+    assert resp is not None
+    assert resp.choices[0].finish_reason == "stop"
+
+
+class TestBedrockStreamLivenessWatchdog:
+    """FIX 1: Bedrock streaming participates in the #58962 cross-turn stale
+    breaker and no longer hangs when the stream stops yielding events."""
+
+    def _make_bedrock_agent(self):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="anthropic.claude-3-sonnet-20240229-v1:0",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "bedrock_converse"
+        agent._interrupt_requested = False
+        return agent
+
+    def test_stalled_stream_bumps_streak_and_aborts(self, monkeypatch):
+        """A Bedrock stream that opens then stops yielding events trips the
+        watchdog: it bumps the cross-turn stale streak and raises TimeoutError
+        instead of hanging forever."""
+        pytest.importorskip("botocore", reason="botocore required for Bedrock tests")
+        import threading as _t
+
+        # Tiny stale timeout so the watchdog trips quickly; give-up threshold
+        # kept above 1 so a single call raises TimeoutError (not the breaker).
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.5")
+        monkeypatch.setenv("HERMES_STREAM_STALE_GIVEUP", "5")
+
+        agent = self._make_bedrock_agent()
+        agent._consecutive_stale_streams = 0
+        release = _t.Event()
+
+        client = MagicMock()
+        client.converse_stream.return_value = _BlockingEventStream(release)
+
+        try:
+            with patch(
+                "agent.bedrock_adapter._get_bedrock_runtime_client",
+                return_value=client,
+            ):
+                with pytest.raises(TimeoutError):
+                    agent._interruptible_streaming_api_call(
+                        {"modelId": agent.model, "messages": []}
+                    )
+        finally:
+            release.set()
+
+        # Watchdog counted exactly one stale kill in the cross-turn breaker.
+        assert agent._consecutive_stale_streams == 1
+
+    def test_pre_elevated_streak_aborts_before_streaming(self, monkeypatch):
+        """A streak already past the give-up threshold aborts at entry with
+        RuntimeError — Bedrock never even opens a stream (cross-turn breaker)."""
+        pytest.importorskip("botocore", reason="botocore required for Bedrock tests")
+
+        monkeypatch.setenv("HERMES_STREAM_STALE_GIVEUP", "5")
+
+        agent = self._make_bedrock_agent()
+        agent._consecutive_stale_streams = 5
+
+        client = MagicMock()
+        with patch(
+            "agent.bedrock_adapter._get_bedrock_runtime_client",
+            return_value=client,
+        ):
+            with pytest.raises(RuntimeError, match="unresponsive"):
+                agent._interruptible_streaming_api_call(
+                    {"modelId": agent.model, "messages": []}
+                )
+
+        client.converse_stream.assert_not_called()
+
+    def test_successful_stream_resets_streak(self, monkeypatch):
+        """A Bedrock stream that completes normally clears any prior stale
+        streak so a recovered provider doesn't carry it into later turns."""
+        pytest.importorskip("botocore", reason="botocore required for Bedrock tests")
+
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "60")
+
+        agent = self._make_bedrock_agent()
+        agent._consecutive_stale_streams = 3  # simulate a prior wedged streak
+
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "hi"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 1}}},
+        ]
+        client = MagicMock()
+        client.converse_stream.return_value = {"stream": iter(events)}
+
+        with patch(
+            "agent.bedrock_adapter._get_bedrock_runtime_client",
+            return_value=client,
+        ):
+            response = agent._interruptible_streaming_api_call(
+                {"modelId": agent.model, "messages": []}
+            )
+
+        assert response.choices[0].message.content == "hi"
+        assert agent._consecutive_stale_streams == 0

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -2134,3 +2134,46 @@ class TestBedrockStreamLivenessWatchdog:
 
         assert response.choices[0].message.content == "hi"
         assert agent._consecutive_stale_streams == 0
+
+
+class TestBedrockReasoningStaleFloor:
+    """The Bedrock inference-profile id -> reasoning stale-timeout floor
+    normalizer must match floor-table keys regardless of whether the model
+    is keyed with a dashed version (``claude-opus-4``) or a dotted version
+    (``claude-sonnet-4.5``). Bedrock always dashes the version, so the
+    normalizer has to try the alternate separator form."""
+
+    @pytest.mark.parametrize(
+        "model_id, expected",
+        [
+            # opus is keyed dashed/base (``claude-opus-4`` -> 240) and
+            # matches the Bedrock dashed id unchanged.
+            ("us.anthropic.claude-opus-4-6-v1:0", 240.0),
+            # sonnet is keyed DOTTED (``claude-sonnet-4.5`` /
+            # ``claude-sonnet-4.6`` -> 180). The Bedrock dashed id must
+            # now resolve via the alternate version-separator form.
+            ("us.anthropic.claude-sonnet-4-5-v1:0", 180.0),
+            ("us.anthropic.claude-sonnet-4-6-v1:0", 180.0),
+            # region prefix variations still strip correctly.
+            ("eu.anthropic.claude-sonnet-4-5-v1:0", 180.0),
+        ],
+    )
+    def test_bedrock_reasoning_models_resolve_floor(self, model_id, expected):
+        from agent.chat_completion_helpers import _bedrock_reasoning_stale_floor
+
+        assert _bedrock_reasoning_stale_floor(model_id) == expected
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            # Non-reasoning Bedrock model -> no floor.
+            "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+            "us.amazon.nova-lite-v1:0",
+            "",
+            None,
+        ],
+    )
+    def test_non_reasoning_bedrock_models_return_none(self, model_id):
+        from agent.chat_completion_helpers import _bedrock_reasoning_stale_floor
+
+        assert _bedrock_reasoning_stale_floor(model_id) is None


### PR DESCRIPTION
## Gateway & streaming reliability hardening (rebased on v0.18.2)

Three reliability fixes for "the daemon is alive but not doing its job" failure modes running the gateway as a long-lived launchd service. Rebased onto current `main` (`bcea5371c`); supersedes the stale #51876. Several fixes from that earlier PR are now in `main` (upstream built equivalents: the OpenAI-path stall watchdog via the #58962 give-up breaker, the tool-batch deadline, the Telegram polling heartbeat, the codex null-output fix) — this PR is only the gaps that remain open at this tip.

### 1. Bedrock streaming has no liveness watchdog (and is excluded from #58962)
`agent/chat_completion_helpers.py`, `agent/bedrock_adapter.py`
- The Bedrock streaming branch polls only for interrupt and `return`s before `_check_stale_giveup`, so a wedged Bedrock stream (connects, then yields no events, throws nothing) hangs with no liveness detection and no cross-turn breaker. Added an `on_event` hook to `stream_converse_with_callbacks` (fires per yielded event = true wire-level liveness), drove a stale timer from it, and wired Bedrock **into the existing #58962 breaker**: entry `_check_stale_giveup`, `_bump_stale_streak` on stall, raise to end the call, and `_reset_stale_streak` on success. `invalidate_runtime_client` can't abort the in-flight botocore `EventStream`, so ending the call lets the streak escalate across turns exactly like the OpenAI path.
- Local providers (Ollama/oMLX/llama-cpp) still got `float("inf")` stale timeout (watchdog disabled) → a wedged local server hangs. Now a finite ceiling, `HERMES_LOCAL_STREAM_STALE_TIMEOUT` (default 900s).

### 2. Long-lived gateway watcher tasks aren't supervised
`gateway/run.py`
- `main` wraps each watcher's inner loop in try/except (good), but the nine long-lived watchers in `start()` are launched with bare `asyncio.create_task` — no handle, no exception logging, no restart. A raise in `_platform_reconnect_watcher`'s outer `while self._running:` loop or its pre-`try` region still dies silently, permanently losing platform reconnection. Added a `_spawn_supervised` helper (track + log + bounded-backoff restart; no respawn on a clean return, to avoid busy-spin) and routed all nine through it.

### 3. launchd respawn storm
`hermes_cli/gateway.py`, `gateway/status.py`
- The launchd plist uses unconditional `KeepAlive <true/>` with no `ThrottleInterval`, so a repeatedly-SIGTERM'd gateway is revived at launchd's 10s floor with nothing to dampen the spin (~40 restarts in 7 min observed). `main`'s new `restart_loop_guard` only skips session auto-resume and never throttles the boot. Added `ThrottleInterval=30` + `ExitTimeOut=25`, plus `record_start_and_check_storm` — a portable circuit breaker (atomic `gateway-starts.log`, backs off when too many starts land in a window; env `HERMES_GATEWAY_MAX_STARTS`/`_START_WINDOW_S`). Writes a different file than `restart_loop_guard` — no collision.

## Test plan
- `pytest tests/run_agent/test_streaming.py tests/agent/test_bedrock_interrupt_post_worker.py tests/gateway/test_platform_reconnect.py tests/gateway/test_status.py` — 191 passing, incl. new regressions for the Bedrock liveness/streak integration, supervised-restart bounds, and the respawn-storm breaker + plist throttle keys.
- Running live on macOS launchd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)