### PR TITLE
fix(web/tavily): authenticate via Authorization header, config-driven

### DIFF
--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -19,6 +19,7 @@ Env vars::
 
     TAVILY_API_KEY=...           # https://app.tavily.com/home (required)
     TAVILY_BASE_URL=...          # optional override of https://api.tavily.com
+    TAVILY_AUTH_STYLE=...        # "header" (default) or "body" (legacy)
 """
 
 from __future__ import annotations
@@ -38,6 +39,12 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     Mirrors :func:`tools.web_tools._tavily_request`. Raises ``ValueError``
     when ``TAVILY_API_KEY`` is unset; the caller catches and surfaces as
     a typed error response.
+
+    Authentication follows Tavily's documented method: the key is sent as an
+    ``Authorization: Bearer <key>`` header. Set ``TAVILY_AUTH_STYLE=body`` to
+    fall back to the legacy in-body ``api_key`` field. Header auth is the
+    default because it lets the key be supplied by an upstream credential
+    proxy, which can rewrite request headers but not JSON request bodies.
     """
     import httpx
 
@@ -51,12 +58,17 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         )
 
     base_url = get_provider_env("TAVILY_BASE_URL") or "https://api.tavily.com"
+    auth_style = (get_provider_env("TAVILY_AUTH_STYLE") or "header").strip().lower()
     payload = dict(payload)  # don't mutate caller's dict
-    payload["api_key"] = api_key
+    headers: Dict[str, str] = {}
+    if auth_style == "body":
+        payload["api_key"] = api_key
+    else:
+        headers["Authorization"] = f"Bearer {api_key}"
     url = f"{base_url}/{endpoint.lstrip('/')}"
     logger.info("Tavily %s request to %s", endpoint, url)
 
-    response = httpx.post(url, json=payload, timeout=60)
+    response = httpx.post(url, json=payload, headers=headers, timeout=60)
     response.raise_for_status()
     return response.json()
 


### PR DESCRIPTION
## What

The Tavily web provider sends the API key inside the JSON request body (`payload["api_key"]`). This change sends it as an `Authorization: Bearer <key>` header instead, and adds a `TAVILY_AUTH_STYLE` env var (`header` default, `body` for the legacy path) so nothing breaks for anyone relying on the old behavior.

## Why

1. **Matches Tavily's current docs.** Tavily's API reference now documents Bearer header auth as the standard method (`Authorization: Bearer tvly-...`). The in-body `api_key` field is legacy.

2. **Works behind a credential proxy.** Some deployments route agent egress through a credential-injecting proxy that attaches the real key at the network edge so the bot never holds it. A proxy can rewrite request headers but not JSON request bodies, so body-only auth cannot be injected.

3. **Precedence matters, and body currently wins.** I verified empirically against the live Tavily API: when a request carries both a placeholder `api_key` in the body and a valid key in the `Authorization` header, Tavily uses the body value and returns `401 Unauthorized`. Header-only auth returns `200`. So simply adding a header is not enough, the body key has to be dropped, which is what this patch does by default.

## Changes

- `plugins/web/tavily/provider.py`: `_tavily_request` sends the key as a Bearer header by default, or in the body when `TAVILY_AUTH_STYLE=body`. Backward compatible.

## Testing

Header auth verified end to end against `api.tavily.com` (search returns real results). Legacy `body` mode preserves the prior request shape.