### PR TITLE
fix(kanban): honor explicit named-board routing

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -29,9 +29,9 @@ Board resolution order (highest precedence first, all optional):
   ``?board=...`` query param).
 * ``HERMES_KANBAN_BOARD`` env var (used by the dispatcher to pin workers
   to the board their task lives on — workers cannot see other boards).
-* ``HERMES_KANBAN_DB`` env var (pins the DB file path directly — legacy
-  override still honoured; highest precedence when the file path itself
-  is what the caller wants to force).
+* ``HERMES_KANBAN_DB`` env var (pins implicit operations, and explicit
+  operations that re-select the same ``HERMES_KANBAN_BOARD``, to the exact
+  dispatcher-resolved path).
 * ``<root>/kanban/current`` — a one-line text file holding the slug of
   the "currently selected" board. Written by ``hermes kanban boards
   switch <slug>``. When absent, the active board is ``default``.
@@ -563,6 +563,57 @@ def _normalize_board_slug(slug: Optional[str]) -> Optional[str]:
     return s
 
 
+def _path_board_selection(board: Optional[str]) -> tuple[Optional[str], bool]:
+    """Return ``(slug, is_explicit)`` for a per-board path lookup.
+
+    ``scoped_current_board`` is explicit too: the CLI ``--board`` surface sets
+    that ContextVar, then legacy handlers call :func:`connect` without a board
+    kwarg. Treating only the direct kwarg as explicit would leave the CLI path
+    vulnerable to an inherited worker DB pin.
+    """
+    slug = _normalize_board_slug(board)
+    if slug is not None:
+        return slug, True
+    scoped = (_CURRENT_BOARD_OVERRIDE.get() or "").strip()
+    if scoped:
+        return _normalize_board_slug(scoped), True
+    return None, False
+
+
+def _path_override_for_selection(
+    env_name: str,
+    selected_slug: Optional[str],
+    *,
+    is_explicit: bool,
+) -> Optional[Path]:
+    """Return a path pin only when it belongs to the selected board.
+
+    Dispatcher-spawned workers carry both a slug and exact path pins. Implicit
+    operations, plus explicit operations targeting that same slug, must keep
+    using the exact path for custom/symlink/Docker layouts. An explicit
+    different slug must not inherit that pin or every named board collapses
+    onto the worker's current DB.
+    """
+    override = os.environ.get(env_name, "").strip()
+    if not override:
+        return None
+    if not is_explicit:
+        return Path(override).expanduser()
+    # A bare path override has no board identity to compare against. Preserve
+    # its legacy "pin everything" semantics; only the dispatcher-style pair
+    # (slug + path) gives us enough information to reject a mismatched pin.
+    pinned_raw = os.environ.get("HERMES_KANBAN_BOARD", "").strip()
+    if not pinned_raw:
+        return Path(override).expanduser()
+    try:
+        pinned_slug = _normalize_board_slug(pinned_raw)
+    except ValueError:
+        return None
+    if pinned_slug == selected_slug:
+        return Path(override).expanduser()
+    return None
+
+
 def kanban_home() -> Path:
     """Return the shared Hermes root that anchors the kanban board.
 
@@ -715,19 +766,22 @@ def kanban_db_path(board: Optional[str] = None) -> Path:
 
     Resolution (highest precedence first):
 
-    1. ``HERMES_KANBAN_DB`` env var — pins the path directly. Honoured for
-       back-compat and for the dispatcher→worker handoff (defense in
-       depth: dispatcher injects this into worker env so workers are
-       immune to any path-resolution disagreement).
-    2. When ``board`` arg is None, the active board from
-       :func:`get_current_board` is used.
+    1. A matching dispatcher path pin (``HERMES_KANBAN_DB`` together with
+       ``HERMES_KANBAN_BOARD``), or a bare legacy path pin. An explicit
+       different board ignores a dispatcher pin belonging to another slug.
+    2. When neither ``board`` nor :func:`scoped_current_board` selects a slug,
+       the active board from :func:`get_current_board` is used.
     3. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
        Other boards → ``<root>/kanban/boards/<slug>/kanban.db``.
     """
-    override = os.environ.get("HERMES_KANBAN_DB", "").strip()
+    slug, is_explicit = _path_board_selection(board)
+    override = _path_override_for_selection(
+        "HERMES_KANBAN_DB",
+        slug,
+        is_explicit=is_explicit,
+    )
     if override:
-        return Path(override).expanduser()
-    slug = _normalize_board_slug(board)
+        return override
     if slug is None:
         slug = get_current_board()
     if slug == DEFAULT_BOARD:
@@ -746,10 +800,14 @@ def workspaces_root(board: Optional[str] = None) -> Path:
     that existing scratch workspaces from before the boards feature are
     preserved. Other boards use ``<root>/kanban/boards/<slug>/workspaces/``.
     """
-    override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
+    slug, is_explicit = _path_board_selection(board)
+    override = _path_override_for_selection(
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        slug,
+        is_explicit=is_explicit,
+    )
     if override:
-        return Path(override).expanduser()
-    slug = _normalize_board_slug(board)
+        return override
     if slug is None:
         slug = get_current_board()
     if slug == DEFAULT_BOARD:

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -2,6 +2,7 @@ import asyncio
 import sqlite3
 from pathlib import Path
 
+import pytest
 
 from gateway.config import Platform
 from gateway.kanban_watchers import (
@@ -128,6 +129,21 @@ def test_kanban_notifier_replays_telegram_dm_topic_delivery_metadata(tmp_path, m
     assert len(adapter.handled) == 1
     assert adapter.handled[0].source.chat_type == "dm"
     assert adapter.handled[0].source.thread_id == "20197"
+
+
+def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "alias-a")
+    kb.create_board("alias-a", name="Alias A")
+    kb.write_board_metadata("alias-b", name="Alias B")
+    alias_a_db = kb.board_dir("alias-a") / "kanban.db"
+    alias_b_db = kb.board_dir("alias-b") / "kanban.db"
+    try:
+        alias_b_db.symlink_to(alias_a_db)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    assert alias_a_db.resolve() == alias_b_db.resolve()
 
 
 def test_active_named_profile_subscription_is_delivered(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -98,12 +98,89 @@ class TestPathResolution:
         assert p == fresh_home / "kanban" / "boards" / "atm10-server" / "kanban.db"
 
 
-    def test_env_var_db_override_still_wins(self, fresh_home, tmp_path, monkeypatch):
-        """``HERMES_KANBAN_DB`` pins the file regardless of board= arg."""
+    def test_env_var_db_override_still_wins_without_explicit_board(
+        self, fresh_home, tmp_path, monkeypatch,
+    ):
+        """``HERMES_KANBAN_DB`` keeps pinning implicit worker operations."""
         forced = tmp_path / "custom.db"
         monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
         assert kb.kanban_db_path() == forced
+
+    def test_bare_env_var_db_override_keeps_legacy_explicit_pin(
+        self, fresh_home, tmp_path, monkeypatch,
+    ):
+        """A path override without a board slug retains legacy precedence."""
+        forced = tmp_path / "custom.db"
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
         assert kb.kanban_db_path(board="ignored") == forced
+
+    def test_explicit_board_beats_different_worker_db_pin(
+        self, fresh_home, tmp_path, monkeypatch,
+    ):
+        """A worker may explicitly target another board without inheriting its own DB."""
+        forced = tmp_path / "worker-board.db"
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "worker-board")
+
+        # Re-selecting the worker's board preserves the exact dispatcher pin.
+        assert kb.kanban_db_path(board="worker-board") == forced
+        # A different explicit slug must resolve independently.
+        assert kb.kanban_db_path(board="other-board") == (
+            fresh_home / "kanban" / "boards" / "other-board" / "kanban.db"
+        )
+        # The CLI --board path uses the scoped override and then calls connect()
+        # without forwarding a board kwarg, so cover that route too.
+        with kb.scoped_current_board("other-board"):
+            assert kb.kanban_db_path() == (
+                fresh_home / "kanban" / "boards" / "other-board" / "kanban.db"
+            )
+
+    def test_explicit_board_beats_malformed_worker_board_pin(
+        self, fresh_home, tmp_path, monkeypatch,
+    ):
+        forced = tmp_path / "worker-board.db"
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "../invalid")
+
+        assert kb.kanban_db_path(board="other-board") == (
+            fresh_home / "kanban" / "boards" / "other-board" / "kanban.db"
+        )
+
+    def test_env_var_workspaces_override(self, fresh_home, tmp_path, monkeypatch):
+        forced = tmp_path / "ws"
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(forced))
+        assert kb.workspaces_root() == forced
+        assert kb.workspaces_root(board="ignored") == forced
+
+    def test_explicit_board_beats_different_worker_workspaces_pin(
+        self, fresh_home, tmp_path, monkeypatch,
+    ):
+        forced = tmp_path / "worker-workspaces"
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(forced))
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "worker-board")
+
+        assert kb.workspaces_root(board="worker-board") == forced
+        assert kb.workspaces_root(board="other-board") == (
+            fresh_home / "kanban" / "boards" / "other-board" / "workspaces"
+        )
+
+
+    def test_list_boards_keeps_distinct_paths_under_worker_pin(
+        self, fresh_home, monkeypatch,
+    ):
+        kb.create_board("worker-board")
+        kb.create_board("other-board")
+        worker_db = fresh_home / "kanban" / "boards" / "worker-board" / "kanban.db"
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "worker-board")
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(worker_db))
+
+        paths = {entry["slug"]: entry["db_path"] for entry in kb.list_boards()}
+
+        assert paths["worker-board"] == str(worker_db)
+        assert paths["other-board"] == str(
+            fresh_home / "kanban" / "boards" / "other-board" / "kanban.db"
+        )
+        assert len(set(paths.values())) == len(paths)
 
 
 # ---------------------------------------------------------------------------
@@ -342,5 +419,53 @@ class TestCLI:
         assert titlesB == ["Task B"]
         assert titlesD == []
 
+    def test_named_board_cli_routes_past_inherited_worker_pin(self, tmp_path):
+        base_env = {"HERMES_HOME": str(tmp_path)}
+        assert _cli(["boards", "create", "alpha"], env_extra=base_env).returncode == 0
+        assert _cli(["boards", "create", "beta"], env_extra=base_env).returncode == 0
+        assert _cli(
+            ["--board", "alpha", "create", "Alpha only", "--assignee", "dev"],
+            env_extra=base_env,
+        ).returncode == 0
+        for title in ("Beta one", "Beta two"):
+            assert _cli(
+                ["--board", "beta", "create", title, "--assignee", "dev"],
+                env_extra=base_env,
+            ).returncode == 0
 
+        alpha_root = tmp_path / "kanban" / "boards" / "alpha"
+        pinned_env = {
+            **base_env,
+            "HERMES_KANBAN_BOARD": "alpha",
+            "HERMES_KANBAN_DB": str(alpha_root / "kanban.db"),
+            "HERMES_KANBAN_WORKSPACES_ROOT": str(alpha_root / "workspaces"),
+        }
+
+        boards = json.loads(
+            _cli(["boards", "list", "--json"], env_extra=pinned_env).stdout
+        )
+        by_slug = {entry["slug"]: entry for entry in boards}
+        assert by_slug["alpha"]["db_path"] == str(alpha_root / "kanban.db")
+        assert by_slug["beta"]["db_path"] == str(
+            tmp_path / "kanban" / "boards" / "beta" / "kanban.db"
+        )
+        assert by_slug["alpha"]["counts"]["ready"] == 1
+        assert by_slug["beta"]["counts"]["ready"] == 2
+
+        beta_list = _cli(
+            ["--board", "beta", "list", "--json"], env_extra=pinned_env
+        )
+        assert beta_list.returncode == 0, beta_list.stderr
+        assert [task["title"] for task in json.loads(beta_list.stdout)] == [
+            "Beta one",
+            "Beta two",
+        ]
+
+    def test_board_flag_rejects_unknown(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        r = _cli(["--board", "ghost", "list"], env_extra=env)
+        # main.py's dispatcher doesn't propagate return codes today, so we
+        # assert the user-visible signal: a stderr error message. Whether
+        # the exit code stays 0 is a separate (pre-existing) issue.
+        assert "does not exist" in r.stderr
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -774,6 +774,38 @@ def multi_board_env(monkeypatch, tmp_path):
     }
 
 
+def test_board_param_routes_show_past_worker_db_pin(tmp_path, monkeypatch):
+    """An explicit tool board must beat a different dispatcher's DB pin."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.create_board("worker-board")
+    kb.create_board("other-board")
+    with kb.connect(board="other-board") as conn:
+        other_tid = kb.create_task(conn, title="other-only", assignee="worker")
+
+    worker_db = kb.board_dir("worker-board") / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "worker-board")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(worker_db))
+
+    out = json.loads(kt._handle_show({
+        "task_id": other_tid,
+        "board": "other-board",
+    }))
+
+    assert out["task"]["id"] == other_tid
+    assert out["task"]["title"] == "other-only"
+
+
 def test_board_param_none_falls_back_to_env(worker_env):
     """When ``board`` is omitted or None, behaviour is unchanged from
     before this feature — calls land on whatever the env resolves to.


### PR DESCRIPTION
## Summary

- stop dispatcher-injected `HERMES_KANBAN_DB` and `HERMES_KANBAN_WORKSPACES_ROOT` pins from overriding an explicit selection of a different board
- preserve implicit worker routing, exact-path routing when re-selecting the pinned board, and legacy bare path overrides that have no board slug
- replace the notifier's accidental global-pin de-duplication fixture with a real symlink alias and add CLI/tool regression coverage

## Root cause

Per-path overrides predate multi-project boards. When multi-board support later added `board=` and CLI scoped-board selection, `kanban_db_path()` and `workspaces_root()` still returned their env override before inspecting the selected slug. Dispatcher workers intentionally inherit both `HERMES_KANBAN_BOARD=<claimed slug>` and exact DB/workspace paths. Any in-worker call that explicitly named another board therefore reused the claimed board's path. `list_boards()` consequently reported every slug with one DB and identical counts, and `--board <other>` / Kanban tools queried the wrong DB.

The old notifier test also manufactured aliases by writing multiple metadata slugs while globally forcing one DB path, so it passed because of the same collapse rather than proving real-path alias de-duplication.

## Test plan

- `python -m pytest tests/hermes_cli/test_kanban_boards.py tests/tools/test_kanban_tools.py tests/gateway/test_kanban_notifier.py -q -o 'addopts='` — 183 passed
- `ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_boards.py tests/tools/test_kanban_tools.py tests/gateway/test_kanban_notifier.py` — passed
- `git diff --check` — passed
- broad Kanban batch — 1022 passed, 1 skipped, 17 failed; clean `origin/main` baseline produced the same 17 order-dependent failures with 1015 passed and 1 skipped, and representative failures pass in isolation
- full `tests/` collection was attempted but the local dev environment does not have the optional `acp` package, so collection stopped on the same missing optional dependency before executing the suite

## Migration and rollback

No schema or data migration is required. No board directories, metadata, aliases, current pointer, or task rows are changed.

Rollback is a normal revert of this commit. That restores the former precedence where any `HERMES_KANBAN_DB` / workspace override wins even when an explicit different board is selected.

## Safe post-merge rollout

1. Update the installed Hermes source during an idle window.
2. Restart only the Hermes gateway/dispatcher processes that must load the new code; no database restart or repair is needed.
3. In a worker-pinned environment, run `hermes kanban boards list --json` and confirm `dailygamehints`, `coursefacts`, and `portfolio-operating-system` report their own DB paths and non-identical live counts.
4. Run `hermes kanban --board dailygamehints stats` and a read-only `list`, then confirm a known DailyGameHints task resolves.
5. Confirm notifier logs show true same-realpath aliases de-duplicated once.
6. If any routing regression appears, stop the restarted processes, revert this commit, restart them again, and re-run the same read-only checks.
