### PR TITLE
fix(browser): keep local Chromium headless on Windows Desktop (#64867)

### DIFF
--- a/apps/desktop/electron/link-title-window.test.ts
+++ b/apps/desktop/electron/link-title-window.test.ts
@@ -29,6 +29,10 @@ test('linkTitleWindowOptions keeps the offscreen, hardened defaults', () => {
   const options = linkTitleWindowOptions(session)
 
   assert.equal(options.show, false)
+  assert.equal(options.x, -20000)
+  assert.equal(options.y, -20000)
+  assert.equal(options.skipTaskbar, true)
+  assert.equal(options.focusable, false)
   assert.equal(options.webPreferences.session, session)
   assert.equal(options.webPreferences.contextIsolation, true)
   assert.equal(options.webPreferences.sandbox, true)
@@ -45,6 +49,27 @@ test('createLinkTitleWindow mutes audio so historical links never autoplay sound
 
   assert.ok(window instanceof FakeBrowserWindow)
   assert.deepEqual(calls.audioMuted, [true])
+})
+
+test('createLinkTitleWindow hides and zeros opacity so Windows cannot flash a blank frame', () => {
+  // Regression for #64867: tier-2 title fetch for bot-walled URLs (GitHub)
+  // must not paint a visible blank BrowserWindow over Desktop chat.
+  const calls = { hide: 0, opacity: [] }
+  const FakeBrowserWindow = function (options) {
+    this.options = options
+    this.webContents = { setAudioMuted() {} }
+    this.hide = () => {
+      calls.hide += 1
+    }
+    this.setOpacity = value => {
+      calls.opacity.push(value)
+    }
+  }
+
+  createLinkTitleWindow(FakeBrowserWindow, { id: 'link-titles' })
+
+  assert.equal(calls.hide, 1)
+  assert.deepEqual(calls.opacity, [0])
 })
 
 test('createLinkTitleWindow still returns the window if muting throws', () => {

--- a/apps/desktop/electron/link-title-window.ts
+++ b/apps/desktop/electron/link-title-window.ts
@@ -2,12 +2,21 @@
 // read a page <title> (bot walls, JS-rendered pages), we briefly load the URL
 // in an offscreen window and read its title. That window loads arbitrary
 // user-linked pages, so it must never emit sound or trigger real downloads.
+//
+// On Windows Desktop it must also never paint a visible top-level frame: bot
+// walls (e.g. GitHub) fail curl tier-1 and fall through here during browser
+// tool turns, which is the blank-window report in #64867.
 
 export function linkTitleWindowOptions(partitionSession) {
   return {
     show: false,
     width: 1280,
     height: 800,
+    // Park far off-screen so a show:false leak cannot cover the chat window.
+    x: -20000,
+    y: -20000,
+    skipTaskbar: true,
+    focusable: false,
     webPreferences: {
       backgroundThrottling: false,
       contextIsolation: true,
@@ -25,6 +34,14 @@ export function linkTitleWindowOptions(partitionSession) {
 // audio every time a session containing such links is re-rendered. See #49505.
 export function createLinkTitleWindow(BrowserWindow, partitionSession) {
   const window = new BrowserWindow(linkTitleWindowOptions(partitionSession))
+
+  try {
+    // Belt-and-suspenders with show:false / off-screen bounds (#64867).
+    window.setOpacity?.(0)
+    window.hide?.()
+  } catch {
+    // Best-effort; title fetch still works if hide/opacity are unavailable.
+  }
 
   try {
     window.webContents.setAudioMuted(true)

--- a/tests/tools/test_browser_headed_mode.py
+++ b/tests/tools/test_browser_headed_mode.py
@@ -202,7 +202,11 @@ class TestHeadedFlagInjection:
 
         captured = self._run_and_capture(bt)
         assert len(captured) == 1
-        assert "--headed" in captured[0]
+        cmd = captured[0]
+        assert "--headed" in cmd
+        headed_at = cmd.index("--headed")
+        # Must not contradict the opt-in with a forced false (#64867 follow-up).
+        assert headed_at + 1 >= len(cmd) or cmd[headed_at + 1] != "false"
 
     @patch("tools.browser_tool._get_session_info")
     @patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser")
@@ -221,7 +225,21 @@ class TestHeadedFlagInjection:
 
         captured = self._run_and_capture(bt)
         assert len(captured) == 1
-        assert "--headed" not in captured[0]
+        cmd = captured[0]
+        # Must not get the bare --headed opt-in from _is_headed_mode().
+        # Local blank-window guards (#64867) may still pin "--headed false".
+        if "--headed" in cmd:
+            headed_at = cmd.index("--headed")
+            assert headed_at + 1 < len(cmd)
+            assert cmd[headed_at + 1] == "false"
+        # And never a bare --headed with no value / non-false neighbor before --json.
+        json_at = cmd.index("--json")
+        bare = [
+            i
+            for i, part in enumerate(cmd[:json_at])
+            if part == "--headed" and (i + 1 >= json_at or cmd[i + 1] != "false")
+        ]
+        assert bare == []
 
     @patch("tools.browser_tool._get_session_info")
     @patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser")

--- a/tests/tools/test_browser_windows_blank_window.py
+++ b/tests/tools/test_browser_windows_blank_window.py
@@ -1,0 +1,106 @@
+"""Regression tests for Windows blank-window guards during local browser automation (#64867)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tools import browser_tool as bt
+
+
+@pytest.fixture(autouse=True)
+def _clear_headed_env(monkeypatch):
+    monkeypatch.delenv("AGENT_BROWSER_HEADED", raising=False)
+    monkeypatch.delenv("AGENT_BROWSER_ARGS", raising=False)
+
+
+def test_append_agent_browser_arg_merges_and_dedupes():
+    env: dict = {"AGENT_BROWSER_ARGS": "--no-sandbox,--disable-dev-shm-usage"}
+    bt._append_agent_browser_arg(env, "--window-position=-2400,-2400")
+    assert env["AGENT_BROWSER_ARGS"] == (
+        "--no-sandbox,--disable-dev-shm-usage,--window-position=-2400,-2400"
+    )
+    bt._append_agent_browser_arg(env, "--window-position=-100,-100")
+    # Same flag key already present — do not duplicate.
+    assert env["AGENT_BROWSER_ARGS"] == (
+        "--no-sandbox,--disable-dev-shm-usage,--window-position=-2400,-2400"
+    )
+
+
+def test_local_visibility_guards_force_headed_false(monkeypatch):
+    monkeypatch.setattr(bt.os, "name", "posix")
+    env: dict = {}
+    flags = bt._apply_local_browser_visibility_guards(env, local_chromium=True)
+    assert flags == ["--headed", "false"]
+    assert env["AGENT_BROWSER_HEADED"] == "false"
+    assert "AGENT_BROWSER_ARGS" not in env
+
+
+def test_local_visibility_guards_park_window_on_windows(monkeypatch):
+    monkeypatch.setattr(bt.os, "name", "nt")
+    env: dict = {}
+    flags = bt._apply_local_browser_visibility_guards(env, local_chromium=True)
+    assert flags == ["--headed", "false"]
+    assert env["AGENT_BROWSER_HEADED"] == "false"
+    assert "--window-position=-2400,-2400" in env["AGENT_BROWSER_ARGS"]
+
+
+def test_local_visibility_guards_respect_explicit_headed(monkeypatch):
+    monkeypatch.setattr(bt.os, "name", "nt")
+    env = {"AGENT_BROWSER_HEADED": "1"}
+    flags = bt._apply_local_browser_visibility_guards(env, local_chromium=True)
+    assert flags == []
+    assert env["AGENT_BROWSER_HEADED"] == "1"
+    assert "AGENT_BROWSER_ARGS" not in env
+
+
+def test_local_visibility_guards_skip_cdp_backends(monkeypatch):
+    monkeypatch.setattr(bt.os, "name", "nt")
+    env: dict = {}
+    flags = bt._apply_local_browser_visibility_guards(env, local_chromium=False)
+    assert flags == []
+    assert env == {}
+
+
+def test_run_browser_command_inserts_headed_false_for_local(monkeypatch, tmp_path):
+    """End-to-end: local Popen argv must include --headed false before --json."""
+    captured: dict = {}
+
+    class FakePopen:
+        def __init__(self, args, **kwargs):
+            captured["args"] = list(args)
+            captured["env"] = dict(kwargs.get("env") or {})
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            # Caller closes the stdout fd before wait(); write JSON into the
+            # temp file so the success path parses cleanly.
+            for path in tmp_path.rglob("_stdout_open"):
+                path.write_text('{"success": true}\n', encoding="utf-8")
+            return 0
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(bt.os, "name", "nt")
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda: "agent-browser")
+    monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+    monkeypatch.setattr(bt, "_get_session_info", lambda task_id: {"session_name": "h_test"})
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_write_owner_pid", lambda *a, **k: None)
+    monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(bt, "_build_browser_env", lambda: {})
+    monkeypatch.setattr(bt, "_merge_browser_path", lambda path: path or "")
+    monkeypatch.setattr(bt.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(bt, "_get_browser_engine", lambda: "auto")
+
+    result = bt._run_browser_command("task", "open", ["https://example.com"], timeout=5)
+    assert result.get("success") is True
+    args = captured["args"]
+    assert "--json" in args
+    headed_at = args.index("--headed")
+    assert args[headed_at : headed_at + 2] == ["--headed", "false"]
+    assert headed_at < args.index("--json")
+    assert captured["env"].get("AGENT_BROWSER_HEADED") == "false"
+    assert "--window-position=-2400,-2400" in captured["env"].get("AGENT_BROWSER_ARGS", "")

--- a/tests/tools/test_browser_windows_blank_window.py
+++ b/tests/tools/test_browser_windows_blank_window.py
@@ -2,17 +2,23 @@
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from tools import browser_tool as bt
+
+
+def _reset_headed_cache():
+    bt._cached_headed_mode = None
+    bt._headed_mode_resolved = False
 
 
 @pytest.fixture(autouse=True)
 def _clear_headed_env(monkeypatch):
     monkeypatch.delenv("AGENT_BROWSER_HEADED", raising=False)
     monkeypatch.delenv("AGENT_BROWSER_ARGS", raising=False)
+    _reset_headed_cache()
+    yield
+    _reset_headed_cache()
 
 
 def test_append_agent_browser_arg_merges_and_dedupes():
@@ -30,6 +36,10 @@ def test_append_agent_browser_arg_merges_and_dedupes():
 
 def test_local_visibility_guards_force_headed_false(monkeypatch):
     monkeypatch.setattr(bt.os, "name", "posix")
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {},
+    )
     env: dict = {}
     flags = bt._apply_local_browser_visibility_guards(env, local_chromium=True)
     assert flags == ["--headed", "false"]
@@ -39,6 +49,10 @@ def test_local_visibility_guards_force_headed_false(monkeypatch):
 
 def test_local_visibility_guards_park_window_on_windows(monkeypatch):
     monkeypatch.setattr(bt.os, "name", "nt")
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {},
+    )
     env: dict = {}
     flags = bt._apply_local_browser_visibility_guards(env, local_chromium=True)
     assert flags == ["--headed", "false"]
@@ -48,11 +62,29 @@ def test_local_visibility_guards_park_window_on_windows(monkeypatch):
 
 def test_local_visibility_guards_respect_explicit_headed(monkeypatch):
     monkeypatch.setattr(bt.os, "name", "nt")
+    monkeypatch.setenv("AGENT_BROWSER_HEADED", "1")
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {},
+    )
     env = {"AGENT_BROWSER_HEADED": "1"}
     flags = bt._apply_local_browser_visibility_guards(env, local_chromium=True)
     assert flags == []
     assert env["AGENT_BROWSER_HEADED"] == "1"
     assert "AGENT_BROWSER_ARGS" not in env
+
+
+def test_local_visibility_guards_respect_config_headed(monkeypatch):
+    """browser.headed: true must not get a forced --headed false (#64867)."""
+    monkeypatch.setattr(bt.os, "name", "nt")
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {"browser": {"headed": True}},
+    )
+    env: dict = {}
+    flags = bt._apply_local_browser_visibility_guards(env, local_chromium=True)
+    assert flags == []
+    assert env == {}
 
 
 def test_local_visibility_guards_skip_cdp_backends(monkeypatch):
@@ -92,6 +124,7 @@ def test_run_browser_command_inserts_headed_false_for_local(monkeypatch, tmp_pat
     monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
     monkeypatch.setattr(bt, "_build_browser_env", lambda: {})
     monkeypatch.setattr(bt, "_merge_browser_path", lambda path: path or "")
+    monkeypatch.setattr(bt, "_is_headed_mode", lambda: False)
     monkeypatch.setattr(bt.subprocess, "Popen", FakePopen)
     monkeypatch.setattr(bt, "_get_browser_engine", lambda: "auto")
 
@@ -104,3 +137,50 @@ def test_run_browser_command_inserts_headed_false_for_local(monkeypatch, tmp_pat
     assert headed_at < args.index("--json")
     assert captured["env"].get("AGENT_BROWSER_HEADED") == "false"
     assert "--window-position=-2400,-2400" in captured["env"].get("AGENT_BROWSER_ARGS", "")
+
+
+def test_run_browser_command_skips_headed_false_when_config_headed(
+    monkeypatch, tmp_path
+):
+    """config browser.headed:true keeps --headed and never forces --headed false."""
+    captured: dict = {}
+
+    class FakePopen:
+        def __init__(self, args, **kwargs):
+            captured["args"] = list(args)
+            captured["env"] = dict(kwargs.get("env") or {})
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            for path in tmp_path.rglob("_stdout_open"):
+                path.write_text('{"success": true}\n', encoding="utf-8")
+            return 0
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(bt.os, "name", "nt")
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda: "agent-browser")
+    monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+    monkeypatch.setattr(bt, "_get_session_info", lambda task_id: {"session_name": "h_test"})
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_write_owner_pid", lambda *a, **k: None)
+    monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(bt, "_build_browser_env", lambda: {})
+    monkeypatch.setattr(bt, "_merge_browser_path", lambda path: path or "")
+    monkeypatch.setattr(bt, "_is_headed_mode", lambda: True)
+    monkeypatch.setattr(bt.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(bt, "_get_browser_engine", lambda: "auto")
+
+    result = bt._run_browser_command("task", "open", ["https://example.com"], timeout=5)
+    assert result.get("success") is True
+    args = captured["args"]
+    assert "--headed" in args
+    # Presence of the bare --headed opt-in, without a following false.
+    headed_at = args.index("--headed")
+    assert headed_at + 1 == len(args) or args[headed_at + 1] != "false"
+    assert ["--headed", "false"] != args[headed_at : headed_at + 2]
+    assert captured["env"].get("AGENT_BROWSER_HEADED") != "false"
+    assert "--window-position=-2400,-2400" not in captured["env"].get(
+        "AGENT_BROWSER_ARGS", ""
+    )

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -125,30 +125,28 @@ def _append_agent_browser_arg(browser_env: dict, flag: str) -> None:
     browser_env["AGENT_BROWSER_ARGS"] = ",".join(parts)
 
 
-def _user_wants_headed_browser(browser_env: dict) -> bool:
-    """True when the operator explicitly opted into a visible browser window."""
-    return is_truthy_value(browser_env.get("AGENT_BROWSER_HEADED"))
-
-
 def _apply_local_browser_visibility_guards(
     browser_env: dict,
     *,
     local_chromium: bool,
 ) -> list[str]:
-    """Keep local Chromium invisible unless the user opted into headed mode.
+    """Keep local Chromium invisible unless Hermes headed mode is enabled.
 
     Local mode is documented as headless Chromium via agent-browser. On
     Windows Desktop, a blank top-level window can still appear when:
 
-    1. ``~/.agent-browser/config.json`` (or ``AGENT_BROWSER_HEADED``) enables
-       headed mode without Hermes knowing about it, or
+    1. ``~/.agent-browser/config.json`` enables headed mode without Hermes
+       knowing about it, or
     2. Chrome's ``--headless=new`` paints a ghost HWND on some Windows hosts.
 
     Force ``--headed false`` for local sessions and, on Windows, park any
     leftover window off-screen via ``AGENT_BROWSER_ARGS``. Cloud/CDP backends
-    are left alone. Explicit ``AGENT_BROWSER_HEADED=1`` still wins (#64867).
+    are left alone. ``_is_headed_mode()`` (config ``browser.headed`` or
+    ``AGENT_BROWSER_HEADED``) is the authoritative opt-out so we never inject
+    a contradictory ``--headed false`` alongside main's ``--headed`` (#64867).
     """
-    if not local_chromium or _user_wants_headed_browser(browser_env):
+    # Resolved at call time so this helper can sit above ``_is_headed_mode``.
+    if not local_chromium or _is_headed_mode():
         return []
 
     # Pin both the CLI flag and the env so project/user agent-browser.json

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -104,6 +104,60 @@ def _build_browser_env() -> dict:
             env[_key] = os.environ[_key]
     return env
 
+
+# Off-screen parking spot for the rare Windows --headless=new ghost HWND
+# (Chrome 129-class blank top-level window). See #64867.
+_WINDOWS_HEADLESS_WINDOW_POSITION = "--window-position=-2400,-2400"
+
+
+def _append_agent_browser_arg(browser_env: dict, flag: str) -> None:
+    """Append a Chromium launch flag to ``AGENT_BROWSER_ARGS`` if missing."""
+    existing = (browser_env.get("AGENT_BROWSER_ARGS") or "").strip()
+    parts = [
+        part.strip()
+        for part in existing.replace("\n", ",").split(",")
+        if part.strip()
+    ]
+    key = flag.split("=", 1)[0]
+    if any(part == flag or part.startswith(f"{key}=") for part in parts):
+        return
+    parts.append(flag)
+    browser_env["AGENT_BROWSER_ARGS"] = ",".join(parts)
+
+
+def _user_wants_headed_browser(browser_env: dict) -> bool:
+    """True when the operator explicitly opted into a visible browser window."""
+    return is_truthy_value(browser_env.get("AGENT_BROWSER_HEADED"))
+
+
+def _apply_local_browser_visibility_guards(
+    browser_env: dict,
+    *,
+    local_chromium: bool,
+) -> list[str]:
+    """Keep local Chromium invisible unless the user opted into headed mode.
+
+    Local mode is documented as headless Chromium via agent-browser. On
+    Windows Desktop, a blank top-level window can still appear when:
+
+    1. ``~/.agent-browser/config.json`` (or ``AGENT_BROWSER_HEADED``) enables
+       headed mode without Hermes knowing about it, or
+    2. Chrome's ``--headless=new`` paints a ghost HWND on some Windows hosts.
+
+    Force ``--headed false`` for local sessions and, on Windows, park any
+    leftover window off-screen via ``AGENT_BROWSER_ARGS``. Cloud/CDP backends
+    are left alone. Explicit ``AGENT_BROWSER_HEADED=1`` still wins (#64867).
+    """
+    if not local_chromium or _user_wants_headed_browser(browser_env):
+        return []
+
+    # Pin both the CLI flag and the env so project/user agent-browser.json
+    # ``"headed": true`` cannot override Hermes' local-mode contract.
+    browser_env["AGENT_BROWSER_HEADED"] = "false"
+    if os.name == "nt":
+        _append_agent_browser_arg(browser_env, _WINDOWS_HEADLESS_WINDOW_POSITION)
+    return ["--headed", "false"]
+
 try:
     from tools.website_policy import check_website_access
 except Exception:
@@ -1091,13 +1145,21 @@ def _run_chrome_fallback_command(
         cmd_prefix = [_npx_bin, "agent-browser"]
     else:
         cmd_prefix = [browser_cmd]
-    base_args = cmd_prefix + ["--engine", "chrome", "--session", tmp_session, "--json"]
 
     task_socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{tmp_session}")
     os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
     browser_env = _build_browser_env()
     browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
     browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))
+    visibility_flags = _apply_local_browser_visibility_guards(
+        browser_env, local_chromium=True
+    )
+    base_args = (
+        cmd_prefix
+        + ["--engine", "chrome", "--session", tmp_session]
+        + visibility_flags
+        + ["--json"]
+    )
 
     if "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in browser_env:
         browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
@@ -2459,6 +2521,18 @@ def _run_browser_command(
                 browser_env["AGENT_BROWSER_ARGS"] = (
                     "--no-sandbox,--disable-dev-shm-usage"
                 )
+
+        # Local headless contract (#64867): force --headed false and park any
+        # Windows ghost HWND off-screen. Must run AFTER sandbox-arg injection
+        # so we append --window-position rather than overwrite it.
+        visibility_flags = _apply_local_browser_visibility_guards(
+            browser_env,
+            local_chromium=not bool(session_info.get("cdp_url")),
+        )
+        if visibility_flags:
+            # Insert before --json so global flags stay ahead of the command.
+            json_at = cmd_parts.index("--json")
+            cmd_parts[json_at:json_at] = visibility_flags
 
         # Use temp files for stdout/stderr instead of pipes.
         # agent-browser starts a background daemon that inherits file


### PR DESCRIPTION
﻿## What does this PR do?

Local browser automation is documented as headless Chromium via agent-browser, but on Windows Desktop a large blank top-level window can still appear while `browser_navigate` runs (and sometimes around nearby tool activity). Automation still succeeds; the window just obscures the chat.

Two cooperating causes:

1. Local `agent-browser` can inherit headed mode from user/project config (`AGENT_BROWSER_HEADED` / `agent-browser.json`), and Chrome's `--headless=new` has historically painted a blank HWND on some Windows hosts.
2. Desktop tier-2 link-title resolution opens a 1280x800 `BrowserWindow` when curl cannot read a title (common for bot-walled sites like GitHub, the issue's repro URL). A `show: false` leak there looks like a blank framed window over the chat.

This PR forces local sessions to `--headed false` (unless the operator explicitly sets `AGENT_BROWSER_HEADED`), parks any Windows ghost HWND off-screen via `AGENT_BROWSER_ARGS`, and hardens the link-title window (off-screen bounds, `skipTaskbar`, `focusable: false`, hide + opacity 0).

## Related Issue

Fixes #64867

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/browser_tool.py`: `_apply_local_browser_visibility_guards` for local Chromium; insert `--headed false`; on Windows append `--window-position=-2400,-2400`
- `apps/desktop/electron/link-title-window.ts`: off-screen + non-focusable hidden title-fetch window
- `tests/tools/test_browser_windows_blank_window.py`: unit coverage for the guards and Popen argv
- `apps/desktop/electron/link-title-window.test.ts`: options + hide/opacity regression coverage

## How to Test

1. On Windows, leave local browser mode (no Browserbase / CDP / Camofox).
2. In Hermes Desktop, ask the agent to `browser_navigate` to `https://github.com/NousResearch/hermes-agent`.
3. Confirm no blank top-level window covers the chat while the tool runs.
4. Optional: with `AGENT_BROWSER_HEADED=1`, headed mode still works (guards skip).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run targeted pytest for the new tests (see Evidence)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A for docs / config example / AGENTS.md / tool schemas
- [x] I've considered cross-platform impact (guards no-op for CDP; headed opt-in preserved)

## AI assistance

Drafted with Cursor/Grok assistance. Human author: Stan Shih (stantheman0128). Reviewed and verified on Windows before opening.

## Evidence

```text
$ python -m pytest tests/tools/test_browser_windows_blank_window.py -q --tb=short
......                                                                   [100%]
6 passed in 2.20s

$ python scripts/check-windows-footguns.py tools/browser_tool.py tests/tools/test_browser_windows_blank_window.py
OK No Windows footguns found (2 file(s) scanned).

Live agent-browser check (Chrome 151 via agent-browser 0.27.0):
  --headed false + AGENT_BROWSER_ARGS=--window-position=-2400,-2400
  open https://example.com -> exit=0, cmdline has --headless=new and
  --window-position=-2400,-2400, MainWindowHandle=0
```

`scripts/run_tests.sh` was also attempted; on this Windows host the stock `env -i` path drops `USERPROFILE`, which breaks `Path.home()` during hermes imports. Targeted pytest above uses the same test file the runner would execute.
