### PR TITLE
fix(desktop): block stale multi-window prompt submit

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.tsx
@@ -1,0 +1,195 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { type MutableRefObject, useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { getSessionMessages } from '@/hermes'
+import { textPart } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $notifications } from '@/store/notifications'
+import { $sessions, setSessions } from '@/store/session'
+import { sessionTileDelegate, setSessionTileDelegate } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
+
+import { useSessionTileDelegate } from './use-session-tile-delegate'
+
+vi.mock('@/hermes', () => ({
+  getSessionMessages: vi.fn(async () => ({ messages: [], session_id: 'session' })),
+  PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_800_000,
+  setApiRequestProfile: vi.fn()
+}))
+
+const STORED_ID = 'stored-tile-peer'
+const RUNTIME_ID = 'rt-tile-peer'
+
+function sessionInfo(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    ended_at: null,
+    id: STORED_ID,
+    input_tokens: 0,
+    is_active: true,
+    last_active: 0,
+    message_count: 2,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: null,
+    started_at: 0,
+    title: 'Tile chat',
+    tool_call_count: 0,
+    ...overrides
+  }
+}
+
+function Harness({
+  onReady,
+  requestGateway,
+  sessionStateByRuntimeIdRef,
+  updateSessionState
+}: {
+  onReady: () => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+  sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
+}) {
+  const runtimeIdByStoredSessionIdRef = useRef(new Map<string, string>([[STORED_ID, RUNTIME_ID]]))
+
+  useSessionTileDelegate({
+    archiveSession: async () => undefined,
+    branchStoredSession: async () => undefined,
+    executeSlashCommand: async () => undefined,
+    removeSession: async () => undefined,
+    requestGateway,
+    runtimeIdByStoredSessionIdRef,
+    sessionStateByRuntimeIdRef,
+    updateSessionState
+  })
+
+  useEffect(() => {
+    onReady()
+  }, [onReady])
+
+  return null
+}
+
+describe('useSessionTileDelegate stale multi-window guard (#65047)', () => {
+  beforeEach(() => {
+    vi.mocked(getSessionMessages).mockReset()
+    vi.mocked(getSessionMessages).mockImplementation(async () => ({ messages: [], session_id: STORED_ID }))
+    $notifications.set([])
+    setSessions(() => [sessionInfo({ profile: 'work-vps' })])
+    setSessionTileDelegate(null as never)
+  })
+
+  afterEach(() => {
+    cleanup()
+    $notifications.set([])
+    $sessions.set([])
+    setSessionTileDelegate(null as never)
+  })
+
+  it('blocks tile submitToSession when a peer window advanced the transcript', async () => {
+    // Resume retains an existing cache (messages.length > 0). A peer Desktop
+    // window can finish a turn while this tile still holds the open-time snapshot.
+    const staleCache = createClientSessionState(STORED_ID, [
+      { id: 'u1', role: 'user', parts: [textPart('a')] },
+      { id: 'a1', role: 'assistant', parts: [textPart('b')] }
+    ])
+    const sessionStateByRuntimeIdRef = { current: new Map([[RUNTIME_ID, staleCache]]) }
+    const seeds: ClientSessionState[] = []
+
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      session_id: STORED_ID,
+      messages: [
+        { content: 'a', role: 'user', timestamp: 1 },
+        { content: 'b', role: 'assistant', timestamp: 2 },
+        { content: 'c', role: 'user', timestamp: 3 },
+        { content: 'd', role: 'assistant', timestamp: 4 }
+      ]
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    await act(async () => {
+      render(
+        <Harness
+          onReady={() => undefined}
+          requestGateway={requestGateway}
+          sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+          updateSessionState={(sessionId, updater, storedSessionId) => {
+            const prev = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState(storedSessionId)
+            const next = updater(prev)
+            sessionStateByRuntimeIdRef.current.set(sessionId, next)
+            seeds.push(next)
+
+            return next
+          }}
+        />
+      )
+    })
+
+    const delegate = sessionTileDelegate()
+    expect(delegate).toBeTruthy()
+
+    await act(async () => {
+      await delegate!.submitToSession(RUNTIME_ID, 'stale tile send')
+    })
+
+    expect(getSessionMessages).toHaveBeenCalledWith(STORED_ID, 'work-vps')
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+    expect(seeds.at(-1)?.messages).toHaveLength(4)
+    expect(seeds.at(-1)?.busy).toBe(false)
+    expect($notifications.get().some(n => n.kind === 'warning')).toBe(true)
+  })
+
+  it('allows tile submitToSession when the authoritative transcript is not ahead', async () => {
+    const freshCache = createClientSessionState(STORED_ID, [
+      { id: 'u1', role: 'user', parts: [textPart('a')] },
+      { id: 'a1', role: 'assistant', parts: [textPart('b')] }
+    ])
+    const sessionStateByRuntimeIdRef = { current: new Map([[RUNTIME_ID, freshCache]]) }
+
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      session_id: STORED_ID,
+      messages: [
+        { content: 'a', role: 'user', timestamp: 1 },
+        { content: 'b', role: 'assistant', timestamp: 2 }
+      ]
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    await act(async () => {
+      render(
+        <Harness
+          onReady={() => undefined}
+          requestGateway={requestGateway}
+          sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+          updateSessionState={(sessionId, updater, storedSessionId) => {
+            const prev = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState(storedSessionId)
+            const next = updater(prev)
+            sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+            return next
+          }}
+        />
+      )
+    })
+
+    await act(async () => {
+      await sessionTileDelegate()!.submitToSession(RUNTIME_ID, 'fresh tile send')
+    })
+
+    expect(getSessionMessages).toHaveBeenCalledWith(STORED_ID, 'work-vps')
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      { session_id: RUNTIME_ID, text: 'fresh tile send' },
+      1_800_000
+    )
+    expect($notifications.get().some(n => n.kind === 'warning')).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -1,7 +1,10 @@
 import { useEffect } from 'react'
 
 import { getSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
+import { translateNow } from '@/i18n'
 import { toChatMessages } from '@/lib/chat-messages'
+import { refreshIfTranscriptStale } from '@/lib/stale-transcript-guard'
+import { notify } from '@/store/notifications'
 import { publishSessionState, setSessionTileDelegate } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
@@ -103,6 +106,37 @@ export function useSessionTileDelegate({
         return runtimeId
       },
       submitToSession: async (runtimeId, text) => {
+        // Same multi-window stale guarantee as useSubmitPrompt (#65047). Tile
+        // resume retains an existing cache (above), so a peer window that
+        // advanced the transcript must be caught here before prompt.submit.
+        const cached = sessionStateByRuntimeIdRef.current.get(runtimeId)
+        const storedSessionId = cached?.storedSessionId
+
+        if (storedSessionId) {
+          const refreshed = await refreshIfTranscriptStale(storedSessionId, cached.messages)
+
+          if (refreshed) {
+            updateSessionState(
+              runtimeId,
+              state => ({
+                ...state,
+                messages: refreshed,
+                busy: false,
+                awaitingResponse: false,
+                pendingBranchGroup: null
+              }),
+              storedSessionId
+            )
+            notify({
+              kind: 'warning',
+              title: translateNow('desktop.staleSessionTitle'),
+              message: translateNow('desktop.staleSessionBody')
+            })
+
+            return
+          }
+        }
+
         await requestGateway('prompt.submit', { session_id: runtimeId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
       },
       updateSession: (runtimeId, updater) => updateSessionState(runtimeId, updater)

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -96,6 +96,7 @@ import { useRouteResume } from '../session/hooks/use-route-resume'
 import { useSessionActions } from '../session/hooks/use-session-actions'
 import { useSessionListActions } from '../session/hooks/use-session-list-actions'
 import { useSessionStateCache } from '../session/hooks/use-session-state-cache'
+import { useTranscriptSync } from '../session/hooks/use-transcript-sync'
 import { newSessionOpensTab, startWorkspaceSession } from '../session/workspace-session-target'
 import { useOverlayRouting } from '../shell/hooks/use-overlay-routing'
 import { useWindowControlsOverlayWidth } from '../shell/hooks/use-window-controls-overlay-width'
@@ -390,6 +391,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     refreshHermesConfig,
     refreshSessions,
     sessionStateByRuntimeIdRef,
+    updateSessionState
+  })
+
+  // Cross-window transcript refresh when another window advances the same chat
+  // (#65047). Soft sync only; submit still has a hard stale guard.
+  useTranscriptSync({
+    activeSessionIdRef,
+    selectedStoredSessionIdRef,
     updateSessionState
   })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -23,9 +23,9 @@ import {
 import { parseTodos } from '@/lib/todos'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
-import { broadcastTranscriptChanged } from '@/store/transcript-sync'
 import { upsertSubagent } from '@/store/subagents'
 import { setSessionTodos } from '@/store/todos'
+import { broadcastTranscriptChanged } from '@/store/transcript-sync'
 
 import type { ClientSessionState } from '../../../types'
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -23,6 +23,7 @@ import {
 import { parseTodos } from '@/lib/todos'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
+import { broadcastTranscriptChanged } from '@/store/transcript-sync'
 import { upsertSubagent } from '@/store/subagents'
 import { setSessionTodos } from '@/store/todos'
 
@@ -578,6 +579,16 @@ export function useMessageStream({
       })
 
       scheduleSessionsRefresh()
+
+      // Ping peers viewing the same stored session so a stale secondary window
+      // can re-pull history before the user sends into an out-of-date context.
+      if (completedState.storedSessionId) {
+        broadcastTranscriptChanged({
+          sessionId: completedState.storedSessionId,
+          messageCount: completedState.messages.length,
+          updatedAt: Date.now()
+        })
+      }
 
       if (compactedTurnRef.current.delete(sessionId)) {
         shouldHydrate = false

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getSession, getSessionMessages } from '@/hermes'
-import { textPart } from '@/lib/chat-messages'
+import { textPart, toChatMessages } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
@@ -1813,6 +1813,61 @@ describe('usePromptActions stale multi-window guard (#65047)', () => {
       },
       1_800_000
     )
+  })
+
+  it('does not block when raw SessionMessage count is higher only because tools fold into ChatMessages', async () => {
+    // user + assistant(tool_calls) + tool + assistant → fewer ChatMessages after
+    // toChatMessages. Comparing raw SessionMessage length would false-positive
+    // forever after a "refresh" and soft-lock every send.
+    const remoteSessionMessages = [
+      { content: 'check the repo', role: 'user' as const, timestamp: 1 },
+      {
+        content: 'Looking.',
+        role: 'assistant' as const,
+        timestamp: 2,
+        tool_calls: [{ id: 'tc-1', function: { name: 'terminal', arguments: '{"command":"ls"}' } }]
+      },
+      {
+        content: '{"output":"ok"}',
+        role: 'tool' as const,
+        tool_call_id: 'tc-1',
+        tool_name: 'terminal',
+        timestamp: 3
+      },
+      { content: 'Done.', role: 'assistant' as const, timestamp: 4 }
+    ]
+
+    const localChat = toChatMessages(remoteSessionMessages)
+    expect(remoteSessionMessages.length).toBeGreaterThan(localChat.length)
+
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      session_id: RUNTIME_SESSION_ID,
+      messages: remoteSessionMessages
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={localChat}
+        storedSessionId={RUNTIME_SESSION_ID}
+      />
+    )
+
+    expect(await handle!.submitText('follow-up after tools')).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'follow-up after tools'
+      },
+      1_800_000
+    )
+    expect($notifications.get().some(n => n.kind === 'warning')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -3,7 +3,7 @@ import type { MutableRefObject } from 'react'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSession } from '@/hermes'
+import { getSession, getSessionMessages } from '@/hermes'
 import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
@@ -30,10 +30,20 @@ import { uploadComposerAttachment, usePromptActions } from '.'
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   getSession: vi.fn(),
+  getSessionMessages: vi.fn(async () => ({ messages: [], session_id: 'session' })),
   PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_800_000,
   setApiRequestProfile: vi.fn(),
   transcribeAudio: vi.fn()
 }))
+
+function resetSessionMessagesMock() {
+  vi.mocked(getSessionMessages).mockReset()
+  vi.mocked(getSessionMessages).mockImplementation(async () => ({ messages: [], session_id: 'session' }))
+}
+
+beforeEach(() => {
+  resetSessionMessagesMock()
+})
 
 // The active id the desktop holds is the *runtime* session id from
 // session.create — deliberately distinct from the stored DB id here, because
@@ -1715,6 +1725,97 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
   })
 })
+
+describe('usePromptActions stale multi-window guard (#65047)', () => {
+  beforeEach(() => {
+    resetSessionMessagesMock()
+    $notifications.set([])
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetSessionMessagesMock()
+    $notifications.set([])
+  })
+
+  it('blocks prompt.submit when the local transcript is behind and refreshes messages', async () => {
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      session_id: RUNTIME_SESSION_ID,
+      messages: [
+        { content: 'a', role: 'user', timestamp: 1 },
+        { content: 'b', role: 'assistant', timestamp: 2 },
+        { content: 'c', role: 'user', timestamp: 3 },
+        { content: 'd', role: 'assistant', timestamp: 4 }
+      ]
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+    const seeds: Record<string, unknown>[] = []
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={[
+          { id: 'u1', role: 'user', parts: [textPart('a')] },
+          { id: 'a1', role: 'assistant', parts: [textPart('b')] }
+        ]}
+        storedSessionId={RUNTIME_SESSION_ID}
+      />
+    )
+
+    const accepted = await handle!.submitText('stale send from secondary window')
+
+    expect(accepted).toBe(false)
+    expect(getSessionMessages).toHaveBeenCalledWith(RUNTIME_SESSION_ID)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+
+    const last = seeds.at(-1) as { busy?: boolean; messages?: unknown[] } | undefined
+    expect(last?.busy).toBe(false)
+    expect(last?.messages).toHaveLength(4)
+    expect($notifications.get().some(n => n.kind === 'warning')).toBe(true)
+  })
+
+  it('allows prompt.submit when the authoritative transcript is not ahead', async () => {
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      session_id: RUNTIME_SESSION_ID,
+      messages: [
+        { content: 'a', role: 'user', timestamp: 1 },
+        { content: 'b', role: 'assistant', timestamp: 2 }
+      ]
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={[
+          { id: 'u1', role: 'user', parts: [textPart('a')] },
+          { id: 'a1', role: 'assistant', parts: [textPart('b')] }
+        ]}
+        storedSessionId={RUNTIME_SESSION_ID}
+      />
+    )
+
+    expect(await handle!.submitText('fresh enough')).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'fresh enough'
+      },
+      1_800_000
+    )
+  })
+})
+
 
 describe('usePromptActions redirectPrompt', () => {
   afterEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1730,12 +1730,14 @@ describe('usePromptActions stale multi-window guard (#65047)', () => {
   beforeEach(() => {
     resetSessionMessagesMock()
     $notifications.set([])
+    setSessions(() => [])
   })
 
   afterEach(() => {
     cleanup()
     resetSessionMessagesMock()
     $notifications.set([])
+    setSessions(() => [])
   })
 
   it('blocks prompt.submit when the local transcript is behind and refreshes messages', async () => {
@@ -1770,13 +1772,48 @@ describe('usePromptActions stale multi-window guard (#65047)', () => {
     const accepted = await handle!.submitText('stale send from secondary window')
 
     expect(accepted).toBe(false)
-    expect(getSessionMessages).toHaveBeenCalledWith(RUNTIME_SESSION_ID)
+    expect(getSessionMessages).toHaveBeenCalledWith(RUNTIME_SESSION_ID, undefined)
     expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
 
     const last = seeds.at(-1) as { busy?: boolean; messages?: unknown[] } | undefined
     expect(last?.busy).toBe(false)
     expect(last?.messages).toHaveLength(4)
     expect($notifications.get().some(n => n.kind === 'warning')).toBe(true)
+  })
+
+  it('routes the hard-guard transcript read through the session owning profile', async () => {
+    const STORED_ID = 'stored-cross-profile'
+    setSessions(() => [sessionInfo({ id: STORED_ID, profile: 'work-vps', title: 'Remote chat' })])
+
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      session_id: STORED_ID,
+      messages: [
+        { content: 'a', role: 'user', timestamp: 1 },
+        { content: 'b', role: 'assistant', timestamp: 2 },
+        { content: 'c', role: 'user', timestamp: 3 },
+        { content: 'd', role: 'assistant', timestamp: 4 }
+      ]
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={[
+          { id: 'u1', role: 'user', parts: [textPart('a')] },
+          { id: 'a1', role: 'assistant', parts: [textPart('b')] }
+        ]}
+        storedSessionId={STORED_ID}
+      />
+    )
+
+    expect(await handle!.submitText('stale cross-profile send')).toBe(false)
+    expect(getSessionMessages).toHaveBeenCalledWith(STORED_ID, 'work-vps')
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
   })
 
   it('allows prompt.submit when the authoritative transcript is not ahead', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -1,8 +1,8 @@
 import { type MutableRefObject, useCallback } from 'react'
 
-import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
+import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS, getSessionMessages } from '@/hermes'
 import type { Translations } from '@/i18n'
-import { type ChatMessage, textPart } from '@/lib/chat-messages'
+import { type ChatMessage, preserveLocalAssistantErrors, textPart, toChatMessages } from '@/lib/chat-messages'
 import { optimisticAttachmentRef } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import { setMutableRef } from '@/lib/mutable-ref'
@@ -73,7 +73,7 @@ interface SubmitPromptDeps {
   }
 }
 
-// Stable identity — a fresh default object per render would churn the
+// Stable identity ??a fresh default object per render would churn the
 // useCallback below on every render.
 const MAIN_SUBMIT_SCOPE: NonNullable<SubmitPromptDeps['scope']> = {
   clearAttachments: clearComposerAttachments,
@@ -122,7 +122,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // workspace-relative paths the remote gateway can resolve). Seed the
       // optimistic message with the pre-sync refs, then rewrite once synced.
       // Images use their base64 preview so the thumbnail renders inline without
-      // a (remote-mode 403-prone) /api/media fetch — see optimisticAttachmentRef.
+      // a (remote-mode 403-prone) /api/media fetch ??see optimisticAttachmentRef.
       let attachmentRefs = attachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
 
       const buildContextText = (atts: ComposerAttachment[]): string => {
@@ -141,8 +141,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         )
       }
 
-      // Queue drains fire on the busy→false settle edge, where busyRef (synced
-      // from $busy by a separate effect) may still read true — honoring it would
+      // Queue drains fire on the busy?�false settle edge, where busyRef (synced
+      // from $busy by a separate effect) may still read true ??honoring it would
       // bounce the drained send. The drain lock serializes them; the user path
       // keeps the guard so a stray Enter mid-turn can't double-submit.
       //
@@ -193,8 +193,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       // Pin the foreground session context for the whole async submit pipeline.
       // Without this, a fast session switch during session.resume / file.attach
-      // can redirect the user's text into a different chat (#54527). Mutable —
-      // not const — because a new-chat submit legitimately re-homes to the
+      // can redirect the user's text into a different chat (#54527). Mutable ??
+      // not const ??because a new-chat submit legitimately re-homes to the
       // session it creates (see the re-pin after createBackendSessionForSend).
       const startingActiveSessionId = activeSessionIdRef.current
       const selectedStoredSessionId = selectedStoredSessionIdRef.current
@@ -219,7 +219,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // under this in-flight submit. sessionContextDrift ignores the churn a
       // busy gateway produces (selection null-resets on a gateway/profile
       // switch, search/hash-only route changes, background active-ref
-      // retargets) so a second-session send doesn't silently abort — it fires
+      // retargets) so a second-session send doesn't silently abort ??it fires
       // only on a real move to a DIFFERENT chat. Reads the live refs/route each
       // call and measures against the (mutable) baseline, which is re-pinned to
       // the created chat after createBackendSessionForSend. submitTargetStoredId
@@ -246,7 +246,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       const targetIsCurrentView = (): boolean => targetStartedInCurrentView && !sessionDriftReason()
 
-      // One submit in flight per session — drop any concurrent re-fire so a
+      // One submit in flight per session ??drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns. The
       // foreground ChatBar and background drainers can briefly overlap during a
       // session switch; this per-session lock makes that safe.
@@ -285,7 +285,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         }
       }
 
-      // Idempotent optimistic insert — re-running with the resolved sessionId
+      // Idempotent optimistic insert ??re-running with the resolved sessionId
       // after createBackendSessionForSend just overwrites with the same id.
       const seedOptimistic = (sid: string) =>
         updateSessionState(
@@ -299,7 +299,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             awaitingResponse: true,
             pendingBranchGroup: null,
             sawAssistantPayload: false,
-            // Fresh submit = new turn — clear any leftover interrupt flag, else
+            // Fresh submit = new turn ??clear any leftover interrupt flag, else
             // mutateStream/completeAssistantMessage drop every delta of this turn
             // (what made drained-after-interrupt sends go silent).
             interrupted: false
@@ -415,7 +415,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // background queue drain only has the durable id). Continue that target
         // conversation; only a genuine new-chat draft may create a new session.
         try {
-          // Re-register on the session's OWNING profile — resuming on whichever
+          // Re-register on the session's OWNING profile ??resuming on whichever
           // profile is live would fork the conversation into the wrong DB (#67603).
           const resumeProfile = await resolveSessionProfile(targetStoredSessionId)
 
@@ -480,7 +480,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         if (!sessionId) {
           // createBackendSessionForSend returns null when the user switched
-          // sessions mid-create (it closes the orphaned session itself) —
+          // sessions mid-create (it closes the orphaned session itself) ??
           // abort silently. Anything else is a real failure worth a toast.
           const createNullDrift = sessionDriftReason()
 
@@ -535,10 +535,62 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         // Rewrite the optimistic message + prompt text with the synced refs so
         // the gateway receives @file: paths that resolve in its workspace.
-        // (Images keep their inline base64 preview — see optimisticAttachmentRef.)
+        // (Images keep their inline base64 preview ??see optimisticAttachmentRef.)
         attachmentRefs = syncedAttachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
         rewriteOptimistic(sessionId)
         const text = buildContextText(syncedAttachments)
+
+        // Multi-window stale guard (#65047): another Desktop window may own the
+        // live transcript while this one still shows an open-time snapshot.
+        // Block send + refresh rather than injecting an out-of-date context.
+        const guardStoredId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
+
+        if (guardStoredId && sessionId) {
+          const localSnapshot = updateSessionState(sessionId, state => state, targetStoredSessionId)
+          const localCount = localSnapshot.messages.filter(message => message.id !== optimisticId).length
+
+          try {
+            const remote = await getSessionMessages(guardStoredId)
+
+            if (sessionDriftReason()) {
+              return abortForSessionSwitch(sessionId)
+            }
+
+            if (remote.messages.length > localCount) {
+              const refreshed = preserveLocalAssistantErrors(
+                toChatMessages(remote.messages),
+                localSnapshot.messages.filter(message => message.id !== optimisticId)
+              )
+
+              updateSessionState(
+                sessionId,
+                state => ({
+                  ...state,
+                  messages: refreshed,
+                  busy: false,
+                  awaitingResponse: false,
+                  pendingBranchGroup: null
+                }),
+                targetStoredSessionId
+              )
+
+              if (targetIsCurrentView()) {
+                scope.setMessages(() => refreshed)
+                notify({
+                  kind: 'warning',
+                  title: copy.staleSessionTitle,
+                  message: copy.staleSessionBody
+                })
+              }
+
+              releaseBusy()
+
+              return false
+            }
+          } catch {
+            // Authoritative check failed: do not soft-lock the composer.
+          }
+        }
 
         const submitParams = (targetId: string) => ({
           session_id: targetId,
@@ -562,7 +614,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // Re-register the session in the gateway and get a fresh live ID.
             // Timeouts recover the same way as "session not found": a starved
             // backend loop (#55578 symptom d) rejects the submit even though
-            // the stored session is fine — resume + retry instead of erroring
+            // the stored session is fine ??resume + retry instead of erroring
             // out and losing the session binding.
             const resumeProfile = await resolveSessionProfile(recoverStoredSessionId)
 
@@ -606,7 +658,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           scope.clearAttachments()
         }
 
-        // Submit landed — the turn now runs (busy stays true), but the submit
+        // Submit landed ??the turn now runs (busy stays true), but the submit
         // window is closed, so release the lock for the next (sequential) send.
         releaseSubmitLock()
 
@@ -615,7 +667,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         releaseBusy()
 
         // A queued drain that raced a not-yet-settled turn gets a transient
-        // "session busy" (4009). Don't surface an error bubble/toast — the entry
+        // "session busy" (4009). Don't surface an error bubble/toast ??the entry
         // stays queued and the composer's bounded auto-drain retries when idle.
         if (options?.fromQueue && isSessionBusyError(err)) {
           return false

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -556,9 +556,14 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
               return abortForSessionSwitch(sessionId)
             }
 
-            if (remote.messages.length > localCount) {
+            // Compare ChatMessage lengths (tools are folded by toChatMessages),
+            // not raw SessionMessage counts — otherwise a tool-using transcript
+            // looks "ahead" forever and soft-locks every subsequent send.
+            const remoteChat = toChatMessages(remote.messages)
+
+            if (remoteChat.length > localCount) {
               const refreshed = preserveLocalAssistantErrors(
-                toChatMessages(remote.messages),
+                remoteChat,
                 localSnapshot.messages.filter(message => message.id !== optimisticId)
               )
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -1,11 +1,12 @@
 import { type MutableRefObject, useCallback } from 'react'
 
-import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS, getSessionMessages } from '@/hermes'
+import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import type { Translations } from '@/i18n'
-import { type ChatMessage, preserveLocalAssistantErrors, textPart, toChatMessages } from '@/lib/chat-messages'
+import { type ChatMessage, textPart } from '@/lib/chat-messages'
 import { optimisticAttachmentRef } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import { setMutableRef } from '@/lib/mutable-ref'
+import { refreshIfTranscriptStale } from '@/lib/stale-transcript-guard'
 import {
   isVoicePlaybackActive,
   markVoicePlaybackInterrupted,
@@ -73,7 +74,7 @@ interface SubmitPromptDeps {
   }
 }
 
-// Stable identity ??a fresh default object per render would churn the
+// Stable identity — a fresh default object per render would churn the
 // useCallback below on every render.
 const MAIN_SUBMIT_SCOPE: NonNullable<SubmitPromptDeps['scope']> = {
   clearAttachments: clearComposerAttachments,
@@ -122,7 +123,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // workspace-relative paths the remote gateway can resolve). Seed the
       // optimistic message with the pre-sync refs, then rewrite once synced.
       // Images use their base64 preview so the thumbnail renders inline without
-      // a (remote-mode 403-prone) /api/media fetch ??see optimisticAttachmentRef.
+      // a (remote-mode 403-prone) /api/media fetch — see optimisticAttachmentRef.
       let attachmentRefs = attachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
 
       const buildContextText = (atts: ComposerAttachment[]): string => {
@@ -141,8 +142,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         )
       }
 
-      // Queue drains fire on the busy?�false settle edge, where busyRef (synced
-      // from $busy by a separate effect) may still read true ??honoring it would
+      // Queue drains fire on the busy→false settle edge, where busyRef (synced
+      // from $busy by a separate effect) may still read true — honoring it would
       // bounce the drained send. The drain lock serializes them; the user path
       // keeps the guard so a stray Enter mid-turn can't double-submit.
       //
@@ -193,8 +194,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       // Pin the foreground session context for the whole async submit pipeline.
       // Without this, a fast session switch during session.resume / file.attach
-      // can redirect the user's text into a different chat (#54527). Mutable ??
-      // not const ??because a new-chat submit legitimately re-homes to the
+      // can redirect the user's text into a different chat (#54527). Mutable —
+      // not const — because a new-chat submit legitimately re-homes to the
       // session it creates (see the re-pin after createBackendSessionForSend).
       const startingActiveSessionId = activeSessionIdRef.current
       const selectedStoredSessionId = selectedStoredSessionIdRef.current
@@ -219,7 +220,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // under this in-flight submit. sessionContextDrift ignores the churn a
       // busy gateway produces (selection null-resets on a gateway/profile
       // switch, search/hash-only route changes, background active-ref
-      // retargets) so a second-session send doesn't silently abort ??it fires
+      // retargets) so a second-session send doesn't silently abort — it fires
       // only on a real move to a DIFFERENT chat. Reads the live refs/route each
       // call and measures against the (mutable) baseline, which is re-pinned to
       // the created chat after createBackendSessionForSend. submitTargetStoredId
@@ -246,7 +247,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       const targetIsCurrentView = (): boolean => targetStartedInCurrentView && !sessionDriftReason()
 
-      // One submit in flight per session ??drop any concurrent re-fire so a
+      // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns. The
       // foreground ChatBar and background drainers can briefly overlap during a
       // session switch; this per-session lock makes that safe.
@@ -285,7 +286,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         }
       }
 
-      // Idempotent optimistic insert ??re-running with the resolved sessionId
+      // Idempotent optimistic insert — re-running with the resolved sessionId
       // after createBackendSessionForSend just overwrites with the same id.
       const seedOptimistic = (sid: string) =>
         updateSessionState(
@@ -299,7 +300,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             awaitingResponse: true,
             pendingBranchGroup: null,
             sawAssistantPayload: false,
-            // Fresh submit = new turn ??clear any leftover interrupt flag, else
+            // Fresh submit = new turn — clear any leftover interrupt flag, else
             // mutateStream/completeAssistantMessage drop every delta of this turn
             // (what made drained-after-interrupt sends go silent).
             interrupted: false
@@ -415,7 +416,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // background queue drain only has the durable id). Continue that target
         // conversation; only a genuine new-chat draft may create a new session.
         try {
-          // Re-register on the session's OWNING profile ??resuming on whichever
+          // Re-register on the session's OWNING profile — resuming on whichever
           // profile is live would fork the conversation into the wrong DB (#67603).
           const resumeProfile = await resolveSessionProfile(targetStoredSessionId)
 
@@ -480,7 +481,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         if (!sessionId) {
           // createBackendSessionForSend returns null when the user switched
-          // sessions mid-create (it closes the orphaned session itself) ??
+          // sessions mid-create (it closes the orphaned session itself) —
           // abort silently. Anything else is a real failure worth a toast.
           const createNullDrift = sessionDriftReason()
 
@@ -535,7 +536,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         // Rewrite the optimistic message + prompt text with the synced refs so
         // the gateway receives @file: paths that resolve in its workspace.
-        // (Images keep their inline base64 preview ??see optimisticAttachmentRef.)
+        // (Images keep their inline base64 preview — see optimisticAttachmentRef.)
         attachmentRefs = syncedAttachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
         rewriteOptimistic(sessionId)
         const text = buildContextText(syncedAttachments)
@@ -543,57 +544,46 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // Multi-window stale guard (#65047): another Desktop window may own the
         // live transcript while this one still shows an open-time snapshot.
         // Block send + refresh rather than injecting an out-of-date context.
+        // Profile is resolved inside refreshIfTranscriptStale so cross-profile
+        // sessions hit the owning backend (see getSessionMessages routing).
         const guardStoredId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
 
         if (guardStoredId && sessionId) {
           const localSnapshot = updateSessionState(sessionId, state => state, targetStoredSessionId)
-          const localCount = localSnapshot.messages.filter(message => message.id !== optimisticId).length
 
-          try {
-            const remote = await getSessionMessages(guardStoredId)
+          const refreshed = await refreshIfTranscriptStale(guardStoredId, localSnapshot.messages, {
+            excludeMessageId: optimisticId
+          })
 
-            if (sessionDriftReason()) {
-              return abortForSessionSwitch(sessionId)
+          if (sessionDriftReason()) {
+            return abortForSessionSwitch(sessionId)
+          }
+
+          if (refreshed) {
+            updateSessionState(
+              sessionId,
+              state => ({
+                ...state,
+                messages: refreshed,
+                busy: false,
+                awaitingResponse: false,
+                pendingBranchGroup: null
+              }),
+              targetStoredSessionId
+            )
+
+            if (targetIsCurrentView()) {
+              scope.setMessages(() => refreshed)
+              notify({
+                kind: 'warning',
+                title: copy.staleSessionTitle,
+                message: copy.staleSessionBody
+              })
             }
 
-            // Compare ChatMessage lengths (tools are folded by toChatMessages),
-            // not raw SessionMessage counts — otherwise a tool-using transcript
-            // looks "ahead" forever and soft-locks every subsequent send.
-            const remoteChat = toChatMessages(remote.messages)
+            releaseBusy()
 
-            if (remoteChat.length > localCount) {
-              const refreshed = preserveLocalAssistantErrors(
-                remoteChat,
-                localSnapshot.messages.filter(message => message.id !== optimisticId)
-              )
-
-              updateSessionState(
-                sessionId,
-                state => ({
-                  ...state,
-                  messages: refreshed,
-                  busy: false,
-                  awaitingResponse: false,
-                  pendingBranchGroup: null
-                }),
-                targetStoredSessionId
-              )
-
-              if (targetIsCurrentView()) {
-                scope.setMessages(() => refreshed)
-                notify({
-                  kind: 'warning',
-                  title: copy.staleSessionTitle,
-                  message: copy.staleSessionBody
-                })
-              }
-
-              releaseBusy()
-
-              return false
-            }
-          } catch {
-            // Authoritative check failed: do not soft-lock the composer.
+            return false
           }
         }
 
@@ -619,7 +609,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // Re-register the session in the gateway and get a fresh live ID.
             // Timeouts recover the same way as "session not found": a starved
             // backend loop (#55578 symptom d) rejects the submit even though
-            // the stored session is fine ??resume + retry instead of erroring
+            // the stored session is fine — resume + retry instead of erroring
             // out and losing the session binding.
             const resumeProfile = await resolveSessionProfile(recoverStoredSessionId)
 
@@ -663,7 +653,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           scope.clearAttachments()
         }
 
-        // Submit landed ??the turn now runs (busy stays true), but the submit
+        // Submit landed — the turn now runs (busy stays true), but the submit
         // window is closed, so release the lock for the next (sequential) send.
         releaseSubmitLock()
 
@@ -672,7 +662,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         releaseBusy()
 
         // A queued drain that raced a not-yet-settled turn gets a transient
-        // "session busy" (4009). Don't surface an error bubble/toast ??the entry
+        // "session busy" (4009). Don't surface an error bubble/toast — the entry
         // stays queued and the composer's bounded auto-drain retries when idle.
         if (options?.fromQueue && isSessionBusyError(err)) {
           return false

--- a/apps/desktop/src/app/session/hooks/use-transcript-sync.ts
+++ b/apps/desktop/src/app/session/hooks/use-transcript-sync.ts
@@ -1,0 +1,96 @@
+import { type MutableRefObject, useEffect } from 'react'
+
+import type { ClientSessionState } from '@/app/types'
+import { getSessionMessages } from '@/hermes'
+import { preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { $busy, $messages, $sessions, sessionMatchesStoredId } from '@/store/session'
+import { onTranscriptChanged, type TranscriptChangedPayload } from '@/store/transcript-sync'
+
+interface TranscriptSyncOptions {
+  activeSessionIdRef: MutableRefObject<string | null>
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
+}
+
+/**
+ * Soft live-sync for multi-window same-session views (#65047 option b):
+ * when another window finishes a turn (or this window regains focus), compare
+ * the authoritative transcript length and rehydrate if we are behind. Does not
+ * fan out gateway events; just a best-effort refresh so the user is not left
+ * staring at an open-time snapshot.
+ */
+export function useTranscriptSync({
+  activeSessionIdRef,
+  selectedStoredSessionIdRef,
+  updateSessionState
+}: TranscriptSyncOptions): void {
+  useEffect(() => {
+    let cancelled = false
+
+    const refreshIfBehind = async (hint?: TranscriptChangedPayload) => {
+      const storedSessionId = selectedStoredSessionIdRef.current
+      const runtimeSessionId = activeSessionIdRef.current
+
+      if (!storedSessionId || !runtimeSessionId || $busy.get() || cancelled) {
+        return
+      }
+
+      if (hint && hint.sessionId !== storedSessionId) {
+        return
+      }
+
+      const localCount = $messages.get().length
+
+      if (hint && hint.messageCount <= localCount) {
+        return
+      }
+
+      const storedProfile = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
+
+      try {
+        const latest = await getSessionMessages(storedSessionId, storedProfile)
+
+        if (cancelled || selectedStoredSessionIdRef.current !== storedSessionId) {
+          return
+        }
+
+        if (latest.messages.length <= localCount) {
+          return
+        }
+
+        const messages = toChatMessages(latest.messages)
+
+        updateSessionState(
+          runtimeSessionId,
+          state => ({
+            ...state,
+            messages: preserveLocalAssistantErrors(messages, state.messages)
+          }),
+          storedSessionId
+        )
+      } catch {
+        // Best-effort: submit-time guard still blocks a stale send.
+      }
+    }
+
+    const unsubscribe = onTranscriptChanged(payload => {
+      void refreshIfBehind(payload)
+    })
+
+    const onFocus = () => {
+      void refreshIfBehind()
+    }
+
+    window.addEventListener('focus', onFocus)
+
+    return () => {
+      cancelled = true
+      unsubscribe()
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [activeSessionIdRef, selectedStoredSessionIdRef, updateSessionState])
+}

--- a/apps/desktop/src/app/session/hooks/use-transcript-sync.ts
+++ b/apps/desktop/src/app/session/hooks/use-transcript-sync.ts
@@ -58,11 +58,13 @@ export function useTranscriptSync({
           return
         }
 
-        if (latest.messages.length <= localCount) {
+        // Normalize through toChatMessages before comparing lengths: raw
+        // SessionMessage rows include tool roles that the UI folds away.
+        const messages = toChatMessages(latest.messages)
+
+        if (messages.length <= localCount) {
           return
         }
-
-        const messages = toChatMessages(latest.messages)
 
         updateSessionState(
           runtimeSessionId,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2777,6 +2777,9 @@ export const en: Translations = {
     sessionUnavailable: 'Session unavailable',
     createSessionFailed: 'Could not create a new session',
     promptFailed: 'Prompt failed',
+    staleSessionTitle: 'Chat out of date',
+    staleSessionBody:
+      'This window was behind another view of the same chat. Latest messages were loaded. Send again if you still want to.',
     providerCredentialRequired: 'Add a provider credential before sending your first message.',
     emptySlashCommand: 'empty slash command',
     desktopCommands: 'Desktop commands',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2662,6 +2662,9 @@ export const ja = defineLocale({
     sessionUnavailable: 'セッションが利用できません',
     createSessionFailed: '新しいセッションを作成できませんでした',
     promptFailed: 'プロンプトに失敗しました',
+    staleSessionTitle: 'チャットが最新ではありません',
+    staleSessionBody:
+      'このウィンドウは同じチャットの別ビューより遅れています。最新のメッセージを読み込みました。送信する場合はもう一度送ってください。',
     providerCredentialRequired: '最初のメッセージを送信する前にプロバイダー認証情報を追加してください。',
     emptySlashCommand: '空のスラッシュコマンド',
     desktopCommands: 'デスクトップコマンド',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2341,6 +2341,8 @@ export interface Translations {
     sessionUnavailable: string
     createSessionFailed: string
     promptFailed: string
+    staleSessionTitle: string
+    staleSessionBody: string
     providerCredentialRequired: string
     emptySlashCommand: string
     desktopCommands: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2555,6 +2555,8 @@ export const zhHant = defineLocale({
     sessionUnavailable: '工作階段不可用',
     createSessionFailed: '無法建立新工作階段',
     promptFailed: '提示詞傳送失敗',
+    staleSessionTitle: '對話已過期',
+    staleSessionBody: '此視窗落後於同一對話的其他視窗。已載入最新訊息。若仍要傳送請再試一次。',
     providerCredentialRequired: '傳送第一則訊息前請先新增提供方憑證。',
     emptySlashCommand: '空的斜線指令',
     desktopCommands: '桌面端指令',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2936,6 +2936,8 @@ export const zh: Translations = {
     sessionUnavailable: '会话不可用',
     createSessionFailed: '无法创建新会话',
     promptFailed: '提示词发送失败',
+    staleSessionTitle: '对话已过期',
+    staleSessionBody: '此窗口落后于同一对话的其他窗口。已加载最新消息。若仍要发送请再试一次。',
     providerCredentialRequired: '发送第一条消息前请先添加提供方凭据。',
     emptySlashCommand: '空 slash 命令',
     desktopCommands: '桌面端命令',

--- a/apps/desktop/src/lib/stale-transcript-guard.test.ts
+++ b/apps/desktop/src/lib/stale-transcript-guard.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getSessionMessages } from '@/hermes'
+import { textPart } from '@/lib/chat-messages'
+import { $sessions, setSessions } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { refreshIfTranscriptStale } from './stale-transcript-guard'
+
+vi.mock('@/hermes', () => ({
+  getSessionMessages: vi.fn(async () => ({ messages: [], session_id: 'session' }))
+}))
+
+function sessionInfo(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    ended_at: null,
+    id: 'stored-1',
+    input_tokens: 0,
+    is_active: true,
+    last_active: 0,
+    message_count: 2,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: null,
+    started_at: 0,
+    title: 'Chat',
+    tool_call_count: 0,
+    ...overrides
+  }
+}
+
+describe('refreshIfTranscriptStale', () => {
+  beforeEach(() => {
+    vi.mocked(getSessionMessages).mockReset()
+    vi.mocked(getSessionMessages).mockImplementation(async () => ({ messages: [], session_id: 'stored-1' }))
+    $sessions.set([])
+  })
+
+  afterEach(() => {
+    $sessions.set([])
+  })
+
+  it('passes the owning profile into getSessionMessages for cross-profile routing', async () => {
+    setSessions(() => [sessionInfo({ id: 'stored-1', profile: 'work-vps' })])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      session_id: 'stored-1',
+      messages: [
+        { content: 'a', role: 'user', timestamp: 1 },
+        { content: 'b', role: 'assistant', timestamp: 2 },
+        { content: 'c', role: 'user', timestamp: 3 }
+      ]
+    })
+
+    const local = [
+      { id: 'u1', role: 'user' as const, parts: [textPart('a')] },
+      { id: 'a1', role: 'assistant' as const, parts: [textPart('b')] }
+    ]
+
+    const refreshed = await refreshIfTranscriptStale('stored-1', local)
+
+    expect(getSessionMessages).toHaveBeenCalledWith('stored-1', 'work-vps')
+    expect(refreshed).toHaveLength(3)
+  })
+
+  it('returns null when the remote transcript is not ahead', async () => {
+    setSessions(() => [sessionInfo()])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      session_id: 'stored-1',
+      messages: [
+        { content: 'a', role: 'user', timestamp: 1 },
+        { content: 'b', role: 'assistant', timestamp: 2 }
+      ]
+    })
+
+    const local = [
+      { id: 'u1', role: 'user' as const, parts: [textPart('a')] },
+      { id: 'a1', role: 'assistant' as const, parts: [textPart('b')] }
+    ]
+
+    expect(await refreshIfTranscriptStale('stored-1', local)).toBeNull()
+  })
+
+  it('fails open (null) when the authoritative read throws', async () => {
+    setSessions(() => [sessionInfo({ profile: 'missing-backend' })])
+    vi.mocked(getSessionMessages).mockRejectedValue(new Error('wrong backend'))
+
+    const local = [{ id: 'u1', role: 'user' as const, parts: [textPart('a')] }]
+
+    expect(await refreshIfTranscriptStale('stored-1', local)).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/stale-transcript-guard.ts
+++ b/apps/desktop/src/lib/stale-transcript-guard.ts
@@ -1,0 +1,44 @@
+import { getSessionMessages } from '@/hermes'
+import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { $sessions, sessionMatchesStoredId } from '@/store/session'
+
+/**
+ * Multi-window stale guard (#65047): another Desktop window (or tile) may own
+ * a fresher transcript while this view still shows an open-time snapshot.
+ *
+ * Returns a refreshed ChatMessage[] when the authoritative transcript is ahead
+ * of the local view; otherwise null. Fail-open on read errors so a wrong-backend
+ * or missing-profile route never soft-locks the composer.
+ *
+ * Always resolves the session's owning profile from `$sessions` so cross-profile
+ * GET routing in {@link getSessionMessages} hits the right backend/state.db.
+ */
+export async function refreshIfTranscriptStale(
+  storedSessionId: string,
+  localMessages: ChatMessage[],
+  options?: { excludeMessageId?: string }
+): Promise<ChatMessage[] | null> {
+  const baseline = options?.excludeMessageId
+    ? localMessages.filter(message => message.id !== options.excludeMessageId)
+    : localMessages
+
+  const localCount = baseline.length
+  const storedProfile = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
+
+  try {
+    const remote = await getSessionMessages(storedSessionId, storedProfile)
+
+    // Compare ChatMessage lengths (tools are folded by toChatMessages), not raw
+    // SessionMessage counts — otherwise a tool-using transcript looks "ahead"
+    // forever and soft-locks every subsequent send.
+    const remoteChat = toChatMessages(remote.messages)
+
+    if (remoteChat.length > localCount) {
+      return preserveLocalAssistantErrors(remoteChat, baseline)
+    }
+  } catch {
+    // Authoritative check failed: do not soft-lock the composer.
+  }
+
+  return null
+}

--- a/apps/desktop/src/store/transcript-sync.test.ts
+++ b/apps/desktop/src/store/transcript-sync.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type ChannelListener = (event: MessageEvent) => void
+
+class FakeBroadcastChannel {
+  static instances = new Map<string, Set<FakeBroadcastChannel>>()
+
+  name: string
+  private listeners = new Set<ChannelListener>()
+
+  constructor(name: string) {
+    this.name = name
+    const group = FakeBroadcastChannel.instances.get(name) ?? new Set()
+    group.add(this)
+    FakeBroadcastChannel.instances.set(name, group)
+  }
+
+  postMessage(data: unknown) {
+    const group = FakeBroadcastChannel.instances.get(this.name)
+
+    if (!group) {
+      return
+    }
+
+    for (const channel of group) {
+      if (channel === this) {
+        continue
+      }
+
+      for (const listener of channel.listeners) {
+        listener({ data } as MessageEvent)
+      }
+    }
+  }
+
+  addEventListener(_type: string, listener: ChannelListener) {
+    this.listeners.add(listener)
+  }
+
+  removeEventListener(_type: string, listener: ChannelListener) {
+    this.listeners.delete(listener)
+  }
+}
+
+describe('transcript-sync', () => {
+  beforeEach(() => {
+    FakeBroadcastChannel.instances.clear()
+    vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('broadcastTranscriptChanged reaches peer windows on hermes:transcript', async () => {
+    const { broadcastTranscriptChanged } = await import('./transcript-sync')
+
+    const peer = new FakeBroadcastChannel('hermes:transcript')
+    const received: unknown[] = []
+    peer.addEventListener('message', event => received.push(event.data))
+
+    broadcastTranscriptChanged({ sessionId: 'stored-1', messageCount: 4, updatedAt: 123 })
+
+    expect(received).toEqual([{ sessionId: 'stored-1', messageCount: 4, updatedAt: 123 }])
+  })
+
+  it('onTranscriptChanged ignores malformed payloads', async () => {
+    const { onTranscriptChanged } = await import('./transcript-sync')
+
+    const received: unknown[] = []
+    onTranscriptChanged(payload => received.push(payload))
+
+    const peer = new FakeBroadcastChannel('hermes:transcript')
+    peer.postMessage({ sessionId: 'x' })
+    peer.postMessage(null)
+    peer.postMessage({ sessionId: 'x', messageCount: 'nope' })
+    peer.postMessage({ sessionId: 'stored-1', messageCount: 2 })
+
+    expect(received).toEqual([{ sessionId: 'stored-1', messageCount: 2 }])
+  })
+})

--- a/apps/desktop/src/store/transcript-sync.ts
+++ b/apps/desktop/src/store/transcript-sync.ts
@@ -5,7 +5,9 @@
 // an out-of-date context (#65047). Distinct from hermes:sessions (sidebar list).
 
 export type TranscriptChangedPayload = {
+  /** Stored session id shared across Desktop windows. */
   sessionId: string
+  /** ChatMessage-normalized length (after toChatMessages), not raw SessionMessage count. */
   messageCount: number
   updatedAt?: number
 }

--- a/apps/desktop/src/store/transcript-sync.ts
+++ b/apps/desktop/src/store/transcript-sync.ts
@@ -1,0 +1,43 @@
+// Cross-window transcript freshness. Each desktop window owns its own gateway
+// transport for a session, so a turn that completes in window A never streams
+// into window B. This bus pings peers with a lightweight (sessionId, count)
+// signature so a stale window can re-pull history before the user sends into
+// an out-of-date context (#65047). Distinct from hermes:sessions (sidebar list).
+
+export type TranscriptChangedPayload = {
+  sessionId: string
+  messageCount: number
+  updatedAt?: number
+}
+
+const CHANNEL = 'hermes:transcript'
+
+const channel = typeof BroadcastChannel === 'undefined' ? null : new BroadcastChannel(CHANNEL)
+
+export function broadcastTranscriptChanged(payload: TranscriptChangedPayload): void {
+  if (!payload.sessionId) {
+    return
+  }
+
+  channel?.postMessage(payload)
+}
+
+export function onTranscriptChanged(handler: (payload: TranscriptChangedPayload) => void): () => void {
+  if (!channel) {
+    return () => {}
+  }
+
+  const listener = (event: MessageEvent<TranscriptChangedPayload>) => {
+    const data = event.data
+
+    if (!data || typeof data.sessionId !== 'string' || typeof data.messageCount !== 'number') {
+      return
+    }
+
+    handler(data)
+  }
+
+  channel.addEventListener('message', listener)
+
+  return () => channel.removeEventListener('message', listener)
+}


### PR DESCRIPTION
## Summary

Closes #65047

Credit: Stan Shih (@stantheman0128). Developed with AI assistance (Cursor / Grok).

Opening the same chat in a second Desktop window freezes that window on the transcript snapshot from open time (one gateway transport per session). The stale window could still send, which can diverge history.

This PR takes issue option (b):

- BroadcastChannel `hermes:transcript` so peer windows can soft-refresh when a turn completes
- Soft refresh on peer ping / window focus via `getSessionMessages`
- Hard guard before `prompt.submit`: if the gateway transcript (converted with `toChatMessages`) is ahead of the local ChatMessage view, toast, refresh, and do not send

Does not add multi-transport fan-out on the gateway.

## Verification

`
cd apps/desktop
npx vitest run --project ui src/store/transcript-sync.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx
# Test Files  2 passed | Tests  57 passed
`

`
python scripts/check-windows-footguns.py --diff HEAD~2
# No Windows footguns found
`

Includes a regression that tool-folded SessionMessages (raw length greater than ChatMessage length) must not false-positive-block submit.

Made with [Cursor](https://cursor.com)