### PR TITLE
Handle list content when stripping think blocks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -37,6 +37,7 @@ from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_res
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED
 from agent.error_classifier import FailoverReason
+from agent.message_content import flatten_message_text
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
 logger = logging.getLogger(__name__)
@@ -639,7 +640,7 @@ def repair_message_sequence_with_cursor(agent, messages: List[Dict]) -> int:
 
 
 
-def strip_think_blocks(agent, content: str) -> str:
+def strip_think_blocks(agent, content: Any) -> str:
     """Remove reasoning/thinking blocks from content, returning only visible text.
 
     Handles four cases:
@@ -670,6 +671,10 @@ def strip_think_blocks(agent, content: str) -> str:
     after punctuation and carries a ``name="..."`` attribute) so prose
     mentions like "Use <function> in JavaScript" are preserved.
     """
+    if not content:
+        return ""
+    if not isinstance(content, str):
+        content = flatten_message_text(content)
     if not content:
         return ""
     # 1. Closed tag pairs — case-insensitive for all variants so

--- a/tests/agent/test_message_content.py
+++ b/tests/agent/test_message_content.py
@@ -23,3 +23,14 @@ def test_flatten_message_text_accepts_object_parts():
     ]
 
     assert flatten_message_text(content) == "object text\nlegacy content"
+
+
+def test_strip_think_blocks_accepts_content_part_lists():
+    from agent.agent_runtime_helpers import strip_think_blocks
+
+    content = [
+        {"type": "thinking", "thinking": "internal scratchpad"},
+        {"type": "output_text", "text": "<think>hidden</think>Visible answer"},
+    ]
+
+    assert strip_think_blocks(None, content) == "Visible answer"


### PR DESCRIPTION
## Summary
- flatten list-shaped assistant content before stripping think/tool-call blocks
- add regression coverage for content-part lists reaching strip_think_blocks

## Verification
- ./venv/bin/python -m pytest tests/agent/test_message_content.py -q
- ./venv/bin/python -m pytest tests/agent/test_memory_provider.py::TestFlattenMessageContent -q

This fixes a production Donna failure where interim assistant delivery retried until API call #99 with: expected string or bytes-like object, got 'list'.