### PR TITLE
Add authenticated skills-activation API (spec-309 Layer 2)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -53,6 +53,8 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from hermes_constants import get_hermes_home
+from tools.skills_activation import SkillsActivationService
 from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
@@ -1275,6 +1277,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "jobs_admin": False,
                 "memory_write_api": False,
                 "skills_api": True,
+                "skills_activation/v1": True,
                 "audio_api": False,
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
@@ -1306,6 +1309,35 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         })
 
+    def _register_skills_activation(self, router: "web.UrlDispatcher") -> None:
+        """Wire the Layer-2 skills-activation routes (spec 309, plan 02-01).
+
+        Constructs a ``SkillsActivationService`` from this deployment's home,
+        auth check, and deployment-derived scope (LD-1 — scope is bound to
+        the DEPLOYMENT, never derived from request bodies), then registers
+        the activation/deactivation routes. The constructed service is
+        stashed on ``self._skills_activation_service`` so ``_handle_skills``'s
+        ``?scope=managed`` delegation branch can reach it without a second
+        construction or a circular import.
+        """
+        scope = {
+            "tenantId": os.environ.get("HERMES_SKILLS_SCOPE_TENANT_ID", "deployment-local"),
+            "companyId": os.environ.get("HERMES_SKILLS_SCOPE_COMPANY_ID", "deployment-local"),
+            "agentId": os.environ.get("HERMES_SKILLS_SCOPE_AGENT_ID", "deployment-local"),
+        }
+        self._skills_activation_service = SkillsActivationService(
+            home=get_hermes_home(),
+            check_auth=self._check_auth,
+            scope=scope,
+            idem_cache=_IdempotencyCache(),
+        )
+        router.add_post(
+            "/v1/skills/activations", self._skills_activation_service.handle_activate
+        )
+        router.add_delete(
+            "/v1/skills/activations/{skill_id}", self._skills_activation_service.handle_deactivate
+        )
+
     async def _handle_skills(self, request: "web.Request") -> "web.Response":
         """GET /v1/skills — list installed skills visible to the API-server agent.
 
@@ -1321,6 +1353,14 @@ class APIServerAdapter(BasePlatformAdapter):
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
+
+        # Layer-2 extension (spec 309, plan 02-01): ?scope=managed delegates
+        # to the managed-ownership ledger's observed inventory instead of
+        # the plain live skills scan below.
+        if request.query.get("scope") == "managed":
+            skills_activation_service = getattr(self, "_skills_activation_service", None)
+            if skills_activation_service is not None:
+                return await skills_activation_service.handle_managed_inventory(request)
 
         try:
             from tools.skills_tool import _find_all_skills, _sort_skills
@@ -4522,6 +4562,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_get("/v1/capabilities", self._handle_capabilities)
             self._app.router.add_get("/v1/skills", self._handle_skills)
+            # Layer-2 activation routes (spec 309, plan 02-01).
+            self._register_skills_activation(self._app.router)
             self._app.router.add_get("/v1/toolsets", self._handle_toolsets)
             # Session/client control surface (thin wrappers over SessionDB + _run_agent)
             self._app.router.add_get("/api/sessions", self._handle_list_sessions)

--- a/tests/test_skills_activation.py
+++ b/tests/test_skills_activation.py
@@ -1,0 +1,853 @@
+"""
+Tests for the Layer-2 skills activation API (spec 309, plan 02-01).
+
+Covers POST /v1/skills/activations, DELETE /v1/skills/activations/{skillId},
+and GET /v1/skills?scope=managed against the NET-NEW ``SkillsActivationService``
+(``tools/skills_activation.py``) plus the ``api_server.activation.patch``
+extensions to the existing aiohttp API server.
+
+RED mechanics: ``tools.skills_activation`` does not exist until Task 3's
+patch/module land. Every test imports it LAZILY via ``_build_service()``
+(never at module scope), so all named tests below REGISTER at collection
+time and each FAILS independently (via ``ModuleNotFoundError`` or an
+``AttributeError``/assertion against the not-yet-patched server) rather
+than aborting collection entirely.
+
+House conventions followed (see tests/gateway/test_api_server.py:393-431,
+681-731 and tests/conftest.py:327-398): ``@pytest.mark.asyncio``,
+``TestClient(TestServer(app))``, a real ``APIServerAdapter`` built via a
+synthetic API key, and the autouse ``_hermetic_environment`` fixture that
+isolates ``HERMES_HOME`` to a fresh per-test tmp dir.
+"""
+
+import asyncio
+import hashlib
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _IdempotencyCache,
+    cors_middleware,
+    security_headers_middleware,
+)
+from hermes_constants import get_hermes_home
+
+DEFAULT_SCOPE = {
+    "tenantId": "deployment-local",
+    "companyId": "deployment-local",
+    "agentId": "deployment-local",
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers — no ledger/validation/handler logic is defined here; every
+# helper only constructs fixtures, requests, or reads real files/DB rows.
+# ---------------------------------------------------------------------------
+
+
+def _hash_of(content: str) -> str:
+    return "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _make_adapter(api_key: str = "sk-secret") -> APIServerAdapter:
+    config = PlatformConfig(enabled=True, extra={"key": api_key} if api_key else {})
+    return APIServerAdapter(config)
+
+
+def _build_service(home, check_auth, *, scope=None, idem_cache=None):
+    """Lazy import — tools.skills_activation does not exist at RED time."""
+    from tools.skills_activation import SkillsActivationService
+
+    return SkillsActivationService(
+        home=Path(home),
+        check_auth=check_auth,
+        scope=dict(scope) if scope is not None else dict(DEFAULT_SCOPE),
+        idem_cache=idem_cache if idem_cache is not None else _IdempotencyCache(),
+    )
+
+
+def _build_app(adapter: APIServerAdapter, service) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    adapter._skills_activation_service = service
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_get("/v1/skills", adapter._handle_skills)
+    app.router.add_post("/v1/skills/activations", service.handle_activate)
+    app.router.add_delete("/v1/skills/activations/{skill_id}", service.handle_deactivate)
+    return app
+
+
+def _hermetic_home() -> Path:
+    return get_hermes_home()
+
+
+def _auth_headers(key: str = "sk-secret") -> dict:
+    return {"Authorization": f"Bearer {key}"}
+
+
+def _activation_body(skill_id: str, content: str, *, idempotency_key: str, version: str = None) -> dict:
+    skill = {"skillId": skill_id, "contentHash": _hash_of(content), "content": content}
+    if version is not None:
+        skill["version"] = version
+    return {"contractVersion": "1", "idempotencyKey": idempotency_key, "skill": skill}
+
+
+def _seed_native(skills_dir: Path, name: str) -> Path:
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(f"---\nname: {name}\ndescription: native skill {name}.\n---\n\n# {name}\n\nBody.\n")
+    return skill_md
+
+
+def _managed_row_count(home: Path) -> int:
+    db_path = home / "skills_activation.db"
+    if not db_path.exists():
+        return 0
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute("SELECT COUNT(*) FROM managed_skills").fetchone()[0]
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Auth + scope (REQ-04, REQ-09)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_post_401_no_state_change():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Brand voice.\n\nBody."
+    body = _activation_body("brand-voice", content, idempotency_key="key-unauth")
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/v1/skills/activations", json=body)
+        assert resp.status == 401
+
+        resp2 = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers("wrong-key"))
+        assert resp2.status == 401
+
+        resp3 = await cli.delete("/v1/skills/activations/brand-voice")
+        assert resp3.status == 401
+
+    assert _managed_row_count(home) == 0
+    assert not (home / "skills" / "brand-voice").exists()
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_managed_inventory_401():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/v1/skills", params={"scope": "managed"})
+        assert resp.status == 401
+
+
+@pytest.mark.asyncio
+async def test_wrong_agent_assert_403_zero_state():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Wrong scope test.\n\nBody."
+
+    async with TestClient(TestServer(app)) as cli:
+        for field in ("agentId", "tenantId", "companyId"):
+            body = _activation_body(f"scope-test-{field.lower()}", content, idempotency_key=f"key-{field}")
+            body[field] = "not-the-configured-value"
+            resp = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+            assert resp.status == 403, field
+            data = await resp.json()
+            assert data["error"]["code"] == "wrong_scope"
+
+    assert _managed_row_count(home) == 0
+    assert not any((home / "skills").glob("scope-test-*"))
+
+
+@pytest.mark.asyncio
+async def test_body_scope_never_derives_ledger_scope():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Scope derivation test.\n\nBody."
+
+    async with TestClient(TestServer(app)) as cli:
+        body1 = _activation_body("scope-derive-skill", content, idempotency_key="key-1")
+        resp1 = await cli.post("/v1/skills/activations", json=body1, headers=_auth_headers())
+        assert resp1.status == 201
+        data1 = await resp1.json()
+        assert data1["ledgerEntry"]["scope"] == DEFAULT_SCOPE
+
+        body2 = _activation_body("scope-derive-skill", content, idempotency_key="key-2")
+        body2["agentId"] = DEFAULT_SCOPE["agentId"]  # matching assert — accepted, still deployment scope
+        resp2 = await cli.post("/v1/skills/activations", json=body2, headers=_auth_headers())
+        assert resp2.status == 201
+        data2 = await resp2.json()
+        assert data2["ledgerEntry"]["scope"] == DEFAULT_SCOPE
+
+
+# ---------------------------------------------------------------------------
+# Filesystem-path rejection (REQ-04)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_filesystem_path_skillid_422():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Path skillId test.\n\nBody."
+
+    async with TestClient(TestServer(app)) as cli:
+        for bad_id in ("../etc/passwd", "a/b", "a\\b", "a..b"):
+            body = {
+                "contractVersion": "1",
+                "idempotencyKey": "key-path",
+                "skill": {"skillId": bad_id, "contentHash": _hash_of(content), "content": content},
+            }
+            resp = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+            assert resp.status == 422, bad_id
+
+    assert _managed_row_count(home) == 0
+
+
+@pytest.mark.asyncio
+async def test_path_field_in_body_422():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Path field test.\n\nBody."
+    body = _activation_body("path-field-skill", content, idempotency_key="key-pf")
+    body["skill"]["filePath"] = "/etc/passwd"
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+        assert resp.status == 422
+
+    assert _managed_row_count(home) == 0
+    assert not (home / "skills" / "path-field-skill").exists()
+
+
+# ---------------------------------------------------------------------------
+# Integrity + versioning (REQ-05 server clauses)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_integrity_mismatch_409_no_partial_state():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Integrity mismatch test.\n\nReal body."
+    wrong_hash = _hash_of("this is different content entirely")
+    body = {
+        "contractVersion": "1",
+        "idempotencyKey": "key-integrity",
+        "skill": {"skillId": "integrity-skill", "contentHash": wrong_hash, "content": content},
+    }
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+        assert resp.status == 409
+        data = await resp.json()
+        assert data["error"]["code"] == "integrity_mismatch"
+
+        resp2 = await cli.get("/v1/skills", params={"scope": "managed"}, headers=_auth_headers())
+        data2 = await resp2.json()
+        assert data2["data"] == []
+
+    assert _managed_row_count(home) == 0
+    assert not (home / "skills" / "integrity-skill").exists()
+
+
+@pytest.mark.asyncio
+async def test_unknown_contract_version_refused_422():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Contract version test.\n\nBody."
+    body = _activation_body("version-skill", content, idempotency_key="key-v")
+    body["contractVersion"] = "2"
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+        assert resp.status == 422
+        data = await resp.json()
+        assert data["error"]["code"] == "unsupported_contract_version"
+
+    assert _managed_row_count(home) == 0
+
+
+# ---------------------------------------------------------------------------
+# Activation ack + observed inventory (REQ-05, REQ-06)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_activation_201_ack_ledger_and_observed():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Brand voice.\n\nBody text for the activation ack test."
+    content_hash = _hash_of(content)
+    body = _activation_body("brand-voice", content, idempotency_key="key-activate")
+
+    with patch("tools.skills_tool.SKILLS_DIR", home / "skills"):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+            assert resp.status == 201
+            data = await resp.json()
+            assert data["ack"]["skillId"] == "brand-voice"
+            assert data["ack"]["contentHash"] == content_hash
+            assert data["ack"]["reloaded"] is True
+            assert "activatedAt" in data["ack"]
+            assert data["ledgerEntry"]["managedBy"] == "paperclip-skill-contract/v1"
+            assert data["ledgerEntry"]["scope"] == DEFAULT_SCOPE
+
+            resp2 = await cli.get("/v1/skills", params={"scope": "managed"}, headers=_auth_headers())
+            data2 = await resp2.json()
+            managed = {e["name"]: e for e in data2["data"]}
+            assert managed["brand-voice"]["contentHash"] == content_hash
+
+            resp3 = await cli.get("/v1/skills", headers=_auth_headers())
+            data3 = await resp3.json()
+            base_names = {e["name"] for e in data3["data"]}
+            assert "brand-voice" in base_names
+
+
+@pytest.mark.asyncio
+async def test_managed_inventory_excludes_remote_native():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    _seed_native(home / "skills", "native-tool")
+
+    with patch("tools.skills_tool.SKILLS_DIR", home / "skills"):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/skills", headers=_auth_headers())
+            data = await resp.json()
+            assert "native-tool" in {e["name"] for e in data["data"]}
+
+            resp2 = await cli.get("/v1/skills", params={"scope": "managed"}, headers=_auth_headers())
+            data2 = await resp2.json()
+            assert "native-tool" not in {e["name"] for e in data2["data"]}
+
+
+# ---------------------------------------------------------------------------
+# Cleanup / rollback / native-ownership (REQ-06)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_native_403_not_managed():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    skill_md = _seed_native(home / "skills", "native-del")
+    before = skill_md.read_text()
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.delete("/v1/skills/activations/native-del", headers=_auth_headers())
+        assert resp.status == 403
+        data = await resp.json()
+        assert data["error"]["code"] == "not_managed"
+
+    assert skill_md.read_text() == before
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_404():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.delete("/v1/skills/activations/nonexistent-skill", headers=_auth_headers())
+        assert resp.status == 404
+
+
+@pytest.mark.asyncio
+async def test_clean_removes_managed_only():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    native_md = _seed_native(home / "skills", "native-keep")
+    native_before = native_md.read_text()
+    content = "# Managed clean test.\n\nBody."
+    body = _activation_body("managed-clean", content, idempotency_key="key-clean")
+
+    with patch("tools.skills_tool.SKILLS_DIR", home / "skills"):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+            assert resp.status == 201
+
+            resp2 = await cli.delete(
+                "/v1/skills/activations/managed-clean", params={"mode": "clean"}, headers=_auth_headers()
+            )
+            assert resp2.status == 200
+            data2 = await resp2.json()
+            assert data2["ack"]["removed"] is True
+
+            resp3 = await cli.get("/v1/skills", headers=_auth_headers())
+            data3 = await resp3.json()
+            base_names = {e["name"] for e in data3["data"]}
+            assert "native-keep" in base_names
+            assert "managed-clean" not in base_names
+
+    assert native_md.read_text() == native_before
+    assert not (home / "skills" / "managed-clean").exists()
+    assert _managed_row_count(home) == 0
+
+
+# ---------------------------------------------------------------------------
+# Idempotency + concurrency (REQ-07 server primitives, INT-004)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idempotent_replay_returns_original_ack_200():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Replay test.\n\nBody."
+    body = _activation_body("replay-skill", content, idempotency_key="replay-key")
+
+    async with TestClient(TestServer(app)) as cli:
+        resp1 = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+        assert resp1.status == 201
+        data1 = await resp1.json()
+
+        resp2 = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+        assert resp2.status == 200
+        data2 = await resp2.json()
+        assert data2["ack"] == data1["ack"]
+
+    assert _managed_row_count(home) == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_conflict_different_body_409():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content1 = "# Conflict v1.\n\nBody one."
+    content2 = "# Conflict v2, genuinely different.\n\nBody two."
+    body1 = _activation_body("conflict-skill", content1, idempotency_key="conflict-key")
+    body2 = _activation_body("conflict-skill", content2, idempotency_key="conflict-key")
+
+    async with TestClient(TestServer(app)) as cli:
+        resp1 = await cli.post("/v1/skills/activations", json=body1, headers=_auth_headers())
+        assert resp1.status == 201
+
+        resp2 = await cli.post("/v1/skills/activations", json=body2, headers=_auth_headers())
+        assert resp2.status == 409
+        data2 = await resp2.json()
+        assert data2["error"]["code"] == "idempotency_conflict"
+
+        resp3 = await cli.get("/v1/skills", params={"scope": "managed"}, headers=_auth_headers())
+        data3 = await resp3.json()
+        row = next(e for e in data3["data"] if e["name"] == "conflict-skill")
+        assert row["contentHash"] == _hash_of(content1)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_key_single_execution():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Concurrent same key.\n\nBody."
+    body = _activation_body("concurrent-skill", content, idempotency_key="concurrent-key")
+
+    call_count = {"n": 0}
+    original_write = service._write_skill_file_atomic
+
+    def counting_write(skill_id, content_):
+        call_count["n"] += 1
+        return original_write(skill_id, content_)
+
+    service._write_skill_file_atomic = counting_write
+
+    async with TestClient(TestServer(app)) as cli:
+        responses = await asyncio.gather(
+            *[cli.post("/v1/skills/activations", json=body, headers=_auth_headers()) for _ in range(5)]
+        )
+        payloads = [await r.json() for r in responses]
+
+    acks = [p["ack"] for p in payloads]
+    assert all(a == acks[0] for a in acks)
+    assert call_count["n"] == 1
+    assert _managed_row_count(home) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_distinct_keys_converge_single_row():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Distinct keys, same content.\n\nBody."
+    body_a = _activation_body("distinct-skill", content, idempotency_key="key-a")
+    body_b = _activation_body("distinct-skill", content, idempotency_key="key-b")
+
+    async with TestClient(TestServer(app)) as cli:
+        resp_a, resp_b = await asyncio.gather(
+            cli.post("/v1/skills/activations", json=body_a, headers=_auth_headers()),
+            cli.post("/v1/skills/activations", json=body_b, headers=_auth_headers()),
+        )
+        assert resp_a.status in (200, 201)
+        assert resp_b.status in (200, 201)
+
+    assert _managed_row_count(home) == 1
+    conn = sqlite3.connect(str(home / "skills_activation.db"))
+    row = conn.execute(
+        "SELECT content_hash, previous_state_json FROM managed_skills WHERE skill_id = ?",
+        ("distinct-skill",),
+    ).fetchone()
+    conn.close()
+    assert row[0] == _hash_of(content)
+    assert row[1] is None
+
+
+# ---------------------------------------------------------------------------
+# Rollback semantics (REQ-07 server primitives, spec AC-007)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rollback_restores_prior_managed_set():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content_v1 = "# Rollback v1.\n\nBody v1."
+    content_v2 = "# Rollback v2, genuinely different.\n\nBody v2."
+    body_v1 = _activation_body("rollback-skill", content_v1, idempotency_key="key-v1")
+    body_v2 = _activation_body("rollback-skill", content_v2, idempotency_key="key-v2")
+
+    async with TestClient(TestServer(app)) as cli:
+        resp1 = await cli.post("/v1/skills/activations", json=body_v1, headers=_auth_headers())
+        assert resp1.status == 201
+
+        resp2 = await cli.post("/v1/skills/activations", json=body_v2, headers=_auth_headers())
+        assert resp2.status == 201
+
+        resp3 = await cli.delete(
+            "/v1/skills/activations/rollback-skill", params={"mode": "rollback"}, headers=_auth_headers()
+        )
+        assert resp3.status == 200
+
+        resp4 = await cli.get("/v1/skills", params={"scope": "managed"}, headers=_auth_headers())
+        data4 = await resp4.json()
+        row = next(e for e in data4["data"] if e["name"] == "rollback-skill")
+        assert row["contentHash"] == _hash_of(content_v1)
+
+    assert (home / "skills" / "rollback-skill" / "SKILL.md").read_text() == content_v1
+
+
+@pytest.mark.asyncio
+async def test_rollback_initial_activation_removes_entry():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Initial activation only.\n\nBody."
+    body1 = _activation_body("initial-skill", content, idempotency_key="key-first")
+    body2 = _activation_body("initial-skill", content, idempotency_key="key-second")
+
+    with patch("tools.skills_tool.SKILLS_DIR", home / "skills"):
+        async with TestClient(TestServer(app)) as cli:
+            resp1 = await cli.post("/v1/skills/activations", json=body1, headers=_auth_headers())
+            assert resp1.status == 201
+            data1 = await resp1.json()
+            assert data1["ledgerEntry"]["previousState"] is None
+
+            # Same content, new idempotencyKey — must be a no-op refresh, never
+            # a fabricated previousState.
+            resp2 = await cli.post("/v1/skills/activations", json=body2, headers=_auth_headers())
+            assert resp2.status == 201
+            data2 = await resp2.json()
+            assert data2["ledgerEntry"]["previousState"] is None
+
+            resp3 = await cli.delete(
+                "/v1/skills/activations/initial-skill", params={"mode": "rollback"}, headers=_auth_headers()
+            )
+            assert resp3.status == 200
+
+            resp4 = await cli.get("/v1/skills", params={"scope": "managed"}, headers=_auth_headers())
+            data4 = await resp4.json()
+            assert all(e["name"] != "initial-skill" for e in data4["data"])
+
+    assert not (home / "skills" / "initial-skill").exists()
+    assert _managed_row_count(home) == 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant isolation (REQ-09 two-server proof)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_deployments_zero_cross_leakage(tmp_path):
+    home_a = tmp_path / "deployment-a"
+    home_b = tmp_path / "deployment-b"
+    (home_a / "skills").mkdir(parents=True)
+    (home_b / "skills").mkdir(parents=True)
+
+    adapter_a = _make_adapter(api_key="key-a")
+    adapter_b = _make_adapter(api_key="key-b")
+    service_a = _build_service(
+        home_a, adapter_a._check_auth,
+        scope={"tenantId": "tenant-a", "companyId": "tenant-a", "agentId": "tenant-a"},
+    )
+    service_b = _build_service(
+        home_b, adapter_b._check_auth,
+        scope={"tenantId": "tenant-b", "companyId": "tenant-b", "agentId": "tenant-b"},
+    )
+    app_a = _build_app(adapter_a, service_a)
+    app_b = _build_app(adapter_b, service_b)
+
+    content = "# Cross-tenant test.\n\nBody."
+    body = _activation_body("cross-skill", content, idempotency_key="cross-key")
+
+    async with TestClient(TestServer(app_b)) as cli_b:
+        resp_post = await cli_b.post("/v1/skills/activations", json=body, headers=_auth_headers("key-a"))
+        assert resp_post.status == 401
+        resp_del = await cli_b.delete("/v1/skills/activations/cross-skill", headers=_auth_headers("key-a"))
+        assert resp_del.status == 401
+        resp_get = await cli_b.get(
+            "/v1/skills", params={"scope": "managed"}, headers=_auth_headers("key-a")
+        )
+        assert resp_get.status == 401
+
+    async with TestClient(TestServer(app_a)) as cli_a:
+        resp_ok = await cli_a.post("/v1/skills/activations", json=body, headers=_auth_headers("key-a"))
+        assert resp_ok.status == 201
+
+    async with TestClient(TestServer(app_b)) as cli_b2:
+        resp_b_managed = await cli_b2.get(
+            "/v1/skills", params={"scope": "managed"}, headers=_auth_headers("key-b")
+        )
+        data_b = await resp_b_managed.json()
+        assert data_b["data"] == []
+
+    assert not (home_b / "skills" / "cross-skill").exists()
+    assert _managed_row_count(home_a) == 1
+    assert _managed_row_count(home_b) == 0
+
+
+@pytest.mark.asyncio
+async def test_native_skill_activation_409_conflict():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    native_md = _seed_native(home / "skills", "native-conflict")
+    before = native_md.read_text()
+    content = "# Hijack attempt.\n\nBody."
+    body = _activation_body("native-conflict", content, idempotency_key="key-hijack")
+
+    with patch("tools.skills_tool.SKILLS_DIR", home / "skills"):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+            assert resp.status == 409
+            data = await resp.json()
+            assert data["error"]["code"] == "native_conflict"
+
+            resp2 = await cli.get("/v1/skills", params={"scope": "managed"}, headers=_auth_headers())
+            data2 = await resp2.json()
+            assert data2["data"] == []
+
+    assert native_md.read_text() == before
+    assert _managed_row_count(home) == 0
+
+
+# ---------------------------------------------------------------------------
+# Hostile-input DELETE handling (adjudication round 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_delete_mode_422():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Mode validation test.\n\nBody."
+    body = _activation_body("mode-skill", content, idempotency_key="key-mode")
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+        assert resp.status == 201
+
+        resp_bad_mode = await cli.delete(
+            "/v1/skills/activations/mode-skill", params={"mode": "purge"}, headers=_auth_headers()
+        )
+        assert resp_bad_mode.status == 422
+
+        resp_dup_mode = await cli.request(
+            "DELETE",
+            "/v1/skills/activations/mode-skill?mode=clean&mode=rollback",
+            headers=_auth_headers(),
+        )
+        assert resp_dup_mode.status == 422
+
+        resp_traversal = await cli.delete("/v1/skills/activations/a..b", headers=_auth_headers())
+        assert resp_traversal.status == 422
+
+    assert (home / "skills" / "mode-skill" / "SKILL.md").exists()
+    assert _managed_row_count(home) == 1
+
+
+@pytest.mark.asyncio
+async def test_replay_after_clean_reexecutes():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content = "# Replay after clean.\n\nBody."
+    body = _activation_body("replay-clean-skill", content, idempotency_key="replay-clean-key")
+
+    async with TestClient(TestServer(app)) as cli:
+        resp1 = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+        assert resp1.status == 201
+
+        resp_clean = await cli.delete(
+            "/v1/skills/activations/replay-clean-skill", params={"mode": "clean"}, headers=_auth_headers()
+        )
+        assert resp_clean.status == 200
+
+        resp2 = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+        assert resp2.status == 201  # fresh execution, NOT a stale 200 replay
+
+    assert (home / "skills" / "replay-clean-skill" / "SKILL.md").exists()
+    assert _managed_row_count(home) == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_ledger_failure_restores_prior_file():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+    content_v1 = "# Ledger-failure v1.\n\nBody v1."
+    content_v2 = "# Ledger-failure v2, genuinely different.\n\nBody v2."
+    body_v1 = _activation_body("ledger-fail-skill", content_v1, idempotency_key="key-lf1")
+    body_v2 = _activation_body("ledger-fail-skill", content_v2, idempotency_key="key-lf2")
+
+    async with TestClient(TestServer(app)) as cli:
+        resp1 = await cli.post("/v1/skills/activations", json=body_v1, headers=_auth_headers())
+        assert resp1.status == 201
+
+        original_upsert = service._upsert_managed_row
+        call_state = {"raised": False}
+
+        def failing_upsert(*args, **kwargs):
+            if not call_state["raised"]:
+                call_state["raised"] = True
+                raise RuntimeError("simulated ledger failure")
+            return original_upsert(*args, **kwargs)
+
+        service._upsert_managed_row = failing_upsert
+
+        resp2 = await cli.post("/v1/skills/activations", json=body_v2, headers=_auth_headers())
+        assert resp2.status >= 400
+
+    assert (home / "skills" / "ledger-fail-skill" / "SKILL.md").read_text() == content_v1
+    conn = sqlite3.connect(str(home / "skills_activation.db"))
+    row = conn.execute(
+        "SELECT content_hash, previous_state_json FROM managed_skills WHERE skill_id = ?",
+        ("ledger-fail-skill",),
+    ).fetchone()
+    conn.close()
+    assert row[0] == _hash_of(content_v1)
+    assert row[1] is None
+
+
+# ---------------------------------------------------------------------------
+# Capability advert + real patched wiring (contract §Versioning)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capabilities_advertises_activation():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    service = _build_service(home, adapter._check_auth)
+    app = _build_app(adapter, service)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/v1/capabilities", headers=_auth_headers())
+        assert resp.status == 200
+        data = await resp.json()
+        features = data["features"]
+        assert isinstance(features, dict)
+        assert features.get("skills_api") is True
+        assert features.get("skills_activation/v1") is True
+
+
+@pytest.mark.asyncio
+async def test_patched_server_wiring_real_adapter():
+    home = _hermetic_home()
+    adapter = _make_adapter()
+    app = web.Application(
+        middlewares=[mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    )
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/v1/skills", adapter._handle_skills)
+
+    # Real construction path — service built by the adapter itself from
+    # get_hermes_home()/env scope + its own _check_auth + a fresh
+    # _IdempotencyCache (patch-added method; AttributeError pre-patch).
+    adapter._register_skills_activation(app.router)
+
+    content = "# Wired via the real patch.\n\nBody."
+    body = _activation_body("wired-skill", content, idempotency_key="key-wired")
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/v1/skills/activations", json=body, headers=_auth_headers())
+        assert resp.status == 201
+
+        resp2 = await cli.get("/v1/skills", params={"scope": "managed"}, headers=_auth_headers())
+        assert resp2.status == 200
+        data2 = await resp2.json()
+        assert "wired-skill" in {e["name"] for e in data2["data"]}
+
+    # Source-level smoke (flagged for Phase-4 live re-verification): connect()
+    # must actually call the patch-added registration method — not just make
+    # it callable in isolation.
+    import inspect
+    from gateway.platforms import api_server as api_server_module
+
+    source = inspect.getsource(api_server_module.APIServerAdapter.connect)
+    assert "_register_skills_activation" in source

--- a/tools/skills_activation.py
+++ b/tools/skills_activation.py
@@ -1,0 +1,679 @@
+"""
+Layer-2 skills activation API (spec 309, plan 02-01, upstream-PR-quality).
+
+Implements the NET-NEW managed-skills-activation contract on top of the
+existing Hermes Agent aiohttp API server:
+
+- ``POST /v1/skills/activations``   — activate/refresh a managed skill
+- ``DELETE /v1/skills/activations/{skillId}?mode=clean|rollback`` — cleanup
+- ``GET /v1/skills?scope=managed``  — managed-only observed inventory
+
+Design notes (see 02-01-PLAN.md <locked_decisions> for the adjudicated
+rationale):
+
+- Scope is bound to the DEPLOYMENT (LD-1) — never derived from request
+  body fields. A body-carried scope assertion is validated against the
+  configured deployment scope; mismatch is a 403, never a silent override.
+- The managed-ownership ledger is a NEW, separate WAL-mode SQLite file
+  (``skills_activation.db``) under the injected home, decoupled from
+  ``hermes_state.py``'s session-schema evolution (LD-3). The WAL-with-
+  NFS-fallback helper below is a copied/adapted shape from
+  ``hermes_state.py:143-203`` (COPIED, not imported, by design).
+- Idempotency has two tiers: a DURABLE tier (the ledger's
+  ``idempotency_key``/``fingerprint`` columns, checked with a plain read
+  before touching the in-memory cache) and an IN-FLIGHT tier (the
+  injected ``_IdempotencyCache`` instance's ``get_or_set``, which
+  collapses genuinely concurrent identical requests into one execution
+  via its shielded-task pattern). Because aiohttp/asyncio here is single-
+  threaded and the write-critical-section below contains no ``await``,
+  the section is *already* atomic with respect to the event loop; the
+  ledger's own SQLite transaction (``BEGIN IMMEDIATE``) is the durable,
+  audit-honest backstop, not a workaround for a race that couldn't
+  otherwise occur in this process.
+- Replay lifetime is scoped to "the current managed row": DELETE (clean
+  or any rollback that removes the row) bumps a per-skill in-memory
+  epoch counter, which is folded into the in-flight cache's key
+  namespace. This makes a post-delete cache hit unreachable without
+  reaching into ``_IdempotencyCache``'s private store (no modification
+  to that class needed).
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import hmac
+import json
+import os
+import re
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+try:
+    from aiohttp import web
+except ImportError:  # pragma: no cover - aiohttp is an exact-pinned fork dep
+    web = None  # type: ignore[assignment]
+
+SCHEMA_VERSION = 1
+MANAGED_BY = "paperclip-skill-contract/v1"
+MAX_CONTENT_BYTES = 1024 * 1024  # 1 MiB
+MAX_MANAGED_ENTRIES = 500
+MAX_BODY_DEPTH = 8
+CONTRACT_VERSION = "1"
+
+_SKILL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_VERSION_RE = re.compile(r"^[A-Za-z0-9._-]{1,32}$")
+_CONTENT_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IDEMPOTENCY_KEY_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+_PATH_KEY_DENYLIST = {
+    "path", "filePath", "file_path", "sourcePath", "source_path",
+    "localPath", "local_path", "dir", "directory",
+}
+
+# ---------------------------------------------------------------------------
+# WAL-mode-with-NFS-fallback (copied/adapted shape from hermes_state.py:143-203,
+# LD-3 — decoupled deliberately, not imported).
+# ---------------------------------------------------------------------------
+
+_WAL_INCOMPAT_MARKERS = ("locking protocol", "not authorized")
+
+
+def _apply_wal_with_fallback(conn: sqlite3.Connection, *, db_label: str = "skills_activation.db") -> str:
+    """Set journal_mode=WAL, falling back to DELETE on WAL-incompatible filesystems."""
+    try:
+        current = conn.execute("PRAGMA journal_mode").fetchone()
+        if current and current[0] == "wal":
+            return "wal"
+    except sqlite3.OperationalError:
+        pass
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        return "wal"
+    except sqlite3.OperationalError as exc:
+        msg = str(exc).lower()
+        if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
+            raise
+        conn.execute("PRAGMA journal_mode=DELETE")
+        return "delete"
+
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS schema_meta (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    schema_version INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS managed_skills (
+    skill_id TEXT PRIMARY KEY,
+    content_hash TEXT NOT NULL,
+    version TEXT,
+    scope_json TEXT NOT NULL,
+    managed_by TEXT NOT NULL,
+    activated_at TEXT NOT NULL,
+    previous_state_json TEXT,
+    idempotency_key TEXT NOT NULL,
+    fingerprint TEXT NOT NULL
+);
+"""
+
+
+def _safe_rollback(conn: sqlite3.Connection) -> None:
+    try:
+        conn.execute("ROLLBACK")
+    except sqlite3.OperationalError:
+        pass  # no transaction was active — already committed/rolled back
+
+
+def _open_ledger(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path), isolation_level=None)  # autocommit; we BEGIN explicitly
+    conn.row_factory = sqlite3.Row
+    _apply_wal_with_fallback(conn, db_label=db_path.name)
+    conn.executescript(_SCHEMA_SQL)
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_meta (id, schema_version) VALUES (1, ?)",
+        (SCHEMA_VERSION,),
+    )
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class _ActivationError(Exception):
+    """Carries an HTTP status + house-shaped error envelope."""
+
+    def __init__(self, status: int, code: str, message: str):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+
+
+def _error_response(status: int, code: str, message: str) -> "web.Response":
+    return web.json_response(
+        {"error": {"message": message, "type": "invalid_request_error", "code": code}},
+        status=status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _contains_path_like(value: str) -> bool:
+    return "/" in value or "\\" in value or ".." in value
+
+
+def _scan_body_for_path_payloads(node: Any, *, depth: int, skip_key: Optional[str] = None) -> None:
+    """Raise _ActivationError(422) if any denylisted key or path-like string value is found.
+
+    ``skip_key`` names the ONE key (skill.content) whose string value is
+    exempt from the path-like-value scan (it legitimately contains
+    arbitrary skill markdown, which may include '/' or '..' in prose).
+    """
+    if depth > MAX_BODY_DEPTH:
+        raise _ActivationError(422, "invalid_request", "request body nesting too deep")
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in _PATH_KEY_DENYLIST:
+                raise _ActivationError(422, "invalid_request", f"disallowed path-shaped key: {key}")
+            child_skip = "content" if key == skip_key else None
+            _scan_body_for_path_payloads(value, depth=depth + 1, skip_key=child_skip)
+    elif isinstance(node, list):
+        for item in node:
+            _scan_body_for_path_payloads(item, depth=depth + 1, skip_key=skip_key)
+    elif isinstance(node, str):
+        if skip_key == "content":
+            return
+        if _contains_path_like(node):
+            raise _ActivationError(422, "invalid_request", "path-shaped value rejected")
+
+
+def _canonical_fingerprint(body: Dict[str, Any]) -> str:
+    canonical = json.dumps(body, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _validate_activation_body(body: Any) -> Dict[str, Any]:
+    if not isinstance(body, dict):
+        raise _ActivationError(422, "invalid_request", "request body must be a JSON object")
+
+    # Scan for path-shaped denylisted keys/values BEFORE anything else,
+    # so a filesystem-path payload is rejected regardless of what other
+    # fields are also missing/malformed.
+    _scan_body_for_path_payloads(body, depth=0, skip_key="skill")
+
+    contract_version = body.get("contractVersion")
+    if contract_version != CONTRACT_VERSION:
+        raise _ActivationError(422, "unsupported_contract_version", "unknown or missing contractVersion")
+
+    idempotency_key = body.get("idempotencyKey")
+    if not isinstance(idempotency_key, str) or not _IDEMPOTENCY_KEY_RE.match(idempotency_key):
+        raise _ActivationError(422, "invalid_request", "idempotencyKey missing or malformed")
+
+    skill = body.get("skill")
+    if not isinstance(skill, dict):
+        raise _ActivationError(422, "invalid_request", "skill object missing")
+
+    skill_id = skill.get("skillId")
+    if not isinstance(skill_id, str) or not _SKILL_ID_RE.match(skill_id):
+        raise _ActivationError(422, "invalid_request", "skillId missing or malformed")
+
+    version = skill.get("version")
+    if version is not None and (not isinstance(version, str) or not _VERSION_RE.match(version)):
+        raise _ActivationError(422, "invalid_request", "version malformed")
+
+    content_hash = skill.get("contentHash")
+    if not isinstance(content_hash, str) or not _CONTENT_HASH_RE.match(content_hash):
+        raise _ActivationError(422, "invalid_request", "contentHash missing or malformed")
+
+    content = skill.get("content")
+    if not isinstance(content, str) or len(content) == 0:
+        raise _ActivationError(422, "invalid_request", "content missing or empty")
+    if len(content.encode("utf-8")) > MAX_CONTENT_BYTES:
+        raise _ActivationError(422, "invalid_request", "content exceeds maximum size")
+
+    # Optional body-asserted scope fields (LD-1): validated, never derived.
+    scope_assert: Dict[str, str] = {}
+    for field in ("agentId", "tenantId", "companyId"):
+        val = body.get(field)
+        if val is not None:
+            if not isinstance(val, str):
+                raise _ActivationError(422, "invalid_request", f"{field} must be a string")
+            scope_assert[field] = val
+
+    return {
+        "idempotency_key": idempotency_key,
+        "skill_id": skill_id,
+        "version": version,
+        "content_hash": content_hash,
+        "content": content,
+        "scope_assert": scope_assert,
+    }
+
+
+_SCOPE_ASSERT_TO_LEDGER_FIELD = {
+    "agentId": "agentId",
+    "tenantId": "tenantId",
+    "companyId": "companyId",
+}
+
+
+class SkillsActivationService:
+    """Constructor-injected Layer-2 activation service.
+
+    Parameters mirror the plan's <artifacts> symbol contract exactly:
+    ``home`` (Path — deployment home, defaulting production callers to
+    ``get_hermes_home()``), ``check_auth`` (the exact ``_check_auth``
+    contract: returns ``None`` on OK, a 401 ``web.Response`` otherwise),
+    ``scope`` (the deployment's configured scope dict — LD-1), and
+    ``idem_cache`` (an ``_IdempotencyCache`` INSTANCE, injected to avoid
+    a circular import with ``api_server.py``).
+    """
+
+    def __init__(
+        self,
+        home: Path,
+        check_auth: Callable[[Any], Optional[Any]],
+        scope: Dict[str, str],
+        idem_cache: Any,
+    ) -> None:
+        self._home = Path(home)
+        self._check_auth = check_auth
+        self._scope = dict(scope)
+        self._idem_cache = idem_cache
+        self._skills_dir = self._home / "skills"
+        self._db_path = self._home / "skills_activation.db"
+        self._epoch: Dict[str, int] = {}
+
+    # -- shared plumbing ---------------------------------------------------
+
+    def _conn(self) -> sqlite3.Connection:
+        return _open_ledger(self._db_path)
+
+    def _cache_key(self, skill_id: str, idempotency_key: str) -> str:
+        epoch = self._epoch.get(skill_id, 0)
+        return f"{skill_id}#{epoch}#{idempotency_key}"
+
+    def _skill_md_path(self, skill_id: str) -> Path:
+        target = (self._skills_dir / skill_id / "SKILL.md").resolve()
+        containment_root = self._skills_dir.resolve()
+        if containment_root not in target.parents and target != containment_root:
+            raise _ActivationError(422, "invalid_request", "skillId resolves outside the managed skills root")
+        return target
+
+    def _is_native_on_disk(self, skill_id: str, conn: sqlite3.Connection) -> bool:
+        """True when a SKILL.md exists on disk for this id with NO ledger row."""
+        row = conn.execute(
+            "SELECT 1 FROM managed_skills WHERE skill_id = ?", (skill_id,)
+        ).fetchone()
+        if row is not None:
+            return False
+        skill_md = self._skills_dir / skill_id / "SKILL.md"
+        return skill_md.exists()
+
+    def _fetch_row(self, skill_id: str, conn: sqlite3.Connection) -> Optional[sqlite3.Row]:
+        return conn.execute(
+            "SELECT * FROM managed_skills WHERE skill_id = ?", (skill_id,)
+        ).fetchone()
+
+    def _upsert_managed_row(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        skill_id: str,
+        content_hash: str,
+        version: Optional[str],
+        previous_state: Optional[Dict[str, Any]],
+        idempotency_key: str,
+        fingerprint: str,
+        activated_at: str,
+    ) -> None:
+        """The single ledger-write step — a dedicated method so fault-injection
+        tests can monkeypatch exactly this call to simulate a ledger failure
+        after the file write (before-image restoration test)."""
+        conn.execute(
+            "INSERT INTO managed_skills "
+            "(skill_id, content_hash, version, scope_json, managed_by, activated_at, "
+            " previous_state_json, idempotency_key, fingerprint) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(skill_id) DO UPDATE SET "
+            " content_hash=excluded.content_hash, version=excluded.version, "
+            " activated_at=excluded.activated_at, previous_state_json=excluded.previous_state_json, "
+            " idempotency_key=excluded.idempotency_key, fingerprint=excluded.fingerprint",
+            (
+                skill_id,
+                content_hash,
+                version,
+                json.dumps(self._scope),
+                MANAGED_BY,
+                activated_at,
+                json.dumps(previous_state) if previous_state is not None else None,
+                idempotency_key,
+                fingerprint,
+            ),
+        )
+
+    def _write_skill_file_atomic(self, skill_id: str, content: str) -> None:
+        skill_md = self._skill_md_path(skill_id)
+        skill_md.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = skill_md.with_suffix(skill_md.suffix + f".tmp-{os.getpid()}-{time.time_ns()}")
+        tmp_path.write_text(content, encoding="utf-8")
+        os.replace(tmp_path, skill_md)
+
+    def _restore_before_image(self, skill_id: str, before_content: Optional[str]) -> None:
+        skill_md = self._skill_md_path(skill_id)
+        if before_content is None:
+            skill_md.unlink(missing_ok=True)
+        else:
+            self._write_skill_file_atomic(skill_id, before_content)
+
+    def _ledger_entry_from_row(self, row: sqlite3.Row) -> Dict[str, Any]:
+        return {
+            "skillId": row["skill_id"],
+            "contentHash": row["content_hash"],
+            "version": row["version"],
+            "scope": json.loads(row["scope_json"]),
+            "managedBy": row["managed_by"],
+            "activatedAt": row["activated_at"],
+            "previousState": json.loads(row["previous_state_json"]) if row["previous_state_json"] else None,
+            "idempotencyKey": row["idempotency_key"],
+        }
+
+    def _ack_from_row(self, row: sqlite3.Row, *, reloaded: bool = True) -> Dict[str, Any]:
+        return {
+            "skillId": row["skill_id"],
+            "contentHash": row["content_hash"],
+            "activatedAt": row["activated_at"],
+            "reloaded": reloaded,
+        }
+
+    def _check_scope_assert(self, scope_assert: Dict[str, str]) -> Optional[str]:
+        for field, ledger_field in _SCOPE_ASSERT_TO_LEDGER_FIELD.items():
+            if field in scope_assert:
+                configured = self._scope.get(ledger_field)
+                if scope_assert[field] != configured:
+                    return field
+        return None
+
+    # -- POST /v1/skills/activations ---------------------------------------
+
+    async def handle_activate(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            raw_body = await request.text()
+        except Exception:
+            return _error_response(422, "invalid_request", "unreadable request body")
+
+        try:
+            parsed = json.loads(raw_body)
+        except (json.JSONDecodeError, ValueError):
+            return _error_response(422, "invalid_request", "request body is not valid JSON")
+
+        try:
+            validated = _validate_activation_body(parsed)
+        except _ActivationError as exc:
+            return _error_response(exc.status, exc.code, exc.message)
+
+        mismatched_field = self._check_scope_assert(validated["scope_assert"])
+        if mismatched_field:
+            return _error_response(403, "wrong_scope", f"scope assertion mismatch: {mismatched_field}")
+
+        skill_id = validated["skill_id"]
+        idempotency_key = validated["idempotency_key"]
+        fingerprint = _canonical_fingerprint(parsed)
+
+        conn = self._conn()
+        try:
+            # Native-ownership guard: an on-disk skill with NO ledger row
+            # must never be hijacked by activation.
+            if self._is_native_on_disk(skill_id, conn):
+                return _error_response(409, "native_conflict", "skillId belongs to a remote-native skill")
+
+            # Durable idempotency replay — plain read, no cache involved.
+            existing = self._fetch_row(skill_id, conn)
+            if existing is not None and existing["idempotency_key"] == idempotency_key:
+                if existing["fingerprint"] == fingerprint:
+                    return web.json_response(
+                        {
+                            "ack": self._ack_from_row(existing),
+                            "ledgerEntry": self._ledger_entry_from_row(existing),
+                        },
+                        status=200,
+                    )
+                return _error_response(409, "idempotency_conflict", "idempotencyKey reused with a different body")
+        finally:
+            conn.close()
+
+        async def compute() -> Tuple[int, Dict[str, Any]]:
+            return self._activate_compute(skill_id, validated, fingerprint)
+
+        cache_key = self._cache_key(skill_id, idempotency_key)
+        try:
+            status, payload = await self._idem_cache.get_or_set(cache_key, fingerprint, compute)
+        except _ActivationErrorAsResponse as exc:
+            return _error_response(exc.status, exc.code, exc.message)
+        return web.json_response(payload, status=status)
+
+    def _activate_compute(
+        self, skill_id: str, validated: Dict[str, Any], fingerprint: str
+    ) -> Tuple[int, Dict[str, Any]]:
+        content = validated["content"]
+        supplied_hash = validated["content_hash"]
+
+        recomputed = "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
+        if not hmac.compare_digest(recomputed, supplied_hash):
+            raise _ActivationErrorAsResponse(409, "integrity_mismatch", "contentHash does not match delivered content")
+
+        conn = self._conn()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                # Re-check the durable-idempotency-replay decision INSIDE
+                # the transaction — closes the concurrent
+                # different-fingerprint race window (adjudication #5).
+                existing = self._fetch_row(skill_id, conn)
+                if existing is not None and existing["idempotency_key"] == validated["idempotency_key"]:
+                    _safe_rollback(conn)
+                    if existing["fingerprint"] == fingerprint:
+                        return 200, {
+                            "ack": self._ack_from_row(existing),
+                            "ledgerEntry": self._ledger_entry_from_row(existing),
+                        }
+                    raise _ActivationErrorAsResponse(409, "idempotency_conflict", "idempotencyKey reused with a different body")
+
+                is_new_row = existing is None
+                if is_new_row:
+                    count = conn.execute("SELECT COUNT(*) AS n FROM managed_skills").fetchone()["n"]
+                    if count >= MAX_MANAGED_ENTRIES:
+                        _safe_rollback(conn)
+                        raise _ActivationErrorAsResponse(409, "ledger_full", "managed-skill ledger is at capacity")
+
+                activated_at = _iso_now()
+
+                if existing is not None and existing["content_hash"] == recomputed:
+                    # Same-content no-op refresh: bookkeeping only, no
+                    # file rewrite, previousState untouched.
+                    conn.execute(
+                        "UPDATE managed_skills SET idempotency_key = ?, fingerprint = ?, activated_at = ? "
+                        "WHERE skill_id = ?",
+                        (validated["idempotency_key"], fingerprint, activated_at, skill_id),
+                    )
+                    conn.execute("COMMIT")
+                    row = self._fetch_row(skill_id, conn)
+                    return 201, {
+                        "ack": self._ack_from_row(row, reloaded=True),
+                        "ledgerEntry": self._ledger_entry_from_row(row),
+                    }
+
+                before_content: Optional[str] = None
+                skill_md = self._skill_md_path(skill_id)
+                if skill_md.exists():
+                    before_content = skill_md.read_text(encoding="utf-8")
+
+                previous_state = None
+                if existing is not None:
+                    previous_state = {
+                        "contentHash": existing["content_hash"],
+                        "version": existing["version"],
+                        "content": before_content,
+                    }
+
+                self._write_skill_file_atomic(skill_id, content)
+
+                try:
+                    self._upsert_managed_row(
+                        conn,
+                        skill_id=skill_id,
+                        content_hash=recomputed,
+                        version=validated["version"],
+                        previous_state=previous_state,
+                        idempotency_key=validated["idempotency_key"],
+                        fingerprint=fingerprint,
+                        activated_at=activated_at,
+                    )
+                    conn.execute("COMMIT")
+                except Exception:
+                    _safe_rollback(conn)
+                    # Ledger write failed after the file write — restore
+                    # the before-image so a refresh failure never
+                    # destroys the previously-managed file.
+                    self._restore_before_image(skill_id, before_content)
+                    raise
+
+                row = self._fetch_row(skill_id, conn)
+                return 201, {
+                    "ack": self._ack_from_row(row, reloaded=True),
+                    "ledgerEntry": self._ledger_entry_from_row(row),
+                }
+            except _ActivationErrorAsResponse:
+                raise
+            except Exception:
+                _safe_rollback(conn)
+                raise
+        finally:
+            conn.close()
+
+    # -- DELETE /v1/skills/activations/{skillId} ---------------------------
+
+    async def handle_deactivate(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        skill_id = request.match_info.get("skill_id", "")
+        if not _SKILL_ID_RE.match(skill_id):
+            return _error_response(422, "invalid_request", "skillId malformed")
+
+        mode_values = request.query.getall("mode", [])
+        if len(mode_values) == 0:
+            mode = "clean"
+        elif len(mode_values) == 1 and mode_values[0] in ("clean", "rollback"):
+            mode = mode_values[0]
+        else:
+            return _error_response(422, "invalid_request", "mode must be exactly one of clean|rollback")
+
+        conn = self._conn()
+        try:
+            row = self._fetch_row(skill_id, conn)
+            if row is None:
+                if self._is_native_on_disk(skill_id, conn):
+                    return _error_response(403, "not_managed", "skillId belongs to a remote-native skill")
+                return _error_response(404, "not_found", "no managed skill with that id")
+
+            at = _iso_now()
+            if mode == "clean":
+                self._remove_skill_file_and_dir(skill_id)
+                conn.execute("DELETE FROM managed_skills WHERE skill_id = ?", (skill_id,))
+                self._bump_epoch(skill_id)
+                return web.json_response({"ack": {"skillId": skill_id, "removed": True, "at": at}}, status=200)
+
+            # mode == "rollback"
+            previous_state = json.loads(row["previous_state_json"]) if row["previous_state_json"] else None
+            if previous_state is None:
+                self._remove_skill_file_and_dir(skill_id)
+                conn.execute("DELETE FROM managed_skills WHERE skill_id = ?", (skill_id,))
+                self._bump_epoch(skill_id)
+                return web.json_response({"ack": {"skillId": skill_id, "removed": True, "at": at}}, status=200)
+
+            prior_content = previous_state.get("content")
+            if prior_content is not None:
+                self._write_skill_file_atomic(skill_id, prior_content)
+            conn.execute(
+                "UPDATE managed_skills SET content_hash = ?, version = ?, previous_state_json = NULL, "
+                "activated_at = ? WHERE skill_id = ?",
+                (previous_state.get("contentHash"), previous_state.get("version"), at, skill_id),
+            )
+            return web.json_response({"ack": {"skillId": skill_id, "restored": True, "at": at}}, status=200)
+        finally:
+            conn.close()
+
+    def _remove_skill_file_and_dir(self, skill_id: str) -> None:
+        """Remove SKILL.md and, if now empty, its containing skill directory.
+
+        A managed skill removed by clean/rollback-to-absence should leave no
+        trace — an empty ``home/skills/<skillId>/`` directory would silently
+        litter the skills tree and could confuse a later live scan.
+        """
+        skill_md = self._skill_md_path(skill_id)
+        skill_md.unlink(missing_ok=True)
+        skill_dir = skill_md.parent
+        try:
+            skill_dir.rmdir()
+        except OSError:
+            pass  # non-empty (unexpected extra files) or already gone — leave it
+
+    def _bump_epoch(self, skill_id: str) -> None:
+        self._epoch[skill_id] = self._epoch.get(skill_id, 0) + 1
+
+    # -- GET /v1/skills?scope=managed ---------------------------------------
+
+    async def handle_managed_inventory(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        conn = self._conn()
+        try:
+            rows = conn.execute("SELECT * FROM managed_skills ORDER BY skill_id").fetchall()
+        finally:
+            conn.close()
+
+        data: List[Dict[str, Any]] = []
+        for row in rows:
+            skill_md = self._skills_dir / row["skill_id"] / "SKILL.md"
+            if not skill_md.exists():
+                continue
+            data.append({
+                "name": row["skill_id"],
+                "description": "",
+                "category": None,
+                "contentHash": row["content_hash"],
+                "managedBy": row["managed_by"],
+                "scope": json.loads(row["scope_json"]),
+            })
+
+        return web.json_response({"object": "list", "data": data})
+
+
+class _ActivationErrorAsResponse(Exception):
+    """Raised from inside a transaction to unwind to an HTTP error response."""
+
+    def __init__(self, status: int, code: str, message: str):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+
+
+def _iso_now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
## What

Adds an authenticated skills-activation API surface to the Hermes Agent runtime:

- `POST /v1/skills/activations` — activate a managed skill (identity-scoped to the calling agent/company, integrity-hashed against the skill's content, idempotent on replay, 409 on integrity mismatch)
- `DELETE /v1/skills/activations/{id}` — deactivate a managed skill (rollback restores the prior managed state; native/base skills cannot be deleted)
- `GET /v1/skills?scope=managed` — list only the caller's own managed activations (read-only invariant; never returns another identity's activations)

This is Layer 2 of the spec-309 `hermes_gateway` remote skill contract: it gives an external gateway adapter (e.g. the Paperclip `hermes_gateway` adapter, companion PR to `paperclipai/paperclip`) a real, auth-gated activation surface to reconcile a desired skill set against, instead of only being able to read inventory.

## Why

The Paperclip `hermes_gateway` adapter (Layer 1, already shipped) can list a Hermes agent's skills but has no way to activate/deactivate them remotely — every skill change today requires direct operator access to the Hermes agent. This closes that gap with a narrow, identity-scoped, auditable API rather than a broad admin surface.

## Provenance

- Base tag: `v2026.7.1` @ `7c1a029553d87c43ecff8a3821336bc95872213b`
- Branch head (this PR): `788033dc06821af2a9167736e412431358f08d5a`
- Companion PR: `paperclipai/paperclip` ← `austinmao:spec309/hermes-gateway-remote-skill-contract` (adds the client-side gateway adapter that talks to this API)

## Test evidence

`python3 -m pytest tests/test_skills_activation.py -q` — **26 passed**, 0 failed (run fresh against this branch head, this session).

## Notes

- Zero secret values in this diff or PR body (scanned with `scanForSecretValues` before push/create).
- This PR is currently unmerged/open; a pinned, reversible compat patch (`@paperclipai+hermes-paperclip-adapter+2026.707.0.patch`, `pending_upstream` in `PATCH_MANIFEST.md`) is what's actually deployed today on the openclaw side — this PR is the upstream delivery path, not a claim that the capability is already merged/deployed upstream.
