### PR TITLE
fix(cron): accept UTF-8 BOM when reading jobs.json

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -865,13 +865,16 @@ def load_jobs() -> List[Dict[str, Any]]:
     _strict_retry = False  # track whether we used the strict=False fallback
 
     try:
-        with open(jobs_file, 'r', encoding='utf-8') as f:
+        # utf-8-sig: Windows Notepad / PowerShell 5.1 Set-Content -Encoding UTF8
+        # write a leading BOM; json.load under plain utf-8 raises
+        # JSONDecodeError("Unexpected UTF-8 BOM") and takes down cron.
+        with open(jobs_file, 'r', encoding='utf-8-sig') as f:
             data = json.load(f)
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         _strict_retry = True
         try:
-            with open(jobs_file, 'r', encoding='utf-8') as f:
+            with open(jobs_file, 'r', encoding='utf-8-sig') as f:
                 data = json.loads(f.read(), strict=False)
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -167,7 +167,9 @@ def _cron_summary(hermes_home: Path) -> str:
     if not jobs_file.exists():
         return "0"
     try:
-        with open(jobs_file, encoding="utf-8") as f:
+        # utf-8-sig: same dialect as cron/jobs.load_jobs — Windows editors
+        # may leave a UTF-8 BOM that plain utf-8 json.load rejects.
+        with open(jobs_file, encoding="utf-8-sig") as f:
             data = json.load(f)
         jobs = data.get("jobs", [])
         active = sum(1 for j in jobs if j.get("enabled", True))

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -529,7 +529,9 @@ def show_status(args):
     if jobs_file.exists():
         import json
         try:
-            with open(jobs_file, encoding="utf-8") as f:
+            # utf-8-sig: same dialect as cron/jobs.load_jobs — Windows editors
+            # may leave a UTF-8 BOM that plain utf-8 json.load rejects.
+            with open(jobs_file, encoding="utf-8-sig") as f:
                 data = json.load(f)
                 jobs = data.get("jobs", [])
                 enabled_jobs = [j for j in jobs if j.get("enabled", True)]

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -2046,3 +2046,120 @@ class TestLateEnvRepointScopesStore:
         assert new_file.is_file()
         # ...and the import-time file is byte-identical to the sentinel.
         assert old_file.read_text(encoding="utf-8") == sentinel
+
+
+# =========================================================================
+# UTF-8 BOM on jobs.json (Windows Notepad / PowerShell 5.1)
+# =========================================================================
+
+class TestJobsJsonUtf8Bom:
+    """jobs.json readers must accept a leading UTF-8 BOM.
+
+    Matching the env-class dialect (utf-8-sig): a BOM from Windows editors
+    must not raise JSONDecodeError / RuntimeError on load_jobs().
+    """
+
+    def test_load_jobs_accepts_utf8_bom(self, tmp_cron_dir):
+        """BOM'd jobs.json loads — the pre-fix crash repro."""
+        import json
+        from pathlib import Path
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        payload = {
+            "jobs": [
+                {
+                    "id": "bomjob01",
+                    "name": "bom-test",
+                    "enabled": True,
+                    "prompt": "hello",
+                    "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+                }
+            ]
+        }
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_bytes(
+            b"\xef\xbb\xbf" + json.dumps(payload).encode("utf-8")
+        )
+
+        loaded = load_jobs()
+        assert [j["id"] for j in loaded] == ["bomjob01"]
+        assert loaded[0]["name"] == "bom-test"
+
+    def test_load_jobs_bomless_regression(self, tmp_cron_dir):
+        """BOM-less UTF-8 jobs.json must keep loading after utf-8-sig."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        payload = {
+            "jobs": [
+                {
+                    "id": "plainjob01",
+                    "name": "plain",
+                    "enabled": True,
+                    "prompt": "hi",
+                    "schedule": {"kind": "interval", "minutes": 30, "display": "every 30m"},
+                }
+            ]
+        }
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(payload), encoding="utf-8")
+
+        loaded = load_jobs()
+        assert [j["id"] for j in loaded] == ["plainjob01"]
+
+    def test_load_jobs_bom_empty_jobs_list(self, tmp_cron_dir):
+        """Minimal BOM'd store ({"jobs": []}) must not raise."""
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_bytes(b'\xef\xbb\xbf{"jobs": []}')
+
+        assert load_jobs() == []
+
+    def test_load_jobs_bom_plus_bare_list_auto_repairs(self, tmp_cron_dir):
+        """BOM + bare list (hand-edited) must load and rewrap to dict envelope."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        bare = [
+            {
+                "id": "barebom01",
+                "name": "bare",
+                "enabled": True,
+                "prompt": "x",
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+            }
+        ]
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_bytes(b"\xef\xbb\xbf" + json.dumps(bare).encode("utf-8"))
+
+        loaded = load_jobs()
+        assert [j["id"] for j in loaded] == ["barebom01"]
+        # Auto-repair rewrites via save_jobs (plain utf-8) — heals the BOM.
+        on_disk = JOBS_FILE.read_bytes()
+        assert not on_disk.startswith(b"\xef\xbb\xbf"), "save_jobs should rewrite without BOM"
+        rewritten = json.loads(on_disk.decode("utf-8"))
+        assert isinstance(rewritten, dict)
+        assert [j["id"] for j in rewritten["jobs"]] == ["barebom01"]
+
+    def test_load_jobs_bom_plus_control_char_uses_strict_false_arm(self, tmp_cron_dir):
+        """BOM + bare control char in a string value exercises the strict=False arm.
+
+        json.load (strict) rejects unescaped control chars; the retry path must
+        also open with utf-8-sig so the BOM does not re-crash the repair.
+        """
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        # Valid JSON structure but with a raw newline inside a string value
+        # (invalid under strict=True). Leading UTF-8 BOM.
+        raw = (
+            b'\xef\xbb\xbf{"jobs": [{"id": "ctrlbom01", "name": "has\nnewline",'
+            b' "enabled": true, "prompt": "x",'
+            b' "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"}}]}'
+        )
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_bytes(raw)
+
+        loaded = load_jobs()
+        assert [j["id"] for j in loaded] == ["ctrlbom01"]
+        assert "newline" in loaded[0]["name"]

--- a/tests/hermes_cli/test_jobs_json_utf8_bom.py
+++ b/tests/hermes_cli/test_jobs_json_utf8_bom.py
@@ -1,0 +1,68 @@
+"""UTF-8 BOM tolerance for independent jobs.json readers (dump/status).
+
+cron/jobs.load_jobs is covered in tests/cron/test_jobs.py. dump and status
+each open jobs.json themselves — keep them on the same utf-8-sig dialect.
+"""
+
+from types import SimpleNamespace
+
+
+def test_dump_cron_summary_accepts_utf8_bom(tmp_path):
+    from hermes_cli.dump import _cron_summary
+
+    cron = tmp_path / "cron"
+    cron.mkdir()
+    (cron / "jobs.json").write_bytes(
+        b'\xef\xbb\xbf{"jobs": [{"id": "j1", "enabled": true},'
+        b' {"id": "j2", "enabled": false}]}'
+    )
+
+    assert _cron_summary(tmp_path) == "1 active / 2 total"
+
+
+def test_dump_cron_summary_bomless_regression(tmp_path):
+    from hermes_cli.dump import _cron_summary
+
+    cron = tmp_path / "cron"
+    cron.mkdir()
+    (cron / "jobs.json").write_text(
+        '{"jobs": [{"id": "j1", "enabled": true}]}',
+        encoding="utf-8",
+    )
+
+    assert _cron_summary(tmp_path) == "1 active / 1 total"
+
+
+def test_status_scheduled_jobs_accepts_utf8_bom(monkeypatch, capsys, tmp_path):
+    """hermes status must not print '(error reading jobs file)' under BOM."""
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    cron = tmp_path / "cron"
+    cron.mkdir()
+    (cron / "jobs.json").write_bytes(
+        b'\xef\xbb\xbf{"jobs": [{"id": "j1", "enabled": true},'
+        b' {"id": "j2", "enabled": true}]}'
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(
+        status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False
+    )
+    monkeypatch.setattr(
+        status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False
+    )
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+    out = capsys.readouterr().out
+    assert "(error reading jobs file)" not in out
+    assert "2 active, 2 total" in out


### PR DESCRIPTION
# fix(cron): accept UTF-8 BOM when reading jobs.json

Fixes #66607

## Summary

Read `jobs.json` with `encoding="utf-8-sig"` on all four independent
readers so a Windows-editor BOM no longer takes down cron.

## Problem

See linked issue (crash-first): plain `utf-8` + leading `EF BB BF` →
`JSONDecodeError: Unexpected UTF-8 BOM` →
`RuntimeError: Cron database corrupted and unrepairable: …`.

## Fix

| File | Change (tip `12b378c78`) |
|------|--------------------------|
| `cron/jobs.py:871` `load_jobs` primary | `utf-8` → `utf-8-sig` |
| `cron/jobs.py:877` `load_jobs` strict=False repair | `utf-8` → `utf-8-sig` |
| `hermes_cli/dump.py:172` `_cron_summary` | `utf-8` → `utf-8-sig` |
| `hermes_cli/status.py:534` Scheduled Jobs | `utf-8` → `utf-8-sig` |

Write path stays plain `utf-8` (Python does not emit a BOM; the next
`save_jobs()` heals a hand-edited BOM'd file).

Dialect matches the env-class fix (#65123 / #65124).

## Tests

- BOM'd `jobs.json` loads (crash repro)
- BOM-less regression
- Empty `{"jobs": []}` + BOM
- BOM + bare list auto-repair (rewrites without BOM)
- BOM + control-char string (exercises `strict=False` arm under BOM)
- dump `_cron_summary` BOM + bomless
- `hermes status` Scheduled Jobs under BOM (no error line; correct counts)

```bash
scripts/run_tests.sh tests/cron/test_jobs.py tests/hermes_cli/test_jobs_json_utf8_bom.py -q -k 'Bom or bom or Utf8 or utf8'
# 8 passed
```

## How to test (manual CLI — Gate 4)

Throwaway home only (`HERMES_HOME=$(mktemp -d)`); never touch real `~/.hermes`.

```bash
TMP=$(mktemp -d)
mkdir -p "$TMP/cron"
printf '\xef\xbb\xbf{"jobs": [{"id": "bom1", "name": "bom-test", "enabled": true, "prompt": "hi", "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"}}]}\n' > "$TMP/cron/jobs.json"
```

**Pre-fix (`upstream/main`):**

```text
$ HERMES_HOME="$TMP" hermes cron list
RuntimeError: Cron database corrupted and unrepairable: Unexpected UTF-8 BOM (decode using utf-8-sig): line 1 column 1 (char 0)

$ HERMES_HOME="$TMP" hermes status
◆ Scheduled Jobs
  Jobs:         (error reading jobs file)

$ HERMES_HOME="$TMP" hermes dump
  cron_jobs:          (error reading)
```

**Post-fix (this branch):**

```text
$ HERMES_HOME="$TMP" hermes cron list
  bom1 [active]
    Name:      bom-test
    Schedule:  every 60m
    ...

$ HERMES_HOME="$TMP" hermes status
◆ Scheduled Jobs
  Jobs:         1 active, 1 total

$ HERMES_HOME="$TMP" hermes dump
  cron_jobs:          1 active / 1 total
```

## Platforms tested

- **macOS 26.5 (Darwin 25.5.0 arm64), Python 3.11.15** — real repro + CLI
  evidence above (synthetic BOM file).
- **Windows-origin BOM** — reasoned only: Notepad / PowerShell 5.1
  `Set-Content -Encoding UTF8` are documented BOM emitters; the fix uses
  the same `utf-8-sig` dialect already used elsewhere for that class. Not
  re-run on a native Windows host in this PR.

## Related / overlap

- Fixes the issue filed with this PR (scoped exactly to the four readers
  above — `Fixes #N` is appropriate).
- #41604 partially changes `load_jobs` encoding only (plus unrelated
  prompt_builder); it is currently merge-dirty vs main and does not cover
  dump/status. This PR is the complete jobs.json-reader fix.

## Explicit non-scope (follow-up, not blockers)

- `hermes_cli/backup.py` `_count_cron_jobs` still plain `utf-8` (count
  returns `None` under BOM → conservative skip, no false wipe)
- `agent/curator_backup.py` parse still plain `utf-8` (snapshot copies
  raw bytes; parse_warning under BOM)

## Test plan (CI)

- [ ] `scripts/run_tests.sh tests/cron/test_jobs.py tests/hermes_cli/test_jobs_json_utf8_bom.py -q -k 'Bom or bom or Utf8 or utf8'`
- [ ] Existing cron job suites remain green on Linux CI
