### PR TITLE
feat(desktop): add tooltip on todo text hover with light background

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { StatusItemRow } from './status-row'
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      statusStack: {
+        running: 'Running',
+        stop: 'Stop',
+        dismiss: 'Dismiss',
+        exit: (code: number) => `exit ${code}`
+      }
+    }
+  })
+}))
+
+describe('StatusItemRow', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows the full todo title in a hover tooltip', async () => {
+    const title = 'A long todo title that would be truncated by max-w-[18rem] truncate'
+
+    render(
+      <StatusItemRow
+        item={{
+          id: 'todo-1',
+          title,
+          state: 'running',
+          type: 'todo',
+          todoStatus: 'in_progress'
+        }}
+      />
+    )
+
+    fireEvent.pointerMove(screen.getByText(title), { pointerType: 'mouse' })
+    const tooltip = await screen.findByRole('tooltip')
+
+    expect(tooltip.textContent).toContain(title)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -120,18 +120,20 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
           ) : undefined
         }
       >
-        <span
-          className={cn(
-            'min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4',
-            failed
-              ? 'text-destructive/90'
-              : item.todoStatus && item.todoStatus !== 'in_progress'
-                ? 'text-muted-foreground/75'
-                : 'text-foreground/92'
-          )}
-        >
-          {item.title}
-        </span>
+        <Tip label={item.title}>
+          <span
+            className={cn(
+              'min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4',
+              failed
+                ? 'text-destructive/90'
+                : item.todoStatus && item.todoStatus !== 'in_progress'
+                  ? 'text-muted-foreground/75'
+                  : 'text-foreground/92'
+            )}
+          >
+            {item.title}
+          </span>
+        </Tip>
         {item.type === 'subagent' && item.currentTool && (
           <span className="shrink-0 truncate text-[0.62rem] leading-4 text-muted-foreground/70">
             {toolLabel(item.currentTool)}

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -52,14 +52,15 @@ function TooltipContent({
         sideOffset={sideOffset}
         {...props}
       >
-        {/* bg-foreground/text-background auto-inverts per theme. leading-normal
+        {/* bg-background text-foreground (theme surface, not inverted). leading-normal
             keeps lines readable; py-1 makes the cloned line-boxes overlap just
-            enough to read as one continuous fill (no gaps between lines). */}
+            enough to read as one continuous fill (no gaps between lines).
+            shadow-nous: shared elevation token per DESIGN.md. */}
         {/* [&>*]:!inline-flex: a block-level label child (e.g. `flex`) collapses
             this inline decoration's geometry, so Radix measures a zero-size chip
             and parks an empty rectangle in the corner (#62022). Force any direct
             child inline-flex so every call site stays safe. */}
-        <span className="box-decoration-clone inline bg-background px-1.5 py-1 text-[11px] font-bold leading-normal text-foreground shadow-[0_1px_4px_rgba(0,0,0,0.15)] [font-family:Arial,sans-serif] [&>*]:!inline-flex">
+        <span className="box-decoration-clone inline bg-background px-1.5 py-1 text-[11px] font-bold leading-normal text-foreground shadow-nous [font-family:Arial,sans-serif] [&>*]:!inline-flex">
           {children}
         </span>
       </TooltipPrimitive.Content>

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -59,7 +59,7 @@ function TooltipContent({
             this inline decoration's geometry, so Radix measures a zero-size chip
             and parks an empty rectangle in the corner (#62022). Force any direct
             child inline-flex so every call site stays safe. */}
-        <span className="box-decoration-clone inline bg-foreground px-1.5 py-1 text-[11px] font-bold leading-normal text-background [font-family:Arial,sans-serif] [&>*]:!inline-flex">
+        <span className="box-decoration-clone inline bg-background px-1.5 py-1 text-[11px] font-bold leading-normal text-foreground shadow-[0_1px_4px_rgba(0,0,0,0.15)] [font-family:Arial,sans-serif] [&>*]:!inline-flex">
           {children}
         </span>
       </TooltipPrimitive.Content>


### PR DESCRIPTION
## Summary

- Wraps the todo item title in the composer status stack with the existing `Tip` component so the full task description appears on hover.
- Flips the tooltip background from inverted (`bg-foreground text-background`) to a light scheme (`bg-background text-foreground`) with a subtle drop shadow for better readability.

## Motivation

When a todo item text is longer than the available width, users previously had no way to read the full description — the text was simply clipped. This change adds a hover tooltip showing the complete text, and improves the tooltip's appearance for general use.

## Changes

### User-facing
- Hovering over a truncated or wrapped todo item in the status stack now shows the full text in a tooltip overlay.

### Internal
- `status-row.tsx`: wraps `{item.title}` with `<Tip label={item.title}>` (Tip is already imported and used in the same file for button labels).
- `tooltip.tsx`: changed TooltipContent inner span from `bg-foreground text-background` to `bg-background text-foreground` with `shadow-[0_1px_4px_rgba(0,0,0,0.15)]`. This makes the tooltip readable against both light and dark themes without relying on inverted colors.

## Testing

- `npx tsc --noEmit`: 0 new errors
- `npx eslint src/app/chat/composer/status-stack/status-row.tsx src/components/ui/tooltip.tsx`: 0 errors, 0 warnings