### PR TITLE
fix(installer): exit hermes-setup on update failure so marker cannot block boot

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/paths.rs
+++ b/apps/bootstrap-installer/src-tauri/src/paths.rs
@@ -90,6 +90,14 @@ pub fn update_in_progress_marker() -> PathBuf {
     hermes_home().join(".hermes-update-in-progress")
 }
 
+/// Sidecar written when an `--update` run reaches a terminal failure (#66356).
+/// The desktop boot gate treats an in-progress marker as stale when this file
+/// exists with a timestamp at or after the in-progress marker's start time —
+/// so a wedged updater that failed to exit cannot block launches forever.
+pub fn update_failed_marker() -> PathBuf {
+    hermes_home().join(".hermes-update-failed")
+}
+
 /// Copy the currently-running installer binary to `installer_dest()` so it's
 /// available for future `--update` runs and shortcut launches.
 ///

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -41,6 +41,16 @@ use crate::events::{BootstrapEvent, LogStream, StageInfo, StageState};
 /// hermes_cli/main.py (sys.exit(2)). We surface a targeted message for this.
 const UPDATE_EXIT_CONCURRENT: i32 = 2;
 
+/// Process exit code when an `--update` handoff ends in terminal failure.
+/// Non-zero so wrappers can distinguish "failed and exited" from the #66356
+/// wedge where the updater logged Failed but stayed alive forever.
+const UPDATE_EXIT_FAILED: i32 = 1;
+
+/// How long to leave the Failed event on the wire before tearing down the
+/// updater process. Long enough for the progress UI to paint; short enough
+/// that a wedged updater cannot block desktop relaunches (#66356).
+const UPDATE_FAILURE_EXIT_DWELL: Duration = Duration::from_millis(750);
+
 /// How long to wait for the old desktop process to release files under the
 /// install tree before giving up and letting `hermes update`'s own guard decide.
 const DESKTOP_EXIT_WAIT: Duration = Duration::from_secs(20);
@@ -82,20 +92,63 @@ pub async fn start_update(app: AppHandle) -> Result<(), String> {
         return Ok(());
     }
     tokio::spawn(async move {
-        if let Err(err) = run_update(app.clone()).await {
-            // run_update already emits a Failed event on the paths that matter;
-            // this catches anything that escaped. Emit defensively.
-            emit(
-                &app,
-                BootstrapEvent::Failed {
-                    stage: None,
-                    error: format!("{err:#}"),
-                },
-            );
-        }
+        let result = run_update(app.clone()).await;
         UPDATE_RUNNING.store(false, Ordering::SeqCst);
+        if let Err(err) = result {
+            // run_update already emits a Failed event on the paths that matter;
+            // this catches anything that escaped. Emit defensively, then end
+            // the handoff: a Failed-but-alive hermes-setup leaves its
+            // update-in-progress marker "live" (pid still running) and the
+            // desktop boot gate parks forever (#66356).
+            finish_failed_update(&app, &err).await;
+        }
     });
     Ok(())
+}
+
+/// Terminal-failure teardown for `--update` mode (#66356).
+///
+/// Order matters: record the failed sidecar first (so a racing desktop can
+/// see "this update already failed"), clear the in-progress marker (Drop on
+/// `UpdateMarkerGuard` already did this on the `run_update` Err path — clear
+/// again idempotently), brief dwell for the Failed event to reach the UI,
+/// then `app.exit(nonzero)` so the process cannot strand a live pid.
+async fn finish_failed_update(app: &AppHandle, err: &anyhow::Error) {
+    emit(
+        app,
+        BootstrapEvent::Failed {
+            stage: None,
+            error: format!("{err:#}"),
+        },
+    );
+    write_update_failed_marker(&crate::paths::update_failed_marker());
+    clear_marker_file(&crate::paths::update_in_progress_marker());
+    tokio::time::sleep(UPDATE_FAILURE_EXIT_DWELL).await;
+    app.exit(UPDATE_EXIT_FAILED);
+}
+
+/// Best-effort remove of a marker file. `NotFound` is success (already gone).
+fn clear_marker_file(path: &Path) {
+    if let Err(err) = std::fs::remove_file(path) {
+        if err.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(?path, %err, "could not clear update marker");
+        }
+    }
+}
+
+/// Write `{failed_at_unix}\n` so the desktop can treat a still-present
+/// in-progress marker as stale when the updater has already failed.
+fn write_update_failed_marker(path: &Path) {
+    let failed_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Err(err) = std::fs::write(path, format!("{failed_at}\n")) {
+        tracing::warn!(?path, %err, "could not write update-failed marker");
+    }
 }
 
 /// RAII guard that owns the "update in progress" marker (see
@@ -151,6 +204,9 @@ async fn run_update(app: AppHandle) -> Result<()> {
     // it, that backend re-locks the venv shim, our `force_kill_other_hermes`
     // straggler-cleanup kills it, and the relaunch/kill cycle loops. The guard
     // removes the marker on every exit path (incl. early returns / panics).
+    // Clear any prior `.hermes-update-failed` first so a healthy new update is
+    // not treated as already-failed by the desktop boot gate (#66356).
+    clear_marker_file(&crate::paths::update_failed_marker());
     let _update_marker = UpdateMarkerGuard::acquire(crate::paths::update_in_progress_marker());
 
     let update_branch = update_branch_from_args(std::env::args().skip(1))
@@ -1131,6 +1187,50 @@ mod tests {
 
         assert!(!marker.exists());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn clear_marker_file_removes_or_ignores_missing() {
+        let dir = unique_tmp_dir("clear-marker");
+        let marker = dir.join(".hermes-update-in-progress");
+        std::fs::write(&marker, "1\n2\n").unwrap();
+
+        clear_marker_file(&marker);
+        assert!(!marker.exists(), "clear must remove an existing marker");
+
+        // Second clear (already gone) must not panic — finish_failed_update
+        // may race Drop of UpdateMarkerGuard.
+        clear_marker_file(&marker);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_update_failed_marker_records_unix_timestamp() {
+        let dir = unique_tmp_dir("failed-marker");
+        let marker = dir.join(".hermes-update-failed");
+
+        write_update_failed_marker(&marker);
+
+        let body = std::fs::read_to_string(&marker).unwrap();
+        let failed_at: u64 = body.lines().next().unwrap().parse().unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(
+            failed_at <= now && now - failed_at < 5,
+            "failed marker must be a recent unix timestamp, got {failed_at} vs now {now}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn failure_exit_constants_are_nonzero_and_bounded() {
+        // Regression anchors for #66356: terminal failure must exit nonzero,
+        // and the dwell before exit must stay short (seconds, not minutes).
+        assert_eq!(UPDATE_EXIT_FAILED, 1);
+        assert!(UPDATE_FAILURE_EXIT_DWELL <= Duration::from_secs(2));
+        assert!(UPDATE_FAILURE_EXIT_DWELL >= Duration::from_millis(100));
     }
 
     #[test]

--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -20,6 +20,7 @@ import path from 'path'
 import { test } from 'vitest'
 
 import {
+  failedMarkerPath,
   isPidAlive,
   markerPath,
   readLiveUpdateMarker,
@@ -127,4 +128,39 @@ test('writeUpdateMarker + dead pid => self-heals on read', () => {
   const res = readLiveUpdateMarker(home, { kill: DEAD })
   assert.equal(res, null, 'a dead-pid marker from writeUpdateMarker self-heals')
   assert.ok(!fs.existsSync(markerPath(home)), 'marker file is pruned')
+})
+
+test('failed sidecar newer than in-progress => no live update even if pid alive (#66356)', () => {
+  const home = tmpHome('failed-newer')
+  const now = 1_000_000_000_000
+  const startedAt = Math.floor(now / 1000) - 30
+  writeMarker(home, 4242, startedAt)
+  // Updater reached terminal Failed after the in-progress marker was written,
+  // but the process is still alive — pid liveness alone must not block boot.
+  fs.writeFileSync(failedMarkerPath(home), `${startedAt + 10}\n`)
+  assert.equal(readLiveUpdateMarker(home, { kill: ALIVE, now: () => now }), null)
+  assert.ok(!fs.existsSync(markerPath(home)), 'in-progress marker pruned')
+  assert.ok(!fs.existsSync(failedMarkerPath(home)), 'failed sidecar pruned')
+})
+
+test('failed sidecar older than in-progress => still a live update', () => {
+  const home = tmpHome('failed-older')
+  const now = 1_000_000_000_000
+  const startedAt = Math.floor(now / 1000) - 5
+  writeMarker(home, 4242, startedAt)
+  // Stale failed marker from a *previous* run must not poison a new update.
+  fs.writeFileSync(failedMarkerPath(home), `${startedAt - 60}\n`)
+  const res = readLiveUpdateMarker(home, { kill: ALIVE, now: () => now })
+  assert.ok(res, 'a new in-progress marker outranks an older failed sidecar')
+  assert.equal(res.pid, 4242)
+  assert.ok(fs.existsSync(markerPath(home)), 'live marker is kept')
+})
+
+test('failed sidecar without parseable in-progress start => does not false-positive', () => {
+  const home = tmpHome('failed-malformed-start')
+  fs.writeFileSync(markerPath(home), '4242\n') // missing started_at
+  fs.writeFileSync(failedMarkerPath(home), `${Math.floor(Date.now() / 1000)}\n`)
+  // Malformed start => ageMs is Infinity => already pruned via age ceiling,
+  // not via the failed-sidecar branch alone. Either way: no live update.
+  assert.equal(readLiveUpdateMarker(home, { kill: ALIVE }), null)
 })

--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -156,6 +156,20 @@ test('failed sidecar older than in-progress => still a live update', () => {
   assert.ok(fs.existsSync(markerPath(home)), 'live marker is kept')
 })
 
+test('writeUpdateMarker clears leftover failed sidecar so same-second cannot poison (#66356)', () => {
+  const home = tmpHome('write-clears-failed')
+  const now = 1_000_000_000_000
+  const sameSecond = Math.floor(now / 1000)
+  // Prior run left a failed sidecar at the exact second a fresh handoff
+  // would stamp — without clearing, failedAt >= startedAt would prune it.
+  fs.writeFileSync(failedMarkerPath(home), `${sameSecond}\n`)
+  writeUpdateMarker(home, 4242, { now: () => now })
+  assert.ok(!fs.existsSync(failedMarkerPath(home)), 'failed sidecar removed on write')
+  const res = readLiveUpdateMarker(home, { kill: ALIVE, now: () => now })
+  assert.ok(res, 'fresh in-progress marker must stay live after writeUpdateMarker')
+  assert.equal(res.pid, 4242)
+})
+
 test('failed sidecar without parseable in-progress start => does not false-positive', () => {
   const home = tmpHome('failed-malformed-start')
   fs.writeFileSync(markerPath(home), '4242\n') // missing started_at

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -14,6 +14,12 @@
  * into the same trap — an infinite respawn/kill loop. The desktop gates local
  * backend startup on this marker and parks until the update finishes.
  *
+ * On terminal update failure the updater also writes
+ * HERMES_HOME/.hermes-update-failed (`{failed_at_unix}`) and exits (#66356).
+ * If a wedged updater somehow leaves the in-progress marker with a still-live
+ * pid after failing, this module treats a failed sidecar at or after the
+ * in-progress start time as "no live update" and prunes the stranded marker.
+ *
  * This module holds the PURE, side-effect-light logic (path, pid liveness,
  * parse + staleness) so it is unit-testable without booting Electron. The
  * polling/boot-progress wrapper lives in main.ts where the boot-progress and
@@ -31,6 +37,10 @@ export const UPDATE_MARKER_MAX_AGE_MS = 20 * 60 * 1000
 
 export function markerPath(hermesHome) {
   return path.join(hermesHome, '.hermes-update-in-progress')
+}
+
+export function failedMarkerPath(hermesHome) {
+  return path.join(hermesHome, '.hermes-update-failed')
 }
 
 // True only if a host process with this pid is currently alive. Signal 0 does
@@ -51,13 +61,35 @@ export function isPidAlive(pid, kill: typeof process.kill = process.kill.bind(pr
   }
 }
 
+function readFailedAtUnix(hermesHome) {
+  try {
+    const raw = fs.readFileSync(failedMarkerPath(hermesHome), 'utf8')
+    const failedAt = Number.parseInt(String(raw).split('\n')[0].trim(), 10)
+
+    return Number.isFinite(failedAt) ? failedAt : null
+  } catch {
+    return null
+  }
+}
+
+function pruneMarkerFiles(hermesHome) {
+  for (const file of [markerPath(hermesHome), failedMarkerPath(hermesHome)]) {
+    try {
+      fs.unlinkSync(file)
+    } catch {
+      void 0
+    }
+  }
+}
+
 /**
  * Read + interpret the marker.
  *
  * Returns `{ pid, ageMs }` only when an update is GENUINELY still running
- * (parseable pid that is alive, within the age ceiling). Returns `null` for
- * every "no live update" case — absent, unreadable, malformed, dead pid, or
- * past the ceiling — and, when a stale marker file exists, deletes it so it
+ * (parseable pid that is alive, within the age ceiling, and not superseded by
+ * a `.hermes-update-failed` sidecar). Returns `null` for every "no live
+ * update" case — absent, unreadable, malformed, dead pid, past the ceiling,
+ * or already-failed — and, when a stale marker file exists, deletes it so it
  * cannot strand future launches.
  *
  * Pure-ish: file I/O against the given path, plus an injectable pid probe and
@@ -89,13 +121,14 @@ export function readLiveUpdateMarker(
   const startedAt = Number.parseInt((startedLine || '').trim(), 10)
   const ageMs = Number.isFinite(startedAt) ? now() - startedAt * 1000 : Infinity
   const alive = Number.isInteger(pid) && isPidAlive(pid, kill)
+  const failedAt = readFailedAtUnix(hermesHome)
+  // #66356: updater logged terminal failure but may still be alive with the
+  // in-progress marker intact. A failed sidecar at/after startedAt wins.
+  const alreadyFailed =
+    failedAt != null && Number.isFinite(startedAt) && failedAt >= startedAt
 
-  if (!alive || ageMs > maxAgeMs) {
-    try {
-      fs.unlinkSync(file)
-    } catch {
-      void 0
-    }
+  if (!alive || ageMs > maxAgeMs || alreadyFailed) {
+    pruneMarkerFiles(hermesHome)
 
     return null
   }

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -157,12 +157,24 @@ export function readLiveUpdateMarker(
  * pid owns it. When the updater finishes it deletes the marker as before.
  * If the updater never starts (spawn failure) the marker still contains a
  * real PID, so `readLiveUpdateMarker` will self-heal once that PID exits.
+ *
+ * Also clears any leftover `.hermes-update-failed` sidecar (mirrors
+ * `run_update` on the installer side). A same-second leftover failed
+ * timestamp would otherwise satisfy `failedAt >= startedAt` and prune the
+ * brand-new in-progress marker (#66356 repair).
  */
 export function writeUpdateMarker(hermesHome, pid, { now = Date.now } = {}) {
   const file = markerPath(hermesHome)
   const startedAt = Math.floor(now() / 1000)
 
   try {
+    // Drop a prior-run failed sidecar before publishing the live marker so
+    // `failedAt >= startedAt` cannot poison a fresh handoff.
+    try {
+      fs.unlinkSync(failedMarkerPath(hermesHome))
+    } catch {
+      void 0
+    }
     fs.writeFileSync(file, `${pid}\n${startedAt}\n`, 'utf8')
   } catch {
     // Best-effort: if we can't write the marker, proceed anyway. The


### PR DESCRIPTION
## Summary

Closes #66356

Credit: Stan Shih (@stantheman0128). Developed with AI assistance (Cursor / Grok).

When a Desktop self-update failed, `hermes-setup` could stay alive after emitting `Failed` without calling `app.exit()`. The in-progress update marker then kept Desktop stuck on "An update is finishing…".

### Changes
- On terminal update failure: emit Failed, write `.hermes-update-failed`, clear the in-progress marker, dwell briefly, then `app.exit(1)`
- Desktop boot gate: a failed sidecar at/after the in-progress start time means the update is not live (prune and continue boot)
- `writeUpdateMarker` clears any leftover failed sidecar so a fresh handoff cannot be poisoned by a same-second leftover file

## Verification

`
cargo test --lib update::
# 17 passed

npx vitest run --project electron electron/update-marker.test.ts
# 14 passed
`

`
python scripts/check-windows-footguns.py --diff origin/main
# clean
`

Made with [Cursor](https://cursor.com)