### PR TITLE
fix(gateway): invalidate agent cache on skill config changes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16408,6 +16408,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
         ("agent", "disabled_toolsets"),
+        ("skills", "disabled"),
+        ("skills", "platform_disabled"),
+        ("skills", "external_dirs"),
         ("memory", "provider"),
     )
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -243,6 +243,24 @@ class TestExtractCacheBustingConfig:
         assert out["compression.protect_last_n"] == 25
         assert out["compression.codex_app_server_auto"] == "hermes"
 
+    def test_reads_skill_catalog_inputs(self):
+        """Skill catalog changes must rebuild the cached agent system prompt."""
+        from gateway.run import GatewayRunner
+
+        out = GatewayRunner._extract_cache_busting_config(
+            {
+                "skills": {
+                    "disabled": ["ce-debug"],
+                    "platform_disabled": {"telegram": ["ce-work"]},
+                    "external_dirs": ["/tmp/team-skills"],
+                }
+            }
+        )
+
+        assert out["skills.disabled"] == ["ce-debug"]
+        assert out["skills.platform_disabled"] == {"telegram": ["ce-work"]}
+        assert out["skills.external_dirs"] == ["/tmp/team-skills"]
+
     def test_missing_keys_yield_none(self):
         """Absent config keys must produce None values (still contribute to signature)."""
         from gateway.run import GatewayRunner


### PR DESCRIPTION
## Summary

- include skill availability settings in the gateway agent cache signature
- rebuild cached agents when disabled skills, platform-specific disables, or external skill directories change
- add regression coverage for all three skill catalog inputs

## Problem

A long-lived gateway session can retain a system prompt that advertises a skill after that skill is disabled in `config.yaml`. Runtime `skill_view` reads the current config and rejects the skill, leaving the prompt catalog and executable skill state inconsistent until `/reset` or a gateway restart.

## Tests

- `python -m pytest tests/gateway/test_agent_cache.py -q -o addopts= --tb=short` — 79 passed
- `python -m pytest tests/gateway/test_fresh_reset_skill_injection.py tests/gateway/test_stacked_skill_platform_disabled.py tests/agent/test_external_skills_dirs_cache.py -q -o addopts= --tb=short` — 17 passed
- `python -m ruff check gateway/run.py tests/gateway/test_agent_cache.py`
- `python -m py_compile gateway/run.py tests/gateway/test_agent_cache.py`
- `git diff --check`