### PR TITLE
fix(agent): drop null assistant turns in pre-API sanitizer (#66429)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2770,6 +2770,63 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             dropped_empty_tool_calls,
         )
 
+    # --- Drop null assistant turns (no payload at all) ---
+    # An assistant message with empty content, no tool_calls, no reasoning and
+    # no codex items carries zero information. Weak/quantized open-weight models
+    # can emit a run of these after tool results, and (unlike thinking-only
+    # turns, handled in drop_thinking_only_and_merge_users) they have no
+    # reasoning to gate on, so nothing else removes them. Left in place they
+    # accumulate on the wire (observed 36 in one request, #66429) and collapse
+    # tool-calling: the model narrates and stops. Runs on the per-call copy
+    # only; the persisted transcript keeps its "(empty)" sentinel for the UI.
+    #
+    # Preserve any assistant turn carrying reasoning or Codex items even when
+    # its visible content is empty — dropping those breaks the Codex
+    # reasoning-replay contract
+    # (test_run_conversation_codex_disables_reasoning_replay_after_invalid_encrypted_content).
+    def _assistant_content_is_empty(content: Any) -> bool:
+        if content is None:
+            return True
+        if isinstance(content, str):
+            return not content.strip()
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    if block:
+                        return False
+                    continue
+                if block.get("type") == "text":
+                    if (block.get("text") or "").strip():
+                        return False
+                elif block.get("type") is not None:
+                    return False  # image/other non-text block = real content
+            return True
+        return False
+
+    def _is_null_assistant(m: Dict[str, Any]) -> bool:
+        if not isinstance(m, dict) or m.get("role") != "assistant":
+            return False
+        if not _assistant_content_is_empty(m.get("content")):
+            return False
+        if isinstance(m.get("tool_calls"), list) and m["tool_calls"]:
+            return False
+        for _k in (
+            "reasoning", "reasoning_content", "reasoning_details",
+            "codex_reasoning_items", "codex_message_items",
+        ):
+            if m.get(_k):
+                return False
+        return True
+
+    _before_null = len(messages)
+    messages = [m for m in messages if not _is_null_assistant(m)]
+    if _before_null != len(messages):
+        _ra().logger.debug(
+            "Pre-call sanitizer: dropped %d null assistant turn(s) "
+            "(no content, no tool_calls, no reasoning; #66429)",
+            _before_null - len(messages),
+        )
+
     # --- Repair tool_calls whose function.name is empty/missing ---
     # Some providers (and partially-streamed responses) emit a tool_call with
     # id="call_xxx" but function.name="". Downstream Responses-API adapters

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1256,6 +1256,64 @@ def try_recover_primary_transport(
 
 
 
+def _merge_adjacent_user_messages(
+    messages: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Merge consecutive ``user`` messages into one, preserving alternation.
+
+    Any pass that drops an assistant turn between two user turns must call
+    this afterward, or the wire payload violates the provider's strict
+    role-alternation invariant (never two same-role messages in a row).
+    Pure: never mutates the caller's dicts. Returns ``(merged, n_merges)``.
+    """
+    merged: List[Dict[str, Any]] = []
+    merges = 0
+    for m in messages:
+        prev = merged[-1] if merged else None
+        if (
+            prev is not None
+            and prev.get("role") == "user"
+            and m.get("role") == "user"
+        ):
+            prev_content = prev.get("content", "")
+            cur_content = m.get("content", "")
+            # Work on a copy of ``prev`` so the caller's input dicts are
+            # never mutated. Callers already hand us per-call copies, but
+            # staying pure means we can be called safely from anywhere.
+            prev_copy = dict(prev)
+            # Only string-content merge is meaningful for role-alternation
+            # purposes. If either side is a list (multimodal), append as a
+            # separate block rather than collapsing.
+            if isinstance(prev_content, str) and isinstance(cur_content, str):
+                sep = "\n\n" if prev_content and cur_content else ""
+                prev_copy["content"] = prev_content + sep + cur_content
+            elif isinstance(prev_content, list) and isinstance(cur_content, list):
+                prev_copy["content"] = list(prev_content) + list(cur_content)
+            elif isinstance(prev_content, list) and isinstance(cur_content, str):
+                if cur_content:
+                    prev_copy["content"] = list(prev_content) + [
+                        {"type": "text", "text": cur_content}
+                    ]
+                else:
+                    prev_copy["content"] = list(prev_content)
+            elif isinstance(prev_content, str) and isinstance(cur_content, list):
+                new_blocks: List[Dict[str, Any]] = []
+                if prev_content:
+                    new_blocks.append({"type": "text", "text": prev_content})
+                new_blocks.extend(cur_content)
+                prev_copy["content"] = new_blocks
+            else:
+                # Unknown content shape — fall back to appending separately
+                # (violates alternation, but safer than raising in a hot path).
+                merged.append(m)
+                continue
+            merged[-1] = prev_copy
+            merges += 1
+        else:
+            merged.append(m)
+    return merged, merges
+
+
 def drop_thinking_only_and_merge_users(
     messages: List[Dict[str, Any]],
     *,
@@ -1293,52 +1351,7 @@ def drop_thinking_only_and_merge_users(
         return messages
 
     # Pass 2: merge any newly-adjacent user messages.
-    merged: List[Dict[str, Any]] = []
-    merges = 0
-    for m in kept:
-        prev = merged[-1] if merged else None
-        if (
-            prev is not None
-            and prev.get("role") == "user"
-            and m.get("role") == "user"
-        ):
-            prev_content = prev.get("content", "")
-            cur_content = m.get("content", "")
-            # Work on a copy of ``prev`` so the caller's input dicts are
-            # never mutated. ``_sanitize_api_messages`` upstream already
-            # hands us per-call copies, but staying pure here means we
-            # can be called safely from anywhere (tests, other loops).
-            prev_copy = dict(prev)
-            # Only string-content merge is meaningful for role-alternation
-            # purposes. If either side is a list (multimodal), append as a
-            # separate block rather than collapsing.
-            if isinstance(prev_content, str) and isinstance(cur_content, str):
-                sep = "\n\n" if prev_content and cur_content else ""
-                prev_copy["content"] = prev_content + sep + cur_content
-            elif isinstance(prev_content, list) and isinstance(cur_content, list):
-                prev_copy["content"] = list(prev_content) + list(cur_content)
-            elif isinstance(prev_content, list) and isinstance(cur_content, str):
-                if cur_content:
-                    prev_copy["content"] = list(prev_content) + [
-                        {"type": "text", "text": cur_content}
-                    ]
-                else:
-                    prev_copy["content"] = list(prev_content)
-            elif isinstance(prev_content, str) and isinstance(cur_content, list):
-                new_blocks: List[Dict[str, Any]] = []
-                if prev_content:
-                    new_blocks.append({"type": "text", "text": prev_content})
-                new_blocks.extend(cur_content)
-                prev_copy["content"] = new_blocks
-            else:
-                # Unknown content shape — fall back to appending separately
-                # (violates alternation, but safer than raising in a hot path).
-                merged.append(m)
-                continue
-            merged[-1] = prev_copy
-            merges += 1
-        else:
-            merged.append(m)
+    merged, merges = _merge_adjacent_user_messages(kept)
 
     _ra().logger.debug(
         "Pre-call sanitizer: dropped %d thinking-only assistant turn(s), "
@@ -2776,8 +2789,9 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # can emit a run of these after tool results, and (unlike thinking-only
     # turns, handled in drop_thinking_only_and_merge_users) they have no
     # reasoning to gate on, so nothing else removes them. Left in place they
-    # accumulate on the wire (observed 36 in one request, #66429) and collapse
-    # tool-calling: the model narrates and stops. Runs on the per-call copy
+    # accumulate on the wire (observed 36 in one request, #66429) and strict
+    # providers reject the empty assistant message outright with HTTP 400
+    # ("assistant message ... must not be empty"). Runs on the per-call copy
     # only; the persisted transcript keeps its "(empty)" sentinel for the UI.
     #
     # Preserve any assistant turn carrying reasoning or Codex items even when
@@ -2819,12 +2833,20 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         return True
 
     _before_null = len(messages)
-    messages = [m for m in messages if not _is_null_assistant(m)]
-    if _before_null != len(messages):
+    _kept_after_null = [m for m in messages if not _is_null_assistant(m)]
+    _dropped_null = _before_null - len(_kept_after_null)
+    if _dropped_null:
+        # Dropping an assistant turn between two user turns leaves them
+        # adjacent (``user → assistant(null) → user`` becomes ``user →
+        # user``), which violates strict role alternation. Repair the
+        # sequence with the same merge pass the thinking-only filter uses.
+        messages, _null_merges = _merge_adjacent_user_messages(_kept_after_null)
         _ra().logger.debug(
             "Pre-call sanitizer: dropped %d null assistant turn(s) "
-            "(no content, no tool_calls, no reasoning; #66429)",
-            _before_null - len(messages),
+            "(no content, no tool_calls, no reasoning; #66429), "
+            "merged %d adjacent user message(s)",
+            _dropped_null,
+            _null_merges,
         )
 
     # --- Repair tool_calls whose function.name is empty/missing ---

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -770,3 +770,63 @@ def test_sanitize_preserves_populated_tool_calls():
     out = sanitize_api_messages(list(messages))
     assistant = [m for m in out if m.get("role") == "assistant"][0]
     assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_Z"]
+
+
+def test_sanitize_drops_null_assistant_turns():
+    """sanitize_api_messages drops assistant turns with no payload at all
+    (empty content, no tool_calls, no reasoning). These accumulate in a
+    runaway loop and collapse tool-calling on open-weight models (#66429)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "tool_calls": []},
+        {"role": "assistant", "content": ""},
+        {"role": "assistant", "content": "   "},
+        {"role": "assistant", "content": None},
+    ]
+    out = sanitize_api_messages(list(messages))
+    leftover_null = [
+        m for m in out
+        if m.get("role") == "assistant"
+        and not (m.get("content") or "").strip()
+        and not m.get("tool_calls")
+    ]
+    assert leftover_null == []
+    # the real turns survive
+    assert [m["role"] for m in out] == ["system", "user"]
+
+
+def test_sanitize_keeps_real_assistant_turns():
+    """Negative control: text answers, real tool calls, and thinking-only
+    turns (empty content WITH reasoning) must NOT be dropped."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "assistant", "content": "real answer"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "read_file", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "result"},
+        {"role": "assistant", "content": "", "reasoning": "thinking..."},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert any((m.get("content") or "") == "real answer" for m in out)
+    assert any(m.get("tool_calls") for m in out)
+    assert any(m.get("reasoning") for m in out)
+
+
+def test_sanitize_keeps_empty_content_with_codex_reasoning():
+    """Regression guard: an assistant turn with empty visible content but
+    codex_reasoning_items must be preserved — dropping it breaks the Codex
+    reasoning-replay contract (the case that must not regress)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "",
+         "codex_reasoning_items": [{"type": "reasoning", "id": "r1"}]},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert any(m.get("codex_reasoning_items") for m in out)

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -774,8 +774,8 @@ def test_sanitize_preserves_populated_tool_calls():
 
 def test_sanitize_drops_null_assistant_turns():
     """sanitize_api_messages drops assistant turns with no payload at all
-    (empty content, no tool_calls, no reasoning). These accumulate in a
-    runaway loop and collapse tool-calling on open-weight models (#66429)."""
+    (empty content, no tool_calls, no reasoning). Strict providers reject the
+    empty assistant message with HTTP 400 (#66429)."""
     from agent.agent_runtime_helpers import sanitize_api_messages
 
     messages = [
@@ -830,3 +830,59 @@ def test_sanitize_keeps_empty_content_with_codex_reasoning():
     ]
     out = sanitize_api_messages(list(messages))
     assert any(m.get("codex_reasoning_items") for m in out)
+
+
+# ── sequence repair after dropping a null assistant turn (#66509 review) ─────
+# Dropping an assistant turn that sat between two user turns leaves them
+# adjacent, which violates strict role alternation. The filter must run the
+# merge pass afterward, exactly as the thinking-only filter does.
+
+
+def test_null_assistant_drop_merges_newly_adjacent_users():
+    """user → assistant(null) → user  must collapse to a single user turn,
+    not leave two consecutive user messages on the wire."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": ""},          # null turn, dropped
+        {"role": "user", "content": "second question"},
+    ]
+    out = sanitize_api_messages(list(messages))
+
+    assert [m["role"] for m in out] == ["system", "user"]
+    roles = [m["role"] for m in out]
+    assert all(a != b for a, b in zip(roles, roles[1:]))
+    merged_user = [m for m in out if m["role"] == "user"][0]["content"]
+    assert "first question" in merged_user
+    assert "second question" in merged_user
+
+
+def test_null_assistant_drop_after_tool_tail_leaves_no_orphan_gap():
+    """tool → assistant(null) → user  becomes  tool → user: dropping the null
+    turn must not strand the tool result or create an invalid pairing."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "do it"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "call_A", "type": "function",
+                         "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_A", "content": "output"},
+        {"role": "assistant", "content": ""},          # null tail, dropped
+        {"role": "user", "content": "next"},
+    ]
+    out = sanitize_api_messages(list(messages))
+
+    assert any(m.get("role") == "tool" and m.get("tool_call_id") == "call_A"
+               for m in out)
+    assert not any(
+        m.get("role") == "assistant"
+        and not (m.get("content") or "").strip()
+        and not m.get("tool_calls")
+        for m in out
+    )
+    roles = [m["role"] for m in out]
+    assert roles == ["system", "user", "assistant", "tool", "user"]


### PR DESCRIPTION
An assistant message with empty content, no tool_calls, no reasoning and no Codex items carries zero information. Weak/quantized open-weight models can emit a run of these after tool results, and each retry appends one more, so a request body accumulates a runaway pile of empty assistant turns (wire capture: 36 in a single request). The chat template renders each as a completed empty turn, and the model — seeing itself "say nothing" many times in a row — stops emitting tool calls and just narrates.

Neither existing chokepoint removes them: sanitize_api_messages only drops empty tool_calls arrays (#58755), and drop_thinking_only_and_merge_users only drops empty turns that carry reasoning. The no-content / no-tool_calls / no-reasoning shape falls through both.

Drop those null turns in sanitize_api_messages, on the per-call copy only (the persisted transcript keeps its "(empty)" sentinel for the UI). Preserve any assistant turn carrying reasoning or Codex items even when its visible content is empty — dropping those breaks the Codex reasoning-replay contract. This guard is why the earlier attempt in #66434 failed CI on
test_run_conversation_codex_disables_reasoning_replay_after_invalid_encrypted_content; that test now passes.

Adds regression coverage: null turns dropped, real turns (text, tool calls, thinking-only) preserved, and empty-content-with-codex-reasoning preserved.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ x ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ X] I've run `pytest tests/ -q` and all tests pass
- [ X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ X] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

