### PR TITLE
fix(telegram): bound drain awaits so a wedged httpx pool cannot freeze the reconnect ladder (#66377)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -543,6 +543,14 @@ _UPDATER_STOP_TIMEOUT = 15.0
 # reconnect ladder from stalling indefinitely and allows the heartbeat loop to
 # trigger its own recovery path. Refs: NousResearch/hermes-agent#59614
 _UPDATER_START_TIMEOUT = 30.0
+# shutdown()/initialize() on the getUpdates httpx request close and rebuild the
+# connection pool. When a connection is wedged on a stale CLOSE-WAIT socket that
+# close can block forever, hanging _drain_polling_connections() and freezing the
+# whole reconnect ladder (the tracked _polling_error_task never completes, so
+# every escalation path stays gated behind its in-flight guard). Bound the drain
+# so the ladder always advances toward the fatal-restart escalation. Matches
+# _UPDATER_STOP_TIMEOUT. Refs: NousResearch/hermes-agent#66377
+_DRAIN_TIMEOUT = 15.0
 # A generation is not healthy until the dedicated getUpdates request returns
 # successfully. This exceeds a normal long-poll cycle for healthy idle bots.
 _POLLING_PROGRESS_TIMEOUT = 60.0
@@ -1987,20 +1995,22 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             return
         try:
-            await polling_req.shutdown()
+            # Bounded: a wedged CLOSE-WAIT socket can make this close hang
+            # forever and freeze the reconnect ladder (#66377).
+            await asyncio.wait_for(polling_req.shutdown(), timeout=_DRAIN_TIMEOUT)
         except Exception:
             logger.debug(
-                "[%s] Polling request shutdown failed (non-fatal)",
+                "[%s] Polling request shutdown failed/timed out (non-fatal)",
                 self.name, exc_info=True,
             )
         try:
-            await polling_req.initialize()
+            await asyncio.wait_for(polling_req.initialize(), timeout=_DRAIN_TIMEOUT)
             logger.debug(
                 "[%s] Polling request pool drained before reconnect", self.name
             )
         except Exception:
             logger.debug(
-                "[%s] Polling request re-initialize failed (non-fatal)",
+                "[%s] Polling request re-initialize failed/timed out (non-fatal)",
                 self.name, exc_info=True,
             )
 

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -326,6 +326,54 @@ async def test_initialize_still_runs_when_shutdown_fails():
 
 
 @pytest.mark.asyncio
+async def test_reconnect_continues_if_drain_hangs(monkeypatch):
+    """If the polling request drain HANGS (wedged httpx pool close on a
+    CLOSE-WAIT socket), the reconnect ladder must still advance rather than
+    freezing the tracked _polling_error_task forever.
+
+    Regression test for #66377: an unbounded ``shutdown()`` /
+    ``initialize()`` in ``_drain_polling_connections`` leaves the handler
+    task pending, which gates every escalation path and silently kills the
+    gateway. The drain awaits are bounded by ``_DRAIN_TIMEOUT``, so the
+    handler must complete and reach ``start_polling`` within a hard bound.
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 1
+
+    mock_app, mock_polling_req = _make_mock_app()
+
+    async def _hang(*args, **kwargs):
+        await asyncio.Event().wait()  # never returns
+
+    # Both drain awaits wedge indefinitely.
+    mock_polling_req.shutdown = AsyncMock(side_effect=_hang)
+    mock_polling_req.initialize = AsyncMock(side_effect=_hang)
+    adapter._app = mock_app
+
+    # Keep the drain timeout tiny so the test stays fast; the real default
+    # is generous enough not to truncate healthy closes.
+    monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 0.01, raising=False)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        # Hard outer bound: on unfixed code the drain hangs forever and this
+        # trips; with the fix the inner wait_for releases well before it.
+        await asyncio.wait_for(
+            adapter._handle_polling_network_error(Exception("Timed out")),
+            timeout=5,
+        )
+
+    # Ladder advanced past the wedged drain despite it never returning.
+    mock_app.updater.start_polling.assert_called_once()
+    assert adapter._polling_network_error_count == 2
+    # The tracked task must not be stuck pending — otherwise every
+    # escalation path stays gated behind an in-flight guard.
+    assert (
+        adapter._polling_error_task is None
+        or adapter._polling_error_task.done()
+    )
+
+
+@pytest.mark.asyncio
 async def test_conflict_retry_also_drains_polling_connections():
     """_handle_polling_conflict must also drain the polling pool on retry."""
     adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

`_drain_polling_connections` in `plugins/platforms/telegram/adapter.py` called `polling_req.shutdown()` and `polling_req.initialize()` with no timeout. When the getUpdates connection is wedged on a stale CLOSE-WAIT socket, `shutdown()` blocks indefinitely. This hangs `_handle_polling_network_error`, which is the body of the tracked task `self._polling_error_task`. Because that task never completes, `_polling_error_task.done()` stays `False` forever, and every re-entry path into the reconnect ladder is gated on that flag:

- `_schedule_polling_recovery` returns early at L2224 (`if self._polling_error_task and not self._polling_error_task.done(): return`).
- `_probe_pending_updates` returns early at L2527 on the same guard.

The effect: the ladder logs `"reconnecting in Ds"` (increment has already happened), then goes completely silent. `_polling_network_error_count` is never advanced past the current attempt, `_set_fatal_error` is never reached, and `Restart=always` never fires. The gateway is alive but permanently deaf.

The fix adds `_DRAIN_TIMEOUT = 15.0` (matching `_UPDATER_STOP_TIMEOUT`) and wraps both drain awaits in `asyncio.wait_for`. On timeout, the existing `except Exception` path logs a non-fatal debug message and the handler returns normally — `_polling_error_task` completes, the in-flight guard clears, and the ladder can advance.

## Related Issue

Fixes #66377

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: added `_DRAIN_TIMEOUT = 15.0` constant near L543 (alongside `_UPDATER_STOP_TIMEOUT`); wrapped `polling_req.shutdown()` and `polling_req.initialize()` in `asyncio.wait_for(..., timeout=_DRAIN_TIMEOUT)`; updated log messages to say "failed/timed out".
- `tests/gateway/test_telegram_network_reconnect.py`: added `test_reconnect_continues_if_drain_hangs` — makes both drain calls hang via `asyncio.Event().wait()`, monkeypatches `_DRAIN_TIMEOUT` to 0.01s for speed, then asserts the handler finishes and `start_polling` is called.

## How to Test

1. Run the new regression test in isolation:
   ```
   pytest tests/gateway/test_telegram_network_reconnect.py::test_reconnect_continues_if_drain_hangs -v
   ```
   On `main` this test hangs until the 5 s outer `wait_for` trips. On this branch it passes in ~0.6 s.

2. Run the full scoped suite to confirm no regressions:
   ```
   pytest tests/gateway/test_telegram_network_reconnect.py \
          tests/gateway/test_telegram_polling_progress.py \
          tests/gateway/test_telegram_pending_update_probe.py \
          tests/gateway/test_telegram_closewait_limits_31599.py \
          tests/test_telegram_polling_progress_ptb.py -q
   ```

3. Run the full test suite:
   ```
   pytest tests/ -q
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the scoped telegram gateway suites (77 tests, all pass); full-suite run left to CI
- [x] I've added tests for my changes (regression test for the hang scenario)
- [ ] I've tested on my platform: N/A — this is a purely async control-flow fix with no platform-specific code paths

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (asyncio timeout behaviour is identical across platforms)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

**Failing before the fix** (`main`, bcea5371c) — the outer 5 s guard fires because the inner drain never returns:

```
FAILED tests/gateway/test_telegram_network_reconnect.py::test_reconnect_continues_if_drain_hangs
- asyncio.exceptions.TimeoutError
```

**Passing after the fix** (branch `fix/issue-66377`) — handler completes, `start_polling` called, ladder advanced:

```
tests/gateway/test_telegram_network_reconnect.py::test_reconnect_continues_if_drain_hangs PASSED  [ 0.58s]
```

**Scoped suite — 77 tests, 0 failures:**

```
tests/gateway/test_telegram_network_reconnect.py    43 passed
tests/gateway/test_telegram_polling_progress.py     22 passed
tests/gateway/test_telegram_pending_update_probe.py  9 passed
tests/gateway/test_telegram_closewait_limits_31599.py 3 passed
tests/test_telegram_polling_progress_ptb.py          1 passed
77 passed in 4.31s
```

---

## What was broken

`_drain_polling_connections` (`plugins/platforms/telegram/adapter.py`) awaited `polling_req.shutdown()` and `polling_req.initialize()` with no timeout. A connection wedged on a stale CLOSE-WAIT socket caused `shutdown()` to block indefinitely, hanging `_handle_polling_network_error` (the body of `_polling_error_task`). That task never completing kept every escalation guard permanently closed, so the reconnect ladder froze at the current attempt and `_set_fatal_error` was never reached. Reported against 0.17.0 and confirmed still present on HEAD (bcea5371c) via the same missing bounds in a substantially reworked version of the same code.

## The fix

Added `_DRAIN_TIMEOUT = 15.0` alongside `_UPDATER_STOP_TIMEOUT` and wrapped both drain awaits in `asyncio.wait_for`. On timeout, the existing `except Exception` path absorbs it (log-and-continue), the handler task completes, and the ladder can advance. Scope: 1 file, ~15 changed lines.

## Evidence

**Failing test before the fix:**

```
FAILED tests/gateway/test_telegram_network_reconnect.py::test_reconnect_continues_if_drain_hangs
asyncio.exceptions.TimeoutError
(outer 5 s wait_for tripped; inner drain never returned)
```

**Passing after the fix (scoped suite green):**

```
77 passed in 4.31s
(new test completes in ~0.6 s; 76 pre-existing tests unaffected)
```

## Human Verification

This fix was developed with AI assistance (Claude Code) as part of a supervised
bug-fix pipeline. A human reviewed the root-cause analysis, the diff, and the
test evidence before this PR was submitted. Please review with the same scrutiny
as any external contribution — and feel free to close if this doesn't fit the
project's direction; no offense taken.

Known limitations: bounding `shutdown()` can leave one connection un-cleanly closed on timeout, potentially leaking an fd for the duration until the subsequent `initialize()` rebuilds the pool. This is strictly better than the prior unbounded hang (a permanently frozen ladder, gateway silently dead). The 15 s timeout is generous enough that healthy closes are not truncated in practice. Additionally, a `shutdown()` that ignores cancellation on timeout may leave one lingering httpx close task per drain attempt (bounded; one per ladder step at most). The fix does not change send-path behaviour: `_request[1]` (used by `send_message`) is not touched.
