### PR TITLE
feat(gateway): /profile <name> switches active profile in messaging platforms

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -330,19 +330,64 @@ class GatewaySlashCommandsMixin:
         return EphemeralReply(f"{header}{_tip_line}")
 
     async def _handle_profile_command(self, event: MessageEvent) -> str:
-        """Handle /profile — show active profile name and home directory."""
+        """Handle /profile [name] — show active profile or switch to a named profile.
+
+        Without arguments: shows the active profile name and home directory.
+        With a name: switches the active profile, closes the current session
+        (to preserve prompt-cache integrity), and instructs the user to start
+        a new session with /new.
+        """
         from hermes_constants import display_hermes_home
-        from hermes_cli.profiles import get_active_profile_name
+        from hermes_cli.profiles import get_active_profile_name, set_active_profile, profile_exists
+
+        args = event.get_command_args().strip()
+
+        # No argument — show current profile
+        if not args:
+            display = display_hermes_home()
+            profile_name = get_active_profile_name()
+            lines = [
+                t("gateway.profile.header", profile=profile_name),
+                t("gateway.profile.home", home=display),
+            ]
+            return "\n".join(lines)
+
+        # Switch profile
+        target_profile = args.lower()
+
+        if not profile_exists(target_profile) and target_profile != "default":
+            return (
+                f"❌ Profile `{target_profile}` does not exist.\n"
+                f"Create it with: `hermes profile create {target_profile}`"
+            )
+
+        current_profile = get_active_profile_name()
+        if target_profile == current_profile:
+            return f"✅ Already on profile `{target_profile}`."
+
+        try:
+            set_active_profile(target_profile)
+        except (ValueError, FileNotFoundError) as e:
+            return f"❌ Failed to switch profile: {e}"
+
+        # Close the current session to preserve prompt-cache integrity.
+        # A mid-conversation profile switch would invalidate the cached
+        # system prompt and tool schemas, breaking the per-conversation
+        # cache contract. The user starts fresh with /new on the new profile.
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        current_entry = await self.async_session_store.get_or_create_session(source)
+        await self.async_session_store.end_session(session_key, reason="profile_switch")
+        self._clear_session_boundary_security_state(session_key)
+        self._evict_cached_agent(session_key)
 
         display = display_hermes_home()
-        profile_name = get_active_profile_name()
-
-        lines = [
-            t("gateway.profile.header", profile=profile_name),
-            t("gateway.profile.home", home=display),
-        ]
-
-        return "\n".join(lines)
+        return (
+            f"✅ Switched from `{current_profile}` to `{target_profile}`.\n"
+            f"📁 Home: `{display}`\n\n"
+            f"⚠️ Current session closed to preserve cache integrity.\n"
+            f"Start a new session with `/new` to continue on `{target_profile}`."
+        )
 
     async def _handle_whoami_command(self, event: MessageEvent) -> str:
         """Handle /whoami — show the user's slash command access on this scope.

--- a/tests/gateway/test_session_boundary_security_state.py
+++ b/tests/gateway/test_session_boundary_security_state.py
@@ -316,3 +316,79 @@ def test_clear_session_boundary_security_state_wakes_blocked_approvals():
     assert other_entry.result is None
     assert session_key not in approval_mod._gateway_queues
     assert other_key in approval_mod._gateway_queues
+
+
+@pytest.mark.asyncio
+async def test_profile_command_no_args_shows_current_profile():
+    """`/profile` without arguments should display the active profile."""
+    runner, _session_key = _make_branch_runner()
+    result = await runner._handle_profile_command(_make_event("/profile"))
+    assert "Active profile" in result or "Profile" in result
+
+
+@pytest.mark.asyncio
+async def test_profile_command_switch_closes_session():
+    """`/profile <name>` should switch the active profile and close the
+    current session to preserve cache integrity."""
+    from hermes_cli.profiles import get_active_profile_name
+
+    runner, session_key = _make_branch_runner()
+    runner.session_store.get_or_create_session.return_value = _make_entry("old-session", _make_source())
+
+    # Mock profile_exists to return True for "rental"
+    import hermes_cli.profiles as profiles_mod
+    original_exists = profiles_mod.profile_exists
+    original_set = profiles_mod.set_active_profile
+    profiles_mod.profile_exists = lambda name: name == "rental"
+    profiles_mod.set_active_profile = lambda name: None
+
+    try:
+        result = await runner._handle_profile_command(_make_event("/profile rental"))
+
+        assert "Switched from" in result
+        assert "rental" in result
+        assert "session closed" in result.lower()
+        assert "/new" in result
+
+        # Session should be ended
+        runner.session_store.end_session.assert_called_once()
+        call_args = runner.session_store.end_session.call_args
+        assert call_args[0][0] == session_key
+        assert call_args[1].get("reason") == "profile_switch"
+    finally:
+        profiles_mod.profile_exists = original_exists
+        profiles_mod.set_active_profile = original_set
+
+
+@pytest.mark.asyncio
+async def test_profile_command_switch_to_same_profile_is_noop():
+    """`/profile <same-name>` should be a no-op."""
+    runner, _session_key = _make_branch_runner()
+
+    import hermes_cli.profiles as profiles_mod
+    original_get = profiles_mod.get_active_profile_name
+    profiles_mod.get_active_profile_name = lambda: "default"
+
+    try:
+        result = await runner._handle_profile_command(_make_event("/profile default"))
+        assert "Already on profile" in result
+        runner.session_store.end_session.assert_not_called()
+    finally:
+        profiles_mod.get_active_profile_name = original_get
+
+
+@pytest.mark.asyncio
+async def test_profile_command_nonexistent_profile_returns_error():
+    """`/profile <nonexistent>` should return an error without switching."""
+    runner, _session_key = _make_branch_runner()
+
+    import hermes_cli.profiles as profiles_mod
+    original_exists = profiles_mod.profile_exists
+    profiles_mod.profile_exists = lambda name: False
+
+    try:
+        result = await runner._handle_profile_command(_make_event("/profile nonexistent"))
+        assert "does not exist" in result
+        runner.session_store.end_session.assert_not_called()
+    finally:
+        profiles_mod.profile_exists = original_exists


### PR DESCRIPTION
## Problem

The `/profile` slash command in messaging platforms (Telegram, Discord, Slack) currently **only displays** the active profile name and home directory. It does not switch profiles.

This contradicts user expectations — the command accepts an optional argument but ignores it on the gateway path. By contrast, `/model <name>` *does* switch the model mid-session. `/profile <name>` should behave analogously.

## Use Case

A user operates two businesses from a single Hermes instance via Telegram:

1. **Marketing agency** (default profile) — client communication, campaign management, analytics
2. **Short-term apartment rentals** (rental profile) — property management, pricing, guest communication, platform integrations

Each profile has its own SOUL.md persona, cron jobs, skills, and memory. Currently, to switch between them in Telegram requires running two separate gateway instances with two Telegram bots — heavy infrastructure for a simple profile switch.

A single-bot `/profile rental` → `/profile default` workflow is far more ergonomic.

## Solution

`/profile <name>` now switches the active profile:

| Command | Behavior |
|---------|----------|
| `/profile` | Show active profile name and home directory (unchanged) |
| `/profile <name>` | Switch active profile, close current session, prompt user to start fresh with `/new` |

## Why close the session?

A mid-conversation profile switch would invalidate the cached system prompt and tool schemas, breaking the per-conversation prompt-cache contract (AGENTS.md: "Prompt caching is sacred"). Closing the session and prompting `/new` preserves cache integrity while keeping the UX simple.

## Tests

Added 4 new tests in `tests/gateway/test_session_boundary_security_state.py`:
- `/profile` without args shows current profile
- `/profile <name>` switches profile and closes session
- `/profile <same-name>` is a no-op
- `/profile <nonexistent>` returns error without switching

All 9 tests pass.

Fixes #65936
