### PR TITLE
fix(mcp): reject non-ASCII OAuth callback state instead of crashing with 500

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11555,7 +11555,13 @@ async def mcp_oauth_callback(
             for candidate in candidates
             if candidate.expected_state is not None
             and state is not None
-            and secrets.compare_digest(candidate.expected_state, state)
+            # Compare as bytes: secrets.compare_digest raises TypeError on a str
+            # with non-ASCII characters, and ``state`` is the attacker-
+            # controllable OAuth-callback query parameter — a crafted non-ASCII
+            # value must miss cleanly (404 "flow expired"), not 500.
+            and secrets.compare_digest(
+                candidate.expected_state.encode("utf-8"), state.encode("utf-8")
+            )
         ),
         None,
     )

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -56,6 +56,42 @@ def test_dashboard_flow_rejects_wrong_state_without_consuming_callback():
     )
 
 
+def test_dashboard_flow_rejects_non_ascii_state_without_crashing():
+    """A crafted OAuth callback with a non-ASCII ``state`` must miss cleanly.
+
+    ``secrets.compare_digest`` raises ``TypeError`` when either str operand
+    holds a non-ASCII character. ``state`` is an attacker-controllable
+    callback query parameter, so the unencoded comparison turned a bogus
+    callback into an unhandled 500 instead of a clean rejection. Comparing the
+    UTF-8 bytes makes a non-ASCII state miss like any other wrong state.
+    """
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-nonascii",
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://agent.example/mcp/oauth/callback/flow-nonascii",
+    )
+    asyncio.run(
+        flow.publish_authorization_url(
+            "https://idp.example/authorize?state=expected-state"
+        )
+    )
+
+    # Before the fix this raised TypeError (an unhandled 500), not ValueError.
+    with pytest.raises(ValueError, match="state mismatch"):
+        flow.deliver_callback(code="attacker", state="café-☠-state", error=None)
+
+    # The legitimate ASCII callback still succeeds afterward.
+    flow.deliver_callback(code="legitimate", state="expected-state", error=None)
+    assert asyncio.run(flow.wait_for_callback()) == (
+        "legitimate",
+        "expected-state",
+    )
+
+
 def test_dashboard_flow_rejects_second_callback():
     from tools.mcp_dashboard_oauth import DashboardOAuthFlow
 

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -69,10 +69,17 @@ class DashboardOAuthFlow:
         with self._lock:
             if self._callback_ready.is_set():
                 raise ValueError("OAuth callback already received")
+            # Compare as bytes: ``secrets.compare_digest`` raises TypeError on a
+            # str containing non-ASCII characters, and ``state`` is an
+            # attacker-controllable OAuth-callback query parameter. Encoding
+            # both operands keeps a crafted non-ASCII state a clean "state
+            # mismatch" rejection instead of an unhandled 500.
             if (
                 self.expected_state is None
                 or state is None
-                or not secrets.compare_digest(self.expected_state, state)
+                or not secrets.compare_digest(
+                    self.expected_state.encode("utf-8"), state.encode("utf-8")
+                )
             ):
                 raise ValueError("OAuth callback state mismatch")
             if error:


### PR DESCRIPTION
## What

The dashboard MCP OAuth callback compared the returned `state` against the expected value via `secrets.compare_digest(expected_state, state)` on **raw str** operands. `state` is an attacker-controllable callback query parameter, and `secrets.compare_digest` raises `TypeError: comparing strings with non-ASCII characters is not supported` when either str operand holds a non-ASCII char. A crafted callback like `?state=café&code=x` then surfaced as an **unhandled 500** on the public callback endpoint instead of the clean "OAuth flow expired" / "state mismatch" rejection.

Same non-ASCII `compare_digest` class as the api-server bearer (#65305) and webhook-signature (#65307) hardenings — the OAuth dashboard callback state was the remaining unencoded comparison.

## Fix

Compare the UTF-8 bytes of both operands at the two callback sites:
- `tools/mcp_dashboard_oauth.py` — `DashboardOAuthFlow.deliver_callback`
- `hermes_cli/web_server.py` — the `mcp_oauth_callback` route

A non-ASCII `state` now misses like any other wrong state.

## Tests

`tests/tools/test_mcp_dashboard_oauth.py` — new `test_dashboard_flow_rejects_non_ascii_state_without_crashing`: a callback with a non-ASCII state is rejected with the clean `state mismatch` ValueError; before the fix it raised TypeError.

```
pytest tests/tools/test_mcp_dashboard_oauth.py tests/hermes_cli/test_mcp_dashboard_oauth.py -q
# 23 passed
```