### PR TITLE
fix(tools): translate MSYS paths to Windows-native before shell lint (#66494)

### DIFF
--- a/contributors/emails/stanshih888@gmail.com
+++ b/contributors/emails/stanshih888@gmail.com
@@ -1,0 +1,2 @@
+stantheman0128
+# PR #66524 MSYS lint path

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -154,27 +154,43 @@ class TestCheckLintBracePaths:
 
 class TestCheckLintWindowsNativePath:
     """#66494: the shell linters shell out to native Windows toolchains
-    (node, tsc, go, rustfmt, python).  On Windows the {file} argument must
-    be a Windows-native path, not a Git Bash ``/e/...`` path.  Native node
-    resolves ``/e/project/x.js`` against the current drive root, producing
-    ``E:\\e\\project\\x.js`` -> ``Cannot find module``.  The lint must reuse
-    the same MSYS->Windows translation the terminal backend uses for its cwd.
+    (node, tsc, go, rustfmt, python).  On a LocalEnvironment Windows host
+    the {file} argument must be a Windows-native path, not a Git Bash
+    ``/e/...`` path.  Native node resolves ``/e/project/x.js`` against the
+    current drive root, producing ``E:\\e\\project\\x.js`` -> ``Cannot find
+    module``.  The lint must reuse the same MSYS->Windows translation the
+    terminal backend uses for its cwd — but only for the local backend.
+    Remote backends keep POSIX paths even when the host is Windows.
     """
 
     @pytest.fixture()
-    def ops(self):
-        obj = ShellFileOperations.__new__(ShellFileOperations)
-        obj._command_cache = {}
-        return obj
+    def local_ops(self):
+        from tools.environments.local import LocalEnvironment
 
-    def test_msys_path_translated_to_windows_native(self, ops):
+        env = object.__new__(LocalEnvironment)
+        env.cwd = r"E:\project"
+        ops = ShellFileOperations(env)
+        ops._command_cache = {}
+        return ops
+
+    @pytest.fixture()
+    def docker_ops(self):
+        from tools.environments.docker import DockerEnvironment
+
+        env = object.__new__(DockerEnvironment)
+        env.cwd = "/workspace"
+        ops = ShellFileOperations(env)
+        ops._command_cache = {}
+        return ops
+
+    def test_msys_path_translated_to_windows_native_on_local(self, local_ops):
         import tools.environments.local as local_env
 
         with patch.object(local_env, "_IS_WINDOWS", True), \
-             patch.object(ops, "_has_command", return_value=True), \
-             patch.object(ops, "_exec") as mock_exec:
+             patch.object(local_ops, "_has_command", return_value=True), \
+             patch.object(local_ops, "_exec") as mock_exec:
             mock_exec.return_value = MagicMock(exit_code=0, stdout="")
-            result = ops._check_lint("/e/project/Fina/js/models.js")
+            result = local_ops._check_lint("/e/project/Fina/js/models.js")
 
         assert result.success is True
         cmd = mock_exec.call_args[0][0]
@@ -184,14 +200,32 @@ class TestCheckLintWindowsNativePath:
         assert "/e/project/Fina/js/models.js" not in cmd
         assert cmd.startswith("node --check")
 
-    def test_posix_path_unchanged_off_windows(self, ops):
+    def test_msys_path_unchanged_on_remote_windows_host(self, docker_ops):
+        """Windows host + Docker/SSH must not rewrite in-backend POSIX paths."""
+        import tools.environments.local as local_env
+
+        with patch.object(local_env, "_IS_WINDOWS", True), \
+             patch.object(docker_ops, "_has_command", return_value=True), \
+             patch.object(docker_ops, "_exec") as mock_exec:
+            mock_exec.return_value = MagicMock(exit_code=0, stdout="")
+            result = docker_ops._check_lint("/e/project/Fina/js/models.js")
+
+        assert result.success is True
+        cmd = mock_exec.call_args[0][0]
+        # Remote Linux path stays POSIX — rewriting to E:/... would break
+        # the in-container toolchain.
+        assert "'/e/project/Fina/js/models.js'" in cmd
+        assert "E:/project/Fina/js/models.js" not in cmd
+        assert cmd.startswith("node --check")
+
+    def test_posix_path_unchanged_off_windows(self, local_ops):
         import tools.environments.local as local_env
 
         with patch.object(local_env, "_IS_WINDOWS", False), \
-             patch.object(ops, "_has_command", return_value=True), \
-             patch.object(ops, "_exec") as mock_exec:
+             patch.object(local_ops, "_has_command", return_value=True), \
+             patch.object(local_ops, "_exec") as mock_exec:
             mock_exec.return_value = MagicMock(exit_code=0, stdout="")
-            result = ops._check_lint("/home/user/app/models.js")
+            result = local_ops._check_lint("/home/user/app/models.js")
 
         assert result.success is True
         cmd = mock_exec.call_args[0][0]

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -152,6 +152,52 @@ class TestCheckLintBracePaths:
         assert "SyntaxError" in result.output
 
 
+class TestCheckLintWindowsNativePath:
+    """#66494: the shell linters shell out to native Windows toolchains
+    (node, tsc, go, rustfmt, python).  On Windows the {file} argument must
+    be a Windows-native path, not a Git Bash ``/e/...`` path.  Native node
+    resolves ``/e/project/x.js`` against the current drive root, producing
+    ``E:\\e\\project\\x.js`` -> ``Cannot find module``.  The lint must reuse
+    the same MSYS->Windows translation the terminal backend uses for its cwd.
+    """
+
+    @pytest.fixture()
+    def ops(self):
+        obj = ShellFileOperations.__new__(ShellFileOperations)
+        obj._command_cache = {}
+        return obj
+
+    def test_msys_path_translated_to_windows_native(self, ops):
+        import tools.environments.local as local_env
+
+        with patch.object(local_env, "_IS_WINDOWS", True), \
+             patch.object(ops, "_has_command", return_value=True), \
+             patch.object(ops, "_exec") as mock_exec:
+            mock_exec.return_value = MagicMock(exit_code=0, stdout="")
+            result = ops._check_lint("/e/project/Fina/js/models.js")
+
+        assert result.success is True
+        cmd = mock_exec.call_args[0][0]
+        # node must receive the Windows-native drive path, forward-slash form.
+        assert "'E:/project/Fina/js/models.js'" in cmd
+        # and NOT the raw MSYS path that node mis-resolves against the drive root.
+        assert "/e/project/Fina/js/models.js" not in cmd
+        assert cmd.startswith("node --check")
+
+    def test_posix_path_unchanged_off_windows(self, ops):
+        import tools.environments.local as local_env
+
+        with patch.object(local_env, "_IS_WINDOWS", False), \
+             patch.object(ops, "_has_command", return_value=True), \
+             patch.object(ops, "_exec") as mock_exec:
+            mock_exec.return_value = MagicMock(exit_code=0, stdout="")
+            result = ops._check_lint("/home/user/app/models.js")
+
+        assert result.success is True
+        cmd = mock_exec.call_args[0][0]
+        assert "'/home/user/app/models.js'" in cmd
+
+
 class TestCheckLintInproc:
     """Verify in-process linters (.py via ast.parse, .json, .yaml, .toml).
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1775,10 +1775,14 @@ class ShellFileOperations(FileOperations):
         # resolved against the current drive root -> ``Cannot find module
         # E:\e\project\x.js`` (#66494).  Hand these tools the same
         # Windows-native path the terminal backend already uses for its
-        # cwd instead of the ``/e/...`` bash form.  Off Windows the path is
-        # left untouched so genuine POSIX names (backslashes and all) survive.
+        # cwd instead of the ``/e/...`` bash form.
+        #
+        # Gate on LocalEnvironment as well as Windows: ShellFileOperations
+        # is shared by Docker/SSH/Modal/etc., and a Windows host must not
+        # rewrite valid in-backend POSIX paths like ``/e/...`` to ``E:/...``.
+        # Off Windows, or on a remote backend, leave the path untouched.
         from tools.environments.local import _IS_WINDOWS, _msys_to_windows_path
-        if _IS_WINDOWS:
+        if _IS_WINDOWS and self._lsp_local_only():
             native = _msys_to_windows_path(path).replace("\\", "/")
             file_arg = "'" + native.replace("'", "'\"'\"'") + "'"
         else:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1767,8 +1767,23 @@ class ShellFileOperations(FileOperations):
         if not self._has_command(base_cmd):
             return LintResult(skipped=True, message=f"{base_cmd} not available")
 
-        # Run linter
-        cmd = linter_cmd.replace("{file}", self._escape_shell_arg(path))
+        # Run linter. The shell linters shell out to native Windows
+        # toolchains (node, npx/tsc, go, rustfmt, python).  Git Bash
+        # single-quotes the {file} argument, which suppresses MSYS
+        # POSIX->Windows argument conversion, so a bash-form path like
+        # ``/e/project/x.js`` reaches native ``node`` verbatim and is
+        # resolved against the current drive root -> ``Cannot find module
+        # E:\e\project\x.js`` (#66494).  Hand these tools the same
+        # Windows-native path the terminal backend already uses for its
+        # cwd instead of the ``/e/...`` bash form.  Off Windows the path is
+        # left untouched so genuine POSIX names (backslashes and all) survive.
+        from tools.environments.local import _IS_WINDOWS, _msys_to_windows_path
+        if _IS_WINDOWS:
+            native = _msys_to_windows_path(path).replace("\\", "/")
+            file_arg = "'" + native.replace("'", "'\"'\"'") + "'"
+        else:
+            file_arg = self._escape_shell_arg(path)
+        cmd = linter_cmd.replace("{file}", file_arg)
         result = self._exec(cmd, timeout=30)
 
         if result.exit_code != 0 and _looks_like_linter_unusable(base_cmd, result.stdout):


### PR DESCRIPTION
## What does this PR do?

On Windows/MSYS the post-write shell linters (`node --check`, `tsc`, `go vet`, `rustfmt`, `py_compile`) received the target file path in Git Bash `/e/...` form. Git Bash single-quotes the `{file}` argument, which suppresses MSYS POSIX to Windows argument conversion, so native `node` got `/e/project/x.js` verbatim and resolved it against the current drive root, producing `Cannot find module 'E:\project\Fina\js\models.js'` on every `.js` edit.

The fix reuses the terminal backend's existing `_msys_to_windows_path` translator, so the automatic lint hands the native toolchain the same Windows-native path the terminal already uses for its cwd. This is exactly the "use the same path-resolution engine as the terminal" approach the issue suggests. Off Windows the path is left untouched, so genuine POSIX names (backslashes and all) still round-trip through the existing shell escaper.

## Related Issue

Fixes #66494

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py`: in `ShellFileOperations._check_lint`, translate the file argument via `_msys_to_windows_path` (then forward-slash form, single-quoted) when `_IS_WINDOWS`, before substituting into the linter command. Off Windows keeps the previous `_escape_shell_arg` path.
- `tests/tools/test_file_operations_edge_cases.py`: add `TestCheckLintWindowsNativePath` covering both the Windows translation (`/e/project/...` -> `'E:/project/...'`, and the raw MSYS path must NOT appear) and the off-Windows passthrough.

## How to Test

1. On Windows/MSYS with native `node` on PATH, edit a `.js` file through `write_file`/`patch` in a project on a non-C: drive (e.g. `E:\`). Before this change the auto-lint reports `Cannot find module 'E:\e\...'`; after it, `node --check` runs against the correct `E:/...` path.
2. `python -m pytest tests/tools/test_file_operations_edge_cases.py -q`

Verification output on this branch:

```
$ python -m pytest tests/tools/test_file_operations_edge_cases.py::TestCheckLintWindowsNativePath -q
..                                                                       [100%]
2 passed in 1.56s

$ python -m pytest tests/tools/test_file_operations_edge_cases.py -q
.....................................                                    [100%]
37 passed in 3.40s
```

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(tools):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (MSYS/Git Bash)

### Documentation & Housekeeping

- [x] Considered cross-platform impact: the translation is gated on `_IS_WINDOWS`; POSIX behavior is unchanged.

---

Disclosure: this change was prepared with AI assistance (Claude) and reviewed before submission.
