### PR TITLE
fix(ci): fall back to github.token for the PR label fetch on fork PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -181,7 +181,9 @@ jobs:
         id: pr-labels
         uses: ./.github/actions/retry
         env:
-          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
+          # Fork PRs cannot read repo secrets, so fall back to the built-in
+          # read-only token; the label fetch only needs read access.
+          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT || github.token }}
         with:
           command: gh pr view "${{ github.event.pull_request.number }}" --json labels --jq '.labels[].name'
       - name: Require ci-reviewed label


### PR DESCRIPTION
## What does this PR do?

Restores CI for pull requests opened from forks. Since 597615ade, the ci-review job's "Fetch PR labels" step authenticates with `secrets.AUTOFIX_BOT_PAT`. Repository secrets are not available to fork-origin `pull_request` runs, so on every fork PR the token resolves empty, `gh` exits 1, the retry wrapper fails the job after three attempts, and the "All required checks pass" aggregate goes red regardless of the PR's content.

This falls back to the built-in read-only token when the PAT is unavailable, which is enough for reading labels. Same-repo runs keep using the PAT, and the gate's decision still keys off the ci-reviewed label, which only maintainers can set, so fork PRs gain no new capability from the fallback.

## Related Issue

Fixes #66559

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `.github/workflows/lint.yml`: the "Fetch PR labels" step's `GH_TOKEN` now falls back to `github.token` when `secrets.AUTOFIX_BOT_PAT` is unavailable (fork-origin runs).

## How to Test

1. The failing case is live today: any fork PR run after 597615ade fails "Fetch PR labels" with the GH_TOKEN error (examples from three different authors in the linked issue), while same-repo #66528 passes the same step, confirming the secret-availability mechanism.
2. With this change the expression resolves to the built-in token on fork runs; `gh pr view --json labels` needs only read access, which that token has.
3. YAML validated by parse; the change is a single expression, no job or step structure touched.

Note: this PR itself edits a CI-sensitive file, so the ci-reviewed gate applies to it, and because it comes from a fork its own ci-review job will keep failing at the broken fetch step until the fix is on main. It needs a maintainer's ci-reviewed label and a merge over the red check.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q`: N/A, workflow-only change with no Python surface
- [ ] I've added tests for my changes: N/A for workflow YAML
- [x] I've tested on my platform: Ubuntu 24.04 (YAML parse plus live failure evidence from Actions runs)

### Documentation & Housekeeping

- [x] I've updated relevant documentation: N/A
- [x] I've updated `cli-config.yaml.example`: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md`: N/A
- [x] I've considered cross-platform impact: N/A (hosted-runner workflow)
- [x] I've updated tool descriptions/schemas: N/A
