### PR TITLE
feat(dev-sandbox): add --from DIR to seed sandbox HERMES_HOME

### DIFF
--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -15,6 +15,10 @@
 #   scripts/dev-sandbox.sh --persistent hermes desktop
 #   scripts/dev-sandbox.sh --persistent -- npm run dev
 #
+# Seed the sandbox HERMES_HOME from an existing directory (e.g. your main
+# ~/.hermes) so config, sessions, skills, etc. are pre-populated:
+#   scripts/dev-sandbox.sh --from ~/.hermes hermes desktop
+#
 # Override the app name (default: HermesSandbox):
 #   HERMES_DEV_SANDBOX_NAME=Staging scripts/dev-sandbox.sh hermes desktop
 #
@@ -27,7 +31,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 print_help() {
   cat <<'EOF'
-Usage: dev-sandbox.sh [--persistent] [--] <command...>
+Usage: dev-sandbox.sh [--persistent] [--from DIR] [--] <command...>
 
 Run a Hermes instance in an isolated sandbox.
 
@@ -35,6 +39,10 @@ Options:
   --persistent    Keep the sandbox dir across restarts (under the worktree
                   git root, in .hermes-sandbox/). Without this flag the
                   sandbox is a temp dir that is removed on exit.
+  --from DIR      Copy DIR into the sandbox HERMES_HOME as the starting
+                  point (config, sessions, skills, etc.).
+                  Ignored if the sandbox HERMES_HOME already has content
+                  (e.g. reusing a --persistent sandbox) to avoid clobbering.
   --delete        Delete the existing persistent sandbox in .hermes-sandbox.
   -h, --help      Show this help message.
 
@@ -45,17 +53,35 @@ Environment:
 Examples:
   dev-sandbox.sh hermes desktop
   dev-sandbox.sh --persistent hermes desktop
+  dev-sandbox.sh --from ~/.hermes hermes desktop
   dev-sandbox.sh -- npm run dev
 EOF
 }
 
 PERSISTENT=false
 DELETE=false
+SEED_DIR=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --persistent)
       PERSISTENT=true
+      shift
+      ;;
+    --from)
+      if [ "$#" -lt 2 ] || [[ "$2" == -* ]]; then
+        echo "error: --from requires a directory argument" >&2
+        exit 1
+      fi
+      SEED_DIR="$2"
+      shift 2
+      ;;
+    --from=*)
+      SEED_DIR="${1#--from=}"
+      if [ -z "$SEED_DIR" ]; then
+        echo "error: --from requires a directory argument" >&2
+        exit 1
+      fi
       shift
       ;;
     --delete)
@@ -75,6 +101,15 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+if [ -n "$SEED_DIR" ]; then
+  if [ ! -d "$SEED_DIR" ]; then
+    echo "error: --from dir '$SEED_DIR' does not exist" >&2
+    exit 1
+  fi
+  # Resolve to absolute path so it's valid after we cd later.
+  SEED_DIR="$(cd "$SEED_DIR" && pwd)"
+fi
 
 if [ "$#" -eq 0 ]; then
   print_help >&2
@@ -128,6 +163,17 @@ export HERMES_DESKTOP_USER_DATA_DIR="$SANDBOX_ROOT/user-data"
 export HERMES_DESKTOP_APP_NAME="$SANDBOX_NAME"
 
 mkdir -p "$HERMES_HOME" "$HERMES_DESKTOP_USER_DATA_DIR"
+
+if [ -n "$SEED_DIR" ]; then
+  # Only seed when the sandbox HERMES_HOME is empty — avoids clobbering an
+  # existing persistent sandbox on re-run.
+  if [ -z "$(ls -A "$HERMES_HOME" 2>/dev/null)" ]; then
+    echo "[sandbox] seeding HERMES_HOME from $SEED_DIR" >&2
+    cp -a "$SEED_DIR/." "$HERMES_HOME/"
+  else
+    echo "[sandbox] --from ignored: $HERMES_HOME already has content" >&2
+  fi
+fi
 
 echo "[sandbox] HERMES_HOME=$HERMES_HOME" >&2
 echo "[sandbox] userData=$HERMES_DESKTOP_USER_DATA_DIR" >&2


### PR DESCRIPTION
## What does this PR do?

Adds a `--from DIR` flag to `scripts/dev-sandbox.sh` that copies an existing HERMES_HOME directory into the sandbox as the starting point before the command runs. This lets you spin up a sandbox pre-populated with your real config, sessions, skills, etc.

```bash
scripts/dev-sandbox.sh --from ~/.hermes hermes desktop
```

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/dev-sandbox.sh`: new `--from DIR` flag (both `--from DIR` and `--from=DIR` forms)
- Copies source dir contents into sandbox `$HERMES_HOME` via `cp -a dir/. dest/` (preserves perms, symlinks, hidden files)
- **Clobber guard**: only seeds when sandbox HERMES_HOME is empty — re-running with `--persistent` won't blow away existing sandbox state; prints `[sandbox] --from ignored: ... already has content`
- **Validation**: errors on nonexistent dir, missing arg, flag-like arg (`--from --`), empty `--from=`
- Updated header comment + `print_help()` to document the new flag

## How to Test

1. Create a fake source dir: `mkdir -p /tmp/seed && echo "test: true" > /tmp/seed/config.yaml && mkdir /tmp/seed/.hidden && echo secret > /tmp/seed/.hidden/secret.txt`
2. Run: `scripts/dev-sandbox.sh --from /tmp/seed --persistent -- echo ran`
3. Verify files copied: `cat .hermes-sandbox/hermes-home/config.yaml` and `cat .hermes-sandbox/hermes-home/.hidden/secret.txt`
4. Re-run the same command — should print `--from ignored: ... already has content` (clobber guard)
5. `scripts/dev-sandbox.sh --from /tmp/nonexistent -- echo no` → error exit
6. `scripts/dev-sandbox.sh --from= -- echo no` → error exit
7. `scripts/dev-sandbox.sh --help` → shows `--from DIR`

Verified: `bash -n` syntax pass + 11/11 functional tests pass (seed copy, hidden files, content integrity, clobber guard, nonexistent dir, equals form, flag-like arg rejection, empty `--from=` rejection, help text, backwards compat).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: standalone bash script, no pytest coverage exists for `scripts/dev-sandbox.sh`
- [x] I've added tests for my changes — N/A: no bash test harness in repo; verified via 11 functional assertions
- [x] I've tested on my platform: NixOS (Linux 7.1.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — inline header comment + help text updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — bash script, POSIX-only by existing design
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A