### PR TITLE
fix(ci): restore fork-safe token fallback on PR gates broken by #66373

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -47,7 +47,12 @@ runs:
       id: classify
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        # Fall back to the built-in read-only token when the caller passes an
+        # empty value. Fork PRs get no repo secrets, so AUTOFIX_BOT_PAT is ""
+        # there, and an input `default:` only applies when the input is omitted,
+        # not when it's passed empty. Without this fallback the compare API
+        # fails on forks and the classifier fails open (every lane forced on).
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
         REPO: ${{ github.repository }}
         EVENT_NAME: ${{ github.event_name }}
         BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
         id: classify
         uses: ./.github/actions/detect-changes
         with:
-          github-token: ${{ secrets.AUTOFIX_BOT_PAT }}
+          # Forks get no repo secrets (AUTOFIX_BOT_PAT is empty); fall back to
+          # the built-in read-only token so classification still works there.
+          github-token: ${{ secrets.AUTOFIX_BOT_PAT || github.token }}
 
   # ─────────────────────────────────────────────────────────────────────
   # Lane-gated sub-workflows. Each runs in parallel after detect finishes.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -177,18 +177,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Fetch PR labels
-        id: pr-labels
-        uses: ./.github/actions/retry
-        env:
-          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
-        with:
-          command: gh pr view "${{ github.event.pull_request.number }}" --json labels --jq '.labels[].name'
       - name: Require ci-reviewed label
         id: label-check
+        env:
+          # Read-only label lookup. Use the built-in GITHUB_TOKEN (present and
+          # read-only on forks) so the gate works on fork PRs; fall back to it
+          # when AUTOFIX_BOT_PAT is empty. `|| true` degrades an API blip to
+          # "label absent" rather than hard-failing the step.
+          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT || github.token }}
         run: |
           set -euo pipefail
-          if echo "${{ steps.pr-labels.outputs.stdout }}" | grep -Fxq 'ci-reviewed'; then
+          PR="${{ github.event.pull_request.number }}"
+          LABELS=$(gh pr view "$PR" --json labels --jq '.labels[].name' || true)
+          if echo "$LABELS" | grep -Fxq 'ci-reviewed'; then
             echo "reviewed=true" >> "$GITHUB_OUTPUT"
             echo "ci-reviewed label present."
             exit 0
@@ -203,7 +204,7 @@ jobs:
       - name: Post or update review warning
         if: steps.label-check.outputs.reviewed != 'true' && github.event.pull_request.head.repo.fork != true
         env:
-          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT || github.token }}
         run: |
           set -euo pipefail
           PR="${{ github.event.pull_request.number }}"
@@ -251,7 +252,7 @@ jobs:
       - name: Update previous warning to passed
         if: steps.label-check.outputs.reviewed == 'true' && github.event.pull_request.head.repo.fork != true
         env:
-          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT || github.token }}
         run: |
           set -euo pipefail
           PR="${{ github.event.pull_request.number }}"

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -238,20 +238,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch PR labels
-        id: pr-labels
-        uses: ./.github/actions/retry
-        env:
-          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
-        with:
-          command: gh pr view "${{ github.event.pull_request.number }}" --json labels --jq '.labels[].name'
       - name: Require explicit MCP catalog review label
         env:
-          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
+          # Read-only label lookup. Use the built-in GITHUB_TOKEN (present and
+          # read-only on forks) so the gate works on fork PRs; fall back to it
+          # when AUTOFIX_BOT_PAT is empty. `|| true` degrades an API blip to
+          # "label absent" rather than hard-failing the step.
+          GH_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT || github.token }}
         run: |
           set -euo pipefail
           PR="${{ github.event.pull_request.number }}"
-          if echo "${{ steps.pr-labels.outputs.stdout }}" | grep -Fxq 'mcp-catalog-reviewed'; then
+          LABELS=$(gh pr view "$PR" --json labels --jq '.labels[].name' || true)
+          if echo "$LABELS" | grep -Fxq 'mcp-catalog-reviewed'; then
             echo "MCP catalog review label present."
             exit 0
           fi


### PR DESCRIPTION
## Summary
Fork PRs can pass CI again. #66373 swapped `GITHUB_TOKEN` → `AUTOFIX_BOT_PAT` across the CI workflows; that PAT is empty on forks (forks get no repo secrets), which broke every fork PR.

Root cause: the empty PAT on forks made (1) `detect-changes` fail the compare API and fail open — force-enabling the `ci_review` lane on every fork PR — and (2) the `ci-reviewed` / `mcp-catalog-reviewed` label gates hard-fail reading labels with an empty token, a dead-end a fork contributor can't clear (can't self-add the label; re-running can't fix it).

## Changes
- `detect-changes/action.yml` + `ci.yml`: classifier token falls back to the built-in read-only `github.token` when `AUTOFIX_BOT_PAT` is empty (`AUTOFIX_BOT_PAT || github.token`). Main repo keeps the authoritative PAT read; forks use `github.token`, which can read the public compare endpoint. An input `default:` only applies on omission, not on an empty passed value — hence the explicit `|| github.token`.
- `lint.yml` (ci-review) + `supply-chain-audit.yml` (mcp-catalog): restore the pre-#66373 inline `gh pr view … || true` label read with the same token fallback, dropping the hard-failing retry "Fetch PR labels" step. Graceful degrade to "label absent" on an API blip.

Kept all of #66373's real improvements (job timeouts, per-file flake retry, network-install retries). Same-repo enforcement is byte-identical to before the regression.

## Validation
| Scenario | Before | After |
|---|---|---|
| Fork PR, normal code | detect fails open → `ci_review=true` → label gate dead-ends | classifies correctly → `ci_review=false`, no gate |
| Fork PR touches CI file | dead-ends (empty PAT) | reads labels via `github.token`, gate enforced normally |
| Same-repo PR | works (PAT present) | unchanged (PAT still used) |

Classifier verified: normal code PR → `ci_review=false`, CI-file PR → `true`, empty diff → fail-open. YAML validated on all 4 files; ci-review/mcp-catalog gate logic diffs byte-identical to the pre-#66373 form modulo the token expression.

## Infographic

![fork-ci-token-fallback](https://v3b.fal.media/files/b/0aa2ab5a/BRupngUlpN-1r9Ty6pteH_C2JPFq0h.png)
