### PR TITLE
fix(terminal): hide console windows on Windows backend probes (#62734)

### DIFF
--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -185,3 +185,89 @@ def test_modal_backend_managed_mode_without_feature_flag_logs_clear_error(monkey
         "Nous Tool Gateway access is not currently available" in record.getMessage()
         for record in caplog.records
     )
+
+
+# ── Windows console-window suppression on backend probes (#62734) ──────────
+
+
+class _RecordingRun:
+    """Stand-in for subprocess.run that records kwargs and reports success."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+
+def test_docker_probe_hides_console_window_on_windows(monkeypatch):
+    """The docker version probe must pass CREATE_NO_WINDOW flags on Windows."""
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    import tools.environments.docker as _docker_env
+    monkeypatch.setattr(_docker_env, "find_docker", lambda: "docker")
+    monkeypatch.setattr(terminal_tool_module, "IS_WINDOWS", True)
+    recorder = _RecordingRun()
+    monkeypatch.setattr(terminal_tool_module.subprocess, "run", recorder)
+
+    ok = terminal_tool_module.check_terminal_requirements()
+
+    assert ok is True
+    assert recorder.calls, "docker probe never ran"
+    _, kwargs = recorder.calls[-1]
+    assert "creationflags" in kwargs, "docker probe must hide its console window on Windows"
+
+
+def test_singularity_probe_hides_console_window_on_windows(monkeypatch):
+    """The apptainer/singularity version probe must pass CREATE_NO_WINDOW on Windows."""
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "singularity")
+    monkeypatch.setattr(terminal_tool_module.shutil, "which", lambda name: "apptainer")
+    monkeypatch.setattr(terminal_tool_module, "IS_WINDOWS", True)
+    recorder = _RecordingRun()
+    monkeypatch.setattr(terminal_tool_module.subprocess, "run", recorder)
+
+    ok = terminal_tool_module.check_terminal_requirements()
+
+    assert ok is True
+    assert recorder.calls, "singularity probe never ran"
+    _, kwargs = recorder.calls[-1]
+    assert "creationflags" in kwargs, "singularity probe must hide its console window on Windows"
+
+
+def test_backend_probes_pass_no_creationflags_on_posix(monkeypatch):
+    """On POSIX the probes must not grow a creationflags kwarg (no-damage guarantee)."""
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    import tools.environments.docker as _docker_env
+    monkeypatch.setattr(_docker_env, "find_docker", lambda: "docker")
+    monkeypatch.setattr(terminal_tool_module, "IS_WINDOWS", False)
+    recorder = _RecordingRun()
+    monkeypatch.setattr(terminal_tool_module.subprocess, "run", recorder)
+
+    ok = terminal_tool_module.check_terminal_requirements()
+
+    assert ok is True
+    _, kwargs = recorder.calls[-1]
+    assert "creationflags" not in kwargs
+
+
+def test_sudo_probe_hides_console_window_on_windows(monkeypatch):
+    """Same class, same file: the sudo -n probe (Win11 ships sudo.exe)."""
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(terminal_tool_module, "IS_WINDOWS", True)
+    recorder = _RecordingRun()
+    monkeypatch.setattr(terminal_tool_module.subprocess, "run", recorder)
+
+    result = terminal_tool_module._sudo_nopasswd_works()
+
+    assert result is True
+    assert recorder.calls, "sudo probe never ran"
+    _, kwargs = recorder.calls[-1]
+    assert "creationflags" in kwargs, "sudo probe must hide its console window on Windows"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -45,6 +45,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
+from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
 from utils import env_var_enabled
 
 logger = logging.getLogger(__name__)
@@ -697,6 +698,7 @@ def _sudo_nopasswd_works() -> bool:
             stderr=subprocess.DEVNULL,
             timeout=3,
             check=False,
+            **({"creationflags": windows_hide_flags()} if IS_WINDOWS else {}),
         )
         return probe.returncode == 0
     except Exception:
@@ -2923,13 +2925,19 @@ def check_terminal_requirements() -> bool:
             if not docker:
                 logger.error("Docker executable not found in PATH or common install locations")
                 return False
-            result = subprocess.run([docker, "version"], capture_output=True, timeout=5, stdin=subprocess.DEVNULL)
+            result = subprocess.run(
+                [docker, "version"], capture_output=True, timeout=5, stdin=subprocess.DEVNULL,
+                **({"creationflags": windows_hide_flags()} if IS_WINDOWS else {}),
+            )
             return result.returncode == 0
 
         elif env_type == "singularity":
             executable = shutil.which("apptainer") or shutil.which("singularity")
             if executable:
-                result = subprocess.run([executable, "--version"], capture_output=True, timeout=5, stdin=subprocess.DEVNULL)
+                result = subprocess.run(
+                    [executable, "--version"], capture_output=True, timeout=5, stdin=subprocess.DEVNULL,
+                    **({"creationflags": windows_hide_flags()} if IS_WINDOWS else {}),
+                )
                 return result.returncode == 0
             return False
 


### PR DESCRIPTION
Closes #62734 (claimed there earlier today).

## Problem

Three `subprocess.run` probe sites in `tools/terminal_tool.py` launch without `CREATE_NO_WINDOW`, so each flashes a visible console window on native Windows:

- `check_terminal_requirements()` — the **docker** `version` probe and the **apptainer/singularity** `--version` probe (the two named in the issue)
- `_sudo_nopasswd_works()` — the `sudo -n true` probe: same class, same file, and Windows 11 ships `sudo.exe` now. Included; say the word and I'll split it out.

## Fix

The house pattern, verbatim: `hermes_cli._subprocess_compat.windows_hide_flags()` — already used at 8 call sites in `agent/`, `cron/`, `gateway/`, and whose docstring names *version probes* as the intended use. `creationflags` passed only when `IS_WINDOWS`; POSIX behavior byte-identical.

## Verification (native Windows 11, CPython 3.13)

Four regression tests appended to `tests/tools/test_terminal_requirements.py` (existing conventions: module handle + monkeypatch, recorder stand-in for `subprocess.run`):

- docker probe asserts `creationflags` on Windows
- singularity probe asserts `creationflags` on Windows
- POSIX asserts **no** `creationflags` (the compat module's no-damage guarantee)
- sudo probe asserts `creationflags` on Windows

A/B: all four **fail without the fix** (stash check), full file **13 passed** with it. `ruff` clean.

Note: running this file through `scripts/run_tests.sh` on native Windows requires the hermetic-env fix in #66496 (`USERPROFILE` passthrough — the file is uncollectable under the wrapper without it; receipt over there). Direct pytest + the wrapper-with-#66496 both green.