### PR TITLE
fix(gateway): persist session /model override and surface write failures

### DIFF
--- a/contributors/emails/stanshih888@gmail.com
+++ b/contributors/emails/stanshih888@gmail.com
@@ -1,0 +1,2 @@
+stantheman0128
+# PR #66586

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2209,12 +2209,21 @@ class SessionStore:
         are re-resolved at rehydration time via the normal runtime provider
         resolution.  Pass ``None`` (or a dict with no persistable values)
         to clear the persisted override, e.g. on /new.
+
+        Raises ``KeyError`` when *session_key* has no routing entry — callers
+        must ``get_or_create_session`` first.  A silent no-op here made
+        session-only ``/model`` switches appear to succeed while never
+        writing through, so the next agent rebuild reverted to
+        ``model.default`` (#66107).
         """
         with self._lock:
             self._ensure_loaded_locked()
             entry = self._entries.get(session_key)
             if entry is None:
-                return
+                raise KeyError(
+                    f"Cannot persist model override: no session entry for "
+                    f"{session_key!r}"
+                )
             cleaned = sanitize_model_override(override)
             if entry.model_override == cleaned:
                 return

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -103,6 +103,74 @@ class GatewaySlashCommandsMixin:
         adapter = self.adapters.get(platform) if getattr(self, "adapters", None) else None
         return getattr(adapter, "typed_command_prefix", "/") if adapter is not None else "/"
 
+    async def _persist_session_model_override(
+        self,
+        *,
+        source: SessionSource,
+        session_key: str,
+        override: dict,
+        new_model: str,
+    ) -> bool:
+        """Write-through a session-only ``/model`` override to the session store.
+
+        Ensures the routing entry exists first (slash commands can run before
+        the normal message-path ``get_or_create_session``), then persists and
+        verifies the non-secret override.  Failures are logged at WARNING —
+        never debug-only — and reported to the caller so the switch
+        confirmation can warn the user (#66107).
+
+        Returns True on success.  When neither ``session_store`` nor an
+        installed ``_async_session_store`` facade is attached (bare test
+        fixtures), returns True and skips disk write-through.  Fixtures that
+        mock ``_async_session_store`` still exercise the write path.
+        """
+        if (
+            getattr(self, "session_store", None) is None
+            and getattr(self, "_async_session_store", None) is None
+        ):
+            return True
+        try:
+            sess_entry = await self.async_session_store.get_or_create_session(source)
+            # Prefer the store's key so write-through and rehydrate agree even
+            # if the command-derived key drifted (e.g. topic recovery).
+            persist_key = getattr(sess_entry, "session_key", None) or session_key
+            if persist_key != session_key:
+                logger.warning(
+                    "Session key mismatch during model override persist: "
+                    "command_key=%s store_key=%s — writing under store_key "
+                    "and mirroring in-memory override",
+                    session_key,
+                    persist_key,
+                )
+                self._session_model_overrides[persist_key] = dict(override)
+            if getattr(sess_entry, "was_auto_reset", False):
+                sess_entry.was_auto_reset = False
+            sess_db = getattr(self, "_session_db", None)
+            if sess_db is not None:
+                try:
+                    await sess_db.update_session_model(
+                        sess_entry.session_id, new_model
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to persist model switch to session DB: %s", exc
+                    )
+            await self.async_session_store.set_model_override(persist_key, override)
+            persisted = await self.async_session_store.get_model_override(persist_key)
+            expected_model = (override or {}).get("model")
+            if not persisted or persisted.get("model") != expected_model:
+                raise RuntimeError(
+                    f"model override write did not stick for session={persist_key}"
+                )
+            return True
+        except Exception:
+            logger.warning(
+                "Failed to persist session model override for session=%s",
+                session_key,
+                exc_info=True,
+            )
+            return False
+
     async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /new or /reset command."""
         source = event.source
@@ -1568,6 +1636,7 @@ class GatewaySlashCommandsMixin:
                     # Captures self + locals needed for the switch logic.
                     _self = self
                     _session_key = session_key
+                    _normalized_source = source
                     _cur_model = current_model
                     _cur_provider = current_provider
                     _cur_base_url = current_base_url
@@ -1655,19 +1724,18 @@ class GatewaySlashCommandsMixin:
 
                         # Persist the new model to the session DB so the
                         # dashboard shows the updated model (#34850).
-                        _sess_db = getattr(_self, "_session_db", None)
-                        if _sess_db is not None:
-                            try:
-                                _sess_entry = await _self.async_session_store.get_or_create_session(
-                                    event.source
-                                )
-                                await _sess_db.update_session_model(
-                                    _sess_entry.session_id, result.new_model
-                                )
-                            except Exception as exc:
-                                logger.debug(
-                                    "Failed to persist model switch to DB: %s", exc
-                                )
+                        # Write-through also requires a routing entry — slash
+                        # commands can run before the normal message-path
+                        # get_or_create_session, and a missing entry used to
+                        # silently no-op inside set_model_override (#66107).
+                        _override = {
+                            "model": result.new_model,
+                            "provider": result.target_provider,
+                            "api_key": result.api_key,
+                            "base_url": result.base_url,
+                            "api_mode": result.api_mode,
+                        }
+                        _self._session_model_overrides[_session_key] = _override
 
                         # Store model note + session override.  Use display
                         # form (strips opaque Palantir prefix) for the user-
@@ -1683,27 +1751,13 @@ class GatewaySlashCommandsMixin:
                             f"via {result.provider_label or result.target_provider}. "
                             f"Adjust your self-identification accordingly.]"
                         )
-                        _self._session_model_overrides[_session_key] = {
-                            "model": result.new_model,
-                            "provider": result.target_provider,
-                            "api_key": result.api_key,
-                            "base_url": result.base_url,
-                            "api_mode": result.api_mode,
-                        }
 
-                        # Write-through the non-secret parts to the session
-                        # store so the picked model survives a gateway restart
-                        # (api_key is never persisted).
-                        try:
-                            await _self.async_session_store.set_model_override(
-                                _session_key,
-                                _self._session_model_overrides[_session_key],
-                            )
-                        except Exception:
-                            logger.debug(
-                                "Failed to persist session model override",
-                                exc_info=True,
-                            )
+                        _persist_ok = await _self._persist_session_model_override(
+                            source=_normalized_source,
+                            session_key=_session_key,
+                            override=_override,
+                            new_model=result.new_model,
+                        )
 
                         # Evict cached agent so the next turn creates a fresh
                         # agent from the override rather than relying on the
@@ -1814,6 +1868,13 @@ class GatewaySlashCommandsMixin:
                             lines.append(t("gateway.model.capabilities_label", capabilities=mi.format_capabilities()))
                         if result.warning_message:
                             lines.append(t("gateway.model.warning_prefix", warning=result.warning_message))
+                        if not _persist_ok:
+                            lines.append(
+                                t(
+                                    "gateway.model.warning_prefix",
+                                    warning=t("gateway.model.persist_failed_hint"),
+                                )
+                            )
                         if persist_global:
                             lines.append(t("gateway.model.saved_global"))
                         else:
@@ -1957,24 +2018,18 @@ class GatewaySlashCommandsMixin:
                         ),
                     )
 
-            # Persist the new model to the session DB so the dashboard
-            # shows the updated model (#34850).
-            _sess_db = getattr(self, "_session_db", None)
-            if _sess_db is not None:
-                try:
-                    _sess_entry = await self.async_session_store.get_or_create_session(source)
-                    # If this session was auto-reset, consume the flag so the
-                    # next regular message's cleanup does not wipe the model
-                    # override just stored below (Closes #48031).
-                    if getattr(_sess_entry, "was_auto_reset", False):
-                        _sess_entry.was_auto_reset = False
-                    await _sess_db.update_session_model(
-                        _sess_entry.session_id, result.new_model
-                    )
-                except Exception as exc:
-                    logger.debug(
-                        "Failed to persist model switch to DB: %s", exc
-                    )
+            # Persist session model + routing write-through. Ensure the routing
+            # entry exists first — /model can run before the normal message-path
+            # get_or_create_session, and a missing entry previously no-op'd
+            # inside set_model_override so the switch silently reverted (#66107).
+            _override = {
+                "model": result.new_model,
+                "provider": result.target_provider,
+                "api_key": result.api_key,
+                "base_url": result.base_url,
+                "api_mode": result.api_mode,
+            }
+            self._session_model_overrides[session_key] = _override
 
             # Store a note to prepend to the next user message so the model
             # knows about the switch (avoids system messages mid-history).
@@ -1990,14 +2045,6 @@ class GatewaySlashCommandsMixin:
                 f"Adjust your self-identification accordingly.]"
             )
 
-            # Store session override so next agent creation uses the new model
-            self._session_model_overrides[session_key] = {
-                "model": result.new_model,
-                "provider": result.target_provider,
-                "api_key": result.api_key,
-                "base_url": result.base_url,
-                "api_mode": result.api_mode,
-            }
             if one_turn:
                 if not hasattr(self, "_pending_one_turn_model_restores"):
                     self._pending_one_turn_model_restores = {}
@@ -2019,16 +2066,19 @@ class GatewaySlashCommandsMixin:
             # the in-memory dict to. (#29923 review defect: the original
             # implementation wrote through, so a crash before the restore
             # rehydrated the once-model permanently.)
+            #
+            # Ensure the routing entry exists first — /model can run before the
+            # normal message-path get_or_create_session, and a missing entry
+            # previously no-op'd inside set_model_override so the switch
+            # silently reverted (#66107).
+            persist_ok = True
             if not one_turn:
-                try:
-                    await self.async_session_store.set_model_override(
-                        session_key,
-                        self._session_model_overrides[session_key],
-                    )
-                except Exception:
-                    logger.debug(
-                        "Failed to persist session model override", exc_info=True
-                    )
+                persist_ok = await self._persist_session_model_override(
+                    source=source,
+                    session_key=session_key,
+                    override=_override,
+                    new_model=result.new_model,
+                )
 
             # Evict cached agent so the next turn creates a fresh agent from the
             # override rather than relying on cache signature mismatch detection.
@@ -2146,6 +2196,14 @@ class GatewaySlashCommandsMixin:
 
             if result.warning_message:
                 lines.append(t("gateway.model.warning_prefix", warning=result.warning_message))
+
+            if not persist_ok:
+                lines.append(
+                    t(
+                        "gateway.model.warning_prefix",
+                        warning=t("gateway.model.persist_failed_hint"),
+                    )
+                )
 
             if persist_global:
                 lines.append(t("gateway.model.saved_global"))

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "Waarskuwing: {warning}"
     saved_global:           "Gestoor in config.yaml (`--global`)"
     session_only_hint:      "_(slegs sessie — voeg `--global` by om permanent te stoor)_"
+    persist_failed_hint:    "kon nie sessie-oorskrywing stoor nie - volgende boodskap kan terugval na die konfigurasie-verstek; kontroleer gateway-logboeke of gebruik `--global`"
     current_label:          "Huidig: `{model}` op {provider}"
     current_tag:            " (huidig)"
     more_models_suffix:     " (+{count} meer)"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "Warnung: {warning}"
     saved_global:           "In config.yaml gespeichert (`--global`)"
     session_only_hint:      "_(nur für diese Sitzung — `--global` ergänzen, um zu speichern)_"
+    persist_failed_hint:    "Sitzungs-Override konnte nicht persistiert werden - die nächste Nachricht fällt möglicherweise auf die Config-Vorgabe zurück; Gateway-Logs prüfen oder `--global` verwenden"
     current_label:          "Aktuell: `{model}` bei {provider}"
     current_tag:            " (aktuell)"
     more_models_suffix:     " (+{count} weitere)"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -54,6 +54,7 @@ gateway:
     warning_prefix:         "Warning: {warning}"
     saved_global:           "Saved to config.yaml (`--global`)"
     session_only_hint:      "_(session only — add `--global` to persist)_"
+    persist_failed_hint:    "could not persist session override - next message may revert to the config default; check gateway logs or use `--global`"
     current_label:          "Current: `{model}` on {provider}"
     current_tag:            " (current)"
     more_models_suffix:     " (+{count} more)"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "Advertencia: {warning}"
     saved_global:           "Guardado en config.yaml (`--global`)"
     session_only_hint:      "_(solo para esta sesión — añade `--global` para guardarlo)_"
+    persist_failed_hint:    "no se pudo persistir el override de sesión - el siguiente mensaje puede volver al valor por defecto de la config; revisa los logs del gateway o usa `--global`"
     current_label:          "Actual: `{model}` en {provider}"
     current_tag:            " (actual)"
     more_models_suffix:     " (+{count} más)"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "Avertissement : {warning}"
     saved_global:           "Enregistré dans config.yaml (`--global`)"
     session_only_hint:      "_(session uniquement — ajoutez `--global` pour conserver)_"
+    persist_failed_hint:    "impossible de persister le remplacement de session - le prochain message peut revenir à la valeur par défaut de la config ; vérifiez les logs du gateway ou utilisez `--global`"
     current_label:          "Actuel : `{model}` chez {provider}"
     current_tag:            " (actuel)"
     more_models_suffix:     " (+{count} autres)"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -43,6 +43,7 @@ gateway:
     warning_prefix:         "Rabhadh: {warning}"
     saved_global:           "Sábháilte i config.yaml (`--global`)"
     session_only_hint:      "_(seisiún amháin — cuir `--global` leis chun é a choinneáil)_"
+    persist_failed_hint:    "níorbh fhéidir an forshcrios seisiúin a bhuanú - d'fhéadfadh an chéad teachtaireacht eile filleadh ar réamhshocrú an chumraíocht; seiceáil logaí an geata nó úsáid `--global`"
     current_label:          "Reatha: `{model}` ar {provider}"
     current_tag:            " (reatha)"
     more_models_suffix:     " (+{count} eile)"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "Figyelmeztetés: {warning}"
     saved_global:           "Mentve a config.yaml fájlba (`--global`)"
     session_only_hint:      "_(csak ehhez a munkamenethez — add hozzá a `--global` opciót a megőrzéshez)_"
+    persist_failed_hint:    "nem sikerült a munkamenet-felülírás mentése - a következő üzenet visszaállhat a config alapértelmezésére; ellenőrizze a gateway naplókat vagy használja a `--global` kapcsolót"
     current_label:          "Aktuális: `{model}` ezen: {provider}"
     current_tag:            " (aktuális)"
     more_models_suffix:     " (+{count} további)"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "Avviso: {warning}"
     saved_global:           "Salvato in config.yaml (`--global`)"
     session_only_hint:      "_(solo per questa sessione — aggiungi `--global` per renderlo permanente)_"
+    persist_failed_hint:    "impossibile persistere l'override di sessione - il messaggio successivo potrebbe tornare al default della config; controlla i log del gateway o usa `--global`"
     current_label:          "Attuale: `{model}` su {provider}"
     current_tag:            " (attuale)"
     more_models_suffix:     " (+{count} altri)"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "警告: {warning}"
     saved_global:           "config.yaml に保存しました (`--global`)"
     session_only_hint:      "_(このセッションのみ — 永続化するには `--global` を追加)_"
+    persist_failed_hint:    "セッション上書きを永続化できませんでした — 次のメッセージで設定のデフォルトに戻る可能性があります。gateway ログを確認するか `--global` を使ってください"
     current_label:          "現在: `{model}` ({provider})"
     current_tag:            " (現在)"
     more_models_suffix:     " (他 {count} 件)"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "경고: {warning}"
     saved_global:           "config.yaml에 저장됨 (`--global`)"
     session_only_hint:      "_(세션 한정 — 영구 저장하려면 `--global`을 추가하세요)_"
+    persist_failed_hint:    "세션 오버라이드를 유지하지 못했습니다 - 다음 메시지가 설정 기본값으로 돌아갈 수 있습니다. gateway 로그를 확인하거나 `--global`을 사용하세요"
     current_label:          "현재: `{model}` ({provider})"
     current_tag:            " (현재)"
     more_models_suffix:     " (+{count}개 더 있음)"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "Aviso: {warning}"
     saved_global:           "Guardado em config.yaml (`--global`)"
     session_only_hint:      "_(apenas para esta sessão — adiciona `--global` para tornar permanente)_"
+    persist_failed_hint:    "não foi possível persistir o override da sessão - a próxima mensagem pode voltar ao padrão da config; verifique os logs do gateway ou use `--global`"
     current_label:          "Atual: `{model}` em {provider}"
     current_tag:            " (atual)"
     more_models_suffix:     " (+{count} mais)"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "Предупреждение: {warning}"
     saved_global:           "Сохранено в config.yaml (`--global`)"
     session_only_hint:      "_(только для этого сеанса — добавьте `--global`, чтобы сохранить)_"
+    persist_failed_hint:    "не удалось сохранить переопределение сессии - следующее сообщение может вернуться к значению по умолчанию из конфига; проверьте логи gateway или используйте `--global`"
     current_label:          "Текущая: `{model}` на {provider}"
     current_tag:            " (текущая)"
     more_models_suffix:     " (+ещё {count})"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "Uyarı: {warning}"
     saved_global:           "config.yaml'a kaydedildi (`--global`)"
     session_only_hint:      "_(yalnızca bu oturum — kalıcı yapmak için `--global` ekleyin)_"
+    persist_failed_hint:    "oturum geçersiz kılması kalıcı yazılamadı - sonraki mesaj yapılandırma varsayılanına dönebilir; gateway günlüklerini kontrol edin veya `--global` kullanın"
     current_label:          "Geçerli: `{model}` ({provider})"
     current_tag:            " (geçerli)"
     more_models_suffix:     " (+{count} tane daha)"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "Попередження: {warning}"
     saved_global:           "Збережено в config.yaml (`--global`)"
     session_only_hint:      "_(лише для цього сеансу — додайте `--global`, щоб зберегти)_"
+    persist_failed_hint:    "не вдалося зберегти перевизначення сесії - наступне повідомлення може повернутися до значення за замовчуванням з конфігу; перевірте логи gateway або використайте `--global`"
     current_label:          "Поточна: `{model}` на {provider}"
     current_tag:            " (поточна)"
     more_models_suffix:     " (+{count} ще)"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "警告：{warning}"
     saved_global:           "已儲存到 config.yaml（`--global`）"
     session_only_hint:      "_（僅本次工作階段有效 — 加上 `--global` 可永久儲存）_"
+    persist_failed_hint:    "無法持久化工作階段覆寫 — 下一則訊息可能會還原為設定預設值；請檢查 gateway 日誌或改用 `--global`"
     current_label:          "目前：`{model}`（{provider}）"
     current_tag:            "（目前）"
     more_models_suffix:     "（還有 {count} 個）"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -39,6 +39,7 @@ gateway:
     warning_prefix:         "警告：{warning}"
     saved_global:           "已保存到 config.yaml（`--global`）"
     session_only_hint:      "_（仅本次会话有效 — 添加 `--global` 可永久保存）_"
+    persist_failed_hint:    "无法持久化会话覆盖 — 下一条消息可能回退到配置默认值；请检查 gateway 日志或使用 `--global`"
     current_label:          "当前：`{model}`（{provider}）"
     current_tag:            "（当前）"
     more_models_suffix:     "（还有 {count} 个）"

--- a/tests/gateway/test_model_switch_persistence.py
+++ b/tests/gateway/test_model_switch_persistence.py
@@ -352,10 +352,29 @@ class TestOneTurnNeverPersisted:
         runner._session_model_overrides = {}
         runner._pending_one_turn_model_restores = {}
         runner._running_agents = {}
+        runner._session_db = None
         # async_session_store is a property over session_store; install the
-        # mock behind the private cache attribute it reads.
+        # mock behind the private cache attribute it reads. Keep session_store
+        # None so the persist helper must honor the async facade (not early-
+        # return just because the sync store is absent).
+        sk = build_session_key(_make_source())
         _store = MagicMock()
         _store.set_model_override = AsyncMock()
+        _store.get_or_create_session = AsyncMock(
+            return_value=SimpleNamespace(
+                session_key=sk,
+                session_id="sess-1",
+                was_auto_reset=False,
+            )
+        )
+        # Echo the written model so the post-write verification passes.
+        _store.get_model_override = AsyncMock(
+            return_value={
+                "model": "gpt-5.5",
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+            }
+        )
         _store._store = None
         runner.session_store = None
         runner._async_session_store = _store

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -232,3 +232,101 @@ def test_sanitize_model_override():
         "provider": "openai",
         "base_url": "https://api.openai.example/v1",
     }
+
+
+def test_set_model_override_missing_entry_raises(store_factory):
+    """Missing routing entry must not silently no-op (#66107)."""
+    store = store_factory()
+    with pytest.raises(KeyError, match="no session entry"):
+        store.set_model_override("agent:main:telegram:dm:missing", OVERRIDE)
+
+
+@pytest.mark.asyncio
+async def test_persist_helper_creates_entry_before_write(store_factory, tmp_path):
+    """Slash /model can run before get_or_create; helper must create then write."""
+    from gateway.run import GatewayRunner
+    from gateway.session import AsyncSessionStore
+
+    store = store_factory()
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = store
+    runner._async_session_store = AsyncSessionStore(store)
+    runner._session_model_overrides = {}
+    runner._session_db = None
+
+    source = _make_source()
+    session_key = store._generate_session_key(source)
+    assert store.get_model_override(session_key) is None
+
+    override = {
+        "model": "gpt-5o",
+        "provider": "openai",
+        "api_key": "sk-live",
+        "base_url": "https://api.openai.example/v1",
+        "api_mode": "responses",
+    }
+    ok = await runner._persist_session_model_override(
+        source=source,
+        session_key=session_key,
+        override=override,
+        new_model="gpt-5o",
+    )
+    assert ok is True
+    assert store.get_model_override(session_key) == {
+        "model": "gpt-5o",
+        "provider": "openai",
+        "base_url": "https://api.openai.example/v1",
+    }
+
+    # Simulated agent-cache eviction / restart: fresh runner rehydrates.
+    runner2 = _make_runner(store_factory())
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        return_value={
+            "api_key": "sk-fresh",
+            "api_mode": "responses",
+            "base_url": "https://api.openai.example/v1",
+            "provider": "openai",
+        },
+    ):
+        runner2._rehydrate_session_model_override(session_key)
+    assert runner2._session_model_overrides[session_key]["model"] == "gpt-5o"
+
+
+@pytest.mark.asyncio
+async def test_persist_helper_returns_false_and_warns_on_write_failure(
+    store_factory, caplog
+):
+    """Write failures must surface at WARNING, not debug-only (#66107)."""
+    import logging
+
+    from gateway.run import GatewayRunner
+    from gateway.session import AsyncSessionStore
+
+    store = store_factory()
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = store
+    runner._async_session_store = AsyncSessionStore(store)
+    runner._session_model_overrides = {}
+    runner._session_db = None
+
+    source = _make_source()
+    session_key = store._generate_session_key(source)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("simulated routing write failure")
+
+    with patch.object(store, "set_model_override", side_effect=_boom):
+        with caplog.at_level(logging.WARNING, logger="gateway.run"):
+            ok = await runner._persist_session_model_override(
+                source=source,
+                session_key=session_key,
+                override={"model": "gpt-5o", "provider": "openai"},
+                new_model="gpt-5o",
+            )
+
+    assert ok is False
+    assert any(
+        "Failed to persist session model override" in r.message for r in caplog.records
+    )
+    assert all(r.levelno >= logging.WARNING for r in caplog.records if "persist" in r.message.lower())


### PR DESCRIPTION
## Summary

Closes #66107

Credit: Stan Shih (@stantheman0128). Developed with AI assistance (Cursor / Grok).

Session-only `/model` (no `--global`) could look successful for one turn, then silently revert to `config.yaml` `model.default` after the next `AIAgent` rebuild. `SessionStore.set_model_override` returned without writing when the routing entry was missing, and slash-command persist failures were swallowed at `logger.debug`.

### Changes
- Raise when the routing entry is missing instead of a silent no-op
- `_persist_session_model_override` always `get_or_create_session` first, verifies the write stuck, logs at WARNING, returns bool
- Picker and typed `/model` paths use it; user reply includes a persist-failed hint on failure

Not a duplicate of open #27504 (that PR is now `/reasoning`-oriented and does not fix this missing-entry `/model` path).

## Verification

`
pytest -q tests/gateway/test_session_model_override_persistence.py
# 12 passed
`

`
python scripts/check-windows-footguns.py --diff HEAD~1
# clean
`

Made with [Cursor](https://cursor.com)