### PR TITLE
fix(ci): fall back to github.token when AUTOFIX_BOT_PAT empty on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,8 @@ jobs:
         id: classify
         uses: ./.github/actions/detect-changes
         with:
-          github-token: ${{ secrets.AUTOFIX_BOT_PAT }}
+          # Fork PRs cannot read repo secrets; fall back so compare does not fail-open.
+          github-token: ${{ secrets.AUTOFIX_BOT_PAT || github.token }}
 
   # ─────────────────────────────────────────────────────────────────────
   # Lane-gated sub-workflows. Each runs in parallel after detect finishes.
@@ -224,7 +225,8 @@ jobs:
 
       - name: Collect timings and generate report
         env:
-          GITHUB_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
+          # Read-only API for timings; PAT preferred, github.token works for fork PRs.
+          GITHUB_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT || github.token }}
         run: |
           python3 scripts/ci/timings_report.py \
             --baseline ci-timings-baseline.json \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -181,7 +181,8 @@ jobs:
         id: pr-labels
         uses: ./.github/actions/retry
         env:
-          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
+          # Fork PRs cannot read repo secrets; label fetch only needs read access.
+          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT || github.token }}
         with:
           command: gh pr view "${{ github.event.pull_request.number }}" --json labels --jq '.labels[].name'
       - name: Require ci-reviewed label


### PR DESCRIPTION
## What does this PR do?

Restores CI for **every** fork PR broken since #66373 (merge `597615ade`, 2026-07-17 ~20:55 UTC).

Empty `secrets.AUTOFIX_BOT_PAT` on fork `pull_request` runs is passed into `detect-changes`, which **overrides** the action default (`github.token`). The compare API then fails (`GH_TOKEN` empty), the classifier **fails open** (`ci_review=true` + all lanes), and the required `CI-sensitive file review` job hard-fails on the same empty PAT.

### Impact first

Every external contributor PR on CI-sensitive *lanes* (and, via fail-open, even PRs that only touch Python/docs/etc.) is red through **no fault of the author**. Real test/lint/docker/js/docs lanes often go green while the required aggregate fails.

### Traced chain (file:line, not paraphrase)

1. **`.github/workflows/ci.yml:56`** — `github-token: ${{ secrets.AUTOFIX_BOT_PAT }}` with **no** `|| github.token` fallback (introduced by #66373 / `597615ade`).
2. **`.github/actions/detect-changes/action.yml:50`** — `GH_TOKEN: ${{ inputs.github-token }}` (empty string overrides action default at lines 11–12).
3. **`action.yml:72–81`** — compare API retries 3×; on failure: `::warning::compare API failed after 3 attempts — failing open (all lanes run)` and `CHANGED=""`.
4. **`scripts/ci/classify_changes.py:106–114`** — empty file list sets **all** lanes true, including **`ci_review=true`**.
5. **`.github/workflows/ci.yml:74,78`** — lint workflow runs with `ci_review: true`.
6. **`.github/workflows/lint.yml:174,184`** — `ci-review` job runs; `GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}` is empty → **"Fetch PR labels"** hard-fails after 3 retries.
7. **`.github/workflows/ci.yml:160–194`** — `All required checks pass` sees lint failure → red required gate.
8. **`.github/workflows/ci.yml:227`** — timings job also gets empty PAT (read-only API; secondary red).

### Live evidence (our run + other victims)

| Run | Head fork | Failure |
|-----|-----------|---------|
| [29615150242](https://github.com/NousResearch/hermes-agent/actions/runs/29615150242) | `pnascimento9596` (#66475, only `env_loader.py` — **not** CI files) | Detect log: `GH_TOKEN:` empty → fail-open → `ci_review=true`; **CI-sensitive file review** + **All required checks pass** red; pytest/ruff/docker/js/docs green |
| [29616122891](https://github.com/NousResearch/hermes-agent/actions/runs/29616122891) | `mssteuer` (#66550) | same: **CI-sensitive file review** |
| [29616879542](https://github.com/NousResearch/hermes-agent/actions/runs/29616879542) | `helix4u` (#66556) | same |
| [29616948596](https://github.com/NousResearch/hermes-agent/actions/runs/29616948596) | `roycepersonalassistant` | same |

Detect log excerpt from 29615150242:
```
GH_TOKEN: 
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
##[warning]compare API failed after 3 attempts — failing open (all lanes run)
Changed files:
(none)
ci_review=true
```

### Introducing change

- PR: #66373 — *fix(ci): make tests, workflows, and attribution reliable under load*
- Merge commit: `597615ade` @ **2026-07-17T20:55:24Z**
- Commit message documents: *ci: use AUTOFIX_BOT_PAT for all gh CLI / GitHub API auth*

### Fix

```yaml
${{ secrets.AUTOFIX_BOT_PAT || github.token }}
```

at:
- **ci.yml detect** (root cause — stop fail-open)
- **ci.yml timings** (read-only API; same empty-secret class)
- **lint.yml label fetch** (hard-fail site when `ci_review` is true for real CI-sensitive diffs)

Comment-post steps in lint stay PAT-only (already `head.repo.fork != true`).

### Relationship to #66559 / #66560

- Issue: **#66559** (already open — not re-filed).
- #66560 only patches **lint.yml** label fetch. That alone is **insufficient** for non-CI fork PRs: detect still fail-opens → `ci_review=true` → label fetch succeeds → **"Fail on missing label"** still reds every fork PR that never touched CI files.
- This PR fixes the **detect fail-open root** and the label-fetch/timings sites. Overlaps #66560 on the lint line intentionally (complete fix in one place).

## Related Issue

Fixes #66559

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test / what was verified

**Meta-limitation (honest):** workflow file changes from a **fork** do not run with the modified content on `pull_request` — GitHub uses the base-branch workflow. So **this PR's own CI will still demonstrate the bug** (red on the same job) until a maintainer merges to main or re-runs from a same-repo branch. Frame that as **live evidence**, not a failure of this fix.

Verified here:
1. Verbatim main-branch chain above (file:line).
2. Expression fallback semantics: empty secret → `github.token`; present PAT → PAT.
3. YAML/text edit only; no job graph changes.
4. Victim pattern across multiple forks after the #66373 merge timestamp.

Needs maintainer eyes: merge (or same-repo re-run) to confirm fork PRs that only touch Python go green without `ci-reviewed`.

## Checklist

### Code

- [x] Conventional Commits
- [x] Searched existing issues/PRs (#66559 / #66560 noted)
- [x] Scope limited to the token fallback sites
- [ ] Full pytest: N/A (workflow-only)
- [x] Platform: macOS host; evidence from Actions logs

### Documentation & Housekeeping

- [x] N/A for docs/config/AGENTS