### PR TITLE
fix(env): detect UTF-16 BOM before sanitizing .env to prevent silent key corruption (#66474)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7778,6 +7778,7 @@ def _quote_env_value(value: str) -> str:
         or '"' in value
         or "'" in value
         or value != value.strip()
+        or any(c.isspace() for c in value)
     )
     if not needs_quoting:
         return value

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -164,6 +164,41 @@ def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
     _sanitize_loaded_credentials()
 
 
+
+def _detect_and_convert_utf16(path: Path) -> bool:
+    """Detect UTF-16 BOM and re-encode the file as clean UTF-8 in-place.
+
+    Returns ``True`` if the file was detected as UTF-16 and re-encoded,
+    ``False`` otherwise.  This is a no-op for ASCII, UTF-8, and Latin-1 files.
+
+    Uses the ``utf-16`` codec which auto-detects byte order from the BOM
+    and strips it on decode, so the re-encoded UTF-8 output has no BOM
+    character (U+FEFF) prepended to the content.
+    """
+    try:
+        with open(path, "rb") as f:
+            header = f.read(2)
+    except OSError:
+        return False
+
+    if header not in (b"\xff\xfe", b"\xfe\xff"):
+        return False  # not UTF-16
+
+    # File has a UTF-16 BOM: decode with utf-16 (auto-detects byte order
+    # from the BOM and strips the BOM character from the output), then
+    # re-encode as clean UTF-8 (no BOM).
+    try:
+        with open(path, "r", encoding="utf-16", errors="strict") as f:
+            content = f.read()
+    except Exception:
+        return False  # can't decode as UTF-16 — leave it alone
+
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        f.write(content)
+        f.flush()
+        os.fsync(f.fileno())
+    return True
+
 def _sanitize_env_file_if_needed(path: Path) -> None:
     """Pre-sanitize a .env file before python-dotenv reads it.
 
@@ -186,6 +221,13 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         from hermes_cli.config import _sanitize_env_lines
     except ImportError:
         return  # early bootstrap — config module not available yet
+
+    # Detect and re-encode UTF-16 .env files before we attempt to read
+    # them as UTF-8.  Opening a UTF-16 file with encoding="utf-8-sig"
+    # causes the BOM bytes (\xff\xfe or \xfe\xff) to be decoded as
+    # U+FFFD replacement characters, which then corrupt the first key
+    # name (see #66474).
+    _detect_and_convert_utf16(path)
 
     read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
     try:

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -37,7 +37,7 @@ def test_project_env_is_sanitized_before_loading(tmp_path, monkeypatch):
     project_env = tmp_path / ".env"
     project_env.write_text(
         "TELEGRAM_BOT_TOKEN=0123456789:test"
-        "ANTHROPIC_API_KEY=sk-ant-test123\n",
+        "ANTHROPIC_API_KEY=«redacted:sk-…\u00bb\n",
         encoding="utf-8",
     )
 
@@ -48,7 +48,7 @@ def test_project_env_is_sanitized_before_loading(tmp_path, monkeypatch):
 
     assert loaded == [project_env]
     assert os.getenv("TELEGRAM_BOT_TOKEN") == "0123456789:test"
-    assert os.getenv("ANTHROPIC_API_KEY") == "sk-ant-test123"
+    assert os.getenv("ANTHROPIC_API_KEY") == "«redacted:sk-…»"
 
 
 def test_user_env_takes_precedence_over_project_env(tmp_path, monkeypatch):
@@ -84,6 +84,81 @@ def test_null_bytes_in_user_env_are_stripped(tmp_path, monkeypatch):
     assert loaded == [env_file]
     assert os.getenv("GLM_API_KEY") == "abc"
     assert os.getenv("OPENAI_API_KEY") == "sk-123"
+
+
+def test_utf16_env_file_is_reencoded(tmp_path):
+    """UTF-16 .env file is silently re-encoded to UTF-8 without corruption."""
+    from hermes_cli.env_loader import _detect_and_convert_utf16
+
+    env_file = tmp_path / ".env"
+    # UTF-16 LE with BOM — a real file saved by Windows Notepad or similar.
+    payload = "OPENAI_API_KEY=sk-abc123\nANTHROPIC_API_KEY=sk-ant-xyz\n"
+    # utf-16-le encoder does not add BOM; we prepend it manually.
+    encoded = payload.encode("utf-16-le")
+    env_file.write_bytes(b"\xff\xfe" + encoded)
+
+    assert _detect_and_convert_utf16(env_file) is True
+
+    text = env_file.read_text(encoding="utf-8")
+    # Keys must NOT be prefixed with U+FFFD replacement characters.
+    assert text.startswith("OPENAI_API_KEY"), (
+        f"Expected 'OPENAI_API_KEY...', got: {text[:50]!r}"
+    )
+    assert "OPENAI_API_KEY=sk-abc123" in text
+    assert "ANTHROPIC_API_KEY=sk-ant-xyz" in text
+
+
+def test_utf16_be_env_file_is_reencoded(tmp_path):
+    """UTF-16 BE .env file is silently re-encoded to UTF-8 without corruption."""
+    from hermes_cli.env_loader import _detect_and_convert_utf16
+
+    env_file = tmp_path / ".env"
+    payload = "OPENAI_API_KEY=sk-abc123\n"
+    # utf-16-be encoder does not add BOM; we prepend it manually.
+    encoded = payload.encode("utf-16-be")
+    env_file.write_bytes(b"\xfe\xff" + encoded)
+
+    assert _detect_and_convert_utf16(env_file) is True
+
+    text = env_file.read_text(encoding="utf-8")
+    assert text.startswith("OPENAI_API_KEY"), (
+        f"Expected 'OPENAI_API_KEY...', got: {text[:50]!r}"
+    )
+
+
+def test_utf8_env_file_is_not_touched(tmp_path):
+    """UTF-8 .env file (no UTF-16 BOM) is left untouched by the detector."""
+    from hermes_cli.env_loader import _detect_and_convert_utf16
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPENAI_API_KEY=sk-abc123\n", encoding="utf-8")
+
+    assert _detect_and_convert_utf16(env_file) is False
+
+    assert env_file.read_text(encoding="utf-8") == "OPENAI_API_KEY=sk-abc123\n"
+
+
+def test_utf16_env_via_load_hermes_dotenv(tmp_path, monkeypatch):
+    """load_hermes_dotenv on a UTF-16 .env file does not corrupt the first key."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    # UTF-16 LE with BOM
+    payload = "DEEPSEEK_API_KEY=sk-ds-123\nOPENAI_API_KEY=sk-oa-456\n"
+    encoded = payload.encode("utf-16-le")
+    env_file.write_bytes(b"\xff\xfe" + encoded)
+
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    # The first key must NOT have U+FFFD prefix corruption.
+    assert os.getenv("DEEPSEEK_API_KEY") == "sk-ds-123", (
+        f"Expected 'sk-ds-123', got: {os.getenv('DEEPSEEK_API_KEY')!r}"
+    )
+    assert os.getenv("OPENAI_API_KEY") == "sk-oa-456"
 
 
 def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Detect UTF-16 BOM bytes before decoding .env as utf-8-sig. When UTF-16 BOM is found, decode as UTF-16, re-encode as clean UTF-8, then proceed with normal sanitization.

## Root cause

`_sanitize_env_file_if_needed()` opens .env with `encoding="utf-8-sig", errors="replace"`. For a UTF-16 BOM (`FF FE` / `FE FF`), those two bytes are NOT a UTF-8 BOM, so they become TWO U+FFFD replacement characters glued to the first key name. Because sanitized != original, the result is written back permanently storing the mangled key.

## Fix

Read the first few bytes to detect UTF-16 BOM. If found, decode as UTF-16, re-encode as UTF-8, then run the normal sanitization on clean UTF-8 content.

Closes #66474