### PR TITLE
fix(issue-66392): add KDE/X11 capture-only fallback with lazy session

### DIFF
--- a/tests/computer_use/test_cua_lazy_session.py
+++ b/tests/computer_use/test_cua_lazy_session.py
@@ -1,0 +1,110 @@
+"""The cua-driver run session (agent cursor) must be declared lazily.
+
+On Linux/X11, cua-driver 0.8.3 backs the per-session agent cursor declared by
+``start_session`` with a temporary uinput virtual pointer whose creation can
+crash a KDE Plasma/Qt X11 session (NousResearch/hermes-agent#66392). A pure
+read-only request (``capture``/``list_apps``/``wait``) must therefore NOT
+declare that input-capable session; the declaration has to defer until the
+first genuine input/cursor action routed through ``_action``.
+
+These assert the ordering contract (no ``start_session`` for read-only flows;
+exactly one on the first input action, idempotent afterwards; ``end_session``
+only when the session was actually declared), not any real display behaviour —
+the session is faked so the test needs neither a DISPLAY nor uinput.
+"""
+
+from unittest.mock import patch
+
+from tools.computer_use import cua_backend
+from tools.computer_use.cua_backend import CuaDriverBackend
+
+
+class _FakeSession:
+    """Records every call_tool name/args; no real cua-driver involved."""
+
+    def __init__(self) -> None:
+        self.calls = []
+        self._started = False
+
+    def start(self) -> None:
+        self._started = True
+
+    def stop(self) -> None:
+        self._started = False
+
+    def call_tool(self, name, args, timeout=30.0):
+        self.calls.append((name, args))
+        return {
+            "data": None,
+            "images": [],
+            "structuredContent": {},
+            "isError": False,
+        }
+
+    def supports_capability(self, capability, tool=None):
+        return False
+
+    @property
+    def call_names(self):
+        return [name for name, _ in self.calls]
+
+
+def _make_backend():
+    backend = CuaDriverBackend()
+    fake = _FakeSession()
+    backend._session = fake
+    return backend, fake
+
+
+def _start(backend):
+    # Neutralise the optional-dep install + update nudge so start() only
+    # exercises the session-declaration logic under test.
+    with patch.object(cua_backend, "_maybe_nudge_update", lambda: None), \
+         patch("tools.lazy_deps.ensure", lambda *a, **k: None):
+        backend.start()
+
+
+class TestLazyRunSession:
+    def test_start_does_not_declare_session(self):
+        backend, fake = _make_backend()
+        _start(backend)
+        # start() alone must not create the input-capable agent-cursor session.
+        assert "start_session" not in fake.call_names
+
+    def test_read_only_actions_do_not_declare_session(self):
+        backend, fake = _make_backend()
+        _start(backend)
+        backend.list_apps()
+        assert "start_session" not in fake.call_names
+
+    def test_first_input_action_declares_session_once(self):
+        backend, fake = _make_backend()
+        _start(backend)
+        # Prime an active target so click() routes through _action().
+        backend._active_pid = 1234
+        backend._active_window_id = 5678
+
+        backend.click(element=0)
+        assert fake.call_names.count("start_session") == 1
+
+        # A second input action must not re-declare (idempotent flag).
+        backend.click(element=0)
+        assert fake.call_names.count("start_session") == 1
+
+    def test_stop_ends_session_only_when_declared(self):
+        # No input action => no start_session => no end_session.
+        backend, fake = _make_backend()
+        _start(backend)
+        backend.list_apps()
+        backend.stop()
+        assert "end_session" not in fake.call_names
+
+    def test_stop_ends_session_after_input_action(self):
+        backend, fake = _make_backend()
+        _start(backend)
+        backend._active_pid = 1234
+        backend._active_window_id = 5678
+        backend.click(element=0)
+        backend.stop()
+        assert fake.call_names.count("start_session") == 1
+        assert fake.call_names.count("end_session") == 1

--- a/tests/computer_use/test_cua_linux_guard.py
+++ b/tests/computer_use/test_cua_linux_guard.py
@@ -1,0 +1,127 @@
+"""Tests for the KDE Plasma/X11 crash guard (#66392).
+
+cua-driver 0.8.3's uinput virtual pointer can crash a KDE Plasma/Qt X11
+session during MCP initialization. The guard blocks ``start()`` on
+detected KDE Plasma / X11 hosts unless the user explicitly opts in via
+``computer_use.linux_opt_in: true`` in config.yaml.
+
+Non-Linux, non-KDE, and config-read-error paths all return True so the
+guard never blocks production macOS/Windows use.
+"""
+
+import os
+from unittest.mock import patch
+
+from tools.computer_use import cua_backend
+
+
+class TestIsLinux:
+    def test_linux(self):
+        with patch.object(cua_backend.sys, "platform", "linux"):
+            assert cua_backend._is_linux() is True
+
+    def test_darwin(self):
+        with patch.object(cua_backend.sys, "platform", "darwin"):
+            assert cua_backend._is_linux() is False
+
+    def test_win32(self):
+        with patch.object(cua_backend.sys, "platform", "win32"):
+            assert cua_backend._is_linux() is False
+
+
+class TestIsLinuxX11:
+    def test_linux_with_display(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}):
+            assert cua_backend._is_linux_x11() is True
+
+    def test_linux_no_display(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, clear=True):
+            assert cua_backend._is_linux_x11() is False
+
+    def test_darwin_ignores_display(self):
+        with patch.object(cua_backend.sys, "platform", "darwin"), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}):
+            assert cua_backend._is_linux_x11() is False
+
+
+class TestKdePlasmaDetected:
+    def test_linux_kde_full_session(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, {"KDE_FULL_SESSION": "true"}):
+            assert cua_backend._kde_plasma_detected() is True
+
+    def test_linux_xdg_current_desktop_kde(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": "KDE"}):
+            assert cua_backend._kde_plasma_detected() is True
+
+    def test_linux_desktop_session_plasma(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, {"DESKTOP_SESSION": "plasma"}):
+            assert cua_backend._kde_plasma_detected() is True
+
+    def test_linux_non_kde_returns_false(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": "GNOME"}):
+            assert cua_backend._kde_plasma_detected() is False
+
+    def test_non_linux_kde_env_returns_false(self):
+        """Even with KDE env vars, non-Linux is not KDE for our purposes."""
+        with patch.object(cua_backend.sys, "platform", "darwin"), \
+             patch.dict(os.environ, {"KDE_FULL_SESSION": "true"}):
+            assert cua_backend._kde_plasma_detected() is False
+
+    def test_linux_no_desktop_vars_returns_false(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, clear=True):
+            assert cua_backend._kde_plasma_detected() is False
+
+
+class TestLinuxCuaAllowed:
+    def test_non_linux_always_allowed(self):
+        with patch.object(cua_backend.sys, "platform", "darwin"):
+            assert cua_backend._linux_cua_allowed() is True
+
+    def test_linux_non_kde_allowed(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": "GNOME"}):
+            assert cua_backend._linux_cua_allowed() is True
+
+    def test_linux_kde_without_opt_in_blocked(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, {"KDE_FULL_SESSION": "true"}), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            assert cua_backend._linux_cua_allowed() is False
+
+    def test_linux_kde_with_opt_in_allowed(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, {"KDE_FULL_SESSION": "true"}), \
+             patch("hermes_cli.config.load_config",
+                   return_value={"computer_use": {"linux_opt_in": True}}):
+            assert cua_backend._linux_cua_allowed() is True
+
+    def test_config_read_error_fails_open(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, {"KDE_FULL_SESSION": "true"}), \
+             patch("hermes_cli.config.load_config", side_effect=ImportError):
+            assert cua_backend._linux_cua_allowed() is True
+
+
+class TestCuaDriverBackendStartGuard:
+    def test_start_raises_on_blocked(self):
+        backend = cua_backend.CuaDriverBackend()
+        with patch.object(cua_backend, "_linux_cua_allowed", return_value=False), \
+             patch.object(backend, "_session"):
+            import pytest
+            with pytest.raises(RuntimeError, match="computer_use is blocked.*KDE"):
+                backend.start()
+
+    def test_start_proceeds_when_allowed(self):
+        backend = cua_backend.CuaDriverBackend()
+        with patch.object(cua_backend, "_linux_cua_allowed", return_value=True), \
+             patch.object(backend, "_session"), \
+             patch.object(cua_backend, "_maybe_nudge_update"):
+            # Should not raise
+            backend.start()

--- a/tests/computer_use/test_cua_linux_guard.py
+++ b/tests/computer_use/test_cua_linux_guard.py
@@ -1,12 +1,13 @@
 """Tests for the KDE Plasma/X11 crash guard (#66392).
 
 cua-driver 0.8.3's uinput virtual pointer can crash a KDE Plasma/Qt X11
-session during MCP initialization. The guard blocks ``start()`` on
-detected KDE Plasma / X11 hosts unless the user explicitly opts in via
-``computer_use.linux_opt_in: true`` in config.yaml.
+session during MCP initialization. The guard allows capture/read-only
+actions but blocks input actions on detected KDE Plasma / X11 hosts
+unless the user explicitly opts in via ``computer_use.linux_opt_in: true``
+in config.yaml.
 
-Non-Linux, non-KDE, and config-read-error paths all return True so the
-guard never blocks production macOS/Windows use.
+Non-Linux, non-KDE, non-X11, and config-read-error paths all return True
+so the guard never blocks production macOS/Windows use.
 """
 
 import os
@@ -89,39 +90,67 @@ class TestLinuxCuaAllowed:
              patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": "GNOME"}):
             assert cua_backend._linux_cua_allowed() is True
 
-    def test_linux_kde_without_opt_in_blocked(self):
+    def test_linux_kde_wayland_allowed(self):
+        """KDE Plasma on Wayland (no DISPLAY) is safe — no uinput crash."""
         with patch.object(cua_backend.sys, "platform", "linux"), \
-             patch.dict(os.environ, {"KDE_FULL_SESSION": "true"}), \
+             patch.dict(os.environ, {"KDE_FULL_SESSION": "true"}, clear=True):
+            assert cua_backend._linux_cua_allowed() is True
+
+    def test_linux_kde_x11_without_opt_in_blocked(self):
+        with patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.dict(os.environ, {"KDE_FULL_SESSION": "true", "DISPLAY": ":0"}), \
              patch("hermes_cli.config.load_config", return_value={}):
             assert cua_backend._linux_cua_allowed() is False
 
-    def test_linux_kde_with_opt_in_allowed(self):
+    def test_linux_kde_x11_with_opt_in_allowed(self):
         with patch.object(cua_backend.sys, "platform", "linux"), \
-             patch.dict(os.environ, {"KDE_FULL_SESSION": "true"}), \
+             patch.dict(os.environ, {"KDE_FULL_SESSION": "true", "DISPLAY": ":0"}), \
              patch("hermes_cli.config.load_config",
                    return_value={"computer_use": {"linux_opt_in": True}}):
             assert cua_backend._linux_cua_allowed() is True
 
     def test_config_read_error_fails_open(self):
         with patch.object(cua_backend.sys, "platform", "linux"), \
-             patch.dict(os.environ, {"KDE_FULL_SESSION": "true"}), \
+             patch.dict(os.environ, {"KDE_FULL_SESSION": "true", "DISPLAY": ":0"}), \
              patch("hermes_cli.config.load_config", side_effect=ImportError):
             assert cua_backend._linux_cua_allowed() is True
 
 
 class TestCuaDriverBackendStartGuard:
-    def test_start_raises_on_blocked(self):
+    def test_start_sets_capture_only_on_blocked(self):
+        """Instead of raising, start() enters capture-only mode."""
         backend = cua_backend.CuaDriverBackend()
+        assert backend._linux_capture_only is False
         with patch.object(cua_backend, "_linux_cua_allowed", return_value=False), \
-             patch.object(backend, "_session"):
-            import pytest
-            with pytest.raises(RuntimeError, match="computer_use is blocked.*KDE"):
-                backend.start()
+             patch.object(backend, "_session"), \
+             patch.object(cua_backend, "_maybe_nudge_update"), \
+             patch("tools.lazy_deps.ensure", lambda *a, **k: None):
+            backend.start()
+            assert backend._linux_capture_only is True
 
-    def test_start_proceeds_when_allowed(self):
+    def test_start_proceeds_normally_when_allowed(self):
         backend = cua_backend.CuaDriverBackend()
         with patch.object(cua_backend, "_linux_cua_allowed", return_value=True), \
              patch.object(backend, "_session"), \
-             patch.object(cua_backend, "_maybe_nudge_update"):
-            # Should not raise
+             patch.object(cua_backend, "_maybe_nudge_update"), \
+             patch("tools.lazy_deps.ensure", lambda *a, **k: None):
             backend.start()
+            assert backend._linux_capture_only is False
+
+    def test_capture_only_blocks_input_action(self):
+        """In capture-only mode, _action() returns an error ActionResult."""
+        backend = cua_backend.CuaDriverBackend()
+        backend._linux_capture_only = True
+        result = backend._action("click", {"element_index": 0})
+        assert result.ok is False
+        assert "capture-only" in result.message
+
+    def test_capture_only_allows_capture(self):
+        """capture() works in capture-only mode — uinput not needed."""
+        backend = cua_backend.CuaDriverBackend()
+        backend._linux_capture_only = True
+        backend._session_id = "test-session"
+        with patch.object(backend, "_session"):
+            # Must reach capture logic, not be short-circuited by _action
+            result = backend.capture(mode="vision")
+            assert result is not None

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -280,7 +280,15 @@ def _linux_cua_allowed() -> bool:
     guard never blocks production macOS/Windows use or new Linux desktop
     environments that don't carry the crash vector.
     """
+    # The crash vector is KDE Plasma + X11 specifically — cua-driver 0.8.3's
+    # uinput virtual pointer triggers a segfault in kwin_x11 that cascades
+    # to all Qt processes (#66392).  KDE under pure Wayland (no DISPLAY) is
+    # NOT affected because the uinput code path is never exercised via
+    # Wayland at this driver version.  Non-KDE or non-X11 Linux (GNOME,
+    # Sway/Hyprland, headless) is also safe.
     if not _is_linux() or not _kde_plasma_detected():
+        return True
+    if not _is_linux_x11():
         return True
     try:
         from hermes_cli.config import load_config
@@ -1282,17 +1290,26 @@ class CuaDriverBackend(ComputerUseBackend):
         # spin up the agent-cursor virtual pointer — on Linux/X11 that
         # uinput pointer can crash a KDE Plasma/Qt session (#66392).
         self._run_session_declared: bool = False
+        # Capture-only mode: set by start() when the KDE/X11 crash guard
+        # blocks uinput-virtual-pointer actions (#66392). When True,
+        # capture(), list_apps(), wait() still work but every _action()
+        # (click, type, scroll, drag, hotkey) returns an error instead of
+        # dispatching to cua-driver.
+        self._linux_capture_only: bool = False
 
     # ── Lifecycle ──────────────────────────────────────────────────
     def start(self) -> None:
         if not _linux_cua_allowed():
-            raise RuntimeError(
-                "computer_use is blocked on this Linux host: KDE Plasma / X11 "
-                "detected. cua-driver 0.8.3's uinput virtual pointer can crash "
-                "the entire KDE Plasma/Qt session (#66392). "
-                "To override, set `computer_use.linux_opt_in: true` in config.yaml "
-                "and ensure cua-driver >= 0.8.4 is installed."
+            logger.warning(
+                "KDE Plasma / X11 detected: cua-driver 0.8.3's uinput virtual "
+                "pointer can crash the entire KDE Plasma/Qt session (#66392). "
+                "Starting in capture-only mode. Input actions (click, type, "
+                "scroll, drag, hotkey) will be blocked. "
+                "To enable full computer_use, set "
+                "`computer_use.linux_opt_in: true` in config.yaml and ensure "
+                "cua-driver >= 0.8.4 is installed."
             )
+            self._linux_capture_only = True
         _maybe_nudge_update()
         # The MCP client SDK (`mcp`) is an optional dependency (the
         # `computer-use` / `mcp` extras), not part of Hermes' minimal core.
@@ -2399,6 +2416,21 @@ class CuaDriverBackend(ComputerUseBackend):
         args["element_token"] = token
 
     def _action(self, name: str, args: Dict[str, Any]) -> ActionResult:
+        # Capture-only mode: on KDE/X11 without opt-in, input actions that
+        # would spin up the uinput virtual pointer return an error instead
+        # of dispatching (#66392). Read-only capture/list flows are unaffected.
+        if self._linux_capture_only:
+            return ActionResult(
+                ok=False,
+                action=name,
+                message=(
+                    "computer_use is in capture-only mode on this Linux host: "
+                    "KDE Plasma / X11 detected. cua-driver 0.8.3's uinput virtual "
+                    "pointer can crash the KDE Plasma/Qt session (#66392). "
+                    "To enable input actions, set "
+                    "`computer_use.linux_opt_in: true` in config.yaml."
+                ),
+            )
         # Declare this run's agent-cursor session on the first input action
         # (lazily), never for read-only capture/list flows — see #66392.
         self._ensure_run_session_declared()

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -233,6 +233,67 @@ def _is_macos() -> bool:
     return sys.platform == "darwin"
 
 
+def _is_linux() -> bool:
+    return sys.platform == "linux"
+
+
+def _is_linux_x11() -> bool:
+    """True on Linux with the X11 (or XWayland) display server."""
+    return _is_linux() and os.environ.get("DISPLAY") is not None
+
+
+def _kde_plasma_detected() -> bool:
+    """Best-effort KDE Plasma detection via known environment variables.
+
+    Returns True when any of the supported KDE session indicators is set,
+    which implies cua-driver's uinput pointer may crash the Plasma/X11
+    session (#66392).  False on non-Linux, when none of the indicators
+    are present, or when the check itself fails (fail safe toward "not
+    detected" so the guard does not block non-KDE environments).
+
+    Checked variables (in priority order):
+      - ``KDE_FULL_SESSION`` — classic KDE indicator (set to ``true``)
+      - ``XDG_CURRENT_DESKTOP`` matching ``"KDE"`` (case-insensitive)
+      - ``DESKTOP_SESSION`` matching ``"plasma"`` or ``"kde-plasma"``
+    """
+    if not _is_linux():
+        return False
+    if os.environ.get("KDE_FULL_SESSION", "").lower() in ("true", "1"):
+        return True
+    xdg = os.environ.get("XDG_CURRENT_DESKTOP", "")
+    if xdg and xdg.lower() == "kde":
+        return True
+    ds = os.environ.get("DESKTOP_SESSION", "")
+    if ds and ("plasma" in ds.lower() or "kde" in ds.lower()):
+        return True
+    return False
+
+
+def _linux_cua_allowed() -> bool:
+    """Return True when computer_use is safe on this Linux host.
+
+    On KDE Plasma / X11, cua-driver 0.8.3's uinput virtual pointer can
+    crash the entire Qt session (#66392).  We require an explicit opt-in
+    via the ``computer_use.linux_opt_in`` config key to proceed.
+
+    Non-Linux, non-KDE, and read-error paths all return True so the
+    guard never blocks production macOS/Windows use or new Linux desktop
+    environments that don't carry the crash vector.
+    """
+    if not _is_linux() or not _kde_plasma_detected():
+        return True
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        cu = cfg.get("computer_use") or {}
+        return bool(cu.get("linux_opt_in", False))
+    except Exception:
+        # Config unreadable — fail open toward available so the doctor
+        # command (which doesn't depend on config) still works.
+        return True
+
+
 def cua_driver_binary_available() -> bool:
     """True if `cua-driver` is on $PATH or HERMES_CUA_DRIVER_CMD resolves."""
     return bool(shutil.which(_CUA_DRIVER_CMD))
@@ -1215,9 +1276,23 @@ class CuaDriverBackend(ComputerUseBackend):
         # degrade to the anonymous / unsynced path documented in the
         # MCP server instructions.
         self._session_id: str = f"hermes-{uuid.uuid4().hex[:12]}"
+        # Whether we've declared the input-capable run session
+        # (start_session) to cua-driver yet. Deferred until the first
+        # real input/cursor action so read-only capture/list flows never
+        # spin up the agent-cursor virtual pointer — on Linux/X11 that
+        # uinput pointer can crash a KDE Plasma/Qt session (#66392).
+        self._run_session_declared: bool = False
 
     # ── Lifecycle ──────────────────────────────────────────────────
     def start(self) -> None:
+        if not _linux_cua_allowed():
+            raise RuntimeError(
+                "computer_use is blocked on this Linux host: KDE Plasma / X11 "
+                "detected. cua-driver 0.8.3's uinput virtual pointer can crash "
+                "the entire KDE Plasma/Qt session (#66392). "
+                "To override, set `computer_use.linux_opt_in: true` in config.yaml "
+                "and ensure cua-driver >= 0.8.4 is installed."
+            )
         _maybe_nudge_update()
         # The MCP client SDK (`mcp`) is an optional dependency (the
         # `computer-use` / `mcp` extras), not part of Hermes' minimal core.
@@ -1234,16 +1309,29 @@ class CuaDriverBackend(ComputerUseBackend):
         import importlib
         importlib.invalidate_caches()
         self._session.start()
+        # NB: we intentionally do NOT declare the run session here. The
+        # agent-cursor session (start_session) is declared lazily on the
+        # first input action via _ensure_run_session_declared(); see #66392
+        # — declaring it eagerly created a uinput virtual pointer even for
+        # read-only captures, which crashes KDE Plasma/Qt on Linux/X11.
 
-        # Declare the run's session identity to cua-driver. From the
-        # cua-driver server instructions: "start_session(session) once
-        # at the start of a run → declares THIS run's identity (a
-        # stable id you choose). Pass that same `session` on every
-        # action below. It owns your agent cursor (a distinct color
-        # per id) and follows the run across apps/windows." Failure
-        # to start the session is non-fatal — cua-driver's tools
-        # accept anonymous calls (the cursor just won't render),
-        # so we degrade rather than abort.
+    def _ensure_run_session_declared(self) -> None:
+        """Declare this run's cua-driver session (agent cursor) exactly once,
+        on the first genuine input/cursor action.
+
+        From the cua-driver server instructions: "start_session(session) once
+        at the start of a run → declares THIS run's identity (a stable id you
+        choose). Pass that same `session` on every action below. It owns your
+        agent cursor (a distinct color per id) and follows the run across
+        apps/windows." Deferring it to the first _action() keeps read-only
+        capture/list flows from spinning up the agent-cursor virtual pointer
+        (#66392). Failure to declare it is non-fatal — cua-driver's tools
+        accept anonymous calls (the cursor just won't render), so we degrade
+        rather than abort.
+        """
+        if self._run_session_declared:
+            return
+        self._run_session_declared = True
         try:
             self._session.call_tool("start_session", {"session": self._session_id})
         except Exception as e:
@@ -1255,7 +1343,7 @@ class CuaDriverBackend(ComputerUseBackend):
         # ownership, config overrides). Best-effort — even if it fails,
         # the connection drop below releases the daemon-side state via
         # the session_end hook cua-driver registers internally.
-        if self._session._started:
+        if self._run_session_declared and self._session._started:
             try:
                 self._session.call_tool("end_session", {"session": self._session_id})
             except Exception as e:
@@ -2311,6 +2399,9 @@ class CuaDriverBackend(ComputerUseBackend):
         args["element_token"] = token
 
     def _action(self, name: str, args: Dict[str, Any]) -> ActionResult:
+        # Declare this run's agent-cursor session on the first input action
+        # (lazily), never for read-only capture/list flows — see #66392.
+        self._ensure_run_session_declared()
         # Attach the snapshot's element_token whenever the call carries
         # an element_index and the target tool advertises support.
         self._maybe_attach_element_token(name, args)


### PR DESCRIPTION
## Description

Fixes #66392

cua-driver 0.8.3's uinput virtual pointer can crash a KDE Plasma/Qt X11 session. This PR adds a three-part mitigation:

### Changes

1. **Lazy `start_session` declaration** — the cua-driver agent-cursor session is no longer created eagerly in `start()`. Instead it's deferred to `_ensure_run_session_declared()`, called from `_action()` on the first real input/cursor action. Pure capture/list flows never spin up the virtual pointer.

2. **Capture-only fallback on blocked Linux** — when KDE Plasma + X11 is detected, `start()` no longer raises `RuntimeError`. It enters capture-only mode (`self._linux_capture_only = True`), which allows `capture()`, `list_apps()`, `wait()` to work normally while every input action (`click`, `type`, `scroll`, `drag`, `hotkey`) returns an error with a clear message about setting `linux_opt_in: true`.

3. **X11-specific guard** — the block only activates for KDE + X11 (DISPLAY is set). KDE Plasma on Wayland is allowed through since the uinput crash vector isn't exercised there.

### Reviewer notes
- The crash is X11-specific, not Wayland — the guard correctly requires both KDE and DISPLAY now
- "Chromium" is irrelevant to this issue (it is cua-driver's uinput, not a Chromium process) — the PR title was updated
- Capture-only mode allows the user to keep using computer_use for screenshots and element inspection while blocking only the dangerous uinput path