### PR TITLE
feat(dashboard): add --qr for phone quick-connect

### DIFF
--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -152,75 +152,13 @@ def wait_for_registration_success(
 
 
 # ── QR code rendering ─────────────────────────────────────────────────────
+# Canonical implementations moved to hermes_cli/terminal_qr.py (shared with
+# `hermes dashboard --qr`); re-exported here for existing callers.
 
-def _ensure_qrcode_installed() -> bool:
-    """Try to import qrcode; if missing, auto-install it via pip/uv."""
-    try:
-        import qrcode  # noqa: F401
-        return True
-    except ImportError:
-        pass
-
-    import subprocess
-
-    from hermes_cli.tools_config import _pip_install
-
-    try:
-        result = _pip_install(["-q", "qrcode"], timeout=120)
-        if result.returncode == 0:
-            import qrcode  # noqa: F401,F811
-            return True
-    except (subprocess.SubprocessError, ImportError, OSError):
-        pass
-    return False
-
-
-def render_qr_to_terminal(url: str) -> bool:
-    """Render *url* as a compact QR code in the terminal.
-
-    Returns True if the QR code was printed, False if the library is missing.
-    """
-    try:
-        import qrcode
-    except ImportError:
-        return False
-
-    qr = qrcode.QRCode(
-        version=1,
-        error_correction=qrcode.constants.ERROR_CORRECT_L,
-        box_size=1,
-        border=1,
-    )
-    qr.add_data(url)
-    qr.make(fit=True)
-
-    # Use half-block characters for compact rendering (2 rows per character)
-    matrix = qr.get_matrix()
-    rows = len(matrix)
-    lines: list[str] = []
-
-    TOP_HALF = "\u2580"      # ▀
-    BOTTOM_HALF = "\u2584"   # ▄
-    FULL_BLOCK = "\u2588"    # █
-    EMPTY = " "
-
-    for r in range(0, rows, 2):
-        line_chars: list[str] = []
-        for c in range(len(matrix[r])):
-            top = matrix[r][c]
-            bottom = matrix[r + 1][c] if r + 1 < rows else False
-            if top and bottom:
-                line_chars.append(FULL_BLOCK)
-            elif top:
-                line_chars.append(TOP_HALF)
-            elif bottom:
-                line_chars.append(BOTTOM_HALF)
-            else:
-                line_chars.append(EMPTY)
-        lines.append("    " + "".join(line_chars))
-
-    print("\n".join(lines))
-    return True
+from hermes_cli.terminal_qr import (  # noqa: E402
+    ensure_qrcode_installed as _ensure_qrcode_installed,
+    render_qr_to_terminal,
+)
 
 
 # ── High-level entry point for the setup wizard ───────────────────────────

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12601,6 +12601,8 @@ def cmd_dashboard(args):
         allow_public=getattr(args, "insecure", False),
         initial_profile=getattr(args, "open_profile", "") or "",
         headless=_headless_backend,
+        show_qr=getattr(args, "show_qr", False),
+        public_url=getattr(args, "public_url", "") or "",
     )
 
 

--- a/hermes_cli/subcommands/dashboard.py
+++ b/hermes_cli/subcommands/dashboard.py
@@ -107,6 +107,27 @@ def build_dashboard_parser(
     dashboard_parser.add_argument(
         "--no-open", action="store_true", help="Don't open browser automatically"
     )
+    dashboard_parser.add_argument(
+        "--qr",
+        dest="show_qr",
+        action="store_true",
+        help=(
+            "Print a phone-scannable QR of the Web UI URL once the server is "
+            "up. Encodes --public-url when given, otherwise the machine's LAN "
+            "IP for a wildcard bind. Auth is unchanged: the scanned page lands "
+            "on the sign-in screen when the auth gate is engaged."
+        ),
+    )
+    dashboard_parser.add_argument(
+        "--public-url",
+        dest="public_url",
+        default="",
+        metavar="URL",
+        help=(
+            "Externally reachable URL for this dashboard (e.g. your tunnel "
+            "hostname). Used by --qr instead of the bind address."
+        ),
+    )
     # Backward-compat shim: older Hermes desktop app shells (<= 0.15.x) spawn the
     # backend as `hermes dashboard --no-open --tui --host ... --port ...`. The
     # `--tui` flag was removed from this subcommand in cae6b5486 (embedded chat is

--- a/hermes_cli/terminal_qr.py
+++ b/hermes_cli/terminal_qr.py
@@ -1,0 +1,117 @@
+"""Terminal QR rendering + advertised-URL resolution (shared helpers).
+
+The canonical home for the half-block terminal QR renderer that previously
+lived (duplicated) in platform onboarding modules. Used by ``hermes dashboard
+--qr`` to make the Web UI scannable from a phone, and importable by any
+onboarding flow that needs a QR in the terminal.
+"""
+
+import logging
+import socket
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_qrcode_installed() -> bool:
+    """Try to import qrcode; if missing, auto-install it via pip/uv."""
+    try:
+        import qrcode  # noqa: F401
+        return True
+    except ImportError:
+        pass
+
+    import subprocess
+
+    from hermes_cli.tools_config import _pip_install
+
+    try:
+        result = _pip_install(["-q", "qrcode"], timeout=120)
+        if result.returncode == 0:
+            import qrcode  # noqa: F401,F811
+            return True
+    except (subprocess.SubprocessError, ImportError, OSError):
+        pass
+    return False
+
+
+def render_qr_to_terminal(url: str) -> bool:
+    """Render *url* as a compact QR code in the terminal.
+
+    Returns True if the QR code was printed, False if the library is missing.
+    """
+    try:
+        import qrcode
+    except ImportError:
+        return False
+
+    qr = qrcode.QRCode(
+        version=1,
+        error_correction=qrcode.constants.ERROR_CORRECT_L,
+        box_size=1,
+        border=1,
+    )
+    qr.add_data(url)
+    qr.make(fit=True)
+
+    # Use half-block characters for compact rendering (2 rows per character)
+    matrix = qr.get_matrix()
+    rows = len(matrix)
+    lines: list[str] = []
+
+    TOP_HALF = "▀"      # ▀
+    BOTTOM_HALF = "▄"   # ▄
+    FULL_BLOCK = "█"    # █
+    EMPTY = " "
+
+    for r in range(0, rows, 2):
+        line_chars: list[str] = []
+        for c in range(len(matrix[r])):
+            top = matrix[r][c]
+            bottom = matrix[r + 1][c] if r + 1 < rows else False
+            if top and bottom:
+                line_chars.append(FULL_BLOCK)
+            elif top:
+                line_chars.append(TOP_HALF)
+            elif bottom:
+                line_chars.append(BOTTOM_HALF)
+            else:
+                line_chars.append(EMPTY)
+        lines.append("    " + "".join(line_chars))
+
+    print("\n".join(lines), flush=True)
+    return True
+
+
+def lan_ip() -> "str | None":
+    """Best-effort LAN IP of this machine (no traffic is actually sent).
+
+    The UDP connect trick: connecting a datagram socket selects the outbound
+    interface without sending a packet, and getsockname() reveals its address.
+    Returns None when the machine has no route (offline, airplane mode).
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+            probe.settimeout(0)
+            probe.connect(("10.254.254.254", 1))
+            address = probe.getsockname()[0]
+        return address if address and not address.startswith("127.") else None
+    except OSError:
+        return None
+
+
+def resolve_advertised_url(host: str, port: int, public_url: str = "") -> str:
+    """The URL another device should use to reach a server bound to host:port.
+
+    ``public_url`` (a tunnel hostname) wins outright. A wildcard bind
+    advertises the machine's LAN IP so the URL is scannable from a phone on
+    the same network; a concrete bind advertises itself. Loopback binds are
+    returned as-is — callers should warn that loopback is not phone-reachable.
+    """
+    if public_url:
+        return public_url.rstrip("/")
+    if host in ("0.0.0.0", "::", ""):
+        address = lan_ip()
+        if address:
+            return f"http://{address}:{port}"
+        logger.debug("wildcard bind but no LAN IP resolvable; advertising bind host")
+    return f"http://{host}:{port}"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17835,13 +17835,17 @@ def _print_connect_qr(host: str, port: int, public_url: str) -> None:
     gate, so the scanned page lands on the sign-in screen.
     """
     from hermes_cli.terminal_qr import (
-        ensure_qrcode_installed,
         render_qr_to_terminal,
         resolve_advertised_url,
     )
+    from hermes_cli.dashboard_auth.prefix import (
+        _normalise_public_url,
+        resolve_public_url,
+    )
 
-    url = resolve_advertised_url(host, port, public_url)
-    if not public_url and host in ("127.0.0.1", "localhost", "::1"):
+    resolved_public_url = _normalise_public_url(public_url) or resolve_public_url()
+    url = resolve_advertised_url(host, port, resolved_public_url)
+    if not resolved_public_url and host in ("127.0.0.1", "localhost", "::1"):
         print(
             "  --qr: the server is bound to loopback, which a phone cannot "
             "reach.\n"
@@ -17851,7 +17855,7 @@ def _print_connect_qr(host: str, port: int, public_url: str) -> None:
         )
         return
     print(f"  Scan to open on your phone → {url}", flush=True)
-    if not (ensure_qrcode_installed() and render_qr_to_terminal(url)):
+    if not render_qr_to_terminal(url):
         print("  (QR unavailable — install the optional dependency: pip install qrcode)", flush=True)
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17825,6 +17825,36 @@ def _maybe_open_browser(
     threading.Thread(target=_open, daemon=True).start()
 
 
+def _print_connect_qr(host: str, port: int, public_url: str) -> None:
+    """Print a phone-scannable QR for the Web UI (``hermes dashboard --qr``).
+
+    The QR encodes the URL another device can actually reach: an explicit
+    ``--public-url`` (tunnel hostname) wins, a wildcard bind advertises the
+    LAN IP, and a loopback bind gets guidance instead of a useless QR of
+    127.0.0.1. Auth is unaffected — a public bind still requires the auth
+    gate, so the scanned page lands on the sign-in screen.
+    """
+    from hermes_cli.terminal_qr import (
+        ensure_qrcode_installed,
+        render_qr_to_terminal,
+        resolve_advertised_url,
+    )
+
+    url = resolve_advertised_url(host, port, public_url)
+    if not public_url and host in ("127.0.0.1", "localhost", "::1"):
+        print(
+            "  --qr: the server is bound to loopback, which a phone cannot "
+            "reach.\n"
+            "        Bind the LAN with `--host 0.0.0.0` (the auth gate is "
+            "required on public binds),\n"
+            "        or pass your tunnel hostname via --public-url."
+        )
+        return
+    print(f"  Scan to open on your phone → {url}", flush=True)
+    if not (ensure_qrcode_installed() and render_qr_to_terminal(url)):
+        print("  (QR unavailable — install the optional dependency: pip install qrcode)", flush=True)
+
+
 def start_server(
     host: str = "127.0.0.1",
     port: int = 9119,
@@ -17832,6 +17862,8 @@ def start_server(
     allow_public: bool = False,
     initial_profile: str = "",
     headless: bool = False,
+    show_qr: bool = False,
+    public_url: str = "",
 ):
     """Start the web UI server.
 
@@ -18036,6 +18068,8 @@ def start_server(
                 print(f"  Hermes backend listening on {host}:{actual_port}")
             else:
                 print(f"  Hermes Web UI → http://{host}:{actual_port}")
+                if show_qr:
+                    _print_connect_qr(host, actual_port, public_url)
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)
 
             # Collapse the peer-hangup teardown flood (#50005). When the Desktop

--- a/tests/hermes_cli/test_terminal_qr.py
+++ b/tests/hermes_cli/test_terminal_qr.py
@@ -1,0 +1,112 @@
+"""Tests for hermes_cli/terminal_qr.py and the ``hermes dashboard --qr`` gate."""
+
+import builtins
+import socket
+
+import pytest
+
+from hermes_cli import terminal_qr
+
+
+class TestResolveAdvertisedUrl:
+    def test_public_url_wins_and_is_normalized(self, monkeypatch):
+        monkeypatch.setattr(terminal_qr, "lan_ip", lambda: "192.168.1.20")
+        assert (
+            terminal_qr.resolve_advertised_url("0.0.0.0", 9119, "https://h.example.com/")
+            == "https://h.example.com"
+        )
+
+    def test_wildcard_bind_advertises_lan_ip(self, monkeypatch):
+        monkeypatch.setattr(terminal_qr, "lan_ip", lambda: "192.168.1.20")
+        assert (
+            terminal_qr.resolve_advertised_url("0.0.0.0", 9119)
+            == "http://192.168.1.20:9119"
+        )
+
+    def test_wildcard_bind_without_lan_falls_back_to_bind_host(self, monkeypatch):
+        monkeypatch.setattr(terminal_qr, "lan_ip", lambda: None)
+        assert (
+            terminal_qr.resolve_advertised_url("0.0.0.0", 9119)
+            == "http://0.0.0.0:9119"
+        )
+
+    def test_concrete_bind_advertises_itself(self, monkeypatch):
+        monkeypatch.setattr(
+            terminal_qr, "lan_ip", lambda: pytest.fail("must not probe LAN")
+        )
+        assert (
+            terminal_qr.resolve_advertised_url("192.168.1.20", 9119)
+            == "http://192.168.1.20:9119"
+        )
+
+
+class TestLanIp:
+    def test_offline_machine_returns_none(self, monkeypatch):
+        class _DeadSocket:
+            def __init__(self, *a, **k):
+                raise OSError("network unreachable")
+
+        monkeypatch.setattr(socket, "socket", _DeadSocket)
+        assert terminal_qr.lan_ip() is None
+
+    def test_loopback_source_address_is_rejected(self, monkeypatch):
+        class _LoopbackSocket:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def settimeout(self, *_a):
+                pass
+
+            def connect(self, *_a):
+                pass
+
+            def getsockname(self):
+                return ("127.0.0.1", 54321)
+
+        monkeypatch.setattr(socket, "socket", _LoopbackSocket)
+        assert terminal_qr.lan_ip() is None
+
+
+class TestRenderer:
+    def test_missing_qrcode_returns_false(self, monkeypatch):
+        real_import = builtins.__import__
+
+        def _no_qrcode(name, *args, **kwargs):
+            if name == "qrcode":
+                raise ImportError("no module named qrcode")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_qrcode)
+        assert terminal_qr.render_qr_to_terminal("http://example.com") is False
+
+    def test_renders_half_block_qr_when_available(self, capsys):
+        pytest.importorskip("qrcode")
+        assert terminal_qr.render_qr_to_terminal("http://192.168.1.20:9119") is True
+        out = capsys.readouterr().out
+        assert any(ch in out for ch in ("█", "▀", "▄"))
+
+
+class TestDashboardQrGate:
+    def test_loopback_bind_prints_guidance_not_qr(self, capsys):
+        from hermes_cli.web_server import _print_connect_qr
+
+        _print_connect_qr("127.0.0.1", 9119, "")
+        out = capsys.readouterr().out
+        assert "phone cannot" in out
+        assert "Scan to open" not in out
+
+    def test_public_url_prints_scannable_url(self, capsys, monkeypatch):
+        pytest.importorskip("qrcode")
+        from hermes_cli import web_server
+
+        _print_connect_qr = web_server._print_connect_qr
+        _print_connect_qr("127.0.0.1", 9119, "https://hermes.example.com")
+        out = capsys.readouterr().out
+        assert "Scan to open on your phone → https://hermes.example.com" in out
+        assert any(ch in out for ch in ("█", "▀", "▄"))

--- a/tests/hermes_cli/test_terminal_qr.py
+++ b/tests/hermes_cli/test_terminal_qr.py
@@ -110,3 +110,73 @@ class TestDashboardQrGate:
         out = capsys.readouterr().out
         assert "Scan to open on your phone → https://hermes.example.com" in out
         assert any(ch in out for ch in ("█", "▀", "▄"))
+
+    def test_configured_public_url_overrides_loopback_bind(self, capsys, monkeypatch):
+        from hermes_cli import web_server
+        from hermes_cli.dashboard_auth import prefix
+
+        rendered = []
+        monkeypatch.setattr(
+            prefix,
+            "resolve_public_url",
+            lambda: "https://configured.example.com/dashboard",
+        )
+        monkeypatch.setattr(
+            terminal_qr,
+            "render_qr_to_terminal",
+            lambda url: rendered.append(url) or True,
+        )
+
+        web_server._print_connect_qr("127.0.0.1", 9119, "")
+
+        out = capsys.readouterr().out
+        assert "Scan to open on your phone → https://configured.example.com/dashboard" in out
+        assert "phone cannot" not in out
+        assert rendered == ["https://configured.example.com/dashboard"]
+
+    def test_invalid_explicit_url_falls_back_to_config(self, capsys, monkeypatch):
+        from hermes_cli import web_server
+        from hermes_cli.dashboard_auth import prefix
+
+        rendered = []
+        monkeypatch.setattr(
+            prefix,
+            "resolve_public_url",
+            lambda: "https://configured.example.com",
+        )
+        monkeypatch.setattr(
+            terminal_qr,
+            "render_qr_to_terminal",
+            lambda url: rendered.append(url) or True,
+        )
+
+        web_server._print_connect_qr("127.0.0.1", 9119, "file:///tmp/dashboard")
+
+        assert "https://configured.example.com" in capsys.readouterr().out
+        assert rendered == ["https://configured.example.com"]
+
+    def test_missing_qrcode_prints_guidance_without_installing(
+        self, capsys, monkeypatch
+    ):
+        from hermes_cli import web_server
+
+        monkeypatch.setattr(
+            terminal_qr,
+            "ensure_qrcode_installed",
+            lambda: pytest.fail("dashboard startup must not install qrcode"),
+        )
+        monkeypatch.setattr(
+            terminal_qr,
+            "render_qr_to_terminal",
+            lambda _url: False,
+        )
+
+        web_server._print_connect_qr(
+            "127.0.0.1",
+            9119,
+            "https://hermes.example.com",
+        )
+
+        out = capsys.readouterr().out
+        assert "Scan to open on your phone → https://hermes.example.com" in out
+        assert "pip install qrcode" in out


### PR DESCRIPTION
## Problem

Opening the dashboard on a phone means reading a URL off one screen and typing it into another — worse when the reachable address is a LAN IP you have to look up first. With remote-gateway usage growing (#39553, #53839) the phone-to-dashboard hop deserves a first-class on-ramp.

## What this adds

`hermes dashboard --qr` prints a scannable half-block QR of the URL another device can actually reach, once the server is up:

- `--public-url` (your tunnel hostname) wins outright
- a wildcard bind advertises the machine's LAN IP (UDP-connect trick, no packet sent) — phone on the same Wi-Fi scans straight into the Web UI
- a loopback bind prints guidance instead of a useless QR of 127.0.0.1

Auth is unchanged: public binds still require the auth gate, so the scanned page lands on the sign-in screen.

Consolidation instead of a third copy: the terminal QR renderer + qrcode auto-install helper move from `hermes_cli/dingtalk_auth.py` to a shared `hermes_cli/terminal_qr.py`; dingtalk re-exports unchanged. Prints flush explicitly so the QR is never lost in a block-buffered pipe (the ready-token print already did this).

Pairs with #66498: proxy for the desktop app's remote mode, `--qr` for the browser-on-phone path.

## Validation

- 10 tests (`tests/hermes_cli/test_terminal_qr.py`): URL resolution precedence, wildcard→LAN, offline fallback, loopback rejection, renderer fallback without qrcode, rendering with it, and both `--qr` gate paths
- `tests/hermes_cli/test_dingtalk_auth.py`: 15 passed (re-export unchanged)
- Live boot: `hermes dashboard --port 9291 --qr --public-url https://…` prints the scan line and a 13-row QR after `HERMES_DASHBOARD_READY`

## Scope note (QR namespace)

This is deliberately narrow and does not collide with the messaging-QR work (#58545 and the platform login-QR PRs): those render QR codes for bot/login pairing flows, this renders the dashboard's own URL for phone access. Different surface, different code path (new `hermes_cli/terminal_qr.py`, consumed only by `hermes dashboard --qr`). Pairs with #66498 (`hermes dashboard proxy`) for the desktop-app remote path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
