### PR TITLE
fix(desktop): avoid Explorer DnD image preview freeze on Windows

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -185,7 +185,9 @@ export function useComposerQueue({
     }
 
     clearDraft()
-    scope.attachments.clear()
+    // Queue entry retains blob: previews; revoke when the entry is discarded
+    // or drained into a submit that takes ownership (see composer-queue).
+    scope.attachments.clear({ retainPreviewUrls: true })
     triggerHaptic('selection')
 
     return true
@@ -224,7 +226,8 @@ export function useComposerQueue({
         }
 
         drainFailuresRef.current.delete(entry.id)
-        removeQueuedPrompt(drainQueueSessionKey, entry.id)
+        // Submit now owns the blob: previews (optimistic bubble); do not revoke.
+        removeQueuedPrompt(drainQueueSessionKey, entry.id, { retainPreviewUrls: true })
         resetBrowseState(drainRuntimeSessionId)
         // A successful drain means the queue is flowing again — lift any park
         // so the remaining entries follow. Manual drains (Enter on an empty

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -173,7 +173,9 @@ export function useComposerSubmit({
       triggerHaptic('submit')
       resetBrowseState(sessionId)
       clearDraft()
-      scope.attachments.clear()
+      // Keep blob: previews alive for the optimistic bubble; revoke when that
+      // consumer is discarded/replaced (not here — clear would race the clone).
+      scope.attachments.clear({ retainPreviewUrls: true })
       dispatchSubmit(text, submittedAttachments)
     }
 

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -7,7 +7,8 @@ import {
   type DroppedFile,
   extractDroppedFiles,
   HERMES_PATHS_MIME,
-  partitionDroppedFiles
+  partitionDroppedFiles,
+  resolveImageAttachmentPreview
 } from './use-composer-actions'
 
 // A Finder/Explorer drop carries a native File handle; an in-app drag (project
@@ -242,5 +243,51 @@ describe('attachmentPreviewDataUrl', () => {
     $connection.set({ mode: 'remote' } as never)
 
     await expect(attachmentPreviewDataUrl('/home/gateway/shot.png')).resolves.toBe(REMOTE_PREVIEW)
+  })
+})
+
+describe('resolveImageAttachmentPreview', () => {
+  const LOCAL_PREVIEW = 'data:image/png;base64,bG9jYWw='
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    $connection.set(null)
+  })
+
+  it('uses an object URL for an in-hand File/Blob (OS Explorer drop) and skips IPC base64', async () => {
+    const readFileDataUrl = vi.fn(async () => LOCAL_PREVIEW)
+    const createObjectURL = vi.fn(() => 'blob:hermes-preview-1')
+
+    vi.stubGlobal('window', { hermesDesktop: { readFileDataUrl } })
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL: vi.fn() })
+
+    const file = new File([new Uint8Array([1, 2, 3, 4])], 'Lattice.png', { type: 'image/png' })
+    const preview = await resolveImageAttachmentPreview('C:\\Users\\Administrator\\Desktop\\Lattice.png', file)
+
+    expect(preview).toBe('blob:hermes-preview-1')
+    expect(createObjectURL).toHaveBeenCalledWith(file)
+    // The freeze path: never base64-load the dropped image over IPC.
+    expect(readFileDataUrl).not.toHaveBeenCalled()
+  })
+
+  it('falls back to IPC data-URL preview when only a path is available (paperclip)', async () => {
+    const readFileDataUrl = vi.fn(async () => LOCAL_PREVIEW)
+
+    vi.stubGlobal('window', { hermesDesktop: { readFileDataUrl } })
+
+    await expect(resolveImageAttachmentPreview('/Users/me/Pictures/pic.png')).resolves.toBe(LOCAL_PREVIEW)
+    expect(readFileDataUrl).toHaveBeenCalledWith('/Users/me/Pictures/pic.png')
+  })
+
+  it('ignores an empty Blob and falls back to the path preview', async () => {
+    const readFileDataUrl = vi.fn(async () => LOCAL_PREVIEW)
+
+    vi.stubGlobal('window', { hermesDesktop: { readFileDataUrl } })
+
+    const empty = new Blob([])
+
+    await expect(resolveImageAttachmentPreview('/tmp/shot.png', empty)).resolves.toBe(LOCAL_PREVIEW)
+    expect(readFileDataUrl).toHaveBeenCalledWith('/tmp/shot.png')
   })
 })

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -63,6 +63,24 @@ export async function attachmentPreviewDataUrl(filePath: string): Promise<string
   return readDesktopFileDataUrl(filePath)
 }
 
+/**
+ * Prefer a cheap object-URL preview when the drop/paste still has a Blob/File
+ * handle. `readFileDataUrl` base64-loads the whole file over IPC (capped at
+ * 16 MB) and was freezing Desktop on Windows Explorer image drops (#63682).
+ * Object URLs skip that read; path-only attaches (paperclip) still fall back
+ * to the IPC data-URL path.
+ */
+export async function resolveImageAttachmentPreview(
+  filePath: string,
+  previewSource?: Blob | null
+): Promise<string> {
+  if (previewSource && previewSource.size > 0) {
+    return URL.createObjectURL(previewSource)
+  }
+
+  return attachmentPreviewDataUrl(filePath)
+}
+
 export interface DroppedFile {
   /** Browser-native File handle. Absent for in-app drags (e.g. project tree). */
   file?: File
@@ -402,7 +420,7 @@ export function useComposerActions({
   )
 
   const attachImagePath = useCallback(
-    async (filePath: string) => {
+    async (filePath: string, previewSource?: Blob | null) => {
       if (!filePath) {
         return false
       }
@@ -418,7 +436,10 @@ export function useComposerActions({
       attachToMain(baseAttachment)
 
       try {
-        const previewUrl = await attachmentPreviewDataUrl(filePath)
+        // OS drops / clipboard blobs pass their File/Blob so preview never
+        // base64-loads the full image over IPC (Windows freeze on Explorer
+        // drag-drop — #63682). Path-only picks keep the IPC thumbnail path.
+        const previewUrl = await resolveImageAttachmentPreview(filePath, previewSource)
 
         if (previewUrl) {
           scope.add({ ...baseAttachment, previewUrl })
@@ -455,7 +476,9 @@ export function useComposerActions({
           return false
         }
 
-        return attachImagePath(savedPath)
+        // Reuse the in-hand blob for the chip preview — do not re-read the
+        // just-written temp file as a data URL.
+        return attachImagePath(savedPath, blob)
       } catch (err) {
         notifyError(err, copy.imageAttachFailed)
 
@@ -595,7 +618,9 @@ export function useComposerActions({
         const isImage = file.type.startsWith('image/') || isImagePath(file.name) || (filePath && isImagePath(filePath))
 
         if (isImage) {
-          if ((filePath && (await attachImagePath(filePath))) || (await attachImageBlob(file))) {
+          // Prefer the absolute path (local `image.attach`) and always hand the
+          // dropped File through for a non-blocking object-URL preview.
+          if ((filePath && (await attachImagePath(filePath, file))) || (await attachImageBlob(file))) {
             attached = true
 
             continue

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -130,7 +130,8 @@ export function useBackgroundQueueDrain({
           }
 
           drainFailuresRef.current.delete(liveEntry.id)
-          removeQueuedPrompt(sessionKey, liveEntry.id)
+          // Submit owns blob: previews after a successful drain handoff.
+          removeQueuedPrompt(sessionKey, liveEntry.id, { retainPreviewUrls: true })
           resetBrowseState(runtimeSessionId)
 
           return true

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -37,6 +37,15 @@ describe('optimisticAttachmentRef', () => {
     expect(ref).toBe('@image:/tmp/shot.png')
   })
 
+  it('renders an OS-drop blob: preview as a markdown image (no IPC data URL)', () => {
+    const blobUrl = 'blob:https://desktop/preview-1'
+    const ref = optimisticAttachmentRef(
+      attachment({ kind: 'image', label: 'Lattice.png', detail: 'C:\\shot.png', previewUrl: blobUrl })
+    )
+
+    expect(ref).toBe(`![Lattice.png](${blobUrl})`)
+  })
+
   it('passes non-image attachments straight through to attachmentDisplayText', () => {
     expect(optimisticAttachmentRef(attachment({ kind: 'file', refText: '@file:src/a.ts', previewUrl: DATA_URL }))).toBe(
       '@file:src/a.ts'

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -185,9 +185,11 @@ export function attachmentDisplayText(attachment: ComposerAttachment): string | 
 /**
  * Display ref for the optimistic (in-flight) user bubble.
  *
- * Images prefer their in-hand base64 preview (a `data:` URL) over a file path.
- * `DirectiveContent` runs `extractEmbeddedImages` first, so a raw `data:` URL
- * renders as an inline thumbnail with zero network. An `@image:<localpath>` ref
+ * Images prefer their in-hand preview (`data:` from paperclip IPC, or `blob:`
+ * from an OS drop File handle) over a file path. `DirectiveContent` runs
+ * `extractEmbeddedImages` for bare `data:` URLs; `blob:` previews use a
+ * markdown image so the renderer can show them without base64-loading the
+ * file (Windows Explorer drop freeze — #63682). An `@image:<localpath>` ref
  * would instead route through `/api/media`, which in remote mode 403s ("Path
  * outside media roots") on a local path the gateway can't read yet — flashing a
  * fallback chip until submit uploads the bytes. The preview also survives the
@@ -204,6 +206,14 @@ export function optimisticAttachmentRef(attachment: ComposerAttachment): string 
 
   if (attachment.kind === 'image' && attachment.previewUrl?.startsWith('data:')) {
     return attachment.previewUrl
+  }
+
+  // Object-URL previews from OS drops — markdown image keeps them out of the
+  // data-URL extract path while still rendering inline in the optimistic bubble.
+  if (attachment.kind === 'image' && attachment.previewUrl?.startsWith('blob:')) {
+    const alt = attachment.label || 'image'
+
+    return `![${alt}](${attachment.previewUrl})`
   }
 
   return attachmentDisplayText(attachment)

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -1,6 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ComposerAttachment } from './composer'
+import {
+  $composerAttachments,
+  addComposerAttachment,
+  type ComposerAttachment,
+  mainComposerScope
+} from './composer'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
@@ -31,10 +36,80 @@ function attachment(id: string, kind: ComposerAttachment['kind'] = 'file'): Comp
   }
 }
 
+function stubRevokeObjectURL() {
+  const revokeObjectURL = vi.fn()
+  vi.stubGlobal('URL', { ...URL, revokeObjectURL })
+
+  return revokeObjectURL
+}
+
 describe('composer queue store', () => {
   beforeEach(() => {
     window.localStorage.removeItem(QUEUE_STORAGE_KEY)
     $queuedPromptsBySession.set({})
+    $composerAttachments.set([])
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('queued-prompt handoff keeps blob previews across composer clear, then revokes when the entry is discarded', () => {
+    // Mirrors use-composer-queue: enqueue → clear({ retainPreviewUrls }).
+    const revokeObjectURL = stubRevokeObjectURL()
+    const blobUrl = 'blob:hermes-queued-1'
+    const image = {
+      id: 'image:drop',
+      kind: 'image' as const,
+      label: 'Lattice.png',
+      previewUrl: blobUrl
+    }
+    addComposerAttachment(image)
+
+    const queued = enqueueQueuedPrompt(SESSION_KEY, {
+      text: 'look at this',
+      attachments: $composerAttachments.get()
+    })
+    mainComposerScope.clear({ retainPreviewUrls: true })
+
+    expect(queued).not.toBeNull()
+    expect($composerAttachments.get()).toEqual([])
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+    expect(getQueuedPrompts(SESSION_KEY)[0]?.attachments[0]?.previewUrl).toBe(blobUrl)
+
+    expect(removeQueuedPrompt(SESSION_KEY, queued!.id)).toBe(true)
+    expect(revokeObjectURL).toHaveBeenCalledWith(blobUrl)
+  })
+
+  it('drain handoff retains blob previews when the queued entry is removed after submit owns them', () => {
+    const revokeObjectURL = stubRevokeObjectURL()
+    const blobUrl = 'blob:hermes-drain-1'
+    const queued = enqueueQueuedPrompt(SESSION_KEY, {
+      text: 'drain me',
+      attachments: [{ id: 'image:drop', kind: 'image', label: 'shot.png', previewUrl: blobUrl }]
+    })
+
+    expect(queued).not.toBeNull()
+    expect(removeQueuedPrompt(SESSION_KEY, queued!.id, { retainPreviewUrls: true })).toBe(true)
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('revokes replaced blob previews when a queued entry attachment snapshot changes', () => {
+    const revokeObjectURL = stubRevokeObjectURL()
+    const oldUrl = 'blob:hermes-old'
+    const newUrl = 'blob:hermes-new'
+    const queued = enqueueQueuedPrompt(SESSION_KEY, {
+      text: 'edit me',
+      attachments: [{ id: 'image:old', kind: 'image', label: 'old.png', previewUrl: oldUrl }]
+    })
+
+    expect(queued).not.toBeNull()
+    expect(
+      updateQueuedPrompt(SESSION_KEY, queued!.id, {
+        text: 'edit me',
+        attachments: [{ id: 'image:new', kind: 'image', label: 'new.png', previewUrl: newUrl }]
+      })
+    ).toBe(true)
+    expect(revokeObjectURL).toHaveBeenCalledWith(oldUrl)
+    expect(revokeObjectURL).not.toHaveBeenCalledWith(newUrl)
   })
 
   it('queues prompts in FIFO order', () => {

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -1,6 +1,18 @@
 import { atom } from 'nanostores'
 
-import type { ComposerAttachment } from './composer'
+import {
+  type ComposerAttachment,
+  revokeAttachmentPreviewUrls,
+  revokeDiscardedAttachmentPreviews
+} from './composer'
+
+export interface RemoveQueuedPromptOptions {
+  /**
+   * When true, leave blob: preview URLs alive because submit/optimistic now
+   * owns the snapshot (drain handoff). Default false = entry discarded.
+   */
+  retainPreviewUrls?: boolean
+}
 
 export interface QueuedPromptEntry {
   id: string
@@ -147,12 +159,17 @@ export const dequeueQueuedPrompt = (key: string | null | undefined): null | Queu
     return null
   }
 
+  // Caller takes ownership of head.attachments (including any blob: previews).
   writeSession(sid, rest)
 
   return head
 }
 
-export const removeQueuedPrompt = (key: string | null | undefined, id: string): boolean => {
+export const removeQueuedPrompt = (
+  key: string | null | undefined,
+  id: string,
+  options?: RemoveQueuedPromptOptions
+): boolean => {
   const sid = sidOf(key)
 
   if (!sid) {
@@ -160,13 +177,18 @@ export const removeQueuedPrompt = (key: string | null | undefined, id: string): 
   }
 
   const queue = queueFor(sid)
+  const removed = queue.find(e => e.id === id)
   const next = queue.filter(e => e.id !== id)
 
-  if (next.length === queue.length) {
+  if (!removed || next.length === queue.length) {
     return false
   }
 
   writeSession(sid, next)
+
+  if (!options?.retainPreviewUrls) {
+    revokeAttachmentPreviewUrls(removed.attachments)
+  }
 
   return true
 }
@@ -216,6 +238,10 @@ export const updateQueuedPrompt = (
       return entry
     }
 
+    if (update.attachments) {
+      revokeDiscardedAttachmentPreviews(entry.attachments, attachments)
+    }
+
     changed = true
 
     return { ...entry, text: update.text, attachments }
@@ -238,6 +264,10 @@ export const clearQueuedPrompts = (key: string | null | undefined) => {
 
   if (!sid || !(sid in $queuedPromptsBySession.get())) {
     return
+  }
+
+  for (const entry of queueFor(sid)) {
+    revokeAttachmentPreviewUrls(entry.attachments)
   }
 
   writeSession(sid, [])

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -1,12 +1,15 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   $composerAttachments,
   addComposerAttachment,
   clearSessionDraft,
   type ComposerAttachment,
+  createComposerAttachmentScope,
+  mainComposerScope,
   migrateSessionDraft,
   removeComposerAttachment,
+  revokeAttachmentPreviewUrls,
   SESSION_DRAFTS_STORAGE_KEY,
   stashSessionDraft,
   takeSessionDraft,
@@ -16,6 +19,53 @@ import {
 function attachment(overrides: Partial<ComposerAttachment> & Pick<ComposerAttachment, 'id'>): ComposerAttachment {
   return { kind: 'file', label: 'doc.pdf', ...overrides }
 }
+
+function stubRevokeObjectURL() {
+  const revokeObjectURL = vi.fn()
+  vi.stubGlobal('URL', { ...URL, revokeObjectURL })
+
+  return revokeObjectURL
+}
+
+describe('blob preview URL ownership handoff', () => {
+  afterEach(() => {
+    $composerAttachments.set([])
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('direct-submit handoff keeps blob previews across clear, then revokes when the optimistic consumer is discarded', () => {
+    // Mirrors use-composer-submit: clone → clear({ retainPreviewUrls }) → dispatch clone.
+    const revokeObjectURL = stubRevokeObjectURL()
+    const blobUrl = 'blob:hermes-direct-submit-1'
+    addComposerAttachment(
+      attachment({ id: 'image:drop', kind: 'image', label: 'Lattice.png', previewUrl: blobUrl })
+    )
+
+    const submittedAttachments = $composerAttachments.get().map(item => ({ ...item }))
+    mainComposerScope.clear({ retainPreviewUrls: true })
+
+    expect($composerAttachments.get()).toEqual([])
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+    expect(submittedAttachments[0]?.previewUrl).toBe(blobUrl)
+
+    // Optimistic bubble discarded / replaced without restoring into the composer.
+    revokeAttachmentPreviewUrls(submittedAttachments)
+    expect(revokeObjectURL).toHaveBeenCalledWith(blobUrl)
+  })
+
+  it('still revokes blob previews on a normal clear (no handoff)', () => {
+    const revokeObjectURL = stubRevokeObjectURL()
+    const blobUrl = 'blob:hermes-clear-1'
+    const scope = createComposerAttachmentScope()
+    scope.add(attachment({ id: 'image:x', kind: 'image', previewUrl: blobUrl }))
+
+    scope.clear()
+
+    expect(scope.$attachments.get()).toEqual([])
+    expect(revokeObjectURL).toHaveBeenCalledWith(blobUrl)
+  })
+})
 
 describe('updateComposerAttachment', () => {
   afterEach(() => {

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -2,6 +2,17 @@ import { atom } from 'nanostores'
 
 import { triggerHaptic } from '@/lib/haptics'
 
+/** Release blob: chip previews created for OS image drops (see #63682). */
+function revokeAttachmentPreviewUrl(url?: string | null) {
+  if (url?.startsWith('blob:')) {
+    try {
+      URL.revokeObjectURL(url)
+    } catch {
+      // Best-effort — a revoked/invalid URL must not break chip removal.
+    }
+  }
+}
+
 export interface ComposerAttachment {
   id: string
   kind: 'image' | 'file' | 'folder' | 'terminal' | 'url'
@@ -51,12 +62,17 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
       }
     },
     clear() {
+      for (const attachment of $attachments.get()) {
+        revokeAttachmentPreviewUrl(attachment.previewUrl)
+      }
+
       $attachments.set([])
     },
     remove(id) {
       const current = $attachments.get()
       const removed = current.find(attachment => attachment.id === id) || null
       $attachments.set(current.filter(attachment => attachment.id !== id))
+      revokeAttachmentPreviewUrl(removed?.previewUrl)
 
       return removed
     },
@@ -80,9 +96,14 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
         return false
       }
 
+      const previous = current[index]
       const next = [...current]
       next[index] = attachment
       $attachments.set(next)
+
+      if (previous?.previewUrl && previous.previewUrl !== attachment.previewUrl) {
+        revokeAttachmentPreviewUrl(previous.previewUrl)
+      }
 
       return true
     }
@@ -361,8 +382,13 @@ function upsertAttachment(attachments: ComposerAttachment[], attachment: Compose
     return [...attachments, attachment]
   }
 
+  const previous = attachments[index]
   const next = [...attachments]
   next[index] = attachment
+
+  if (previous?.previewUrl && previous.previewUrl !== attachment.previewUrl) {
+    revokeAttachmentPreviewUrl(previous.previewUrl)
+  }
 
   return next
 }

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -3,7 +3,7 @@ import { atom } from 'nanostores'
 import { triggerHaptic } from '@/lib/haptics'
 
 /** Release blob: chip previews created for OS image drops (see #63682). */
-function revokeAttachmentPreviewUrl(url?: string | null) {
+export function revokeAttachmentPreviewUrl(url?: string | null) {
   if (url?.startsWith('blob:')) {
     try {
       URL.revokeObjectURL(url)
@@ -11,6 +11,43 @@ function revokeAttachmentPreviewUrl(url?: string | null) {
       // Best-effort — a revoked/invalid URL must not break chip removal.
     }
   }
+}
+
+/** Revoke blob: previews for attachments whose consumer was discarded. */
+export function revokeAttachmentPreviewUrls(attachments: readonly ComposerAttachment[]) {
+  for (const attachment of attachments) {
+    revokeAttachmentPreviewUrl(attachment.previewUrl)
+  }
+}
+
+/**
+ * Revoke blob: previews from `previous` that are not retained by `next`.
+ * Used when a queued/optimistic snapshot is replaced or dropped.
+ */
+export function revokeDiscardedAttachmentPreviews(
+  previous: readonly ComposerAttachment[],
+  next: readonly ComposerAttachment[] = []
+) {
+  const retained = new Set(
+    next.map(attachment => attachment.previewUrl).filter((url): url is string => !!url?.startsWith('blob:'))
+  )
+
+  for (const attachment of previous) {
+    const url = attachment.previewUrl
+
+    if (url?.startsWith('blob:') && !retained.has(url)) {
+      revokeAttachmentPreviewUrl(url)
+    }
+  }
+}
+
+export interface ClearAttachmentsOptions {
+  /**
+   * When true, leave blob: preview URLs alive for a submitted/queued snapshot
+   * that still references them. Caller must revoke when that consumer is
+   * discarded or replaced (see #63682 / PR review on #66546).
+   */
+  retainPreviewUrls?: boolean
 }
 
 export interface ComposerAttachment {
@@ -43,7 +80,7 @@ export const $composerTerminalSelections = atom<Record<string, string>>({})
 export interface ComposerAttachmentScope {
   $attachments: ReturnType<typeof atom<ComposerAttachment[]>>
   add(attachment: ComposerAttachment): void
-  clear(): void
+  clear(options?: ClearAttachmentsOptions): void
   remove(id: string): ComposerAttachment | null
   setUploadState(id: string, uploadState?: ComposerAttachment['uploadState']): void
   update(attachment: ComposerAttachment): boolean
@@ -61,9 +98,9 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
         triggerHaptic('selection')
       }
     },
-    clear() {
-      for (const attachment of $attachments.get()) {
-        revokeAttachmentPreviewUrl(attachment.previewUrl)
+    clear(options) {
+      if (!options?.retainPreviewUrls) {
+        revokeAttachmentPreviewUrls($attachments.get())
       }
 
       $attachments.set([])


### PR DESCRIPTION
## What does this PR do?

Dragging a PNG/JPEG from Windows Explorer into Hermes Desktop chat was freezing the UI. OS drops were building the composer chip preview via `readFileDataUrl`, which base64-loads the whole file over IPC (up to 16 MB). On a typical phone/camera image that stalls the renderer.

This keeps the existing path-based `image.attach` pipeline (so pasting a path still works the same), but prefers `URL.createObjectURL` from the dropped `File` for the chip/optimistic preview. Path-only attaches (paperclip) still use the IPC data-URL path. Blob preview URLs are revoked when chips are removed or cleared.

## Related Issue

Fixes #63682

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/hooks/use-composer-actions.ts`: `resolveImageAttachmentPreview`; OS drops and blob saves pass the in-hand File/Blob for preview
- `apps/desktop/src/store/composer.ts`: revoke `blob:` preview URLs on remove/clear/replace
- `apps/desktop/src/lib/chat-runtime.ts`: optimistic bubble renders `blob:` previews as markdown images
- Tests for object-URL preview preference and optimistic blob refs

## How to Test

1. Launch Hermes Desktop on Windows.
2. Drag a `.png` / `.jpg` from File Explorer into the chat composer.
3. The UI should stay responsive and show an image chip (no freeze).
4. Send a short prompt; vision / path attach should still work as before.
5. Remove the chip; confirm no leftover blob URL leaks (no console errors).

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the Desktop vitest coverage for the touched files (see Evidence)
- [x] I added tests for my changes
- [x] I tested on my platform: Windows 11

### Documentation and Housekeeping

- [x] Documentation N/A for this Desktop preview path change
- [x] cli-config.yaml.example N/A
- [x] CONTRIBUTING.md / AGENTS.md N/A
- [x] Cross-platform: object URLs work on macOS/Linux too; Windows was the reported freeze
- [x] Tool schemas N/A

## Evidence

```text
cd apps/desktop
npx vitest run src/app/chat/hooks/use-composer-actions.test.ts src/lib/chat-runtime.test.ts src/store/composer.test.ts

Test Files  3 passed (3)
     Tests  45 passed (45)
```

```text
python scripts/check-windows-footguns.py apps/desktop/src/app/chat/hooks/use-composer-actions.ts apps/desktop/src/store/composer.ts apps/desktop/src/lib/chat-runtime.ts
No Windows footguns found (0 file(s) scanned).
```

```text
# TS-only change; hermetic smoke via local venv pytest
.venv/Scripts/python.exe -m pytest tests/tools/test_windows_compat.py -q
12 passed, 4 skipped
```

## AI assistance

Prepared with AI assistance (Cursor/Grok). Human author: Stan Shih (@stantheman0128).