### PR TITLE
fix(web_server): delegate gateway restart to service manager when supervised

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3425,8 +3425,30 @@ def _validate_messaging_env_value(platform_id: str, key: str, value: str) -> Non
             )
 
 
+def _supervised_gateway_restart_available() -> bool:
+    """True when a service manager (launchd/systemd/s6) owns the gateway.
+
+    When the gateway is supervised, the desktop backend (``hermes serve``)
+    must NOT spawn its own ``hermes gateway restart`` child. That child runs
+    ``gateway run --replace``, which SIGTERMs the supervised instance; the
+    supervisor's KeepAlive then respawns it, producing a restart/flap loop.
+    Delegating the restart to the supervisor avoids the double-supervisor fight.
+    """
+    try:
+        from hermes_cli.service_manager import detect_service_manager
+    except Exception:
+        return False
+    try:
+        kind = detect_service_manager()
+    except Exception:
+        return False
+    # "none" means no usable init system — the dashboard itself owns the
+    # gateway, so a local restart child is correct there.
+    return kind in ("launchd", "systemd", "s6")
+
+
 def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Popen, bool]:
-    """Spawn ``hermes gateway restart``, reusing an in-flight restart.
+    """Restart the gateway, delegating to the supervisor when one is present.
 
     Multiple dashboard paths can request a restart in quick succession
     (restart button double-click, or a stale cached frontend firing its own
@@ -3434,8 +3456,59 @@ def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Po
     concurrent ``hermes gateway restart`` children race each other on the
     manual kill-and-start path, so reuse the live one instead.
 
+    When the gateway is supervised by a service manager (launchd/systemd/s6),
+    delegate the restart to the supervisor instead of spawning a ``hermes
+    gateway restart`` child under ``hermes serve``. That child would otherwise
+    SIGTERM the supervised instance and trigger a KeepAlive flap loop. We still
+    record a synthetic Popen-like handle so callers that poll the previous child
+    behave, but no gateway child is left under ``hermes serve``.
+
     Returns ``(proc, reused)``.
     """
+    if _supervised_gateway_restart_available():
+        try:
+            # Delegate to the platform-native restart (drain-aware on macOS,
+            # systemctl on Linux, s6 in containers). This is the only correct
+            # restart path when the gateway is supervised — it never spawns a
+            # hermes-serve child.
+            from hermes_cli.service_manager import detect_service_manager
+            kind = detect_service_manager()
+            if kind == "launchd":
+                from hermes_cli.gateway import launchd_restart
+                launchd_restart()
+            elif kind == "systemd":
+                from hermes_cli.gateway import systemd_restart
+                systemd_restart()
+            elif kind == "s6":
+                from hermes_cli.service_manager import S6ServiceManager
+                S6ServiceManager().restart("")
+            else:  # pragma: no cover - guarded by _supervised_gateway_restart_available
+                raise RuntimeError(f"unsupported service manager: {kind}")
+            _log.info(
+                "Gateway restart delegated to %s service manager; "
+                "desktop backend did NOT spawn its own gateway child.",
+                kind,
+            )
+
+            # Synthesize a completed, non-gateway handle (typed loosely as Any)
+            # so callers that inspect _ACTION_PROCS don't see a stray hermes-serve
+            # gateway child and the return type stays satisfied.
+            class _SupervisorRestartHandle:
+                pid = 0
+                returncode = 0
+
+                def poll(self) -> Optional[int]:
+                    return 0
+
+            handle: Any = _SupervisorRestartHandle()
+            handle.args = ["launchctl", "kickstart", "-k", "gui/*/ai.hermes.gateway"]
+            return handle, False
+        except Exception as exc:
+            _log.warning(
+                "Service-manager gateway restart delegation failed (%s) — "
+                "falling back to local restart",
+                exc,
+            )
     subcommand = _gateway_subcommand(profile, "restart")
     existing = _ACTION_PROCS.get("gateway-restart")
     if existing is not None and existing.poll() is None:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import json
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -3018,6 +3019,10 @@ class TestWebServerEndpoints:
 
         monkeypatch.setattr(ws, "_telegram_onboarding_request_sync", fake_request)
         ws._ACTION_PROCS.pop("gateway-restart", None)
+        # Force the local (non-supervised) restart path these tests exercise.
+        # On hosts where a service manager owns the gateway, _spawn_gateway_restart
+        # delegates to it instead of spawning a `hermes gateway restart` child.
+        monkeypatch.setattr(ws, "_supervised_gateway_restart_available", lambda: False)
         restart_calls = []
 
         class FakeRestartProc:
@@ -3091,6 +3096,8 @@ class TestWebServerEndpoints:
 
         monkeypatch.setattr(ws, "_telegram_onboarding_request_sync", fake_request)
         ws._ACTION_PROCS.pop("gateway-restart", None)
+        # Force the local (non-supervised) restart path this test exercises.
+        monkeypatch.setattr(ws, "_supervised_gateway_restart_available", lambda: False)
 
         def fail_spawn_action(subcommand, name):
             assert subcommand == ["gateway", "restart"]
@@ -3151,6 +3158,8 @@ class TestWebServerEndpoints:
             }
 
         monkeypatch.setattr(ws, "_telegram_onboarding_request_sync", fake_request)
+        # Force the local (non-supervised) restart path this test exercises.
+        monkeypatch.setattr(ws, "_supervised_gateway_restart_available", lambda: False)
 
         class FakeRunningProc:
             pid = 5151
@@ -3180,6 +3189,81 @@ class TestWebServerEndpoints:
         assert applied_data["needs_restart"] is False
         assert applied_data["restart_started"] is True
         assert applied_data["restart_pid"] == 5151
+
+    def test_gateway_restart_delegates_to_supervisor_when_supervised(
+        self, monkeypatch
+    ):
+        """When a service manager owns the gateway, _spawn_gateway_restart must
+        delegate to it and NOT spawn a `hermes gateway restart` child under the
+        dashboard/serve process (that child would SIGTERM the supervised
+        instance and trigger a KeepAlive flap loop)."""
+        import hermes_cli.web_server as ws
+
+        delegated = {}
+        monkeypatch.setattr(
+            ws, "_supervised_gateway_restart_available", lambda: True
+        )
+
+        def fake_launchd_restart():
+            delegated["launchd_restart"] = True
+
+        def fail_spawn_action(subcommand, name):
+            raise AssertionError(
+                "must not spawn a hermes gateway restart child when supervised"
+            )
+
+        monkeypatch.setattr(ws, "_spawn_hermes_action", fail_spawn_action)
+        # Patch the delegated restart call inside _spawn_gateway_restart.
+        import hermes_cli.gateway as gw
+
+        monkeypatch.setattr(gw, "launchd_restart", fake_launchd_restart)
+
+        ws._ACTION_PROCS.pop("gateway-restart", None)
+        proc, reused = ws._spawn_gateway_restart(None)
+
+        assert delegated.get("launchd_restart") is True, (
+            "expected delegation to the service manager restart"
+        )
+        # The returned handle must be a synthetic non-gateway object, not a
+        # subprocess.Popen spawned under the serve process.
+        assert not isinstance(proc, subprocess.Popen)
+        assert reused is False
+
+    def test_gateway_restart_falls_back_to_local_when_supervisor_fails(
+        self, monkeypatch
+    ):
+        """If the service-manager delegation raises, _spawn_gateway_restart must
+        fall back to spawning a local `hermes gateway restart` child rather than
+        silently dropping the restart request."""
+        import hermes_cli.web_server as ws
+        import hermes_cli.gateway as gw
+
+        monkeypatch.setattr(
+            ws, "_supervised_gateway_restart_available", lambda: True
+        )
+        monkeypatch.setattr(
+            gw, "launchd_restart", lambda: (_ for _ in ()).throw(RuntimeError("kickstart failed"))
+        )
+
+        spawned = []
+        monkeypatch.setattr(
+            ws,
+            "_spawn_hermes_action",
+            lambda subcommand, name: spawned.append((subcommand, name)) or _FakeLocalProc(),
+        )
+
+        class _FakeLocalProc:
+            pid = 9999
+
+            def poll(self):
+                return 0
+
+        ws._ACTION_PROCS.pop("gateway-restart", None)
+        proc, reused = ws._spawn_gateway_restart(None)
+
+        assert spawned == [(["gateway", "restart"], "gateway-restart")], (
+            "expected fallback to local gateway restart child"
+        )
 
     def test_telegram_onboarding_apply_requires_ready_pairing(self, monkeypatch):
         import hermes_cli.web_server as ws


### PR DESCRIPTION
## Summary
- When the gateway is supervised by a service manager (launchd/systemd/s6), the desktop backend (`hermes serve`) must not spawn its own `hermes gateway restart` child.
- That child runs `gateway run --replace`, which SIGTERMs the supervised instance; the supervisor's KeepAlive then respawns it, producing a restart/flap loop (observed as repeated SIGTERM/restart cycles on macOS when both launchd and the desktop app are running).
- `_spawn_gateway_restart` now detects a supervising service manager and delegates the restart to it (`launchd_restart` / `systemd_restart` / s6) instead of spawning a child under the serve process.
- Still returns a synthetic handle so existing callers (the `/api/gateway/restart` route, Telegram/WhatsApp onboarding) behave, and falls back to the local restart child if delegation fails.

## Root cause
Desktop GUI "Restart Server" → `POST /api/gateway/restart` → `web_server.restart_gateway()` → `_spawn_gateway_restart()` spawned `hermes gateway restart` **as a child of `hermes serve`**. On a launchd-supervised host this killed the supervised gateway, which KeepAlive immediately respawned — a double-supervisor fight.

## Test plan
- [x] New unit test: delegation path calls the service manager and does NOT spawn a `hermes gateway restart` child.
- [x] New unit test: fallback to local restart child when delegation raises.
- [x] Updated the 3 existing onboarding tests that asserted the local-only spawn to force the non-supervised path.
- [x] All 5 target tests pass locally (`tests/hermes_cli/test_web_server.py -k "gateway_restart or telegram_onboarding_apply"`).

## Notes
- Verified live on macOS/launchd: delegating to `launchctl kickstart` keeps the gateway launchd-owned (ppid=1); `hermes serve` no longer acquires a gateway child.
- `web_server.py` parses clean; lint clean (Pyright import warnings are false positives for the venv package).
