### PR TITLE
test(browser): prevent live Chrome launch

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8352,13 +8352,16 @@ def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
 
     monkeypatch.setattr(urllib.request, "urlopen", _opener)
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        # Patch the active process-spawn seam; a stale helper mock orphaned real Chrome.
         with patch(
-            "hermes_cli.browser_connect.try_launch_chrome_debug", return_value=True
-        ):
+            "hermes_cli.browser_connect.launch_chrome_debug",
+            return_value=ChromeDebugLaunch(launched=True),
+        ) as launch_chrome:
             resp = server.handle_request(
                 {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
             )
 
+    launch_chrome.assert_called_once()
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
     assert resp["result"]["messages"] == [


### PR DESCRIPTION
## Summary

- patch the active `launch_chrome_debug` seam in the browser connect retry test
- return the production-shaped `ChromeDebugLaunch` result
- assert the launch seam is invoked once

## Why

The test still mocked the removed `try_launch_chrome_debug` helper after production moved to `launch_chrome_debug`. As a result, running the suite launched a real detached Chrome process with a pytest temporary profile. Those orphaned processes survived pytest and surfaced fresh Chrome windows and macOS keychain dialogs on the developer desktop.

## Verification

- `pytest tests/test_tui_gateway_server.py -q` — 349 passed
- focused `browser.manage` selection — 20 passed
- exact regression test passed
- Ruff passed
- `git diff --check` passed
- verified no pytest-profile Chrome process remained after the test run
