### PR TITLE
fix(mcp): reconnect message-less closed transports

### DIFF
--- a/tests/tools/test_mcp_resource_content.py
+++ b/tests/tools/test_mcp_resource_content.py
@@ -239,10 +239,14 @@ class TestErrorPathResourceText:
             finally:
                 loop.close()
 
-        with mock_patch.dict(mcp_tool._servers, {"test-server": fake_server}), \
-             mock_patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_fake_run_on_mcp_loop):
-            fake_session.call_tool = AsyncMock()
-            yield fake_session, mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        mcp_tool._reset_server_error("test-server")
+        try:
+            with mock_patch.dict(mcp_tool._servers, {"test-server": fake_server}), \
+                 mock_patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_fake_run_on_mcp_loop):
+                fake_session.call_tool = AsyncMock()
+                yield fake_session, mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        finally:
+            mcp_tool._reset_server_error("test-server")
 
     def test_error_embedded_resource_text_surfaced(self, _handler):
         from unittest.mock import AsyncMock

--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -121,27 +121,28 @@ def test_is_session_expired_rejects_mixed_group_with_user_interruption():
     assert _is_session_expired_error(exc) is False
 
 
-def test_exception_tree_finds_interruption_beyond_recursion_limit():
-    """Arbitrarily deep wrapper trees must not overflow Python's call stack."""
+def test_is_session_expired_finds_closed_resource_beyond_recursion_limit():
+    """The full classifier must handle arbitrarily deep transport wrappers."""
     import sys
 
-    from tools.mcp_tool import _exception_tree_contains_interruption
+    from anyio import ClosedResourceError
+    from tools.mcp_tool import _is_session_expired_error
 
     class NestedException(Exception):
         exceptions: tuple[BaseException, ...]
 
-    exc = InterruptedError("cancel")
+    exc = ClosedResourceError()
     for _ in range(sys.getrecursionlimit() + 100):
         wrapper = NestedException("wrapped")
         wrapper.exceptions = (exc,)
         exc = wrapper
 
-    assert _exception_tree_contains_interruption(exc) is True
+    assert _is_session_expired_error(exc) is True
 
 
-def test_exception_tree_handles_cyclic_exceptions_graph():
-    """Malformed exception graphs may contain cycles and must terminate safely."""
-    from tools.mcp_tool import _exception_tree_contains_interruption
+def test_is_session_expired_handles_cyclic_graph_without_transport_error():
+    """A cyclic non-transport graph must terminate and classify false."""
+    from tools.mcp_tool import _is_session_expired_error
 
     class CyclicException(Exception):
         exceptions: tuple[BaseException, ...]
@@ -151,7 +152,23 @@ def test_exception_tree_handles_cyclic_exceptions_graph():
     first.exceptions = (second,)
     second.exceptions = (first,)
 
-    assert _exception_tree_contains_interruption(first) is False
+    assert _is_session_expired_error(first) is False
+
+
+def test_is_session_expired_finds_transport_error_in_cyclic_graph():
+    """Cycle detection must not prevent scanning reachable transport errors."""
+    from anyio import ClosedResourceError
+    from tools.mcp_tool import _is_session_expired_error
+
+    class CyclicException(Exception):
+        exceptions: tuple[BaseException, ...]
+
+    first = CyclicException("first")
+    second = CyclicException("second")
+    first.exceptions = (second, ClosedResourceError())
+    second.exceptions = (first,)
+
+    assert _is_session_expired_error(first) is True
 
 
 def test_is_session_expired_rejects_empty_message():

--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -121,6 +121,39 @@ def test_is_session_expired_rejects_mixed_group_with_user_interruption():
     assert _is_session_expired_error(exc) is False
 
 
+def test_exception_tree_finds_interruption_beyond_recursion_limit():
+    """Arbitrarily deep wrapper trees must not overflow Python's call stack."""
+    import sys
+
+    from tools.mcp_tool import _exception_tree_contains_interruption
+
+    class NestedException(Exception):
+        exceptions: tuple[BaseException, ...]
+
+    exc = InterruptedError("cancel")
+    for _ in range(sys.getrecursionlimit() + 100):
+        wrapper = NestedException("wrapped")
+        wrapper.exceptions = (exc,)
+        exc = wrapper
+
+    assert _exception_tree_contains_interruption(exc) is True
+
+
+def test_exception_tree_handles_cyclic_exceptions_graph():
+    """Malformed exception graphs may contain cycles and must terminate safely."""
+    from tools.mcp_tool import _exception_tree_contains_interruption
+
+    class CyclicException(Exception):
+        exceptions: tuple[BaseException, ...]
+
+    first = CyclicException("first")
+    second = CyclicException("second")
+    first.exceptions = (second,)
+    second.exceptions = (first,)
+
+    assert _exception_tree_contains_interruption(first) is False
+
+
 def test_is_session_expired_rejects_empty_message():
     """Bare exceptions with no message shouldn't match."""
     from tools.mcp_tool import _is_session_expired_error

--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -10,6 +10,7 @@ Before the #13383 fix, this class of failure fell through as a plain
 tool error with no recovery path, so every subsequent call on the
 affected MCP server failed until the gateway was manually restarted.
 """
+import asyncio
 import json
 import threading
 from unittest.mock import MagicMock
@@ -90,6 +91,36 @@ def test_is_session_expired_rejects_interrupted_error():
     assert _is_session_expired_error(InterruptedError("Invalid or expired session")) is False
 
 
+def test_is_session_expired_detects_message_less_anyio_transport_failures():
+    """Recognized stream failures have no text for marker matching."""
+    from anyio import BrokenResourceError, EndOfStream
+    from tools.mcp_tool import _is_session_expired_error
+
+    assert _is_session_expired_error(BrokenResourceError()) is True
+    assert _is_session_expired_error(EndOfStream()) is True
+
+
+def test_is_session_expired_detects_wrapped_closed_resource():
+    """AnyIO task groups may wrap a message-less transport close."""
+    from anyio import ClosedResourceError
+    from tools.mcp_tool import _is_session_expired_error
+
+    exc = ExceptionGroup("MCP transport failed", [ClosedResourceError()])
+    assert _is_session_expired_error(exc) is True
+
+
+def test_is_session_expired_rejects_mixed_group_with_user_interruption():
+    """Cancellation anywhere in the tree takes precedence over transport loss."""
+    from anyio import ClosedResourceError
+    from tools.mcp_tool import _is_session_expired_error
+
+    exc = ExceptionGroup(
+        "cancelled MCP transport",
+        [InterruptedError("cancel"), ClosedResourceError()],
+    )
+    assert _is_session_expired_error(exc) is False
+
+
 def test_is_session_expired_rejects_empty_message():
     """Bare exceptions with no message shouldn't match."""
     from tools.mcp_tool import _is_session_expired_error
@@ -158,6 +189,86 @@ def _install_stub_server(name: str = "wpcom"):
     # reconnect readiness probe (``srv.session is not None``).
     server.session = MagicMock()
     return server, reconnect_flag
+
+
+@pytest.mark.parametrize(
+    "transport_config, expected_route",
+    [
+        ({"command": "librarian-mcp"}, "stdio"),
+        ({"url": "https://neo4j.example.test/mcp", "skip_preflight": True}, "http"),
+    ],
+    ids=["stdio", "http"],
+)
+def test_call_tool_handler_rebuilds_configured_server_transport(
+    monkeypatch, tmp_path, transport_config, expected_route
+):
+    """The real server run loop selects and rebuilds its configured transport."""
+    from anyio import ClosedResourceError
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask, _make_tool_handler
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    mcp_tool._ensure_mcp_loop()
+    transport_ready = threading.Event()
+    routes = []
+    configs = []
+    sessions = []
+    call_count = {"n": 0}
+
+    class _Session:
+        async def call_tool(self, *args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise ClosedResourceError
+            result = MagicMock()
+            result.isError = False
+            result.content = [MagicMock(type="text", text="reconnected")]
+            result.structuredContent = None
+            return result
+
+    class _LifecycleTask(MCPServerTask):
+        async def _serve_transport(self, route, config):
+            routes.append(route)
+            configs.append(dict(config))
+            self.session = _Session()
+            sessions.append(self.session)
+            self._ready.set()
+            transport_ready.set()
+            return await self._wait_for_lifecycle_event()
+
+        async def _run_stdio(self, config):
+            return await self._serve_transport("stdio", config)
+
+        async def _run_http(self, config):
+            return await self._serve_transport("http", config)
+
+    server = _LifecycleTask("resumed")
+    mcp_tool._servers["resumed"] = server
+    mcp_tool._server_error_counts.pop("resumed", None)
+    mcp_tool._server_breaker_opened_at.pop("resumed", None)
+    loop = mcp_tool._mcp_loop
+    assert loop is not None
+    run_future = asyncio.run_coroutine_threadsafe(
+        server.run(transport_config), loop
+    )
+
+    try:
+        assert transport_ready.wait(3), "server lifecycle did not establish transport"
+        handler = _make_tool_handler("resumed", "health", 10.0)
+        parsed = json.loads(handler({}))
+
+        assert parsed == {"result": "reconnected"}
+        assert call_count["n"] == 2
+        assert routes == [expected_route, expected_route]
+        assert configs == [transport_config, transport_config]
+        assert len(sessions) == 2
+        assert sessions[0] is not sessions[1]
+    finally:
+        loop.call_soon_threadsafe(server._shutdown_event.set)
+        run_future.result(timeout=5)
+        mcp_tool._servers.pop("resumed", None)
+        mcp_tool._server_error_counts.pop("resumed", None)
+        mcp_tool._server_breaker_opened_at.pop("resumed", None)
 
 
 def test_call_tool_handler_reconnects_on_session_expired(monkeypatch, tmp_path):
@@ -268,16 +379,19 @@ def test_session_expired_retry_waits_for_new_session(monkeypatch, tmp_path):
 
     server._reconnect_event = _ReconnectAdapter()
     mcp_tool._servers["hindsight"] = server
-    mcp_tool._server_error_counts.pop("hindsight", None)
+    mcp_tool._server_error_counts["hindsight"] = 7
+    mcp_tool._server_breaker_opened_at["hindsight"] = 123.0
 
     try:
         handler = _make_tool_handler("hindsight", "get_bank", 10.0)
         parsed = json.loads(handler({}))
         assert parsed.get("result") == "bank ok", parsed
         assert mcp_tool._server_error_counts.get("hindsight", 0) == 0
+        assert "hindsight" not in mcp_tool._server_breaker_opened_at
     finally:
         mcp_tool._servers.pop("hindsight", None)
         mcp_tool._server_error_counts.pop("hindsight", None)
+        mcp_tool._server_breaker_opened_at.pop("hindsight", None)
 
 
 def test_call_tool_handler_non_session_expired_error_falls_through(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3536,22 +3536,6 @@ _SESSION_EXPIRED_MARKERS: tuple = (
 )
 
 
-def _exception_tree_contains_interruption(exc: BaseException) -> bool:
-    """Return whether ``exc`` or any nested exception is user cancellation."""
-    stack = [exc]
-    seen: set[int] = set()
-    while stack:
-        current = stack.pop()
-        identity = id(current)
-        if identity in seen:
-            continue
-        seen.add(identity)
-        if isinstance(current, InterruptedError):
-            return True
-        stack.extend(getattr(current, "exceptions", ()))
-    return False
-
-
 def _is_session_expired_error(exc: BaseException) -> bool:
     """Return True if ``exc`` looks like an MCP transport session expiry.
 
@@ -3566,35 +3550,50 @@ def _is_session_expired_error(exc: BaseException) -> bool:
     ``streamablehttp_client`` + ``ClientSession`` pair, which is
     exactly what ``MCPServerTask._reconnect_event`` triggers.
     """
-    if _exception_tree_contains_interruption(exc):
-        return False
-
     # AnyIO's stream exceptions are commonly message-less. In particular,
     # ``str(ClosedResourceError()) == ""``, so marker matching alone misses the
-    # exact failure emitted by both MCP stdio and HTTP transports. Match the
-    # SDK's transport-closed exception types before inspecting text.
+    # exact failure emitted by both MCP stdio and HTTP transports.
     try:
         from anyio import BrokenResourceError, ClosedResourceError, EndOfStream
 
-        if isinstance(exc, (BrokenResourceError, ClosedResourceError, EndOfStream)):
-            return True
+        transport_error_types = (
+            BrokenResourceError,
+            ClosedResourceError,
+            EndOfStream,
+        )
     except ImportError:  # pragma: no cover - AnyIO is supplied by the MCP SDK
-        pass
+        transport_error_types = ()
 
-    # AnyIO task groups can wrap the transport exception in an
-    # ExceptionGroup whose own string omits the message-less leaf details.
-    nested = getattr(exc, "exceptions", ())
-    if nested and any(_is_session_expired_error(child) for child in nested):
-        return True
+    # ExceptionGroup trees can be arbitrarily deep or even cyclic when custom
+    # exceptions expose ``exceptions``. Traverse once, iteratively, and inspect
+    # every reachable node so user interruption always overrides transport
+    # markers or types found elsewhere in the graph.
+    stack = [exc]
+    seen: set[int] = set()
+    transport_error_found = False
+    while stack:
+        current = stack.pop()
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
 
-    # Exception messages vary across SDK versions + server
-    # implementations, so match on a small allow-list of stable
-    # substrings rather than exception type.  Kept narrow to avoid
-    # false positives on unrelated server errors.
-    msg = str(exc).lower()
-    if not msg:
-        return False
-    return any(marker in msg for marker in _SESSION_EXPIRED_MARKERS)
+        if isinstance(current, InterruptedError):
+            return False
+        if isinstance(current, transport_error_types):
+            transport_error_found = True
+
+        # Exception messages vary across SDK versions + server
+        # implementations, so match on a small allow-list of stable
+        # substrings rather than exception type. Kept narrow to avoid
+        # false positives on unrelated server errors.
+        msg = str(current).lower()
+        if msg and any(marker in msg for marker in _SESSION_EXPIRED_MARKERS):
+            transport_error_found = True
+
+        stack.extend(getattr(current, "exceptions", ()))
+
+    return transport_error_found
 
 
 def _handle_session_expired_and_retry(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3536,6 +3536,16 @@ _SESSION_EXPIRED_MARKERS: tuple = (
 )
 
 
+def _exception_tree_contains_interruption(exc: BaseException) -> bool:
+    """Return whether ``exc`` or any nested exception is user cancellation."""
+    if isinstance(exc, InterruptedError):
+        return True
+    return any(
+        _exception_tree_contains_interruption(child)
+        for child in getattr(exc, "exceptions", ())
+    )
+
+
 def _is_session_expired_error(exc: BaseException) -> bool:
     """Return True if ``exc`` looks like an MCP transport session expiry.
 
@@ -3550,8 +3560,27 @@ def _is_session_expired_error(exc: BaseException) -> bool:
     ``streamablehttp_client`` + ``ClientSession`` pair, which is
     exactly what ``MCPServerTask._reconnect_event`` triggers.
     """
-    if isinstance(exc, InterruptedError):
+    if _exception_tree_contains_interruption(exc):
         return False
+
+    # AnyIO's stream exceptions are commonly message-less. In particular,
+    # ``str(ClosedResourceError()) == ""``, so marker matching alone misses the
+    # exact failure emitted by both MCP stdio and HTTP transports. Match the
+    # SDK's transport-closed exception types before inspecting text.
+    try:
+        from anyio import BrokenResourceError, ClosedResourceError, EndOfStream
+
+        if isinstance(exc, (BrokenResourceError, ClosedResourceError, EndOfStream)):
+            return True
+    except ImportError:  # pragma: no cover - AnyIO is supplied by the MCP SDK
+        pass
+
+    # AnyIO task groups can wrap the transport exception in an
+    # ExceptionGroup whose own string omits the message-less leaf details.
+    nested = getattr(exc, "exceptions", ())
+    if nested and any(_is_session_expired_error(child) for child in nested):
+        return True
+
     # Exception messages vary across SDK versions + server
     # implementations, so match on a small allow-list of stable
     # substrings rather than exception type.  Kept narrow to avoid
@@ -3629,10 +3658,10 @@ def _handle_session_expired_and_retry(
         try:
             parsed = json.loads(result)
             if "error" not in parsed:
-                _server_error_counts[server_name] = 0
+                _reset_server_error(server_name)
                 return result
         except (json.JSONDecodeError, TypeError):
-            _server_error_counts[server_name] = 0
+            _reset_server_error(server_name)
             return result
     except Exception as retry_exc:
         logger.warning(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3538,12 +3538,18 @@ _SESSION_EXPIRED_MARKERS: tuple = (
 
 def _exception_tree_contains_interruption(exc: BaseException) -> bool:
     """Return whether ``exc`` or any nested exception is user cancellation."""
-    if isinstance(exc, InterruptedError):
-        return True
-    return any(
-        _exception_tree_contains_interruption(child)
-        for child in getattr(exc, "exceptions", ())
-    )
+    stack = [exc]
+    seen: set[int] = set()
+    while stack:
+        current = stack.pop()
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if isinstance(current, InterruptedError):
+            return True
+        stack.extend(getattr(current, "exceptions", ()))
+    return False
 
 
 def _is_session_expired_error(exc: BaseException) -> bool:


### PR DESCRIPTION
## Summary

- recognize message-less AnyIO `ClosedResourceError`, `BrokenResourceError`, and `EndOfStream` failures (including nested exception groups) as stale MCP transports
- preserve interruption precedence, rebuild the existing server-owned transport, wait for a distinct ready session, and retry the interrupted operation once
- reset both circuit-breaker count and open timestamp after successful recovery without rebuilding registered handlers or tool schemas
- exercise the real `MCPServerTask.run()` lifecycle for both stdio and Streamable HTTP configurations

This is a follow-up to #13383: the existing text-based recovery handles explicit "expired session" responses, but AnyIO transport-close exceptions are commonly message-less and therefore bypassed that classifier.

## Verification

- `scripts/run_tests.sh tests/tools/test_mcp_tool_session_expired.py tests/tools/test_mcp_circuit_breaker.py tests/tools/test_mcp_reconnect_signal.py tests/tools/test_mcp_reconnect_retry_reset.py -j 4` — 37 passed
- `scripts/run_tests.sh -j 8 <all tests/tools/test_mcp*.py + test_refresh_agent_mcp_tools.py + tests/tui_gateway/*.py + tests/test_tui_gateway*.py + test_tui_mcp_late_refresh.py>` — 77 files, 1426 passed
- `ruff check .` — passed
- `git diff --check` — passed
- operational stdio smoke: a real FastMCP child intentionally exited during the first call; the already-registered handler transparently returned from a fresh session on the single retry, with the same registry entry, handler identity, and schema, and breaker count reset to zero

## Recovery contract reviewed

- bounded reconnect lifecycle/backoff remains unchanged
- per-server RPC lock and reconnect event preserve serialized/single-flight behavior
- exactly one handler retry is attempted
- cancellation/interruption is never reclassified as transport expiry
- tool registration/schema identity remains stable across reconnect
