### PR TITLE
fix(lmstudio): default to model's max_context_length when not explicitly configured (#66572)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3243,7 +3243,13 @@ def ensure_lmstudio_model_loaded(
         return None
 
     max_ctx = target_entry.get("max_context_length")
-    if isinstance(max_ctx, int) and max_ctx > 0:
+    # When target_context_length is 0 (sentinel for "not configured, use
+    # default"), prefer the model's reported max_context_length so the
+    # initial load doesn't settle on a hardcoded floor (64000).  An
+    # explicitly configured value is honoured (capped at max_ctx).
+    if target_context_length <= 0:
+        target_context_length = max_ctx if (isinstance(max_ctx, int) and max_ctx > 0) else 65536
+    elif isinstance(max_ctx, int) and max_ctx > 0:
         target_context_length = min(target_context_length, max_ctx)
 
     for inst in target_entry.get("loaded_instances") or []:

--- a/run_agent.py
+++ b/run_agent.py
@@ -778,11 +778,13 @@ class AIAgent:
             logger.debug("LM Studio explicit preload skipped: lmstudio_load_mode=jit")
             return
         try:
-            from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
             from hermes_cli.models import ensure_lmstudio_model_loaded
             if config_context_length is None:
                 config_context_length = getattr(self, "_config_context_length", None)
-            target_ctx = max(config_context_length or 0, MINIMUM_CONTEXT_LENGTH)
+            # When no explicit context_length is configured (None), pass 0 as
+            # sentinel so ensure_lmstudio_model_loaded defaults to the model's
+            # reported max_context_length instead of a hardcoded floor.
+            target_ctx = config_context_length if config_context_length is not None else 0
             loaded_ctx = ensure_lmstudio_model_loaded(
                 self.model, self.base_url, getattr(self, "api_key", ""), target_ctx,
             )

--- a/tests/run_agent/test_lmstudio_load_mode.py
+++ b/tests/run_agent/test_lmstudio_load_mode.py
@@ -44,7 +44,7 @@ def test_lmstudio_explicit_load_mode_preserves_preload(monkeypatch):
 
     assert len(calls) == 1
     assert calls[0][0][:3] == ("test/model", "http://127.0.0.1:1234/v1", "")
-    assert calls[0][0][3] == 64000
+    assert calls[0][0][3] == 0  # sentinel 0 = "use model's max_context_length"
 
 
 def test_missing_lmstudio_load_mode_defaults_to_explicit(monkeypatch):


### PR DESCRIPTION
## Problem

LM Studio models were initialized with exactly 64000 tokens context when no explicit `model.context_length` was configured in config.yaml (`MINIMUM_CONTEXT_LENGTH`). Users with models supporting larger windows hit premature compaction loops and infinite compaction cycles (#66572).

## Fix

Two changes:

1. **`_ensure_lmstudio_runtime_loaded`** (`run_agent.py`): pass `0` as sentinel when no explicit config context_length is set, instead of `MINIMUM_CONTEXT_LENGTH=64000`.

2. **`ensure_lmstudio_model_loaded`** (`hermes_cli/models.py`): handle the `0` sentinel by defaulting to the model's `max_context_length` from LM Studio's `/api/v1/models` endpoint. An explicitly configured `context_length` in config.yaml is still honoured and capped at `max_ctx`.

## Tests

- 3 existing LM Studio load-mode tests pass (updated one assertion from 64000 → 0 sentinel)
- 93 provider parity tests pass