### PR TITLE
feat(computer-use): draw self-localization action marker on follow-up captures

### DIFF
--- a/tests/tools/test_computer_use_action_marker.py
+++ b/tests/tools/test_computer_use_action_marker.py
@@ -1,0 +1,142 @@
+"""Tests for the computer_use self-localization action marker.
+
+Codex-style self-localization: after an action (click / drag / ...), the
+follow-up capture PNG has a marker drawn at the resolved landing point so the
+model can *see* where its own action landed, instead of only seeing a tinted
+cursor on the user's physical screen.
+
+These tests exercise the pure compositing layer
+(`tools.computer_use.action_marker`) — no cua-driver, no live screen. The
+marker is drawn onto an in-memory PNG and the result is decoded back to
+pixels to prove the marker is really there.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+
+from tools.computer_use.action_marker import (
+    ActionMarker,
+    overlay_action_marker,
+    pillow_available,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _white_png(width: int = 200, height: int = 160) -> bytes:
+    """A plain white PNG so any marker pixel is trivially detectable."""
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (255, 255, 255)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _decode(png_bytes: bytes):
+    from PIL import Image
+
+    return Image.open(io.BytesIO(png_bytes)).convert("RGB")
+
+
+def _has_non_white_near(img, cx: int, cy: int, radius: int = 24) -> bool:
+    """True if any non-white pixel exists within `radius` of (cx, cy)."""
+    w, h = img.size
+    px = img.load()
+    for x in range(max(0, cx - radius), min(w, cx + radius + 1)):
+        for y in range(max(0, cy - radius), min(h, cy + radius + 1)):
+            if px[x, y] != (255, 255, 255):
+                return True
+    return False
+
+
+pytestmark = pytest.mark.skipif(
+    not pillow_available(),
+    reason="Pillow not installed — marker compositing degrades to a no-op",
+)
+
+
+# ---------------------------------------------------------------------------
+# Click marker
+# ---------------------------------------------------------------------------
+
+def test_click_marker_draws_pixels_at_landing_point():
+    base = _white_png()
+    marker = ActionMarker(kind="click", point=(100, 80), label="click")
+
+    out = overlay_action_marker(base, marker)
+
+    assert out != base, "compositing should change the PNG bytes"
+    img = _decode(out)
+    # The crosshair passes exactly through the landing point.
+    assert _has_non_white_near(img, 100, 80, radius=2), (
+        "expected marker pixels at the exact click landing point"
+    )
+
+
+def test_click_marker_leaves_far_corner_untouched():
+    base = _white_png()
+    marker = ActionMarker(kind="click", point=(100, 80))
+
+    out = overlay_action_marker(base, marker)
+    img = _decode(out)
+
+    # A corner far from the marker must stay white (marker doesn't blanket
+    # the whole image / hide the UI).
+    assert not _has_non_white_near(img, 4, 4, radius=3)
+
+
+def test_click_marker_preserves_image_dimensions():
+    base = _white_png(200, 160)
+    out = overlay_action_marker(base, ActionMarker(kind="click", point=(50, 50)))
+    img = _decode(out)
+    assert img.size == (200, 160)
+
+
+# ---------------------------------------------------------------------------
+# Drag marker
+# ---------------------------------------------------------------------------
+
+def test_drag_marker_draws_along_the_path():
+    base = _white_png()
+    marker = ActionMarker(kind="drag", start=(20, 20), end=(180, 140), label="drag")
+
+    out = overlay_action_marker(base, marker)
+    img = _decode(out)
+
+    # Endpoints marked.
+    assert _has_non_white_near(img, 20, 20, radius=6), "drag start not marked"
+    assert _has_non_white_near(img, 180, 140, radius=6), "drag end not marked"
+    # A midpoint along the line is drawn (the connecting arrow shaft).
+    assert _has_non_white_near(img, 100, 80, radius=6), "drag shaft not drawn"
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation & guards
+# ---------------------------------------------------------------------------
+
+def test_marker_with_no_coordinates_returns_original():
+    base = _white_png()
+    # A click marker with no point (e.g. element bounds were unresolvable)
+    # must not raise and must return the image unchanged.
+    out = overlay_action_marker(base, ActionMarker(kind="click", point=None))
+    assert out == base
+
+
+def test_out_of_bounds_point_does_not_raise():
+    base = _white_png(100, 100)
+    marker = ActionMarker(kind="click", point=(999, 999))
+    # Should be a no-throw; drawing partially or not at all is fine.
+    out = overlay_action_marker(base, marker)
+    assert isinstance(out, (bytes, bytearray))
+
+
+def test_invalid_png_bytes_returns_original():
+    junk = b"not-a-real-png"
+    out = overlay_action_marker(junk, ActionMarker(kind="click", point=(10, 10)))
+    assert out == junk

--- a/tests/tools/test_computer_use_marker_dispatch.py
+++ b/tests/tools/test_computer_use_marker_dispatch.py
@@ -1,0 +1,143 @@
+"""E2E test for computer_use self-localization marker through the dispatch path.
+
+Exercises `tools.computer_use.tool._dispatch` end-to-end: a click with
+`capture_after=True` must return a multimodal envelope whose screenshot has a
+marker composited at the click's landing point. The image is decoded back to
+pixels to prove the marker really lands where the action did — not mocked.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+
+from unittest.mock import patch
+
+from tools.computer_use.action_marker import ActionMarker, pillow_available
+from tools.computer_use.backend import CaptureResult
+
+
+def _white_png_b64(w: int = 200, h: int = 160) -> str:
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), (255, 255, 255)).save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+class _StubBackend:
+    """Minimal backend that records a click marker and returns a white PNG.
+
+    Mirrors the contract the tool layer depends on: click() records a pending
+    marker, capture() returns a plain screenshot, consume_action_marker()
+    hands the marker over one-shot.
+    """
+
+    def __init__(self):
+        self._last_app = "StubApp"
+        self._pending = None
+
+    def click(self, *, element=None, x=None, y=None, button="left",
+              click_count=1, modifiers=None):
+        from tools.computer_use.backend import ActionResult
+
+        self._pending = ActionMarker(kind="click", point=(x, y), label="click")
+        return ActionResult(ok=True, action="click", message="clicked")
+
+    def capture(self, mode="som", app=None):
+        return CaptureResult(
+            mode=mode, width=200, height=160,
+            png_b64=_white_png_b64(), elements=[], app="StubApp",
+            window_title="w", png_bytes_len=100, image_mime_type="image/png",
+        )
+
+    def consume_action_marker(self):
+        m, self._pending = self._pending, None
+        return m
+
+
+pytestmark = pytest.mark.skipif(
+    not pillow_available(), reason="Pillow not installed"
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_aux_vision_routing():
+    """Keep the multimodal envelope: don't reroute the screenshot to aux vision.
+
+    The follow-up capture returns a native multimodal image envelope only when
+    aux-vision routing is off. In CI/dev the ambient config may enable it,
+    which would flatten the image into text and hide the marker pixels we're
+    asserting on.
+    """
+    with patch(
+        "tools.computer_use.tool._should_route_through_aux_vision",
+        return_value=False,
+    ):
+        yield
+
+
+def _decode(b64: str):
+    from PIL import Image
+
+    raw = base64.b64decode(b64)
+    return Image.open(io.BytesIO(raw)).convert("RGB")
+
+
+def _non_white_near(img, cx, cy, radius=3) -> bool:
+    w, h = img.size
+    px = img.load()
+    for x in range(max(0, cx - radius), min(w, cx + radius + 1)):
+        for y in range(max(0, cy - radius), min(h, cy + radius + 1)):
+            if px[x, y] != (255, 255, 255):
+                return True
+    return False
+
+
+def test_click_capture_after_marks_landing_point():
+    from tools.computer_use.tool import _dispatch
+
+    backend = _StubBackend()
+    resp = _dispatch(backend, "click", {
+        "coordinate": [120, 90],
+        "capture_after": True,
+    })
+
+    assert isinstance(resp, dict) and resp.get("_multimodal")
+    url = resp["content"][1]["image_url"]["url"]
+    b64 = url.split("base64,", 1)[1]
+    img = _decode(b64)
+    # Marker crosshair passes through the exact click point.
+    assert _non_white_near(img, 120, 90, radius=2), "no marker at click point"
+    # Far corner untouched.
+    assert not _non_white_near(img, 3, 3, radius=2)
+
+
+def test_show_action_marker_false_leaves_screenshot_clean():
+    from tools.computer_use.tool import _dispatch
+
+    backend = _StubBackend()
+    resp = _dispatch(backend, "click", {
+        "coordinate": [120, 90],
+        "capture_after": True,
+        "show_action_marker": False,
+    })
+
+    assert isinstance(resp, dict) and resp.get("_multimodal")
+    url = resp["content"][1]["image_url"]["url"]
+    b64 = url.split("base64,", 1)[1]
+    img = _decode(b64)
+    # No marker → the whole white image stays white.
+    assert not _non_white_near(img, 120, 90, radius=30)
+
+
+def test_marker_is_one_shot_not_restamped():
+    from tools.computer_use.tool import _dispatch
+
+    backend = _StubBackend()
+    # First click stamps a marker and consumes it.
+    _dispatch(backend, "click", {"coordinate": [50, 50], "capture_after": True})
+    # A plain capture afterwards must NOT carry a stale marker.
+    assert backend.consume_action_marker() is None

--- a/tools/computer_use/action_marker.py
+++ b/tools/computer_use/action_marker.py
@@ -1,0 +1,170 @@
+"""Self-localization action markers for computer_use captures.
+
+Codex-style self-localization: cua-driver draws a tinted agent cursor on the
+*user's physical screen*, but that overlay never lands in the PNG the model
+receives — so after a click/drag the model cannot see where its own action
+went. Game loops, drags, and precise manipulation fall apart because the model
+has no visual confirmation of its landing point.
+
+This module composites a lightweight marker onto the *follow-up* capture PNG
+(the one produced by ``capture_after=True``) at the resolved landing point of
+the immediately preceding action:
+
+  * click / double_click / right/middle click → a translucent ringed crosshair
+    centered on the click point.
+  * drag → a start ring, an end ring, and a connecting arrow shaft so the model
+    sees the whole gesture.
+
+Design constraints (mirrors AGENTS.md "narrow waist"):
+  * Pure, dependency-light, and *lazy* about Pillow. Pillow is an optional
+    dependency; when it is not importable the compositor degrades to a no-op
+    (returns the original bytes unchanged) so the capture path never breaks.
+  * The marker is drawn with a bright outline and a translucent fill so it is
+    unmistakable without blanketing the UI underneath.
+  * This is the *last action's landing point*, semantically distinct from the
+    SOM overlay's numbered "next-click candidates" — the two coexist.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+Point = Tuple[int, int]
+
+
+@dataclass
+class ActionMarker:
+    """Describes where the previous action landed, for compositing.
+
+    Exactly one geometry is used depending on ``kind``:
+      * kind="click" (and double/right/middle) → ``point`` is the landing pixel.
+      * kind="drag" → ``start`` and ``end`` are the gesture endpoints.
+    """
+
+    kind: str = "click"
+    point: Optional[Point] = None
+    start: Optional[Point] = None
+    end: Optional[Point] = None
+    label: str = ""
+
+
+# High-contrast red-orange; the RGBA alpha keeps the fill translucent so the
+# underlying UI stays legible. Outline is fully opaque for a crisp edge.
+_OUTLINE_RGBA = (255, 40, 40, 255)
+_FILL_RGBA = (255, 60, 60, 70)
+_SHAFT_RGBA = (255, 40, 40, 220)
+_CLICK_RADIUS = 16
+_DRAG_ENDPOINT_RADIUS = 11
+
+
+def pillow_available() -> bool:
+    """True iff Pillow can be imported. Used to gate compositing/tests."""
+    try:
+        import PIL  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _has_geometry(marker: ActionMarker) -> bool:
+    if marker.kind == "drag":
+        return marker.start is not None and marker.end is not None
+    return marker.point is not None
+
+
+def overlay_action_marker(png_bytes: bytes, marker: ActionMarker) -> bytes:
+    """Return ``png_bytes`` with ``marker`` drawn on top.
+
+    Degrades gracefully to the original bytes when:
+      * Pillow is unavailable,
+      * the marker carries no usable coordinates,
+      * or the input is not a decodable image.
+
+    Never raises for a drawing problem — a broken marker must not sink the
+    capture that carries it.
+    """
+    if not png_bytes or not _has_geometry(marker):
+        return png_bytes
+    try:
+        from PIL import Image, ImageDraw
+    except Exception:
+        # Pillow not installed — self-localization is a nice-to-have, so we
+        # silently return the untouched screenshot.
+        return png_bytes
+
+    try:
+        base = Image.open(io.BytesIO(png_bytes)).convert("RGBA")
+    except Exception:
+        # Not a real/parseable image — hand back exactly what we got.
+        return png_bytes
+
+    try:
+        overlay = Image.new("RGBA", base.size, (0, 0, 0, 0))
+        draw = ImageDraw.Draw(overlay)
+        if marker.kind == "drag":
+            _draw_drag(draw, marker.start, marker.end)
+        else:
+            _draw_click(draw, marker.point)
+
+        composited = Image.alpha_composite(base, overlay).convert("RGB")
+        out = io.BytesIO()
+        composited.save(out, format="PNG")
+        return out.getvalue()
+    except Exception:
+        # Any drawing/encoding failure → fall back to the original screenshot.
+        return png_bytes
+
+
+def _draw_click(draw, point: Optional[Point]) -> None:
+    if point is None:
+        return
+    x, y = int(point[0]), int(point[1])
+    r = _CLICK_RADIUS
+    # Translucent filled ring.
+    draw.ellipse([x - r, y - r, x + r, y + r], fill=_FILL_RGBA,
+                 outline=_OUTLINE_RGBA, width=3)
+    # Crosshair through the exact landing point.
+    draw.line([x - r - 6, y, x + r + 6, y], fill=_OUTLINE_RGBA, width=2)
+    draw.line([x, y - r - 6, x, y + r + 6], fill=_OUTLINE_RGBA, width=2)
+    # Center dot so the precise pixel is unambiguous.
+    draw.ellipse([x - 2, y - 2, x + 2, y + 2], fill=_OUTLINE_RGBA)
+
+
+def _draw_drag(draw, start: Optional[Point], end: Optional[Point]) -> None:
+    if start is None or end is None:
+        return
+    x0, y0 = int(start[0]), int(start[1])
+    x1, y1 = int(end[0]), int(end[1])
+    re = _DRAG_ENDPOINT_RADIUS
+    # Connecting shaft.
+    draw.line([x0, y0, x1, y1], fill=_SHAFT_RGBA, width=3)
+    _draw_arrow_head(draw, (x0, y0), (x1, y1))
+    # Start ring (hollow) and end ring (filled) to encode direction.
+    draw.ellipse([x0 - re, y0 - re, x0 + re, y0 + re],
+                 outline=_OUTLINE_RGBA, width=3)
+    draw.ellipse([x1 - re, y1 - re, x1 + re, y1 + re],
+                 fill=_FILL_RGBA, outline=_OUTLINE_RGBA, width=3)
+
+
+def _draw_arrow_head(draw, start: Point, end: Point) -> None:
+    import math
+
+    x0, y0 = start
+    x1, y1 = end
+    dx, dy = x1 - x0, y1 - y0
+    dist = math.hypot(dx, dy)
+    if dist < 1e-6:
+        return
+    ux, uy = dx / dist, dy / dist
+    head_len = 14.0
+    head_w = 8.0
+    # Base of the arrow head, stepped back from the tip.
+    bx, by = x1 - ux * head_len, y1 - uy * head_len
+    # Perpendicular unit vector.
+    px, py = -uy, ux
+    left = (bx + px * head_w, by + py * head_w)
+    right = (bx - px * head_w, by - py * head_w)
+    draw.polygon([(x1, y1), left, right], fill=_OUTLINE_RGBA)

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -49,6 +49,7 @@ import threading
 import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
+from tools.computer_use.action_marker import ActionMarker
 from tools.computer_use.backend import (
     ActionResult,
     CaptureResult,
@@ -1197,6 +1198,14 @@ class CuaDriverBackend(ComputerUseBackend):
         # element. Cleared whenever a fresh capture overwrites the
         # snapshot context.
         self._snapshot_tokens: Dict[int, str] = {}
+        # Codex-style self-localization: the resolved landing point of the
+        # most recent pointer action (click/drag/...). Consumed by the
+        # follow-up capture (capture_after=True) so the model sees a marker
+        # at *its own* action site in the returned PNG. Also caches the last
+        # snapshot's element_index -> center-pixel map so element-index
+        # clicks (which carry no explicit x/y) can still be localized.
+        self._last_action_marker: Optional[ActionMarker] = None
+        self._element_centers: Dict[int, Tuple[int, int]] = {}
         # Per-instance cua-driver session id. cua-driver's MCP server
         # instructions ask every consumer to declare a stable session
         # at the start of a run (start_session) and tear it down at
@@ -1730,6 +1739,15 @@ class CuaDriverBackend(ComputerUseBackend):
                 for e in elements
                 if e.element_token
             }
+            # Cache element_index -> center pixel for self-localization of
+            # element-index clicks/drags (which resolve to a frame server-side
+            # and carry no explicit x/y). Only elements with real bounds
+            # contribute; markdown-parsed (0,0,0,0) frames are skipped.
+            self._element_centers = {
+                e.index: e.center()
+                for e in elements
+                if e.bounds and any(e.bounds[2:])
+            }
 
             # Image may arrive as an MCP image part or inside
             # structuredContent (screenshot_png_b64) depending on the driver
@@ -1764,6 +1782,57 @@ class CuaDriverBackend(ComputerUseBackend):
             png_bytes_len=png_bytes_len,
             image_mime_type=image_mime_type,
         )
+
+    # ── Self-localization markers ──────────────────────────────────
+    def _record_point_marker(
+        self,
+        *,
+        kind: str,
+        x: Optional[int],
+        y: Optional[int],
+        element: Optional[int],
+        label: str,
+    ) -> None:
+        """Remember where a point action (click/double_click/...) landed.
+
+        Explicit x/y take precedence; an element index resolves to the cached
+        center pixel from the last snapshot. When neither yields a pixel (e.g.
+        an element click on a driver that returned no bounds), the marker is
+        cleared so the follow-up capture is left unmarked rather than pointing
+        at a stale location.
+        """
+        point: Optional[Tuple[int, int]] = None
+        if x is not None and y is not None:
+            point = (int(x), int(y))
+        elif element is not None:
+            point = self._element_centers.get(element)
+        self._last_action_marker = (
+            ActionMarker(kind=kind, point=point, label=label) if point else None
+        )
+
+    def _record_drag_marker(
+        self,
+        *,
+        start: Optional[Tuple[int, int]],
+        end: Optional[Tuple[int, int]],
+    ) -> None:
+        """Remember a drag gesture's endpoints for the follow-up capture."""
+        if start and end:
+            self._last_action_marker = ActionMarker(
+                kind="drag", start=start, end=end, label="drag",
+            )
+        else:
+            self._last_action_marker = None
+
+    def consume_action_marker(self) -> Optional[ActionMarker]:
+        """Return and clear the pending self-localization marker.
+
+        One-shot: the follow-up capture consumes it so a later capture with no
+        preceding action doesn't re-stamp a stale point.
+        """
+        marker = self._last_action_marker
+        self._last_action_marker = None
+        return marker
 
     # ── Pointer ────────────────────────────────────────────────────
     def click(
@@ -1815,6 +1884,14 @@ class CuaDriverBackend(ComputerUseBackend):
         if modifiers:
             args["modifier"] = modifiers
 
+        # Record the resolved landing point for self-localization on the
+        # follow-up capture. Explicit x/y wins; otherwise resolve the element
+        # index to its cached center pixel from the last snapshot.
+        self._record_point_marker(
+            kind="click",
+            x=x, y=y, element=element,
+            label=("double_click" if click_count == 2 else "click"),
+        )
         return self._action(tool, args)
 
     def drag(
@@ -1839,6 +1916,10 @@ class CuaDriverBackend(ComputerUseBackend):
             args["from_element"] = from_element
             args["to_element"] = to_element
             args["window_id"] = self._active_window_id
+            self._record_drag_marker(
+                start=self._element_centers.get(from_element),
+                end=self._element_centers.get(to_element),
+            )
         elif from_xy is not None and to_xy is not None:
             if self._active_window_id is None:
                 return ActionResult(ok=False, action="drag",
@@ -1846,6 +1927,10 @@ class CuaDriverBackend(ComputerUseBackend):
             args["from_x"], args["from_y"] = int(from_xy[0]), int(from_xy[1])
             args["to_x"], args["to_y"] = int(to_xy[0]), int(to_xy[1])
             args["window_id"] = self._active_window_id
+            self._record_drag_marker(
+                start=(int(from_xy[0]), int(from_xy[1])),
+                end=(int(to_xy[0]), int(to_xy[1])),
+            )
         else:
             return ActionResult(ok=False, action="drag",
                                 message="drag requires from_element/to_element or from_coordinate/to_coordinate.")

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -224,8 +224,24 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                 "description": (
                     "If true, take a follow-up capture after the action "
                     "and include it in the response. Saves a round-trip "
-                    "when you need to verify an action's effect."
+                    "when you need to verify an action's effect. The "
+                    "follow-up screenshot is stamped with a marker at the "
+                    "landing point of the action you just performed "
+                    "(click crosshair / drag arrow) so you can see where "
+                    "your own action went — self-localization. Disable the "
+                    "marker with show_action_marker=false."
                 ),
+            },
+            "show_action_marker": {
+                "type": "boolean",
+                "description": (
+                    "Default true. When a follow-up capture is taken "
+                    "(capture_after=true) after a click/drag, draw a marker "
+                    "at the resolved landing point so you can visually "
+                    "confirm where your action landed. Set false to get the "
+                    "unmarked screenshot."
+                ),
+                "default": True,
             },
         },
         "required": ["action"],

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -355,6 +355,9 @@ def _summarize_action(action: str, args: Dict[str, Any]) -> str:
 
 def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) -> Any:
     capture_after = bool(args.get("capture_after"))
+    # Self-localization marker defaults on; honor an explicit false.
+    show_marker = args.get("show_action_marker", True)
+    show_marker = bool(show_marker) if show_marker is not None else True
 
     if action == "capture":
         mode = str(args.get("mode", "som"))
@@ -387,7 +390,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         if not app:
             return json.dumps({"error": "focus_app requires `app`"})
         res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action in {"click", "double_click", "right_click", "middle_click"}:
         button = args.get("button")
@@ -408,7 +411,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             x=x, y=y, button=button or "left", click_count=click_count,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action == "drag":
         has_elements = args.get("from_element") is not None and args.get("to_element") is not None
@@ -425,7 +428,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             button=args.get("button", "left"),
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action == "scroll":
         coord = args.get("coordinate") or (None, None)
@@ -437,22 +440,22 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             y=coord[1] if coord and coord[1] is not None else None,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action == "type":
         res = backend.type_text(args.get("text", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action == "key":
         res = backend.key(args.get("keys", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action == "set_value":
         value = args.get("value")
         if value is None:
             return json.dumps({"error": "set_value requires `value`"})
         res = backend.set_value(value=str(value), element=args.get("element"))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     return json.dumps({"error": f"unknown action {action!r}"})
 
@@ -856,8 +859,39 @@ def _route_capture_through_aux_vision(
     })
 
 
+def _apply_action_marker(backend: ComputerUseBackend, cap: CaptureResult) -> None:
+    """Composite the previous action's landing-point marker onto `cap`.
+
+    Codex-style self-localization: the follow-up screenshot gets a marker at
+    the resolved pixel where the just-executed click/drag landed, so the model
+    can visually confirm its own action site. Mutates `cap.png_b64` in place.
+
+    Best-effort and non-fatal: if the backend has no pending marker, Pillow is
+    unavailable, or compositing fails, the capture is returned unchanged.
+    """
+    consume = getattr(backend, "consume_action_marker", None)
+    if not callable(consume):
+        return
+    marker = consume()
+    if marker is None or not cap.png_b64:
+        return
+    try:
+        from tools.computer_use.action_marker import overlay_action_marker
+
+        raw = base64.b64decode(cap.png_b64, validate=False)
+        marked = overlay_action_marker(raw, marker)
+        if marked is not raw and marked != raw:
+            cap.png_b64 = base64.b64encode(marked).decode("ascii")
+            cap.png_bytes_len = len(marked)
+            # The compositor always re-encodes as PNG.
+            cap.image_mime_type = "image/png"
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("action-marker compositing failed: %s", e)
+
+
 def _maybe_follow_capture(
     backend: ComputerUseBackend, res: ActionResult, do_capture: bool,
+    show_marker: bool = True,
 ) -> Any:
     if not do_capture:
         return _text_response(res)
@@ -880,6 +914,11 @@ def _maybe_follow_capture(
     except Exception as e:
         logger.warning("follow-up capture failed: %s", e)
         return _text_response(res)
+    # Draw the self-localization marker at the just-executed action's landing
+    # point so the model sees where *its own* action went (the cua-driver agent
+    # cursor only paints the user's physical screen, never this PNG).
+    if show_marker:
+        _apply_action_marker(backend, cap)
     # Combine action summary with the capture.
     resp = _capture_response(cap)
     if isinstance(resp, dict) and resp.get("_multimodal"):


### PR DESCRIPTION
Split from PR #66548 per review feedback. Adds CUA action markers to follow-up captures, with focused dispatch and marker tests.