### PR TITLE
fix(dashboard): route password-only provider to /login on direct /auth/login hit

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -201,6 +201,21 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             login_url = f"{login_url}?next={quote(safe_next, safe='')}"
         return RedirectResponse(url=login_url, status_code=302)
 
+    if getattr(p, "supports_password", False):
+        # Password-only providers (e.g. BasicAuthProvider) have no OAuth
+        # redirect: start_login() raises NotImplementedError, so a direct or
+        # bookmarked hit to /auth/login 500s. _auto_sso_response already
+        # guards this for the auto-SSO bounce; mirror it here for the explicit
+        # login route and send the user to the /login form instead.
+        from urllib.parse import quote as _quote
+        from hermes_cli.dashboard_auth.prefix import prefix_from_request
+        _prefix = prefix_from_request(request)
+        _loc = (
+            f"{_prefix}/login?next={_quote(next, safe='')}" if next
+            else f"{_prefix}/login"
+        )
+        return RedirectResponse(url=_loc, status_code=302)
+
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))
     except ProviderError as e:


### PR DESCRIPTION
## Problem

The `auth_login` route (`hermes_cli/dashboard_auth/routes.py`) calls `provider.start_login()` unconditionally. For a password-only provider (e.g. `BasicAuthProvider`), `start_login()` raises `NotImplementedError` because there is no OAuth redirect to build. A user hitting `/auth/login` directly — or via a bookmark — therefore gets a **500** instead of a usable login form.

## Fix

`_auto_sso_response` in `middleware.py` already short-circuits password-capable providers (returns `None` so the auto-SSO bounce is skipped). This PR mirrors that same `supports_password` guard in the explicit `auth_login` route: redirect to the `/login` form instead of calling `start_login()`, preserving the `?next` target.

## Scope

- Single guard added in `auth_login`, consistent with the existing middleware guard.
- No behaviour change for OAuth/SSO providers.
- Fixes a 500 → correct redirect for single-password-provider dashboard setups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)