### PR TITLE
fix(desktop): stop button sends interrupt to wrong session + stale events re-arm busy

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -249,6 +249,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
               }
 
               if (busy) {
+                // Don't re-arm busy from a stale session.info if the user
+                // just clicked Stop (interrupted=true). The backend's
+                // cooperative interrupt may not have propagated yet, so
+                // running is still true in the heartbeat. The turn's
+                // finally block will emit running=false to clear busy.
+                if (state.interrupted) {
+                  return state
+                }
+
                 return {
                   ...state,
                   busy,
@@ -307,14 +316,27 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           triggerHaptic('streamStart')
         }
 
-        updateSessionState(sessionId, state => ({
-          ...state,
-          busy: true,
-          awaitingResponse: true,
-          sawAssistantPayload: false,
-          interrupted: false,
-          turnStartedAt: Date.now()
-        }))
+        updateSessionState(sessionId, state => {
+          // If the user clicked Stop (cancelRun set interrupted=true), don't
+          // let a stale message.start from a chained turn (goal follow-up,
+          // completion drain) or an in-flight LLM response re-arm busy.
+          // The interrupt is user intent — the backend's cooperative cancel
+          // may not have propagated yet, so its events are stale. The turn's
+          // finally block will emit session.info with running=false to clear
+          // busy for real once the agent loop actually exits.
+          if (state.interrupted) {
+            return state
+          }
+
+          return {
+            ...state,
+            busy: true,
+            awaitingResponse: true,
+            sawAssistantPayload: false,
+            interrupted: false,
+            turnStartedAt: Date.now()
+          }
+        })
 
         if (isActiveEvent) {
           setTurnStartedAt(Date.now())

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -514,7 +514,16 @@ export function usePromptActions({
   )
 
   const cancelRun = useCallback(async () => {
-    const sessionId = activeSessionId || activeSessionIdRef.current
+    // Read from the ref, not the closure-captured `activeSessionId`. The
+    // actions bag is a stable ref mutated in place (Object.assign on each
+    // ContribWiring render), and ChatRoutesSurface is memoized on that stable
+    // ref — so it does NOT re-render when activeSessionId changes, which means
+    // the ChatView element's onCancel prop holds a stale cancelRun closure.
+    // The closure's `activeSessionId` can be a previous session's id (or null
+    // from a new-chat draft), sending session.interrupt to the wrong session.
+    // The ref is updated via useEffect on every activeSessionId change, so it
+    // always reflects the current session — same pattern submitText uses.
+    const sessionId = activeSessionIdRef.current
 
     const releaseBusy = () => {
       setMutableRef(busyRef, false)
@@ -589,7 +598,6 @@ export function usePromptActions({
       notifyError(stopError, copy.stopFailed)
     }
   }, [
-    activeSessionId,
     activeSessionIdRef,
     busyRef,
     copy.stopFailed,


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop app's Stop button not canceling the running inference turn, broken by the `ChatRoutesSurface` memo refactor (`0f922002e` / `860a3f67b`).

Two coupled fixes:

**1. Stale `cancelRun` closure sends `session.interrupt` to the wrong session**

The contrib refactor introduced an `actions` stable-ref pattern: `actionsRef.current` is `Object.assign`'d in place each render so memoized surfaces don't re-render. The intent is that surfaces read `actions.*` lazily at call time. But `<ChatView onCancel={actions.onCancel} />` captures the value eagerly at element creation time. Since `ChatRoutesSurface` is `memo`'d on `actions` (stable ref identity), it does NOT re-render when `activeSessionId` changes — so the `chatView` element's `onCancel` prop holds a stale `cancelRun` closure with a stale `activeSessionId`.

The stale `cancelRun` reads `activeSessionId` from its closure (the value at creation time), which can be a previous session's id or `null` from a new-chat draft. It sends `session.interrupt` with that stale id — the backend interrupts the wrong session (or none), and the real inference keeps running.

`submitText` didn't have this problem because it already reads `activeSessionIdRef.current` (updated via `useEffect`), not the closure value. `cancelRun` was the odd one out — it used `activeSessionId || activeSessionIdRef.current`, prioritizing the stale closure.

**Fix:** `cancelRun` now reads `activeSessionIdRef.current` directly, matching `submitText`'s pattern. Removed `activeSessionId` from its dep array.

**2. Gateway events re-arm `busy` after the user clicks Stop**

`cancelRun` sets `interrupted: true, busy: false` optimistically. But the backend's interrupt is cooperative — `agent.interrupt()` sets `_interrupt_requested`, and the agent only checks it at the top of the next loop iteration. Between the optimistic cancel and the agent actually exiting, two event types could re-arm `busy: true`:

- **`message.start`** (from a chained turn — goal follow-up, completion drain — that fires after the interrupted turn's `finally` block): unconditionally set `busy: true, interrupted: false`, wiping the cancel
- **`session.info` with `running: true`** (heartbeat while the cooperative interrupt hasn't propagated): set `busy: true` without checking `interrupted`

**Fix:** both handlers now check `state.interrupted` — if the user just clicked Stop, stale backend events are ignored until the turn's `finally` block emits `running: false` to clear `busy` for real. `interrupted` is cleared to `false` on the next explicit `prompt.submit` (already handled in `submit.ts`). `completeAssistantMessage` already checked `state.interrupted` correctly.

## Related Issue

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts` — `cancelRun` reads `activeSessionIdRef.current` instead of stale closure `activeSessionId`; removed `activeSessionId` from dep array
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts` — `message.start` handler checks `state.interrupted` before re-arming `busy: true`; `session.info` running→busy handler checks `state.interrupted` before re-arming

## How to Test

1. Start a long-running turn in the desktop app (e.g. "write a long essay")
2. Click the Stop button (square icon in the composer)
3. The UI should go neutral and the inference should actually stop
4. Switch sessions, start a turn in session A, switch to session B, click Stop — should interrupt session B (the one you're looking at), not session A
5. `cd apps/desktop && npx vitest run src/app/session/hooks/use-prompt-actions/index.test.tsx src/app/session/hooks/use-message-stream/` — 81 tests pass

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the changes
- [x] Tests pass locally
- [x] No new dependencies
- [x] No new core tools or env vars
