### PR TITLE
feat(kanban): structured blocker ownership (reviewer/automation/parked never masquerade as human asks)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -80,6 +80,10 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        "block_kind": t.block_kind,
+        "block_recurrences": t.block_recurrences,
+        "blocker_owner_kind": t.blocker_owner_kind,
+        "blocker_owner": t.blocker_owner,
     }
 
 
@@ -587,7 +591,26 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "triage to break unblock loops. Omit for a generic block."
         ),
     )
-
+    p_block.add_argument(
+        "--owner-kind", dest="owner_kind", default=None,
+        choices=sorted(kb.VALID_BLOCKER_OWNER_KINDS - {"unknown"}),
+        help=(
+            "WHO must clear this block (orthogonal to --kind). 'human' = a "
+            "named person must decide/act (pass --owner); 'reviewer' = "
+            "awaiting review (the review-required lane; auto-set from a "
+            "'review-required' reason, never a named person); 'automation' = "
+            "an agent/cron/pipeline; 'external' = a third party/system; "
+            "'acceptance' = batchable verification; 'parked' = shelved, "
+            "don't nag. Omit for legacy/unknown — never defaults to human."
+        ),
+    )
+    p_block.add_argument(
+        "--owner", dest="owner", default=None,
+        help=(
+            "Specific owner / required-from string; kept only for "
+            "--owner-kind human or external."
+        ),
+    )
     p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
     p_schedule.add_argument("task_id")
     p_schedule.add_argument("reason", nargs="*", help="Reason/timing note (also appended as a comment)")
@@ -2038,6 +2061,8 @@ def _cmd_edit(args: argparse.Namespace) -> int:
 def _cmd_block(args: argparse.Namespace) -> int:
     reason = " ".join(args.reason).strip() if args.reason else None
     kind = getattr(args, "kind", None)
+    owner_kind = getattr(args, "owner_kind", None)
+    owner = getattr(args, "owner", None)
     author = _profile_author()
     ids = [args.task_id] + list(getattr(args, "ids", None) or [])
     failed: list[str] = []
@@ -2050,6 +2075,8 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 tid,
                 reason=reason,
                 kind=kind,
+                blocker_owner_kind=owner_kind,
+                blocker_owner=owner,
                 expected_run_id=_worker_run_id_for(tid),
             ):
                 failed.append(tid)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -124,6 +124,101 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
 VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 
+# ---------------------------------------------------------------------------
+# Blocker OWNERSHIP (orthogonal to VALID_BLOCK_KINDS above).
+#
+# ``block_kind`` answers "what retry/routing behaviour does this block want"
+# (dependency vs needs_input vs capability vs transient). It does NOT answer
+# "who is on the hook to clear this block". Reports historically inferred the
+# owner from free text in the reason ("Daniel", "your review", ...), which
+# collapsed reviewer work, autonomous automation, parked work, and true human
+# decisions into one undifferentiated "blocked on Daniel" queue (see the
+# 36-card false personal queue). ``blocker_owner_kind`` makes ownership a
+# first-class structured field owned by the kernel, so downstream reports and
+# triage never have to guess from prose:
+#
+#   * ``human``      — a specific person must make a decision / take an action.
+#                      Pair with ``blocker_owner`` naming who (e.g. "daniel").
+#                      Never the implicit default — a block is only human-owned
+#                      when a caller says so.
+#   * ``reviewer``   — awaiting code/PR review (the ``review-required`` lane).
+#                      Owned by whoever reviews, NOT by a named human.
+#   * ``automation`` — waiting on an autonomous agent / cron / pipeline
+#                      (merge, rebase, packaging). No human ask.
+#   * ``external``   — waiting on a third party / external system / service.
+#                      ``blocker_owner`` may name it (e.g. "upstream-ci").
+#   * ``acceptance`` — awaiting acceptance/verification that can be batched
+#                      (e.g. an in-game walk-through). Distinct from a blocking
+#                      human decision; can be swept in a batch, not nagged.
+#   * ``parked``     — deliberately shelved work. Not an ask of anyone; must
+#                      never be nagged as a pending human queue item.
+#   * ``unknown``    — legacy / un-classified rows (persisted as NULL). Reports
+#                      may apply a conservative prose fallback for these ONLY.
+#
+# ``blocker_owner`` carries a specific owner/required-from string and is only
+# meaningful when ``blocker_owner_kind`` is ``human`` or ``external``; it is
+# cleared for every other kind so no code path can smuggle a name (like
+# "daniel") in behind a non-human kind.
+VALID_BLOCKER_OWNER_KINDS = {
+    "human",
+    "reviewer",
+    "automation",
+    "external",
+    "acceptance",
+    "parked",
+    "unknown",
+}
+
+# Owner kinds that carry a meaningful ``blocker_owner`` (required-from) string.
+# For every other kind the owner string is dropped on write.
+_OWNER_KINDS_WITH_OWNER = {"human", "external"}
+
+
+def derive_blocker_owner(
+    reason: Optional[str],
+    owner_kind: Optional[str],
+    owner: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Normalise a (owner_kind, owner) pair for persistence.
+
+    Rules (kernel-owned, so reports never re-derive from prose):
+
+    * An explicit ``owner_kind`` wins and is validated against
+      :data:`VALID_BLOCKER_OWNER_KINDS`. ``"unknown"`` normalises to ``None``
+      (stored as NULL) so legacy and explicitly-unknown rows read identically.
+    * With no explicit kind, the only conservative inference the kernel makes
+      is the well-established ``review-required`` convention → ``reviewer``.
+      Everything else stays ``None`` (unknown) — the kernel NEVER defaults a
+      block to ``human``, so no card silently becomes a personal ask.
+    * ``owner`` (required-from) is retained only for ``human`` / ``external``;
+      it is dropped for every other kind so a name can't ride in behind a
+      non-human classification.
+
+    Returns the normalised ``(owner_kind, owner)`` to store on the task row.
+    Raises ``ValueError`` on an unrecognised explicit ``owner_kind``.
+    """
+    if owner_kind is not None:
+        owner_kind = str(owner_kind).strip().lower() or None
+    if owner_kind is not None and owner_kind not in VALID_BLOCKER_OWNER_KINDS:
+        raise ValueError(
+            f"blocker owner kind must be one of "
+            f"{sorted(VALID_BLOCKER_OWNER_KINDS)} or None"
+        )
+    if owner_kind == "unknown":
+        owner_kind = None
+
+    if owner_kind is None:
+        # Conservative, single well-known inference: the review-required lane
+        # is reviewer-owned, never a named human.
+        if reason and "review-required" in reason.lower():
+            owner_kind = "reviewer"
+
+    owner_str: Optional[str] = None
+    if owner_kind in _OWNER_KINDS_WITH_OWNER and owner:
+        owner_str = str(owner).strip() or None
+
+    return owner_kind, owner_str
+
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
 # unblocker (usually a cron) and routes the task to ``triage`` instead of back
@@ -915,6 +1010,13 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Structured blocker ownership (one of VALID_BLOCKER_OWNER_KINDS) or None
+    # for legacy/unknown rows. Answers "who clears this block"; review-required
+    # defaults to reviewer, never a named human. Set by ``block_task``.
+    blocker_owner_kind: Optional[str] = None
+    # Specific owner / required-from string; only meaningful for 'human' /
+    # 'external' kinds, None otherwise.
+    blocker_owner: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -998,6 +1100,16 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            blocker_owner_kind=(
+                row["blocker_owner_kind"]
+                if "blocker_owner_kind" in keys and row["blocker_owner_kind"]
+                else None
+            ),
+            blocker_owner=(
+                row["blocker_owner"]
+                if "blocker_owner" in keys and row["blocker_owner"]
+                else None
             ),
         )
 
@@ -1176,7 +1288,17 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Structured blocker OWNERSHIP (orthogonal to block_kind above). One of
+    -- VALID_BLOCKER_OWNER_KINDS (human / reviewer / automation / external /
+    -- acceptance / parked) or NULL for legacy/unknown rows. Answers "who is on
+    -- the hook to clear this block" so reports never infer ownership from the
+    -- free-text reason. review-required defaults to reviewer, never human.
+    blocker_owner_kind   TEXT,
+    -- Specific owner / required-from string. Only meaningful (and only
+    -- persisted) when blocker_owner_kind is 'human' or 'external'; NULL
+    -- otherwise so a name can't ride in behind a non-human classification.
+    blocker_owner        TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1985,6 +2107,18 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "tasks",
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+
+    if "blocker_owner_kind" not in cols:
+        # Structured blocker ownership. NULL on existing rows = unknown/legacy,
+        # which reports treat conservatively (prose fallback) — no card silently
+        # becomes a human ask on migration.
+        _add_column_if_missing(
+            conn, "tasks", "blocker_owner_kind", "blocker_owner_kind TEXT"
+        )
+    if "blocker_owner" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "blocker_owner", "blocker_owner TEXT"
         )
 
     # Indexes over additive ``tasks`` columns must be created after the
@@ -4173,7 +4307,9 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL,
                        block_kind   = NULL,
-                       block_recurrences = 0
+                       block_recurrences = 0,
+                       blocker_owner_kind = NULL,
+                       blocker_owner = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
                 """,
@@ -4190,7 +4326,9 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL,
                        block_kind   = NULL,
-                       block_recurrences = 0
+                       block_recurrences = 0,
+                       blocker_owner_kind = NULL,
+                       blocker_owner = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
                    AND current_run_id = ?
@@ -4879,6 +5017,8 @@ def block_task(
     *,
     reason: Optional[str] = None,
     kind: Optional[str] = None,
+    blocker_owner_kind: Optional[str] = None,
+    blocker_owner: Optional[str] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
@@ -4905,6 +5045,16 @@ def block_task(
       can use it to signal "this might clear on its own"; it still participates
       in the loop breaker so a forever-flaky task eventually escalates.
 
+    ``blocker_owner_kind`` / ``blocker_owner`` are the ORTHOGONAL ownership
+    dimension (see :data:`VALID_BLOCKER_OWNER_KINDS`). ``kind`` says what retry
+    behaviour the block wants; ``blocker_owner_kind`` says who is on the hook to
+    clear it. They are normalised through :func:`derive_blocker_owner`, so:
+    ``review-required`` reasons default to ``reviewer`` (never a named human),
+    an owner string is only kept for ``human``/``external``, and the kernel
+    never silently defaults a block to ``human``. The classification is
+    persisted on the task row and echoed into the block event payload so
+    reports consume structured fields instead of scanning prose.
+
     Returns True on any successful transition (to ``blocked``, ``todo``, or
     ``triage``), False when the task wasn't in a blockable state.
     """
@@ -4912,6 +5062,18 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    # Normalise ownership once; raises ValueError on an unknown owner kind.
+    owner_kind_final, owner_final = derive_blocker_owner(
+        reason, blocker_owner_kind, blocker_owner
+    )
+
+    def _stamp_owner() -> None:
+        conn.execute(
+            "UPDATE tasks SET blocker_owner_kind = ?, blocker_owner = ? "
+            "WHERE id = ?",
+            (owner_kind_final, owner_final, task_id),
+        )
+
     routed_to = "blocked"
     recurrences = 0
     with write_txn(conn):
@@ -4950,6 +5112,7 @@ def block_task(
             )
             if cur.rowcount != 1:
                 return False
+            _stamp_owner()
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -4961,7 +5124,11 @@ def block_task(
                 )
             _append_event(
                 conn, task_id, "dependency_wait",
-                {"reason": reason, "kind": kind}, run_id=run_id,
+                {
+                    "reason": reason, "kind": kind,
+                    "blocker_owner_kind": owner_kind_final,
+                    "blocker_owner": owner_final,
+                }, run_id=run_id,
             )
             routed_to = "todo"
             _blocked_task = get_task(conn, task_id)
@@ -5004,6 +5171,7 @@ def block_task(
             )
             if cur.rowcount != 1:
                 return False
+            _stamp_owner()
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -5020,6 +5188,8 @@ def block_task(
                     "kind": kind,
                     "recurrences": recurrences,
                     "limit": BLOCK_RECURRENCE_LIMIT,
+                    "blocker_owner_kind": owner_kind_final,
+                    "blocker_owner": owner_final,
                 },
                 run_id=run_id,
             )
@@ -5058,6 +5228,7 @@ def block_task(
                 )
             if cur.rowcount != 1:
                 return False
+            _stamp_owner()
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -5073,7 +5244,12 @@ def block_task(
                 )
             _append_event(
                 conn, task_id, "blocked",
-                {"reason": reason, "kind": kind, "recurrences": recurrences},
+                {
+                    "reason": reason, "kind": kind,
+                    "recurrences": recurrences,
+                    "blocker_owner_kind": owner_kind_final,
+                    "blocker_owner": owner_final,
+                },
                 run_id=run_id,
             )
         _blocked_task = get_task(conn, task_id)
@@ -5212,7 +5388,8 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # start for the dispatcher's retry budget.
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
-            "consecutive_failures = 0, last_failure_error = NULL "
+            "consecutive_failures = 0, last_failure_error = NULL, "
+            "blocker_owner_kind = NULL, blocker_owner = NULL "
             "WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (new_status, task_id),
         )
@@ -7106,7 +7283,8 @@ def _record_task_failure(
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
-                    "consecutive_failures = ?, last_failure_error = ? "
+                    "consecutive_failures = ?, last_failure_error = ?, "
+                    "blocker_owner_kind = 'automation', blocker_owner = NULL "
                     "WHERE id = ? AND status IN ('running', 'ready')",
                     (failures, error[:500], task_id),
                 )
@@ -7116,7 +7294,8 @@ def _record_task_failure(
                 # counter fields.
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', "
-                    "consecutive_failures = ?, last_failure_error = ? "
+                    "consecutive_failures = ?, last_failure_error = ?, "
+                    "blocker_owner_kind = 'automation', blocker_owner = NULL "
                     "WHERE id = ? AND status IN ('ready', 'running')",
                     (failures, error[:500], task_id),
                 )
@@ -7140,6 +7319,8 @@ def _record_task_failure(
                 "limit_source": limit_source,
                 "error": error[:500],
                 "trigger_outcome": outcome,
+                "blocker_owner_kind": "automation",
+                "blocker_owner": None,
             }
             if event_payload_extra:
                 payload.update(event_payload_extra)

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -105,9 +105,31 @@
     todo: "Waiting on dependencies or unassigned",
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
-    blocked: "Worker asked for human input",
+    blocked: "Waiting to be cleared (see blocker owner)",
     done: "Completed",
     archived: "Archived",
+  };
+  // Structured blocker ownership (mirrors VALID_BLOCKER_OWNER_KINDS in
+  // hermes_cli/kanban_db.py). Answers WHO clears a block so the board never
+  // implies every blocked card is a human ask. Labels are text, not
+  // colour-only, so ownership is legible without relying on red-vs-green.
+  const BLOCKER_OWNER_LABEL = {
+    human: "Human",
+    reviewer: "Review",
+    automation: "Automation",
+    external: "External",
+    acceptance: "Acceptance",
+    parked: "Parked",
+    unknown: "Unclassified",
+  };
+  const BLOCKER_OWNER_HINT = {
+    human: "A named person must decide or act before this can proceed.",
+    reviewer: "Awaiting code/PR review — owned by a reviewer, not a personal ask.",
+    automation: "Waiting on an autonomous agent / cron / pipeline. No human ask.",
+    external: "Waiting on a third party or external system.",
+    acceptance: "Awaiting batchable acceptance/verification — not a blocking decision.",
+    parked: "Deliberately shelved. Not an ask of anyone; do not nag.",
+    unknown: "Legacy / unclassified block — ownership not yet recorded.",
   };
   const FALLBACK_DESTRUCTIVE = {
     done: "Mark this task as done? The worker's claim is released and dependent children become ready.",
@@ -2865,6 +2887,18 @@
                   className: "hermes-kanban-needs-assignee",
                   title: tx(i18n, "needsAssigneeHint", "Dependencies are satisfied, but the dispatcher skips this task until you assign a profile."),
                 }, tx(i18n, "needsAssignee", "Needs assignee"))
+              : null,
+            t.status === "blocked" && t.blocker_owner_kind
+              ? h(Badge, {
+                  variant: "outline",
+                  className: cn(
+                    "hermes-kanban-blocker-owner",
+                    "hermes-kanban-blocker-owner--" + t.blocker_owner_kind,
+                  ),
+                  title: BLOCKER_OWNER_HINT[t.blocker_owner_kind] || "Blocker ownership.",
+                },
+                  BLOCKER_OWNER_LABEL[t.blocker_owner_kind] || t.blocker_owner_kind,
+                  t.blocker_owner ? ": " + t.blocker_owner : "")
               : null,
           ),
           h("div", { className: "hermes-kanban-card-title" },

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -304,6 +304,45 @@
   font-weight: 500;
   color: color-mix(in srgb, var(--color-foreground) 80%, var(--color-muted-foreground));
 }
+
+/* Structured blocker ownership badges. Each kind gets a distinct hue AND a
+   text label (rendered in the JS), so ownership is never conveyed by colour
+   alone — it reads legibly in monochrome or for colour-blind operators. */
+.hermes-kanban-blocker-owner {
+  font-size: 0.6rem !important;
+  padding: 0.05rem 0.3rem !important;
+  color: var(--color-foreground);
+  border: 1px solid var(--color-border);
+}
+.hermes-kanban-blocker-owner--human {
+  background: color-mix(in srgb, var(--color-warning, #d4b348) 20%, transparent);
+  border-color: color-mix(in srgb, var(--color-warning, #d4b348) 55%, var(--color-border));
+}
+.hermes-kanban-blocker-owner--reviewer {
+  background: color-mix(in srgb, var(--color-ring) 16%, transparent);
+  border-color: color-mix(in srgb, var(--color-ring) 45%, var(--color-border));
+}
+.hermes-kanban-blocker-owner--automation {
+  background: color-mix(in srgb, var(--color-muted-foreground) 14%, transparent);
+}
+.hermes-kanban-blocker-owner--external {
+  background: color-mix(in srgb, var(--color-info, #4a90d9) 16%, transparent);
+  border-color: color-mix(in srgb, var(--color-info, #4a90d9) 45%, var(--color-border));
+}
+.hermes-kanban-blocker-owner--acceptance {
+  background: color-mix(in srgb, var(--color-success, #4caf50) 15%, transparent);
+  border-color: color-mix(in srgb, var(--color-success, #4caf50) 45%, var(--color-border));
+}
+.hermes-kanban-blocker-owner--parked {
+  background: color-mix(in srgb, var(--color-muted-foreground) 10%, transparent);
+  color: var(--color-muted-foreground);
+  border-style: dashed;
+}
+.hermes-kanban-blocker-owner--unknown {
+  background: transparent;
+  color: var(--color-muted-foreground);
+  border-style: dotted;
+}
 .hermes-kanban-unassigned {
   font-style: italic;
 }

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -810,6 +810,12 @@ class UpdateTaskBody(BaseModel):
     body: Optional[str] = None
     result: Optional[str] = None
     block_reason: Optional[str] = None
+    # Structured blocker ownership — forwarded to block_task when status
+    # transitions to 'blocked'. Lets the dashboard classify who owns a block
+    # (human / reviewer / automation / external / acceptance / parked) instead
+    # of leaving reports to infer it from the reason prose.
+    blocker_owner_kind: Optional[str] = None
+    blocker_owner: Optional[str] = None
     # Structured handoff fields — forwarded to complete_task when status
     # transitions to 'done'. Dashboard parity with ``hermes kanban
     # complete --summary ... --metadata ...``.
@@ -849,7 +855,12 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     metadata=payload.metadata,
                 )
             elif s == "blocked":
-                ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
+                ok = kanban_db.block_task(
+                    conn, task_id,
+                    reason=payload.block_reason,
+                    blocker_owner_kind=payload.blocker_owner_kind,
+                    blocker_owner=payload.blocker_owner,
+                )
             elif s == "scheduled":
                 ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
             elif s == "ready":

--- a/tests/hermes_cli/test_kanban_blocker_ownership.py
+++ b/tests/hermes_cli/test_kanban_blocker_ownership.py
@@ -1,0 +1,274 @@
+"""Focused tests for structured blocker ownership.
+
+Proves the acceptance criteria from the "structured blocker ownership" work:
+
+* reviewer-owned cards (review-required) never read as human asks;
+* true explicit human decisions DO read as human asks and carry the owner;
+* automation / parked / acceptance work is distinguishable and never nagged;
+* a non-human owner kind cannot smuggle a name in via ``blocker_owner``;
+* legacy rows (NULL) stay unknown — migration never invents a human owner;
+* completion and unblock both clear the ownership fields.
+
+These assert kernel behaviour (contracts about how ownership is normalised
+and persisted), not a snapshot of any particular board's data.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _blocked(conn, *, reason=None, owner_kind=None, owner=None, kind=None):
+    """Create → claim → block a task and return the reloaded Task."""
+    t = kb.create_task(conn, title="x", assignee="a")
+    kb.claim_task(conn, t)
+    assert kb.block_task(
+        conn, t,
+        reason=reason,
+        kind=kind,
+        blocker_owner_kind=owner_kind,
+        blocker_owner=owner,
+    )
+    return kb.get_task(conn, t)
+
+
+# ---------------------------------------------------------------------------
+# derive_blocker_owner — the pure normaliser
+# ---------------------------------------------------------------------------
+
+def test_review_required_defaults_to_reviewer_not_human():
+    ok, owner = kb.derive_blocker_owner(
+        "review-required: PR #123 needs eyes", None, None
+    )
+    assert ok == "reviewer"
+    assert owner is None
+
+
+def test_kernel_never_defaults_to_human():
+    # A reason that merely mentions a person must NOT become a human owner
+    # unless the caller explicitly classifies it as such.
+    ok, owner = kb.derive_blocker_owner("waiting on Daniel to merge", None, None)
+    assert ok is None
+    assert owner is None
+
+
+def test_explicit_human_keeps_owner():
+    ok, owner = kb.derive_blocker_owner("need a call", "human", "daniel")
+    assert ok == "human"
+    assert owner == "daniel"
+
+
+def test_external_keeps_owner():
+    ok, owner = kb.derive_blocker_owner("upstream ci", "external", "github-ci")
+    assert ok == "external"
+    assert owner == "github-ci"
+
+
+@pytest.mark.parametrize("kind", ["reviewer", "automation", "acceptance", "parked"])
+def test_non_human_kinds_drop_owner(kind):
+    # A name cannot ride in behind a non-human/external classification.
+    ok, owner = kb.derive_blocker_owner("x", kind, "daniel")
+    assert ok == kind
+    assert owner is None
+
+
+def test_explicit_kind_beats_review_required_inference():
+    ok, owner = kb.derive_blocker_owner(
+        "review-required: but actually parked", "parked", None
+    )
+    assert ok == "parked"
+
+
+def test_unknown_normalises_to_none():
+    ok, owner = kb.derive_blocker_owner("x", "unknown", None)
+    assert ok is None
+    assert owner is None
+
+
+def test_invalid_owner_kind_rejected():
+    with pytest.raises(ValueError):
+        kb.derive_blocker_owner("x", "boss", None)
+
+
+# ---------------------------------------------------------------------------
+# block_task — persistence + event payload
+# ---------------------------------------------------------------------------
+
+def test_review_required_block_is_reviewer_owned(kanban_home):
+    with kb.connect() as conn:
+        task = _blocked(conn, reason="review-required: needs eyes on PR #9")
+        assert task.status == "blocked"
+        assert task.blocker_owner_kind == "reviewer"
+        assert task.blocker_owner is None
+
+
+def test_human_block_persists_owner(kanban_home):
+    with kb.connect() as conn:
+        task = _blocked(
+            conn, reason="which pricing model?",
+            owner_kind="human", owner="daniel",
+        )
+        assert task.blocker_owner_kind == "human"
+        assert task.blocker_owner == "daniel"
+
+
+def test_automation_block_never_human(kanban_home):
+    with kb.connect() as conn:
+        task = _blocked(
+            conn, reason="waiting on the merge bot",
+            owner_kind="automation", owner="daniel",
+        )
+        assert task.blocker_owner_kind == "automation"
+        # owner dropped: automation is not a person
+        assert task.blocker_owner is None
+
+
+def test_parked_block_distinguishable(kanban_home):
+    with kb.connect() as conn:
+        task = _blocked(conn, reason="shelved for now", owner_kind="parked")
+        assert task.blocker_owner_kind == "parked"
+
+
+def test_block_event_carries_structured_owner(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        kb.claim_task(conn, t)
+        kb.block_task(
+            conn, t, reason="need a decision",
+            blocker_owner_kind="human", blocker_owner="daniel",
+        )
+        events = kb.list_events(conn, t)
+        blocked_ev = [e for e in events if e.kind == "blocked"][-1]
+        assert blocked_ev.payload["blocker_owner_kind"] == "human"
+        assert blocked_ev.payload["blocker_owner"] == "daniel"
+
+
+def test_invalid_owner_kind_rejected_in_block(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        kb.claim_task(conn, t)
+        with pytest.raises(ValueError):
+            kb.block_task(conn, t, reason="x", blocker_owner_kind="boss")
+
+
+# ---------------------------------------------------------------------------
+# clearing — unblock and complete wipe ownership
+# ---------------------------------------------------------------------------
+
+def test_unblock_clears_owner(kanban_home):
+    with kb.connect() as conn:
+        task = _blocked(conn, reason="need input", owner_kind="human", owner="d")
+        assert task.blocker_owner_kind == "human"
+        assert kb.unblock_task(conn, task.id)
+        reloaded = kb.get_task(conn, task.id)
+        assert reloaded.blocker_owner_kind is None
+        assert reloaded.blocker_owner is None
+
+
+def test_complete_clears_owner(kanban_home):
+    with kb.connect() as conn:
+        task = _blocked(conn, reason="need input", owner_kind="human", owner="d")
+        assert kb.complete_task(conn, task.id, result="done")
+        reloaded = kb.get_task(conn, task.id)
+        assert reloaded.status == "done"
+        assert reloaded.blocker_owner_kind is None
+        assert reloaded.blocker_owner is None
+
+
+# ---------------------------------------------------------------------------
+# migration / legacy compatibility
+# ---------------------------------------------------------------------------
+
+def test_legacy_rows_read_as_unknown(kanban_home):
+    """A row with NULL ownership (legacy / un-classified) reads as unknown,
+    never as a human ask."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="legacy", assignee="a")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="waiting on Daniel")  # no owner kind
+        task = kb.get_task(conn, t)
+        # No explicit classification and reason isn't review-required →
+        # stays unknown (NULL), so reports don't auto-file it under a person.
+        assert task.blocker_owner_kind is None
+        assert task.blocker_owner is None
+
+
+def test_migration_adds_columns_to_legacy_db(kanban_home):
+    """Opening a DB missing the ownership columns adds them without error."""
+    with kb.connect() as conn:
+        conn.execute("ALTER TABLE tasks DROP COLUMN blocker_owner_kind")
+        conn.execute("ALTER TABLE tasks DROP COLUMN blocker_owner")
+        conn.commit()
+    # Re-init should re-add the columns idempotently.
+    kb.init_db()
+    with kb.connect() as conn:
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+        assert "blocker_owner_kind" in cols
+        assert "blocker_owner" in cols
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — `hermes kanban block --owner-kind ... --owner ...`
+# ---------------------------------------------------------------------------
+
+def test_cli_block_flags_persist_ownership(kanban_home):
+    import argparse
+
+    from hermes_cli import kanban as kc
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="cli", assignee="a")
+        kb.claim_task(conn, t)
+
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+
+    args = parser.parse_args(
+        ["kanban", "block", t, "which tier?", "--owner-kind", "human", "--owner", "daniel"]
+    )
+    assert kc.kanban_command(args) == 0
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, t)
+    assert task.status == "blocked"
+    assert task.blocker_owner_kind == "human"
+    assert task.blocker_owner == "daniel"
+
+
+def test_cli_block_review_required_defaults_reviewer(kanban_home):
+    import argparse
+
+    from hermes_cli import kanban as kc
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="cli", assignee="a")
+        kb.claim_task(conn, t)
+
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+
+    # No owner flags; a review-required reason must classify as reviewer.
+    args = parser.parse_args(
+        ["kanban", "block", t, "review-required: PR #9 needs eyes"]
+    )
+    assert kc.kanban_command(args) == 0
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, t)
+    assert task.blocker_owner_kind == "reviewer"
+    assert task.blocker_owner is None

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -353,6 +353,9 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "completed_at": task.completed_at,
         "current_run_id": task.current_run_id,
         "model_override": task.model_override,
+        "block_kind": task.block_kind,
+        "blocker_owner_kind": task.blocker_owner_kind,
+        "blocker_owner": task.blocker_owner,
         "parents": parents,
         "children": children,
         "parent_count": len(parents),
@@ -398,6 +401,9 @@ def _handle_show(args: dict, **kw) -> str:
                     "result": t.result,
                     "current_run_id": t.current_run_id,
                     "model_override": t.model_override,
+                    "block_kind": t.block_kind,
+                    "blocker_owner_kind": t.blocker_owner_kind,
+                    "blocker_owner": t.blocker_owner,
                 }
 
             def _run_dict(r):
@@ -687,6 +693,8 @@ def _handle_block(args: dict, **kw) -> str:
         return tool_error("reason is required — explain what input you need")
     reason = redact_sensitive_text(str(reason), force=True)
     kind = args.get("kind")
+    blocker_owner_kind = args.get("blocker_owner_kind")
+    blocker_owner = args.get("blocker_owner")
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -694,6 +702,15 @@ def _handle_block(args: dict, **kw) -> str:
             conn.close()
             return tool_error(
                 f"kind must be one of {sorted(kb.VALID_BLOCK_KINDS)} (or omit it)"
+            )
+        if (
+            blocker_owner_kind is not None
+            and blocker_owner_kind not in kb.VALID_BLOCKER_OWNER_KINDS
+        ):
+            conn.close()
+            return tool_error(
+                f"blocker_owner_kind must be one of "
+                f"{sorted(kb.VALID_BLOCKER_OWNER_KINDS)} (or omit it)"
             )
         # Goal-mode block gate (Issue #38696, sibling of the kanban_complete
         # judge gate in #38367). kanban_block is a second exit path out of
@@ -724,6 +741,11 @@ def _handle_block(args: dict, **kw) -> str:
                 conn, tid,
                 reason=reason,
                 kind=kind,
+                blocker_owner_kind=blocker_owner_kind,
+                blocker_owner=(
+                    redact_sensitive_text(str(blocker_owner), force=True)
+                    if blocker_owner else None
+                ),
                 expected_run_id=_worker_run_id(tid),
             )
             if not ok:
@@ -740,6 +762,8 @@ def _handle_block(args: dict, **kw) -> str:
                 run_id=run.id if run else None,
                 status=landed.status if landed else "blocked",
                 block_kind=kind,
+                blocker_owner_kind=landed.blocker_owner_kind if landed else None,
+                blocker_owner=landed.blocker_owner if landed else None,
             )
         finally:
             conn.close()
@@ -1551,6 +1575,34 @@ KANBAN_BLOCK_SCHEMA = {
                     "Why you're blocked. 'dependency' waits in todo and "
                     "resumes automatically; the others surface to a human. "
                     "Omit only if none apply."
+                ),
+            },
+            "blocker_owner_kind": {
+                "type": "string",
+                "enum": [
+                    "human", "reviewer", "automation",
+                    "external", "acceptance", "parked",
+                ],
+                "description": (
+                    "WHO must clear this block (independent of 'kind'). "
+                    "'human' = a specific person must decide/act (name them "
+                    "in blocker_owner); 'reviewer' = awaiting code/PR review "
+                    "(the review-required lane — this is the default when the "
+                    "reason says 'review-required', never a named person); "
+                    "'automation' = waiting on an agent/cron/pipeline (merge, "
+                    "rebase, packaging); 'external' = a third party/system; "
+                    "'acceptance' = batchable verification (e.g. an in-game "
+                    "walk-through); 'parked' = deliberately shelved, don't "
+                    "nag. Omit for legacy/unknown — the kernel never defaults "
+                    "a block to human."
+                ),
+            },
+            "blocker_owner": {
+                "type": "string",
+                "description": (
+                    "Specific owner / required-from string, kept only for "
+                    "blocker_owner_kind 'human' or 'external' (e.g. a name or "
+                    "an external system). Ignored for other kinds."
                 ),
             },
             "board": _board_schema_prop(),

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -265,6 +265,47 @@ hermes kanban unblock  t_abc t_def
 hermes kanban block    t_abc "need input" --ids t_def t_hij
 ```
 
+### Blocker ownership — who clears a block
+
+A blocked card has two orthogonal dimensions. `--kind`
+(`dependency`/`needs_input`/`capability`/`transient`) says **what retry
+behaviour** the block wants. `--owner-kind` says **who is on the hook to
+clear it**, so reports and triage never have to guess ownership from the
+free-text reason:
+
+| `--owner-kind` | Meaning | `--owner` used? |
+|---|---|---|
+| `human` | A specific person must decide/act | yes — name them |
+| `reviewer` | Awaiting code/PR review (the review-required lane) | no |
+| `automation` | Waiting on an agent/cron/pipeline (merge, rebase, packaging) | no |
+| `external` | Waiting on a third party / external system | yes |
+| `acceptance` | Batchable verification (e.g. an in-game walk-through) | no |
+| `parked` | Deliberately shelved — do not nag | no |
+
+```bash
+hermes kanban block t_abc "which pricing tier?" --owner-kind human --owner daniel
+hermes kanban block t_def "review-required: PR #9" --owner-kind reviewer
+hermes kanban block t_hij "shelved until Q3"      --owner-kind parked
+```
+
+Rules the kernel enforces (`hermes_cli/kanban_db.py`):
+
+- The kernel **never defaults a block to `human`.** Omit `--owner-kind` and
+  the card stays unclassified (NULL) — legacy rows read the same way. Reports
+  may apply a conservative prose fallback for those old rows only.
+- A `review-required:` reason auto-classifies as `reviewer` when no owner kind
+  is given, so review work never masquerades as a personal ask.
+- `--owner` is retained only for `human`/`external`; it is dropped for every
+  other kind, so a name can't ride in behind a non-human classification.
+- Ownership is persisted on the task row **and** echoed into the block event
+  payload, and is cleared on unblock and completion.
+
+The same fields are available to workers via `kanban_block`
+(`blocker_owner_kind` / `blocker_owner`), to the dashboard's task-update API
+(`PATCH` body), and are surfaced as a labelled badge on each blocked card
+(text, not colour-only).
+
+
 ## How workers interact with the board
 
 **Workers do not shell out to `hermes kanban`.** When the dispatcher spawns a worker it sets `HERMES_KANBAN_TASK=t_abcd` in the child's env, and that env var flips on a dedicated **kanban toolset** in the model's schema. The same toolset is also available to orchestrator profiles that enable `kanban` in their toolsets config. These tools read and mutate the board directly via the Python `kanban_db` layer, same as the CLI does. A running worker calls these like any other tool; it never sees or needs the `hermes kanban` CLI.
@@ -274,7 +315,7 @@ hermes kanban block    t_abc "need input" --ids t_def t_hij
 | `kanban_show` | Read the current task (title, body, prior attempts, parent handoffs, comments, full pre-formatted `worker_context`). Defaults to the env's task id. | — |
 | `kanban_list` | List task summaries with filters for `assignee`, `status`, `tenant`, archived visibility, and limit. Intended for orchestrators discovering board work. | — |
 | `kanban_complete` | Finish with `summary` + `metadata` structured handoff. | at least one of `summary` / `result` |
-| `kanban_block` | Stop work and route by why: `kind=dependency` (waits in `todo`, auto-resumes), `needs_input`/`capability`/`transient` (surface to a human). Repeated same-kind re-blocks auto-escalate to `triage`. | `reason` |
+| `kanban_block` | Stop work and route by why: `kind=dependency` (waits in `todo`, auto-resumes), `needs_input`/`capability`/`transient` (surface to a human). Repeated same-kind re-blocks auto-escalate to `triage`. Optional `blocker_owner_kind` (+ `blocker_owner`) records who clears it — `review-required` reasons default to `reviewer`, never a named human. | `reason` |
 | `kanban_heartbeat` | Signal liveness during long operations. Pure side-effect. | — |
 | `kanban_comment` | Append a durable note to the task thread. | `task_id`, `body` |
 | `kanban_create` | (Orchestrators) fan out into child tasks with an `assignee`, optional `parents`, `skills`, etc. | `title`, `assignee` |
@@ -666,7 +707,7 @@ hermes kanban comment <id> "<text>" [--author NAME]
 
 # Bulk verbs — accept multiple ids:
 hermes kanban complete <id>... [--result "..."]
-hermes kanban block <id> "<reason>" [--ids <id>...]
+hermes kanban block <id> "<reason>" [--ids <id>...]   # optional: --kind, --owner-kind, --owner
 hermes kanban unblock <id>...
 hermes kanban archive <id>...
 


### PR DESCRIPTION
## Problem

In Hermes Kanban, `review-required` cards, autonomous merge/rebase work, agent-owned packaging, parked work, and true human decisions all share `status=blocked` with free-text reasons. Reports then infer ownership from prose (words like `Daniel`, `your review`), which collapses all of them into one undifferentiated "blocked on Daniel" queue (observed live as a 36-card false personal queue).

## Design

Add a small structured **blocker ownership** discriminator owned by the Kanban kernel — orthogonal to the existing `block_kind` (which governs retry/routing behaviour). Ownership answers *who clears the block*:

`blocker_owner_kind` ∈ {`human`, `reviewer`, `automation`, `external`, `acceptance`, `parked`} (NULL = legacy/unknown). `blocker_owner` carries a specific name/required-from string, kept only for `human`/`external`.

Kernel rules (in `derive_blocker_owner`):
- **Never defaults to `human`.** Omit the kind and the row stays unclassified (NULL); legacy rows read identically. Reports may apply a conservative prose fallback for NULL rows only.
- A `review-required:` reason auto-classifies as `reviewer` when no kind is given — review work never masquerades as a personal ask.
- `blocker_owner` is dropped for every kind except `human`/`external`, so a name can't ride in behind a non-human classification.
- Persisted on the task row **and** echoed into the block event payload; cleared on unblock and completion. Dispatcher auto-fail blocks classify as `automation`.

## Surfaces

- **DB** (`hermes_cli/kanban_db.py`): two new columns, additive/idempotent migration, normaliser, event payloads, unblock/complete/auto-fail wiring.
- **CLI**: `hermes kanban block --owner-kind <k> [--owner <name>]`.
- **Tool** (`kanban_block`): `blocker_owner_kind` / `blocker_owner` params + schema + validation + owner-string redaction.
- **API/dashboard**: board & task JSON expose the fields (`asdict`); `PATCH /tasks/:id` forwards them to `block_task`; board cards show a **labelled** blocker-owner badge (text, not colour-only) and the stale "Worker asked for human input" column copy is fixed.
- **Docs**: new "Blocker ownership" section in `kanban.md` + CLI/tool reference updates.

## Backward compatibility

Legacy callers that omit the new fields are unchanged. Existing rows migrate to NULL (unknown), never to a human ask. No automatic card closure/deletion.

## Tests

`tests/hermes_cli/test_kanban_blocker_ownership.py` (23 focused tests) proves: reviewer/automation/parked never read as human asks; explicit human decisions carry the owner; names can't ride behind non-human kinds; `review-required` defaults to reviewer via both the normaliser and the CLI; legacy rows stay unknown; migration is idempotent; unblock/complete clear ownership.

Receipts: 725 passed across the kanban suite (db, block_kinds, cli, core, tools, redaction, dashboard, blocked_sticky, blocker_ownership), 0 failed.

## Cross-profile collector

The engineering profile's private report collector (`starbright-engineering/scripts/kanban_reporting_collector.py`) is not edited in-repo (separate profile's private data). An exact patch that switches it to consume the structured fields first (prose fallback for legacy NULL rows only, preserving privacy redaction) is provided as an out-of-band artifact for the owner to apply.