### PR TITLE
feat(skills): add size audit command

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -11,6 +11,7 @@ handler are thin wrappers that parse args and delegate.
 """
 
 import json
+import os
 import re
 import shutil
 from pathlib import Path
@@ -1037,20 +1038,50 @@ def _skill_size_level(chars: int) -> str:
 def _skill_size_source(
     *,
     name: str,
-    scan_dir: Path,
+    skill_dir: Path,
     local_skills_dir: Path,
-    hub_installed: Dict[str, Any],
+    hub_install_paths: set[str],
     builtin_names: set[str],
 ) -> str:
-    if name in hub_installed:
+    try:
+        resolved_skill_dir = skill_dir.resolve()
+    except OSError:
+        resolved_skill_dir = skill_dir.absolute()
+
+    if os.path.normcase(str(resolved_skill_dir)) in hub_install_paths:
         return "hub"
+    try:
+        resolved_skill_dir.relative_to(local_skills_dir.resolve())
+    except (OSError, ValueError):
+        return "external"
     if name in builtin_names:
         return "builtin"
+    return "local"
+
+
+def _hub_install_paths(
+    local_skills_dir: Path,
+    hub_installed: list[dict[str, Any]],
+) -> set[str]:
+    """Return safe resolved install directories recorded by the hub lock."""
     try:
-        scan_dir.resolve().relative_to(local_skills_dir.resolve())
-        return "local"
-    except Exception:
-        return "external"
+        local_root = local_skills_dir.resolve()
+    except OSError:
+        local_root = local_skills_dir.absolute()
+
+    paths: set[str] = set()
+    for entry in hub_installed:
+        install_path = entry.get("install_path")
+        if not isinstance(install_path, str) or not install_path.strip():
+            continue
+        candidate = local_skills_dir / Path(install_path)
+        try:
+            resolved = candidate.resolve()
+            resolved.relative_to(local_root)
+        except (OSError, ValueError):
+            continue
+        paths.add(os.path.normcase(str(resolved)))
+    return paths
 
 
 def _skill_category_for_path(skill_md: Path, scan_dir: Path) -> str:
@@ -1082,20 +1113,24 @@ def collect_skill_size_audit(
 
     ensure_hub_dirs()
     local_skills_dir = get_skills_dir()
-    hub_installed = {e["name"]: e for e in HubLockFile().list_installed()}
+    hub_paths = _hub_install_paths(
+        local_skills_dir,
+        HubLockFile().list_installed(),
+    )
     builtin_names = set(_read_manifest())
 
     entries: list[dict[str, Any]] = []
     seen_paths: set[str] = set()
+    seen_names: set[str] = set()
 
     for scan_dir in get_all_skills_dirs():
         if not scan_dir.exists():
             continue
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
             try:
-                key = str(skill_md.resolve())
+                key = os.path.normcase(str(skill_md.resolve()))
             except Exception:
-                key = str(skill_md)
+                key = os.path.normcase(str(skill_md))
             if key in seen_paths:
                 continue
             seen_paths.add(key)
@@ -1116,15 +1151,19 @@ def collect_skill_size_audit(
 
             name = str(frontmatter.get("name") or skill_md.parent.name)
             description = str(frontmatter.get("description") or "")
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+
             chars = len(content)
             if chars < min_chars:
                 continue
 
             source = _skill_size_source(
                 name=name,
-                scan_dir=scan_dir,
+                skill_dir=skill_md.parent,
                 local_skills_dir=local_skills_dir,
-                hub_installed=hub_installed,
+                hub_install_paths=hub_paths,
                 builtin_names=builtin_names,
             )
             if source_filter != "all" and source != source_filter:
@@ -1146,7 +1185,7 @@ def collect_skill_size_audit(
                     "source": source,
                     "chars": chars,
                     "bytes": byte_count,
-                    "lines": content.count("\n") + (1 if content else 0),
+                    "lines": len(content.splitlines()),
                     "description_chars": len(description),
                     "level": _skill_size_level(chars),
                     "has_references": references_dir.is_dir(),

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -27,6 +27,10 @@ from agent.skill_utils import is_excluded_skill_path
 
 _console = Console()
 
+SKILL_SIZE_WARN_CHARS = 25_000
+SKILL_SIZE_LARGE_CHARS = 50_000
+SKILL_SIZE_OVERSIZED_CHARS = 100_000
+
 
 def _display_source(r) -> str:
     """Human-facing source label for a result row.
@@ -1020,6 +1024,237 @@ def do_list(source_filter: str = "all",
     c.print(summary)
 
 
+def _skill_size_level(chars: int) -> str:
+    if chars >= SKILL_SIZE_OVERSIZED_CHARS:
+        return "oversized"
+    if chars >= SKILL_SIZE_LARGE_CHARS:
+        return "large"
+    if chars >= SKILL_SIZE_WARN_CHARS:
+        return "warn"
+    return "ok"
+
+
+def _skill_size_source(
+    *,
+    name: str,
+    scan_dir: Path,
+    local_skills_dir: Path,
+    hub_installed: Dict[str, Any],
+    builtin_names: set[str],
+) -> str:
+    if name in hub_installed:
+        return "hub"
+    if name in builtin_names:
+        return "builtin"
+    try:
+        scan_dir.resolve().relative_to(local_skills_dir.resolve())
+        return "local"
+    except Exception:
+        return "external"
+
+
+def _skill_category_for_path(skill_md: Path, scan_dir: Path) -> str:
+    try:
+        rel_parent = skill_md.parent.relative_to(scan_dir)
+    except ValueError:
+        return ""
+    parts = rel_parent.parts
+    if len(parts) <= 1:
+        return ""
+    return "/".join(parts[:-1])
+
+
+def collect_skill_size_audit(
+    *,
+    source_filter: str = "all",
+    min_chars: int = 0,
+) -> Dict[str, Any]:
+    """Return installed SKILL.md size diagnostics without loading skills.
+
+    This is intentionally filesystem-based rather than ``skill_view``-based:
+    the point is to inspect large skill bodies without injecting their full
+    contents into an agent conversation.
+    """
+    from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files, parse_frontmatter
+    from hermes_constants import get_skills_dir
+    from tools.skills_hub import HubLockFile, ensure_hub_dirs
+    from tools.skills_sync import _read_manifest
+
+    ensure_hub_dirs()
+    local_skills_dir = get_skills_dir()
+    hub_installed = {e["name"]: e for e in HubLockFile().list_installed()}
+    builtin_names = set(_read_manifest())
+
+    entries: list[dict[str, Any]] = []
+    seen_paths: set[str] = set()
+
+    for scan_dir in get_all_skills_dirs():
+        if not scan_dir.exists():
+            continue
+        for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
+            try:
+                key = str(skill_md.resolve())
+            except Exception:
+                key = str(skill_md)
+            if key in seen_paths:
+                continue
+            seen_paths.add(key)
+
+            parse_error = ""
+            try:
+                content = skill_md.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                content = ""
+                parse_error = str(exc)
+
+            frontmatter: dict[str, Any] = {}
+            if content:
+                try:
+                    frontmatter, _body = parse_frontmatter(content)
+                except Exception as exc:
+                    parse_error = str(exc)
+
+            name = str(frontmatter.get("name") or skill_md.parent.name)
+            description = str(frontmatter.get("description") or "")
+            chars = len(content)
+            if chars < min_chars:
+                continue
+
+            source = _skill_size_source(
+                name=name,
+                scan_dir=scan_dir,
+                local_skills_dir=local_skills_dir,
+                hub_installed=hub_installed,
+                builtin_names=builtin_names,
+            )
+            if source_filter != "all" and source != source_filter:
+                continue
+
+            try:
+                byte_count = skill_md.stat().st_size
+            except OSError:
+                byte_count = len(content.encode("utf-8"))
+
+            skill_dir = skill_md.parent
+            references_dir = skill_dir / "references"
+            scripts_dir = skill_dir / "scripts"
+
+            entries.append(
+                {
+                    "name": name,
+                    "category": _skill_category_for_path(skill_md, scan_dir),
+                    "source": source,
+                    "chars": chars,
+                    "bytes": byte_count,
+                    "lines": content.count("\n") + (1 if content else 0),
+                    "description_chars": len(description),
+                    "level": _skill_size_level(chars),
+                    "has_references": references_dir.is_dir(),
+                    "has_scripts": scripts_dir.is_dir(),
+                    "path": str(skill_md),
+                    "parse_error": parse_error,
+                }
+            )
+
+    entries.sort(key=lambda e: (e["chars"], e["bytes"], e["name"]), reverse=True)
+    totals = {
+        "skills": len(entries),
+        "chars": sum(int(e["chars"]) for e in entries),
+        "bytes": sum(int(e["bytes"]) for e in entries),
+        "warn_or_larger": sum(1 for e in entries if e["level"] != "ok"),
+        "large_or_larger": sum(1 for e in entries if e["level"] in {"large", "oversized"}),
+        "oversized": sum(1 for e in entries if e["level"] == "oversized"),
+    }
+    return {
+        "thresholds": {
+            "warn_chars": SKILL_SIZE_WARN_CHARS,
+            "large_chars": SKILL_SIZE_LARGE_CHARS,
+            "oversized_chars": SKILL_SIZE_OVERSIZED_CHARS,
+        },
+        "totals": totals,
+        "skills": entries,
+    }
+
+
+def do_audit_size(
+    *,
+    source_filter: str = "all",
+    min_chars: int = 0,
+    limit: int = 20,
+    as_json: bool = False,
+    console: Optional[Console] = None,
+) -> None:
+    """Show installed SKILL.md size diagnostics."""
+    c = console or _console
+    data = collect_skill_size_audit(
+        source_filter=source_filter,
+        min_chars=max(0, min_chars),
+    )
+
+    if limit and limit > 0:
+        shown = data["skills"][:limit]
+    else:
+        shown = data["skills"]
+
+    if as_json:
+        payload = dict(data)
+        payload["skills"] = shown
+        payload["shown"] = len(shown)
+        c.print(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            markup=False,
+            highlight=False,
+            soft_wrap=True,
+        )
+        return
+
+    title = "Skill Size Audit"
+    if source_filter != "all":
+        title += f" ({source_filter})"
+    table = Table(title=title)
+    table.add_column("Name", style="bold cyan", overflow="fold")
+    table.add_column("Category", style="dim")
+    table.add_column("Source", style="dim")
+    table.add_column("Level", style="dim")
+    table.add_column("Chars", justify="right")
+    table.add_column("Lines", justify="right")
+    table.add_column("Desc", justify="right")
+    table.add_column("Refs", justify="center")
+    table.add_column("Scripts", justify="center")
+
+    level_style = {
+        "ok": "green",
+        "warn": "yellow",
+        "large": "bold yellow",
+        "oversized": "bold red",
+    }
+
+    for entry in shown:
+        level = entry["level"]
+        table.add_row(
+            entry["name"],
+            entry["category"],
+            entry["source"],
+            f"[{level_style.get(level, 'dim')}]{level}[/]",
+            f"{entry['chars']:,}",
+            f"{entry['lines']:,}",
+            f"{entry['description_chars']:,}",
+            "yes" if entry["has_references"] else "no",
+            "yes" if entry["has_scripts"] else "no",
+        )
+
+    c.print(table)
+    totals = data["totals"]
+    c.print(
+        "[dim]"
+        f"{totals['skills']} scanned, "
+        f"{totals['warn_or_larger']} >= {SKILL_SIZE_WARN_CHARS:,} chars, "
+        f"{totals['large_or_larger']} >= {SKILL_SIZE_LARGE_CHARS:,} chars, "
+        f"{totals['oversized']} >= {SKILL_SIZE_OVERSIZED_CHARS:,} chars"
+        "[/]\n"
+    )
+
+
 def do_check(name: Optional[str] = None, console: Optional[Console] = None) -> None:
     """Check hub-installed skills for upstream updates."""
     from tools.skills_hub import check_for_skill_updates
@@ -1727,6 +1962,13 @@ def skills_command(args) -> None:
     elif action == "audit":
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))
+    elif action == "audit-size":
+        do_audit_size(
+            source_filter=getattr(args, "source", "all"),
+            min_chars=getattr(args, "min_chars", 0),
+            limit=getattr(args, "limit", 20),
+            as_json=getattr(args, "json", False),
+        )
     elif action == "uninstall":
         do_uninstall(args.name)
     elif action == "reset":
@@ -1766,7 +2008,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|list-modified|diff|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|inspect|list|list-modified|diff|check|update|audit|audit-size|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 
@@ -1792,6 +2034,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
         /skills audit my-skill
         /skills audit --deep
         /skills audit my-skill --deep
+        /skills audit-size
         /skills uninstall my-skill
         /skills tap list
         /skills tap add owner/repo
@@ -1914,6 +2157,38 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
         name = args[0] if args and not args[0].startswith("--") else None
         deep = "--deep" in args
         do_audit(name=name, console=c, deep=deep)
+
+    elif action == "audit-size":
+        source = "all"
+        limit = 20
+        min_chars = 0
+        as_json = "--json" in args
+        i = 0
+        while i < len(args):
+            if args[i] == "--source" and i + 1 < len(args):
+                source = args[i + 1]
+                i += 2
+            elif args[i] == "--limit" and i + 1 < len(args):
+                try:
+                    limit = int(args[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            elif args[i] == "--min-chars" and i + 1 < len(args):
+                try:
+                    min_chars = int(args[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            else:
+                i += 1
+        do_audit_size(
+            source_filter=source,
+            min_chars=min_chars,
+            limit=limit,
+            as_json=as_json,
+            console=c,
+        )
 
     elif action == "uninstall":
         if not args:

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -152,6 +152,40 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Run AST-level analysis on Python files (opt-in diagnostic)",
     )
 
+    skills_audit_size = skills_subparsers.add_parser(
+        "audit-size",
+        help="Show installed SKILL.md size diagnostics",
+        description=(
+            "Scan installed SKILL.md files without loading them through "
+            "skill_view. Reports large skill bodies, description lengths, "
+            "and source classification so oversized skills can be trimmed "
+            "before they consume context."
+        ),
+    )
+    skills_audit_size.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON instead of a table",
+    )
+    skills_audit_size.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum rows to show (default: 20; use 0 for all)",
+    )
+    skills_audit_size.add_argument(
+        "--min-chars",
+        type=int,
+        default=0,
+        help="Only show skills with SKILL.md at least this many characters",
+    )
+    skills_audit_size.add_argument(
+        "--source",
+        default="all",
+        choices=["all", "hub", "builtin", "local", "external"],
+        help="Filter by source classification (default: all)",
+    )
+
     skills_uninstall = skills_subparsers.add_parser(
         "uninstall", help="Remove a hub-installed skill"
     )

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -1,3 +1,4 @@
+import json
 from io import StringIO
 from unittest.mock import patch
 
@@ -5,7 +6,17 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import (
+    SKILL_SIZE_LARGE_CHARS,
+    SKILL_SIZE_WARN_CHARS,
+    collect_skill_size_audit,
+    do_audit_size,
+    do_check,
+    do_install,
+    do_list,
+    do_update,
+    handle_skills_slash,
+)
 
 
 class _DummyLockFile:
@@ -68,6 +79,35 @@ def _capture(source_filter: str = "all") -> str:
     console = Console(file=sink, force_terminal=False, color_system=None)
     do_list(source_filter=source_filter, console=console)
     return sink.getvalue()
+
+
+def _write_skill(root, relative, *, name=None, description="short", body="body"):
+    skill_dir = root / relative
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_name = name or skill_dir.name
+    content = (
+        "---\n"
+        f"name: {skill_name}\n"
+        f"description: {description}\n"
+        "---\n"
+        f"{body}"
+    )
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir / "SKILL.md"
+
+
+def _isolate_size_audit(monkeypatch, tmp_path, hub_env, *, hub_entries=None, builtin_manifest=None):
+    import agent.skill_utils as skill_utils
+    import hermes_constants
+    import tools.skills_hub as tools_hub
+    import tools.skills_sync as skills_sync
+
+    skills_dir = tmp_path / "skills"
+    monkeypatch.setattr(skill_utils, "get_all_skills_dirs", lambda: [skills_dir])
+    monkeypatch.setattr(hermes_constants, "get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr(tools_hub, "HubLockFile", lambda: _DummyLockFile(hub_entries or []))
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(builtin_manifest or {}))
+    return skills_dir
 
 
 def _capture_check(monkeypatch, results, name=None) -> str:
@@ -220,6 +260,77 @@ def test_do_list_platform_env_is_ignored(three_source_env, monkeypatch):
     _capture()
 
     assert seen["platform"] is None
+
+
+def test_collect_skill_size_audit_reports_size_levels_without_loading_skill_view(
+    monkeypatch, tmp_path, hub_env
+):
+    skills_dir = _isolate_size_audit(
+        monkeypatch,
+        tmp_path,
+        hub_env,
+        hub_entries=[{"name": "hub-large", "source": "github"}],
+        builtin_manifest={"builtin-warn": "abc123"},
+    )
+    _write_skill(skills_dir, "ops/hub-large", name="hub-large", body="x" * SKILL_SIZE_LARGE_CHARS)
+    _write_skill(skills_dir, "writing/builtin-warn", name="builtin-warn", body="y" * SKILL_SIZE_WARN_CHARS)
+    _write_skill(skills_dir, "local-small", name="local-small", body="z")
+    _write_skill(
+        skills_dir,
+        "ops/hub-large/references/archived-copy",
+        name="archived-copy",
+        body="should not be scanned",
+    )
+    (skills_dir / "ops" / "hub-large" / "scripts").mkdir()
+
+    data = collect_skill_size_audit()
+
+    names = [entry["name"] for entry in data["skills"]]
+    assert names == ["hub-large", "builtin-warn", "local-small"]
+    by_name = {entry["name"]: entry for entry in data["skills"]}
+    assert by_name["hub-large"]["source"] == "hub"
+    assert by_name["hub-large"]["level"] == "large"
+    assert by_name["hub-large"]["category"] == "ops"
+    assert by_name["hub-large"]["has_scripts"] is True
+    assert by_name["builtin-warn"]["source"] == "builtin"
+    assert by_name["builtin-warn"]["level"] == "warn"
+    assert by_name["local-small"]["source"] == "local"
+    assert by_name["local-small"]["level"] == "ok"
+    assert data["totals"]["large_or_larger"] == 1
+    assert data["totals"]["warn_or_larger"] == 2
+
+
+def test_do_audit_size_json_honors_filters_and_limit(monkeypatch, tmp_path, hub_env):
+    skills_dir = _isolate_size_audit(monkeypatch, tmp_path, hub_env)
+    _write_skill(skills_dir, "big", name="big", body="x" * 200)
+    _write_skill(skills_dir, "small", name="small", body="x")
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    do_audit_size(min_chars=100, limit=1, as_json=True, console=console)
+
+    payload = json.loads(sink.getvalue())
+    assert payload["shown"] == 1
+    assert payload["totals"]["skills"] == 1
+    assert payload["skills"][0]["name"] == "big"
+    assert payload["skills"][0]["chars"] >= 200
+    assert payload["thresholds"]["warn_chars"] == SKILL_SIZE_WARN_CHARS
+
+
+def test_handle_skills_slash_audit_size_renders_table(monkeypatch, tmp_path, hub_env):
+    skills_dir = _isolate_size_audit(monkeypatch, tmp_path, hub_env)
+    _write_skill(skills_dir, "big", name="big", body="x" * SKILL_SIZE_WARN_CHARS)
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    handle_skills_slash("/skills audit-size --min-chars 100 --limit 1", console=console)
+    output = sink.getvalue()
+
+    assert "Skill Size Audit" in output
+    assert "big" in output
+    assert "warn" in output
 
 
 def test_do_check_reports_available_updates(monkeypatch):
@@ -780,4 +891,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -81,7 +81,15 @@ def _capture(source_filter: str = "all") -> str:
     return sink.getvalue()
 
 
-def _write_skill(root, relative, *, name=None, description="short", body="body"):
+def _write_skill(
+    root,
+    relative,
+    *,
+    name=None,
+    description="short",
+    body="body",
+    terminal_newline=False,
+):
     skill_dir = root / relative
     skill_dir.mkdir(parents=True, exist_ok=True)
     skill_name = name or skill_dir.name
@@ -92,6 +100,8 @@ def _write_skill(root, relative, *, name=None, description="short", body="body")
         "---\n"
         f"{body}"
     )
+    if terminal_newline:
+        content += "\n"
     (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir / "SKILL.md"
 
@@ -269,7 +279,13 @@ def test_collect_skill_size_audit_reports_size_levels_without_loading_skill_view
         monkeypatch,
         tmp_path,
         hub_env,
-        hub_entries=[{"name": "hub-large", "source": "github"}],
+        hub_entries=[
+            {
+                "name": "hub-large",
+                "source": "github",
+                "install_path": "ops/hub-large",
+            }
+        ],
         builtin_manifest={"builtin-warn": "abc123"},
     )
     _write_skill(skills_dir, "ops/hub-large", name="hub-large", body="x" * SKILL_SIZE_LARGE_CHARS)
@@ -298,6 +314,65 @@ def test_collect_skill_size_audit_reports_size_levels_without_loading_skill_view
     assert by_name["local-small"]["level"] == "ok"
     assert data["totals"]["large_or_larger"] == 1
     assert data["totals"]["warn_or_larger"] == 2
+
+
+def test_collect_skill_size_audit_counts_terminal_newline_once(
+    monkeypatch, tmp_path, hub_env
+):
+    skills_dir = _isolate_size_audit(monkeypatch, tmp_path, hub_env)
+    _write_skill(skills_dir, "newline", terminal_newline=True)
+
+    data = collect_skill_size_audit()
+
+    assert data["skills"][0]["lines"] == 5
+
+
+def test_collect_skill_size_audit_uses_active_source_and_suppresses_collisions(
+    monkeypatch, tmp_path, hub_env
+):
+    import agent.skill_utils as skill_utils
+
+    skills_dir = _isolate_size_audit(
+        monkeypatch,
+        tmp_path,
+        hub_env,
+        hub_entries=[
+            {
+                "name": "shared",
+                "source": "github",
+                "install_path": "hub/shared",
+            }
+        ],
+        builtin_manifest={"external-builtin-name": "abc123"},
+    )
+    external_dir = tmp_path / "external-skills"
+    local_path = _write_skill(skills_dir, "local/shared", name="shared")
+    _write_skill(external_dir, "shared", name="shared", body="x" * 200)
+    external_path = _write_skill(
+        external_dir,
+        "external-builtin-name",
+        name="external-builtin-name",
+    )
+    monkeypatch.setattr(
+        skill_utils,
+        "get_all_skills_dirs",
+        lambda: [skills_dir, external_dir],
+    )
+
+    data = collect_skill_size_audit()
+
+    by_name = {entry["name"]: entry for entry in data["skills"]}
+    assert set(by_name) == {"shared", "external-builtin-name"}
+    assert by_name["shared"]["source"] == "local"
+    assert by_name["shared"]["path"] == str(local_path)
+    assert by_name["external-builtin-name"]["source"] == "external"
+    assert by_name["external-builtin-name"]["path"] == str(external_path)
+    assert collect_skill_size_audit(source_filter="hub")["skills"] == []
+    external_only = collect_skill_size_audit(source_filter="external")
+    assert [entry["name"] for entry in external_only["skills"]] == [
+        "external-builtin-name"
+    ]
+    assert collect_skill_size_audit(min_chars=100)["skills"] == []
 
 
 def test_do_audit_size_json_honors_filters_and_limit(monkeypatch, tmp_path, hub_env):

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1054,6 +1054,7 @@ Subcommands:
 | `check` | Check installed hub skills for upstream updates. |
 | `update` | Reinstall hub skills with upstream changes when available. |
 | `audit` | Re-scan installed hub skills. |
+| `audit-size` | Report effective `SKILL.md` sizes and progressive-disclosure support directories without loading skill bodies. |
 | `uninstall` | Remove a hub-installed skill. |
 | `reset` | Un-stick a bundled skill flagged as `user_modified` by clearing its manifest entry. With `--restore`, also replaces the user copy with the bundled version. |
 | `opt-out` | Stop bundled skills from being seeded into the active profile. Writes a `.no-bundled-skills` marker so the installer, `hermes update`, and any sync skip bundled-skill seeding. Safe by default — nothing on disk is touched. With `--remove`, also deletes already-present bundled skills that are **unmodified** (user-edited, hub-installed, and hand-written skills are never removed; previews and confirms first, `--yes` to skip). |
@@ -1078,6 +1079,8 @@ hermes skills install https://sharethis.chat/SKILL.md                     # Dire
 hermes skills install https://example.com/SKILL.md --name my-skill        # Override name when frontmatter has none
 hermes skills check
 hermes skills update
+hermes skills audit-size --min-chars 25000
+hermes skills audit-size --source external --json
 hermes skills config
 hermes skills reset google-workspace
 hermes skills reset google-workspace --restore --yes

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -531,6 +531,7 @@ hermes skills list --source hub                   # List hub-installed skills
 hermes skills check                               # Check installed hub skills for upstream updates
 hermes skills update                              # Reinstall hub skills with upstream changes when needed
 hermes skills audit                               # Re-scan all hub skills for security
+hermes skills audit-size --min-chars 25000        # Find large active SKILL.md files without loading them
 hermes skills uninstall k8s                       # Remove a hub skill
 hermes skills reset google-workspace              # Un-stick a bundled skill from "user-modified" (see below)
 hermes skills reset google-workspace --restore    # Also restore the bundled version, deleting your local edits
@@ -538,6 +539,12 @@ hermes skills publish skills/my-skill --to github --repo owner/repo
 hermes skills snapshot export setup.json          # Export skill config
 hermes skills tap add myorg/skills-repo           # Add a custom GitHub source
 ```
+
+`hermes skills audit-size` scans the effective local-first skill set and reports
+character, byte, line, and description sizes along with source provenance and
+the presence of `references/` or `scripts/` directories. Use `--source` to
+filter by `hub`, `builtin`, `local`, or `external`, `--limit 0` to show all
+rows, and `--json` for machine-readable output.
 
 ### Supported hub sources
 


### PR DESCRIPTION
## What does this PR do?

Adds `hermes skills audit-size`, a filesystem-based diagnostic for installed `SKILL.md` files. It reports size thresholds, source classification, description length, line count, and progressive-disclosure support directories without loading the skill body through `skill_view`.

This helps users and maintainers find oversized skills before cleanup or review workflows accidentally spend large amounts of context reading the full skill contents.

## Related Issue

No linked issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `collect_skill_size_audit()` and `do_audit_size()` in `hermes_cli/skills_hub.py`.
- Wired the CLI parser for `hermes skills audit-size` in `hermes_cli/subcommands/skills.py`.
- Wired `/skills audit-size` for slash-command use.
- Added JSON/table output with `--json`, `--limit`, `--min-chars`, and `--source` options.
- Added tests for size thresholds, source classification, support-directory skipping, JSON output, and slash command rendering in `tests/hermes_cli/test_skills_hub.py`.

## How to Test

1. `python -m pytest tests/hermes_cli/test_skills_hub.py -q`
2. `python -m pytest tests/hermes_cli/test_subcommands_followup.py -q`
3. `python -m ruff check hermes_cli/skills_hub.py hermes_cli/subcommands/skills.py tests/hermes_cli/test_skills_hub.py`
4. `python hermes skills audit-size --limit 3 --json`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

`python hermes skills audit-size --limit 3 --json` completed successfully against the local install and reported 171 active skills, 12 skills at or above 25k characters, and 0 skills at or above 50k / 100k characters.