### PR TITLE
fix(cli): show configured Azure Foundry deployment aliases in the model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2334,6 +2334,33 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         manifest_ids = get_curated_nous_model_ids()
         if manifest_ids:
             return manifest_ids
+    if normalized == "azure-foundry":
+        # Azure Foundry deployment aliases are user-specific, so the static
+        # catalog is intentionally empty. Surface only configured aliases here:
+        # an unfiltered /models response can mix chat deployments with image,
+        # audio, and embedding entries that do not belong in an agent picker.
+        model_cfg = _get_model_config_dict()
+        cfg_provider = normalize_provider(str(model_cfg.get("provider", "") or ""))
+        configured: list[str] = []
+        if cfg_provider == "azure-foundry":
+            default = str(model_cfg.get("default") or "").strip()
+            if default:
+                configured.append(default)
+
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.fallback_config import get_fallback_chain
+
+            for entry in get_fallback_chain(load_config() or {}):
+                if normalize_provider(str(entry.get("provider") or "")) != "azure-foundry":
+                    continue
+                fallback_model = str(entry.get("model") or "").strip()
+                if fallback_model and fallback_model.lower() not in {m.lower() for m in configured}:
+                    configured.append(fallback_model)
+        except Exception:
+            pass
+
+        return configured
     if normalized == "stepfun":
         try:
             from hermes_cli.auth import resolve_api_key_provider_credentials
@@ -2650,6 +2677,17 @@ def cached_provider_model_ids(
     normalized = normalize_provider(provider) or (provider or "")
     if not normalized:
         return []
+
+    # Azure Foundry exposes user-defined deployment aliases, not a stable
+    # provider catalog. Always derive them from current config and discard any
+    # legacy cache entry that may contain raw image/embedding deployments.
+    if normalized == "azure-foundry":
+        aliases = provider_model_ids(normalized, force_refresh=force_refresh)
+        cache = _load_provider_models_cache()
+        if normalized in cache:
+            del cache[normalized]
+            _save_provider_models_cache(cache)
+        return list(aliases or [])
 
     cache = _load_provider_models_cache()
     fp = _credential_fingerprint(normalized)

--- a/tests/hermes_cli/test_azure_foundry_model_picker.py
+++ b/tests/hermes_cli/test_azure_foundry_model_picker.py
@@ -1,0 +1,119 @@
+"""Regression coverage for Azure Foundry deployment aliases in model pickers."""
+
+from __future__ import annotations
+
+import hermes_cli.config as config_mod
+import hermes_cli.model_switch as model_switch
+import hermes_cli.models as models
+
+
+def test_azure_foundry_aliases_keep_primary_first_and_deduplicate_fallbacks(monkeypatch):
+    monkeypatch.setattr(
+        models,
+        "_get_model_config_dict",
+        lambda: {
+            "provider": "azure-foundry",
+            "default": "gpt-5.6-sol",
+            "base_url": "https://example.openai.azure.com/openai/v1",
+        },
+    )
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {
+            "fallback_providers": [
+                {"provider": "azure-foundry", "model": "GPT-5.6-SOL"},
+                {"provider": "azure-foundry", "model": "gpt-5.5"},
+            ]
+        },
+    )
+
+    assert models.provider_model_ids("azure-foundry") == ["gpt-5.6-sol", "gpt-5.5"]
+
+
+def test_azure_foundry_picker_surfaces_fallback_alias_when_another_provider_is_primary(monkeypatch):
+    monkeypatch.setattr(
+        models,
+        "_get_model_config_dict",
+        lambda: {"provider": "xai-oauth", "default": "grok-4.5"},
+    )
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {
+            "fallback_providers": [
+                {
+                    "provider": "azure-foundry",
+                    "model": "gpt-5.6-sol",
+                    "base_url": "https://example.openai.azure.com/openai/v1",
+                }
+            ]
+        },
+    )
+
+    assert models.provider_model_ids("azure-foundry") == ["gpt-5.6-sol"]
+
+
+def test_azure_foundry_picker_supports_legacy_fallback_model(monkeypatch):
+    monkeypatch.setattr(
+        models,
+        "_get_model_config_dict",
+        lambda: {"provider": "xai-oauth", "default": "grok-4.5"},
+    )
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {
+            "fallback_model": {
+                "provider": "azure-foundry",
+                "model": "gpt-5.6-sol",
+            }
+        },
+    )
+
+    assert models.provider_model_ids("azure-foundry") == ["gpt-5.6-sol"]
+
+
+def test_azure_foundry_aliases_bypass_stale_raw_model_cache(monkeypatch):
+    monkeypatch.setattr(
+        models,
+        "_get_model_config_dict",
+        lambda: {"provider": "azure-foundry", "default": "gpt-5.6-sol"},
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(
+        models,
+        "_load_provider_models_cache",
+        lambda: {
+            "azure-foundry": {
+                "fp": models._credential_fingerprint("azure-foundry"),
+                "at": 9_999_999_999,
+                "models": ["text-embedding-3-large", "gpt-image-1"],
+            }
+        },
+    )
+    saved = []
+    monkeypatch.setattr(models, "_save_provider_models_cache", saved.append)
+
+    assert models.cached_provider_model_ids("azure-foundry") == ["gpt-5.6-sol"]
+    assert saved and "azure-foundry" not in saved[-1]
+
+
+def test_interactive_picker_retains_azure_row_with_configured_alias(monkeypatch):
+    monkeypatch.setattr(
+        model_switch,
+        "list_authenticated_providers",
+        lambda **_kwargs: [
+            {
+                "slug": "azure-foundry",
+                "name": "Azure Foundry",
+                "models": ["gpt-5.6-sol"],
+                "total_models": 1,
+            }
+        ],
+    )
+
+    rows = model_switch.list_picker_providers()
+
+    assert [row["slug"] for row in rows] == ["azure-foundry"]
+    assert rows[0]["models"] == ["gpt-5.6-sol"]


### PR DESCRIPTION
# fix(cli) — show configured Azure Foundry deployment aliases in the model picker

## Problem

For users authenticated to an **Azure Foundry** endpoint, the interactive model picker (`hermes model`) shows an **empty model list**, even when a deployment alias is fully configured (as the primary model or in the fallback chain) and the endpoint is healthy.

Root cause: `azure-foundry` is the one provider whose static catalog in `hermes_cli/models.py` is intentionally empty (`"azure-foundry": []` — deployment aliases are user-specific, not a stable provider catalog). But `provider_model_ids()` had no special case for it, so it returned the empty static list verbatim. The picker then renders nothing — the configured alias is invisible and unselectable, even though the runtime fallback chain resolves and uses it correctly.

## Fix

Derive picker entries from **configured aliases only**, never from a raw `/models` dump (an Azure `/models` response can mix chat deployments with image, audio, and embedding entries that do not belong in an agent picker):

- `provider_model_ids("azure-foundry")`: returns the configured default (when azure-foundry is the active provider) plus any `azure-foundry` entries in the fallback chain — primary first, case-insensitive dedup. Handles both `fallback_providers` list and legacy `fallback_model` key.
- `cached_provider_model_ids("azure-foundry")`: always derives from current config and **discards any legacy cache entry** for the provider (stale caches can hold raw image/embedding deployment names).

## Tests

`tests/hermes_cli/test_azure_foundry_model_picker.py` — 5 regression tests:

1. Primary-first ordering + case-insensitive fallback dedup.
2. Alias surfaces when azure-foundry is only a fallback (another provider primary).
3. Legacy `fallback_model` config shape supported.
4. Stale raw-model cache bypassed and purged.
5. Interactive picker retains the azure-foundry row with its configured alias.

## Verification

- `git apply --check` against `main` @ `594308d4b` — both hunks apply (offset 1 line).
- `pytest tests/hermes_cli/test_azure_foundry_model_picker.py` — **5/5 passed** (3.05s) on a scratch copy of current `main`.
- No behavior change for any other provider.

---
