### PR TITLE
fix(agent): inject placeholder thought_signature for Gemini tool calls lacking it (#66587)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5917,14 +5917,27 @@ class AIAgent:
         if not isinstance(tool_calls, list):
             return api_msg
         from agent.transports.chat_completions import _model_consumes_thought_signature
+        needs_thought_sig = _model_consumes_thought_signature(model)
         _STRIP_KEYS = {"call_id", "response_item_id"}
-        if not _model_consumes_thought_signature(model):
+        if not needs_thought_sig:
             _STRIP_KEYS = _STRIP_KEYS | {"extra_content"}
-        api_msg["tool_calls"] = [
-            {k: v for k, v in tc.items() if k not in _STRIP_KEYS}
-            if isinstance(tc, dict) else tc
-            for tc in tool_calls
-        ]
+        sanitized = []
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                sanitized.append(tc)
+                continue
+            new_tc = {k: v for k, v in tc.items() if k not in _STRIP_KEYS}
+            # Gemini 3 thinking models require a thought_signature on every
+            # functionCall part.  Tool calls created by a non-Gemini model
+            # earlier in the same session will lack extra_content — inject a
+            # minimal placeholder so Gemini does not reject the history with
+            # HTTP 400 "Function call is missing a thought_signature".
+            if needs_thought_sig and "extra_content" not in new_tc:
+                new_tc["extra_content"] = {
+                    "google": {"thought_signature": ""}
+                }
+            sanitized.append(new_tc)
+        api_msg["tool_calls"] = sanitized
         return api_msg
 
     @staticmethod


### PR DESCRIPTION
## Problem

Gemini 3 thinking models require a `thought_signature` on every `functionCall` part in the conversation history (#66587). When a session switches from a non-Gemini model back to Gemini, tool calls created by the earlier model lack `extra_content`/thought_signature, causing Gemini to reject the request with HTTP 400:

> Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly.

## Fix

In `_sanitize_tool_calls_for_strict_api` (`run_agent.py`), when the outgoing model is Gemini-family and a tool call lacks `extra_content`, inject a minimal placeholder:

```python
{"extra_content": {"google": {"thought_signature": ""}}}
```

This prevents the Gemini 400 error. The same `_model_consumes_thought_signature` gate controls both the preserve/strip decision for existing extra_content and the injection decision, so non-Gemini providers are unaffected.

## Tests

- 93 existing provider parity tests pass
- 11 manual unit tests covering: non-Gemini (strips), Gemini (preserves existing + injects placeholder), Gemma (injects), default model=None (strips), google/ prefix routing, empty/no tool_calls, strict providers (strips everything)