### PR TITLE
fix #66518: stdio MCP watchdog kills every healthy child on WSL2 — use tolerance for create_time equality

### DIFF
--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -61,6 +61,12 @@ except ImportError:  # pragma: no cover - psutil is a hard dependency elsewhere
 
 _POLL_INTERVAL_S = 2.0
 _TERM_GRACE_S = 3.0
+# Tolerance for WSL2/VM btime drift after host-clock resync (issue #66518).
+# On WSL2, /proc/stat btime can shift by a few seconds after Windows
+# sleep/hibernate, causing exact create_time equality to falsely detect
+# PID reuse and kill healthy children. Real PID reuse differs by
+# minutes-to-days, so a small window loses no protection.
+_CREATE_TIME_TOLERANCE_S = 30.0
 
 
 def _is_orphaned(original_ppid: int, parent_create_time: float, getppid=os.getppid) -> bool:
@@ -70,6 +76,10 @@ def _is_orphaned(original_ppid: int, parent_create_time: float, getppid=os.getpp
     ``getppid() == 1`` check (Linux reparents orphans to a subreaper, not
     always PID 1), and guards against PID reuse via the recorded creation
     time of the original parent.
+
+    Uses a tolerance window (``_CREATE_TIME_TOLERANCE_S``) instead of exact
+    float equality to handle WSL2/VM clock resync where ``btime`` drifts
+    after host sleep — see issue #66518.
     """
     if getppid() != original_ppid:
         return True
@@ -80,7 +90,7 @@ def _is_orphaned(original_ppid: int, parent_create_time: float, getppid=os.getpp
     try:
         if not psutil.pid_exists(original_ppid):
             return True
-        return psutil.Process(original_ppid).create_time() != parent_create_time
+        return abs(psutil.Process(original_ppid).create_time() - parent_create_time) > _CREATE_TIME_TOLERANCE_S
     except psutil.Error:
         return True
 

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -48,19 +48,30 @@ def _env_float(name: str, default: float) -> float:
 
 _WATCHDOG_POLL_S = max(0.05, _env_float("HERMES_SLASH_WATCHDOG_POLL_S", 2.0))
 _ORPHAN_GRACE_S = max(0.0, _env_float("HERMES_SLASH_WATCHDOG_GRACE_S", 5.0))
+# Tolerance for WSL2/VM btime drift after host-clock resync (issue #66518).
+# On WSL2, /proc/stat btime can shift by a few seconds after Windows
+# sleep/hibernate, causing exact create_time equality to falsely detect
+# PID reuse. Real PID reuse differs by minutes-to-days, so a small window
+# loses no protection.
+_CREATE_TIME_TOLERANCE_S = 30.0
 _in_flight = threading.Event()  # set while a command is executing
 
 
 def _is_orphaned(original_ppid, parent_create_time, getppid=os.getppid) -> bool:
     """True once our spawning gateway is gone. Compare to the ORIGINAL ppid
     (never ==1: Linux reparents to a subreaper) and guard PID reuse via
-    create_time."""
+    create_time.
+
+    Uses a tolerance window (``_CREATE_TIME_TOLERANCE_S``) instead of exact
+    float equality to handle WSL2/VM clock resync where ``btime`` drifts
+    after host sleep — see issue #66518.
+    """
     if getppid() != original_ppid:
         return True
     try:
         if not psutil.pid_exists(original_ppid):
             return True
-        return psutil.Process(original_ppid).create_time() != parent_create_time
+        return abs(psutil.Process(original_ppid).create_time() - parent_create_time) > _CREATE_TIME_TOLERANCE_S
     except psutil.Error:
         return True
 


### PR DESCRIPTION
## Summary

Fixes #66518 — On WSL2 (and any VM whose clock resyncs after a host sleep), the stdio MCP watchdog's PID-reuse guard uses exact float equality to compare `psutil.Process(...).create_time()`, but WSL2's `/proc/stat btime` shifts by a few seconds after Windows sleep/hibernate, causing the watchdog to kill every healthy child ~2s after spawn.

## Root cause

```python
# Before (exact equality — breaks on btime drift):
return psutil.Process(original_ppid).create_time() != parent_create_time
```

The gateway records `create_time` at startup under the old `btime`. After a clock resync, the watchdog reads a new `create_time` with a constant delta (e.g. 3.0s), and `_is_orphaned` returns True → `_terminate_process_group(proc)` kills the healthy server immediately.

## Fix

Use a 30-second tolerance window instead of exact float equality:

```python
# After (tolerance for WSL2/VM btime drift):
_CREATE_TIME_TOLERANCE_S = 30.0
return abs(psutil.Process(original_ppid).create_time() - parent_create_time) > _CREATE_TIME_TOLERANCE_S
```

Real PID reuse differs by **minutes to days**, so a 30s window loses no protection while fully covering the WSL2 btime drift window (~2-5s typically).

## Files changed

- **`tools/mcp_stdio_watchdog.py`** — MCP server parent-death watchdog
- **`tui_gateway/slash_worker.py`** — TUI slash-command worker watchdog (same defect)

Both sites now include:
1. `_CREATE_TIME_TOLERANCE_S = 30.0` constant with explanatory comment
2. `abs(diff) > tolerance` instead of `!=`
3. Updated docstring noting the tolerance and issue reference