### PR TITLE
fix(bedrock): serve 1M context window for Claude Opus 4.6+/Sonnet 4.6

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1305,9 +1305,20 @@ def classify_bedrock_error(error_message: str) -> str:
 # detection is unavailable.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
-    # Anthropic Claude models on Bedrock
-    "anthropic.claude-opus-4-6":     200_000,
-    "anthropic.claude-sonnet-4-6":   200_000,
+    # Anthropic Claude models on Bedrock.
+    # Opus 4.6/4.7/4.8 and Sonnet 4.6 serve a 1M context window on Bedrock
+    # when the request carries the ``context-1m-2025-08-07`` beta header,
+    # which build_anthropic_bedrock_client() attaches by default (see
+    # agent/anthropic_adapter.py). These entries must stay in sync with that
+    # header and with DEFAULT_CONTEXT_LENGTHS in agent/model_metadata.py —
+    # otherwise the 1M window is unlocked on the wire but the agent's budget
+    # is capped at 200K. Longer keys win the substring match in
+    # get_bedrock_context_length(), so the versioned 1M entries below take
+    # precedence over the generic ``anthropic.claude-opus-4`` fallback.
+    "anthropic.claude-opus-4-8":     1_000_000,
+    "anthropic.claude-opus-4-7":     1_000_000,
+    "anthropic.claude-opus-4-6":     1_000_000,
+    "anthropic.claude-sonnet-4-6":   1_000_000,
     "anthropic.claude-sonnet-4-5":   200_000,
     "anthropic.claude-haiku-4-5":    200_000,
     "anthropic.claude-opus-4":       200_000,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1167,11 +1167,19 @@ class TestBedrockContextLength:
 
     def test_claude_opus_4_6(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 200_000
+        # Opus 4.6 serves 1M on Bedrock via the context-1m-2025-08-07 beta.
+        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 1_000_000
+
+    def test_claude_opus_4_8(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Opus 4.8 (incl. global/us inference profiles) serves 1M on Bedrock.
+        assert get_bedrock_context_length("global.anthropic.claude-opus-4-8") == 1_000_000
+        assert get_bedrock_context_length("anthropic.claude-opus-4-8-20270101-v1:0") == 1_000_000
 
     def test_claude_sonnet_versioned(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 200_000
+        # Sonnet 4.6 serves 1M on Bedrock via the context-1m-2025-08-07 beta.
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 1_000_000
 
     def test_nova_pro(self):
         from agent.bedrock_adapter import get_bedrock_context_length
@@ -1187,8 +1195,11 @@ class TestBedrockContextLength:
 
     def test_inference_profile_resolves(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        # Cross-region inference profiles contain the base model ID
-        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 200_000
+        # Cross-region inference profiles contain the base model ID.
+        # Sonnet 4.6 serves 1M on Bedrock via the context-1m beta.
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 1_000_000
+        # Sonnet 4.5 (no 1M) still resolves to 200K via the same path.
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-5") == 200_000
 
     def test_longest_prefix_wins(self):
         from agent.bedrock_adapter import get_bedrock_context_length


### PR DESCRIPTION
## Summary

Bedrock Claude Opus 4.6/4.7/4.8 and Sonnet 4.6 serve a **1M context window**, but Hermes was budgeting them at **200K** — so long sessions compressed at ~half the real capacity.

The two halves of the code disagreed:

- **On the wire:** `build_anthropic_bedrock_client` (`agent/anthropic_adapter.py`) attaches the `context-1m-2025-08-07` beta header to every Bedrock Claude request, unlocking the 1M window at the API.
- **In the budget:** `get_model_context_length` resolves Bedrock via the static `BEDROCK_CONTEXT_LENGTHS` table (`agent/bedrock_adapter.py`), which capped **every** Claude model at 200K.

`opus-4-8` had no entry at all, so `global.anthropic.claude-opus-4-8` substring-matched the generic `anthropic.claude-opus-4` → 200K key. Result: 1M unlocked on the wire, 200K enforced by the agent.

## Fix

Set the 1M-capable Bedrock Claude models to `1_000_000` in `BEDROCK_CONTEXT_LENGTHS`, matching the beta header and the existing `DEFAULT_CONTEXT_LENGTHS` entries in `agent/model_metadata.py`:

| Model | Before | After |
|-------|--------|-------|
| `anthropic.claude-opus-4-8` | 200K (fell through to `opus-4`) | **1M** |
| `anthropic.claude-opus-4-7` | 200K (fell through) | **1M** |
| `anthropic.claude-opus-4-6` | 200K | **1M** |
| `anthropic.claude-sonnet-4-6` | 200K | **1M** |
| Sonnet 4.5 / Opus 4 / Sonnet 4 / Haiku 4.5 / 3.x | 200K | 200K (unchanged) |

Longer keys win the substring match in `get_bedrock_context_length`, so the generic `anthropic.claude-opus-4` fallback still catches unversioned IDs at 200K.

## Test Plan

- Updated the 3 tests in `tests/agent/test_bedrock_adapter.py` that encoded the stale 200K assumption (opus-4-6, sonnet-4-6, inference-profile), added an opus-4-8 case and a Sonnet-4.5-stays-200K guard.
- `scripts/run_tests.sh tests/agent/test_bedrock_adapter.py` → **137 passed, 0 failed**.
