### PR TITLE
fix(gateway): revoke typing lease on turn completion

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3875,6 +3875,7 @@ class BasePlatformAdapter(ABC):
         interval: float = 2.0,
         metadata=None,
         stop_event: asyncio.Event | None = None,
+        completion_event: asyncio.Event | None = None,
     ) -> None:
         """
         Continuously send typing indicator until cancelled.
@@ -3886,6 +3887,11 @@ class BasePlatformAdapter(ABC):
         the agent is waiting for dangerous-command approval).  This is critical
         for Slack's Assistant API where ``assistant_threads_setStatus`` disables
         the compose box — pausing lets the user type ``/approve`` or ``/deny``.
+
+        ``stop_event`` remains the reusable session interrupt signal so adapter
+        overrides keep their existing steering contract. ``completion_event``
+        is scoped to one background turn and prevents a delayed or
+        cancellation-resistant refresher from outliving that turn.
 
         Each ``send_typing`` call is bounded by a ~1.5s timeout so a slow
         network round-trip can't stall the refresh cadence.  Telegram- and
@@ -3900,9 +3906,16 @@ class BasePlatformAdapter(ABC):
         # gated on network health.  Must stay below ``interval`` so a slow
         # call gets abandoned before the next scheduled tick.
         _send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
+
+        def _typing_should_stop() -> bool:
+            return bool(
+                (stop_event is not None and stop_event.is_set())
+                or (completion_event is not None and completion_event.is_set())
+            )
+
         try:
             while True:
-                if stop_event is not None and stop_event.is_set():
+                if _typing_should_stop():
                     return
                 if chat_id not in self._typing_paused:
                     try:
@@ -3921,12 +3934,12 @@ class BasePlatformAdapter(ABC):
                             "[%s] send_typing error (non-fatal): %s",
                             self.name, typing_err,
                         )
-                if stop_event is None:
+                if stop_event is None and completion_event is None:
                     await asyncio.sleep(interval)
                     continue
                 loop = asyncio.get_running_loop()
                 deadline = loop.time() + interval
-                while not stop_event.is_set():
+                while not _typing_should_stop():
                     remaining = deadline - loop.time()
                     if remaining <= 0:
                         break
@@ -3935,7 +3948,7 @@ class BasePlatformAdapter(ABC):
                     # shutdown paths stuck awaiting the typing task on Python
                     # 3.11/pytest-asyncio; sleep cancellation is immediate.
                     await asyncio.sleep(min(0.25, remaining))
-                if stop_event.is_set():
+                if _typing_should_stop():
                     return
         except asyncio.CancelledError:
             pass  # Normal cancellation when handler completes
@@ -4922,14 +4935,36 @@ class BasePlatformAdapter(ABC):
         # typing_task stays None; _stop_typing_refresh already no-ops on None.
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
         typing_task: Optional[asyncio.Task] = None
+        typing_completion_event = asyncio.Event()
         if getattr(self.config, "typing_indicator", True):
             _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}
             try:
                 _keep_typing_sig = inspect.signature(self._keep_typing)
             except (TypeError, ValueError):
                 _keep_typing_sig = None
-            if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
+            _keep_typing_accepts_kwargs = bool(
+                _keep_typing_sig
+                and any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in _keep_typing_sig.parameters.values()
+                )
+            )
+            if (
+                _keep_typing_sig is None
+                or _keep_typing_accepts_kwargs
+                or "stop_event" in _keep_typing_sig.parameters
+            ):
+                # Preserve the established stop_event contract for adapter
+                # overrides: it is the reusable session interrupt signal.
                 _keep_typing_kwargs["stop_event"] = interrupt_event
+            if (
+                _keep_typing_sig is not None
+                and (
+                    _keep_typing_accepts_kwargs
+                    or "completion_event" in _keep_typing_sig.parameters
+                )
+            ):
+                _keep_typing_kwargs["completion_event"] = typing_completion_event
             typing_task = asyncio.create_task(
                 self._keep_typing(
                     event.source.chat_id,
@@ -4938,6 +4973,10 @@ class BasePlatformAdapter(ABC):
             )
 
         async def _stop_typing_task() -> None:
+            # Revoke this turn's typing lease before best-effort cancellation.
+            # A delayed or cancellation-resistant refresh task must not resume
+            # sending platform typing actions after cleanup unpauses the chat.
+            typing_completion_event.set()
             await self._stop_typing_refresh(
                 event.source.chat_id,
                 typing_task,

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -28,10 +28,13 @@ import pytest
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
     Platform,
     PlatformConfig,
     SendResult,
 )
+from gateway.session import SessionSource, build_session_key
 
 
 class _StubAdapter(BasePlatformAdapter):
@@ -49,6 +52,22 @@ class _StubAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id):
         return {"id": chat_id, "type": "dm"}
+
+
+class _ForwardingStubAdapter(_StubAdapter):
+    """Match adapters such as LINE that forward optional lifecycle kwargs."""
+
+    def __init__(self):
+        super().__init__()
+        self.forwarded_typing_kwargs = []
+        self.typing_exited = asyncio.Event()
+
+    async def _keep_typing(self, chat_id, *args, **kwargs):
+        self.forwarded_typing_kwargs.append(kwargs)
+        try:
+            return await super()._keep_typing(chat_id, *args, **kwargs)
+        finally:
+            self.typing_exited.set()
 
 
 class TestKeepTypingTimeoutPerTick:
@@ -234,3 +253,285 @@ class TestKeepTypingTimeoutPerTick:
             ("discord-chat", True),
         ]
         assert "discord-chat" not in adapter._typing_paused
+
+    @pytest.mark.asyncio
+    async def test_completed_turn_signals_cancellation_resistant_typing_loop(
+        self, monkeypatch
+    ):
+        adapter = _StubAdapter()
+        started = asyncio.Event()
+        stopped = asyncio.Event()
+        observed_stop_events = []
+
+        async def handler(event):
+            await asyncio.wait_for(started.wait(), timeout=1.0)
+            return None
+
+        async def cancellation_resistant_keep_typing(
+            chat_id, metadata=None, stop_event=None, completion_event=None
+        ):
+            observed_stop_events.append(completion_event)
+            assert completion_event is not None
+            started.set()
+            while not completion_event.is_set():
+                try:
+                    await asyncio.sleep(0.01)
+                except asyncio.CancelledError:
+                    continue
+            stopped.set()
+
+        monkeypatch.setattr(adapter, "_keep_typing", cancellation_resistant_keep_typing)
+        adapter._message_handler = handler
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="completion-chat",
+            chat_type="dm",
+            user_id="u1",
+        )
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-completion",
+        )
+        session_key = build_session_key(source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        try:
+            await asyncio.wait_for(
+                adapter._process_message_background(event, session_key),
+                timeout=2.0,
+            )
+            assert observed_stop_events[0].is_set()
+            await asyncio.wait_for(stopped.wait(), timeout=1.0)
+        finally:
+            if observed_stop_events:
+                observed_stop_events[0].set()
+                await asyncio.wait_for(stopped.wait(), timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_forwarding_override_receives_interrupt_and_completion_events(
+        self, monkeypatch
+    ):
+        adapter = _ForwardingStubAdapter()
+        first_tick = asyncio.Event()
+        release_handler = asyncio.Event()
+        calls = []
+
+        async def send_typing(chat_id, metadata=None):
+            calls.append(chat_id)
+            first_tick.set()
+
+        async def handler(event):
+            await release_handler.wait()
+            return None
+
+        monkeypatch.setattr(adapter, "send_typing", send_typing)
+        adapter._message_handler = handler
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="forwarding-chat",
+            chat_type="dm",
+            user_id="u1",
+        )
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-forward",
+        )
+        session_key = build_session_key(source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._process_message_background(event, session_key)
+        )
+
+        await asyncio.wait_for(first_tick.wait(), timeout=1.0)
+        forwarded = adapter.forwarded_typing_kwargs[0]
+        assert forwarded["stop_event"] is adapter._active_sessions[session_key]
+
+        await adapter.interrupt_session_activity(session_key, source.chat_id)
+        calls_after_interrupt = len(calls)
+        await asyncio.wait_for(adapter.typing_exited.wait(), timeout=1.0)
+        assert len(calls) == calls_after_interrupt
+        assert forwarded["stop_event"].is_set()
+        assert not forwarded["completion_event"].is_set()
+
+        release_handler.set()
+        await asyncio.wait_for(task, timeout=1.0)
+        assert forwarded["completion_event"].is_set()
+
+    @pytest.mark.asyncio
+    async def test_explicit_stop_event_override_keeps_interrupt_contract(
+        self, monkeypatch
+    ):
+        adapter = _StubAdapter()
+        started = asyncio.Event()
+        exited = asyncio.Event()
+        release_handler = asyncio.Event()
+        observed_stop_events = []
+
+        async def explicit_stop_only_keep_typing(
+            chat_id, metadata=None, stop_event=None
+        ):
+            observed_stop_events.append(stop_event)
+            assert stop_event is not None
+            started.set()
+            await stop_event.wait()
+            exited.set()
+
+        async def handler(event):
+            await release_handler.wait()
+            return None
+
+        monkeypatch.setattr(adapter, "_keep_typing", explicit_stop_only_keep_typing)
+        adapter._message_handler = handler
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="legacy-override-chat",
+            chat_type="dm",
+            user_id="u1",
+        )
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-legacy",
+        )
+        session_key = build_session_key(source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._process_message_background(event, session_key)
+        )
+
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        assert observed_stop_events == [adapter._active_sessions[session_key]]
+        await adapter.interrupt_session_activity(session_key, source.chat_id)
+        await asyncio.wait_for(exited.wait(), timeout=1.0)
+
+        release_handler.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_opaque_legacy_override_fails_closed_and_releases_session(
+        self, monkeypatch
+    ):
+        adapter = _StubAdapter()
+        started = asyncio.Event()
+        exited = asyncio.Event()
+        release_handler = asyncio.Event()
+        observed_stop_events = []
+
+        class OpaqueLegacyKeepTyping:
+            @property
+            def __signature__(self):
+                raise ValueError("opaque callable")
+
+            async def __call__(self, chat_id, metadata=None, stop_event=None):
+                observed_stop_events.append(stop_event)
+                assert stop_event is not None
+                started.set()
+                await stop_event.wait()
+                exited.set()
+
+        async def handler(event):
+            await release_handler.wait()
+            return None
+
+        monkeypatch.setattr(adapter, "_keep_typing", OpaqueLegacyKeepTyping())
+        adapter._message_handler = handler
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="opaque-override-chat",
+            chat_type="dm",
+            user_id="u1",
+        )
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-opaque",
+        )
+        session_key = build_session_key(source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._process_message_background(event, session_key)
+        )
+        adapter._session_tasks[session_key] = task
+
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        assert observed_stop_events == [adapter._active_sessions[session_key]]
+        await adapter.interrupt_session_activity(session_key, source.chat_id)
+        await asyncio.wait_for(exited.wait(), timeout=1.0)
+
+        release_handler.set()
+        await asyncio.wait_for(task, timeout=1.0)
+        assert session_key not in adapter._active_sessions
+        assert session_key not in adapter._session_tasks
+
+    @pytest.mark.asyncio
+    async def test_pending_handoff_gets_fresh_typing_completion_event(
+        self, monkeypatch
+    ):
+        adapter = _ForwardingStubAdapter()
+        first_tick = asyncio.Event()
+        second_tick = asyncio.Event()
+        release_second = asyncio.Event()
+        send_count = 0
+
+        async def send_typing(chat_id, metadata=None):
+            nonlocal send_count
+            send_count += 1
+            (first_tick if send_count == 1 else second_tick).set()
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="handoff-chat",
+            chat_type="dm",
+            user_id="u1",
+        )
+        first = MessageEvent(
+            text="first",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-first",
+        )
+        second = MessageEvent(
+            text="second",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-second",
+        )
+        session_key = build_session_key(source)
+
+        async def handler(event):
+            if event.text == "first":
+                await first_tick.wait()
+                adapter._pending_messages[session_key] = second
+                return None
+            await second_tick.wait()
+            await release_second.wait()
+            return None
+
+        monkeypatch.setattr(adapter, "send_typing", send_typing)
+        adapter._message_handler = handler
+        adapter._active_sessions[session_key] = asyncio.Event()
+        first_task = asyncio.create_task(
+            adapter._process_message_background(first, session_key)
+        )
+        adapter._session_tasks[session_key] = first_task
+
+        await asyncio.wait_for(first_task, timeout=1.0)
+        await asyncio.wait_for(second_tick.wait(), timeout=1.0)
+        first_events, second_events = adapter.forwarded_typing_kwargs
+        assert first_events["completion_event"].is_set()
+        assert not second_events["completion_event"].is_set()
+        assert (
+            first_events["completion_event"]
+            is not second_events["completion_event"]
+        )
+        assert first_events["stop_event"] is second_events["stop_event"]
+
+        release_second.set()
+        await asyncio.wait_for(adapter._session_tasks[session_key], timeout=1.0)
+        assert second_events["completion_event"].is_set()


### PR DESCRIPTION
## Problem

The shared gateway typing refresher is still vulnerable to an orphaned-task race after the current pause/cancel hardening.

At turn cleanup, `_stop_typing_refresh()` pauses the chat, cancels `_keep_typing`, and waits up to 0.5 seconds. If adapter/network cleanup delays or suppresses cancellation, the helper times out and removes the pause. The surviving refresher can then resume sending typing actions every two seconds even though the turn is complete and the gateway is idle.

This is the residual leaked-task mechanism reported in #28004 and its Teams duplicate #62394. Existing delivery-order work such as #29172 moves cleanup earlier, but still relies on cancellation terminating the refresher.

## Fix

Treat typing as a per-turn lease:

- create a dedicated completion event for each `_process_message_background()` turn
- set that event before best-effort task cancellation and adapter cleanup
- preserve the established `stop_event` contract as the reusable session interrupt so older adapter overrides retain immediate steering behavior
- make `_keep_typing()` exit when either completion or interruption is signaled
- pass the completion signal through adapters that explicitly accept it or expose `**kwargs` (notably LINE)

This preserves active typing while work is running and prevents a cancellation-resistant refresher from rearming typing after cleanup unpauses the chat.

## Regression coverage

- normal completion revokes a cancellation-resistant typing loop
- user interruption stops a forwarding adapter without falsely completing its turn
- opaque legacy overrides fail closed to the established interrupt-only contract and release session ownership
- pending-message handoff receives a fresh completion lease while retaining the session interrupt guard
- existing timeout, pause, Telegram, session-drain, restart-resume, and LINE behavior remains covered

## Validation

- `320 passed` across 10 isolated files via `scripts/run_tests.sh -j 4` (the repository's hermetic CI-parity runner)
- includes `10 passed` focused typing lifecycle tests and `76 passed` LINE plugin tests
- Ruff, compile, and `git diff --check` pass

Tested on macOS (Apple Silicon) with Python 3.11.

Follow-up to #28004. Addresses the remaining leaked-refresher mechanism documented in #62394.
