### PR TITLE
fix(desktop): remove hardcoded max-width truncation on status-stack todo text

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -122,7 +122,7 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
       >
         <span
           className={cn(
-            'min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4',
+            'min-w-0 text-[0.73rem] leading-4',
             failed
               ? 'text-destructive/90'
               : item.todoStatus && item.todoStatus !== 'in_progress'


### PR DESCRIPTION
## Summary

Fixes todo item text being silently truncated at 288px (`max-w-[18rem]`) in the composer status stack. Long task descriptions are clipped with no way to see the full content — no tooltip, no scroll, no overflow indicator.

## Root cause

`status-row.tsx:125` sets `max-w-[18rem] truncate` on the todo title `<span>`, which limits the text to 288px and applies `text-overflow: ellipsis`. The parent flex container already provides proper constraint through its `min-w-0 flex-1` layout — the hardcoded `max-w-[18rem]` is redundant and overly restrictive.

## Fix

Remove the `max-w-[18rem] truncate` classes. The text now flows naturally within the available space. The parent's flex shrink constraint still prevents layout breakage — the span simply uses the space it's given.

## Testing

- `npx tsc --noEmit`: 0 new errors
- `npx eslint src/app/chat/composer/status-stack/status-row.tsx`: 0 errors, 0 warnings