### PR TITLE
fix(web): hide intermediate cmd.exe when opening profile terminal

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14962,7 +14962,12 @@ async def open_profile_terminal_endpoint(name: str):
         command = _profile_setup_command(name)
 
         if sys.platform.startswith("win"):
-            subprocess.Popen(["cmd.exe", "/c", "start", "", command])
+            # Hide the intermediate cmd.exe flash; `start` still opens a
+            # visible terminal for the profile setup command.
+            subprocess.Popen(
+                ["cmd.exe", "/c", "start", "", command],
+                creationflags=windows_hide_flags(),
+            )
         elif sys.platform == "darwin":
             escaped = command.replace("\\", "\\\\").replace('"', '\\"')
             applescript = (

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5452,14 +5452,25 @@ class TestNewEndpoints:
         (get_hermes_home() / "profiles" / "coder").mkdir(parents=True)
         calls = []
         monkeypatch.setattr(web_server.sys, "platform", "win32")
-        monkeypatch.setattr(web_server.subprocess, "Popen", lambda args, **kwargs: calls.append(args))
+        monkeypatch.setattr(
+            web_server,
+            "windows_hide_flags",
+            lambda: 0x08000000,
+        )
+        monkeypatch.setattr(
+            web_server.subprocess,
+            "Popen",
+            lambda args, **kwargs: calls.append((args, kwargs)),
+        )
 
         resp = self.client.post("/api/profiles/coder/open-terminal")
 
         assert resp.status_code == 200
         assert calls
-        assert calls[0][:4] == ["cmd.exe", "/c", "start", ""]
-        assert calls[0][-1] == "coder setup"
+        args, kwargs = calls[0]
+        assert args[:4] == ["cmd.exe", "/c", "start", ""]
+        assert args[-1] == "coder setup"
+        assert kwargs.get("creationflags") == 0x08000000
 
     def test_profiles_create_rejects_invalid_name(self):
         resp = self.client.post("/api/profiles", json={"name": "Has Spaces"})


### PR DESCRIPTION
## What does this PR do?

Hide the intermediate `cmd.exe` console flash when the portal opens a profile setup terminal on Windows. `start` still opens a visible terminal for the user.

Credit: Stan Shih (stantheman0128)

## Related Issue

Unfiled Windows footgun found while auditing `open-terminal` against `windows_hide_flags()` coverage.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: pass `creationflags=windows_hide_flags()` to the Windows `open-terminal` Popen
- `tests/hermes_cli/test_web_server.py`: assert `creationflags` on the Windows path

## How to Test

1. `python -m pytest tests/hermes_cli/test_web_server.py::TestNewEndpoints::test_profile_open_terminal_uses_windows_cmd -q`
2. Live: `CREATE_NO_WINDOW` Popen of `cmd.exe /c start /b ...` returns exit 0

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs (no open PR for this open-terminal site)
- [x] PR contains only related changes
- [x] Targeted pytest passed (2/2 open-terminal tests)
- [x] Added/updated tests
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] N/A docs
- [x] N/A config
- [x] Cross-platform: POSIX paths unchanged; Windows-only creationflags

## AI assistance

Prepared with Cursor (Grok). Human reviewed.

## Evidence

```
python -m pytest ...test_profile_open_terminal_uses_windows_cmd ...macos... -q
..  2 passed in 6.21s
```