### PR TITLE
fix(kanban): stop dispatcher terminal config leaking into assignee workers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8636,6 +8636,18 @@ def _default_spawn(
         # This only happens in test fixtures where the isolated
         # HERMES_HOME never had profiles created.
         pass
+    # Isolation boundary: do not leak the dispatcher/gateway profile's
+    # terminal.* config into an assignee worker running on a different profile.
+    # `env = dict(os.environ)` above copies the dispatcher's already-exported
+    # TERMINAL_* values (docker image/volumes/network, container limits, ssh
+    # target, backend, sandbox, ...). Strip the profile-derived ones so the
+    # child `hermes -p <assignee>` rebuilds them from the assignee profile via
+    # config.apply_terminal_config_to_env, instead of inheriting the
+    # dispatcher's or failing to receive its own (#66541). The task-specific
+    # TERMINAL_CWD / TERMINAL_TIMEOUT are re-applied below.
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+    for _terminal_env_var in TERMINAL_CONFIG_ENV_MAP.values():
+        env.pop(_terminal_env_var, None)
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -429,6 +429,69 @@ class TestWorkerSpawnEnv:
         expected_ws = fresh_home / "kanban" / "boards" / "spawntest" / "workspaces"
         assert env["HERMES_KANBAN_WORKSPACES_ROOT"] == str(expected_ws)
 
+    def test_default_spawn_strips_dispatcher_terminal_profile_env(
+        self, fresh_home, monkeypatch
+    ):
+        """A worker on a non-default profile must not inherit the dispatcher's
+        profile-derived TERMINAL_* config (docker image/volumes/network,
+        container limits, backend, ...). Those leak the dispatcher's isolation
+        settings across the profile boundary; the child must rebuild them from
+        its own profile (#66541). The task-specific TERMINAL_CWD pin still wins.
+        """
+        # Values the dispatcher/gateway exported from ITS profile's terminal:.
+        monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "dispatcher/image:latest")
+        monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", "/host/secret:/mnt")
+        monkeypatch.setenv("TERMINAL_DOCKER_NETWORK", "dispatcher-net")
+        monkeypatch.setenv("TERMINAL_CONTAINER_MEMORY", "8g")
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+        captured = {}
+
+        class FakeProc:
+            pid = 999
+
+        def fake_popen(cmd, *args, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+            return FakeProc()
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+        ws = fresh_home / "ws"
+        ws.mkdir(parents=True, exist_ok=True)
+
+        task = kb.Task(
+            id="t_iso",
+            title="isolation",
+            body=None,
+            assignee="teknium",
+            status="ready",
+            priority=0,
+            created_by="user",
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+        )
+
+        kb._default_spawn(task, str(ws), board=None)
+
+        env = captured["env"]
+        for leaked in (
+            "TERMINAL_DOCKER_IMAGE",
+            "TERMINAL_DOCKER_VOLUMES",
+            "TERMINAL_DOCKER_NETWORK",
+            "TERMINAL_CONTAINER_MEMORY",
+            "TERMINAL_ENV",
+        ):
+            assert leaked not in env, f"{leaked} leaked into the worker env"
+        # Task-specific pins are still applied after the strip.
+        assert env["HERMES_KANBAN_TASK"] == "t_iso"
+        assert env["TERMINAL_CWD"] == str(ws)
+
     def test_default_board_spawn_keeps_legacy_paths(self, fresh_home, monkeypatch):
         captured = {}
 


### PR DESCRIPTION
## What does this PR do?

A Kanban task assigned to a non-default profile could start a worker whose terminal tool used the dispatcher/gateway profile's `terminal:` configuration instead of the assignee profile's. This PR keeps the profile boundary intact so a worker uses its own profile's terminal isolation settings.

Verified against `origin/main` `d9ee3424`: `hermes_cli/kanban_db.py::_default_spawn` builds the worker env with `env = dict(os.environ)`, which copies the dispatcher's already-exported profile-derived `TERMINAL_*` values (docker image/volumes/network, container limits, ssh target, backend, sandbox, ...). It switches `HERMES_HOME` to the assignee profile but never rebuilds those `TERMINAL_*`. When the child `hermes -p <assignee>` starts, `config.apply_terminal_config_to_env` only overrides a var when the assignee `config.yaml` sets that `terminal.*` key, so any key the assignee does not set keeps the dispatcher's inherited value. The boundary leaks both ways: an assignee can receive host paths / container options meant only for the dispatcher, and can miss its own approved Docker volumes.

The fix strips the profile-derived `TERMINAL_*` (the `config.TERMINAL_CONFIG_ENV_MAP` values) right after the env copy, so the child rebuilds terminal config from the assignee profile via `apply_terminal_config_to_env`. This mirrors the existing precedent of dropping leaked env vars from spawned workers (for example #63189). The task-specific `TERMINAL_CWD` / `TERMINAL_TIMEOUT` that `_default_spawn` sets are applied afterward and are unaffected (`_worker_terminal_timeout_env` already handles an absent baseline).

## Related Issue

Fixes #66541

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (profile / container isolation boundary)

## Changes Made

- `hermes_cli/kanban_db.py`: in `_default_spawn`, after copying the environment and switching `HERMES_HOME`, pop the `TERMINAL_CONFIG_ENV_MAP` env vars so the assignee profile's terminal config is rebuilt in the child instead of inherited from the dispatcher.
- `tests/hermes_cli/test_kanban_boards.py`: add `test_default_spawn_strips_dispatcher_terminal_profile_env`.

## How to Test

1. Set dispatcher terminal env, e.g. `TERMINAL_DOCKER_IMAGE`, `TERMINAL_DOCKER_VOLUMES`, `TERMINAL_DOCKER_NETWORK`, `TERMINAL_CONTAINER_MEMORY`, `TERMINAL_ENV`.
2. Dispatch a Kanban task assigned to a non-default profile.
3. Before: the worker's terminal env carries the dispatcher's values. After: those are stripped and the worker rebuilds terminal config from its own profile; task-specific `TERMINAL_CWD` is still pinned.

Real output (Windows 11, pytest 8.4.2):

```
$ python -m pytest tests/hermes_cli/test_kanban_boards.py -k "default_spawn" -q
2 passed, 55 deselected

$ python -m pytest tests/hermes_cli/test_kanban_boards.py -q
2 failed, 55 passed
```

The two failures are `test_remove_clears_init_cache_for_recreated_db[True/False]`, a pre-existing Windows-only `os.rename` PermissionError during board removal that also fails on origin/main with this change stashed (A/B confirmed), unrelated to this diff.

```
$ python -m pytest tests/cron/test_terminal_cwd_lock.py tests/gateway/test_config_cwd_bridge.py tests/cli/test_cwd_env_respect.py -q
44 passed

$ python scripts/check-windows-footguns.py --diff origin/main
No Windows footguns found (2 file(s) scanned).
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(kanban): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the relevant suites (kanban_boards, terminal/cwd bridge, cron cwd lock, cli cwd) and they pass; the full `pytest tests/` tree is not run here because it has pre-existing Windows-only failures unrelated to this change (documented above)
- [x] I've added a test for this fix
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A (no user-facing docs; behavior is internal worker isolation)
- [x] N/A (no config keys added or changed)
- [x] N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact: the strip is `dict.pop`, platform-neutral; footgun scan clean

<!-- AI-assisted: reported and fixed by Stan Shih (stantheman0128); investigation and patch done with Claude (Claude Code), human-reviewed before submitting. -->
