### PR TITLE
fix(desktop): preserve project cwd on fresh-draft config refresh

### DIFF
--- a/apps/desktop/src/app/session/hooks/fresh-draft-config-sync.composition.test.tsx
+++ b/apps/desktop/src/app/session/hooks/fresh-draft-config-sync.composition.test.tsx
@@ -73,6 +73,7 @@ function FreshDraftConfigSyncHarness({
     creatingSessionRef,
     ensureSessionState: () => ({}) as ClientSessionState,
     getRouteToken: () => 'token',
+    getRoutedStoredSessionId: () => selectedStoredSessionIdRef.current,
     navigate: vi.fn() as never,
     requestGateway: vi.fn().mockResolvedValue({}),
     resetViewSync: vi.fn(),
@@ -85,6 +86,7 @@ function FreshDraftConfigSyncHarness({
   })
 
   useBackgroundSync({
+    activeGatewayProfile: 'default',
     activeIsMessaging: false,
     activeSessionId,
     freshDraftReady,

--- a/apps/desktop/src/app/session/hooks/fresh-draft-config-sync.composition.test.tsx
+++ b/apps/desktop/src/app/session/hooks/fresh-draft-config-sync.composition.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { useStore } from '@nanostores/react'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getHermesConfig } from '@/hermes'
+import { persistString } from '@/lib/storage'
+import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
+import {
+  $activeSessionId,
+  $currentCwd,
+  $freshDraftReady,
+  setActiveSessionId,
+  setCurrentCwd,
+  setFreshDraftReady,
+  setNewChatWorkspaceTarget
+} from '@/store/session'
+
+import type { ClientSessionState } from '../../types'
+
+import { useBackgroundSync } from '../../contrib/hooks/use-background-sync'
+import { useHermesConfig } from './use-hermes-config'
+import { useSessionActions } from './use-session-actions'
+
+vi.mock('@/hermes', () => ({
+  getHermesConfig: vi.fn(),
+  getHermesConfigDefaults: vi.fn().mockResolvedValue({}),
+  deleteSession: vi.fn(),
+  getSessionMessages: vi.fn(),
+  listAllProfileSessions: vi.fn(),
+  setApiRequestProfile: vi.fn(),
+  setSessionArchived: vi.fn()
+}))
+
+const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
+const PROJECT_CWD = 'C:\\Users\\example\\work\\project'
+const CONFIGURED_HOME_CWD = 'C:\\Users\\example'
+
+type DraftHandle = Pick<ReturnType<typeof useSessionActions>, 'startFreshSessionDraft'>
+
+/**
+ * Composes the real fresh-draft action with background-sync config refresh —
+ * the seam #65274 regressed: startFreshSessionDraft clears the session ref and
+ * seeds project cwd, then useBackgroundSync reloads config.yaml terminal.cwd.
+ */
+function FreshDraftConfigSyncHarness({
+  gatewayState,
+  onReady
+}: {
+  gatewayState: string
+  onReady: (handle: DraftHandle) => void
+}) {
+  const activeSessionIdRef = useRef<string | null>('prior-session')
+  const busyRef = useRef(false)
+  const creatingSessionRef = useRef(false)
+  const selectedStoredSessionIdRef = useRef<string | null>('stored-prior')
+  const runtimeIdByStoredSessionIdRef = useRef(new Map<string, string>())
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+
+  const activeSessionId = useStore($activeSessionId)
+  const freshDraftReady = useStore($freshDraftReady)
+
+  const { refreshHermesConfig } = useHermesConfig({
+    activeSessionIdRef,
+    refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
+  })
+
+  const actions = useSessionActions({
+    activeSessionId,
+    activeSessionIdRef,
+    busyRef,
+    creatingSessionRef,
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    navigate: vi.fn() as never,
+    requestGateway: vi.fn().mockResolvedValue({}),
+    resetViewSync: vi.fn(),
+    runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionId: selectedStoredSessionIdRef.current,
+    selectedStoredSessionIdRef,
+    sessionStateByRuntimeIdRef,
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as ClientSessionState
+  })
+
+  useBackgroundSync({
+    activeIsMessaging: false,
+    activeSessionId,
+    freshDraftReady,
+    gatewayState,
+    refreshActiveMessagingTranscript: vi.fn(),
+    refreshCronJobs: vi.fn(),
+    refreshCurrentModel: vi.fn(),
+    refreshHermesConfig,
+    refreshMessagingSessions: vi.fn(),
+    refreshSessions: vi.fn(),
+    requestGateway: vi.fn().mockResolvedValue({})
+  })
+
+  useEffect(() => {
+    onReady({ startFreshSessionDraft: actions.startFreshSessionDraft })
+  }, [actions, onReady])
+
+  return null
+}
+
+describe('fresh-draft + background-sync config composition (#65274)', () => {
+  beforeEach(() => {
+    setActiveSessionId('prior-session')
+    setCurrentCwd('C:\\Users\\example\\other-worktree')
+    setFreshDraftReady(false)
+    setNewChatWorkspaceTarget(undefined)
+    persistString(WORKSPACE_CWD_KEY, null)
+    $projectTree.set([
+      {
+        id: 'p_app',
+        label: 'App',
+        path: PROJECT_CWD,
+        repos: [{ groups: [], id: PROJECT_CWD, label: 'project', path: PROJECT_CWD, sessionCount: 0 }],
+        sessionCount: 0
+      }
+    ])
+    $projectScope.set('p_app')
+    vi.mocked(getHermesConfig).mockResolvedValue({
+      terminal: { cwd: CONFIGURED_HOME_CWD }
+    } as Awaited<ReturnType<typeof getHermesConfig>>)
+  })
+
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+    setCurrentCwd('')
+    setFreshDraftReady(false)
+    setNewChatWorkspaceTarget(undefined)
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
+    persistString(WORKSPACE_CWD_KEY, null)
+    vi.clearAllMocks()
+  })
+
+  it('keeps project cwd after startFreshSessionDraft triggers background config refresh', async () => {
+    let handle: DraftHandle | null = null
+
+    render(
+      <FreshDraftConfigSyncHarness gatewayState="open" onReady={h => (handle = h)} />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      handle!.startFreshSessionDraft()
+    })
+
+    // Draft must clear the active session and seed the project root before the
+    // background-sync effect reloads config (terminal.cwd is often Path.home()).
+    expect($activeSessionId.get()).toBeNull()
+    expect($freshDraftReady.get()).toBe(true)
+    expect($currentCwd.get()).toBe(PROJECT_CWD)
+
+    await waitFor(() => {
+      expect(getHermesConfig).toHaveBeenCalled()
+    })
+
+    // Without $freshDraftReady the null session ref would let terminal.cwd win.
+    expect($currentCwd.get()).toBe(PROJECT_CWD)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/fresh-draft-config-sync.composition.test.tsx
+++ b/apps/desktop/src/app/session/hooks/fresh-draft-config-sync.composition.test.tsx
@@ -40,7 +40,7 @@ const CONFIGURED_HOME_CWD = 'C:\\Users\\example'
 type DraftHandle = Pick<ReturnType<typeof useSessionActions>, 'startFreshSessionDraft'>
 
 /**
- * Composes the real fresh-draft action with background-sync config refresh —
+ * Composes the real fresh-draft action with background-sync config refresh ??
  * the seam #65274 regressed: startFreshSessionDraft clears the session ref and
  * seeds project cwd, then useBackgroundSync reloads config.yaml terminal.cwd.
  */
@@ -62,8 +62,7 @@ function FreshDraftConfigSyncHarness({
   const freshDraftReady = useStore($freshDraftReady)
 
   const { refreshHermesConfig } = useHermesConfig({
-    activeSessionIdRef,
-    refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
+    activeSessionIdRef
   })
 
   const actions = useSessionActions({

--- a/apps/desktop/src/app/session/hooks/fresh-draft-config-sync.composition.test.tsx
+++ b/apps/desktop/src/app/session/hooks/fresh-draft-config-sync.composition.test.tsx
@@ -40,7 +40,7 @@ const CONFIGURED_HOME_CWD = 'C:\\Users\\example'
 type DraftHandle = Pick<ReturnType<typeof useSessionActions>, 'startFreshSessionDraft'>
 
 /**
- * Composes the real fresh-draft action with background-sync config refresh ??
+ * Composes the real fresh-draft action with background-sync config refresh —
  * the seam #65274 regressed: startFreshSessionDraft clears the session ref and
  * seeds project cwd, then useBackgroundSync reloads config.yaml terminal.cwd.
  */

--- a/apps/desktop/src/app/session/hooks/fresh-draft-config-sync.composition.test.tsx
+++ b/apps/desktop/src/app/session/hooks/fresh-draft-config-sync.composition.test.tsx
@@ -17,9 +17,9 @@ import {
   setNewChatWorkspaceTarget
 } from '@/store/session'
 
+import { useBackgroundSync } from '../../contrib/hooks/use-background-sync'
 import type { ClientSessionState } from '../../types'
 
-import { useBackgroundSync } from '../../contrib/hooks/use-background-sync'
 import { useHermesConfig } from './use-hermes-config'
 import { useSessionActions } from './use-session-actions'
 


### PR DESCRIPTION
## What does this PR do?

Keeps a Project-scoped fresh Desktop session on the Project primary path when `/new`, `/reset`, or "New session in main" runs.

`startFreshSessionDraft()` already seeds `$currentCwd` from `resolveNewSessionCwd()` (or an explicit workspace target), then clears the active session ref and sets `$freshDraftReady`. Background sync then calls `refreshHermesConfig()`, which used to treat a null session as "apply `terminal.cwd`". On a default local setup that value is `Path.home()`, so the seeded project path was replaced by the home directory.

The guard now also keeps the seeded cwd while `$freshDraftReady` is true. Cold-start / no-draft behavior from #38855 is unchanged: with no active session and no fresh draft, configured `terminal.cwd` still overrides a stale remembered workspace.

## Related Issue

Fixes #65274

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-hermes-config.ts`: treat `$freshDraftReady` like an attached session for the `terminal.cwd` override
- `apps/desktop/src/app/session/hooks/use-hermes-config.test.ts`: cover project-scoped and explicitly detached fresh drafts

## How to Test

1. Open Hermes Desktop on Windows, select a Project with a repo primary path.
2. From a Project-bound session, run `/new` (or use "New session in main").
3. Run `pwd` in the fresh session. It should stay on the Project path, not `C:\Users\<user>`.
4. Confirm an existing Project-bound session still keeps its cwd across config refresh.
5. Confirm a detached fresh draft (`workspaceTarget: null`) stays empty and is not forced to home.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the Desktop vitest coverage for this hook (see Evidence)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Evidence

```text
cd apps/desktop
npx vitest run src/app/session/hooks/use-hermes-config.test.ts

Test Files  1 passed (1)
     Tests  8 passed (8)
```

```text
python scripts/check-windows-footguns.py --diff origin/main
No Windows footguns found (0 file(s) scanned).
```

```text
# hermetic runner smoke (venv with pytest; TS-only change)
HERMES_PYTHON=.../.venv/Scripts/python.exe ./scripts/run_tests.sh -j 2 tests/tools/test_windows_compat.py
=== Summary: 1 files, 12 tests passed, 0 failed ===
```

## AI assistance

Prepared with AI assistance (Cursor/Grok). Human author: Stan Shih (@stantheman0128).
