### PR TITLE
fix(curator): guard background review writes against manually authored skills

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -374,6 +374,23 @@ def _background_review_write_guard(
                     f"skill '{name}'."
                 ),
             }
+        # Manually authored skills (created_by != "agent") are off-limits
+        # to autonomous curation. This prevents the LLM consolidation pass
+        # from archiving skills the user placed manually (e.g. via URL
+        # install or direct SKILL.md authoring), which lack the
+        # `created_by: "agent"` marker.
+        usage_data = skill_usage.load_usage()
+        usage_rec = usage_data.get(name)
+        if isinstance(usage_rec, dict) and not skill_usage._is_curator_managed_record(usage_rec):
+            return {
+                "success": False,
+                "error": (
+                    f"Refusing background curator {action} for skill "
+                    f"'{name}': the skill records show it is not agent-created "
+                    f"(created_by={usage_rec.get('created_by')!r}). Manually authored "
+                    f"skills are off-limits to autonomous curation."
+                ),
+            }
     except Exception:
         logger.debug("owned skill guard lookup failed for %s", name, exc_info=True)
     return None


### PR DESCRIPTION
## Problem

The curator's LLM consolidation pass (background review fork) can archive manually authored skills — skills the user placed via URL install, direct `SKILL.md` authoring, or external sources like Gitee. These skills carry `created_by=None` in `.usage.json`, not `created_by="agent"`.

The `_background_review_write_guard` already blocks writes to pinned, external, bundled, hub-installed, and protected built-in skills — but had no check for manually authored skills.

### Real impact

The guard already caught a real case: the user's `auto-dev` skill (use_count=50, patch_count=119) was archived 28 seconds after its last use during a curator auto-run. The skill had to be restored manually with `hermes curator restore`.

## Fix

Adds a check inside `_background_review_write_guard()`: if the skill has an existing usage record and its `created_by` is not `"agent"`, refuse the background curator write. Skills with no record at all (new/unknown skills, freshly seeded built-ins) are not blocked — they pass through as before.

## Testing

- `tests/tools/test_skill_manager_tool.py`: 154 passed, 3 skipped, 1 pre-existing Windows symlink failure (unrelated)
- `tests/tools/test_skill_usage.py`: 40 passed (excluding flaky concurrent-bump test)
- `tests/tools/test_skill_provenance.py`: 5 passed

Co-authored-by: MaoZhiqin <1940428933@qq.com>