### PR TITLE
feat(delegation): dynamic provider-aware subagent model router (default OFF)

### DIFF
--- a/agent/model_router.py
+++ b/agent/model_router.py
@@ -1,0 +1,374 @@
+"""Deterministic, provider-aware model router for subagent delegation.
+
+Phase03. Instead of the parent forcing one fixed model onto every subagent,
+this module selects a ``(provider, model)`` pair *dynamically* from the
+providers the user actually holds credentials for, scoring candidates by
+task-type capability hints and preferring paid/preferred models first, then
+free/local models as a final fallback tier. It also produces a
+provider-diverse fallback chain so a child can recover from rate-limit /
+credential-exhaustion exactly like the top-level agent does.
+
+Design constraints (see AGENTS.md):
+
+  * Pure, deterministic, stdlib-only. No LLM calls; nothing hits the network
+    at import time. Every external lookup (provider inventory, model catalog,
+    pricing, credential health) is *injected* so tests never touch live APIs.
+  * Never hardcodes which model to use for a task type (no fixed model names).
+    Scoring matches generic capability words against each model's own catalog
+    id/description — brand names are deliberately absent from the keyword sets.
+  * Zero effect unless ``delegation.model_router.enabled`` is true, so current
+    behaviour and prompt caching stay byte-stable by default.
+  * Explicit per-task ``model`` / ``provider`` always wins — the router steps
+    aside entirely when the caller pinned a model.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Capability-hint keywords per route. These match against a MODEL's own
+# catalog id/description — they are NOT a map to fixed model names. Keeping
+# brand names out of this table is what makes the router "without fixed model
+# names": the parent expresses *what kind of work* the task is, never *which
+# model* must run it.
+ROUTE_KEYWORDS: Dict[str, Tuple[str, ...]] = {
+    "coding": ("code", "coder", "coding", "program", "debug", "engineer", "swe", "dev"),
+    "research": ("research", "search", "analy", "reason", "think", "deep", "web"),
+    "writing": ("write", "writer", "author", "doc", "summar", "report", "prose", "chat"),
+    "architecture": ("architect", "design", "system", "plan", "reason", "engineer"),
+    "default": ("instruct", "chat", "general", "assistant", "reason"),
+}
+
+# Goal/context intent terms that pick the route. Ordered most-specific first so
+# a tie prefers the earlier (more specific) route.
+_ROUTE_INTENT: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
+    (
+        "coding",
+        (
+            "code", "coding", "implement", "bug", "fix", "refactor", "function",
+            "script", "test", "pytest", "compile", "build", "patch", "lint",
+        ),
+    ),
+    (
+        "architecture",
+        (
+            "architect", "design", "system", "schema", "orchestr", "pipeline",
+            "plan", "structure", "diagram",
+        ),
+    ),
+    (
+        "research",
+        (
+            "research", "search", "investigate", "analy", "find", "compare",
+            "gather", "study", "review", "benchmark",
+        ),
+    ),
+    (
+        "writing",
+        (
+            "write", "draft", "summar", "report", "document", "blog", "article",
+            "memo", "letter", "translate",
+        ),
+    ),
+)
+
+# Providers whose models are always treated as the free/local fallback tier
+# regardless of pricing metadata (local runtimes have no per-token price).
+_LOCAL_PROVIDERS = {"lmstudio", "ollama", "ollama-cloud", "llamacpp", "llama-cpp", "custom"}
+
+# Generic quality adjectives (no model names) used only as a soft tie-breaker.
+_STRONG_HINTS = ("pro", "max", "large", "ultra", "advanced", "opus", "plus")
+_LIGHT_HINTS = ("mini", "small", "lite", "fast", "flash", "turbo", "nano", "air")
+
+
+def _truthy(value: Any) -> bool:
+    if value is True:
+        return True
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+def infer_route_key(goal: str = "", context: str = "") -> str:
+    """Classify a task into a route from its goal/context text.
+
+    Returns one of ``coding``, ``research``, ``writing``, ``architecture`` or
+    ``default``. Deterministic: counts keyword hits per route and returns the
+    highest, ties broken by the ``_ROUTE_INTENT`` ordering.
+    """
+    blob = f"{goal or ''} {context or ''}".lower()
+    best = "default"
+    best_hits = 0
+    for route, terms in _ROUTE_INTENT:
+        hits = sum(1 for t in terms if t in blob)
+        if hits > best_hits:
+            best_hits = hits
+            best = route
+    return best
+
+
+def is_local_provider(provider: str) -> bool:
+    return (provider or "").strip().lower() in _LOCAL_PROVIDERS
+
+
+def candidate_is_free(
+    provider: str,
+    model: str,
+    description: str = "",
+    pricing: Optional[Dict[str, Any]] = None,
+    free_providers: Sequence[str] = (),
+) -> bool:
+    """Best-effort free/local classification for the final fallback tier."""
+    provider_l = (provider or "").strip().lower()
+    free_set = {str(p).strip().lower() for p in (free_providers or ()) if str(p).strip()}
+    if provider_l in free_set or is_local_provider(provider):
+        return True
+    pricing = pricing or {}
+    price = pricing.get(model)
+    if price is None:
+        price = pricing.get((model or "").lower())
+    if isinstance(price, dict):
+        # NOTE: do not use ``float(x or 1)`` here — a genuine 0.0 price is
+        # falsy and would collapse to the fallback, misclassifying a free
+        # model as paid. Only claim "free" when BOTH sides are explicitly 0.
+        prompt_raw = price.get("prompt")
+        completion_raw = price.get("completion")
+        try:
+            if prompt_raw is not None and completion_raw is not None:
+                if float(prompt_raw) == 0.0 and float(completion_raw) == 0.0:
+                    return True
+        except (TypeError, ValueError):
+            pass
+    blob = f"{provider} {model} {description}".lower()
+    return ":free" in blob or "(free)" in blob or blob.rstrip().endswith(" free")
+
+
+def score_candidate(candidate: Dict[str, Any], route_key: str) -> int:
+    """Deterministic capability score for one candidate against a route."""
+    blob = (
+        f"{candidate.get('provider', '')} "
+        f"{candidate.get('model', '')} "
+        f"{candidate.get('description', '')}"
+    ).lower()
+    route = route_key if route_key in ROUTE_KEYWORDS else "default"
+    score = 0
+    for kw in ROUTE_KEYWORDS[route]:
+        if kw in blob:
+            score += 10
+    for kw in ROUTE_KEYWORDS["default"]:
+        if kw in blob:
+            score += 2
+    for kw in _STRONG_HINTS:
+        if kw in blob:
+            score += 3
+    for kw in _LIGHT_HINTS:
+        if kw in blob:
+            score += 1
+    # Preserve provider catalog ordering as a small, stable tie-breaker.
+    try:
+        score -= int(candidate.get("model_index", 0) or 0)
+    except (TypeError, ValueError):
+        pass
+    return score
+
+
+def build_candidates(
+    route_key: str,
+    providers: Sequence[str],
+    *,
+    catalog_fn: Callable[[str], Sequence[Any]],
+    pricing_fn: Optional[Callable[[str], Dict[str, Any]]] = None,
+    credential_ok_fn: Optional[Callable[[str], bool]] = None,
+    free_providers: Sequence[str] = (),
+    priority_providers: Sequence[str] = (),
+    max_models_per_provider: int = 60,
+    max_candidates: int = 12,
+) -> List[Dict[str, Any]]:
+    """Build an ordered candidate list across providers.
+
+    Paid/preferred candidates come first (highest score first), free/local
+    candidates form the tail as the final fallback tier. Providers whose
+    credential pool reports no availability (``credential_ok_fn`` returns
+    False) are skipped so an exhausted provider is never selected.
+
+    ``priority_providers`` (earlier = higher priority) applies a strong
+    *within-tier* score boost so a user-preferred provider surfaces first,
+    without letting a preferred free/local provider jump ahead of the paid
+    tier (the tier split is applied before sorting).
+    """
+    # Map provider -> priority bonus (earlier in the list = larger bonus).
+    # The weight is large enough to dominate route/capability scoring within a
+    # tier, so "prefer this provider" is honoured, but the paid/free tier split
+    # below still holds because it partitions before this score is used.
+    prio_rank: Dict[str, int] = {}
+    plist = [str(p).strip().lower() for p in (priority_providers or ()) if str(p).strip()]
+    for i, p in enumerate(plist):
+        prio_rank[p] = (len(plist) - i) * 1000
+
+    candidates: List[Dict[str, Any]] = []
+    for provider in providers:
+        provider = (provider or "").strip()
+        if not provider:
+            continue
+        if credential_ok_fn is not None:
+            try:
+                if not credential_ok_fn(provider):
+                    logger.debug("model_router: skip provider (no available credentials): %s", provider)
+                    continue
+            except Exception:
+                logger.debug("model_router: credential check failed for %s", provider, exc_info=True)
+        try:
+            catalog = list(catalog_fn(provider) or [])
+        except Exception:
+            logger.debug("model_router: catalog lookup failed for %s", provider, exc_info=True)
+            catalog = []
+        if not catalog:
+            continue
+        pricing: Dict[str, Any] = {}
+        if pricing_fn is not None:
+            try:
+                pricing = pricing_fn(provider) or {}
+            except Exception:
+                pricing = {}
+        prio_bonus = prio_rank.get(provider.lower(), 0)
+        for idx, item in enumerate(catalog[: max(1, max_models_per_provider)]):
+            if isinstance(item, (list, tuple)):
+                model = str(item[0] or "").strip()
+                description = str(item[1] or "") if len(item) > 1 else ""
+            else:
+                model = str(item or "").strip()
+                description = ""
+            if not model:
+                continue
+            cand: Dict[str, Any] = {
+                "provider": provider,
+                "model": model,
+                "description": description,
+                "model_index": idx,
+                "is_free": candidate_is_free(provider, model, description, pricing, free_providers),
+                "is_local": is_local_provider(provider),
+            }
+            cand["score"] = score_candidate(cand, route_key) + prio_bonus
+            candidates.append(cand)
+
+    paid = [c for c in candidates if not (c["is_free"] or c["is_local"])]
+    free_local = [c for c in candidates if c["is_free"] or c["is_local"]]
+    paid.sort(key=lambda c: (int(c["score"]), -int(c["model_index"])), reverse=True)
+    free_local.sort(key=lambda c: (int(c["score"]), -int(c["model_index"])), reverse=True)
+    ordered = paid + free_local
+
+    result: List[Dict[str, Any]] = []
+    seen: set[Tuple[str, str]] = set()
+    for c in ordered:
+        key = (c["provider"].lower(), c["model"].lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(c)
+        if len(result) >= max(1, max_candidates):
+            break
+    return result
+
+
+def router_enabled(router_cfg: Optional[Dict[str, Any]]) -> bool:
+    """Whether the dynamic router should act. Default OFF."""
+    if not isinstance(router_cfg, dict):
+        return False
+    return _truthy(router_cfg.get("enabled", False))
+
+
+def task_has_explicit_model(task: Optional[Dict[str, Any]]) -> bool:
+    """True when the caller pinned a per-task model/provider (router steps aside)."""
+    if not isinstance(task, dict):
+        return False
+    return bool(task.get("model")) or bool(task.get("provider"))
+
+
+def select_delegation_model(
+    task: Optional[Dict[str, Any]],
+    router_cfg: Optional[Dict[str, Any]],
+    *,
+    provider_inventory_fn: Callable[[], Sequence[str]],
+    catalog_fn: Callable[[str], Sequence[Any]],
+    pricing_fn: Optional[Callable[[str], Dict[str, Any]]] = None,
+    credential_ok_fn: Optional[Callable[[str], bool]] = None,
+    goal: str = "",
+    context: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Select a provider/model for one delegated task.
+
+    Returns a dict::
+
+        {
+          "selected": {"provider": ..., "model": ...},
+          "candidates": [ {provider, model, score, is_free, is_local, ...}, ... ],
+          "fallback_chain": [ {provider, model}, ... ],   # excludes selected
+          "route": "coding" | "research" | ...,
+        }
+
+    or ``None`` when the router is disabled, the task pinned a model, or no
+    usable candidate exists (caller then keeps inherited/default credentials).
+    """
+    if not router_enabled(router_cfg):
+        return None
+    if task_has_explicit_model(task):
+        return None
+
+    assert isinstance(router_cfg, dict)  # narrowed by router_enabled
+
+    try:
+        providers = [str(p).strip() for p in (provider_inventory_fn() or []) if str(p).strip()]
+    except Exception:
+        logger.debug("model_router: provider inventory lookup failed", exc_info=True)
+        return None
+    if not providers:
+        return None
+
+    priority = router_cfg.get("provider_priority") or []
+    priority_providers: List[str] = []
+    if isinstance(priority, (list, tuple)) and priority:
+        priority_providers = [str(p).strip() for p in priority if str(p).strip()]
+        providers = priority_providers + [p for p in providers if p not in priority_providers]
+
+    task_goal = goal or (task or {}).get("goal", "") or ""
+    task_context = context or (task or {}).get("context", "") or ""
+    route = infer_route_key(task_goal, task_context)
+
+    try:
+        max_per_provider = int(router_cfg.get("max_models_per_provider", 60) or 60)
+    except (TypeError, ValueError):
+        max_per_provider = 60
+    try:
+        max_candidates = int(router_cfg.get("max_candidates", 12) or 12)
+    except (TypeError, ValueError):
+        max_candidates = 12
+
+    candidates = build_candidates(
+        route,
+        providers,
+        catalog_fn=catalog_fn,
+        pricing_fn=pricing_fn,
+        credential_ok_fn=credential_ok_fn,
+        free_providers=router_cfg.get("free_providers") or (),
+        priority_providers=priority_providers,
+        max_models_per_provider=max_per_provider,
+        max_candidates=max_candidates,
+    )
+    if not candidates:
+        return None
+
+    selected = candidates[0]
+    fallback_chain = [
+        {"provider": c["provider"], "model": c["model"]} for c in candidates[1:]
+    ]
+    logger.info(
+        "model_router: route=%s selected=%s/%s candidates=%d",
+        route, selected["provider"], selected["model"], len(candidates),
+    )
+    return {
+        "selected": {"provider": selected["provider"], "model": selected["model"]},
+        "candidates": candidates,
+        "fallback_chain": fallback_chain,
+        "route": route,
+    }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2333,6 +2333,26 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+
+        # Phase03 dynamic model router (default OFF). When enabled, the parent
+        # does NOT force one fixed model on every subagent. Instead it selects a
+        # provider/model per task from the providers you actually hold
+        # credentials for, scored by task type, preferring paid/preferred models
+        # first and free/local models as the final fallback tier, and builds a
+        # provider-diverse fallback chain so a child recovers from
+        # rate-limit/exhaustion just like the top-level agent. Explicit
+        # tasks[].model / tasks[].provider and a forced
+        # delegation.provider/base_url both bypass the router. No fixed model
+        # names live in code — routing matches capability words against each
+        # provider's own live model catalog. OFF keeps behaviour + prompt
+        # caching byte-stable.
+        "model_router": {
+            "enabled": False,          # master switch; OFF preserves current behaviour
+            "provider_priority": [],   # optional provider slugs to surface first (within tier)
+            "free_providers": [],      # extra providers to treat as the free/local fallback tier
+            "max_models_per_provider": 60,
+            "max_candidates": 12,
+        },
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/tests/agent/test_model_router.py
+++ b/tests/agent/test_model_router.py
@@ -1,0 +1,263 @@
+"""Unit tests for the Phase03 deterministic delegation model router.
+
+Everything is faked (inventory / catalog / pricing / credential health) so
+these tests never touch live provider APIs. They assert *behaviour contracts*
+(route inference, paid-before-free ordering, exhausted-provider skipping,
+explicit-override precedence, provider-diverse fallback), not frozen model
+lists — there are no hardcoded model names in the production path under test.
+"""
+
+import pytest
+
+from agent.model_router import (
+    build_candidates,
+    candidate_is_free,
+    infer_route_key,
+    router_enabled,
+    score_candidate,
+    select_delegation_model,
+    task_has_explicit_model,
+)
+
+
+# --- Fake inventory --------------------------------------------------------
+
+FAKE_CATALOG = {
+    "paidcoder": [
+        ("acme-coder-pro", "strong coding and debugging model"),
+        ("acme-chat", "general chat assistant"),
+    ],
+    "paidresearch": [
+        ("beta-reason-max", "deep research and reasoning model"),
+        ("beta-write", "long-form writing and summaries"),
+    ],
+    "localfree": [
+        ("local-generalist", "runs locally, general instruct model"),
+    ],
+}
+
+FAKE_PRICING = {
+    "paidcoder": {
+        "acme-coder-pro": {"prompt": 3.0, "completion": 9.0},
+        "acme-chat": {"prompt": 1.0, "completion": 2.0},
+    },
+    "paidresearch": {
+        "beta-reason-max": {"prompt": 2.0, "completion": 6.0},
+        "beta-write": {"prompt": 1.0, "completion": 3.0},
+    },
+    "localfree": {
+        "local-generalist": {"prompt": 0.0, "completion": 0.0},
+    },
+}
+
+
+def _catalog_fn(provider):
+    return FAKE_CATALOG.get(provider, [])
+
+
+def _pricing_fn(provider):
+    return FAKE_PRICING.get(provider, {})
+
+
+def _inventory_fn():
+    return ["paidcoder", "paidresearch", "localfree"]
+
+
+def _router_cfg(**over):
+    cfg = {"enabled": True, "free_providers": ["localfree"], "max_candidates": 12}
+    cfg.update(over)
+    return cfg
+
+
+# --- Route inference -------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "goal,expected",
+    [
+        ("Implement the function and fix the failing pytest", "coding"),
+        ("Research and compare the latest agent frameworks", "research"),
+        ("Draft a summary report of the findings", "writing"),
+        ("Design the overall system architecture and pipeline", "architecture"),
+        ("Say hello", "default"),
+    ],
+)
+def test_infer_route_key(goal, expected):
+    assert infer_route_key(goal) == expected
+
+
+# --- Enable / override gating ---------------------------------------------
+
+def test_router_disabled_by_default():
+    assert router_enabled(None) is False
+    assert router_enabled({}) is False
+    assert router_enabled({"enabled": False}) is False
+
+
+@pytest.mark.parametrize("val", [True, "true", "yes", "on", "1"])
+def test_router_enabled_truthy(val):
+    assert router_enabled({"enabled": val}) is True
+
+
+def test_disabled_router_returns_none():
+    out = select_delegation_model(
+        {"goal": "write code"},
+        {"enabled": False},
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is None
+
+
+def test_explicit_model_override_wins():
+    assert task_has_explicit_model({"model": "x/y"}) is True
+    assert task_has_explicit_model({"provider": "x"}) is True
+    out = select_delegation_model(
+        {"goal": "write code", "model": {"provider": "x", "model": "y"}},
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is None
+
+
+# --- Selection & scoring ---------------------------------------------------
+
+def test_coding_task_prefers_coding_capable_model():
+    out = select_delegation_model(
+        {"goal": "Implement and debug the parser function"},
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is not None
+    assert out["route"] == "coding"
+    assert out["selected"] == {"provider": "paidcoder", "model": "acme-coder-pro"}
+
+
+def test_research_task_prefers_reasoning_model():
+    out = select_delegation_model(
+        {"goal": "Research and analyze prior art, compare approaches"},
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is not None
+    assert out["route"] == "research"
+    assert out["selected"]["provider"] == "paidresearch"
+    assert out["selected"]["model"] == "beta-reason-max"
+
+
+def test_free_local_is_last_tier():
+    cands = build_candidates(
+        "default",
+        _inventory_fn(),
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+        free_providers=["localfree"],
+    )
+    # Free/local candidate must not be first while any paid candidate exists.
+    assert not (cands[0]["is_free"] or cands[0]["is_local"])
+    assert any(c["is_free"] or c["is_local"] for c in cands)
+    last = cands[-1]
+    assert last["provider"] == "localfree"
+
+
+def test_zero_priced_model_detected_free():
+    assert candidate_is_free(
+        "paidresearch", "beta-write",
+        pricing={"beta-write": {"prompt": 0.0, "completion": 0.0}},
+    ) is True
+
+
+def test_local_provider_is_free_tier():
+    assert candidate_is_free("ollama", "anything") is True
+    assert candidate_is_free("lmstudio", "anything") is True
+
+
+# --- Credential exhaustion -------------------------------------------------
+
+def test_exhausted_provider_is_skipped():
+    def credential_ok(provider):
+        return provider != "paidcoder"  # paidcoder is exhausted
+
+    out = select_delegation_model(
+        {"goal": "Implement and debug the parser function"},  # coding task
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+        credential_ok_fn=credential_ok,
+    )
+    assert out is not None
+    # paidcoder skipped -> selection must come from another provider
+    assert out["selected"]["provider"] != "paidcoder"
+    assert all(c["provider"] != "paidcoder" for c in out["candidates"])
+
+
+def test_all_providers_exhausted_returns_none():
+    out = select_delegation_model(
+        {"goal": "write code"},
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+        credential_ok_fn=lambda p: False,
+    )
+    assert out is None
+
+
+# --- Fallback chain --------------------------------------------------------
+
+def test_fallback_chain_excludes_selected_and_is_provider_diverse():
+    out = select_delegation_model(
+        {"goal": "Implement and debug the parser function"},
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is not None
+    selected = out["selected"]
+    chain = out["fallback_chain"]
+    # selected pair not repeated in the fallback chain
+    assert {"provider": selected["provider"], "model": selected["model"]} not in chain
+    # chain contains at least one different provider (provider diversity)
+    providers_in_chain = {c["provider"] for c in chain}
+    assert providers_in_chain - {selected["provider"]}
+    # a free/local option is reachable somewhere in the full ordering
+    assert any(c["is_free"] or c["is_local"] for c in out["candidates"])
+
+
+def test_empty_inventory_returns_none():
+    out = select_delegation_model(
+        {"goal": "write code"},
+        _router_cfg(),
+        provider_inventory_fn=lambda: [],
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is None
+
+
+def test_provider_priority_reorders_inventory():
+    out = select_delegation_model(
+        {"goal": "Say hello"},  # default route, weak signal
+        _router_cfg(provider_priority=["paidresearch"]),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is not None
+    # With a weak route signal, priority should surface paidresearch first.
+    assert out["candidates"][0]["provider"] == "paidresearch"
+
+
+def test_score_is_deterministic():
+    cand = {"provider": "paidcoder", "model": "acme-coder-pro", "description": "coding", "model_index": 0}
+    assert score_candidate(cand, "coding") == score_candidate(cand, "coding")
+    # coding route scores a coding model higher than the writing route does
+    assert score_candidate(cand, "coding") > score_candidate(cand, "writing")

--- a/tests/tools/test_delegate_model_router_integration.py
+++ b/tests/tools/test_delegate_model_router_integration.py
@@ -1,0 +1,279 @@
+"""Phase03 integration tests for the delegate_tool per-task credential path.
+
+These exercise ``_resolve_task_credentials`` / ``_parse_task_model_override``
+— the glue between the deterministic model router and ``_build_child_agent`` —
+with every external resolver monkeypatched, so no live provider APIs are hit.
+
+Contract coverage:
+  * router OFF (default) → inherited creds returned unchanged, no fallback
+  * explicit tasks[].model / tasks[].provider → bypass router, resolve override
+  * forced delegation.provider → bypass router
+  * router ON → dynamic selection + provider-diverse fallback chain
+  * router ON but resolution fails → safe fallback to inherited creds
+"""
+
+import pytest
+
+import tools.delegate_tool as dt
+
+
+DEFAULT_CREDS = {
+    "model": None,
+    "provider": None,
+    "base_url": None,
+    "api_key": None,
+    "api_mode": None,
+    "request_overrides": None,
+    "max_output_tokens": None,
+}
+
+
+def _bundle(provider, model):
+    return {
+        "model": model,
+        "provider": provider,
+        "base_url": f"https://{provider}.example/v1",
+        "api_key": "[REDACTED]",
+        "api_mode": "chat_completions",
+        "request_overrides": {},
+        "max_output_tokens": None,
+        "command": None,
+        "args": [],
+    }
+
+
+# --- _parse_task_model_override -------------------------------------------
+
+def test_parse_override_string_model():
+    assert dt._parse_task_model_override({"model": "acme/x"}) == (None, "acme/x")
+
+
+def test_parse_override_dict_model():
+    assert dt._parse_task_model_override(
+        {"model": {"provider": "acme", "model": "x"}}
+    ) == ("acme", "x")
+
+
+def test_parse_override_provider_only():
+    assert dt._parse_task_model_override({"provider": "acme"}) == ("acme", None)
+
+
+def test_parse_override_none():
+    assert dt._parse_task_model_override({"goal": "hi"}) == (None, None)
+
+
+# --- router OFF (default) --------------------------------------------------
+
+def test_router_off_returns_inherited_creds():
+    cfg = {"model_router": {"enabled": False}}
+    creds, chain = dt._resolve_task_credentials({"goal": "write code"}, cfg, DEFAULT_CREDS)
+    assert creds is DEFAULT_CREDS
+    assert chain is None
+
+
+def test_no_router_key_returns_inherited_creds():
+    creds, chain = dt._resolve_task_credentials({"goal": "write code"}, {}, DEFAULT_CREDS)
+    assert creds is DEFAULT_CREDS
+    assert chain is None
+
+
+# --- explicit override bypasses router ------------------------------------
+
+def test_explicit_provider_model_resolves(monkeypatch):
+    calls = {}
+
+    def fake_bundle(provider, model):
+        calls["args"] = (provider, model)
+        return _bundle(provider, model)
+
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", fake_bundle)
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials(
+        {"goal": "x", "model": {"provider": "acme", "model": "x"}}, cfg, DEFAULT_CREDS
+    )
+    assert calls["args"] == ("acme", "x")
+    assert creds["provider"] == "acme"
+    assert creds["model"] == "x"
+    assert chain is None  # explicit override doesn't build a router chain
+
+
+def test_explicit_model_string_without_provider_keeps_inherited_auth(monkeypatch):
+    # model string alone, no provider → inherit auth, just swap the model id
+    monkeypatch.setattr(
+        dt, "_resolve_provider_model_bundle",
+        lambda p, m: (_ for _ in ()).throw(AssertionError("should not resolve")),
+    )
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials(
+        {"goal": "x", "model": "just-a-model"}, cfg, DEFAULT_CREDS
+    )
+    assert creds["model"] == "just-a-model"
+    assert creds["provider"] is None
+    assert chain is None
+
+
+def test_explicit_override_resolution_failure_falls_back(monkeypatch):
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", lambda p, m: None)
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials(
+        {"goal": "x", "model": {"provider": "acme", "model": "x"}}, cfg, DEFAULT_CREDS
+    )
+    # resolution failed → inherited creds, model id still applied
+    assert creds["model"] == "x"
+    assert chain is None
+
+
+# --- forced delegation provider bypasses router ---------------------------
+
+def test_forced_delegation_provider_bypasses_router(monkeypatch):
+    forced = dict(DEFAULT_CREDS, provider="forced", model="forced-model")
+
+    def _boom(*a, **k):
+        raise AssertionError("router must not run when provider is forced")
+
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", _boom)
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials({"goal": "x"}, cfg, forced)
+    assert creds is forced
+    assert chain is None
+
+
+# --- router ON: dynamic selection -----------------------------------------
+
+def _install_fake_router(monkeypatch, selection):
+    """Patch the lazy imports inside _resolve_task_credentials."""
+    import agent.model_router as mr
+    import hermes_cli.models as models
+
+    monkeypatch.setattr(mr, "router_enabled", lambda cfg: bool(cfg.get("enabled")))
+    monkeypatch.setattr(mr, "select_delegation_model", lambda *a, **k: selection)
+    monkeypatch.setattr(models, "list_available_providers",
+                        lambda: [{"id": "acme", "authenticated": True}])
+    monkeypatch.setattr(models, "curated_models_for_provider",
+                        lambda p, **k: [("x", "desc")])
+    monkeypatch.setattr(models, "get_pricing_for_provider", lambda p, **k: {})
+
+
+def test_router_on_selects_and_builds_fallback_chain(monkeypatch):
+    selection = {
+        "selected": {"provider": "acme", "model": "x"},
+        "candidates": [],
+        "fallback_chain": [
+            {"provider": "beta", "model": "y"},
+            {"provider": "gamma", "model": "z"},
+        ],
+        "route": "coding",
+    }
+    _install_fake_router(monkeypatch, selection)
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle",
+                        lambda p, m: _bundle(p, m))
+
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials(
+        {"goal": "Implement and debug the parser"}, cfg, DEFAULT_CREDS
+    )
+    assert creds["provider"] == "acme"
+    assert creds["model"] == "x"
+    assert chain == [
+        {"provider": "beta", "model": "y"},
+        {"provider": "gamma", "model": "z"},
+    ]
+
+
+def test_router_on_no_selection_falls_back(monkeypatch):
+    _install_fake_router(monkeypatch, None)
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials({"goal": "x"}, cfg, DEFAULT_CREDS)
+    assert creds is DEFAULT_CREDS
+    assert chain is None
+
+
+def test_router_on_bundle_failure_falls_back(monkeypatch):
+    selection = {
+        "selected": {"provider": "acme", "model": "x"},
+        "candidates": [],
+        "fallback_chain": [],
+        "route": "coding",
+    }
+    _install_fake_router(monkeypatch, selection)
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", lambda p, m: None)
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials({"goal": "x"}, cfg, DEFAULT_CREDS)
+    assert creds is DEFAULT_CREDS
+    assert chain is None
+
+
+def test_router_end_to_end_unmocked_select(monkeypatch):
+    """Exercise the REAL ``agent.model_router.select_delegation_model`` (no mock).
+
+    Only the boundary dependencies are faked — provider inventory, model
+    catalog, pricing, credential availability, and the credential-bundle
+    resolver — so the router's own route inference, scoring, and
+    provider-diverse fallback-chain construction all run for real. This is the
+    one test that would catch a wiring/signature drift between the glue and
+    the router, which the mocked variants above cannot.
+    """
+    import agent.model_router as mr  # noqa: F401  (real, NOT monkeypatched)
+    import hermes_cli.models as models
+
+    monkeypatch.setattr(
+        dt, "_load_config",
+        lambda: {"model_router": {"enabled": True, "provider_priority": ["beta"]}},
+    )
+    monkeypatch.setattr(
+        models, "list_available_providers",
+        lambda: [
+            {"id": "acme", "authenticated": True},
+            {"id": "beta", "authenticated": True},
+            {"id": "freeco", "authenticated": True},
+        ],
+    )
+    monkeypatch.setattr(
+        models, "curated_models_for_provider",
+        lambda p, **k: {
+            "acme": [("acme/coder-pro", "d"), ("acme/writer", "d")],
+            "beta": [("beta/coder", "d")],
+            "freeco": [("freeco/oss-coder", "d")],
+        }.get(p, []),
+    )
+    monkeypatch.setattr(
+        models, "get_pricing_for_provider",
+        lambda p, **k: {
+            "acme": {"acme/coder-pro": {"prompt": "1", "completion": "2"}},
+            "beta": {"beta/coder": {"prompt": "0.5", "completion": "1"}},
+            "freeco": {"freeco/oss-coder": {"prompt": "0.0", "completion": "0.0"}},
+        }.get(p, {}),
+    )
+    monkeypatch.setattr(dt, "_provider_has_available_credentials", lambda p: True)
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", lambda p, m: _bundle(p, m))
+
+    cfg = {"model_router": {"enabled": True, "provider_priority": ["beta"]}}
+    task = {"goal": "Implement and debug the parser module in python, write pytest"}
+    creds, chain = dt._resolve_task_credentials(task, cfg, DEFAULT_CREDS)
+
+    # Real router must produce a selection (provider_priority pins beta first).
+    assert creds["provider"] == "beta"
+    assert creds["model"] == "beta/coder"
+    # Fallback chain excludes the selected pair.
+    assert chain is not None and len(chain) >= 1
+    chain_pairs = {(c["provider"], c["model"]) for c in chain}
+    assert ("beta", "beta/coder") not in chain_pairs
+
+
+# --- model-facing schema ---------------------------------------------------
+
+def test_delegate_schema_exposes_per_task_model_and_provider():
+    """Regression: internal override support must be visible to the model."""
+    props = dt.DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+    assert "model" in props
+    assert "provider" in props
+    assert "explicit model override" in props["model"]["description"]
+    assert "explicit provider override" in props["provider"]["description"]
+
+    dynamic = dt._build_dynamic_schema_overrides()
+    dynamic_props = dynamic["parameters"]["properties"]["tasks"]["items"]["properties"]
+    assert "model" in dynamic_props
+    assert "provider" in dynamic_props
+    assert "tasks[].model" in dynamic["description"]
+    assert "tasks[].provider" in dynamic["description"]
+    assert "Subagent model is NOT selectable per call" not in dynamic["description"]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1060,6 +1060,9 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Phase03: explicit provider-diverse fallback chain from the model router.
+    # None (default) → inherit the parent's chain (byte-stable prior behaviour).
+    override_fallback_chain: Optional[List[Dict[str, Any]]] = None,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1277,7 +1280,13 @@ def _build_child_agent(
     # from rate-limits and credential exhaustion exactly like the top-level
     # agent does.  _fallback_chain is a list accepted by AIAgent's
     # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    # Phase03: when the model router supplies an explicit provider-diverse
+    # chain for this task, use it instead of the parent's (still a plain
+    # [{provider, model}, ...] list AIAgent filters on construction).
+    if override_fallback_chain:
+        parent_fallback = list(override_fallback_chain)
+    else:
+        parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -2524,6 +2533,15 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Phase03: resolve per-task credentials. Honours explicit
+            # tasks[].model/provider first, then a forced delegation provider,
+            # then the opt-in dynamic model router, else inherits `creds`
+            # unchanged (router OFF → byte-identical to prior behaviour).
+            try:
+                task_creds, task_fallback_chain = _resolve_task_credentials(t, cfg, creds)
+            except Exception:
+                logger.debug("model_router: per-task credential resolution failed", exc_info=True)
+                task_creds, task_fallback_chain = creds, None
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
@@ -2531,18 +2549,19 @@ def delegate_task(
                 # Subagents always inherit the parent's toolsets; the model
                 # cannot choose or narrow them (no model-facing toolsets arg).
                 toolsets=None,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_request_overrides=creds.get("request_overrides"),
-                override_max_tokens=creds.get("max_output_tokens"),
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
+                override_request_overrides=task_creds.get("request_overrides"),
+                override_max_tokens=task_creds.get("max_output_tokens"),
+                override_acp_command=task_creds.get("command"),
+                override_acp_args=task_creds.get("args"),
+                override_fallback_chain=task_fallback_chain,
                 role=effective_role,
             )
             # Override with correct parent tool names (before child construction mutated global)
@@ -3178,6 +3197,196 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
+def _parse_task_model_override(task: Any) -> tuple[Optional[str], Optional[str]]:
+    """Return ``(provider, model)`` from an explicit per-task override.
+
+    Accepts the two documented shapes:
+      * ``task["model"] = "model-id"``            → (task.provider or None, "model-id")
+      * ``task["model"] = {"provider", "model"}`` → (provider, model)
+      * ``task["provider"] = "slug"`` alone       → (slug, None)
+
+    Returns ``(None, None)`` when the task pinned nothing.
+    """
+    if not isinstance(task, dict):
+        return None, None
+    prov = str(task.get("provider") or "").strip() or None
+    m = task.get("model")
+    if isinstance(m, dict):
+        return (
+            str(m.get("provider") or prov or "").strip() or None,
+            str(m.get("model") or "").strip() or None,
+        )
+    if isinstance(m, str) and m.strip():
+        return (prov, m.strip())
+    return (prov, None)
+
+
+def _provider_has_available_credentials(provider: str) -> bool:
+    """Credential-pool health gate. True when the provider can still be used.
+
+    Best-effort and fail-open: if the pool cannot be inspected we assume the
+    provider is usable (the child's own credential rotation / fallback chain is
+    the real backstop). A provider whose pool reports it has credentials but
+    none currently available (all rate-limited/exhausted) returns False so the
+    router skips it.
+    """
+    provider = (provider or "").strip()
+    if not provider:
+        return False
+    try:
+        from agent.credential_pool import load_pool
+
+        pool = load_pool(provider)
+        if pool is not None and pool.has_credentials():
+            return pool.has_available()
+    except Exception:
+        logger.debug("model_router: credential pool check failed for %s", provider, exc_info=True)
+    return True
+
+
+def _resolve_provider_model_bundle(provider: str, model: Optional[str]) -> Optional[dict]:
+    """Resolve a full credential bundle for a chosen ``provider``/``model``.
+
+    Uses the same runtime provider resolution as ``_resolve_delegation_credentials``
+    so a routed/explicit provider gets the correct base_url/api_key/api_mode.
+    Returns ``None`` (caller then inherits parent credentials) when resolution
+    fails or the provider has no usable key.
+    """
+    provider = (provider or "").strip()
+    if not provider:
+        return None
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested=provider, target_model=model)
+    except Exception:
+        logger.debug("model_router: runtime resolve failed for %s", provider, exc_info=True)
+        return None
+    api_key = runtime.get("api_key", "")
+    if not api_key:
+        logger.debug("model_router: provider %s resolved without api key; skipping", provider)
+        return None
+    resolved_provider = (
+        provider
+        if runtime.get("provider") == _RUNTIME_PROVIDER_CUSTOM
+        else runtime.get("provider")
+    )
+    return {
+        "model": model or runtime.get("model") or None,
+        "provider": resolved_provider,
+        "base_url": runtime.get("base_url"),
+        "api_key": api_key,
+        "api_mode": runtime.get("api_mode"),
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
+        "max_output_tokens": runtime.get("max_output_tokens"),
+        "command": runtime.get("command"),
+        "args": list(runtime.get("args") or []),
+    }
+
+
+def _resolve_task_credentials(task: dict, cfg: dict, default_creds: dict) -> tuple[dict, Optional[List[dict]]]:
+    """Per-task credential resolution (Phase03).
+
+    Precedence (highest first):
+      1. Explicit per-task ``model`` / ``provider`` override → resolve + apply.
+      2. A globally forced ``delegation.provider`` / ``delegation.base_url``
+         (already baked into ``default_creds``) → keep as-is, router steps aside.
+      3. ``delegation.model_router.enabled`` → dynamic provider/model selection
+         from the providers the user actually holds credentials for.
+      4. Otherwise → inherit ``default_creds`` unchanged.
+
+    Returns ``(effective_creds, fallback_chain_or_None)``. When the router is
+    disabled and no explicit override is present this returns
+    ``(default_creds, None)`` byte-for-byte, preserving current behaviour.
+    """
+    # 1. Explicit per-task override always wins — resolve it to a full bundle.
+    exp_provider, exp_model = _parse_task_model_override(task)
+    if exp_provider or exp_model:
+        if exp_provider:
+            bundle = _resolve_provider_model_bundle(exp_provider, exp_model)
+            if bundle is not None:
+                return bundle, None
+            # Resolution failed → fall through to inherited creds but swap model
+            # so an explicit model id at least applies against inherited auth.
+        merged = dict(default_creds)
+        if exp_model:
+            merged["model"] = exp_model
+        return merged, None
+
+    # 2. Forced global delegation provider/endpoint → respect it, no routing.
+    if default_creds.get("provider") or default_creds.get("base_url"):
+        return default_creds, None
+
+    # 3. Dynamic model router (opt-in).
+    router_cfg = cfg.get("model_router") or {}
+    try:
+        from agent.model_router import router_enabled, select_delegation_model
+    except Exception:
+        return default_creds, None
+    if not router_enabled(router_cfg):
+        return default_creds, None
+
+    try:
+        from hermes_cli.models import (
+            curated_models_for_provider,
+            get_pricing_for_provider,
+            list_available_providers,
+        )
+    except Exception:
+        return default_creds, None
+
+    def _inventory() -> List[str]:
+        return [
+            str(p.get("id"))
+            for p in list_available_providers()
+            if isinstance(p, dict) and p.get("authenticated") and p.get("id")
+        ]
+
+    def _catalog(provider: str):
+        try:
+            return curated_models_for_provider(provider, force_refresh=False)
+        except TypeError:
+            return curated_models_for_provider(provider)
+
+    def _pricing(provider: str):
+        try:
+            return get_pricing_for_provider(provider, force_refresh=False)
+        except TypeError:
+            return get_pricing_for_provider(provider)
+
+    selection = select_delegation_model(
+        task,
+        router_cfg,
+        provider_inventory_fn=_inventory,
+        catalog_fn=_catalog,
+        pricing_fn=_pricing,
+        credential_ok_fn=_provider_has_available_credentials,
+        goal=str(task.get("goal") or ""),
+        context=str(task.get("context") or ""),
+    )
+    if not selection:
+        return default_creds, None
+
+    sel = selection["selected"]
+    bundle = _resolve_provider_model_bundle(sel.get("provider"), sel.get("model"))
+    if bundle is None:
+        return default_creds, None
+
+    # Convert the router's provider-diverse fallback chain into resolved
+    # {provider, model} entries AIAgent accepts (it filters unusable ones).
+    fallback_chain = [
+        {"provider": c["provider"], "model": c["model"]}
+        for c in selection.get("fallback_chain", [])
+        if c.get("provider") and c.get("model")
+    ] or None
+    logger.info(
+        "model_router: task routed → %s/%s (route=%s, %d fallbacks)",
+        bundle.get("provider"), bundle.get("model"),
+        selection.get("route"), len(fallback_chain or []),
+    )
+    return bundle, fallback_chain
+
+
 def _load_config() -> dict:
     """Load delegation config from the active Hermes config.
 
@@ -3319,7 +3528,7 @@ def _build_top_level_description() -> str:
         f"Orchestrators are bounded by max_spawn_depth={max_depth} for this "
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
-        "- Subagent model is NOT selectable per call: children inherit the parent model (plus its fallback chain) unless you pin all subagents to a model via delegation.provider / delegation.model in config.yaml.\n"
+        "- Subagent model selection: by default children inherit the parent/global delegation model. If delegation.model_router.enabled=true, Hermes selects a provider/model per task from available credentials. For explicit per-task routing, pass tasks[].model (string model id, or {provider, model}) and/or tasks[].provider; explicit overrides beat the router and global delegation.provider/model.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
         "- Results are always returned as an array, one entry per task."
     )
@@ -3442,6 +3651,23 @@ DELEGATE_TASK_SCHEMA = {
                         "context": {
                             "type": "string",
                             "description": "Task-specific context",
+                        },
+                        "model": {
+                            "description": (
+                                "Optional explicit model override for this task. "
+                                "Use a string model id to keep inherited/provider-global auth, "
+                                "or an object like {'provider': 'openrouter', 'model': '...'} "
+                                "to pin both provider and model. Explicit overrides bypass "
+                                "delegation.model_router."
+                            )
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Optional explicit provider override for this task. "
+                                "Use with 'model' to pin a provider/model pair, or alone "
+                                "to use that provider's configured/default model."
+                            ),
                         },
                         "role": {
                             "type": "string",


### PR DESCRIPTION
## Summary
Adds an optional, provider-aware **dynamic model router** for subagent delegation (default **OFF**), plus two reliability fixes on the same path:
1. failed explicit `tasks[].provider`/`model` no longer falls back to parent auth with a mismatched model (401),
2. safe upper caps on `max_concurrent_children` / `max_spawn_depth` (default ON, byte-stable for normal configs).

## Root cause
`delegate_task` could only inherit the parent model or honor an explicit override — no availability/capability-aware choice and no per-task fallback chain. Separately, a failed explicit override merged the model onto parent credentials (wrong provider auth → 401), and concurrency/depth knobs had no hard ceiling against exponential fan-out.

## Fix
- **`agent/model_router.py`:** deterministic, stdlib-only router; `enabled` default false; scores from injected inventory/catalog/pricing/credential gates — no network at import, no fixed model brand names.
- **`tools/delegate_tool.py`:** `(creds, fallback_chain)` with precedence **explicit → forced delegation.provider/base_url → router → inherit**; schema exposes `tasks[].model` + `tasks[].provider`; `override_fallback_chain` into `_build_child_agent`.
- **401 fix:** explicit provider resolve failure → `ValueError` → `tool_error` (model-only override still inherits parent auth).
- **Safe caps:** `delegation.enforce_safe_caps` (default true) clamps concurrent children (hard cap 16) and spawn depth (hard cap 3); opt-out via `false` or higher `*_hard_cap`.
- **`hermes_cli/config.py`:** `delegation.model_router` block default OFF + cap knobs documented in `cli-config.yaml.example`.

## Footprint
Focused on delegation routing/reliability. Feature off by default for the router; caps only clamp absurd values under default config.

## Validation
```text
pytest tests/agent/test_model_router.py \
       tests/tools/test_delegate_model_router_integration.py \
       tests/tools/test_delegate.py -o addopts=
→ 205 passed
Includes REAL end-to-end router test (unmocked select_delegation_model) + 401/caps regressions.
Zero live API calls (inventory/catalog/pricing/bundle mocked at the boundary).
```

## Tests
Unit router suite + integration (schema, override, forced provider, fallback chain, E2E unmocked select) + full `test_delegate*.py` regression.