### PR TITLE
fix: reject steer outside its active turn

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5977,7 +5977,7 @@ def test_session_steer_calls_agent_steer_when_agent_supports_it():
         def interrupt(self, *args, **kwargs):
             calls["interrupt_called"] = True
 
-    server._sessions["sid"] = _session(agent=_Agent())
+    server._sessions["sid"] = _session(agent=_Agent(), running=True)
     try:
         resp = server.handle_request(
             {
@@ -6015,8 +6015,259 @@ def test_session_steer_rejects_empty_text():
     assert resp["error"]["code"] == 4002
 
 
+def test_session_steer_rejects_idle_session_without_stashing_for_a_future_turn():
+    calls = {}
+
+    class _Agent:
+        def steer(self, text):
+            calls["steer_text"] = text
+            return True
+
+    server._sessions["sid"] = _session(agent=_Agent(), running=False)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.steer",
+                "params": {"session_id": "sid", "text": "late guidance"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp["error"]["code"] == 4009
+    assert "steer_text" not in calls
+
+
+def test_session_steer_rejects_isolated_turn_instead_of_steering_dormant_agent():
+    calls = {}
+
+    class _Agent:
+        def steer(self, text):
+            calls["steer_text"] = text
+            return True
+
+    server._sessions["sid"] = _session(
+        agent=_Agent(),
+        running=True,
+        _compute_host_active=True,
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.steer",
+                "params": {"session_id": "sid", "text": "isolated guidance"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp is not None
+    assert resp["error"]["code"] == 4009
+    assert "steer_text" not in calls
+
+
+def test_session_steer_rejects_initial_compute_host_dispatch_window(monkeypatch):
+    session = _session(agent=None, running=True, _compute_host_active=False)
+    server._sessions["sid"] = session
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_args: True)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.steer",
+                "params": {"session_id": "sid", "text": "isolated guidance"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp is not None
+    assert resp["error"]["code"] == 4009
+
+
+def test_session_steer_rechecks_running_under_completion_lock():
+    calls = {}
+
+    class _Agent:
+        def steer(self, text):
+            calls["steer_text"] = text
+            return True
+
+    session = _session(agent=_Agent(), running=True)
+    server._sessions["sid"] = session
+    started = threading.Event()
+    response = {}
+
+    def send_steer():
+        started.set()
+        response["value"] = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.steer",
+                "params": {"session_id": "sid", "text": "completion race"},
+            }
+        )
+
+    session["history_lock"].acquire()
+    try:
+        worker = threading.Thread(target=send_steer)
+        worker.start()
+        assert started.wait(timeout=1)
+        # Model message.complete winning the same per-session lock.
+        session["running"] = False
+    finally:
+        session["history_lock"].release()
+    worker.join(timeout=1)
+    server._sessions.pop("sid", None)
+
+    assert not worker.is_alive()
+    assert response["value"]["error"]["code"] == 4009
+    assert "steer_text" not in calls
+
+
+def test_finish_session_turn_discards_steer_not_consumed_by_target_turn():
+    class _Agent:
+        def __init__(self):
+            self.pending_steer = "late guidance"
+
+        def _drain_pending_steer(self):
+            pending = self.pending_steer
+            self.pending_steer = None
+            return pending
+
+    agent = _Agent()
+    session = _session(
+        agent=agent,
+        running=True,
+        inflight_turn={"request_id": "turn-1"},
+    )
+
+    server._finish_session_turn(session, agent)
+
+    assert session["running"] is False
+    assert session["inflight_turn"] is None
+    assert agent.pending_steer is None
+
+
+def test_finish_session_turn_closes_even_when_late_steer_cleanup_fails():
+    class _Agent:
+        def _drain_pending_steer(self):
+            raise RuntimeError("broken steer slot")
+
+    agent = _Agent()
+    session = _session(
+        agent=agent,
+        running=True,
+        inflight_turn={"request_id": "turn-1"},
+    )
+
+    server._finish_session_turn(session, agent)
+
+    assert session["running"] is False
+    assert session["inflight_turn"] is None
+
+
+def test_finish_session_turn_does_not_clear_a_new_turn_started_after_cleanup():
+    drain_started = threading.Event()
+    allow_drain = threading.Event()
+
+    class _Agent:
+        def _drain_pending_steer(self):
+            drain_started.set()
+            assert allow_drain.wait(timeout=1)
+            return None
+
+    agent = _Agent()
+    session = _session(
+        agent=agent,
+        running=True,
+        inflight_turn={"request_id": "turn-1"},
+    )
+
+    finisher = threading.Thread(target=server._finish_session_turn, args=(session, agent))
+    finisher.start()
+    assert drain_started.wait(timeout=1)
+
+    next_turn_attempting = threading.Event()
+    next_turn_started = threading.Event()
+
+    def start_next_turn():
+        next_turn_attempting.set()
+        with session["history_lock"]:
+            assert session["running"] is False
+            session["running"] = True
+            next_turn_started.set()
+
+    starter = threading.Thread(target=start_next_turn)
+    starter.start()
+    assert next_turn_attempting.wait(timeout=1)
+    assert not next_turn_started.wait(timeout=0.05)
+    allow_drain.set()
+    finisher.join(timeout=1)
+    starter.join(timeout=1)
+
+    assert not finisher.is_alive()
+    assert not starter.is_alive()
+    assert next_turn_started.is_set()
+    assert session["running"] is True
+
+
+def test_claim_refusal_finalizes_provisional_notification_turn(monkeypatch):
+    from tools import async_delegation
+
+    class _Agent:
+        pending_steer = "arrived before claim"
+
+        def _drain_pending_steer(self):
+            pending = self.pending_steer
+            self.pending_steer = None
+            return pending
+
+    agent = _Agent()
+    session = _session(agent=agent, running=True)
+    monkeypatch.setattr(async_delegation, "claim_event_delivery", lambda *_args: None)
+
+    claim = server._claim_session_event_delivery(session, {"type": "completion"}, "test")
+
+    assert claim is None
+    assert session["running"] is False
+    assert agent.pending_steer is None
+
+
+def test_queued_dispatch_failure_discards_steer_accepted_in_dispatch_window(monkeypatch):
+    class _Agent:
+        pending_steer: str | None = None
+
+        def _drain_pending_steer(self):
+            pending = self.pending_steer
+            self.pending_steer = None
+            return pending
+
+    agent = _Agent()
+    session = _session(
+        agent=agent,
+        running=False,
+        queued_prompt={"text": "next turn", "transport": None},
+    )
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_args: False)
+
+    def fail_dispatch(*_args):
+        agent.pending_steer = "accepted before synchronous failure"
+        raise RuntimeError("dispatch failed")
+
+    monkeypatch.setattr(server, "_run_prompt_submit", fail_dispatch)
+
+    assert server._drain_queued_prompt("rid", "sid", session) is True
+    assert session["running"] is False
+    assert agent.pending_steer is None
+
+
 def test_session_steer_errors_when_agent_has_no_steer_method():
-    server._sessions["sid"] = _session(agent=types.SimpleNamespace())  # no steer()
+    server._sessions["sid"] = _session(
+        agent=types.SimpleNamespace(), running=True
+    )  # no steer()
     try:
         resp = server.handle_request(
             {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5480,9 +5480,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             resp = _submit_prompt_to_compute_host(rid, sid, session, queued["text"])
             if resp.get("error"):
                 message = str(((resp.get("error") or {}).get("message")) or "queued prompt failed")
-                with session["history_lock"]:
-                    session["running"] = False
-                    _clear_inflight_turn(session)
+                _finish_session_turn(session, session.get("agent"))
                 _emit("error", sid, {"message": message})
         else:
             _run_prompt_submit(rid, sid, session, queued["text"])
@@ -5492,8 +5490,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             f"{type(exc).__name__}: {exc}",
             file=sys.stderr,
         )
-        with session["history_lock"]:
-            session["running"] = False
+        _finish_session_turn(session, session.get("agent"))
     return True
 
 
@@ -8807,14 +8804,75 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
-    agent = session.get("agent")
-    if agent is None or not hasattr(agent, "steer"):
-        return _err(rid, 4010, "agent does not support steer")
-    try:
-        accepted = agent.steer(text)
-    except Exception as exc:
-        return _err(rid, 5000, f"steer failed: {exc}")
+    assert session is not None
+    # Serialize against prompt completion. `running` is set/cleared under this
+    # same per-session lock, so a steer either lands in the active turn before
+    # completion wins the lock or is rejected after completion clears it. An
+    # idle steer must never remain queued for an unrelated future turn.
+    with session["history_lock"]:
+        if not session.get("running"):
+            return _err(rid, 4009, "session is not running")
+        if session.get("_compute_host_active") or _session_uses_compute_host(session):
+            return _err(rid, 4009, "session steer is unavailable for an isolated turn")
+        agent = session.get("agent")
+        if agent is None or not hasattr(agent, "steer"):
+            return _err(rid, 4010, "agent does not support steer")
+        try:
+            accepted = agent.steer(text)
+        except Exception as exc:
+            return _err(rid, 5000, f"steer failed: {exc}")
     return _ok(rid, {"status": "queued" if accepted else "rejected", "text": text})
+
+
+def _finish_session_turn_locked(session: dict, agent: Any) -> tuple[Any, Exception | None]:
+    """Close the current turn while the caller holds ``history_lock``."""
+    drain_steer = getattr(agent, "_drain_pending_steer", None)
+    dropped_steer = None
+    drain_error = None
+    try:
+        dropped_steer = drain_steer() if callable(drain_steer) else None
+    except Exception as exc:
+        drain_error = exc
+    session["running"] = False
+    session["last_active"] = time.time()
+    _clear_inflight_turn(session)
+    return dropped_steer, drain_error
+
+
+def _log_finished_session_steer(
+    dropped_steer: Any, drain_error: Exception | None
+) -> None:
+    if drain_error:
+        logger.warning("Failed to discard late /steer: %s", drain_error)
+    if dropped_steer:
+        logger.info("Discarded late /steer after its target turn completed")
+
+
+def _finish_session_turn(session: dict, agent: Any) -> None:
+    """Atomically close a turn and discard guidance it did not consume.
+
+    A steer can race the final provider response after the turn's last tool
+    batch. AIAgent normally preserves such guidance for a future turn; the
+    gateway must not let guidance accepted for one turn leak into an unrelated
+    later prompt.
+    """
+    with session["history_lock"]:
+        dropped_steer, drain_error = _finish_session_turn_locked(session, agent)
+    _log_finished_session_steer(dropped_steer, drain_error)
+
+
+def _claim_session_event_delivery(session: dict, event: dict, owner: str) -> Any:
+    """Claim a provisional notification turn or atomically roll it back."""
+    from tools.async_delegation import claim_event_delivery
+
+    try:
+        claim = claim_event_delivery(event, owner)
+    except Exception:
+        _finish_session_turn(session, session.get("agent"))
+        raise
+    if claim is None:
+        _finish_session_turn(session, session.get("agent"))
+    return claim
 
 
 @method("terminal.resize")
@@ -8840,6 +8898,7 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    assert session is not None
     isolation_cfg = _load_dashboard_process_isolation_config()
     turn_isolation = _session_uses_compute_host(session, isolation_cfg)
     # Re-bind to the current client transport for this request. This keeps
@@ -8917,15 +8976,19 @@ def _(rid, params: dict) -> dict:
                     )
                 },
             )
-            with session["history_lock"]:
-                session["running"] = False
-                _clear_inflight_turn(session)
+            _finish_session_turn(session, session.get("agent"))
             return
+        dropped_steer = None
+        drain_error = None
         with session["history_lock"]:
-            if session.get("_turn_cancel_requested") or not session.get("running"):
-                session["running"] = False
-                _clear_inflight_turn(session)
-                return
+            cancelled = session.get("_turn_cancel_requested") or not session.get("running")
+            if cancelled:
+                dropped_steer, drain_error = _finish_session_turn_locked(
+                    session, session.get("agent")
+                )
+        if cancelled:
+            _log_finished_session_steer(dropped_steer, drain_error)
+            return
         _run_prompt_submit(rid, sid, session, text)
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
@@ -9191,9 +9254,9 @@ def _notification_poller_loop(
 
         rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
+            complete_event_delivery, release_event_delivery,
         )
-        _claim = claim_event_delivery(evt, "tui-poller")
+        _claim = _claim_session_event_delivery(session, evt, "tui-poller")
         if _claim is None:
             continue
         try:
@@ -9207,8 +9270,7 @@ def _notification_poller_loop(
                 f"{type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )
-            with session["history_lock"]:
-                session["running"] = False
+            _finish_session_turn(session, session.get("agent"))
 
     # Drain any remaining events after stop signal (process all pending
     # before exiting so nothing is lost on shutdown). Events owned by other
@@ -9259,9 +9321,9 @@ def _notification_poller_loop(
 
         rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
+            complete_event_delivery, release_event_delivery,
         )
-        _claim = claim_event_delivery(evt, "tui-poller")
+        _claim = _claim_session_event_delivery(session, evt, "tui-poller")
         if _claim is None:
             continue
         try:
@@ -9275,8 +9337,7 @@ def _notification_poller_loop(
                 f"{type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )
-            with session["history_lock"]:
-                session["running"] = False
+            _finish_session_turn(session, session.get("agent"))
 
     # Hand any other sessions' events back to the shared queue.
     for evt in deferred:
@@ -9779,10 +9840,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             if home_token is not None:
                 reset_hermes_home_override(home_token)
             _clear_session_context(session_tokens)
-            with session["history_lock"]:
-                session["running"] = False
-                session["last_active"] = time.time()
-                _clear_inflight_turn(session)
+            _finish_session_turn(session, agent)
             _emit("session.info", sid, _session_info(agent, session))
 
         # A user prompt that arrived mid-turn (interrupt + queue) wins over
@@ -9813,8 +9871,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     f"{type(_cont_exc).__name__}: {_cont_exc}",
                     file=sys.stderr,
                 )
-                with session["history_lock"]:
-                    session["running"] = False
+                _finish_session_turn(session, session.get("agent"))
 
         # Drain completion notifications that arrived during this turn.
         # The background poller handles between-turn delivery; this is
@@ -9845,9 +9902,9 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         break
                     session["running"] = True
                 from tools.async_delegation import (
-                    claim_event_delivery, complete_event_delivery, release_event_delivery,
+                    complete_event_delivery, release_event_delivery,
                 )
-                _claim = claim_event_delivery(_evt, "tui-post-turn")
+                _claim = _claim_session_event_delivery(session, _evt, "tui-post-turn")
                 if _claim is None:
                     continue
                 try:
@@ -9861,8 +9918,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         f"{type(_n_exc).__name__}: {_n_exc}",
                         file=sys.stderr,
                     )
-                    with session["history_lock"]:
-                        session["running"] = False
+                    _finish_session_turn(session, session.get("agent"))
         except Exception as _drain_exc:
             print(
                 f"[tui_gateway] completion queue drain failed: "


### PR DESCRIPTION
## Summary

Fix `session.steer` so guidance can never be accepted for one turn and leak into a later unrelated turn.

- reject idle sessions with deterministic RPC code `4009`
- serialize the active-state check and `agent.steer()` under the same per-session `history_lock` used by completion
- reject compute-host-isolated turns instead of steering a dormant in-process agent
- discard steer that arrives after the target turn's final tool batch at normal completion, agent initialization failure, or cancellation
- keep cancellation predicate + cleanup atomic so an old waiter cannot clear a newly started turn
- preserve turn teardown even if late-steer cleanup itself fails
- finalize provisional notification turns when event claims refuse or raise
- drain late steer on queued, goal-continuation, and notification dispatch failures

## Why

`AIAgent.steer()` intentionally preserves undelivered guidance for the next tool result. The gateway previously exposed it whenever a session object existed, even if no turn was active. A late request could therefore be queued into a future unrelated prompt. A running-only check still leaves a final-response race after the last tool batch, so completion must also discard guidance not consumed by the target turn.

## Tests

- active steer succeeds without interrupting
- idle steer rejects with `4009` and does not call the agent
- completion-lock race rejects deterministically
- isolated compute-host turn rejects instead of touching a dormant agent
- late pending steer is discarded on completion
- cleanup failure cannot leave `running` stuck
- next-turn start waits behind cleanup and remains running afterward

Verification on current upstream `main`:

- focused gateway tests: 12 passed
- Ruff: passed
- `git diff --check`: passed
- full gateway file: 357 passed; one unrelated existing local-browser test failed because no Chromium-family binary is installed

Exact commit: `91b9c42e45600d7a79fc427e23521b50d21cfb3e`

Exact patch SHA-256: `256a58de80dc8beb63d8d14fec2f5504971945d852f268c5c80327f131f4183f`
