### PR TITLE
fix(desktop): don't drop a new chat's first send when it carries an attachment

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1711,6 +1711,157 @@ describe('usePromptActions sleep/wake session recovery', () => {
   })
 })
 
+describe('usePromptActions new-chat attachment drift (#65733)', () => {
+  const CREATED_RUNTIME_ID = 'rt-new-chat'
+  const CREATED_STORED_ID = 'stored-new-chat'
+
+  afterEach(() => {
+    cleanup()
+    $connection.set(null)
+    vi.restoreAllMocks()
+  })
+
+  function imageAttachment(): ComposerAttachment {
+    return {
+      id: 'image:pic.png',
+      kind: 'image',
+      label: 'pic.png',
+      path: '/Users/alice/Pictures/pic.png'
+    }
+  }
+
+  it('submits a new chat with an image — the late route re-home landing during upload is not user drift', async () => {
+    // Remote mode + a brand-new chat + an image attachment is the exact #65733
+    // repro. createBackendSessionForSend re-homes the session refs synchronously
+    // and (in the real app) calls navigate(), but that navigate only flips the
+    // route token on the NEXT render — which here lands WHILE image.attach_bytes
+    // is in flight. The pre-fix drift check read that self re-home as a user
+    // session switch and silently aborted: no prompt.submit, nothing on disk.
+    $connection.set({ mode: 'remote' } as never)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl: vi.fn(async () => 'data:image/png;base64,aGVsbG8=') }
+    })
+
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+
+    // The pre-create route; the created chat's route only lands on a later
+    // render, simulated by flipping this while the upload is awaited.
+    let routeToken = 'route-new-draft'
+    const getRouteToken = () => routeToken
+
+    // Mirror the real create: session refs retarget synchronously before it
+    // returns. The route token is deliberately NOT flipped here — that is the
+    // deferred navigate() that lands during the upload below.
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = CREATED_RUNTIME_ID
+      selectedStoredSessionIdRef.current = CREATED_STORED_ID
+
+      return CREATED_RUNTIME_ID
+    })
+
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'image.attach_bytes') {
+        // The create's navigate() re-home lands here, mid-upload.
+        routeToken = 'route-created-session'
+
+        return { attached: true, path: '/remote/work/.hermes/desktop-attachments/pic.png' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={getRouteToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const ok = await handle!.submitText('look at this', { attachments: [imageAttachment()] })
+
+    // The submit must reach the gateway against the chat create minted, not
+    // bounce back to the composer.
+    expect(ok).toBe(true)
+    expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
+
+    const submit = calls.find(c => c.method === 'prompt.submit')
+    expect(submit).toBeDefined()
+    expect(submit?.params).toMatchObject({ session_id: CREATED_RUNTIME_ID })
+    expect(calls.map(c => c.method)).toEqual(['image.attach_bytes', 'prompt.submit'])
+  })
+
+  it('still aborts when the user genuinely switches away during the image upload', async () => {
+    // The fix must not blind the drift guard: a REAL switch mid-upload still
+    // retargets the session refs synchronously, so the created-session drift
+    // check catches it and the send is dropped rather than misrouted.
+    $connection.set({ mode: 'remote' } as never)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl: vi.fn(async () => 'data:image/png;base64,aGVsbG8=') }
+    })
+
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = CREATED_RUNTIME_ID
+      selectedStoredSessionIdRef.current = CREATED_STORED_ID
+
+      return CREATED_RUNTIME_ID
+    })
+
+    const calls: string[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      calls.push(method)
+
+      if (method === 'image.attach_bytes') {
+        // User switches to another chat while the upload is in flight: every
+        // switch path retargets these refs synchronously.
+        activeSessionIdRef.current = 'rt-other-chat'
+        selectedStoredSessionIdRef.current = 'stored-other-chat'
+
+        return { attached: true, path: '/remote/work/.hermes/desktop-attachments/pic.png' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const ok = await handle!.submitText('look at this', { attachments: [imageAttachment()] })
+
+    expect(ok).toBe(false)
+    expect(calls).not.toContain('prompt.submit')
+  })
+})
+
 describe('usePromptActions submit session-context isolation (#54527)', () => {
   const STORED_SESSION_A = 'stored-project-a'
   const STORED_SESSION_B = 'stored-project-b'

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -175,9 +175,23 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       let startingRouteToken = getRouteToken()
 
+      // Set once this submit itself mints a new chat (see the re-pin after
+      // createBackendSessionForSend): that create re-homes selection + route to
+      // the session it made, but the navigate() only lands on the NEXT React
+      // render. A submit that then awaits real work — an image/file upload —
+      // sees the route token flip mid-flight and would misread our own re-home
+      // as a user session switch, silently aborting EVERY first send that
+      // carries an attachment (#65733). Inside that window drift is judged by
+      // the session refs — every real switch retargets them synchronously —
+      // instead of the deferred route token.
+      let createdSessionId: null | string = null
+
       const sessionContextDrifted = (): boolean =>
         targetStartedInCurrentView &&
-        (selectedStoredSessionIdRef.current !== startingStoredSessionId || getRouteToken() !== startingRouteToken)
+        (createdSessionId !== null
+          ? activeSessionIdRef.current !== createdSessionId ||
+            selectedStoredSessionIdRef.current !== startingStoredSessionId
+          : selectedStoredSessionIdRef.current !== startingStoredSessionId || getRouteToken() !== startingRouteToken)
 
       const targetIsCurrentView = (): boolean => targetStartedInCurrentView && !sessionContextDrifted()
 
@@ -428,8 +442,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         // Re-pin the baseline to the created chat for the rest of the
         // pipeline; the closures (seedOptimistic et al) see the new value.
+        // From here on drift is judged against the created session id, not the
+        // route token: createBackendSessionForSend's navigate() re-homes the
+        // route on a LATER render, so a following upload await would otherwise
+        // read our own re-home as a user switch (#65733).
         startingStoredSessionId = selectedStoredSessionIdRef.current
         startingRouteToken = getRouteToken()
+        createdSessionId = sessionId
 
         seedOptimistic(sessionId)
       }


### PR DESCRIPTION
## What does this PR do?

Fixes the first send of a brand-new chat being silently dropped when it carries an attachment (image or file) in remote-gateway mode. The optimistic message disappears, the composer bounces back, no `prompt.submit` reaches the gateway, and the freshly-minted route ends up 404-ing, with no error surfaced. Text-only sends are unaffected, which is what made this present as "new chats with images just don't start."

The root cause is a race in the submit drift guard. On a new chat, `createBackendSessionForSend()` re-homes the session refs and calls `navigate()` to the chat it just created, but the react-router location (and the `routeToken` the guard reads) only updates on the **next** render. The pipeline re-pins its drift baseline immediately after create, so it captures the *pre-create* route token. It then awaits the real attachment upload (`image.attach_bytes` / `file.attach`), during which React re-renders and the route token flips to the new session. The post-upload `sessionContextDrifted()` check compares against the stale token, misreads our own re-home as a user session switch, and takes the silent `abortForSessionSwitch()` path.

The fix: once a submit has minted its own session, judge drift by the created session id instead of the deferred route token. Every real session switch retargets `activeSessionIdRef` / `selectedStoredSessionIdRef` synchronously, so a genuine switch away during the upload is still detected and still aborts; we only stop treating our own late `navigate()` as drift. Paths that don't create a session are unchanged and keep using the route token.

## Related Issue

Fixes #65733

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts`: track a `createdSessionId` for the post-create window and make `sessionContextDrifted()` compare against it (via the synchronously-retargeted session refs) instead of the route token once this submit has created the session.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx`: added two regression tests: a new chat + image in remote mode where the route re-home lands mid-upload (submit must still reach the gateway with the created session id), and a genuine mid-upload session switch (must still abort, so the guard isn't blinded).

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/app/session/hooks/use-prompt-actions/index.test.tsx`
2. Both new tests under `new-chat attachment drift (#65733)` pass; the full file is green (54/54).
3. To confirm they actually catch the regression: revert the change in `submit.ts` and the first new test fails with the submit resolving `false` (the dropped send). Restore it and it passes.

Manual repro (remote gateway): open Desktop, start a new chat, attach an image, send - before the fix the send is swallowed; after, it goes through and streams a response.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass - N/A (desktop/TypeScript change; verified with the desktop `vitest` suite instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (desktop vitest suite)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A
