### PR TITLE
fix(save_env_value): quote values with internal spaces to prevent shell-sourcing breakage (#66482)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7778,6 +7778,7 @@ def _quote_env_value(value: str) -> str:
         or '"' in value
         or "'" in value
         or value != value.strip()
+        or any(c.isspace() for c in value)
     )
     if not needs_quoting:
         return value


### PR DESCRIPTION
## Summary

One-line fix: extend the `needs_quoting` trigger in `_quote_env_value()` to also fire when any character in the value is whitespace (`any(c.isspace() for c in value)`).

## Root cause

`needs_quoting` checked for `#`, quotes, and leading/trailing whitespace — but not internal whitespace. A path like `/Users/paulo/Library/Application Support/hermes/keys/id_ed25519` was written unquoted, which breaks `set -a; . .env` (POSIX word-splitting).

## Changes

- `hermes_cli/config.py` line 7781: added `or any(c.isspace() for c in value)` to the `needs_quoting` condition
- Escaping/wrapping is unchanged (existing `replace('\\', ...)` / `f'...'` handles the quoting correctly)

Closes #66482