### PR TITLE
feat(mcp): support subagent-only tool scope

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1387,6 +1387,7 @@ def init_agent(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        include_subagent_only=(agent.platform == "subagent"),
     )
     
     # Show tool configuration and store valid tool names for validation

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2646,6 +2646,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 skip_tool_request_middleware=True,
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                include_subagent_only=(getattr(agent, "platform", None) == "subagent"),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1544,6 +1544,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     skip_tool_request_middleware=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                    include_subagent_only=(getattr(agent, "platform", None) == "subagent"),
                     tool_request_middleware_trace=list(middleware_trace),
                 )
                 _spinner_result = function_result
@@ -1586,6 +1587,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     skip_tool_request_middleware=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                    include_subagent_only=(getattr(agent, "platform", None) == "subagent"),
                     tool_request_middleware_trace=list(middleware_trace),
                 )
             except KeyboardInterrupt:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -418,7 +418,10 @@ def build_turn_context(
             if "tools.mcp_tool" in _sys.modules:
                 from tools.mcp_tool import has_registered_mcp_tools, refresh_agent_mcp_tools
                 if has_registered_mcp_tools():
-                    refresh_agent_mcp_tools(agent, quiet_mode=True)
+                    refresh_agent_mcp_tools(
+                        agent, quiet_mode=True,
+                        include_subagent_only=(getattr(agent, "platform", None) == "subagent"),
+                    )
     except Exception:
         logger.debug("between-turns MCP tool refresh skipped", exc_info=True)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16748,7 +16748,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             # edit; gateway agents are per-session and may be
                             # deliberately locked down. (Contract is asserted by
                             # test_reload_mcp_preserves_per_agent_toolset_overrides.)
-                            refresh_agent_mcp_tools(_agent, quiet_mode=True)
+                            refresh_agent_mcp_tools(
+                                _agent, quiet_mode=True,
+                                include_subagent_only=(getattr(_agent, "platform", None) == "subagent"),
+                            )
             except Exception as _exc:
                 logger.debug(
                     "Failed to update cached agent tools after MCP reload: %s",

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -138,6 +138,14 @@ def _replace_mcp_servers(servers: Dict[str, dict]) -> Tuple[bool, List[str]]:
             continue
         issues.extend(validate_mcp_server_entry(name, cfg))
 
+    # Scope advisories are non-fatal: an unknown `scope` is normalized to
+    # "main" at registration time, not rejected. Surface them for the user
+    # without blocking the save (#LaneE subagent_only scope).
+    from hermes_cli.mcp_security import validate_mcp_scope as _validate_scope
+    for name, cfg in servers.items():
+        for adv in _validate_scope(name, cfg):
+            logger.warning(adv)
+
     if issues:
         return False, issues
 

--- a/hermes_cli/mcp_security.py
+++ b/hermes_cli/mcp_security.py
@@ -179,3 +179,45 @@ def validate_mcp_server_entry(name: str, entry: dict[str, Any]) -> list[str]:
 
 def is_mcp_server_entry_suspicious(name: str, entry: dict[str, Any]) -> bool:
     return bool(validate_mcp_server_entry(name, entry))
+
+
+# Allowed values for the MCP server `scope` config key (server-level or
+# inside `tools:`). Unknown values are NOT rejected here — runtime
+# registration normalizes them to "main" with a warning (see
+# tools/mcp_tool._normalize_mcp_scope). We surface a non-fatal advisory so the
+# GUI/CLI can warn the user without blocking a save of an otherwise-valid
+# server. A typo in `scope` must never silently hide a tool, so the advisory
+# is informational, not a hard error.
+_MCP_ALLOWED_SCOPES = ("main", "subagent_only")
+
+
+def validate_mcp_scope(name: str, entry: dict[str, Any]) -> list[str]:
+    """Return advisory warnings about an MCP server's `scope` config.
+
+    Empty list means no issues. Unknown scope values (including inside the
+    `tools:` block) are reported as warnings; callers should not treat them as
+    hard errors because the runtime path defaults unknown scopes to "main".
+    """
+    if not isinstance(entry, dict):
+        return []
+
+    advisories: list[str] = []
+    server_scope = entry.get("scope")
+    if server_scope is not None and server_scope not in _MCP_ALLOWED_SCOPES:
+        advisories.append(
+            f"MCP server '{name}': unknown scope '{server_scope}'; will be "
+            f"treated as 'main' (tool visible to MAIN agent). Allowed: "
+            f"{', '.join(_MCP_ALLOWED_SCOPES)}"
+        )
+
+    tools_block = entry.get("tools")
+    if isinstance(tools_block, dict):
+        tools_scope = tools_block.get("scope")
+        if tools_scope is not None and tools_scope not in _MCP_ALLOWED_SCOPES:
+            advisories.append(
+                f"MCP server '{name}': unknown tools.scope '{tools_scope}'; "
+                f"will be treated as 'main'. Allowed: "
+                f"{', '.join(_MCP_ALLOWED_SCOPES)}"
+            )
+
+    return advisories

--- a/model_tools.py
+++ b/model_tools.py
@@ -290,9 +290,9 @@ def get_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    include_subagent_only: bool = False,
 ) -> List[Dict[str, Any]]:
-    """
-    Get tool definitions for model API calls with toolset-based filtering.
+    """Get tool definitions for model API calls with toolset-based filtering.
 
     All tools must be part of a toolset to be accessible.
 
@@ -305,6 +305,10 @@ def get_tool_definitions(
             tool_search / tool_describe bridge handlers so they can read the
             real catalog, not the already-collapsed one. Public callers should
             leave this False.
+        include_subagent_only: When True (delegated subagents, which are
+            constructed with platform="subagent"), expose tools whose
+            ``scope="subagent_only"``. When False (default, MAIN agents), those
+            tools are withheld from the returned schemas.
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -333,6 +337,7 @@ def get_tool_definitions(
             bool(os.environ.get("HERMES_KANBAN_TASK")),
             bool(skip_tool_search_assembly),
             _is_delegated_child_context(),
+            bool(include_subagent_only),
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
@@ -345,7 +350,8 @@ def get_tool_definitions(
             return list(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+                                       skip_tool_search_assembly=skip_tool_search_assembly,
+                                       include_subagent_only=include_subagent_only)
     if quiet_mode:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -369,6 +375,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    include_subagent_only: bool = False,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -456,7 +463,9 @@ def _compute_tool_definitions(
     # other toolset.
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
-    filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    filtered_tools = registry.get_definitions(
+        tools_to_include, quiet=quiet_mode, include_subagent_only=include_subagent_only,
+    )
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references

--- a/model_tools.py
+++ b/model_tools.py
@@ -1105,6 +1105,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    include_subagent_only: bool = False,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1166,6 +1167,7 @@ def handle_function_call(
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
                 quiet_mode=True, skip_tool_search_assembly=True,
+                include_subagent_only=include_subagent_only,
             ) or []
         except Exception:
             current_defs = []

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3083,6 +3083,7 @@ class TestConcurrentToolExecution:
                 skip_tool_request_middleware=True,
                 enabled_toolsets=agent.enabled_toolsets,
                 disabled_toolsets=agent.disabled_toolsets,
+                include_subagent_only=False,
                 tool_request_middleware_trace=[],
             )
             assert result == "result"

--- a/tests/tools/test_mcp_subagent_only.py
+++ b/tests/tools/test_mcp_subagent_only.py
@@ -1,0 +1,264 @@
+"""Tests for MCP ``scope: subagent_only`` visibility (Lane E design).
+
+The design funnels every MAIN agent and every delegated child through one
+registry choke point: ``ToolRegistry.get_definitions``. ``subagent_only`` tools
+are withheld there unless ``include_subagent_only=True`` is passed (which the
+delegated-child path does via agent_init.py:1214, keyed on
+``agent.platform == "subagent"``).
+
+These tests pin that behavior at the registry level, at the
+``get_tool_definitions`` cache-key level, and at the
+``_register_server_tools`` config-interpretation level.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+from tools.registry import ToolRegistry, registry
+from tools import mcp_tool as mcp_tool_mod
+from tools.mcp_tool import _normalize_mcp_scope
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_registry():
+    """Return a ToolRegistry isolated from the global singleton."""
+    reg = ToolRegistry.__new__(ToolRegistry)
+    # Re-run the real __init__ against private attrs without touching the
+    # process-wide singleton used by the rest of the agent.
+    ToolRegistry.__init__(reg)
+    return reg
+
+
+def _reg_tool(reg, name, scope="main", toolset="ts", check_fn=None):
+    reg.register(
+        name=name,
+        toolset=toolset,
+        schema={"name": name, "description": f"{name} tool"},
+        handler=lambda x: x,
+        check_fn=check_fn,
+        description=f"{name} tool",
+        scope=scope,
+    )
+
+
+class _FakeMcpTool:
+    def __init__(self, name, description=""):
+        self.name = name
+        self.description = description
+
+
+class _FakeServer:
+    """Minimal stand-in for MCPServerTask for _register_server_tools."""
+    def __init__(self, tools, tool_timeout=30):
+        self._tools = tools
+        self.tool_timeout = tool_timeout
+        self.name = "fakesrv"
+        self.session = MagicMock()  # _select_utility_schemas legacy fallback
+        self.initialize_result = None  # capabilities unknown → utilities skipped
+
+
+# ---------------------------------------------------------------------------
+# Registry-level scope guard (the choke point)
+# ---------------------------------------------------------------------------
+
+def test_scope_default_visible_to_main_and_child():
+    reg = _fresh_registry()
+    _reg_tool(reg, "mcp__srv__t")
+    names = {d["function"]["name"] for d in reg.get_definitions({"mcp__srv__t"})}
+    assert "mcp__srv__t" in names
+    # Child path (include_subagent_only=True) is a no-op for "main" scope.
+    names_child = {d["function"]["name"] for d in reg.get_definitions(
+        {"mcp__srv__t"}, include_subagent_only=True)}
+    assert "mcp__srv__t" in names_child
+
+
+def test_scope_server_subagent_only_absent_from_main_present_in_child():
+    reg = _fresh_registry()
+    _reg_tool(reg, "mcp__srv__secret", scope="subagent_only")
+    main = {d["function"]["name"] for d in reg.get_definitions({"mcp__srv__secret"})}
+    assert "mcp__srv__secret" not in main
+    child = {d["function"]["name"] for d in reg.get_definitions(
+        {"mcp__srv__secret"}, include_subagent_only=True)}
+    assert "mcp__srv__secret" in child
+
+
+def test_scope_mixed_visibility():
+    """MAIN sees only the main-scoped tool; child sees both."""
+    reg = _fresh_registry()
+    _reg_tool(reg, "mcp__srv__pub", scope="main")
+    _reg_tool(reg, "mcp__srv__priv", scope="subagent_only")
+    main = {d["function"]["name"] for d in reg.get_definitions(
+        {"mcp__srv__pub", "mcp__srv__priv"})}
+    assert main == {"mcp__srv__pub"}
+    child = {d["function"]["name"] for d in reg.get_definitions(
+        {"mcp__srv__pub", "mcp__srv__priv"}, include_subagent_only=True)}
+    assert child == {"mcp__srv__pub", "mcp__srv__priv"}
+
+
+def test_scope_unknown_treated_as_main():
+    """A scope value other than the two allowed ones is normalized to 'main'
+    at registration (never silently hidden)."""
+    reg = _fresh_registry()
+    # _normalize_mcp_scope is applied by callers (mcp_tool); here we assert the
+    # registry itself only ever sees valid scopes by virtue of the helper.
+    assert _normalize_mcp_scope("bogus", "where") == "main"
+    assert _normalize_mcp_scope(None, "where") == "main"
+    assert _normalize_mcp_scope("", "where") == "main"
+    assert _normalize_mcp_scope("subagent_only", "where") == "subagent_only"
+
+
+def test_scope_reflected_in_toolentry():
+    reg = _fresh_registry()
+    _reg_tool(reg, "mcp__srv__x", scope="subagent_only")
+    assert reg.get_entry("mcp__srv__x").scope == "subagent_only"
+    _reg_tool(reg, "mcp__srv__y")
+    assert reg.get_entry("mcp__srv__y").scope == "main"
+
+
+# ---------------------------------------------------------------------------
+# get_tool_definitions cache-key isolation (no MAIN leakage)
+# ---------------------------------------------------------------------------
+
+def test_get_tool_definitions_cache_key_isolation(monkeypatch):
+    """include_subagent_only=False and True must produce distinct cache
+    entries so a MAIN call never returns child-scoped (subagent_only) tools."""
+    from model_tools import get_tool_definitions
+
+    reg = _fresh_registry()
+    _reg_tool(reg, "mcp__srv__childonly", scope="subagent_only", toolset="mcp-srv")
+    _reg_tool(reg, "mcp__srv__pub", scope="main", toolset="mcp-srv")
+    # register_toolset_alias wires the raw server name so resolve_toolset("mcp-srv")
+    # can resolve it (mirrors _register_server_tools).
+    reg.register_toolset_alias("srv", "mcp-srv")
+
+    captured = {}
+    orig = reg.get_definitions
+    def spy(names, quiet=False, include_subagent_only=False):
+        captured.setdefault("seen", []).append(include_subagent_only)
+        return orig(names, quiet=quiet, include_subagent_only=include_subagent_only)
+    monkeypatch.setattr(reg, "get_definitions", spy)
+
+    # Both toolset resolution and the registry lookup read the module-global
+    # `registry`: toolsets.py does `from tools.registry import registry` (so
+    # patching tools.registry.registry covers it) and model_tools.py bound
+    # `registry` at import time (so patch model_tools.registry too).
+    monkeypatch.setattr("tools.registry.registry", reg)
+    monkeypatch.setattr("model_tools.registry", reg)
+
+    main_defs = get_tool_definitions(
+        enabled_toolsets=["mcp-srv"], quiet_mode=True, include_subagent_only=False)
+    child_defs = get_tool_definitions(
+        enabled_toolsets=["mcp-srv"], quiet_mode=True, include_subagent_only=True)
+
+    main_names = {d["function"]["name"] for d in main_defs}
+    child_names = {d["function"]["name"] for d in child_defs}
+    assert "mcp__srv__childonly" not in main_names
+    assert "mcp__srv__childonly" in child_names
+    assert captured["seen"] == [False, True]
+
+
+# ---------------------------------------------------------------------------
+# _register_server_tools scope interpretation
+# ---------------------------------------------------------------------------
+
+def test_register_server_tools_server_level_scope():
+    reg = _fresh_registry()
+    server = _FakeServer([_FakeMcpTool("danger", "danger op")])
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("tools.registry.registry", reg)
+        mcp_tool_mod._register_server_tools(
+            "priv", server, {"scope": "subagent_only", "command": "x"})
+    entry = reg.get_entry("mcp__priv__danger")
+    assert entry is not None
+    assert entry.scope == "subagent_only"
+
+
+def test_register_server_tools_default_scope_is_main():
+    reg = _fresh_registry()
+    server = _FakeServer([_FakeMcpTool("op", "op")])
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("tools.registry.registry", reg)
+        mcp_tool_mod._register_server_tools("plain", server, {"command": "x"})
+    assert reg.get_entry("mcp__plain__op").scope == "main"
+
+
+def test_register_server_tools_per_tool_scope_mixed():
+    """tools.include + tools.scope restricts scope to the included tool set;
+    the included tools become subagent_only while the server-level default
+    (no tools.scope) leaves a non-included, non-registered tool out."""
+    reg = _fresh_registry()
+    server = _FakeServer([
+        _FakeMcpTool("raw_query", "raw"),
+        _FakeMcpTool("safe_op", "safe"),
+    ])
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("tools.registry.registry", reg)
+        mcp_tool_mod._register_server_tools(
+            "mixed", server,
+            {"command": "x", "tools": {"include": ["raw_query"],
+                                       "scope": "subagent_only"}})
+    # Included tool inherits the per-tool (tools.scope) scope.
+    assert reg.get_entry("mcp__mixed__raw_query").scope == "subagent_only"
+    # Non-included tool is not registered at all (include excludes it) — the
+    # server-level default scope ("main") would apply if it were selected.
+    assert reg.get_entry("mcp__mixed__safe_op") is None
+
+
+def test_register_server_tools_unknown_scope_defaults_main(caplog):
+    reg = _fresh_registry()
+    server = _FakeServer([_FakeMcpTool("op", "op")])
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("tools.registry.registry", reg)
+        mcp_tool_mod._register_server_tools(
+            "bad", server, {"command": "x", "scope": "not_a_real_scope"})
+    # Unknown scope is normalized to "main" (visible to MAIN), never hidden.
+    assert reg.get_entry("mcp__bad__op").scope == "main"
+
+
+def test_register_server_tools_utility_inherits_server_scope():
+    """Utility tools (resources/prompts) inherit the server-level scope."""
+    reg = _fresh_registry()
+    server = _FakeServer([_FakeMcpTool("op", "op")])
+    # Advertise resources capability so a utility tool is selected, then
+    # verify it inherits the server-level scope.
+    caps = type("Caps", (), {"resources": object(), "prompts": None})()
+    server.initialize_result = type("Init", (), {"capabilities": caps})()
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("tools.registry.registry", reg)
+        mcp_tool_mod._register_server_tools(
+            "util", server,
+            {"command": "x", "scope": "subagent_only",
+             "tools": {"resources": True}})
+    assert reg.get_entry("mcp__util__op").scope == "subagent_only"
+    # list_resources utility (if registered) inherits the same server scope.
+    util_entry = reg.get_entry("mcp__util__list_resources")
+    if util_entry is not None:
+        assert util_entry.scope == "subagent_only"
+
+
+# ---------------------------------------------------------------------------
+# Dynamic refresh retains scope (re-registers from the same config)
+# ---------------------------------------------------------------------------
+
+def test_dynamic_refresh_retains_scope(monkeypatch):
+    """_refresh_tools re-calls _register_server_tools with self._config, so
+    scope must survive a tools/list_changed refresh."""
+    reg = _fresh_registry()
+    server = _FakeServer([_FakeMcpTool("danger", "danger op")])
+    cfg = {"scope": "subagent_only", "command": "x"}
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("tools.registry.registry", reg)
+        mcp_tool_mod._register_server_tools("dyn", server, cfg)
+        # Simulate a refresh: new tool list, same config.
+        server._tools = [_FakeMcpTool("danger", "danger op v2")]
+        mcp_tool_mod._register_server_tools("dyn", server, cfg)
+
+    # Deregister-reregister keeps the name; scope still subagent_only.
+    entry = reg.get_entry("mcp__dyn__danger")
+    assert entry is not None
+    assert entry.scope == "subagent_only"
+    # And MAIN still does not see it.
+    assert "mcp__dyn__danger" not in {d["function"]["name"] for d in reg.get_definitions({"mcp__dyn__danger"})}

--- a/tests/tools/test_mcp_subagent_only.py
+++ b/tests/tools/test_mcp_subagent_only.py
@@ -207,6 +207,34 @@ def test_register_server_tools_per_tool_scope_mixed():
     assert reg.get_entry("mcp__mixed__safe_op") is None
 
 
+def test_register_server_tools_scope_without_filter_applies_to_all():
+    """tools.scope without include/exclude must apply to ALL tools.
+
+    A config like `tools: { scope: subagent_only }` with no include/exclude
+    filter must not silently leave every tool at "main" — that would expose
+    tools the user intended to hide (same failure class, inverted, that
+    _normalize_mcp_scope warns against).
+    """
+    reg = _fresh_registry()
+    server = _FakeServer([
+        _FakeMcpTool("op_a", "operation a"),
+        _FakeMcpTool("op_b", "operation b"),
+    ])
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("tools.registry.registry", reg)
+        mcp_tool_mod._register_server_tools(
+            "nofilter", server,
+            {"command": "x", "tools": {"scope": "subagent_only"}})
+    # Both tools registered (no filter) and both scoped subagent_only.
+    assert reg.get_entry("mcp__nofilter__op_a").scope == "subagent_only"
+    assert reg.get_entry("mcp__nofilter__op_b").scope == "subagent_only"
+    # MAIN must not see either tool.
+    main_defs = {d["function"]["name"] for d in reg.get_definitions(
+        {"mcp__nofilter__op_a", "mcp__nofilter__op_b"})}
+    assert "mcp__nofilter__op_a" not in main_defs
+    assert "mcp__nofilter__op_b" not in main_defs
+
+
 def test_register_server_tools_unknown_scope_defaults_main(caplog):
     reg = _fresh_registry()
     server = _FakeServer([_FakeMcpTool("op", "op")])

--- a/tests/tools/test_mcp_subagent_only.py
+++ b/tests/tools/test_mcp_subagent_only.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 from tools.registry import ToolRegistry, registry
 from tools import mcp_tool as mcp_tool_mod
 from tools.mcp_tool import _normalize_mcp_scope
+from model_tools import get_tool_definitions
 
 
 # ---------------------------------------------------------------------------
@@ -262,3 +263,69 @@ def test_dynamic_refresh_retains_scope(monkeypatch):
     assert entry.scope == "subagent_only"
     # And MAIN still does not see it.
     assert "mcp__dyn__danger" not in {d["function"]["name"] for d in reg.get_definitions({"mcp__dyn__danger"})}
+
+
+# ---------------------------------------------------------------------------
+# Child exposure: child toolset derivation + Tool Search catalog
+# ---------------------------------------------------------------------------
+
+def test_child_inherits_registered_mcp_toolset(monkeypatch):
+    """With enabled_toolsets=None (default), the child's toolsets are derived
+    from the parent's *main-visible* valid_tool_names, which deliberately
+    excludes subagent_only-scoped MCP tools. The derivation must still fold the
+    registered mcp-* toolsets back in so the child (which passes
+    include_subagent_only=True downstream) can call them, while MAIN cannot."""
+    from tools import delegate_tool as dt
+
+    reg = _fresh_registry()
+    # A main-visible tool and a subagent_only-scoped MCP tool, both in mcp-srv.
+    _reg_tool(reg, "mcp__srv__pub", scope="main", toolset="mcp-srv")
+    _reg_tool(reg, "mcp__srv__secret", scope="subagent_only", toolset="mcp-srv")
+    reg.register_toolset_alias("srv", "mcp-srv")
+
+    monkeypatch.setattr("tools.registry.registry", reg)
+    monkeypatch.setattr("model_tools.registry", reg)
+
+    # Simulate the parent of a delegated child: default-enabled, but its
+    # visible schema excludes the subagent_only tool.
+    class _FakeParent:
+        enabled_toolsets = None
+        valid_tool_names = ["mcp__srv__pub"]  # secret withheld from MAIN schema
+        disabled_toolsets = None
+
+    inherited = dt._registered_mcp_toolsets()
+    assert "mcp-srv" in inherited, "registered MCP toolset must be discoverable"
+    # Replicate the derivation fold-in done in _build_child_agent.
+    parent_toolsets = {
+        ts
+        for n in _FakeParent.valid_tool_names
+        if (ts := __import__("model_tools").get_toolset_for_tool(n)) is not None
+    }
+    parent_toolsets.update(inherited)
+    assert "mcp-srv" in parent_toolsets
+
+
+def test_child_tool_search_catalog_includes_subagent_only(monkeypatch):
+    """The Tool Search bridge catalog (handle_function_call path) must surface
+    subagent_only tools for a child agent (platform='subagent') but withhold
+    them for MAIN."""
+    reg = _fresh_registry()
+    _reg_tool(reg, "mcp__srv__childonly", scope="subagent_only", toolset="mcp-srv")
+    _reg_tool(reg, "mcp__srv__pub", scope="main", toolset="mcp-srv")
+    reg.register_toolset_alias("srv", "mcp-srv")
+
+    monkeypatch.setattr("tools.registry.registry", reg)
+    monkeypatch.setattr("model_tools.registry", reg)
+
+    main_catalog = get_tool_definitions(
+        enabled_toolsets=["mcp-srv"], quiet_mode=True,
+        skip_tool_search_assembly=True, include_subagent_only=False,
+    )
+    child_catalog = get_tool_definitions(
+        enabled_toolsets=["mcp-srv"], quiet_mode=True,
+        skip_tool_search_assembly=True, include_subagent_only=True,
+    )
+    main_names = {d["function"]["name"] for d in main_catalog}
+    child_names = {d["function"]["name"] for d in child_catalog}
+    assert "mcp__srv__childonly" not in main_names
+    assert "mcp__srv__childonly" in child_names

--- a/tests/tools/test_mcp_subagent_only.py
+++ b/tests/tools/test_mcp_subagent_only.py
@@ -148,10 +148,14 @@ def test_get_tool_definitions_cache_key_isolation(monkeypatch):
     monkeypatch.setattr("tools.registry.registry", reg)
     monkeypatch.setattr("model_tools.registry", reg)
 
+    # skip_tool_search_assembly=True: test scoping at the registry level,
+    # not tiered-disclosure bridge behavior (tested separately in tool_search tests).
     main_defs = get_tool_definitions(
-        enabled_toolsets=["mcp-srv"], quiet_mode=True, include_subagent_only=False)
+        enabled_toolsets=["mcp-srv"], quiet_mode=True, include_subagent_only=False,
+        skip_tool_search_assembly=True)
     child_defs = get_tool_definitions(
-        enabled_toolsets=["mcp-srv"], quiet_mode=True, include_subagent_only=True)
+        enabled_toolsets=["mcp-srv"], quiet_mode=True, include_subagent_only=True,
+        skip_tool_search_assembly=True)
 
     main_names = {d["function"]["name"] for d in main_defs}
     child_names = {d["function"]["name"] for d in child_defs}

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -652,6 +652,30 @@ def _get_inherit_mcp_toolsets() -> bool:
     return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
 
 
+def _registered_mcp_toolsets() -> List[str]:
+    """Return every MCP toolset currently registered in the tool registry.
+
+    Used when deriving a delegated child's toolsets from the parent's
+    *main-visible* ``valid_tool_names``. Subagent-only-scoped MCP tools are
+    deliberately withheld from that set (see ``ToolEntry.scope``), so a naive
+    derivation would drop their ``mcp-<server>`` toolset and leave the child
+    unable to call them. We fold the registered MCP toolsets back in so a
+    child (which passes ``include_subagent_only=True`` to the schema builder)
+    still receives every configured MCP server's toolsets.
+    """
+    try:
+        from tools.registry import registry
+
+        names = [
+            ts
+            for ts in registry.get_available_toolsets()
+            if _is_mcp_toolset_name(ts)
+        ]
+    except Exception:
+        names = []
+    return names
+
+
 def _is_mcp_toolset_name(name: str) -> bool:
     """Return True for canonical MCP toolsets and their registered aliases."""
     if not name:
@@ -1255,7 +1279,14 @@ def _build_child_agent(
     if parent_enabled is not None:
         parent_toolsets = set(parent_enabled)
     elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
-        # enabled_toolsets is None (all tools) — derive from loaded tool names
+        # enabled_toolsets is None (all tools) — derive from loaded tool names.
+        # NOTE: valid_tool_names is the *main-visible* schema, so subagent_only
+        # scoped MCP tools are intentionally absent (see ToolEntry.scope). When
+        # MCP toolset inheritance is on, fold the registered mcp-* toolsets back
+        # in so delegated children still receive them — a child passes
+        # include_subagent_only=True to the schema builder, so it can call the
+        # scoped tools that MAIN cannot. Without this, scope=subagent_only would
+        # hide the tool from the child too (defeating the feature).
         import model_tools
 
         parent_toolsets = {
@@ -1263,6 +1294,8 @@ def _build_child_agent(
             for name in parent_agent.valid_tool_names
             if (ts := model_tools.get_toolset_for_tool(name)) is not None
         }
+        if _get_inherit_mcp_toolsets():
+            parent_toolsets.update(_registered_mcp_toolsets())
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6066,6 +6066,7 @@ def refresh_agent_mcp_tools(
     enabled_override=None,
     disabled_override=None,
     quiet_mode: bool = True,
+    include_subagent_only: bool = False,
 ) -> set:
     """Re-derive an already-built agent's tool snapshot from the live registry.
 
@@ -6134,6 +6135,7 @@ def refresh_agent_mcp_tools(
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
             quiet_mode=quiet_mode,
+            include_subagent_only=include_subagent_only,
         )
         or []
     )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5543,9 +5543,10 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
     # Visibility scope (see ToolEntry.scope). Server-level `scope` applies to
     # all of this server's tools (and its utility tools). A `scope` inside the
-    # `tools:` block applies only to the tool(s) selected by include/exclude:
-    # when include/exclude filtered the tool in, and tools.scope is set, that
-    # narrower scope wins; otherwise the server-level scope (or "main") applies.
+    # `tools:` block overrides for the include/exclude-selected tools when a
+    # filter is present; when no include/exclude filter is set, `tools.scope`
+    # applies to ALL tools of the server (so `tools: { scope: subagent_only }`
+    # without a filter does not silently leave every tool at "main").
     server_scope = _normalize_mcp_scope(config.get("scope"), f"mcp_servers.{name}.scope")
     tools_scope = _normalize_mcp_scope(
         tools_filter.get("scope"), f"mcp_servers.{name}.tools.scope"
@@ -5559,11 +5560,17 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         return True
 
     def _tool_scope(tool_name: str) -> str:
-        # Per-tool scope only narrows when the tools block explicitly scopes
-        # the include/exclude-selected set AND this tool was actually selected
-        # by that filter. Mirrors include/exclude precedence.
-        if (include_set or exclude_set) and tools_filter.get("scope"):
-            if _should_register(tool_name):
+        if tools_filter.get("scope"):
+            if include_set or exclude_set:
+                # Per-tool scope applies only to the include/exclude-selected
+                # set. Mirrors include/exclude precedence.
+                if _should_register(tool_name):
+                    return tools_scope
+            else:
+                # No include/exclude filter: tools.scope applies to ALL tools
+                # of this server. Without this, `tools: { scope: subagent_only }`
+                # would silently leave every tool at "main" — the same failure
+                # class (inverted) that _normalize_mcp_scope warns against.
                 return tools_scope
         return server_scope
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5216,6 +5216,31 @@ def mcp_prefixed_tool_name(server_name: str, tool_name: str) -> str:
     return f"{MCP_TOOL_NAME_PREFIX}{safe_server}{_MCP_NAME_DELIM}{safe_tool}"
 
 
+# Allowed values for the MCP server `scope` config key (server-level or
+# inside `tools:`). Anything else is treated as "main" with a warning so a
+# typo never silently hides a tool from the MAIN agent.
+_MCP_SCOPE_ALLOWED = ("main", "subagent_only")
+
+
+def _normalize_mcp_scope(value, where: str) -> str:
+    """Validate and normalize an MCP `scope` config value.
+
+    Returns "main" or "subagent_only". Unknown/empty/absent values default to
+    "main" and emit a warning. This is the single normalization point so the
+    registry only ever sees a valid scope.
+    """
+    if not value:
+        return "main"
+    if value not in _MCP_SCOPE_ALLOWED:
+        logger.warning(
+            "MCP server config %s: unknown scope value %r; defaulting to "
+            "'main' (tool visible to MAIN agent). Allowed values: %s",
+            where, value, ", ".join(_MCP_SCOPE_ALLOWED),
+        )
+        return "main"
+    return value
+
+
 def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
     """Convert an MCP tool listing to the Hermes registry schema format.
 
@@ -5516,12 +5541,31 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     include_set = _normalize_name_filter(tools_filter.get("include"), f"mcp_servers.{name}.tools.include")
     exclude_set = _normalize_name_filter(tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude")
 
+    # Visibility scope (see ToolEntry.scope). Server-level `scope` applies to
+    # all of this server's tools (and its utility tools). A `scope` inside the
+    # `tools:` block applies only to the tool(s) selected by include/exclude:
+    # when include/exclude filtered the tool in, and tools.scope is set, that
+    # narrower scope wins; otherwise the server-level scope (or "main") applies.
+    server_scope = _normalize_mcp_scope(config.get("scope"), f"mcp_servers.{name}.scope")
+    tools_scope = _normalize_mcp_scope(
+        tools_filter.get("scope"), f"mcp_servers.{name}.tools.scope"
+    )
+
     def _should_register(tool_name: str) -> bool:
         if include_set:
             return matches_name_filter(tool_name, include_set)
         if exclude_set:
             return not matches_name_filter(tool_name, exclude_set)
         return True
+
+    def _tool_scope(tool_name: str) -> str:
+        # Per-tool scope only narrows when the tools block explicitly scopes
+        # the include/exclude-selected set AND this tool was actually selected
+        # by that filter. Mirrors include/exclude precedence.
+        if (include_set or exclude_set) and tools_filter.get("scope"):
+            if _should_register(tool_name):
+                return tools_scope
+        return server_scope
 
     for mcp_tool in server._tools:
         if not _should_register(mcp_tool.name):
@@ -5552,6 +5596,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             check_fn=_make_check_fn(name),
             is_async=False,
             description=schema["description"],
+            scope=_tool_scope(mcp_tool.name),
         )
         _track_mcp_tool_server(tool_name_prefixed, name)
         registered_names.append(tool_name_prefixed)
@@ -5589,6 +5634,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],
+            scope=server_scope,
         )
         _track_mcp_tool_server(util_name, name)
         registered_names.append(util_name)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -90,12 +90,13 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars", "dynamic_schema_overrides",
+        "max_result_size_chars", "dynamic_schema_overrides", "scope",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 scope: str = "main"):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -106,6 +107,14 @@ class ToolEntry:
         self.description = description
         self.emoji = emoji
         self.max_result_size_chars = max_result_size_chars
+        # Visibility scope. "main" (default) = visible to every agent.
+        # "subagent_only" = withheld from the MAIN agent's tool schema and
+        # exposed only to delegated subagents (platform="subagent"). Honored
+        # by get_definitions() when include_subagent_only is False. Unknown
+        # values are normalized to "main" by the caller (see
+        # tools/mcp_tool.py _normalize_mcp_scope) so a typo never silently
+        # hides a tool.
+        self.scope = scope
         # Optional zero-arg callable returning a dict of schema overrides
         # applied at get_definitions() time. Use for fields that depend on
         # runtime config (e.g. delegate_task's description must reflect the
@@ -376,6 +385,7 @@ class ToolRegistry:
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
         override: bool = False,
+        scope: str = "main",
     ):
         """Register a tool.  Called at module-import time by each tool file.
 
@@ -445,6 +455,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                scope=scope,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -527,7 +538,8 @@ class ToolRegistry:
     # Schema retrieval
     # ------------------------------------------------------------------
 
-    def get_definitions(self, tool_names: Set[str], quiet: bool = False) -> List[dict]:
+    def get_definitions(self, tool_names: Set[str], quiet: bool = False,
+                        include_subagent_only: bool = False) -> List[dict]:
         """Return OpenAI-format tool schemas for the requested tool names.
 
         Only tools whose ``check_fn()`` returns True (or have no check_fn)
@@ -537,6 +549,14 @@ class ToolRegistry:
         etc.); TTL chosen so env-var changes (``hermes tools enable foo``)
         still take effect in near-real-time without forcing a full cache
         flush on every call.
+
+        ``include_subagent_only`` controls exposure of ``scope="subagent_only"``
+        tools (see ``ToolEntry.scope``). When ``False`` (the default, used for
+        MAIN agents), those tools are withheld from the returned schemas so the
+        model cannot call them directly. When ``True`` (used for delegated
+        subagents, which are constructed with ``platform="subagent"``), they are
+        included. This is the single choke point every ``tools/list``/schema
+        build passes through, so scoping lives here and nowhere else.
         """
         result = []
         # Per-call cache on top of the 30 s TTL — handles repeat probes of the
@@ -547,6 +567,16 @@ class ToolRegistry:
         for name in sorted(tool_names):
             entry = entries_by_name.get(name)
             if not entry:
+                continue
+            # Scope guard: subagent_only tools are withheld from non-subagent
+            # agents (MAIN). Delegated children pass include_subagent_only=True
+            # (they are subagents by construction: AIAgent(platform="subagent")).
+            if entry.scope == "subagent_only" and not include_subagent_only:
+                if not quiet:
+                    logger.debug(
+                        "Tool %s withheld from MAIN schema (scope=subagent_only)",
+                        name,
+                    )
                 continue
             if entry.check_fn:
                 if entry.check_fn not in check_results:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5574,7 +5574,10 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
             try:
                 from tools.mcp_tool import refresh_agent_mcp_tools
 
-                added = refresh_agent_mcp_tools(agent, quiet_mode=True)
+                added = refresh_agent_mcp_tools(
+                    agent, quiet_mode=True,
+                    include_subagent_only=(getattr(agent, "platform", None) == "subagent"),
+                )
             except Exception as exc:
                 logger.warning(
                     "Late MCP refresh: tool snapshot rebuild failed for %s: %s",
@@ -14946,6 +14949,7 @@ def _(rid, params: dict) -> dict:
                     agent,
                     enabled_override=_load_enabled_toolsets(),
                     quiet_mode=True,
+                    include_subagent_only=(getattr(agent, "platform", None) == "subagent"),
                 )
             except Exception as _exc:
                 logger.warning(

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -61,6 +61,7 @@ mcp_servers:
 | `tools` | mapping | both | Filtering and utility-tool policy |
 | `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
+| `scope` | string | both | Restrict this server's tools to delegated subagents only (`subagent_only`) or to all agents (`main`, default) |
 
 ## `tools` policy keys
 
@@ -70,6 +71,7 @@ mcp_servers:
 | `exclude` | string or list | Blacklist server-native MCP tools |
 | `resources` | bool-like | Enable/disable `list_resources` + `read_resource` |
 | `prompts` | bool-like | Enable/disable `list_prompts` + `get_prompt` |
+| `scope` | string | Restrict only the `include`/`exclude`-selected tools to delegated subagents (`subagent_only`) or all agents (`main`, default) |
 
 ## Filtering semantics
 
@@ -154,6 +156,61 @@ Behavior:
 - no discovery
 - no tool registration
 - config remains in place for later reuse
+
+## `scope` — restrict a server or tool to delegated subagents
+
+`scope` controls **who may call** a server's tools. It has two values:
+
+- `main` (default) — the tool is available to the MAIN agent and all subagents.
+  This is exactly today's behavior; omitting `scope` is byte-for-byte identical.
+- `subagent_only` — the tool is **withheld from the MAIN agent's tool schema**
+  and exposed **only to subagents** spawned via `delegate_task`. Use this for
+  powerful or risky operations you want a focused worker to perform without the
+  top-level agent calling them directly. This *adds* a containment surface
+  (MAIN can no longer reach the tool); it never removes capability from a child.
+
+`scope` can be set at two granularities:
+
+1. **Server-level** — applies to every tool of the server (and its utility
+   tools):
+
+   ```yaml
+   mcp_servers:
+     risky-server:
+       command: npx
+       args: [risky-server]
+       scope: subagent_only
+   ```
+
+2. **`tools:`-level** — applies only to the tool set selected by
+   `tools.include` / `tools.exclude`. Precedence mirrors `include` over
+   `exclude`: if `include` is set and `tools.scope: subagent_only`, only those
+   included tools are scoped; the rest of the server's tools remain `main`
+   (visible to MAIN).
+
+   ```yaml
+   mcp_servers:
+     mixed-server:
+       url: https://example.internal/mcp
+       tools:
+         include: [dangerous_op, raw_query]
+         scope: subagent_only   # only dangerous_op + raw_query become subagent_only
+   ```
+
+**Unknown / misspelled `scope` values are not silently hidden.** A value other
+than `main` or `subagent_only` is logged as a warning and treated as `main`, so
+a typo keeps the tool visible rather than accidentally hiding it.
+
+### How child exposure works
+
+Both the MAIN agent and every delegated child funnel through the same tool
+registry and schema assembly. The MAIN agent passes `include_subagent_only=False`
+(which hides `subagent_only` tools), while a delegated child is constructed with
+`platform="subagent"` and passes `include_subagent_only=True`. The corresponding
+`mcp-<server>` toolset must also be present in the child's toolset set. Default
+`inherit_mcp_toolsets: true` preserves the parent's MCP toolsets automatically;
+when inheritance is disabled, include that server toolset explicitly in the
+delegation. In either case, the MAIN agent never sees the scoped tools.
 
 ## Empty result behavior
 

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -163,11 +163,12 @@ Behavior:
 
 - `main` (default) — the tool is available to the MAIN agent and all subagents.
   This is exactly today's behavior; omitting `scope` is byte-for-byte identical.
-- `subagent_only` — the tool is **withheld from the MAIN agent's tool schema**
+- `subagent_only` — the tool is **omitted from the MAIN agent's tool schema**
   and exposed **only to subagents** spawned via `delegate_task`. Use this for
   powerful or risky operations you want a focused worker to perform without the
-  top-level agent calling them directly. This *adds* a containment surface
-  (MAIN can no longer reach the tool); it never removes capability from a child.
+  top-level agent calling them directly. This hides the tool from MAIN's model
+  schema (the standard containment mechanism); it never removes capability from
+  a child.
 
 `scope` can be set at two granularities:
 
@@ -182,8 +183,10 @@ Behavior:
        scope: subagent_only
    ```
 
-2. **`tools:`-level** — applies only to the tool set selected by
-   `tools.include` / `tools.exclude`. Precedence mirrors `include` over
+2. **`tools:`-level** — overrides for the tool set selected by
+   `tools.include` / `tools.exclude`. When a filter is present, `tools.scope`
+   applies only to the selected tools; when no filter is set, `tools.scope`
+   applies to ALL tools of the server. Precedence mirrors `include` over
    `exclude`: if `include` is set and `tools.scope: subagent_only`, only those
    included tools are registered **and** scoped `subagent_only`. Tools the
    `include` list does not select are *not* registered at all (the `include`

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -185,8 +185,11 @@ Behavior:
 2. **`tools:`-level** — applies only to the tool set selected by
    `tools.include` / `tools.exclude`. Precedence mirrors `include` over
    `exclude`: if `include` is set and `tools.scope: subagent_only`, only those
-   included tools are scoped; the rest of the server's tools remain `main`
-   (visible to MAIN).
+   included tools are registered **and** scoped `subagent_only`. Tools the
+   `include` list does not select are *not* registered at all (the `include`
+   filter is a whitelist), so there is no `main`-visible remainder from this
+   server — the scoped tools are simply hidden from MAIN and exposed to
+   children, while the server contributes no other tools.
 
    ```yaml
    mcp_servers:


### PR DESCRIPTION
## Summary

Adds an opt-in MCP tool visibility scope for tools that should be available to delegated subagents but omitted from the main agent's model schema.

- supports server-level `scope: subagent_only`
- supports `tools.scope: subagent_only` with existing include/exclude selection semantics
- keeps absent/default scope behavior unchanged
- preserves scope across dynamic `tools/list` refreshes
- isolates main/child tool-definition caches
- validates scope values and fails open to existing visible behavior with a warning
- documents child toolset inheritance requirements

## Clean branch provenance

This PR is based directly on current upstream `main`:

- upstream base: `d9ee342414042bba7bca43438f19d2fba9a54806`
- feature commit: `b9433337aa722b03afdb84de2a4b7827e45594dc`
- commit count over upstream: 1
- changed files: 8

## Motivation

Some MCP servers expose powerful or very large tool surfaces that are better used by focused delegated agents. Previously, Hermes had no way to keep those tools out of the main agent schema while retaining them for `delegate_task` children.

## Configuration

```yaml
mcp_servers:
  analysis-server:
    command: ...
    scope: subagent_only
```

Per-selected-tool scope is also supported under `tools.scope`.

## Compatibility

No `scope` or `scope: main` preserves existing behavior: tools remain visible to both the main agent and delegated children. Unknown values emit a warning and fall back to `main`.

## Validation

- fresh upstream-base focused/dependent suite: 143 passed
- `git diff --check upstream/main..HEAD`: clean
- independent adversarial review: APPROVE
- production-config smoke: MAIN had 0 RE-scoped tools; delegated child had 303 RE-scoped tools; cache isolation passed
