### PR TITLE
feat(status-bar): Claude-style cache/cost/permissions HUD on TUI + classic CLI

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2006,7 +2006,11 @@ def init_agent(
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
-    
+    # Most recent API call's cache split — status bar "cache R=… fresh=…" uses these.
+    agent.last_cache_read_tokens = 0
+    agent.last_cache_write_tokens = 0
+    agent.last_prompt_tokens = 0
+   
     # ── Ollama num_ctx injection ──
     # Ollama defaults to 2048 context regardless of the model's capabilities.
     # When running against an Ollama server, detect the model's max context

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -189,6 +189,9 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+    agent.last_cache_read_tokens = canonical_usage.cache_read_tokens
+    agent.last_cache_write_tokens = canonical_usage.cache_write_tokens
+    agent.last_prompt_tokens = prompt_tokens
 
     cost_result = estimate_usage_cost(
         agent.model,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2183,6 +2183,9 @@ def run_conversation(
                     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
                     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+                    agent.last_cache_read_tokens = canonical_usage.cache_read_tokens
+                    agent.last_cache_write_tokens = canonical_usage.cache_write_tokens
+                    agent.last_prompt_tokens = prompt_tokens
 
                     # Log API call details for debugging/observability
                     _cache_pct = ""

--- a/cli.py
+++ b/cli.py
@@ -4497,6 +4497,43 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
     @staticmethod
+    def _format_status_cache_fresh(snapshot: Dict[str, Any]) -> str:
+        """Claude-style `cache R=134K(96%) fresh=5K` for the status bar."""
+        cache_read = int(snapshot.get("last_cache_read_tokens") or 0)
+        if cache_read <= 0:
+            cache_read = int(snapshot.get("session_cache_read_tokens") or 0)
+        if cache_read <= 0:
+            return ""
+        last_prompt = int(snapshot.get("last_prompt_tokens") or 0)
+        ctx_used = int(snapshot.get("context_tokens") or 0)
+        denom = last_prompt or ctx_used or cache_read
+        hit = max(0, min(100, round(cache_read / denom * 100)))
+        parts = [f"cache R={format_token_count_compact(cache_read)}({hit}%)"]
+        fresh_base = last_prompt or ctx_used
+        if fresh_base > 0:
+            parts.append(f"fresh={format_token_count_compact(max(0, fresh_base - cache_read))}")
+        return " ".join(parts)
+
+    def _status_bar_show_cost(self) -> bool:
+        try:
+            from hermes_cli.config import load_config
+            display = (load_config() or {}).get("display") or {}
+            return bool(display.get("show_cost"))
+        except Exception:
+            return False
+
+    @staticmethod
+    def _format_status_cost(amount: float) -> str:
+        if amount is None or amount <= 0:
+            return ""
+        if amount < 0.01:
+            return "<$0.01"
+        if amount < 10:
+            return f"${amount:.2f}"
+        # 3dp max; drop trailing zeros so 12.5 stays $12.5 not $12.500
+        return f"${amount:.3f}".rstrip("0").rstrip(".")
+
+    @staticmethod
     def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float, live: bool = False) -> str:
         """Format per-prompt elapsed time for the status bar.
 
@@ -4581,6 +4618,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "session_output_tokens": 0,
             "session_cache_read_tokens": 0,
             "session_cache_write_tokens": 0,
+            "last_cache_read_tokens": 0,
+            "last_cache_write_tokens": 0,
+            "last_prompt_tokens": 0,
+            "session_estimated_cost_usd": 0.0,
             "session_prompt_tokens": 0,
             "session_completion_tokens": 0,
             "session_total_tokens": 0,
@@ -4627,6 +4668,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         snapshot["session_output_tokens"] = getattr(agent, "session_output_tokens", 0) or 0
         snapshot["session_cache_read_tokens"] = getattr(agent, "session_cache_read_tokens", 0) or 0
         snapshot["session_cache_write_tokens"] = getattr(agent, "session_cache_write_tokens", 0) or 0
+        snapshot["last_cache_read_tokens"] = getattr(agent, "last_cache_read_tokens", 0) or 0
+        snapshot["last_cache_write_tokens"] = getattr(agent, "last_cache_write_tokens", 0) or 0
+        snapshot["last_prompt_tokens"] = getattr(agent, "last_prompt_tokens", 0) or 0
+        snapshot["session_estimated_cost_usd"] = float(getattr(agent, "session_estimated_cost_usd", 0.0) or 0.0)
         snapshot["session_prompt_tokens"] = getattr(agent, "session_prompt_tokens", 0) or 0
         snapshot["session_completion_tokens"] = getattr(agent, "session_completion_tokens", 0) or 0
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
@@ -5075,7 +5120,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if width < 52:
                 text = f"⚕ {snapshot['model_short']} · {duration_label}"
                 if yolo_active:
-                    text += " · ⚠ YOLO"
+                    text += " · bypass permissions on"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
@@ -5087,13 +5132,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     parts.append(f"▶ {bg_count}")
                 bg_proc_count = snapshot.get("active_background_processes", 0)
                 if bg_proc_count:
-                    parts.append(f"⚙ {bg_proc_count}")
+                    parts.append(f"{bg_proc_count} shells")
                 bg_subagent_count = snapshot.get("active_background_subagents", 0)
                 if bg_subagent_count:
                     parts.append(f"⛓ {bg_subagent_count}")
                 parts.append(duration_label)
                 if yolo_active:
-                    parts.append("⚠ YOLO")
+                    parts.append("bypass permissions on")
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
             if snapshot["context_length"]:
@@ -5105,6 +5150,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             compressions = snapshot.get("compressions", 0)
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            cache_fresh = self._format_status_cache_fresh(snapshot)
+            if cache_fresh:
+                parts.append(cache_fresh)
+            if self._status_bar_show_cost():
+                cost_label = self._format_status_cost(float(snapshot.get("session_estimated_cost_usd") or 0.0))
+                if cost_label:
+                    parts.append(cost_label)
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -5112,7 +5164,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 parts.append(f"▶ {bg_count}")
             bg_proc_count = snapshot.get("active_background_processes", 0)
             if bg_proc_count:
-                parts.append(f"⚙ {bg_proc_count}")
+                parts.append(f"{bg_proc_count} shells")
             bg_subagent_count = snapshot.get("active_background_subagents", 0)
             if bg_subagent_count:
                 parts.append(f"⛓ {bg_subagent_count}")
@@ -5124,7 +5176,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if idle_since:
                 parts.append(idle_since)
             if yolo_active:
-                parts.append("⚠ YOLO")
+                parts.append("bypass permissions on")
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
@@ -5152,7 +5204,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 ]
                 if yolo_active:
                     frags.append(("class:status-bar-dim", " · "))
-                    frags.append(("class:status-bar-yolo", "⚠ YOLO"))
+                    frags.append(("class:status-bar-yolo", "bypass permissions on"))
                 frags.append(("class:status-bar", " "))
             else:
                 percent = snapshot["context_percent"]
@@ -5176,7 +5228,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         frags.append(("class:status-bar-strong", f"▶ {bg_count}"))
                     if bg_proc_count:
                         frags.append(("class:status-bar-dim", " · "))
-                        frags.append(("class:status-bar-strong", f"⚙ {bg_proc_count}"))
+                        frags.append(("class:status-bar-strong", f"{bg_proc_count} shells"))
                     if bg_subagent_count:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
@@ -5186,7 +5238,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     ])
                     if yolo_active:
                         frags.append(("class:status-bar-dim", " · "))
-                        frags.append(("class:status-bar-yolo", "⚠ YOLO"))
+                        frags.append(("class:status-bar-yolo", "bypass permissions on"))
                     frags.append(("class:status-bar", " "))
                 else:
                     if snapshot["context_length"]:
@@ -5211,6 +5263,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    cache_fresh = self._format_status_cache_fresh(snapshot)
+                    if cache_fresh:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-dim", cache_fresh))
+                    if self._status_bar_show_cost():
+                        cost_label = self._format_status_cost(float(snapshot.get("session_estimated_cost_usd") or 0.0))
+                        if cost_label:
+                            frags.append(("class:status-bar-dim", " │ "))
+                            frags.append(("class:status-bar-strong", cost_label))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -5219,7 +5280,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         frags.append(("class:status-bar-strong", f"▶ {bg_count}"))
                     if bg_proc_count:
                         frags.append(("class:status-bar-dim", " │ "))
-                        frags.append(("class:status-bar-strong", f"⚙ {bg_proc_count}"))
+                        frags.append(("class:status-bar-strong", f"{bg_proc_count} shells"))
                     if bg_subagent_count:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
@@ -5239,7 +5300,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         frags.append(("class:status-bar-dim", idle_since))
                     if yolo_active:
                         frags.append(("class:status-bar-dim", " │ "))
-                        frags.append(("class:status-bar-yolo", "⚠ YOLO"))
+                        frags.append(("class:status-bar-yolo", "bypass permissions on"))
                     frags.append(("class:status-bar", " "))
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -39,6 +39,9 @@ def _attach_agent(
         session_output_tokens=output_tokens if output_tokens is not None else completion_tokens,
         session_cache_read_tokens=cache_read_tokens,
         session_cache_write_tokens=cache_write_tokens,
+        last_cache_read_tokens=cache_read_tokens,
+        last_cache_write_tokens=cache_write_tokens,
+        session_estimated_cost_usd=0.0,
         session_prompt_tokens=prompt_tokens,
         session_completion_tokens=completion_tokens,
         session_total_tokens=total_tokens,
@@ -135,8 +138,9 @@ class TestCLIStatusBar:
             context_length=200_000,
         )
 
-        text = cli_obj._build_status_bar_text(width=120)
-        assert "$" not in text  # cost is never shown in status bar
+        with patch.object(cli_obj, "_status_bar_show_cost", return_value=False):
+            text = cli_obj._build_status_bar_text(width=120)
+        assert "$" not in text  # cost hidden when display.show_cost is false
 
     def test_build_status_bar_text_collapses_for_narrow_terminal(self):
         cli_obj = _attach_agent(
@@ -678,3 +682,52 @@ class TestIdleSinceLastTurn:
         cli_obj._prompt_duration = 7.0
         text = cli_obj._build_status_bar_text(width=160)
         assert "✓ 42s" in text
+
+
+class TestCLIStatusBarClaudeExtras:
+    def test_format_status_cache_fresh(self):
+        cli_obj = _make_cli()
+        label = cli_obj._format_status_cache_fresh(
+            {
+                "last_cache_read_tokens": 134_000,
+                "context_tokens": 139_000,
+            }
+        )
+        assert "cache R=" in label
+        assert "fresh=" in label
+        assert "96%" in label or "97%" in label  # 134/139 ~ 96%
+
+    def test_cost_shown_when_config_enabled(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10000,
+            completion_tokens=5000,
+            total_tokens=15000,
+            api_calls=7,
+            context_tokens=50000,
+            context_length=200_000,
+            cache_read_tokens=40_000,
+        )
+        cli_obj.agent.session_estimated_cost_usd = 12.5
+        cli_obj.agent.last_cache_read_tokens = 40_000
+        with patch.object(cli_obj, "_status_bar_show_cost", return_value=True):
+            text = cli_obj._build_status_bar_text(width=160)
+        assert "$12.50" in text or "$12.5" in text
+        assert "cache R=" in text
+        assert "fresh=" in text
+
+    def test_yolo_uses_bypass_permissions_label(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10000,
+            completion_tokens=5000,
+            total_tokens=15000,
+            api_calls=7,
+            context_tokens=12400,
+            context_length=200_000,
+        )
+        with patch.object(cli_obj, "_is_session_yolo_active", return_value=True):
+            text = cli_obj._build_status_bar_text(width=160)
+        assert "bypass permissions on" in text
+        assert "⚠ YOLO" not in text
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3243,7 +3243,22 @@ def _get_usage(agent) -> dict:
         "completion": g("session_completion_tokens"),
         "total": g("session_total_tokens"),
         "calls": g("session_api_calls"),
+        # Claude-style status-bar fields. Prefer last-call cache/prompt so
+        # hit% matches the latest API usage line (cache=R/prompt), not the
+        # cumulative session sum.
+        "cache_read": int(getattr(agent, "last_cache_read_tokens", 0) or 0),
+        "cache_write": int(getattr(agent, "last_cache_write_tokens", 0) or 0),
+        "session_cache_read": int(getattr(agent, "session_cache_read_tokens", 0) or 0),
+        "last_prompt": int(getattr(agent, "last_prompt_tokens", 0) or 0),
+        "cost_usd": float(getattr(agent, "session_estimated_cost_usd", 0.0) or 0.0),
+        "cost_status": getattr(agent, "session_cost_status", None) or "unknown",
     }
+    # Fallback only when last-call is missing but session has cache history
+    # (e.g. restored agent mid-session without last_* fields).
+    if not usage["cache_read"]:
+        usage["cache_read"] = int(getattr(agent, "session_cache_read_tokens", 0) or 0)
+    if not usage["cache_write"]:
+        usage["cache_write"] = int(getattr(agent, "session_cache_write_tokens", 0) or 0)
     comp = getattr(agent, "context_compressor", None)
     if comp:
         # context_used is the *current-window* occupancy. Do NOT fall back to
@@ -3278,6 +3293,12 @@ def _get_usage(agent) -> dict:
     try:
         from tools.async_delegation import active_count as _async_active_count
         usage["active_subagents"] = _async_active_count()
+    except Exception:
+        pass
+    # Background shell / terminal processes (Claude Code "N shells").
+    try:
+        from tools.process_registry import process_registry
+        usage["active_shells"] = int(process_registry.count_running() or 0)
     except Exception:
         pass
     # Dev-only live credits-spent readout (L0 usage-aware-credits). Gated on

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -132,6 +132,7 @@ describe('StatusRule background-subagent indicator', () => {
   it('spells out the auto-resume hint when idle with subagents in flight', () => {
     const element = StatusRule({
       ...baseProps,
+      cols: 140,
       usage: { ...baseProps.usage, active_subagents: 1 }
     })
 
@@ -141,6 +142,7 @@ describe('StatusRule background-subagent indicator', () => {
   it('pluralizes the resume hint for multiple in-flight subagents', () => {
     const element = StatusRule({
       ...baseProps,
+      cols: 140,
       usage: { ...baseProps.usage, active_subagents: 3 }
     })
 
@@ -419,5 +421,65 @@ describe('StatusRule idle-since read-out', () => {
     })
 
     expect(findComponentByName(element, 'IdleSince')).toBeNull()
+  })
+})
+
+describe('StatusRule Claude-style status extras', () => {
+  it('renders cache/fresh, cost, permissions, and shells when provided', () => {
+    const element = StatusRule({
+      ...baseProps,
+      cols: 160,
+      showCost: true,
+      yolo: true,
+      usage: {
+        ...baseProps.usage,
+        cache_read: 134_000,
+        last_prompt: 139_000,
+        context_used: 139_000,
+        context_max: 200_000,
+        context_percent: 70,
+        cost_usd: 127.093,
+        active_shells: 3
+      }
+    })
+
+    const rendered = textContent(element)
+    expect(rendered).toContain('cache R=')
+    expect(rendered).toContain('fresh=')
+    expect(rendered).toContain('$127.093')
+    expect(rendered).toContain('bypass permissions on')
+    expect(rendered).toContain('3 shells')
+    expect(rendered).toContain('[opus 4.8]')
+  })
+
+  it('hides cost when showCost is false', () => {
+    const element = StatusRule({
+      ...baseProps,
+      cols: 160,
+      showCost: false,
+      usage: { ...baseProps.usage, cost_usd: 12.5 }
+    })
+    expect(textContent(element)).not.toContain('$12')
+  })
+})
+
+describe('StatusRule cache hit pinning', () => {
+  it('always shows compact cache hit on medium width', () => {
+    const element = StatusRule({
+      ...baseProps,
+      cols: 72,
+      usage: {
+        ...baseProps.usage,
+        cache_read: 71_168,
+        last_prompt: 71_614,
+        context_used: 71_614,
+        context_max: 200_000,
+        context_percent: 36
+      }
+    })
+    const rendered = textContent(element)
+    // Compact form must appear even when full "cache R=… fresh=…" is too wide.
+    expect(rendered).toMatch(/R=.*\(/)
+    expect(rendered).toContain('%')
   })
 })

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -174,6 +174,7 @@ export interface UiState {
 
   sections: SectionVisibility
   sessionTitle: string
+  showCost: boolean
   showReasoning: boolean
   indicatorStyle: IndicatorStyle
   sid: null | string

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -23,6 +23,7 @@ const buildUiState = (): UiState => ({
   pasteCollapseChars: 2000,
   sections: {},
   sessionTitle: '',
+  showCost: false,
   showReasoning: false,
   sid: null,
   status: 'summoning hermes…',

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -227,6 +227,7 @@ export const applyDisplay = (
     pasteCollapseLines: _pasteCollapseLinesFromConfig(cfg),
     pasteCollapseChars: _pasteCollapseCharsFromConfig(cfg),
     sections: resolveSections(d.sections),
+    showCost: !!d.show_cost,
     showReasoning: !!d.show_reasoning,
     statusBar: normalizeStatusBar(d.tui_statusbar),
     streaming: d.streaming !== false

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -11,7 +11,7 @@ import { FACES } from '../content/faces.js'
 import { VERBS } from '../content/verbs.js'
 import { fmtDuration } from '../domain/messages.js'
 import { stickyPromptFromViewport } from '../domain/viewport.js'
-import { buildSubagentTree, treeTotals, widthByDepth } from '../lib/subagentTree.js'
+import { buildSubagentTree, fmtCost, treeTotals, widthByDepth } from '../lib/subagentTree.js'
 import { fmtK } from '../lib/text.js'
 import { useScrollbarSnapshot, useViewportSnapshot } from '../lib/viewportStore.js'
 import type { Theme } from '../theme.js'
@@ -374,8 +374,60 @@ const shortModelLabel = (model: string) =>
     .replace(/\b(\d+)\s+(\d+)\b/g, '$1.$2')
     .trim()
 
-const modelLabel = (model: string, effort?: string, fast?: boolean) =>
-  [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
+const modelLabel = (model: string, effort?: string, fast?: boolean) => {
+  const core = shortModelLabel(model)
+  const bracketed = core ? `[${core}]` : ''
+  return [bracketed, effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
+}
+
+/**
+ * Claude-style cache line.
+ * Full:  `cache R=134k(96%) fresh=5k`
+ * Compact (narrow): `R=134k(96%)`
+ *
+ * Hit% uses last API prompt size (preferred) so it matches the backend
+ * log line `cache=R/prompt (N%)`, not the cumulative session sum.
+ */
+export const formatCacheFresh = (usage: Usage, compact = false): string => {
+  const cacheRead = Math.max(0, Number(usage.cache_read ?? 0) || 0)
+  if (cacheRead <= 0) {
+    return ''
+  }
+
+  // Denominator priority: last API prompt → context_used → cache_read itself.
+  const lastPrompt = Math.max(0, Number(usage.last_prompt ?? 0) || 0)
+  const ctxUsed = Math.max(0, Number(usage.context_used ?? 0) || 0)
+  const denom = lastPrompt > 0 ? lastPrompt : ctxUsed > 0 ? ctxUsed : cacheRead
+  const hit = Math.max(0, Math.min(100, Math.round((cacheRead / denom) * 100)))
+  const freshBase = lastPrompt > 0 ? lastPrompt : ctxUsed
+  const fresh = freshBase > 0 ? Math.max(0, freshBase - cacheRead) : 0
+
+  if (compact) {
+    return `R=${fmtK(cacheRead)}(${hit}%)`
+  }
+
+  const pieces = [`cache R=${fmtK(cacheRead)}(${hit}%)`]
+  if (freshBase > 0) {
+    pieces.push(`fresh=${fmtK(fresh)}`)
+  }
+  return pieces.join(' ')
+}
+
+/** Claude-like dollar amount with up to 3 decimals for larger sessions. */
+export const formatStatusCost = (usd?: number): string => {
+  if (usd == null || !Number.isFinite(usd) || usd <= 0) {
+    return ''
+  }
+  if (usd < 0.01) {
+    return '<$0.01'
+  }
+  // Prefer existing compact helper under $10; 3dp above that (Claude shows $127.093).
+  if (usd < 10) {
+    return fmtCost(usd)
+  }
+  // 3dp max (Claude shows $127.093); strip trailing zeros: 12.5 not 12.500
+  return `$${Number(usd.toFixed(3))}`
+}
 
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
@@ -418,8 +470,10 @@ export function StatusRule({
   lastTurnEndedAt,
   liveSessionCount,
   sessionStartedAt,
+  showCost = false,
   turnStartedAt,
   voiceLabel,
+  yolo = false,
   onSessionCountClick,
   t
 }: StatusRuleProps) {
@@ -439,6 +493,11 @@ export function StatusRule({
 
   const bar = !segs.compactCtx && usage.context_max ? ctxBar(pct) : ''
   const modelText = modelLabel(model, modelReasoningEffort, modelFast)
+  // Cache hit is high-signal — prefer full form, fall back to compact so it
+  // still appears on medium-width terminals instead of being shed as tail.
+  const cacheFull = formatCacheFresh(usage, false)
+  const cacheCompact = formatCacheFresh(usage, true)
+  const cachePinned = cacheCompact
 
   // A credits notice replaces the status/verb slot, but only when idle —
   // while busy the FaceTicker always wins (R1 render priority). The notice
@@ -468,7 +527,9 @@ export function StatusRule({
     slotWidth +
     stringWidth(' │ ') +
     stringWidth(modelText) +
-    (ctxLabel ? stringWidth(' │ ') + stringWidth(ctxLabel) : 0)
+    (ctxLabel ? stringWidth(' │ ') + stringWidth(ctxLabel) : 0) +
+    // Pin compact cache hit (`R=134k(96%)`) so it is not dropped by tail budget.
+    (cachePinned ? stringWidth(' │ ') + stringWidth(cachePinned) : 0)
 
   const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel, essentialWidth)
 
@@ -502,6 +563,24 @@ export function StatusRule({
       ? `Δ ${(usage.dev_credits_spent_micros / 10000).toFixed(1)}¢`
       : ''
 
+  // Decide cache BEFORE other tail segments so full form can claim budget first.
+  let cacheFreshText = ''
+  let showCache = false
+  if (cacheFull) {
+    const fullW = SEP + stringWidth(cacheFull)
+    const compactW = cacheCompact ? SEP + stringWidth(cacheCompact) : 0
+    // Compact width is already reserved in essentialWidth; only need extra
+    // budget to upgrade full = max(0, fullW - compactW).
+    const upgrade = Math.max(0, fullW - compactW)
+    if (upgrade === 0 || fits(upgrade)) {
+      cacheFreshText = cacheFull
+      showCache = true
+    } else {
+      cacheFreshText = cacheCompact
+      showCache = true
+    }
+  }
+
   const showBar = !!bar && fits(SEP + stringWidth(`[${bar}] ${pct != null ? `${pct}%` : ''}`))
   const showDuration = segs.duration && !!sessionStartedAt && fits(SEP + MAX_DURATION_WIDTH)
 
@@ -528,6 +607,19 @@ export function StatusRule({
     subagentCount === 1 ? '↩ resumes when subagent finishes' : `↩ resumes when ${subagentCount} subagents finish`
 
   const showResumeHint = !busy && subagentCount > 0 && fits(SEP + stringWidth(resumeHintText))
+  // Claude-style cost / permissions / shells (cache decided above).
+  const costText = showCost ? formatStatusCost(usage.cost_usd) : ''
+  const permsText = yolo ? 'bypass permissions on' : ''
+  const shellCount =
+    typeof usage.active_shells === 'number' && usage.active_shells > 0
+      ? usage.active_shells
+      : 0
+  const shellsText = shellCount > 0 ? `${shellCount} shell${shellCount === 1 ? '' : 's'}` : ''
+
+  const showCostSeg = !!costText && fits(SEP + stringWidth(costText))
+  const showPerms = !!permsText && fits(SEP + stringWidth(permsText))
+  const showShells = !!shellsText && fits(SEP + stringWidth(shellsText))
+
   // Dev-gated readout (HERMES_DEV_CREDITS), lowest priority,
   // so it consumes tail budget LAST and drops first on a narrow terminal.
   const showDevCredits = !!devCreditsText && fits(SEP + stringWidth(devCreditsText))
@@ -589,11 +681,35 @@ export function StatusRule({
               {ctxLabel}
             </Text>
           ) : null}
+          {showCache ? (
+            <Text color={t.color.accent} wrap="truncate-end">
+              {' │ '}
+              {cacheFreshText}
+            </Text>
+          ) : null}
         </Box>
         {showBar ? (
           <Text color={t.color.muted} wrap="truncate-end">
             {' │ '}
             <Text color={barColor}>[{bar}]</Text> <Text color={barColor}>{pct != null ? `${pct}%` : ''}</Text>
+          </Text>
+        ) : null}
+        {showCostSeg ? (
+          <Text color={t.color.accent} wrap="truncate-end">
+            {' │ '}
+            {costText}
+          </Text>
+        ) : null}
+        {showPerms ? (
+          <Text color={t.color.warn} wrap="truncate-end">
+            {' │ '}
+            {permsText}
+          </Text>
+        ) : null}
+        {showShells ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {' │ '}
+            {shellsText}
           </Text>
         ) : null}
         {showDuration ? (
@@ -782,12 +898,16 @@ interface StatusRuleProps {
   indicatorStyle?: IndicatorStyle
   notice?: Notice | null
   sessionStartedAt?: null | number
+  /** When true, render estimated session $ cost (display.show_cost). */
+  showCost?: boolean
   status: string
   statusColor: string
   t: Theme
   turnStartedAt?: null | number
   usage: Usage
   voiceLabel?: string
+  /** Effective approval bypass (YOLO / approvals.mode=off). */
+  yolo?: boolean
   onSessionCountClick?: () => void
 }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -479,12 +479,14 @@ const StatusRulePane = memo(function StatusRulePane({
         notice={ui.notice}
         onSessionCountClick={() => patchOverlayState({ sessions: true })}
         sessionStartedAt={status.sessionStartedAt}
+        showCost={ui.showCost}
         status={ui.status}
         statusColor={status.statusColor}
         t={ui.theme}
         turnStartedAt={status.turnStartedAt}
         usage={ui.usage}
         voiceLabel={status.voiceLabel}
+        yolo={!!ui.info?.yolo}
       />
     </Box>
   )

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -315,9 +315,12 @@ export interface SessionUndoResponse {
 }
 
 export interface SessionUsageResponse {
+  active_shells?: number
   active_subagents?: number
   cache_read?: number
   cache_write?: number
+  last_prompt?: number
+  session_cache_read?: number
   calls?: number
   compressions?: number
   context_max?: number

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -150,6 +150,7 @@ export interface McpServerStatus {
 }
 
 export interface SessionInfo {
+  approval_mode?: string
   cwd?: string
   fast?: boolean
   install_warning?: string
@@ -167,10 +168,16 @@ export interface SessionInfo {
   update_command?: string
   usage?: Usage
   version?: string
+  yolo?: boolean
 }
 
 export interface Usage {
+  active_shells?: number
   active_subagents?: number
+  cache_read?: number
+  cache_write?: number
+  last_prompt?: number
+  session_cache_read?: number
   calls: number
   compressions?: number
   context_max?: number


### PR DESCRIPTION
Summary
Adds a Claude Code-style status HUD to Hermes TUI + classic CLI:

Expose last-call cache_read / cache_write / last_prompt, cost, and active_shells via tui_gateway usage payload
Pin compact cache hit in TUI StatusRule essentials; progressive disclosure when width allows
Gate $ cost on display.show_cost
Classic CLI kept in minimal sync (cache fresh, cost, bypass-permissions wording, shells)
Cache hit% denominator prefers last_prompt (matches API log cache=R/prompt)
No fabricated cache — omit segment when cache_read <= 0
Scope (14 files only)
Agent counters + usage update, gateway payload, TUI StatusRule/wiring/types, classic CLI, tests.

Out of scope: website i18n, package-lock, Desktop Electron statusbar (follow-up PR).

Invariants
Prompt cache sacred — render-side usage fields only; no mid-conversation system-prompt rebuild
No fabricated cache when cache_read <= 0
Hit% uses last_prompt then context_used
Cost only when display.show_cost / available cost data
YOLO label maps to bypass permissions on text only
Test plan
 cd ui-tui && npx vitest run src/__tests__/appChromeStatusRule.test.tsx (21 passed)
 pytest tests/cli/test_cli_status_bar.py (48 passed)
 Manual: display.interface=tui, display.show_cost=true, wide terminal, 2+ turns on a cache-capable route
 Expect roughly: [model] │ used/max │ cache R=…(%) … │ $… │ bypass… │ N shells
Notes
Local install patches under $HERMES_HOME/hermes-agent are wiped by hermes update until this lands.