### PR TITLE
feat(slack): add native clarify choice buttons

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -85,6 +85,21 @@ class _ThreadContextCache:
     parent_text: str = ""  # Raw text of the thread parent (for reply_to_text injection)
 
 
+@dataclass
+class _SlackClarifyPrompt:
+    """Server-side binding for one interactive Slack clarify prompt."""
+
+    clarify_id: str
+    choices: Tuple[str, ...]
+    session_key: str
+    team_id: str
+    channel_id: str
+    thread_ts: str
+    message_ts: str
+    created_at: float = field(default_factory=time.monotonic)
+    awaiting_text: bool = False
+
+
 def check_slack_requirements() -> bool:
     """Check if Slack dependencies are available.
 
@@ -456,6 +471,10 @@ class SlackAdapter(BasePlatformAdapter):
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}
+        # Active Slack clarify prompts are bound server-side to their exact
+        # workspace/channel/thread/message. Button values carry only an ID +
+        # canonical choice index and cannot substitute arbitrary responses.
+        self._clarify_prompts: Dict[str, _SlackClarifyPrompt] = {}
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
@@ -1215,6 +1234,10 @@ class SlackAdapter(BasePlatformAdapter):
                 "hermes_confirm_cancel",
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
+
+            self._app.action("hermes_clarify_choice")(
+                self._handle_clarify_action
+            )
 
             self._app.action("hermes_feedback")(self._handle_feedback_action)
 
@@ -3782,6 +3805,308 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         await self.handle_message(msg_event)
+
+    # ----- Clarify choice buttons (Block Kit) -----
+
+    def _prune_clarify_prompts(self) -> None:
+        """Expire abandoned prompt bindings and cap adapter memory."""
+        try:
+            from tools.clarify_gateway import get_clarify_timeout
+
+            ttl = max(float(get_clarify_timeout()) + 60.0, 60.0)
+        except Exception:
+            ttl = 3660.0
+        cutoff = time.monotonic() - ttl
+        for clarify_id, prompt in list(self._clarify_prompts.items()):
+            if prompt.created_at < cutoff:
+                self._clarify_prompts.pop(clarify_id, None)
+        if len(self._clarify_prompts) > 1024:
+            oldest = sorted(
+                self._clarify_prompts.values(), key=lambda prompt: prompt.created_at
+            )[: len(self._clarify_prompts) - 1024]
+            for prompt in oldest:
+                self._clarify_prompts.pop(prompt.clarify_id, None)
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a bound multiple-choice clarify prompt as Slack buttons."""
+        if not choices or len(choices) > 4:
+            return await super().send_clarify(
+                chat_id=chat_id,
+                question=question,
+                choices=choices,
+                clarify_id=clarify_id,
+                session_key=session_key,
+                metadata=metadata,
+            )
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+
+        team_id = (
+            self._metadata_team_id(metadata)
+            or self._channel_team.get(chat_id, "")
+        )
+        if not team_id:
+            logger.warning(
+                "[Slack] Cannot send clarify prompt: workspace is unresolved for %s",
+                chat_id,
+            )
+            return SendResult(
+                success=False,
+                error="Slack workspace could not be resolved for clarify prompt",
+            )
+        client = self._team_clients.get(team_id)
+        if client is None:
+            logger.warning(
+                "[Slack] Cannot send clarify prompt: workspace %s is not connected",
+                team_id,
+            )
+            return SendResult(
+                success=False,
+                error=f"Slack workspace {team_id} is not connected",
+            )
+
+        # Slack caps button values at 2,000 characters. Clarify IDs are
+        # normally short random tokens, but fail over safely if a caller
+        # supplies an oversized value rather than posting invalid blocks.
+        value_probe = json.dumps(
+            {"id": str(clarify_id), "other": True},
+            separators=(",", ":"),
+        )
+        if len(value_probe) > 2000 or len(value_probe.encode("utf-8")) > 2000:
+            return await super().send_clarify(
+                chat_id=chat_id,
+                question=question,
+                choices=choices,
+                clarify_id=clarify_id,
+                session_key=session_key,
+                metadata=metadata,
+            )
+
+        self._prune_clarify_prompts()
+        canonical_choices = tuple(str(choice) for choice in choices)
+        elements = []
+        for index, choice in enumerate(canonical_choices):
+            value = json.dumps(
+                {"id": str(clarify_id), "index": index},
+                separators=(",", ":"),
+            )
+            label = choice.strip() or f"Option {index + 1}"
+            elements.append({
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": label[:75],
+                    "emoji": True,
+                },
+                "action_id": "hermes_clarify_choice",
+                "value": value,
+            })
+        elements.append({
+            "type": "button",
+            "text": {
+                "type": "plain_text",
+                "text": "Other (type answer)",
+                "emoji": True,
+            },
+            "action_id": "hermes_clarify_choice",
+            "value": json.dumps(
+                {"id": str(clarify_id), "other": True},
+                separators=(",", ":"),
+            ),
+        })
+
+        question_text = str(question or "").strip()
+        option_lines = "\n".join(
+            f"{index + 1}. {choice}"
+            for index, choice in enumerate(canonical_choices)
+        )
+        section_text = f"❓ {question_text}\n\n{option_lines}"
+        if len(section_text) > 3000:
+            section_text = section_text[:2997] + "..."
+        blocks = [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": section_text},
+            },
+            {
+                "type": "actions",
+                "block_id": f"hermes_clarify_{str(clarify_id)[:200]}",
+                "elements": elements,
+            },
+        ]
+        thread_ts = self._resolve_thread_ts(None, metadata)
+        kwargs: Dict[str, Any] = {
+            "channel": chat_id,
+            "text": question_text or "Choose an option",
+            "blocks": blocks,
+        }
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+
+        try:
+            result = await client.chat_postMessage(**kwargs)
+            message_ts = str(result.get("ts") or "")
+            if not message_ts:
+                return SendResult(
+                    success=False, error="Slack did not return a message timestamp"
+                )
+            self._clarify_prompts[str(clarify_id)] = _SlackClarifyPrompt(
+                clarify_id=str(clarify_id),
+                choices=canonical_choices,
+                session_key=str(session_key),
+                team_id=str(team_id),
+                channel_id=str(chat_id),
+                thread_ts=str(thread_ts or ""),
+                message_ts=message_ts,
+            )
+            return SendResult(
+                success=True, message_id=message_ts, raw_response=result
+            )
+        except Exception as e:
+            logger.error("[Slack] send_clarify failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
+    async def _handle_clarify_action(self, ack, body, action) -> None:
+        """Resolve an authorized, origin-bound Slack clarify choice once."""
+        await ack()
+
+        team_id = self._event_team_id({}, body)
+        message = body.get("message") or {}
+        message_ts = str(message.get("ts") or "")
+        thread_ts = str(message.get("thread_ts") or "")
+        channel_id = str((body.get("channel") or {}).get("id") or "")
+        user = body.get("user") or {}
+        user_id = str(user.get("id") or "")
+        user_name = str(user.get("name") or user_id or "unknown")
+        if not team_id or not message_ts or not channel_id or not user_id:
+            logger.warning("[Slack] Clarify callback missing required routing fields")
+            return
+        client = self._team_clients.get(team_id)
+        if client is None:
+            logger.warning(
+                "[Slack] Ignoring clarify callback for disconnected workspace %s",
+                team_id,
+            )
+            return
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+            team_id=team_id,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized clarify click by %s (%s) - ignoring",
+                user_name,
+                user_id,
+            )
+            return
+
+        try:
+            payload = json.loads(str(action.get("value") or ""))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            logger.warning("[Slack] Malformed clarify button value")
+            return
+        if not isinstance(payload, dict):
+            return
+        clarify_id = payload.get("id")
+        if not isinstance(clarify_id, str) or not clarify_id:
+            return
+
+        self._prune_clarify_prompts()
+        prompt = self._clarify_prompts.get(clarify_id)
+        if prompt is None or prompt.awaiting_text:
+            return
+        if (
+            prompt.team_id != team_id
+            or prompt.channel_id != channel_id
+            or prompt.message_ts != message_ts
+            or prompt.thread_ts != thread_ts
+        ):
+            logger.warning("[Slack] Clarify callback origin binding mismatch")
+            return
+
+        decision_text = "This question was already answered or has expired."
+        if payload.get("other") is True and set(payload) == {"id", "other"}:
+            from tools.clarify_gateway import mark_awaiting_text
+
+            if mark_awaiting_text(clarify_id):
+                prompt.awaiting_text = True
+                decision_text = (
+                    f"✏️ {user_name} chose Other — reply with your answer."
+                )
+            else:
+                self._clarify_prompts.pop(clarify_id, None)
+        elif set(payload) == {"id", "index"}:
+            index = payload.get("index")
+            if isinstance(index, bool) or not isinstance(index, int):
+                return
+            if not 0 <= index < len(prompt.choices):
+                return
+            from tools.clarify_gateway import resolve_gateway_choice
+
+            resolved, canonical_choice = resolve_gateway_choice(clarify_id, index)
+            self._clarify_prompts.pop(clarify_id, None)
+            if resolved and canonical_choice is not None:
+                decision_text = f"✅ {user_name} selected: {canonical_choice}"
+        else:
+            return
+
+        original_text = ""
+        for block in message.get("blocks") or []:
+            if block.get("type") == "section":
+                original_text = str((block.get("text") or {}).get("text") or "")
+                break
+        updated_blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": original_text[:3000] or "Clarification prompt",
+                },
+            },
+            {
+                "type": "context",
+                "elements": [{
+                    "type": "plain_text",
+                    "text": decision_text[:2000],
+                    "emoji": True,
+                }],
+            },
+        ]
+        try:
+            await client.chat_update(
+                channel=channel_id,
+                ts=message_ts,
+                text=decision_text,
+                blocks=updated_blocks,
+            )
+        except Exception as e:
+            logger.warning("[Slack] Failed to update clarify prompt: %s", e)
+            # Resolution/text-capture state is already authoritative. If Slack
+            # refuses the in-place update, post an explicit status message via
+            # the exact bound workspace client so stale-looking buttons cannot
+            # leave the user without instructions.
+            fallback_kwargs: Dict[str, Any] = {
+                "channel": channel_id,
+                "text": decision_text,
+            }
+            if prompt.thread_ts:
+                fallback_kwargs["thread_ts"] = prompt.thread_ts
+            try:
+                await client.chat_postMessage(**fallback_kwargs)
+            except Exception as fallback_error:
+                logger.error(
+                    "[Slack] Failed to post clarify status fallback: %s",
+                    fallback_error,
+                )
 
     # ----- Approval button support (Block Kit) -----
 

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -1,0 +1,468 @@
+"""Slack Block Kit rendering and callbacks for clarify choices."""
+
+import json
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+class _AuthRunner:
+    def __init__(self, allowed=True):
+        self.allowed = allowed
+        self.sources = []
+
+    async def handle(self, event):
+        return None
+
+    def _is_user_authorized(self, source):
+        self.sources.append(source)
+        return self.allowed
+
+
+def _make_adapter(*, allowed=True):
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+    adapter._app = MagicMock()
+    adapter._bot_user_id = "U_BOT"
+    client1 = AsyncMock()
+    client1.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+    client1.chat_update = AsyncMock()
+    client2 = AsyncMock()
+    client2.chat_postMessage = AsyncMock(return_value={"ts": "2222.3333"})
+    client2.chat_update = AsyncMock()
+    adapter._team_clients = {"T1": client1, "T2": client2}
+    adapter._team_bot_user_ids = {"T1": "U_BOT", "T2": "U_BOT_2"}
+    adapter._channel_team = {"C1": "T1"}
+    runner = _AuthRunner(allowed=allowed)
+    adapter.set_message_handler(runner.handle)
+    return adapter, client1, client2, runner
+
+
+async def _prime_prompt(adapter, *, team_id="T1", thread_ts="9999.0000"):
+    return await adapter.send_clarify(
+        chat_id="C1",
+        question="What should we do next?",
+        choices=["Ship now", "Schedule next"],
+        clarify_id="clarify-123",
+        session_key="agent:main:slack:dm:C1",
+        metadata={"thread_id": thread_ts, "slack_team_id": team_id},
+    )
+
+
+def _button_body(
+    *,
+    msg_ts="1234.5678",
+    team_id="T1",
+    channel_id="C1",
+    thread_ts="9999.0000",
+    user_id="U_RYAN",
+    user_name="ryan",
+):
+    return {
+        "team": {"id": team_id},
+        "message": {
+            "ts": msg_ts,
+            "thread_ts": thread_ts,
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "❓ What next?"},
+                },
+                {"type": "actions", "elements": []},
+            ],
+        },
+        "channel": {"id": channel_id},
+        "user": {"id": user_id, "name": user_name},
+    }
+
+
+def _choice_action(index=0, clarify_id="clarify-123"):
+    return {
+        "action_id": "hermes_clarify_choice",
+        "value": json.dumps({"id": clarify_id, "index": index}),
+    }
+
+
+def _other_action(clarify_id="clarify-123"):
+    return {
+        "action_id": "hermes_clarify_choice",
+        "value": json.dumps({"id": clarify_id, "other": True}),
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_clarify_uses_canonical_indices_and_binds_prompt():
+    adapter, client1, _client2, _runner = _make_adapter()
+
+    result = await _prime_prompt(adapter)
+
+    assert result.success is True
+    kwargs = client1.chat_postMessage.await_args.kwargs
+    assert kwargs["thread_ts"] == "9999.0000"
+    assert kwargs["text"] == "What should we do next?"
+    elements = kwargs["blocks"][1]["elements"]
+    assert [element["text"]["text"] for element in elements] == [
+        "Ship now",
+        "Schedule next",
+        "Other (type answer)",
+    ]
+    assert [json.loads(element["value"]) for element in elements] == [
+        {"id": "clarify-123", "index": 0},
+        {"id": "clarify-123", "index": 1},
+        {"id": "clarify-123", "other": True},
+    ]
+    prompt = adapter._clarify_prompts["clarify-123"]
+    assert prompt.choices == ("Ship now", "Schedule next")
+    assert (prompt.team_id, prompt.channel_id, prompt.thread_ts, prompt.message_ts) == (
+        "T1",
+        "C1",
+        "9999.0000",
+        "1234.5678",
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_workspace_fails_closed_without_primary_client_fallback():
+    adapter, client1, client2, _runner = _make_adapter()
+    adapter._channel_team.clear()
+    adapter._app.client = AsyncMock()
+
+    result = await adapter.send_clarify(
+        chat_id="UNMAPPED",
+        question="Pick",
+        choices=["A", "B"],
+        clarify_id="missing-team",
+        session_key="session",
+        metadata=None,
+    )
+
+    assert result.success is False
+    assert "workspace" in result.error.lower()
+    adapter._app.client.chat_postMessage.assert_not_awaited()
+    client1.chat_postMessage.assert_not_awaited()
+    client2.chat_postMessage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_workspace_fails_closed_without_client_fallback():
+    adapter, client1, client2, _runner = _make_adapter()
+
+    result = await _prime_prompt(adapter, team_id="UNKNOWN")
+
+    assert result.success is False
+    assert "workspace" in result.error.lower()
+    client1.chat_postMessage.assert_not_awaited()
+    client2.chat_postMessage.assert_not_awaited()
+    assert adapter._clarify_prompts == {}
+
+
+@pytest.mark.asyncio
+async def test_send_clarify_selects_metadata_workspace_client():
+    adapter, client1, client2, _runner = _make_adapter()
+
+    result = await _prime_prompt(adapter, team_id="T2")
+
+    assert result.message_id == "2222.3333"
+    client1.chat_postMessage.assert_not_awaited()
+    client2.chat_postMessage.assert_awaited_once()
+    assert adapter._clarify_prompts["clarify-123"].team_id == "T2"
+
+
+@pytest.mark.asyncio
+async def test_rendering_respects_section_label_and_value_limits():
+    adapter, client1, _client2, _runner = _make_adapter()
+    choice = "🚀" * 100
+
+    await adapter.send_clarify(
+        chat_id="C1",
+        question="Q" * 4000,
+        choices=[choice],
+        clarify_id="limits",
+        session_key="session",
+        metadata={"slack_team_id": "T1"},
+    )
+
+    blocks = client1.chat_postMessage.await_args.kwargs["blocks"]
+    assert len(blocks[0]["text"]["text"]) <= 3000
+    button = blocks[1]["elements"][0]
+    assert len(button["text"]["text"]) <= 75
+    assert len(button["value"]) <= 2000
+    assert json.loads(button["value"]) == {"id": "limits", "index": 0}
+
+
+@pytest.mark.asyncio
+async def test_oversized_button_value_falls_back_to_text():
+    adapter, client1, _client2, _runner = _make_adapter()
+    adapter.send = AsyncMock(return_value=MagicMock(success=True))
+
+    await adapter.send_clarify(
+        chat_id="C1",
+        question="Pick",
+        choices=["A"],
+        clarify_id="x" * 2100,
+        session_key="session",
+        metadata={"slack_team_id": "T1"},
+    )
+
+    client1.chat_postMessage.assert_not_awaited()
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_more_than_four_choices_falls_back_to_text():
+    adapter, client1, _client2, _runner = _make_adapter()
+    adapter.send = AsyncMock(return_value=MagicMock(success=True))
+
+    await adapter.send_clarify(
+        chat_id="C1",
+        question="Pick",
+        choices=["1", "2", "3", "4", "5"],
+        clarify_id="too-many",
+        session_key="session",
+        metadata={"slack_team_id": "T1"},
+    )
+
+    client1.chat_postMessage.assert_not_awaited()
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_open_ended_clarify_uses_text_fallback():
+    adapter, client1, _client2, _runner = _make_adapter()
+    adapter.send = AsyncMock(return_value=MagicMock(success=True))
+
+    result = await adapter.send_clarify(
+        chat_id="C1",
+        question="Tell me more",
+        choices=None,
+        clarify_id="open",
+        session_key="session",
+        metadata={"thread_id": "9999.0000", "slack_team_id": "T1"},
+    )
+
+    assert result.success is True
+    client1.chat_postMessage.assert_not_awaited()
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_authorized_choice_resolves_canonical_value_and_updates_correct_workspace():
+    adapter, client1, _client2, runner = _make_adapter(allowed=True)
+    await _prime_prompt(adapter)
+    ack = AsyncMock()
+
+    with patch(
+        "tools.clarify_gateway.resolve_gateway_choice",
+        return_value=(True, "Ship now"),
+    ) as resolve:
+        await adapter._handle_clarify_action(ack, _button_body(), _choice_action())
+
+    ack.assert_awaited_once()
+    resolve.assert_called_once_with("clarify-123", 0)
+    assert runner.sources[0].scope_id == "T1"
+    update = client1.chat_update.await_args.kwargs
+    assert (update["channel"], update["ts"]) == ("C1", "1234.5678")
+    assert all(block["type"] != "actions" for block in update["blocks"])
+    assert "Ship now" in update["text"] and "ryan" in update["text"]
+    assert "clarify-123" not in adapter._clarify_prompts
+
+
+@pytest.mark.asyncio
+async def test_disconnected_workspace_client_fails_before_resolution():
+    adapter, client1, _client2, _runner = _make_adapter(allowed=True)
+    await _prime_prompt(adapter)
+    adapter._team_clients.pop("T1")
+
+    with patch("tools.clarify_gateway.resolve_gateway_choice") as resolve:
+        await adapter._handle_clarify_action(
+            AsyncMock(), _button_body(), _choice_action()
+        )
+
+    resolve.assert_not_called()
+    client1.chat_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [
+        _button_body(team_id="WRONG"),
+        _button_body(channel_id="WRONG"),
+        _button_body(msg_ts="WRONG"),
+        _button_body(thread_ts="WRONG"),
+    ],
+)
+async def test_mismatched_origin_binding_fails_closed(body):
+    adapter, client1, _client2, _runner = _make_adapter(allowed=True)
+    await _prime_prompt(adapter)
+
+    with patch("tools.clarify_gateway.resolve_gateway_choice") as resolve:
+        await adapter._handle_clarify_action(AsyncMock(), body, _choice_action())
+
+    resolve.assert_not_called()
+    client1.chat_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_choice_fails_closed_with_workspace_scope():
+    adapter, client1, _client2, runner = _make_adapter(allowed=False)
+    await _prime_prompt(adapter)
+
+    with patch("tools.clarify_gateway.resolve_gateway_choice") as resolve:
+        await adapter._handle_clarify_action(
+            AsyncMock(), _button_body(), _choice_action()
+        )
+
+    resolve.assert_not_called()
+    client1.chat_update.assert_not_awaited()
+    assert runner.sources[0].scope_id == "T1"
+
+
+@pytest.mark.asyncio
+async def test_other_switches_to_text_capture_and_keeps_bounded_binding():
+    adapter, client1, _client2, _runner = _make_adapter(allowed=True)
+    await _prime_prompt(adapter)
+
+    with patch("tools.clarify_gateway.mark_awaiting_text", return_value=True) as mark:
+        await adapter._handle_clarify_action(
+            AsyncMock(), _button_body(), _other_action()
+        )
+
+    mark.assert_called_once_with("clarify-123")
+    assert adapter._clarify_prompts["clarify-123"].awaiting_text is True
+    update = client1.chat_update.await_args.kwargs
+    assert "reply with your answer" in update["text"].lower()
+    assert all(block["type"] != "actions" for block in update["blocks"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_other", [False, True])
+async def test_update_failure_posts_workspace_bound_fallback(use_other):
+    adapter, client1, _client2, _runner = _make_adapter(allowed=True)
+    await _prime_prompt(adapter)
+    client1.chat_update.side_effect = RuntimeError("update failed")
+
+    if use_other:
+        action = _other_action()
+        resolver_patch = patch(
+            "tools.clarify_gateway.mark_awaiting_text", return_value=True
+        )
+    else:
+        action = _choice_action()
+        resolver_patch = patch(
+            "tools.clarify_gateway.resolve_gateway_choice",
+            return_value=(True, "Ship now"),
+        )
+
+    with resolver_patch:
+        await adapter._handle_clarify_action(
+            AsyncMock(), _button_body(), action
+        )
+
+    assert client1.chat_postMessage.await_count == 2
+    fallback = client1.chat_postMessage.await_args.kwargs
+    assert fallback["channel"] == "C1"
+    assert fallback["thread_ts"] == "9999.0000"
+    if use_other:
+        assert "reply with your answer" in fallback["text"].lower()
+    else:
+        assert "ship now" in fallback["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_text_wins_race_then_button_is_shown_as_expired():
+    adapter, client1, _client2, _runner = _make_adapter(allowed=True)
+    await _prime_prompt(adapter)
+
+    with patch(
+        "tools.clarify_gateway.resolve_gateway_choice",
+        return_value=(False, None),
+    ):
+        await adapter._handle_clarify_action(
+            AsyncMock(), _button_body(), _choice_action()
+        )
+
+    assert "already answered" in client1.chat_update.await_args.kwargs["text"].lower()
+    assert "clarify-123" not in adapter._clarify_prompts
+
+
+@pytest.mark.asyncio
+async def test_duplicate_or_replayed_click_cannot_resolve_twice():
+    adapter, _client1, _client2, _runner = _make_adapter(allowed=True)
+    await _prime_prompt(adapter)
+
+    with patch(
+        "tools.clarify_gateway.resolve_gateway_choice",
+        return_value=(True, "Ship now"),
+    ) as resolve:
+        await adapter._handle_clarify_action(
+            AsyncMock(), _button_body(), _choice_action()
+        )
+        await adapter._handle_clarify_action(
+            AsyncMock(), _button_body(), _choice_action()
+        )
+
+    resolve.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body,value",
+    [
+        ({}, json.dumps({"id": "clarify-123", "index": 0})),
+        (_button_body(), "not-json"),
+        (_button_body(), "{}"),
+        (_button_body(), json.dumps({"id": "clarify-123", "index": "0"})),
+        (_button_body(), json.dumps({"id": "substituted", "index": 0})),
+    ],
+)
+async def test_malformed_or_substituted_callback_fails_closed(body, value):
+    adapter, client1, _client2, _runner = _make_adapter(allowed=True)
+    await _prime_prompt(adapter)
+    action = {"action_id": "hermes_clarify_choice", "value": value}
+
+    with patch("tools.clarify_gateway.resolve_gateway_choice") as resolve:
+        await adapter._handle_clarify_action(AsyncMock(), body, action)
+
+    resolve.assert_not_called()
+    client1.chat_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_failure_creates_no_callback_state():
+    adapter, client1, _client2, _runner = _make_adapter()
+    client1.chat_postMessage.side_effect = RuntimeError("send failed")
+
+    result = await _prime_prompt(adapter)
+
+    assert result.success is False
+    assert adapter._clarify_prompts == {}
+
+
+@pytest.mark.asyncio
+async def test_expired_prompt_state_is_pruned():
+    adapter, _client1, _client2, _runner = _make_adapter()
+    await _prime_prompt(adapter)
+    adapter._clarify_prompts["clarify-123"].created_at = time.monotonic() - 999999
+
+    await adapter.send_clarify(
+        chat_id="C1",
+        question="Another",
+        choices=["A"],
+        clarify_id="fresh",
+        session_key="session",
+        metadata={"slack_team_id": "T1"},
+    )
+
+    assert "clarify-123" not in adapter._clarify_prompts
+    assert "fresh" in adapter._clarify_prompts

--- a/tests/gateway/test_slack_plugin_action_handlers.py
+++ b/tests/gateway/test_slack_plugin_action_handlers.py
@@ -71,6 +71,13 @@ from hermes_cli.plugins import (  # noqa: E402
 )
 
 
+def _close_coro_task(coro):
+    """Mock create_task without leaking an unawaited coroutine."""
+    if asyncio.iscoroutine(coro):
+        coro.close()
+    return MagicMock()
+
+
 # ---------------------------------------------------------------------------
 # PluginContext.register_slack_action_handler — input validation + queuing
 # ---------------------------------------------------------------------------
@@ -248,7 +255,7 @@ def _connect_with_recording_app(
          patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
          patch("gateway.status.release_scoped_lock"), \
          patch("hermes_cli.plugins.get_plugin_manager", return_value=fake_mgr), \
-         patch("asyncio.create_task"):
+         patch("asyncio.create_task", side_effect=_close_coro_task):
         result = asyncio.run(adapter.connect())
 
     return result, registered_actions
@@ -414,10 +421,11 @@ class TestSlackAdapterPluginActionWiring:
              patch("gateway.status.release_scoped_lock"), \
              patch("hermes_cli.plugins.get_plugin_manager",
                    side_effect=RuntimeError("plugins broken")), \
-             patch("asyncio.create_task"):
+             patch("asyncio.create_task", side_effect=_close_coro_task):
             result = asyncio.run(adapter.connect())
 
         assert result is True
         # Built-ins still wired even when plugin loader failed.
         action_ids = [aid for aid, _cb in registered_actions]
         assert "hermes_approve_once" in action_ids
+        assert "hermes_clarify_choice" in action_ids

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -124,6 +124,56 @@ class TestClarifyPrimitive:
 
         assert cm.resolve_gateway_clarify("nope", "anything") is False
 
+    def test_second_resolver_cannot_overwrite_first_response(self):
+        """Button/text races are consume-once; the first valid answer wins."""
+        from tools import clarify_gateway as cm
+
+        cm.register("once", "sk-once", "Pick", ["A", "B"])
+        assert cm.resolve_gateway_clarify("once", "A") is True
+        assert cm.resolve_gateway_clarify("once", "B") is False
+        assert cm.wait_for_response("once", timeout=0.1) == "A"
+
+    def test_choice_index_resolves_canonical_server_side_value(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("choice", "sk-choice", "Pick", ["First", "Second"])
+        resolved, value = cm.resolve_gateway_choice("choice", 1)
+        assert (resolved, value) == (True, "Second")
+        assert cm.wait_for_response("choice", timeout=0.1) == "Second"
+
+    def test_choice_index_rejects_out_of_range_and_already_resolved(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("choice-bad", "sk-choice-bad", "Pick", ["First"])
+        assert cm.resolve_gateway_choice("choice-bad", 9) == (False, None)
+        assert cm.resolve_gateway_choice("choice-bad", 0) == (True, "First")
+        assert cm.resolve_gateway_choice("choice-bad", 0) == (False, None)
+
+    def test_mark_awaiting_text_rejects_resolved_entry(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("other-race", "sk-other-race", "Pick", ["A"])
+        assert cm.resolve_gateway_clarify("other-race", "A") is True
+        assert cm.mark_awaiting_text("other-race") is False
+
+    def test_concurrent_resolvers_only_one_wins(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("race", "sk-race", "Pick", ["A", "B"])
+        barrier = threading.Barrier(3)
+
+        def resolve(value):
+            barrier.wait()
+            return cm.resolve_gateway_clarify("race", value)
+
+        with ThreadPoolExecutor(2) as pool:
+            futures = [pool.submit(resolve, "A"), pool.submit(resolve, "B")]
+            barrier.wait()
+            results = [future.result(timeout=2) for future in futures]
+
+        assert sorted(results) == [False, True]
+        assert cm.wait_for_response("race", timeout=0.1) in {"A", "B"}
+
     def test_resolve_after_wait_completes_is_noop(self):
         """A late resolve on a finished entry doesn't blow up."""
         from tools import clarify_gateway as cm

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -148,18 +148,42 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
 # =========================================================================
 
 def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
-    """Unblock the agent thread waiting on ``clarify_id``.
+    """Unblock the agent thread waiting on ``clarify_id`` exactly once.
 
-    Returns True if an entry was found and resolved, False otherwise
-    (already resolved, expired, or never existed).
+    Returns True only for the first resolver. Button callbacks and typed
+    replies can arrive on different threads, so response + event are mutated
+    while holding the same lock used by every resolver.
     """
     with _lock:
         entry = _entries.get(clarify_id)
-        if entry is None:
+        if entry is None or entry.event.is_set():
             return False
-    entry.response = str(response) if response is not None else ""
-    entry.event.set()
-    return True
+        entry.response = str(response) if response is not None else ""
+        entry.event.set()
+        return True
+
+
+def resolve_gateway_choice(
+    clarify_id: str,
+    choice_index: int,
+) -> tuple[bool, Optional[str]]:
+    """Atomically resolve a canonical registered choice by zero-based index.
+
+    Platform callbacks carry only ``clarify_id`` + an index. Looking up the
+    value server-side prevents clients from substituting arbitrary responses.
+    """
+    with _lock:
+        entry = _entries.get(clarify_id)
+        if entry is None or entry.event.is_set() or not entry.choices:
+            return False, None
+        if isinstance(choice_index, bool) or not isinstance(choice_index, int):
+            return False, None
+        if not 0 <= choice_index < len(entry.choices):
+            return False, None
+        choice = str(entry.choices[choice_index])
+        entry.response = choice
+        entry.event.set()
+        return True, choice
 
 
 def get_pending_for_session(
@@ -221,7 +245,7 @@ def mark_awaiting_text(clarify_id: str) -> bool:
     """
     with _lock:
         entry = _entries.get(clarify_id)
-        if entry is None:
+        if entry is None or entry.event.is_set() or entry.awaiting_text:
             return False
         entry.awaiting_text = True
         return True

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -312,6 +312,11 @@ render as interactive buttons. When buttons can't be delivered and
 Hermes falls back to a text prompt, the prompt instructs you to reply
 with `!approve` / `!deny` — the form that works inside threads.
 
+Multiple-choice questions from the `clarify` tool also render as native
+Block Kit buttons, including an **Other (type answer)** option. A selection
+resumes the same agent run in the same thread; open-ended questions and
+choices exceeding Slack's Block Kit limits automatically fall back to text.
+
 ### Advanced: emit only the slash-commands array
 
 If you maintain your Slack manifest by hand and just want the slash


### PR DESCRIPTION
## Summary

- render Hermes `clarify` choices as native Slack Block Kit buttons
- bind callbacks to the exact workspace, channel, thread, message, and canonical server-side choice
- make button/text resolution consume-once and race-safe
- preserve open-ended and oversized text fallback behavior
- remove stale controls after resolution and post a bound fallback if `chat.update` fails
- document Slack choice buttons

## Security

- missing, unknown, and disconnected workspaces fail closed
- clicking user goes through the existing workspace-scoped authorization path
- callback values contain only the clarify ID and canonical choice index
- origin mismatches, malformed callbacks, replays, and duplicate clicks are ignored
- pending callback state is TTL-pruned and bounded

## Test plan

- `python -m pytest -q -W error tests/gateway/test_slack_clarify_buttons.py tests/gateway/test_slack_plugin_action_handlers.py tests/tools/test_clarify_gateway.py -n 0 --tb=short` — 64 passed
- `python -m pytest tests/gateway/test_slack*.py -q --tb=short -n 0` — 464 passed
- `python -m pytest tests/tools/test_clarify_tool.py tests/tools/test_clarify_gateway.py tests/gateway/test_clarify_active_session_bypass.py -q --tb=short -n 0` — 53 passed

Independent security review passed with no remaining concerns.
