### PR TITLE
fix(gateway): wait for Telegram adapter degraded state before startup notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1403,6 +1403,13 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
+# Maximum time to wait for adapters with a degraded-send gate to become
+# ready before sending restart/startup lifecycle notifications. Set just
+# above the Telegram polling progress verifier's 60s budget so a
+# slow-but-recovering first getUpdates still beats this deadline.
+_STARTUP_LIFECYCLE_READY_TIMEOUT = 65.0
+
+
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
@@ -7860,6 +7867,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Notify the chat that initiated /restart that the gateway is back.
         planned_restart_notification_pending = _planned_restart_notification_pending()
+
+        # Wait for adapters that use a degraded-send gate (e.g. Telegram's
+        # _send_path_degraded) to become fully ready before sending
+        # lifecycle notifications. The flag is only cleared after the first
+        # successful getUpdates, which can take well over the 1.0s settle
+        # above on networks requiring fallback IPs — Telegram's own polling
+        # verifier allows 60s. Only wait when a lifecycle notification is
+        # actually pending, so normal startup is unaffected (#66589).
+        if connected_count > 0 and (
+            _restart_notification_pending() or planned_restart_notification_pending
+        ):
+            await self._wait_for_degraded_send_paths()
         # Capture, before _send_restart_notification() unlinks the marker,
         # whether this process booted from a chat-originated /restart. Used as
         # a one-shot signal by the /restart redelivery guard so a missing
@@ -16126,6 +16145,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exit_code_path.unlink(missing_ok=True)
 
         return True
+
+    async def _wait_for_degraded_send_paths(self, timeout: Optional[float] = None) -> None:
+        """Wait until adapters that gate sends behind a degraded flag are ready.
+
+        Telegram sets ``_send_path_degraded`` while its first getUpdates is in
+        flight and clears it on the first successful poll; sends attempted in
+        that window are rejected with ``send_path_degraded`` (#66589). Waiting
+        here lets restart/startup lifecycle notifications survive networks
+        where the first poll needs fallback-IP discovery and takes many
+        seconds.
+
+        Event-driven when the adapter exposes ``_polling_progress_event`` —
+        that event is recreated every polling generation, so it is re-fetched
+        each round and waited in short slices. Adapters that expose the flag
+        without the event fall back to short polling. Only invoked from
+        ``start()`` when a lifecycle notification is actually pending, so
+        normal startup pays nothing for this.
+        """
+        if timeout is None:
+            timeout = _STARTUP_LIFECYCLE_READY_TIMEOUT
+        deadline = time.monotonic() + timeout
+        for platform, adapter in self.adapters.items():
+            if not hasattr(adapter, "_send_path_degraded"):
+                continue
+            platform_name = getattr(platform, "value", platform)
+            logged_wait = False
+            while getattr(adapter, "_send_path_degraded", False):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "%s adapter send path still degraded after %.0fs; "
+                        "sending lifecycle notifications anyway",
+                        platform_name, timeout,
+                    )
+                    break
+                if not logged_wait:
+                    logged_wait = True
+                    logger.info(
+                        "Waiting for %s adapter send path to become ready "
+                        "before sending lifecycle notifications",
+                        platform_name,
+                    )
+                progress = getattr(adapter, "_polling_progress_event", None)
+                if isinstance(progress, asyncio.Event):
+                    try:
+                        # Short slices: the event is recreated each polling
+                        # generation, so re-check the flag and re-fetch it
+                        # often rather than sleeping on a stale event.
+                        await asyncio.wait_for(
+                            progress.wait(), timeout=min(2.0, remaining)
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+                else:
+                    await asyncio.sleep(min(0.5, remaining))
 
     async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
         """Notify the chat that initiated /restart that the gateway is back."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1403,11 +1403,32 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
+def _is_degraded_send_rejection(result: object) -> bool:
+    """True when adapter.send() refused the send because its path is degraded.
+
+    Telegram short-circuits send() with ``SendResult(success=False,
+    error="send_path_degraded", retryable=True)`` while its first getUpdates
+    is still in flight (#66589). That failure means the message never left
+    the process, so lifecycle notification markers must survive it.
+    """
+    return (
+        result is not None
+        and getattr(result, "success", True) is False
+        and getattr(result, "error", None) == "send_path_degraded"
+    )
+
+
 # Maximum time to wait for adapters with a degraded-send gate to become
 # ready before sending restart/startup lifecycle notifications. Set just
 # above the Telegram polling progress verifier's 60s budget so a
 # slow-but-recovering first getUpdates still beats this deadline.
 _STARTUP_LIFECYCLE_READY_TIMEOUT = 65.0
+
+# Bound for the background retry that delivers lifecycle notifications whose
+# startup send was rejected with send_path_degraded. Generous because the
+# adapter already survived the startup wait; still finite so a wedged
+# adapter can't keep a stale marker eligible indefinitely.
+_DEFERRED_LIFECYCLE_RETRY_TIMEOUT = 120.0
 
 
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
@@ -3181,6 +3202,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # marker-missing fallback only suppresses a /restart when we KNOW we
         # just came out of a restart cycle — never on a genuine fresh boot.
         self._booted_from_restart: bool = False
+        # Number of home-channel startup sends rejected with
+        # "send_path_degraded" by the most recent
+        # _send_home_channel_startup_notifications() call. Lets start()
+        # decide whether the planned-restart marker must survive for the
+        # deferred retry (#66589).
+        self._last_home_notify_degraded: int = 0
+        # Background task delivering lifecycle notifications retained after a
+        # degraded startup send. Tracked so it isn't garbage-collected early.
+        self._deferred_lifecycle_retry_task: Optional[asyncio.Task] = None
         self._stop_task: Optional[asyncio.Task] = None
         self._restart_task: Optional[asyncio.Task] = None
         self._executor_lock = threading.Lock()
@@ -7894,12 +7924,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # in .restart_notify.json, so keep that lifecycle in the originating
         # chat/topic instead of also leaking it to the configured home channel.
         if planned_restart_notification_pending:
+            delivered: set[tuple[str, str, Optional[str]]] = set()
             try:
-                await self._send_home_channel_startup_notifications(
+                delivered = await self._send_home_channel_startup_notifications(
                     skip_targets=None,
                 )
             finally:
-                _clear_planned_restart_notification()
+                # Retain the marker when nothing was delivered and at least
+                # one send was rejected with send_path_degraded, so the
+                # deferred retry can still deliver it (#66589). Deleting the
+                # only durable record after a refused send would silently
+                # drop the promised notification.
+                if delivered or not self._last_home_notify_degraded:
+                    _clear_planned_restart_notification()
+
+        # If a lifecycle marker survived startup because the send path was
+        # still degraded, retry delivery in the background once the adapter
+        # reports readiness instead of dropping the notification.
+        self._schedule_deferred_lifecycle_retry()
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
@@ -16201,12 +16243,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     await asyncio.sleep(min(0.5, remaining))
 
-    async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
+    def _schedule_deferred_lifecycle_retry(self) -> None:
+        """Retry lifecycle notifications whose startup send was refused.
+
+        start() keeps .restart_notify.json / .restart_pending.json when the
+        send was rejected with send_path_degraded (#66589). When no marker
+        survived there is nothing to do.
+        """
+        if not (_restart_notification_pending() or _planned_restart_notification_pending()):
+            return
+        if self._deferred_lifecycle_retry_task is not None and not self._deferred_lifecycle_retry_task.done():
+            return
+        logger.info("Scheduling deferred lifecycle notification retry")
+        self._deferred_lifecycle_retry_task = asyncio.create_task(
+            self._retry_deferred_lifecycle_notifications()
+        )
+
+    async def _retry_deferred_lifecycle_notifications(self) -> None:
+        """Deliver retained lifecycle notifications once adapters are ready.
+
+        Waits (bounded) for the degraded send paths to clear, then retries
+        delivery exactly once per marker and clears any leftovers so a stale
+        marker can't produce a spurious "gateway restarted" message after a
+        future unrelated restart.
+        """
+        try:
+            await self._wait_for_degraded_send_paths(
+                timeout=_DEFERRED_LIFECYCLE_RETRY_TIMEOUT
+            )
+            if _restart_notification_pending():
+                # Second refusal must not keep the marker: this is the last
+                # chance, and a permanent marker is worse than a logged drop.
+                await self._send_restart_notification(retain_marker_on_degraded=False)
+        except Exception:
+            logger.warning("Deferred restart-notification retry failed", exc_info=True)
+            (_hermes_home / ".restart_notify.json").unlink(missing_ok=True)
+        try:
+            if _planned_restart_notification_pending():
+                try:
+                    await self._send_home_channel_startup_notifications(skip_targets=None)
+                finally:
+                    _clear_planned_restart_notification()
+        except Exception:
+            logger.warning("Deferred home-channel notification retry failed", exc_info=True)
+            _clear_planned_restart_notification()
+
+    async def _send_restart_notification(self, *, retain_marker_on_degraded: bool = True) -> Optional[tuple[str, str, Optional[str]]]:
         """Notify the chat that initiated /restart that the gateway is back."""
         notify_path = _hermes_home / ".restart_notify.json"
         if not notify_path.exists():
             return None
 
+        # Set when the send was refused with send_path_degraded: the message
+        # never left the process, so the marker — the only durable record of
+        # the promised notification — must survive for the deferred retry.
+        retain_marker = False
         try:
             data = json.loads(notify_path.read_text())
             platform_str = data.get("platform")
@@ -16253,6 +16344,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # we must inspect the result before claiming success — otherwise
             # the log line is misleading and hides real delivery failures.
             if result is not None and getattr(result, "success", True) is False:
+                if retain_marker_on_degraded and _is_degraded_send_rejection(result):
+                    retain_marker = True
+                    logger.warning(
+                        "Restart notification to %s:%s refused (send_path_degraded); "
+                        "marker retained for deferred retry",
+                        platform_str,
+                        chat_id,
+                    )
+                    return None
                 logger.warning(
                     "Restart notification to %s:%s was not delivered: %s",
                     platform_str,
@@ -16271,7 +16371,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Restart notification failed: %s", e)
             return None
         finally:
-            notify_path.unlink(missing_ok=True)
+            if not retain_marker:
+                notify_path.unlink(missing_ok=True)
 
     async def _send_home_channel_startup_notifications(
         self,
@@ -16287,6 +16388,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         delivered: set[tuple[str, str, Optional[str]]] = set()
         skipped = skip_targets or set()
         message = "♻️ Gateway online — Hermes is back and ready."
+        # Read by start() to decide whether the planned-restart marker must
+        # survive for the deferred retry: a send_path_degraded rejection
+        # means the message never left the process (#66589).
+        self._last_home_notify_degraded = 0
 
         for platform, adapter in self.adapters.items():
             home = self.config.get_home_channel(platform)
@@ -16329,6 +16434,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     else:
                         result = await adapter.send(str(home.chat_id), message)
                 if result is not None and getattr(result, "success", True) is False:
+                    if _is_degraded_send_rejection(result):
+                        self._last_home_notify_degraded += 1
                     logger.warning(
                         "Home-channel startup notification failed for %s:%s: %s",
                         platform.value,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2060,6 +2060,13 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
+# Maximum time to wait for adapters with a degraded-send gate to become
+# ready before sending restart/startup lifecycle notifications. Set just
+# above the Telegram polling progress verifier's 60s budget so a
+# slow-but-recovering first getUpdates still beats this deadline.
+_STARTUP_LIFECYCLE_READY_TIMEOUT = 65.0
+
+
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
@@ -13292,6 +13299,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Notify the chat that initiated /restart that the gateway is back.
         chat_restart_notification_pending = _restart_notification_pending()
         planned_restart_notification_pending = _planned_restart_notification_pending()
+
+        # Wait for adapters that use a degraded-send gate (e.g. Telegram's
+        # _send_path_degraded) to become fully ready before sending
+        # lifecycle notifications. The flag is only cleared after the first
+        # successful getUpdates, which can take well over the 1.0s settle
+        # above on networks requiring fallback IPs — Telegram's own polling
+        # verifier allows 60s. Only wait when a lifecycle notification is
+        # actually pending, so normal startup is unaffected (#66589).
+        if connected_count > 0 and (
+            _restart_notification_pending() or planned_restart_notification_pending
+        ):
+            await self._wait_for_degraded_send_paths()
         # Capture, before _send_restart_notification() unlinks the marker,
         # whether this process booted from a chat-originated /restart. Used as
         # a one-shot signal by the /restart redelivery guard so a missing
@@ -24398,6 +24417,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exit_code_path.unlink(missing_ok=True)
 
         return True
+
+    async def _wait_for_degraded_send_paths(self, timeout: Optional[float] = None) -> None:
+        """Wait until adapters that gate sends behind a degraded flag are ready.
+
+        Telegram sets ``_send_path_degraded`` while its first getUpdates is in
+        flight and clears it on the first successful poll; sends attempted in
+        that window are rejected with ``send_path_degraded`` (#66589). Waiting
+        here lets restart/startup lifecycle notifications survive networks
+        where the first poll needs fallback-IP discovery and takes many
+        seconds.
+
+        Event-driven when the adapter exposes ``_polling_progress_event`` —
+        that event is recreated every polling generation, so it is re-fetched
+        each round and waited in short slices. Adapters that expose the flag
+        without the event fall back to short polling. Only invoked from
+        ``start()`` when a lifecycle notification is actually pending, so
+        normal startup pays nothing for this.
+        """
+        if timeout is None:
+            timeout = _STARTUP_LIFECYCLE_READY_TIMEOUT
+        deadline = time.monotonic() + timeout
+        for platform, adapter in self.adapters.items():
+            if not hasattr(adapter, "_send_path_degraded"):
+                continue
+            platform_name = getattr(platform, "value", platform)
+            logged_wait = False
+            while getattr(adapter, "_send_path_degraded", False):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "%s adapter send path still degraded after %.0fs; "
+                        "sending lifecycle notifications anyway",
+                        platform_name, timeout,
+                    )
+                    break
+                if not logged_wait:
+                    logged_wait = True
+                    logger.info(
+                        "Waiting for %s adapter send path to become ready "
+                        "before sending lifecycle notifications",
+                        platform_name,
+                    )
+                progress = getattr(adapter, "_polling_progress_event", None)
+                if isinstance(progress, asyncio.Event):
+                    try:
+                        # Short slices: the event is recreated each polling
+                        # generation, so re-check the flag and re-fetch it
+                        # often rather than sleeping on a stale event.
+                        await asyncio.wait_for(
+                            progress.wait(), timeout=min(2.0, remaining)
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+                else:
+                    await asyncio.sleep(min(0.5, remaining))
 
     async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
         """Notify the chat that initiated /restart that the gateway is back."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2060,11 +2060,32 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
+def _is_degraded_send_rejection(result: object) -> bool:
+    """True when adapter.send() refused the send because its path is degraded.
+
+    Telegram short-circuits send() with ``SendResult(success=False,
+    error="send_path_degraded", retryable=True)`` while its first getUpdates
+    is still in flight (#66589). That failure means the message never left
+    the process, so lifecycle notification markers must survive it.
+    """
+    return (
+        result is not None
+        and getattr(result, "success", True) is False
+        and getattr(result, "error", None) == "send_path_degraded"
+    )
+
+
 # Maximum time to wait for adapters with a degraded-send gate to become
 # ready before sending restart/startup lifecycle notifications. Set just
 # above the Telegram polling progress verifier's 60s budget so a
 # slow-but-recovering first getUpdates still beats this deadline.
 _STARTUP_LIFECYCLE_READY_TIMEOUT = 65.0
+
+# Bound for the background retry that delivers lifecycle notifications whose
+# startup send was rejected with send_path_degraded. Generous because the
+# adapter already survived the startup wait; still finite so a wedged
+# adapter can't keep a stale marker eligible indefinitely.
+_DEFERRED_LIFECYCLE_RETRY_TIMEOUT = 120.0
 
 
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
@@ -6968,6 +6989,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # marker-missing fallback only suppresses a /restart when we KNOW we
         # just came out of a restart cycle — never on a genuine fresh boot.
         self._booted_from_restart: bool = False
+        # Number of home-channel startup sends rejected with
+        # "send_path_degraded" by the most recent
+        # _send_home_channel_startup_notifications() call. Lets the boot-send
+        # path decide whether the planned-restart marker must survive for the
+        # deferred retry (#66589).
+        self._last_home_notify_degraded: int = 0
+        # Home-channel targets the most recent
+        # _send_home_channel_startup_notifications() call delivered to. The
+        # deferred lifecycle retry skips these so a retained planned-restart
+        # marker only re-sends to targets that were refused (#66589).
+        self._last_home_notify_delivered: set[tuple[str, str, Optional[str]]] = set()
+        # Boot-path send task created by _await_startup_boot_sends(). The
+        # deferred lifecycle retry waits for it before touching markers, so
+        # a boot send that outlived the restore gate can't race a duplicate
+        # notification send.
+        self._boot_sends_task: Optional[asyncio.Task] = None
+        # Background task delivering lifecycle notifications retained after a
+        # degraded startup send. Tracked so it isn't garbage-collected early.
+        self._deferred_lifecycle_retry_task: Optional[asyncio.Task] = None
         self._stop_task: Optional[asyncio.Task] = None
         self._restart_task: Optional[asyncio.Task] = None
         self._executor_lock = threading.Lock()
@@ -12012,10 +12052,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         skip_targets=None,
                     )
                 finally:
-                    _clear_planned_restart_notification()
+                    # Retain the marker when at least one send was rejected
+                    # with send_path_degraded, so the deferred retry can
+                    # still deliver it (#66589). Deleting the only durable
+                    # record after a refused send would silently drop the
+                    # promised notification — including the multi-target
+                    # case where one home channel succeeded and another was
+                    # refused. Non-degraded failures keep the existing
+                    # cleanup.
+                    if not self._last_home_notify_degraded:
+                        _clear_planned_restart_notification()
             await self._redeliver_claimed_obligations(claimed)
 
         boot_task = asyncio.create_task(_boot_sends())
+        self._boot_sends_task = boot_task
         timeout = _startup_restore_drain_timeout_secs()
         if timeout > 0:
             _done, pending = await asyncio.wait({boot_task}, timeout=timeout)
@@ -13326,6 +13376,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         await self._await_startup_boot_sends(
             planned_restart_notification_pending=planned_restart_notification_pending,
         )
+
+        # If a lifecycle marker survived startup because the send path was
+        # still degraded, retry delivery in the background once the adapter
+        # reports readiness instead of dropping the notification.
+        self._schedule_deferred_lifecycle_retry()
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
@@ -24473,12 +24528,81 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     await asyncio.sleep(min(0.5, remaining))
 
-    async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
+    def _schedule_deferred_lifecycle_retry(self) -> None:
+        """Retry lifecycle notifications whose startup send was refused.
+
+        The boot-send path keeps .restart_notify.json / .restart_pending.json
+        when the send was rejected with send_path_degraded (#66589). When no
+        marker survived there is nothing to do.
+        """
+        if not (_restart_notification_pending() or _planned_restart_notification_pending()):
+            return
+        if self._deferred_lifecycle_retry_task is not None and not self._deferred_lifecycle_retry_task.done():
+            return
+        logger.info("Scheduling deferred lifecycle notification retry")
+        self._deferred_lifecycle_retry_task = asyncio.create_task(
+            self._retry_deferred_lifecycle_notifications()
+        )
+
+    async def _retry_deferred_lifecycle_notifications(self) -> None:
+        """Deliver retained lifecycle notifications once adapters are ready.
+
+        Waits (bounded) for the degraded send paths to clear, then retries
+        delivery exactly once per marker and clears any leftovers so a stale
+        marker can't produce a spurious "gateway restarted" message after a
+        future unrelated restart.
+        """
+        # Boot-path sends may still be running in the background after the
+        # restore-gate drain timeout (#91969). They own the lifecycle markers
+        # until they finish, so wait for them first rather than racing a
+        # duplicate send against an in-flight boot send.
+        boot_task = self._boot_sends_task
+        if boot_task is not None and not boot_task.done():
+            try:
+                await asyncio.wait({boot_task}, timeout=_DEFERRED_LIFECYCLE_RETRY_TIMEOUT)
+            except Exception:
+                logger.warning("Deferred lifecycle retry: boot-send wait failed", exc_info=True)
+            if not boot_task.done():
+                logger.warning(
+                    "Deferred lifecycle retry skipped: boot-path sends still "
+                    "running; markers stay with the boot task."
+                )
+                return
+        try:
+            await self._wait_for_degraded_send_paths(
+                timeout=_DEFERRED_LIFECYCLE_RETRY_TIMEOUT
+            )
+            if _restart_notification_pending():
+                # Second refusal must not keep the marker: this is the last
+                # chance, and a permanent marker is worse than a logged drop.
+                await self._send_restart_notification(retain_marker_on_degraded=False)
+        except Exception:
+            logger.warning("Deferred restart-notification retry failed", exc_info=True)
+            (_hermes_home / ".restart_notify.json").unlink(missing_ok=True)
+        try:
+            if _planned_restart_notification_pending():
+                try:
+                    # Skip targets already delivered at startup: the marker
+                    # was retained for the refused ones only.
+                    await self._send_home_channel_startup_notifications(
+                        skip_targets=self._last_home_notify_delivered,
+                    )
+                finally:
+                    _clear_planned_restart_notification()
+        except Exception:
+            logger.warning("Deferred home-channel notification retry failed", exc_info=True)
+            _clear_planned_restart_notification()
+
+    async def _send_restart_notification(self, *, retain_marker_on_degraded: bool = True) -> Optional[tuple[str, str, Optional[str]]]:
         """Notify the chat that initiated /restart that the gateway is back."""
         notify_path = _hermes_home / ".restart_notify.json"
         if not notify_path.exists():
             return None
 
+        # Set when the send was refused with send_path_degraded: the message
+        # never left the process, so the marker — the only durable record of
+        # the promised notification — must survive for the deferred retry.
+        retain_marker = False
         try:
             data = json.loads(notify_path.read_text(encoding="utf-8"))
             platform_str = data.get("platform")
@@ -24532,6 +24656,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # we must inspect the result before claiming success — otherwise
             # the log line is misleading and hides real delivery failures.
             if result is not None and getattr(result, "success", True) is False:
+                if retain_marker_on_degraded and _is_degraded_send_rejection(result):
+                    retain_marker = True
+                    logger.warning(
+                        "Restart notification to %s:%s refused (send_path_degraded); "
+                        "marker retained for deferred retry",
+                        platform_str,
+                        chat_id,
+                    )
+                    return None
                 logger.warning(
                     "Restart notification to %s:%s was not delivered: %s",
                     platform_str,
@@ -24550,7 +24683,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Restart notification failed: %s", e)
             return None
         finally:
-            notify_path.unlink(missing_ok=True)
+            if not retain_marker:
+                notify_path.unlink(missing_ok=True)
 
     async def _send_home_channel_startup_notifications(
         self,
@@ -24566,6 +24700,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         delivered: set[tuple[str, str, Optional[str]]] = set()
         skipped = skip_targets or set()
         message = "♻️ Gateway online — Hermes is back and ready."
+        # Read by the boot-send path to decide whether the planned-restart
+        # marker must survive for the deferred retry: a send_path_degraded
+        # rejection means the message never left the process (#66589).
+        self._last_home_notify_degraded = 0
 
         for platform, platform_cfg in self.config.platforms.items():
             home = platform_cfg.home_channel
@@ -24611,6 +24749,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     result = await transport.adapter.send(str(home.chat_id), message)
                 if result is not None and getattr(result, "success", True) is False:
+                    if _is_degraded_send_rejection(result):
+                        self._last_home_notify_degraded += 1
                     logger.warning(
                         "Home-channel startup notification failed for %s:%s: %s",
                         platform.value,
@@ -24633,6 +24773,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exc,
                 )
 
+        self._last_home_notify_delivered = delivered
         return delivered
 
     async def _send_session_db_warning_notifications(self) -> None:

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -80,6 +80,10 @@ def make_restart_runner(
     runner._restart_after_turn_timeout = DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT
     runner._cron_drain_timeout = DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
     runner._stop_task = None
+    runner._last_home_notify_degraded = 0
+    runner._last_home_notify_delivered = set()
+    runner._boot_sends_task = None
+    runner._deferred_lifecycle_retry_task = None
     runner._busy_input_mode = "interrupt"
     runner._update_prompt_pending = {}
     runner._voice_mode = {}

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -785,3 +785,185 @@ async def test_degraded_send_path_wait_skips_adapters_without_gate():
     started = time.monotonic()
     await runner._wait_for_degraded_send_paths(timeout=5.0)
     assert time.monotonic() - started < 1.0
+
+
+# ── marker retention + deferred retry for refused lifecycle sends (#66589) ──
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_retains_marker_on_degraded_rejection(
+    tmp_path, monkeypatch
+):
+    """A send_path_degraded refusal must not delete the only durable record."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="send_path_degraded", retryable=True),
+    )
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    assert notify_path.exists(), "marker must survive a refused (not failed) send"
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_clears_marker_when_retain_disabled(
+    tmp_path, monkeypatch
+):
+    """The deferred retry's last-chance send must not keep the marker forever."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="send_path_degraded", retryable=True),
+    )
+
+    delivered_target = await runner._send_restart_notification(retain_marker_on_degraded=False)
+
+    assert delivered_target is None
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_still_clears_marker_on_real_failure(
+    tmp_path, monkeypatch
+):
+    """Non-degraded failures (e.g. 'Chat not found') keep the old cleanup behavior."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="Chat not found"),
+    )
+
+    await runner._send_restart_notification()
+
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_home_channel_notification_counts_degraded_rejection(tmp_path, monkeypatch):
+    """start() uses _last_home_notify_degraded to retain .restart_pending.json."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="send_path_degraded", retryable=True),
+    )
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == set()
+    assert runner._last_home_notify_degraded == 1
+
+
+@pytest.mark.asyncio
+async def test_deferred_retry_delivers_retained_restart_notification(
+    tmp_path, monkeypatch
+):
+    """Marker retained at startup is delivered once the adapter recovers."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+
+    await runner._retry_deferred_lifecycle_notifications()
+
+    assert not notify_path.exists()
+    adapter.send.assert_awaited_once()
+    call = adapter.send.await_args
+    assert call is not None
+    assert call.args[0] == "42"
+
+
+@pytest.mark.asyncio
+async def test_deferred_retry_clears_marker_when_adapter_never_recovers(
+    tmp_path, monkeypatch
+):
+    """A second refusal clears the marker: bounded loss beats a permanent stale marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="send_path_degraded", retryable=True),
+    )
+
+    await runner._retry_deferred_lifecycle_notifications()
+
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_deferred_retry_delivers_retained_planned_notification(
+    tmp_path, monkeypatch
+):
+    """The home-channel path is retried too, then the planned marker is cleared."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    (tmp_path / ".restart_pending.json").write_text("{}")
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+
+    await runner._retry_deferred_lifecycle_notifications()
+
+    assert not (tmp_path / ".restart_pending.json").exists()
+    adapter.send.assert_awaited_once()
+    call = adapter.send.await_args
+    assert call is not None
+    assert call.args[0] == "home-42"
+
+
+@pytest.mark.asyncio
+async def test_schedule_deferred_retry_noop_without_markers(tmp_path, monkeypatch):
+    """Normal startup (no retained markers) must not spawn a retry task."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, _adapter = make_restart_runner()
+    runner._deferred_lifecycle_retry_task = None
+
+    runner._schedule_deferred_lifecycle_retry()
+
+    assert runner._deferred_lifecycle_retry_task is None

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -1,6 +1,8 @@
 """Tests for /restart notification — the gateway notifies the requester on comeback."""
 
+import asyncio
 import json
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -688,3 +690,98 @@ async def test_restart_shutdown_notification_anchors_telegram_dm_topic():
         "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "462",
     }
+
+
+# ── startup lifecycle: wait for degraded send paths (#66589) ─────────────
+
+
+class _DegradedSendAdapter:
+    """Minimal stand-in for an adapter gating sends behind a degraded flag.
+
+    Mirrors the Telegram contract: ``_send_path_degraded`` clears on the
+    first successful getUpdates, and ``_polling_progress_event`` (recreated
+    every polling generation) signals that progress.
+    """
+
+    def __init__(self):
+        self._send_path_degraded = True
+        self._polling_progress_event = asyncio.Event()
+
+
+@pytest.mark.asyncio
+async def test_degraded_send_path_wait_returns_when_adapter_becomes_ready(monkeypatch):
+    """Readiness arriving after the 1s settle window is picked up promptly."""
+    monkeypatch.setattr(gateway_run, "_STARTUP_LIFECYCLE_READY_TIMEOUT", 10.0)
+
+    runner, _adapter = make_restart_runner()
+    degraded = _DegradedSendAdapter()
+    runner.adapters = {Platform.TELEGRAM: degraded}  # pyright: ignore[reportAttributeAccessIssue]
+
+    async def heal_after_settle():
+        await asyncio.sleep(1.5)  # readiness lands after the 1.0s settle
+        degraded._polling_progress_event.set()
+        degraded._send_path_degraded = False
+
+    healer = asyncio.create_task(heal_after_settle())
+    started = time.monotonic()
+    await runner._wait_for_degraded_send_paths()
+    elapsed = time.monotonic() - started
+    await healer
+
+    # Returns soon after the event fires, not at the 10s deadline.
+    assert elapsed < 5.0
+
+
+@pytest.mark.asyncio
+async def test_degraded_send_path_wait_is_bounded_when_never_ready(monkeypatch):
+    """A stuck adapter must not stall startup notifications indefinitely."""
+    monkeypatch.setattr(gateway_run, "_STARTUP_LIFECYCLE_READY_TIMEOUT", 1.0)
+
+    runner, _adapter = make_restart_runner()
+    degraded = _DegradedSendAdapter()  # never heals
+    runner.adapters = {Platform.TELEGRAM: degraded}  # pyright: ignore[reportAttributeAccessIssue]
+
+    started = time.monotonic()
+    await runner._wait_for_degraded_send_paths()
+    elapsed = time.monotonic() - started
+
+    assert 0.9 <= elapsed < 5.0
+
+
+@pytest.mark.asyncio
+async def test_degraded_send_path_wait_follows_recreated_progress_event(monkeypatch):
+    """The waiter must not sleep on a stale event from a prior polling generation."""
+    monkeypatch.setattr(gateway_run, "_STARTUP_LIFECYCLE_READY_TIMEOUT", 10.0)
+
+    runner, _adapter = make_restart_runner()
+    degraded = _DegradedSendAdapter()
+    runner.adapters = {Platform.TELEGRAM: degraded}  # pyright: ignore[reportAttributeAccessIssue]
+
+    async def regenerate_then_heal():
+        await asyncio.sleep(0.5)
+        # Telegram recreates the event on every new polling generation.
+        degraded._polling_progress_event = asyncio.Event()
+        await asyncio.sleep(0.5)
+        degraded._polling_progress_event.set()
+        degraded._send_path_degraded = False
+
+    healer = asyncio.create_task(regenerate_then_heal())
+    started = time.monotonic()
+    await runner._wait_for_degraded_send_paths()
+    elapsed = time.monotonic() - started
+    await healer
+
+    # Picks up the new event within a slice instead of hanging on the old
+    # one until the deadline.
+    assert elapsed < 5.0
+
+
+@pytest.mark.asyncio
+async def test_degraded_send_path_wait_skips_adapters_without_gate():
+    """Adapters exposing no degraded flag are ignored (no wait, no error)."""
+    runner, adapter = make_restart_runner()
+    assert not hasattr(adapter, "_send_path_degraded")
+
+    started = time.monotonic()
+    await runner._wait_for_degraded_send_paths(timeout=5.0)
+    assert time.monotonic() - started < 1.0

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -13,6 +13,7 @@ from gateway.config import HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.session import build_session_key
 from tests.gateway.restart_test_helpers import (
+    RestartTestAdapter,
     make_restart_runner,
     make_restart_source,
 )
@@ -690,3 +691,106 @@ async def test_schedule_deferred_retry_noop_without_markers(tmp_path, monkeypatc
     runner._schedule_deferred_lifecycle_retry()
 
     assert runner._deferred_lifecycle_retry_task is None
+
+
+@pytest.mark.asyncio
+async def test_boot_sends_retain_planned_marker_on_partial_degraded_refusal(
+    tmp_path, monkeypatch
+):
+    """Multi-target case: one home channel delivered, another refused with
+    send_path_degraded — the marker must survive so the deferred retry can
+    still reach the refused target (#66589)."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    pending_path = tmp_path / ".restart_pending.json"
+    pending_path.write_text("{}")
+
+    runner, tg_adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-tg",
+        name="TG Home",
+    )
+    runner.config.platforms[Platform.DISCORD] = PlatformConfig(enabled=True, token="***")
+    runner.config.platforms[Platform.DISCORD].home_channel = HomeChannel(
+        platform=Platform.DISCORD,
+        chat_id="home-dc",
+        name="DC Home",
+    )
+    dc_adapter = RestartTestAdapter()
+    dc_adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="send_path_degraded", retryable=True),
+    )
+    runner.adapters[Platform.DISCORD] = dc_adapter
+    tg_adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+    runner._claim_pending_obligations = AsyncMock(return_value=[])
+    runner._redeliver_claimed_obligations = AsyncMock()
+
+    await runner._await_startup_boot_sends(planned_restart_notification_pending=True)
+
+    # The degraded refusal keeps the marker even though telegram succeeded.
+    assert pending_path.exists()
+    assert runner._last_home_notify_degraded == 1
+    assert runner._last_home_notify_delivered == {("telegram", "home-tg", None)}
+
+
+@pytest.mark.asyncio
+async def test_deferred_retry_skips_already_delivered_home_targets(tmp_path, monkeypatch):
+    """The deferred retry re-sends only to targets refused at startup."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    pending_path = tmp_path / ".restart_pending.json"
+    pending_path.write_text("{}")
+
+    runner, tg_adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-tg",
+        name="TG Home",
+    )
+    runner.config.platforms[Platform.DISCORD] = PlatformConfig(enabled=True, token="***")
+    runner.config.platforms[Platform.DISCORD].home_channel = HomeChannel(
+        platform=Platform.DISCORD,
+        chat_id="home-dc",
+        name="DC Home",
+    )
+    dc_adapter = RestartTestAdapter()
+    dc_adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="2"))
+    runner.adapters[Platform.DISCORD] = dc_adapter
+    tg_adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+    # Startup delivered to telegram before a discord refusal retained the marker.
+    runner._last_home_notify_delivered = {("telegram", "home-tg", None)}
+
+    await runner._retry_deferred_lifecycle_notifications()
+
+    assert not pending_path.exists()
+    tg_adapter.send.assert_not_awaited()
+    dc_adapter.send.assert_awaited_once()
+    dc_call = dc_adapter.send.await_args
+    assert dc_call is not None
+    assert dc_call.args[0] == "home-dc"
+
+
+@pytest.mark.asyncio
+async def test_deferred_retry_waits_for_in_flight_boot_sends(tmp_path, monkeypatch):
+    """A boot send that outlived the restore gate owns the markers; the
+    deferred retry must wait for it instead of racing a duplicate send."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+
+    async def finish_boot_send():
+        await asyncio.sleep(0.1)
+        notify_path.unlink(missing_ok=True)
+
+    runner._boot_sends_task = asyncio.create_task(finish_boot_send())
+
+    await runner._retry_deferred_lifecycle_notifications()
+
+    # The boot task consumed the marker; the retry must not double-send.
+    adapter.send.assert_not_awaited()
+    assert not notify_path.exists()

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -1,6 +1,8 @@
 """Tests for /restart notification — the gateway notifies the requester on comeback."""
 
+import asyncio
 import json
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -413,3 +415,96 @@ async def test_shutdown_notifications_are_fully_muted_when_flag_disabled():
     adapter.send.assert_not_awaited()
 
 
+# ── startup lifecycle: wait for degraded send paths (#66589) ─────────────
+
+
+class _DegradedSendAdapter:
+    """Minimal stand-in for an adapter gating sends behind a degraded flag.
+
+    Mirrors the Telegram contract: ``_send_path_degraded`` clears on the
+    first successful getUpdates, and ``_polling_progress_event`` (recreated
+    every polling generation) signals that progress.
+    """
+
+    def __init__(self):
+        self._send_path_degraded = True
+        self._polling_progress_event = asyncio.Event()
+
+
+@pytest.mark.asyncio
+async def test_degraded_send_path_wait_returns_when_adapter_becomes_ready(monkeypatch):
+    """Readiness arriving after the 1s settle window is picked up promptly."""
+    monkeypatch.setattr(gateway_run, "_STARTUP_LIFECYCLE_READY_TIMEOUT", 10.0)
+
+    runner, _adapter = make_restart_runner()
+    degraded = _DegradedSendAdapter()
+    runner.adapters = {Platform.TELEGRAM: degraded}  # pyright: ignore[reportAttributeAccessIssue]
+
+    async def heal_after_settle():
+        await asyncio.sleep(1.5)  # readiness lands after the 1.0s settle
+        degraded._polling_progress_event.set()
+        degraded._send_path_degraded = False
+
+    healer = asyncio.create_task(heal_after_settle())
+    started = time.monotonic()
+    await runner._wait_for_degraded_send_paths()
+    elapsed = time.monotonic() - started
+    await healer
+
+    # Returns soon after the event fires, not at the 10s deadline.
+    assert elapsed < 5.0
+
+
+@pytest.mark.asyncio
+async def test_degraded_send_path_wait_is_bounded_when_never_ready(monkeypatch):
+    """A stuck adapter must not stall startup notifications indefinitely."""
+    monkeypatch.setattr(gateway_run, "_STARTUP_LIFECYCLE_READY_TIMEOUT", 1.0)
+
+    runner, _adapter = make_restart_runner()
+    degraded = _DegradedSendAdapter()  # never heals
+    runner.adapters = {Platform.TELEGRAM: degraded}  # pyright: ignore[reportAttributeAccessIssue]
+
+    started = time.monotonic()
+    await runner._wait_for_degraded_send_paths()
+    elapsed = time.monotonic() - started
+
+    assert 0.9 <= elapsed < 5.0
+
+
+@pytest.mark.asyncio
+async def test_degraded_send_path_wait_follows_recreated_progress_event(monkeypatch):
+    """The waiter must not sleep on a stale event from a prior polling generation."""
+    monkeypatch.setattr(gateway_run, "_STARTUP_LIFECYCLE_READY_TIMEOUT", 10.0)
+
+    runner, _adapter = make_restart_runner()
+    degraded = _DegradedSendAdapter()
+    runner.adapters = {Platform.TELEGRAM: degraded}  # pyright: ignore[reportAttributeAccessIssue]
+
+    async def regenerate_then_heal():
+        await asyncio.sleep(0.5)
+        # Telegram recreates the event on every new polling generation.
+        degraded._polling_progress_event = asyncio.Event()
+        await asyncio.sleep(0.5)
+        degraded._polling_progress_event.set()
+        degraded._send_path_degraded = False
+
+    healer = asyncio.create_task(regenerate_then_heal())
+    started = time.monotonic()
+    await runner._wait_for_degraded_send_paths()
+    elapsed = time.monotonic() - started
+    await healer
+
+    # Picks up the new event within a slice instead of hanging on the old
+    # one until the deadline.
+    assert elapsed < 5.0
+
+
+@pytest.mark.asyncio
+async def test_degraded_send_path_wait_skips_adapters_without_gate():
+    """Adapters exposing no degraded flag are ignored (no wait, no error)."""
+    runner, adapter = make_restart_runner()
+    assert not hasattr(adapter, "_send_path_degraded")
+
+    started = time.monotonic()
+    await runner._wait_for_degraded_send_paths(timeout=5.0)
+    assert time.monotonic() - started < 1.0

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -508,3 +508,185 @@ async def test_degraded_send_path_wait_skips_adapters_without_gate():
     started = time.monotonic()
     await runner._wait_for_degraded_send_paths(timeout=5.0)
     assert time.monotonic() - started < 1.0
+
+
+# ── marker retention + deferred retry for refused lifecycle sends (#66589) ──
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_retains_marker_on_degraded_rejection(
+    tmp_path, monkeypatch
+):
+    """A send_path_degraded refusal must not delete the only durable record."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="send_path_degraded", retryable=True),
+    )
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    assert notify_path.exists(), "marker must survive a refused (not failed) send"
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_clears_marker_when_retain_disabled(
+    tmp_path, monkeypatch
+):
+    """The deferred retry's last-chance send must not keep the marker forever."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="send_path_degraded", retryable=True),
+    )
+
+    delivered_target = await runner._send_restart_notification(retain_marker_on_degraded=False)
+
+    assert delivered_target is None
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_still_clears_marker_on_real_failure(
+    tmp_path, monkeypatch
+):
+    """Non-degraded failures (e.g. 'Chat not found') keep the old cleanup behavior."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="Chat not found"),
+    )
+
+    await runner._send_restart_notification()
+
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_home_channel_notification_counts_degraded_rejection(tmp_path, monkeypatch):
+    """start() uses _last_home_notify_degraded to retain .restart_pending.json."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="send_path_degraded", retryable=True),
+    )
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == set()
+    assert runner._last_home_notify_degraded == 1
+
+
+@pytest.mark.asyncio
+async def test_deferred_retry_delivers_retained_restart_notification(
+    tmp_path, monkeypatch
+):
+    """Marker retained at startup is delivered once the adapter recovers."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+
+    await runner._retry_deferred_lifecycle_notifications()
+
+    assert not notify_path.exists()
+    adapter.send.assert_awaited_once()
+    call = adapter.send.await_args
+    assert call is not None
+    assert call.args[0] == "42"
+
+
+@pytest.mark.asyncio
+async def test_deferred_retry_clears_marker_when_adapter_never_recovers(
+    tmp_path, monkeypatch
+):
+    """A second refusal clears the marker: bounded loss beats a permanent stale marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="send_path_degraded", retryable=True),
+    )
+
+    await runner._retry_deferred_lifecycle_notifications()
+
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_deferred_retry_delivers_retained_planned_notification(
+    tmp_path, monkeypatch
+):
+    """The home-channel path is retried too, then the planned marker is cleared."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    (tmp_path / ".restart_pending.json").write_text("{}")
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+
+    await runner._retry_deferred_lifecycle_notifications()
+
+    assert not (tmp_path / ".restart_pending.json").exists()
+    adapter.send.assert_awaited_once()
+    call = adapter.send.await_args
+    assert call is not None
+    assert call.args[0] == "home-42"
+
+
+@pytest.mark.asyncio
+async def test_schedule_deferred_retry_noop_without_markers(tmp_path, monkeypatch):
+    """Normal startup (no retained markers) must not spawn a retry task."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, _adapter = make_restart_runner()
+    runner._deferred_lifecycle_retry_task = None
+
+    runner._schedule_deferred_lifecycle_retry()
+
+    assert runner._deferred_lifecycle_retry_task is None


### PR DESCRIPTION
## What

Fixes a race condition where Telegram startup notifications fail with `send_path_degraded` after planned gateway restarts.

## Root Cause

The Telegram adapter's `_send_path_degraded` flag is set during polling initialization and only cleared after the first successful `getUpdates`. On networks requiring fallback IPs (DoH discovery + retry), this can take >1 second. The gateway only waited `1.0s` before sending startup notifications, so the send was rejected.

## Fix

After the initial 1.0s settle wait, poll all adapters for the `_send_path_degraded` flag and wait until it clears (max 10s) before sending startup notifications.

## Testing

- 26/27 restart notification tests pass
- The 1 failing test (`test_restart_command_uses_detached_without_systemd`) is environment-related (systemd detection in containers) and fails both before and after this change

## Related Issues

- Fixes #66589
- Related: #65057 (same root cause, shutdown phase)
