### PR TITLE
fix(mcp): prevent stdio reconnect subprocess leaks

### DIFF
--- a/tests/tools/test_mcp_reconnect_process_lifecycle.py
+++ b/tests/tools/test_mcp_reconnect_process_lifecycle.py
@@ -1,0 +1,304 @@
+"""Regression tests for bounded stdio MCP reconnect process lifecycles."""
+
+import asyncio
+import os
+import signal
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process groups are POSIX-only")
+def test_watchdog_child_stays_in_sdk_owned_process_group(monkeypatch):
+    """The watchdog must not create a nested group the SDK cannot reap."""
+    from tools import mcp_stdio_watchdog as watchdog
+
+    proc = MagicMock()
+    proc.wait.return_value = 0
+    proc.poll.return_value = 0
+    popen = MagicMock(return_value=proc)
+    monkeypatch.setattr(watchdog.subprocess, "Popen", popen)
+    monkeypatch.setattr(watchdog.threading.Thread, "start", lambda self: None)
+
+    assert watchdog.main([
+        "--ppid", str(os.getpid()),
+        "--create-time", "1.0",
+        "--", "fake-mcp-server",
+    ]) == 0
+
+    kwargs = popen.call_args.kwargs
+    assert kwargs.get("start_new_session", False) is False, (
+        "a nested process group lets the SDK kill only the watchdog while the "
+        "real MCP server and Chromium descendants survive"
+    )
+
+
+def test_reaper_escalates_when_group_survives_dead_leader(monkeypatch):
+    """A dead wrapper PID must not suppress SIGKILL of live descendants."""
+    from tools import mcp_tool
+
+    pid = 424242
+    pgid = 424242
+    with mcp_tool._lock:
+        mcp_tool._stdio_pids.clear()
+        mcp_tool._orphan_stdio_pids.clear()
+        mcp_tool._orphan_stdio_pid_servers.clear()
+        mcp_tool._stdio_pgids.clear()
+        mcp_tool._orphan_stdio_pids.add(pid)
+        mcp_tool._orphan_stdio_pid_servers[pid] = "browser"
+        mcp_tool._stdio_pgids[pid] = pgid
+
+    killpg = MagicMock()
+    monkeypatch.setattr(mcp_tool.os, "killpg", killpg)
+    monkeypatch.setattr(mcp_tool.time, "sleep", lambda _seconds: None)
+
+    with patch("gateway.status._pid_exists", return_value=False):
+        mcp_tool._kill_orphaned_mcp_children(server_name="browser")
+
+    assert call(pgid, signal.SIGTERM) in killpg.call_args_list
+    assert call(pgid, 0) in killpg.call_args_list
+    assert call(pgid, signal.SIGKILL) in killpg.call_args_list
+
+
+@pytest.mark.asyncio
+async def test_run_stdio_reaps_same_server_before_spawn_and_after_exit(monkeypatch):
+    """Each attempt must synchronously reap its predecessor before returning."""
+    from tools import mcp_tool
+
+    server = mcp_tool.MCPServerTask("browser")
+    reaper = MagicMock()
+    monkeypatch.setattr(mcp_tool, "_kill_orphaned_mcp_children", reaper)
+    monkeypatch.setattr(mcp_tool, "_snapshot_child_pids", lambda: set())
+    monkeypatch.setattr(mcp_tool, "_write_stderr_log_header", lambda _name: None)
+    monkeypatch.setattr(mcp_tool, "_get_mcp_stderr_log", lambda: MagicMock())
+    monkeypatch.setattr(mcp_tool, "_wrap_command_with_watchdog", lambda command, args: (command, args))
+    monkeypatch.setattr(
+        "tools.osv_check.check_package_for_malware",
+        lambda _command, _args: None,
+    )
+
+    transport = MagicMock()
+    transport.__aenter__ = AsyncMock(return_value=(object(), object()))
+    transport.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(mcp_tool, "stdio_client", lambda *a, **kw: transport)
+
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.initialize = AsyncMock(side_effect=RuntimeError("handshake failed"))
+    monkeypatch.setattr(mcp_tool, "ClientSession", lambda *a, **kw: session)
+
+    with pytest.raises(RuntimeError, match="handshake failed"):
+        await server._run_stdio({"command": "fake", "connect_timeout": 1})
+
+    assert reaper.call_args_list == [
+        call(include_active=True, server_name="browser"),
+        call(include_active=True, server_name="browser"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reconnect_breaker_trips_at_configured_failure_count(monkeypatch):
+    """The reconnect loop must park at N failures, not spawn attempt N+1."""
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 3)
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", AsyncMock())
+    calls = 0
+
+    class FailingTask(mcp_tool.MCPServerTask):
+        def _is_http(self):
+            return False
+
+        async def _run_stdio(self, config):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                self._ready.set()  # establish once, then lose the connection
+            raise RuntimeError(f"failure {calls}")
+
+        def _deregister_tools(self):
+            self._registered_tool_names = []
+
+        async def _wait_for_reconnect_or_shutdown(self, timeout=None):
+            return "shutdown"
+
+    server = FailingTask("browser")
+    await server.run({"command": "fake"})
+
+    assert calls == 3
+    assert server._reconnect_retries == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.skipif(os.name != "posix", reason="process groups are POSIX-only")
+async def test_ten_stdio_reconnects_keep_one_tree_and_reap_previous_pids(
+    monkeypatch, tmp_path
+):
+    """Ten real stdio reconnects must never accumulate MCP/browser trees."""
+    import json
+    import sys
+    import time
+
+    psutil = pytest.importorskip("psutil")
+    from tools import mcp_tool
+
+    records_path = tmp_path / "processes.jsonl"
+    fixture_path = tmp_path / "mcp_fixture.py"
+    fixture_path.write_text(
+        "import json, os, signal, subprocess, sys, time\n"
+        "from mcp.server.fastmcp import FastMCP\n"
+        f"records_path = {str(records_path)!r}\n"
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(300)'], "
+        "stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)\n"
+        "with open(records_path, 'a', encoding='utf-8') as fh:\n"
+        "    fh.write(json.dumps({'server': os.getpid(), 'child': child.pid, "
+        "'pgid': os.getpgrp()}) + '\\n')\n"
+        "    fh.flush()\n"
+        "mcp = FastMCP('reconnect-fixture')\n"
+        "@mcp.tool()\n"
+        "def ping(): return 'pong'\n"
+        "mcp.run(transport='stdio')\n"
+    )
+
+    monkeypatch.setattr(
+        "tools.osv_check.check_package_for_malware",
+        lambda _command, _args: None,
+    )
+
+    def records():
+        if not records_path.exists():
+            return []
+        return [json.loads(line) for line in records_path.read_text().splitlines() if line]
+
+    def alive(pid):
+        try:
+            proc = psutil.Process(pid)
+            return proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE
+        except psutil.Error:
+            return False
+
+    async def wait_for(predicate, timeout=15):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            await asyncio.sleep(0.05)
+        raise AssertionError("timed out waiting for subprocess lifecycle transition")
+
+    server = mcp_tool.MCPServerTask("browser-regression")
+    run_task = asyncio.create_task(server.run({
+        "command": sys.executable,
+        "args": [str(fixture_path)],
+        "connect_timeout": 10,
+    }))
+
+    try:
+        await asyncio.wait_for(server._ready.wait(), timeout=15)
+        await wait_for(lambda: len(records()) == 1)
+
+        for generation in range(1, 11):
+            previous = records()[-1]
+            server._reconnect_event.set()
+            await wait_for(lambda: len(records()) == generation + 1)
+            await wait_for(
+                lambda: not alive(previous["server"]) and not alive(previous["child"])
+            )
+
+            seen = records()
+            assert sum(alive(item["server"]) for item in seen) <= 1
+            assert all(not alive(item["child"]) for item in seen[:-1])
+    finally:
+        await server.shutdown()
+        await asyncio.wait_for(run_task, timeout=15)
+        for item in records():
+            try:
+                os.killpg(item["pgid"], signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+
+    assert all(
+        not alive(pid)
+        for item in records()
+        for pid in (item["server"], item["child"])
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_reaps_tree_before_awaiting_cancelled_transport(monkeypatch):
+    """A timed-out aclose must be force-reaped before cancellation can hang."""
+    from tools import mcp_tool
+
+    events = []
+    release = asyncio.Event()
+
+    async def hung_transport():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            events.append("cancel-observed")
+            await release.wait()
+
+    server = mcp_tool.MCPServerTask("browser")
+    server._task = asyncio.create_task(hung_transport())
+    await asyncio.sleep(0)
+
+    def reap(**kwargs):
+        events.append("reap")
+        release.set()
+
+    monkeypatch.setattr(mcp_tool, "_MCP_SHUTDOWN_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(mcp_tool, "_MCP_CANCEL_GRACE_SECONDS", 0.1)
+    monkeypatch.setattr(mcp_tool, "_kill_orphaned_mcp_children", reap)
+
+    await server.shutdown()
+
+    assert events[:2] == ["reap", "cancel-observed"]
+
+
+@pytest.mark.asyncio
+async def test_same_named_stdio_tasks_serialize_their_process_lifecycle():
+    """Concurrent task instances may not own two trees for one server name."""
+    from tools import mcp_tool
+
+    active = 0
+    max_active = 0
+    first_entered = asyncio.Event()
+    release = asyncio.Event()
+
+    class ProbeTask(mcp_tool.MCPServerTask):
+        async def _run_stdio_locked(self, config):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            first_entered.set()
+            await release.wait()
+            active -= 1
+
+    first = ProbeTask("browser")
+    second = ProbeTask("browser")
+    first_run = asyncio.create_task(first._run_stdio({"command": "fake"}))
+    await first_entered.wait()
+    second_run = asyncio.create_task(second._run_stdio({"command": "fake"}))
+    await asyncio.sleep(0.05)
+
+    assert max_active == 1
+    release.set()
+    await asyncio.gather(first_run, second_run)
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_force_reaps_server_owned_process_tree(monkeypatch):
+    """Shutdown must reap even if transport teardown never recorded an orphan."""
+    from tools import mcp_tool
+
+    server = mcp_tool.MCPServerTask("browser")
+    reaper = MagicMock()
+    monkeypatch.setattr(mcp_tool, "_kill_orphaned_mcp_children", reaper)
+
+    await server.shutdown()
+
+    reaper.assert_called_once_with(include_active=True, server_name="browser")

--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -19,9 +19,9 @@ complete" on the *legitimate* new connection.
 
 Fix: don't spawn the MCP server command directly. Spawn this supervisor
 instead, which:
-  1. execs the real command as its own child (own process group via
-     ``start_new_session``, so it doesn't inherit the supervisor's
-     controlling terminal weirdly and so we can killpg it cleanly);
+  1. execs the real command as its own child in the supervisor's SDK-owned
+     process group, so the MCP SDK's SIGTERM/SIGKILL teardown reaches the
+     supervisor, real server, and descendants as one tree;
   2. transparently passes stdin/stdout/stderr through — the MCP stdio
      protocol talks directly over those pipes, so the supervisor must be a
      no-op relay, not a bytes-in-the-middle proxy;
@@ -121,7 +121,13 @@ def _terminate_process_group(proc: subprocess.Popen) -> None:
 def _watchdog_loop(proc: subprocess.Popen, original_ppid: int, parent_create_time: float) -> None:
     while proc.poll() is None:
         if _is_orphaned(original_ppid, parent_create_time):
-            _terminate_process_group(proc)
+            # stdio_client starts this watchdog in a fresh session/process
+            # group. The real server intentionally inherits that group, so a
+            # hard parent death can atomically reap the entire owned tree.
+            try:
+                os.killpg(os.getpgrp(), signal.SIGKILL)
+            except (AttributeError, ProcessLookupError, PermissionError, OSError):
+                _terminate_process_group(proc)
             return
         time.sleep(_POLL_INTERVAL_S)
 
@@ -142,29 +148,16 @@ def main(argv: list[str] | None = None) -> int:
         print("mcp_stdio_watchdog: no command given after '--'", file=sys.stderr)
         return 2
 
-    # New process group so we can killpg() the whole tree the real command
-    # may spawn (e.g. mcp-remote's own child `node` process), without
-    # touching our own group or the (already-gone) original parent's.
+    # Do NOT create another process group here. mcp.client.stdio already
+    # starts this watchdog in a fresh session. A nested group would let the
+    # SDK kill only the watchdog while npx/Playwright/Chromium survive.
     proc = subprocess.Popen(
         real_argv,
         stdin=sys.stdin,
         stdout=sys.stdout,
         stderr=sys.stderr,
-        start_new_session=True,
+        start_new_session=False,
     )
-
-    # Because the real server lives in its OWN process group (above), the
-    # parent's graceful-shutdown killpg of *our* group no longer reaches it.
-    # Forward SIGTERM/SIGINT to the child's group so graceful teardown
-    # (`_kill_orphaned_mcp_children`, shutdown sweeps) still kills a wedged
-    # server that ignores stdin EOF — otherwise the watchdog wrap would
-    # invert the bug it fixes.
-    def _forward_shutdown(signum, frame):  # noqa: ARG001
-        _terminate_process_group(proc)
-        sys.exit(128 + signum)
-
-    signal.signal(signal.SIGTERM, _forward_shutdown)
-    signal.signal(signal.SIGINT, _forward_shutdown)
 
     watchdog = threading.Thread(
         target=_watchdog_loop,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -330,6 +330,28 @@ _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
+_MCP_SHUTDOWN_GRACE_SECONDS = 10.0
+_MCP_CANCEL_GRACE_SECONDS = 2.0
+# Per-name locks make reap -> spawn -> registration -> teardown atomic even if
+# duplicate MCPServerTask instances are created concurrently. Store the owning
+# event loop too so isolated test/CLI loops do not reuse a lock across loops.
+_stdio_lifecycle_locks: Dict[str, tuple[asyncio.AbstractEventLoop, asyncio.Lock]] = {}
+
+
+def _get_stdio_lifecycle_lock(server_name: str) -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    with _lock:
+        entry = _stdio_lifecycle_locks.get(server_name)
+        if entry is not None and entry[0] is loop:
+            return entry[1]
+        if entry is not None and entry[1].locked():
+            raise RuntimeError(
+                f"MCP server '{server_name}' has an active stdio lifecycle on "
+                "a different event loop"
+            )
+        lifecycle_lock = asyncio.Lock()
+        _stdio_lifecycle_locks[server_name] = (loop, lifecycle_lock)
+        return lifecycle_lock
 # While parked (reconnect budget exhausted, tools deregistered) the run task
 # wakes on this cadence and attempts one revival probe. Without it a parked
 # server is unrevivable: its tools are out of the registry, so no tool call
@@ -2217,7 +2239,13 @@ class MCPServerTask:
         return "reconnect"
 
     async def _run_stdio(self, config: dict):
-        """Run the server using stdio transport."""
+        """Run one stdio lifecycle while holding the per-server spawn guard."""
+        lifecycle_lock = _get_stdio_lifecycle_lock(self.name)
+        async with lifecycle_lock:
+            return await self._run_stdio_locked(config)
+
+    async def _run_stdio_locked(self, config: dict):
+        """Run the server using stdio transport with exclusive ownership."""
         if not _MCP_AVAILABLE:
             raise ImportError(
                 f"MCP server '{self.name}' requires the 'mcp' Python SDK, but "
@@ -2301,7 +2329,11 @@ class MCPServerTask:
         # available for scoped call sites.  Run in a worker thread: the
         # reaper blocks up to 2s (SIGTERM → wait → SIGKILL) when orphans
         # exist, which would otherwise stall the shared MCP event loop.
-        await asyncio.to_thread(_kill_orphaned_mcp_children)
+        await asyncio.to_thread(
+            _kill_orphaned_mcp_children,
+            include_active=True,
+            server_name=self.name,
+        )
 
         # Snapshot child PIDs before spawning so we can track the new one.
         pids_before = _snapshot_child_pids()
@@ -2415,6 +2447,14 @@ class MCPServerTask:
                             # Nothing left to reap — drop the pgid entry so
                             # PID-reuse can't surface stale pgroup state later.
                             _stdio_pgids.pop(pid, None)
+            # Reap synchronously before run() can spawn a replacement. The
+            # active sweep is a per-server concurrency guard for bookkeeping
+            # races: never permit two live stdio trees for one server name.
+            await asyncio.to_thread(
+                _kill_orphaned_mcp_children,
+                include_active=True,
+                server_name=self.name,
+            )
 
     # Content types a real MCP Streamable-HTTP endpoint may return on the
     # initial POST/GET. Anything else on a 2xx response means the URL is not
@@ -3032,7 +3072,7 @@ class MCPServerTask:
                     return
 
                 self._reconnect_retries += 1
-                if self._reconnect_retries > _MAX_RECONNECT_RETRIES:
+                if self._reconnect_retries >= _MAX_RECONNECT_RETRIES:
                     logger.warning(
                         "MCP server '%s' failed after %d reconnection attempts, "
                         "parking; will self-probe every %ds until it recovers: %s",
@@ -3114,18 +3154,39 @@ class MCPServerTask:
         # returning "reconnect".
         self._reconnect_event.set()
         if self._task and not self._task.done():
-            try:
-                await asyncio.wait_for(self._task, timeout=10)
-            except asyncio.TimeoutError:
+            done, _pending = await asyncio.wait(
+                {self._task}, timeout=_MCP_SHUTDOWN_GRACE_SECONDS
+            )
+            if not done:
                 logger.warning(
-                    "MCP server '%s' shutdown timed out, cancelling task",
+                    "MCP server '%s' shutdown timed out; force-reaping its "
+                    "process tree before cancelling the transport task",
                     self.name,
                 )
+                # A hung SDK __aexit__ may not respond to cancellation while
+                # its stdio child is alive. Kill the owned group first so pipe
+                # readers unblock, then cancel and wait without letting
+                # asyncio.wait_for extend its own timeout during cancellation.
+                await asyncio.to_thread(
+                    _kill_orphaned_mcp_children,
+                    include_active=True,
+                    server_name=self.name,
+                )
                 self._task.cancel()
-                try:
-                    await self._task
-                except asyncio.CancelledError:
-                    pass
+                done, _pending = await asyncio.wait(
+                    {self._task}, timeout=_MCP_CANCEL_GRACE_SECONDS
+                )
+                if not done:
+                    logger.error(
+                        "MCP server '%s' transport task ignored cancellation "
+                        "after process-tree reap; abandoning task during shutdown",
+                        self.name,
+                    )
+                else:
+                    try:
+                        self._task.result()
+                    except asyncio.CancelledError:
+                        pass
         if self._pending_refresh_tasks:
             for task in list(self._pending_refresh_tasks):
                 task.cancel()
@@ -3133,6 +3194,13 @@ class MCPServerTask:
             self._pending_refresh_tasks.clear()
         self._deregister_tools()
         self.session = None
+        # Last-resort teardown for a hung/cancelled transport whose context
+        # manager never completed its own cleanup bookkeeping.
+        await asyncio.to_thread(
+            _kill_orphaned_mcp_children,
+            include_active=True,
+            server_name=self.name,
+        )
 
     def _deregister_tools(self) -> None:
         """Drop this server's tools from the global registry (idempotent).
@@ -5783,7 +5851,7 @@ def _kill_orphaned_mcp_children(
         pids: Dict[int, str] = {}
         for opid in _orphan_stdio_pids:
             owner = _orphan_stdio_pid_servers.get(opid, "orphan")
-            if server_name is not None and owner != server_name:
+            if server_name is not None and owner not in (server_name, "orphan"):
                 continue
             pids[opid] = owner
         for opid in pids:
@@ -5866,8 +5934,22 @@ def _kill_orphaned_mcp_children(
     # existence check before escalating to SIGKILL.
     from gateway.status import _pid_exists
     for pid, server_name in pids.items():
-        if not _pid_exists(pid):
-            continue  # Good — exited after SIGTERM
+        pid_alive = _pid_exists(pid)
+        pgid = pgids.get(pid)
+        pgroup_alive = False
+        if (
+            not pid_alive
+            and pgid is not None
+            and pgid != _my_pgid
+            and getattr(os, "killpg", None) is not None
+        ):
+            try:
+                os.killpg(pgid, 0)
+                pgroup_alive = True
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        if not pid_alive and not pgroup_alive:
+            continue  # Good — leader and descendants exited after SIGTERM
         _send_signal(pid, _sigkill, server_name)
         logger.warning(
             "Force-killed MCP process %d (%s) after SIGTERM timeout",


### PR DESCRIPTION
## Summary

- keep the watchdog, real stdio MCP server, and descendants in the MCP SDK-owned process group so transport teardown reaches the whole tree
- synchronously reap a server's prior stdio tree before respawn and after transport exit, with per-server lifecycle serialization to prevent concurrent duplicate ownership
- detect and `SIGKILL` surviving process groups even when the wrapper/leader PID has exited
- trip the reconnect circuit breaker at the configured five failures (`>=`, not an off-by-one sixth attempt)
- make shutdown bounded: force-reap a hung stdio tree before cancellation, then abandon a cancellation-resistant task after a second bounded grace period
- add unit and real-process regressions, including ten sequential reconnects with a stubborn SIGTERM-ignoring descendant

## Root cause

`mcp.client.stdio` already launches the watchdog in a fresh session/process group, but `mcp_stdio_watchdog.py` launched the real command with `start_new_session=True`. That nested process group let SDK teardown kill the watchdog while `npx @playwright/mcp`, Chromium, and other descendants survived. Repeated keepalive reconnects could therefore accumulate unbounded browser trees.

## Validation

- focused lifecycle/stability/reconnect suite: **45 passed**
- final independent focused review rerun: **8 new regression tests passed**, **37 focused tests passed**
- broad `tests/tools/test_mcp*.py`: **653 passed**, with 5 order-dependent failures in `test_mcp_structured_content.py`; that file passes **5/5 in isolation** and the failures are due to pre-existing shared circuit-breaker state from earlier tests
- `python -m py_compile` passed
- `ruff check` passed
- `git diff --check` passed

POSIX-only process-group integration coverage is skipped on non-POSIX platforms.