### PR TITLE
fix(agent): handle block-form content in _interim_assistant_visible_text

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4828,6 +4828,17 @@ class AIAgent:
         if visible:
             return visible
         content = assistant_msg.get("content")
+        if isinstance(content, list):
+            # Anthropic block-form content (thinking/text blocks). Keep only
+            # visible text blocks — thinking is never interim-deliverable.
+            parts = []
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "text" and isinstance(block.get("text"), str):
+                        parts.append(block["text"])
+                elif isinstance(block, str):
+                    parts.append(block)
+            content = "".join(parts)
         return self._strip_think_blocks(content or "").strip()
 
     def _interim_text_was_delivered(self, text: str) -> bool:

--- a/tests/run_agent/test_interim_visible_text_block_content.py
+++ b/tests/run_agent/test_interim_visible_text_block_content.py
@@ -1,0 +1,70 @@
+"""Regression: _interim_assistant_visible_text must handle Anthropic
+block-form content (list of thinking/text dicts), not just plain strings.
+
+2026-07-17: after the v0.18 update, extended-thinking responses put
+``content`` as a list of blocks; ``_strip_think_blocks``'s ``re.sub`` then
+raised ``TypeError: expected string or bytes-like object, got 'list'`` in
+the outer conversation loop on every tool round (API call #39-43 spam).
+"""
+
+import types
+
+import pytest
+
+from run_agent import AIAgent
+
+
+@pytest.fixture
+def agent():
+    a = AIAgent.__new__(AIAgent)
+    # _interim_assistant_visible_text needs only these two helpers.
+    a._extract_codex_interim_visible_parts = types.MethodType(
+        lambda self, msg: [], a
+    )
+    return a
+
+
+def _msg(content):
+    return {"role": "assistant", "content": content}
+
+
+def test_plain_string_content_still_works(agent):
+    assert agent._interim_assistant_visible_text(_msg("hello")) == "hello"
+
+
+def test_none_content_returns_empty(agent):
+    assert agent._interim_assistant_visible_text(_msg(None)) == ""
+
+
+def test_block_list_content_extracts_text_blocks(agent):
+    content = [
+        {"type": "thinking", "thinking": "secret reasoning"},
+        {"type": "text", "text": "visible answer"},
+    ]
+    assert agent._interim_assistant_visible_text(_msg(content)) == "visible answer"
+
+
+def test_block_list_skips_thinking_and_joins_text(agent):
+    content = [
+        {"type": "text", "text": "part one "},
+        {"type": "redacted_thinking", "data": "opaque"},
+        {"type": "text", "text": "part two"},
+    ]
+    assert (
+        agent._interim_assistant_visible_text(_msg(content))
+        == "part one part two"
+    )
+
+
+def test_block_list_with_raw_strings(agent):
+    assert agent._interim_assistant_visible_text(_msg(["a", "b"])) == "ab"
+
+
+def test_block_list_only_thinking_returns_empty(agent):
+    content = [{"type": "thinking", "thinking": "only reasoning"}]
+    assert agent._interim_assistant_visible_text(_msg(content)) == ""
+
+
+def test_think_tags_still_stripped_from_block_text(agent):
+    content = [{"type": "text", "text": "<think>hidden</think>shown"}]
+    assert agent._interim_assistant_visible_text(_msg(content)) == "shown"


### PR DESCRIPTION
## Symptom

After updating to current main, every tool round on an Anthropic extended-thinking conversation logs an outer-loop error:

```
ERROR agent.conversation_loop: Outer loop error in API call #43
  File "agent/conversation_loop.py", line 4931, in run_conversation
    agent._interim_assistant_visible_text(previous_msg)
  File "run_agent.py", line 4831, in _interim_assistant_visible_text
    return self._strip_think_blocks(content or "").strip()
  File "agent/agent_runtime_helpers.py", line 678, in strip_think_blocks
    content = re.sub(r'<think>.*?</think>', '', content, ...)
TypeError: expected string or bytes-like object, got 'list'
```

## Cause

`_interim_assistant_visible_text` assumes `assistant_msg["content"]` is a string, but Anthropic extended-thinking responses carry content as a **list of blocks** (`thinking` / `redacted_thinking` / `text` dicts). The list is passed straight into `_strip_think_blocks` → `re.sub`, which raises. The duplicate-interim comparison in the outer loop (conversation_loop.py:4931) hits this on every tool round once a block-form assistant message is in history.

## Fix

Flatten block-form content to visible text before stripping: keep `text` blocks, skip `thinking`/`redacted_thinking`, tolerate raw strings in the list. Plain-string and None content behave exactly as before. Sibling call path (`current_interim_visible` on the fresh assistant_msg) goes through the same helper, so both sites are covered by the one fix.

## Tests

Regression tests cover: plain string, None, block list with thinking+text, multiple text blocks joined, raw-string lists, thinking-only (empty result), and `<think>` tag stripping still applied to block text.