### PR TITLE
feat: add guarded async context compression

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1945,6 +1945,16 @@ def init_agent(
         _bg_compression_raw if isinstance(_bg_compression_raw, dict) else None
     )
     agent.background_compression = None
+    if agent.background_compression_config.enabled:
+        _ra().logger.info(
+            "background compression enabled: shadow_only=%s prepare>=%.0f%% "
+            "apply>=%.0f%% min_delta=%d workers=%d",
+            agent.background_compression_config.shadow_only,
+            agent.background_compression_config.prepare_threshold * 100,
+            agent.background_compression_config.apply_threshold * 100,
+            agent.background_compression_config.min_delta_tokens,
+            agent.background_compression_config.max_workers,
+        )
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1947,8 +1947,9 @@ def init_agent(
     agent.background_compression = None
     if agent.background_compression_config.enabled:
         _ra().logger.info(
-            "background compression enabled: shadow_only=%s prepare>=%.0f%% "
-            "apply>=%.0f%% min_delta=%d workers=%d",
+            "background compression enabled: shadow_only=%s prepare<=%.0f%% "
+            "apply<=%.0f%% (effective gates derived per model so "
+            "prepare < apply < sync trigger) min_delta=%d workers=%d",
             agent.background_compression_config.shadow_only,
             agent.background_compression_config.prepare_threshold * 100,
             agent.background_compression_config.apply_threshold * 100,

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1933,6 +1933,19 @@ def init_agent(
     agent.compression_in_place = compression_in_place
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
 
+    # Background (asynchronous) compression preparation — compression.background
+    # in config.yaml, parsed once here so the loop/gateway never re-read config.
+    # Ships disabled; when enabled it defaults to shadow mode (generate and
+    # validate candidates, never apply). The controller itself is created
+    # lazily on the first qualifying trigger.
+    from agent.async_context_compression import BackgroundCompressionConfig
+
+    _bg_compression_raw = _compression_cfg.get("background")
+    agent.background_compression_config = BackgroundCompressionConfig.from_dict(
+        _bg_compression_raw if isinstance(_bg_compression_raw, dict) else None
+    )
+    agent.background_compression = None
+
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).
     _ctx = getattr(agent.context_compressor, "context_length", 0)

--- a/agent/async_context_compression.py
+++ b/agent/async_context_compression.py
@@ -329,8 +329,51 @@ class BackgroundCompressionController:
         with self._lock:
             return self._candidate
 
-    def _bump(self, key: str) -> None:
-        self.stats[key] = self.stats.get(key, 0) + 1
+    def _bump(self, key: str, amount: int = 1) -> None:
+        self.stats[key] = self.stats.get(key, 0) + amount
+
+    _TELEMETRY_COUNTERS = (
+        "candidate_started",
+        "candidate_ready",
+        "candidate_failed",
+        "candidate_discarded_stale",
+        "candidate_applied",
+        "candidate_cancelled",
+        "candidate_shadow_validated",
+        "sync_fallback_count",
+        "suffix_messages_preserved",
+        "background_provider_error",
+    )
+
+    def telemetry_snapshot(self) -> Dict[str, Any]:
+        """Structured metrics for logs, /status surfaces and the benchmark.
+
+        Counters default to 0 so dashboards see a stable shape; duration
+        distributions are summarised as count/p50/p95/max in milliseconds.
+        """
+        def _dist(values: List[float]) -> Dict[str, Any]:
+            if not values:
+                return {"count": 0, "p50_ms": None, "p95_ms": None, "max_ms": None}
+            ordered = sorted(values)
+            return {
+                "count": len(ordered),
+                "p50_ms": ordered[len(ordered) // 2],
+                "p95_ms": ordered[min(len(ordered) - 1, int(len(ordered) * 0.95))],
+                "max_ms": ordered[-1],
+            }
+
+        with self._lock:
+            stats = dict(self.stats)
+            state = self._state.value
+            generation = self._generation
+        snapshot: Dict[str, Any] = {
+            key: stats.get(key, 0) for key in self._TELEMETRY_COUNTERS
+        }
+        snapshot["state"] = state
+        snapshot["generation"] = generation
+        snapshot["candidate_prepare_ms"] = _dist(list(self.prepare_durations_ms))
+        snapshot["candidate_apply_ms"] = _dist(list(self.apply_durations_ms))
+        return snapshot
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -448,7 +491,14 @@ class BackgroundCompressionController:
                     current = True
                 else:
                     current = False
-            self._bump("candidate_failed" if current else "candidate_discarded_stale")
+            if current:
+                self._bump("candidate_failed")
+                # The dominant failure source is the summariser provider call
+                # (timeout / 4xx / 5xx); count it separately so a flaky aux
+                # model is visible without log spelunking.
+                self._bump("background_provider_error")
+            else:
+                self._bump("candidate_discarded_stale")
             logger.debug(
                 "background compression preparation failed (gen=%d current=%s): %s",
                 generation, current, exc,
@@ -758,6 +808,10 @@ def maybe_apply_prepared_candidate(
         return None
     if result is not None:
         controller.apply_durations_ms.append((time.monotonic() - started) * 1000.0)
+        controller._bump(
+            "suffix_messages_preserved",
+            max(0, len(messages) - candidate.prefix_message_count),
+        )
     return result
 
 

--- a/agent/async_context_compression.py
+++ b/agent/async_context_compression.py
@@ -302,6 +302,7 @@ class BackgroundCompressionController:
         # Operational counters (formalized as telemetry in the config task).
         self.stats: Dict[str, int] = {}
         self.prepare_durations_ms: List[float] = []
+        self.apply_durations_ms: List[float] = []
 
     # -- introspection ------------------------------------------------------
 
@@ -518,11 +519,11 @@ class BackgroundCompressionController:
             max_age_turns=self._config.max_candidate_age_turns,
         )
         if not ok:
-            self._discard(reason)
+            self.discard(reason)
             return None
         return candidate
 
-    def _discard(self, reason: str) -> None:
+    def discard(self, reason: str) -> None:
         with self._lock:
             self._candidate = None
             self._state = CandidateState.STALE
@@ -714,16 +715,30 @@ def maybe_apply_prepared_candidate(
         return None
 
     # Real apply: shared atomic commit lives in conversation_compression so
-    # the synchronous path and the background path can never diverge.
+    # the synchronous path and the background path can never diverge. Any
+    # failure here degrades to the synchronous fallback — a background
+    # feature must never block the user's turn.
     from agent.conversation_compression import apply_prepared_candidate
 
-    return apply_prepared_candidate(
-        agent,
-        candidate,
-        messages,
-        system_message,
-        controller=controller,
-    )
+    started = time.monotonic()
+    try:
+        result = apply_prepared_candidate(
+            agent,
+            candidate,
+            messages,
+            system_message,
+            controller=controller,
+        )
+    except Exception as exc:
+        logger.warning(
+            "background compression apply failed — falling back to the "
+            "synchronous path: %s", exc,
+        )
+        controller._bump("sync_fallback_count")
+        return None
+    if result is not None:
+        controller.apply_durations_ms.append((time.monotonic() - started) * 1000.0)
+    return result
 
 
 __all__ = [

--- a/agent/async_context_compression.py
+++ b/agent/async_context_compression.py
@@ -691,6 +691,11 @@ def maybe_apply_prepared_candidate(
     cfg = _agent_config(agent)
     if cfg is None or not cfg.enabled:
         return None
+    # Same gate as the synchronous triggers: an agent with compaction off —
+    # including the background-review fork, which shares the parent's live
+    # session_id — must never rewrite the transcript (#38727).
+    if not getattr(agent, "compression_enabled", False):
+        return None
     controller = getattr(agent, "background_compression", None)
     if not isinstance(controller, BackgroundCompressionController):
         return None

--- a/agent/async_context_compression.py
+++ b/agent/async_context_compression.py
@@ -695,6 +695,21 @@ def maybe_apply_prepared_candidate(
     if not isinstance(controller, BackgroundCompressionController):
         return None
 
+    # Apply gate: below ``apply_threshold`` the candidate stays warm — the
+    # apply limit sits deliberately under the synchronous threshold so the
+    # swap happens before the sync path would have paused the user. When the
+    # context length is unknown (plugin engines) the gate is skipped and the
+    # in-lock validation remains the only arbiter.
+    engine = getattr(agent, "context_compressor", None)
+    tokens = _numeric(current_tokens)
+    if tokens <= 0 and engine is not None:
+        tokens = _numeric(getattr(engine, "last_prompt_tokens", 0))
+    context_length = (
+        _numeric(getattr(engine, "context_length", 0)) if engine is not None else 0.0
+    )
+    if context_length > 0 and tokens < cfg.apply_threshold * context_length:
+        return None
+
     session_id = getattr(agent, "session_id", "") or ""
     candidate = controller.take_valid_candidate(
         session_id=session_id,

--- a/agent/async_context_compression.py
+++ b/agent/async_context_compression.py
@@ -650,6 +650,75 @@ def _agent_config(agent: Any) -> Optional[BackgroundCompressionConfig]:
     return None
 
 
+# ── effective gate derivation ──────────────────────────────────────────────
+#
+# ``prepare_threshold`` / ``apply_threshold`` are configured as fractions of
+# the context window, but the synchronous trigger is NOT a plain fraction:
+# ``ContextEngine.threshold_tokens`` folds in the configured ratio, the
+# small-context floor, the minimum-context degenerate-window rule and the
+# Codex autoraise. Against the shipped ``compression.threshold: 0.50`` the
+# absolute 0.65/0.82 defaults sit past the synchronous trigger, so the sync
+# path would always fire first and a prepared candidate could never apply.
+# The gates therefore derive from the engine's live trigger at decision
+# time: a configured value that already fires first is honored; one that
+# would not is clamped to a fraction of the synchronous trigger, keeping
+# ``prepare < apply < synchronous`` for every profile.
+_PREPARE_FRACTION_OF_SYNC = 0.80
+_APPLY_FRACTION_OF_SYNC = 0.96
+
+_gate_clamp_logged = False
+
+
+def resolve_effective_gate_tokens(
+    cfg: BackgroundCompressionConfig, engine: Any
+) -> Tuple[float, float, float]:
+    """Return ``(prepare_tokens, apply_tokens, sync_tokens)`` with ordering enforced.
+
+    ``sync_tokens`` is the engine's live ``threshold_tokens`` (0.0 when the
+    engine has no token model — plugin engines). A gate of 0.0 means "no
+    opinion": callers skip that comparison and the in-lock validation stays
+    the only arbiter, preserving the legacy behavior for such engines.
+    """
+    global _gate_clamp_logged
+    context_length = (
+        _numeric(getattr(engine, "context_length", 0)) if engine is not None else 0.0
+    )
+    sync_tokens = (
+        _numeric(getattr(engine, "threshold_tokens", 0)) if engine is not None else 0.0
+    )
+    prepare_tokens = cfg.prepare_threshold * context_length if context_length > 0 else 0.0
+    apply_tokens = cfg.apply_threshold * context_length if context_length > 0 else 0.0
+
+    clamped = False
+    if sync_tokens > 0:
+        max_apply = sync_tokens * _APPLY_FRACTION_OF_SYNC
+        max_prepare = sync_tokens * _PREPARE_FRACTION_OF_SYNC
+        if apply_tokens <= 0 or apply_tokens > max_apply:
+            clamped = clamped or apply_tokens > max_apply
+            apply_tokens = max_apply
+        if prepare_tokens <= 0 or prepare_tokens > max_prepare:
+            clamped = clamped or prepare_tokens > max_prepare
+            prepare_tokens = max_prepare
+    if apply_tokens > 0 and prepare_tokens >= apply_tokens:
+        # A user-forced inversion (prepare >= apply) still resolves to a
+        # strictly ordered pair instead of a gate that can never open.
+        prepare_tokens = apply_tokens * (_PREPARE_FRACTION_OF_SYNC / _APPLY_FRACTION_OF_SYNC)
+        clamped = True
+    if clamped and not _gate_clamp_logged:
+        _gate_clamp_logged = True
+        logger.info(
+            "background compression: configured thresholds (prepare=%.2f apply=%.2f) "
+            "would not fire before the synchronous trigger (%s tokens) — using "
+            "derived gates prepare=%s apply=%s so prepare < apply < sync holds.",
+            cfg.prepare_threshold,
+            cfg.apply_threshold,
+            f"{int(sync_tokens):,}",
+            f"{int(prepare_tokens):,}",
+            f"{int(apply_tokens):,}",
+        )
+    return prepare_tokens, apply_tokens, sync_tokens
+
+
 def maybe_prepare_background_compression(
     agent: Any,
     messages: List[Dict[str, Any]],
@@ -690,8 +759,8 @@ def maybe_prepare_background_compression(
     tokens = _numeric(current_tokens)
     if tokens <= 0:
         tokens = _numeric(getattr(engine, "last_prompt_tokens", 0))
-    context_length = _numeric(getattr(engine, "context_length", 0))
-    if context_length > 0 and tokens < cfg.prepare_threshold * context_length:
+    prepare_gate, _apply_gate, _sync_gate = resolve_effective_gate_tokens(cfg, engine)
+    if prepare_gate > 0 and tokens < prepare_gate:
         return False
 
     controller = getattr(agent, "background_compression", None)
@@ -750,19 +819,33 @@ def maybe_apply_prepared_candidate(
     if not isinstance(controller, BackgroundCompressionController):
         return None
 
-    # Apply gate: below ``apply_threshold`` the candidate stays warm — the
-    # apply limit sits deliberately under the synchronous threshold so the
-    # swap happens before the sync path would have paused the user. When the
-    # context length is unknown (plugin engines) the gate is skipped and the
-    # in-lock validation remains the only arbiter.
+    # Apply gate: below the effective apply limit the candidate stays warm.
+    # The limit derives from the engine's live synchronous trigger (see
+    # ``resolve_effective_gate_tokens``) so the swap always lands before the
+    # sync path would have paused the user. When the engine has no token
+    # model (plugin engines) the gate is skipped and the in-lock validation
+    # remains the only arbiter.
     engine = getattr(agent, "context_compressor", None)
     tokens = _numeric(current_tokens)
     if tokens <= 0 and engine is not None:
         tokens = _numeric(getattr(engine, "last_prompt_tokens", 0))
-    context_length = (
-        _numeric(getattr(engine, "context_length", 0)) if engine is not None else 0.0
-    )
-    if context_length > 0 and tokens < cfg.apply_threshold * context_length:
+    _prepare_gate, apply_gate, sync_gate = resolve_effective_gate_tokens(cfg, engine)
+    # Preemption backstop: when the synchronous path would fire on this very
+    # preflight (token trigger or non-token triggers like message-count
+    # hygiene), a ready valid candidate must win regardless of the apply
+    # gate — never leave a finished summary warm while the blocking path
+    # redoes the same work.
+    sync_would_fire = False
+    if engine is not None:
+        should = getattr(engine, "should_compress", None)
+        if callable(should):
+            try:
+                sync_would_fire = bool(should(int(tokens)))
+            except Exception:
+                sync_would_fire = sync_gate > 0 and tokens >= sync_gate
+        else:
+            sync_would_fire = sync_gate > 0 and tokens >= sync_gate
+    if apply_gate > 0 and tokens < apply_gate and not sync_would_fire:
         return None
 
     session_id = getattr(agent, "session_id", "") or ""
@@ -827,5 +910,6 @@ __all__ = [
     "maybe_apply_prepared_candidate",
     "maybe_prepare_background_compression",
     "merge_candidate_with_live_messages",
+    "resolve_effective_gate_tokens",
     "validate_candidate",
 ]

--- a/agent/async_context_compression.py
+++ b/agent/async_context_compression.py
@@ -1,0 +1,742 @@
+"""Background-prepared context compression candidates.
+
+This module owns the *preparation* side of asynchronous context compression:
+freezing a prefix of the conversation, generating a compressed candidate on a
+single background worker, and validating that candidate before it is ever
+applied. It deliberately knows nothing about persistence — applying a
+candidate (SQLite lock, ``archive_and_compact``, session rotation, system
+prompt rebuild) stays in ``agent/conversation_compression.py`` so both the
+synchronous path and the background path share one commit implementation.
+
+Design invariants (see tests/run_agent/test_async_context_compression.py):
+
+* Preparation never mutates live state. The worker receives a deep copy of a
+  frozen prefix; the live ``messages`` list, the live compressor, the session
+  id and the database are never touched from the worker thread.
+* A candidate is only usable when the live conversation still starts with the
+  exact frozen prefix (same session, same generation, same canonical digest)
+  and no tool call is currently open.
+* Failures stay in the background: a worker exception marks the controller
+  ``FAILED`` and the synchronous compression path remains the fallback.
+
+This is a fresh implementation of the idea from PR #23892, rebuilt against
+the current compression locks and persistence; no code is carried over.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import logging
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ── canonical digest & message-shape primitives ────────────────────────────
+
+
+def _semantic_view(message: Any) -> Any:
+    """Project a message onto the fields that are actually sent to the
+    provider.
+
+    Internal bookkeeping keys (``_db_persisted`` and any other
+    underscore-prefixed marker) must not affect the digest: persistence
+    flags flip between preparation and apply without changing what the
+    model sees.
+    """
+    if not isinstance(message, dict):
+        return repr(message)
+    return {k: v for k, v in message.items() if not k.startswith("_")}
+
+
+def canonical_prefix_digest(messages: List[Dict[str, Any]], count: int) -> str:
+    """SHA-256 over the canonical JSON of the first ``count`` messages."""
+    count = max(0, min(int(count), len(messages)))
+    payload = json.dumps(
+        [_semantic_view(m) for m in messages[:count]],
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=repr,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _has_tool_calls(message: Any) -> bool:
+    return isinstance(message, dict) and bool(message.get("tool_calls"))
+
+
+def align_prefix_boundary(messages: List[Dict[str, Any]], count: int) -> int:
+    """Largest safe boundary ``<= count`` that never splits a tool group.
+
+    A boundary is unsafe when it would separate an assistant message carrying
+    ``tool_calls`` from any of its ``role="tool"`` results — either by cutting
+    immediately after the assistant message or between two of its results.
+    The boundary retreats until the cut lands before the whole group.
+    """
+    boundary = max(0, min(int(count), len(messages)))
+    while 0 < boundary < len(messages):
+        cut_follows_tool_call = _has_tool_calls(messages[boundary - 1])
+        cut_inside_results = (
+            isinstance(messages[boundary], dict)
+            and messages[boundary].get("role") == "tool"
+        )
+        if not cut_follows_tool_call and not cut_inside_results:
+            break
+        boundary -= 1
+    return boundary
+
+
+def has_open_tool_call(messages: List[Dict[str, Any]]) -> bool:
+    """True when any assistant ``tool_calls`` id lacks a ``tool`` result."""
+    pending: set = set()
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            for tc in msg["tool_calls"]:
+                tc_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                if tc_id:
+                    pending.add(tc_id)
+        elif msg.get("role") == "tool":
+            pending.discard(msg.get("tool_call_id"))
+    return bool(pending)
+
+
+# ── data structures ────────────────────────────────────────────────────────
+
+
+class CandidateState(Enum):
+    IDLE = "idle"
+    PREPARING = "preparing"
+    READY = "ready"
+    STALE = "stale"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True)
+class PreparedCompressionCandidate:
+    """An immutable, pre-computed compression of a frozen conversation prefix."""
+
+    session_id: str
+    generation: int
+    prefix_message_count: int
+    prefix_digest: str
+    prepared_messages: Tuple[Dict[str, Any], ...]
+    source_prompt_tokens: int
+    created_at_monotonic: float
+    created_at_turn: int
+    used_fallback: bool
+    summary_error: Optional[str]
+
+
+@dataclass
+class PrepareResult:
+    """Worker return value carrying summariser metadata alongside messages."""
+
+    messages: List[Dict[str, Any]]
+    used_fallback: bool = False
+    summary_error: Optional[str] = None
+
+
+def _coerce_bool(raw: Any, default: bool) -> bool:
+    if isinstance(raw, bool):
+        return raw
+    if raw is None:
+        return default
+    if isinstance(raw, str):
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(raw)
+
+
+def _coerce_float(raw: Any, default: float) -> float:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(raw: Any, default: int) -> int:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class BackgroundCompressionConfig:
+    """Parsed ``compression.background`` config block.
+
+    The feature ships disabled and, when enabled, defaults to shadow mode:
+    candidates are generated and validated but never applied.
+    """
+
+    enabled: bool = False
+    shadow_only: bool = True
+    prepare_threshold: float = 0.65
+    apply_threshold: float = 0.82
+    min_delta_tokens: int = 20_000
+    min_frozen_messages: int = 12
+    max_candidate_age_turns: int = 12
+    max_workers: int = 1
+    foreground_priority: bool = True
+    fallback_sync: bool = True
+    apply_only_between_turns: bool = True
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Dict[str, Any]]) -> "BackgroundCompressionConfig":
+        raw = raw if isinstance(raw, dict) else {}
+        defaults = cls()
+        return cls(
+            enabled=_coerce_bool(raw.get("enabled"), defaults.enabled),
+            shadow_only=_coerce_bool(raw.get("shadow_only"), defaults.shadow_only),
+            prepare_threshold=_coerce_float(
+                raw.get("prepare_threshold"), defaults.prepare_threshold
+            ),
+            apply_threshold=_coerce_float(
+                raw.get("apply_threshold"), defaults.apply_threshold
+            ),
+            min_delta_tokens=_coerce_int(
+                raw.get("min_delta_tokens"), defaults.min_delta_tokens
+            ),
+            min_frozen_messages=_coerce_int(
+                raw.get("min_frozen_messages"), defaults.min_frozen_messages
+            ),
+            max_candidate_age_turns=_coerce_int(
+                raw.get("max_candidate_age_turns"), defaults.max_candidate_age_turns
+            ),
+            max_workers=max(1, _coerce_int(raw.get("max_workers"), defaults.max_workers)),
+            foreground_priority=_coerce_bool(
+                raw.get("foreground_priority"), defaults.foreground_priority
+            ),
+            fallback_sync=_coerce_bool(raw.get("fallback_sync"), defaults.fallback_sync),
+            apply_only_between_turns=_coerce_bool(
+                raw.get("apply_only_between_turns"), defaults.apply_only_between_turns
+            ),
+        )
+
+
+# ── validation ─────────────────────────────────────────────────────────────
+
+
+def validate_candidate(
+    candidate: PreparedCompressionCandidate,
+    *,
+    session_id: str,
+    messages: List[Dict[str, Any]],
+    current_generation: Optional[int] = None,
+    current_turn: Optional[int] = None,
+    max_age_turns: Optional[int] = None,
+) -> Tuple[bool, str]:
+    """Check every safety invariant a candidate must satisfy before apply.
+
+    Returns ``(ok, reason)`` where ``reason`` is a stable machine-readable
+    slug used by telemetry and tests.
+    """
+    if candidate is None:
+        return False, "no_candidate"
+    if candidate.session_id != session_id:
+        return False, "session_mismatch"
+    if current_generation is not None and candidate.generation != current_generation:
+        return False, "stale_generation"
+    if (
+        current_turn is not None
+        and max_age_turns is not None
+        and current_turn - candidate.created_at_turn > max_age_turns
+    ):
+        return False, "expired"
+    if candidate.prefix_message_count > len(messages):
+        return False, "prefix_out_of_range"
+    live_digest = canonical_prefix_digest(messages, candidate.prefix_message_count)
+    if live_digest != candidate.prefix_digest:
+        return False, "digest_mismatch"
+    return True, ""
+
+
+def merge_candidate_with_live_messages(
+    candidate: PreparedCompressionCandidate,
+    live_messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Prepared prefix + the live suffix, suffix objects preserved verbatim.
+
+    The prepared messages are deep-copied so later in-place mutation of the
+    live transcript can never reach back into the immutable candidate. The
+    suffix keeps the exact live objects — byte-for-byte survival is the
+    whole point.
+    """
+    merged: List[Dict[str, Any]] = [copy.deepcopy(m) for m in candidate.prepared_messages]
+    merged.extend(live_messages[candidate.prefix_message_count:])
+    return merged
+
+
+# ── controller ─────────────────────────────────────────────────────────────
+
+
+class BackgroundCompressionController:
+    """Single-worker lifecycle manager for compression candidates.
+
+    All public methods are safe to call from the foreground thread and never
+    raise on worker failures. State transitions are serialized under one
+    lock; a monotonically increasing *generation* invalidates in-flight work
+    on supersede/cancel/reset without blocking on the worker.
+    """
+
+    def __init__(self, config: BackgroundCompressionConfig) -> None:
+        self._config = config
+        self._lock = threading.Lock()
+        self._executor: Optional[ThreadPoolExecutor] = None
+        self._generation = 0
+        self._state = CandidateState.IDLE
+        self._candidate: Optional[PreparedCompressionCandidate] = None
+        self._last_error: Optional[str] = None
+        self._settled = threading.Event()
+        self._settled.set()
+        # Operational counters (formalized as telemetry in the config task).
+        self.stats: Dict[str, int] = {}
+        self.prepare_durations_ms: List[float] = []
+
+    # -- introspection ------------------------------------------------------
+
+    @property
+    def config(self) -> BackgroundCompressionConfig:
+        return self._config
+
+    @property
+    def state(self) -> CandidateState:
+        with self._lock:
+            return self._state
+
+    @property
+    def generation(self) -> int:
+        with self._lock:
+            return self._generation
+
+    @property
+    def last_error(self) -> Optional[str]:
+        with self._lock:
+            return self._last_error
+
+    def peek_candidate(self) -> Optional[PreparedCompressionCandidate]:
+        with self._lock:
+            return self._candidate
+
+    def _bump(self, key: str) -> None:
+        self.stats[key] = self.stats.get(key, 0) + 1
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def try_start_preparation(
+        self,
+        *,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        prepare_fn: Callable[[List[Dict[str, Any]]], Any],
+        prefix_count: Optional[int] = None,
+        current_turn: int = 0,
+        source_prompt_tokens: int = 0,
+    ) -> bool:
+        """Freeze a prefix and submit background preparation.
+
+        Returns False (without side effects) when the feature is disabled,
+        the session id is empty, or the aligned prefix is too short. A new
+        start supersedes any in-flight or ready candidate: only the newest
+        generation can ever install its result.
+        """
+        if not self._config.enabled:
+            return False
+        if not session_id:
+            return False
+
+        requested = len(messages) if prefix_count is None else prefix_count
+        boundary = align_prefix_boundary(messages, requested)
+        if boundary < max(1, self._config.min_frozen_messages):
+            logger.debug(
+                "background compression: aligned prefix too short (%d < %d) — not starting",
+                boundary, self._config.min_frozen_messages,
+            )
+            return False
+
+        # Snapshot BEFORE taking the controller lock: deepcopy can be slow and
+        # the foreground caller is the only writer of ``messages`` right now.
+        frozen_prefix = copy.deepcopy(messages[:boundary])
+        prefix_digest = canonical_prefix_digest(messages, boundary)
+
+        with self._lock:
+            self._generation += 1
+            generation = self._generation
+            self._candidate = None
+            self._state = CandidateState.PREPARING
+            self._last_error = None
+            self._settled = threading.Event()
+            settled = self._settled
+            if self._executor is None:
+                self._executor = ThreadPoolExecutor(
+                    max_workers=max(1, self._config.max_workers),
+                    thread_name_prefix="bg-compression",
+                )
+            executor = self._executor
+        self._bump("candidate_started")
+
+        executor.submit(
+            self._run_preparation,
+            generation,
+            settled,
+            session_id,
+            frozen_prefix,
+            prefix_digest,
+            boundary,
+            source_prompt_tokens,
+            current_turn,
+            prepare_fn,
+        )
+        return True
+
+    def _run_preparation(
+        self,
+        generation: int,
+        settled: threading.Event,
+        session_id: str,
+        frozen_prefix: List[Dict[str, Any]],
+        prefix_digest: str,
+        prefix_count: int,
+        source_prompt_tokens: int,
+        created_at_turn: int,
+        prepare_fn: Callable[[List[Dict[str, Any]]], Any],
+    ) -> None:
+        """Worker body. Never raises; installs only if still the newest gen."""
+        started = time.monotonic()
+        try:
+            raw = prepare_fn(frozen_prefix)
+            if isinstance(raw, PrepareResult):
+                prepared = raw.messages
+                used_fallback = raw.used_fallback
+                summary_error = raw.summary_error
+            else:
+                prepared = raw
+                used_fallback = False
+                summary_error = None
+            if not prepared:
+                raise RuntimeError("preparation produced no messages")
+            candidate = PreparedCompressionCandidate(
+                session_id=session_id,
+                generation=generation,
+                prefix_message_count=prefix_count,
+                prefix_digest=prefix_digest,
+                prepared_messages=tuple(copy.deepcopy(m) for m in prepared),
+                source_prompt_tokens=source_prompt_tokens,
+                created_at_monotonic=time.monotonic(),
+                created_at_turn=created_at_turn,
+                used_fallback=used_fallback,
+                summary_error=summary_error,
+            )
+        except BaseException as exc:  # noqa: BLE001 — must never leak to foreground
+            with self._lock:
+                if generation == self._generation:
+                    self._state = CandidateState.FAILED
+                    self._candidate = None
+                    self._last_error = f"{type(exc).__name__}: {exc}"
+                    settled.set()
+                    current = True
+                else:
+                    current = False
+            self._bump("candidate_failed" if current else "candidate_discarded_stale")
+            logger.debug(
+                "background compression preparation failed (gen=%d current=%s): %s",
+                generation, current, exc,
+            )
+            return
+
+        duration_ms = (time.monotonic() - started) * 1000.0
+        with self._lock:
+            if generation == self._generation and self._state is CandidateState.PREPARING:
+                self._candidate = candidate
+                self._state = CandidateState.READY
+                settled.set()
+                installed = True
+            else:
+                installed = False
+        if installed:
+            self._bump("candidate_ready")
+            self.prepare_durations_ms.append(duration_ms)
+            logger.debug(
+                "background compression candidate ready: gen=%d prefix=%d prepared=%d in %.0fms",
+                generation, prefix_count, len(candidate.prepared_messages), duration_ms,
+            )
+        else:
+            self._bump("candidate_discarded_stale")
+
+    def wait_until_settled(self, timeout: Optional[float] = None) -> bool:
+        """Block until the newest preparation finished (test/replay helper)."""
+        with self._lock:
+            settled = self._settled
+        return settled.wait(timeout)
+
+    # -- consumption --------------------------------------------------------
+
+    def take_valid_candidate(
+        self,
+        *,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        current_turn: Optional[int] = None,
+    ) -> Optional[PreparedCompressionCandidate]:
+        """Return the candidate iff every safety invariant holds right now.
+
+        An open tool call is a *temporal* refusal: the candidate survives and
+        may apply once the result lands. Every other mismatch is permanent
+        for this candidate, so it is discarded (``STALE``).
+
+        The candidate is NOT consumed on success — callers clear it with
+        :meth:`mark_applied` only after their commit is confirmed.
+        """
+        with self._lock:
+            candidate = self._candidate
+            generation = self._generation
+        if candidate is None:
+            return None
+
+        if has_open_tool_call(messages):
+            logger.debug(
+                "background compression: open tool call — apply deferred, candidate kept"
+            )
+            return None
+
+        ok, reason = validate_candidate(
+            candidate,
+            session_id=session_id,
+            messages=messages,
+            current_generation=generation,
+            current_turn=current_turn,
+            max_age_turns=self._config.max_candidate_age_turns,
+        )
+        if not ok:
+            self._discard(reason)
+            return None
+        return candidate
+
+    def _discard(self, reason: str) -> None:
+        with self._lock:
+            self._candidate = None
+            self._state = CandidateState.STALE
+            self._last_error = reason
+        self._bump("candidate_discarded_stale")
+        logger.debug("background compression candidate discarded: %s", reason)
+
+    def mark_applied(self, candidate: PreparedCompressionCandidate) -> None:
+        """Clear the candidate after its commit was confirmed."""
+        with self._lock:
+            if self._candidate is candidate:
+                self._candidate = None
+                self._state = CandidateState.IDLE
+        self._bump("candidate_applied")
+
+    def record_shadow_validation(
+        self, candidate: PreparedCompressionCandidate
+    ) -> None:
+        """Shadow mode: count a would-have-applied candidate, then drop it."""
+        with self._lock:
+            if self._candidate is candidate:
+                self._candidate = None
+                self._state = CandidateState.IDLE
+        self._bump("candidate_shadow_validated")
+
+    # -- invalidation -------------------------------------------------------
+
+    def cancel(self) -> None:
+        """Best-effort cancel: invalidate the in-flight generation."""
+        with self._lock:
+            self._generation += 1
+            self._candidate = None
+            self._state = CandidateState.CANCELLED
+            self._settled.set()
+        self._bump("candidate_cancelled")
+
+    def reset(self) -> None:
+        """Session boundary (/new, /reset, model switch): drop everything."""
+        with self._lock:
+            self._generation += 1
+            self._candidate = None
+            self._state = CandidateState.IDLE
+            self._last_error = None
+            self._settled.set()
+
+    def shutdown(self, wait: bool = False) -> None:
+        with self._lock:
+            executor = self._executor
+            self._executor = None
+            self._generation += 1
+            self._candidate = None
+            self._state = CandidateState.IDLE
+            self._settled.set()
+        if executor is not None:
+            executor.shutdown(wait=wait, cancel_futures=True)
+
+
+# ── loop-facing helpers ────────────────────────────────────────────────────
+
+
+def _numeric(value: Any) -> float:
+    """Best-effort float for engine attributes that may be mocks/absent."""
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    return 0.0
+
+
+def _agent_config(agent: Any) -> Optional[BackgroundCompressionConfig]:
+    cfg = getattr(agent, "background_compression_config", None)
+    if isinstance(cfg, BackgroundCompressionConfig):
+        return cfg
+    return None
+
+
+def maybe_prepare_background_compression(
+    agent: Any,
+    messages: List[Dict[str, Any]],
+    *,
+    current_tokens: Optional[int] = None,
+    current_turn: int = 0,
+) -> bool:
+    """Start background preparation when every trigger condition holds.
+
+    Called between turns / after a completed tool round. Returns True only
+    when a new preparation was actually submitted. Never raises and never
+    touches the agent when the feature is disabled.
+    """
+    cfg = _agent_config(agent)
+    if cfg is None or not cfg.enabled:
+        return False
+    if not getattr(agent, "compression_enabled", False):
+        return False
+    session_id = getattr(agent, "session_id", "") or ""
+    if not session_id:
+        return False
+    engine = getattr(agent, "context_compressor", None)
+    if engine is None:
+        return False
+
+    # Engines opt in via the ContextEngine hook; legacy plugins default to
+    # False and keep the feature inert regardless of config.
+    can_prepare = getattr(engine, "can_prepare_compression", None)
+    try:
+        if not callable(can_prepare) or not can_prepare(
+            messages, current_tokens=current_tokens
+        ):
+            return False
+    except Exception as exc:
+        logger.debug("can_prepare_compression raised — treating as opt-out: %s", exc)
+        return False
+
+    tokens = _numeric(current_tokens)
+    if tokens <= 0:
+        tokens = _numeric(getattr(engine, "last_prompt_tokens", 0))
+    context_length = _numeric(getattr(engine, "context_length", 0))
+    if context_length > 0 and tokens < cfg.prepare_threshold * context_length:
+        return False
+
+    controller = getattr(agent, "background_compression", None)
+    if controller is None:
+        controller = BackgroundCompressionController(cfg)
+        agent.background_compression = controller
+    if controller.state is CandidateState.PREPARING:
+        return False
+
+    existing = controller.peek_candidate()
+    if (
+        existing is not None
+        and tokens - existing.source_prompt_tokens < cfg.min_delta_tokens
+    ):
+        return False
+
+    if has_open_tool_call(messages):
+        return False
+
+    def _prepare(frozen_prefix: List[Dict[str, Any]]) -> Any:
+        return engine.prepare_compression(frozen_prefix, current_tokens=int(tokens) or None)
+
+    return controller.try_start_preparation(
+        session_id=session_id,
+        messages=messages,
+        prepare_fn=_prepare,
+        current_turn=current_turn,
+        source_prompt_tokens=int(tokens),
+    )
+
+
+def maybe_apply_prepared_candidate(
+    agent: Any,
+    messages: List[Dict[str, Any]],
+    system_message: str,
+    *,
+    current_tokens: Optional[int] = None,
+    current_turn: int = 0,
+) -> Optional[Tuple[List[Dict[str, Any]], str]]:
+    """Between-turn apply gate.
+
+    Returns ``(compressed_messages, new_system_prompt)`` when a valid
+    candidate was applied, or None in every other case (feature disabled,
+    no/invalid candidate, shadow mode, below apply threshold) — callers then
+    continue with the existing synchronous path.
+    """
+    cfg = _agent_config(agent)
+    if cfg is None or not cfg.enabled:
+        return None
+    controller = getattr(agent, "background_compression", None)
+    if not isinstance(controller, BackgroundCompressionController):
+        return None
+
+    session_id = getattr(agent, "session_id", "") or ""
+    candidate = controller.take_valid_candidate(
+        session_id=session_id,
+        messages=messages,
+        current_turn=current_turn,
+    )
+    if candidate is None:
+        return None
+
+    if cfg.shadow_only:
+        controller.record_shadow_validation(candidate)
+        logger.info(
+            "background compression shadow: candidate for session=%s would apply "
+            "(prefix=%d prepared=%d)",
+            session_id, candidate.prefix_message_count,
+            len(candidate.prepared_messages),
+        )
+        return None
+
+    # Real apply: shared atomic commit lives in conversation_compression so
+    # the synchronous path and the background path can never diverge.
+    from agent.conversation_compression import apply_prepared_candidate
+
+    return apply_prepared_candidate(
+        agent,
+        candidate,
+        messages,
+        system_message,
+        controller=controller,
+    )
+
+
+__all__ = [
+    "BackgroundCompressionConfig",
+    "BackgroundCompressionController",
+    "CandidateState",
+    "PreparedCompressionCandidate",
+    "PrepareResult",
+    "align_prefix_boundary",
+    "canonical_prefix_digest",
+    "has_open_tool_call",
+    "maybe_apply_prepared_candidate",
+    "maybe_prepare_background_compression",
+    "merge_candidate_with_live_messages",
+    "validate_candidate",
+]

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -16,6 +16,7 @@ Improvements over v2:
   - Richer tool call/result detail in summarizer input
 """
 
+import copy
 import hashlib
 import json
 import logging
@@ -3119,6 +3120,112 @@ This compaction should PRIORITISE preserving all information related to the focu
     # ------------------------------------------------------------------
     # Main compression entry point
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Background preparation (ContextEngine optional hooks)
+    # ------------------------------------------------------------------
+
+    def clone_for_background(self) -> "ContextCompressor":
+        """Dedicated instance for a background worker.
+
+        ``compress()`` mutates counters, cooldowns and the iterative-summary
+        state, so a background worker must never drive the live instance.
+        The clone carries the same effective configuration plus a copy of the
+        previous summary (for iterative updates), but deliberately no session
+        binding — it cannot persist cooldowns/streaks or touch state.db.
+        """
+        clone = ContextCompressor(
+            model=self.model,
+            threshold_percent=self.threshold_percent,
+            protect_first_n=self.protect_first_n,
+            protect_last_n=self.protect_last_n,
+            summary_target_ratio=self.summary_target_ratio,
+            quiet_mode=self.quiet_mode,
+            summary_model_override=self.summary_model or None,
+            base_url=self.base_url,
+            api_key=self.api_key,
+            config_context_length=self.context_length,
+            provider=self.provider,
+            api_mode=self.api_mode,
+            abort_on_summary_failure=self.abort_on_summary_failure,
+            max_tokens=self.max_tokens,
+        )
+        # Live tuning may have drifted from constructor-derived values
+        # (aux-feasibility auto-lowering, small-context floors, manual
+        # overrides). Copy the effective values so the clone compacts with
+        # exactly the same boundaries the live instance would.
+        clone.threshold_percent = self.threshold_percent
+        clone.threshold_tokens = self.threshold_tokens
+        clone.context_length = self.context_length
+        clone.protect_first_n = self.protect_first_n
+        clone.protect_last_n = self.protect_last_n
+        clone.tail_token_budget = self.tail_token_budget
+        clone._previous_summary = self._previous_summary
+        clone.last_prompt_tokens = self.last_prompt_tokens
+        return clone
+
+    def can_prepare_compression(
+        self, messages: List[Dict[str, Any]], current_tokens: int = None
+    ) -> bool:
+        """Built-in compressor opts in unless automatic compaction is blocked.
+
+        The same cooldown/anti-thrashing breaker that stops synchronous
+        auto-compaction also stops background preparation — a candidate the
+        apply path would refuse is wasted summariser spend.
+        """
+        return not self._automatic_compression_blocked()
+
+    def prepare_compression(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int = None,
+        focus_topic: str = None,
+    ):
+        """Compress a frozen prefix on a dedicated clone.
+
+        Runs inside the background worker. The input is deep-copied before
+        the clone touches it, so neither the live compressor nor the
+        caller's list is ever mutated. Returns a PrepareResult, or None when
+        the clone aborted or made no structural progress.
+        """
+        from agent.async_context_compression import PrepareResult
+
+        clone = self.clone_for_background()
+        frozen = copy.deepcopy(list(messages))
+        compressed = clone.compress(
+            frozen, current_tokens=current_tokens, focus_topic=focus_topic
+        )
+        if clone._last_compress_aborted or not clone._last_compression_made_progress:
+            if not self.quiet_mode:
+                logger.debug(
+                    "background preparation produced no candidate (aborted=%s error=%s)",
+                    clone._last_compress_aborted, clone._last_summary_error,
+                )
+            return None
+        return PrepareResult(
+            messages=compressed,
+            used_fallback=bool(clone._last_summary_fallback_used),
+            summary_error=clone._last_summary_error,
+        )
+
+    def adopt_prepared_state(self, candidate) -> None:
+        """Adopt live bookkeeping after a prepared candidate was committed.
+
+        Mirrors the synchronous post-compression state: the compaction count
+        advances, the candidate's summary becomes the base for the next
+        iterative update, and threshold decisions wait for the next
+        provider-reported usage instead of trusting rough estimates.
+        """
+        self.compression_count += 1
+        prepared = list(candidate.prepared_messages)
+        _idx, summary_body = self._find_latest_context_summary(
+            prepared, 0, len(prepared)
+        )
+        if summary_body:
+            self._previous_summary = summary_body
+        self.last_prompt_tokens = -1
+        self.last_completion_tokens = 0
+        self.awaiting_real_usage_after_compression = True
 
     def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False) -> List[Dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -139,6 +139,53 @@ class ContextEngine(ABC):
         """
         return True
 
+    # -- Optional: background compression preparation ----------------------
+    #
+    # Engines may opt in to background-prepared compression: a frozen,
+    # deep-copied prefix of the conversation is summarized off-thread and
+    # the result is applied later, between turns, after revalidation. All
+    # three hooks default to no-ops so engines written before this feature
+    # keep working unchanged (the feature stays inert for them).
+
+    def can_prepare_compression(
+        self, messages: List[Dict[str, Any]], current_tokens: int = None
+    ) -> bool:
+        """Whether this engine supports preparing compression in background.
+
+        Default False: legacy/plugin engines never receive background work
+        unless they explicitly opt in. Implementations should also return
+        False while temporarily unable to compress (e.g. failure cooldown).
+        """
+        return False
+
+    def prepare_compression(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int = None,
+        focus_topic: str = None,
+    ):
+        """Produce a compressed message list WITHOUT mutating engine state.
+
+        Called from a background worker thread with a frozen deep copy of a
+        conversation prefix. Implementations must run on a dedicated
+        instance/state copy — never on the live engine, whose counters and
+        iterative-summary state belong to the foreground.
+
+        Returns a list of messages, an
+        ``agent.async_context_compression.PrepareResult``, or None when no
+        useful candidate could be produced.
+        """
+        return None
+
+    def adopt_prepared_state(self, candidate) -> None:
+        """Adopt bookkeeping AFTER a prepared candidate was committed.
+
+        ``candidate`` is an
+        ``agent.async_context_compression.PreparedCompressionCandidate``.
+        The default is a no-op.
+        """
+        return None
+
     # -- Optional: session lifecycle ---------------------------------------
 
     def on_session_start(self, session_id: str, **kwargs) -> None:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -175,6 +175,203 @@ class _CompressionLockLeaseRefresher:
                 break
 
 
+class _CompressionLockGuard:
+    """Session-scoped compression lock shared by the synchronous path and the
+    background-candidate apply path.
+
+    Atomic, state.db-backed lock per session_id.  Without this, two AIAgent
+    instances that share the same session_id (most commonly the parent-turn
+    agent and its background-review fork — see ``agent/background_review.py``:
+    ``review_agent.session_id = agent.session_id``) can each call compress()
+    on overlapping snapshots of the same conversation.  Both succeed, both
+    rotate ``agent.session_id`` to a fresh id, both create child sessions in
+    state.db parented to the same old id.  The gateway's SessionEntry only
+    catches one rotation, so the other child becomes an orphan that silently
+    accumulates writes — Damien's repro shape.
+
+    Acquire keyed on the OLD session_id (the rotation target's parent),
+    because that's the id that competing paths see and read from SessionEntry
+    at the start of their own compression attempt.
+
+    Semantics are identical to the historical inline block in
+    ``compress_context()``: the legacy module-skew probe fails open only for
+    the exact structural absence of the lock API; every other lookup or
+    acquisition failure fails closed.  ``release()`` stops the lease
+    refresher and releases holder-qualified, so releasing a lock we never
+    acquired is a no-op.
+    """
+
+    def __init__(self, agent: Any) -> None:
+        self._agent = agent
+        self._db = getattr(agent, "_session_db", None)
+        self._sid = agent.session_id or ""
+        self._holder: Optional[str] = None
+        self._refresher: Optional[_CompressionLockLeaseRefresher] = None
+        self.acquired = False
+
+    @property
+    def session_id(self) -> str:
+        return self._sid
+
+    def acquire(self, *, emit_busy_warning: bool = True) -> bool:
+        agent = self._agent
+        _lock_db = self._db
+        _lock_sid = self._sid
+        if _lock_db is None or not _lock_sid:
+            # Nothing to lock against — historical behavior proceeds unlocked.
+            self.acquired = True
+            return True
+
+        # Probe whether the lock subsystem is actually available on this
+        # SessionDB instance. A process running mismatched module versions can
+        # have this call site while its long-lived SessionDB instance predates
+        # the lock API. Only that structural absence is safe to fail open for:
+        # compression must make progress rather than spin forever after an
+        # update. Once the method has been resolved, every exception from its
+        # implementation fails closed because proceeding without a lock can
+        # fork the session lineage.
+        _try_acquire_lock = None
+        _lock_lookup_error: Optional[Exception] = None
+        _legacy_session_db_without_lock_api = False
+        try:
+            _legacy_session_db_without_lock_api = _lock_api_is_absent_on_session_db(
+                _lock_db
+            )
+        except Exception as exc:
+            _lock_lookup_error = exc
+        if _lock_lookup_error is None and not _legacy_session_db_without_lock_api:
+            try:
+                _try_acquire_lock = _lock_db.try_acquire_compression_lock
+                if not callable(_try_acquire_lock):
+                    _lock_lookup_error = TypeError(
+                        "compression lock API is present but not callable"
+                    )
+            except Exception as exc:
+                _lock_lookup_error = exc
+
+        try:
+            _lock_ttl = float(
+                getattr(agent, "_compression_lock_ttl_seconds", 300.0) or 300.0
+            )
+        except (TypeError, ValueError):
+            _lock_ttl = 300.0
+        _lock_refresh_interval = getattr(
+            agent, "_compression_lock_refresh_interval", None
+        )
+
+        _lock_holder = _compression_lock_holder(agent)
+        if _lock_lookup_error is not None:
+            # Attribute lookup itself failed for a reason other than a missing
+            # lock API. It is unsafe to proceed without a lock in that case.
+            logger.warning(
+                "compression lock lookup raised unexpectedly for session=%s "
+                "(%s: %s) — skipping compression this cycle",
+                _lock_sid,
+                type(_lock_lookup_error).__name__,
+                _lock_lookup_error,
+            )
+            self.acquired = False
+            return False
+        if _try_acquire_lock is None:
+            # The lock API itself is absent on this in-memory instance. Log
+            # once and proceed unlocked so an update-version skew cannot leave
+            # the outer auto-compression loop making no progress forever.
+            if getattr(agent, "_last_compression_lock_error_sid", None) != _lock_sid:
+                agent._last_compression_lock_error_sid = _lock_sid
+                logger.warning(
+                    "compression lock subsystem unavailable for session=%s "
+                    "— proceeding without lock. This usually means a stale "
+                    "in-memory module after an update; restart the process "
+                    "(or `hermes update`) to resync.",
+                    _lock_sid,
+                )
+            self._holder = None
+            self.acquired = True  # acquired-but-unlocked compatibility path
+            return True
+
+        try:
+            _lock_acquired = _try_acquire_lock(
+                _lock_sid, _lock_holder, ttl_seconds=_lock_ttl
+            )
+        except Exception as _lock_err:
+            # The method exists and entered its implementation but failed.
+            # Do not mistake an internal AttributeError or TypeError for
+            # version skew: fail closed and preserve session lineage. A
+            # failure after SQLite committed the acquire can leave our
+            # holder row behind, so release it best-effort before returning;
+            # release is holder-qualified and safe when acquisition never
+            # succeeded.
+            try:
+                _lock_db.release_compression_lock(_lock_sid, _lock_holder)
+            except Exception as _release_err:
+                logger.debug(
+                    "compression lock cleanup after failed acquire failed: %s",
+                    _release_err,
+                )
+            logger.warning(
+                "compression lock acquisition raised unexpectedly for "
+                "session=%s (%s: %s) — skipping compression this cycle",
+                _lock_sid,
+                type(_lock_err).__name__,
+                _lock_err,
+            )
+            self.acquired = False
+            return False
+
+        if not _lock_acquired:
+            try:
+                existing = _lock_db.get_compression_lock_holder(_lock_sid)
+            except Exception:
+                existing = None
+            logger.warning(
+                "compression skipped: another path is compressing session=%s "
+                "(holder=%s) — returning messages unchanged to avoid session fork",
+                _lock_sid,
+                existing,
+            )
+            # Surface to the user once — quiet for downstream auto-compress
+            # loops. The background apply path passes emit_busy_warning=False:
+            # silently stepping aside IS its designed behavior, not a
+            # user-facing anomaly.
+            if emit_busy_warning and getattr(
+                agent, "_last_compression_lock_warning_sid", None
+            ) != _lock_sid:
+                agent._last_compression_lock_warning_sid = _lock_sid
+                try:
+                    agent._emit_warning(
+                        "⚠ Skipping concurrent compression — another path "
+                        "is already compressing this session. Will retry "
+                        "after it finishes."
+                    )
+                except Exception:
+                    pass
+            self.acquired = False
+            return False
+
+        self._holder = _lock_holder
+        self._refresher = _CompressionLockLeaseRefresher(
+            _lock_db,
+            _lock_sid,
+            _lock_holder,
+            _lock_ttl,
+            _lock_refresh_interval,
+        ).start()
+        self.acquired = True
+        return True
+
+    def release(self) -> None:
+        """Release the lock keyed on the OLD session_id (before rotation)."""
+        if self._refresher is not None:
+            self._refresher.stop()
+            self._refresher = None
+        if self._db is not None and self._sid and self._holder:
+            try:
+                self._db.release_compression_lock(self._sid, self._holder)
+            except Exception as _rel_err:
+                logger.debug("compression lock release failed: %s", _rel_err)
+            self._holder = None
+
+
 def check_compression_model_feasibility(agent: Any) -> None:
     """Warn at session start if the auxiliary compression model's context
     window is smaller than the main model's compression threshold.
@@ -543,9 +740,6 @@ def compress_context(
     # engine session-switch. The conversation keeps one durable id for life,
     # eliminating the session-rotation bug cluster. Default False during rollout.
     in_place = bool(getattr(agent, "compression_in_place", False))
-    # Set True once the in-place DB write actually completes (the DB block can
-    # raise and skip it). Surfaced to the gateway via agent._last_compaction_in_place.
-    compacted_in_place = False
     logger.info(
         "context compression started: session=%s messages=%d tokens=~%s model=%s focus=%r",
         agent.session_id or "none", _pre_msg_count,
@@ -555,20 +749,8 @@ def compress_context(
     agent._emit_status(COMPACTION_STATUS)
 
     # ── Compression lock ────────────────────────────────────────────────
-    # Atomic, state.db-backed lock per session_id.  Without this, two
-    # AIAgent instances that share the same session_id (most commonly the
-    # parent-turn agent and its background-review fork — see
-    # ``agent/background_review.py``: ``review_agent.session_id =
-    # agent.session_id``) can each call compress() on overlapping
-    # snapshots of the same conversation.  Both succeed, both rotate
-    # ``agent.session_id`` to a fresh id, both create child sessions in
-    # state.db parented to the same old id.  The gateway's SessionEntry
-    # only catches one rotation, so the other child becomes an orphan
-    # that silently accumulates writes — Damien's repro shape.
-    #
-    # Acquire keyed on the OLD session_id (the rotation target's parent),
-    # because that's the id that competing paths see and read from
-    # SessionEntry at the start of their own compression attempt.
+    # See _CompressionLockGuard for the full rationale (orphan-session fork
+    # protection, legacy-skew fail-open rules, lease refresh).
     #
     # If we can't acquire the lock, another path is mid-compression on
     # this session.  Aborting is correct: the messages are unchanged, the
@@ -576,139 +758,16 @@ def compress_context(
     # and our caller's auto-compress loop sees ``len(returned) == len(input)``
     # and stops retrying for this cycle. The session is NOT corrupted —
     # we just sit out this round and let the winner finish.
-    _lock_db = getattr(agent, "_session_db", None)
-    _lock_sid = agent.session_id or ""
-    _lock_holder: Optional[str] = None
-    # Probe whether the lock subsystem is actually available on this
-    # SessionDB instance. A process running mismatched module versions can have
-    # this call site while its long-lived SessionDB instance predates the lock
-    # API. Only that structural absence is safe to fail open for: compression
-    # must make progress rather than spin forever after an update. Once the
-    # method has been resolved, every exception from its implementation fails
-    # closed because proceeding without a lock can fork the session lineage.
-    _try_acquire_lock = None
-    _lock_lookup_error: Optional[Exception] = None
-    _legacy_session_db_without_lock_api = False
-    if _lock_db is not None:
-        try:
-            _legacy_session_db_without_lock_api = _lock_api_is_absent_on_session_db(
-                _lock_db
-            )
-        except Exception as exc:
-            _lock_lookup_error = exc
-        if _lock_lookup_error is None and not _legacy_session_db_without_lock_api:
-            try:
-                _try_acquire_lock = _lock_db.try_acquire_compression_lock
-                if not callable(_try_acquire_lock):
-                    _lock_lookup_error = TypeError(
-                        "compression lock API is present but not callable"
-                    )
-            except Exception as exc:
-                _lock_lookup_error = exc
-    try:
-        _lock_ttl = float(getattr(agent, "_compression_lock_ttl_seconds", 300.0) or 300.0)
-    except (TypeError, ValueError):
-        _lock_ttl = 300.0
-    _lock_refresh_interval = getattr(agent, "_compression_lock_refresh_interval", None)
-    _lock_refresher: Optional[_CompressionLockLeaseRefresher] = None
-    if _lock_db is not None and _lock_sid:
-        _lock_holder = _compression_lock_holder(agent)
-        if _lock_lookup_error is not None:
-            # Attribute lookup itself failed for a reason other than a missing
-            # lock API. It is unsafe to proceed without a lock in that case.
-            _lock_holder = None
-            logger.warning(
-                "compression lock lookup raised unexpectedly for session=%s "
-                "(%s: %s) — skipping compression this cycle",
-                _lock_sid, type(_lock_lookup_error).__name__, _lock_lookup_error,
-            )
-            _lock_acquired = False
-        elif _try_acquire_lock is None:
-            # The lock API itself is absent on this in-memory instance. Log once
-            # and proceed unlocked so an update-version skew cannot leave the
-            # outer auto-compression loop making no progress forever.
-            _lock_holder = None
-            if getattr(agent, "_last_compression_lock_error_sid", None) != _lock_sid:
-                agent._last_compression_lock_error_sid = _lock_sid
-                logger.warning(
-                    "compression lock subsystem unavailable for session=%s "
-                    "— proceeding without lock. This usually means a stale "
-                    "in-memory module after an update; restart the process "
-                    "(or `hermes update`) to resync.",
-                    _lock_sid,
-                )
-            _lock_acquired = True  # acquired-but-unlocked compatibility path
-        else:
-            try:
-                _lock_acquired = _try_acquire_lock(
-                    _lock_sid, _lock_holder, ttl_seconds=_lock_ttl
-                )
-            except Exception as _lock_err:
-                # The method exists and entered its implementation but failed.
-                # Do not mistake an internal AttributeError or TypeError for
-                # version skew: fail closed and preserve session lineage. A
-                # failure after SQLite committed the acquire can leave our
-                # holder row behind, so release it best-effort before returning
-                # unchanged messages; release is holder-qualified and safe when
-                # acquisition never succeeded.
-                try:
-                    _lock_db.release_compression_lock(_lock_sid, _lock_holder)
-                except Exception as _release_err:
-                    logger.debug(
-                        "compression lock cleanup after failed acquire failed: %s",
-                        _release_err,
-                    )
-                _lock_holder = None
-                logger.warning(
-                    "compression lock acquisition raised unexpectedly for "
-                    "session=%s (%s: %s) — skipping compression this cycle",
-                    _lock_sid, type(_lock_err).__name__, _lock_err,
-                )
-                _lock_acquired = False
-        if not _lock_acquired:
-            try:
-                existing = _lock_db.get_compression_lock_holder(_lock_sid)
-            except Exception:
-                existing = None
-            logger.warning(
-                "compression skipped: another path is compressing session=%s "
-                "(holder=%s) — returning messages unchanged to avoid session fork",
-                _lock_sid, existing,
-            )
-            _lock_holder = None  # don't release a lock we don't own
-            # Surface to the user once — quiet for downstream auto-compress loops
-            if getattr(agent, "_last_compression_lock_warning_sid", None) != _lock_sid:
-                agent._last_compression_lock_warning_sid = _lock_sid
-                try:
-                    agent._emit_warning(
-                        "⚠ Skipping concurrent compression — another path "
-                        "is already compressing this session. Will retry "
-                        "after it finishes."
-                    )
-                except Exception:
-                    pass
-            _existing_sp = getattr(agent, "_cached_system_prompt", None)
-            if not _existing_sp:
-                _existing_sp = agent._build_system_prompt(system_message)
-            return messages, _existing_sp
-        if _lock_holder is not None:
-            _lock_refresher = _CompressionLockLeaseRefresher(
-                _lock_db,
-                _lock_sid,
-                _lock_holder,
-                _lock_ttl,
-                _lock_refresh_interval,
-            ).start()
+    _lock_guard = _CompressionLockGuard(agent)
+    if not _lock_guard.acquire():
+        _existing_sp = getattr(agent, "_cached_system_prompt", None)
+        if not _existing_sp:
+            _existing_sp = agent._build_system_prompt(system_message)
+        return messages, _existing_sp
 
     def _release_lock() -> None:
         """Release the lock keyed on the OLD session_id (before rotation)."""
-        if _lock_refresher is not None:
-            _lock_refresher.stop()
-        if _lock_db is not None and _lock_sid and _lock_holder:
-            try:
-                _lock_db.release_compression_lock(_lock_sid, _lock_holder)
-            except Exception as _rel_err:
-                logger.debug("compression lock release failed: %s", _rel_err)
+        _lock_guard.release()
 
     # Notify external memory provider before compression discards context
     if agent._memory_manager:
@@ -781,326 +840,26 @@ def compress_context(
         return messages, _existing_sp
 
     try:
-        summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
-        if summary_error:
-            if getattr(agent, "_last_compression_summary_warning", None) != summary_error:
-                agent._last_compression_summary_warning = summary_error
-                agent._emit_warning(
-                    f"⚠ Compression summary failed: {summary_error}. "
-                    "Inserted a fallback context marker."
-                )
-        else:
-            # No hard failure — but did the configured aux model error out
-            # and get recovered by retrying on main?  Surface that so users
-            # know their auxiliary.compression.model setting is broken even
-            # though compression succeeded.
-            _aux_fail_model = getattr(agent.context_compressor, "_last_aux_model_failure_model", None)
-            _aux_fail_err = getattr(agent.context_compressor, "_last_aux_model_failure_error", None)
-            if _aux_fail_model:
-                # Dedup on (model, error) so we don't spam on every compaction
-                _aux_key = (_aux_fail_model, _aux_fail_err)
-                if getattr(agent, "_last_aux_fallback_warning_key", None) != _aux_key:
-                    agent._last_aux_fallback_warning_key = _aux_key
-                    agent._emit_warning(
-                        f"ℹ Configured compression model '{_aux_fail_model}' failed "
-                        f"({_aux_fail_err or 'unknown error'}). Recovered using main model — "
-                        "check auxiliary.compression.model in config.yaml."
-                    )
-
-        todo_snapshot = agent._todo_store.format_for_injection()
-        if todo_snapshot:
-            compressed.append({"role": "user", "content": todo_snapshot})
-        _ensure_compressed_has_user_turn(messages, compressed)
-
-        agent._invalidate_system_prompt()
-        new_system_prompt = agent._build_system_prompt(system_message)
-        agent._cached_system_prompt = new_system_prompt
-
-        if agent._session_db:
-            try:
-                # Trigger memory extraction on the current session before the
-                # transcript is rewritten (runs in BOTH modes — the logical
-                # conversation's pre-compaction turns are about to be summarized
-                # away regardless of whether the id rotates).
-                agent.commit_memory_session(messages)
-
-                if in_place:
-                    # ── In-place compaction: keep the same session_id ──────────
-                    # No end_session, no new row, no parent_session_id, no title
-                    # renumber, no contextvar/env/logging re-sync. The session's
-                    # id, title, cwd, /goal, and gateway routing all stay put.
-                    #
-                    # Durable, NON-DESTRUCTIVE replace: soft-archive the
-                    # pre-compaction turns (active=0, kept on disk + FTS-searchable +
-                    # recoverable) and insert `compressed` as the new live (active=1)
-                    # set, atomically. `compressed` already carries the surviving
-                    # tail (current-turn messages the compressor kept via
-                    # protect_last_n), so we DON'T pre-flush here — a flush would
-                    # INSERT current-turn rows that archive_and_compact would then
-                    # archive alongside the rest (harmless but wasted writes). The
-                    # live-context load filters active=1, so a resume reloads ONLY
-                    # the compacted set; the original turns remain under the SAME id
-                    # for search/recovery (Teknium review — keep one durable id
-                    # WITHOUT destroying history, unlike a hard replace_messages).
-                    # See #38763.
-                    agent._session_db.archive_and_compact(agent.session_id, compressed)
-                    # Reset the flush identity set so the next turn's appends are
-                    # diffed against the COMPACTED transcript: the compacted dicts
-                    # are passed as conversation_history next turn and skipped by
-                    # identity, so only genuinely new turn messages get appended
-                    # (no dup of the summary, no resurrection of dropped turns).
-                    agent._flushed_db_message_ids = set()
-                    # Rotation-independent signal: the conversation was compacted in
-                    # place (id unchanged). The gateway reads this (NOT an id-change
-                    # diff) to re-baseline transcript handling.
-                    compacted_in_place = True
-                else:
-                    # ── Rotation (legacy): end this session, fork a continuation ─
-                    # Flush any un-persisted current-turn messages to the OLD
-                    # session before ending it, so they survive in the preserved
-                    # parent transcript (#47202). (In-place skips this — see above.)
-                    try:
-                        agent._flush_messages_to_session_db(messages)
-                    except Exception:
-                        pass  # best-effort — don't block compression on a flush error
-                    # Propagate title to the new session with auto-numbering
-                    old_title = agent._session_db.get_session_title(agent.session_id)
-                    agent._session_db.end_session(agent.session_id, "compression")
-                    old_session_id = agent.session_id
-                    agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
-                    # Ordering contract: the agent thread updates the contextvar here;
-                    # the gateway propagates to SessionEntry after run_in_executor returns.
-                    try:
-                        from gateway.session_context import set_current_session_id
-
-                        set_current_session_id(agent.session_id)
-                    except Exception:
-                        os.environ["HERMES_SESSION_ID"] = agent.session_id
-                    # The gateway/tools session context (ContextVar + env) and the
-                    # logging session context are SEPARATE mechanisms. The call above
-                    # moves the former; the ``[session_id]`` tag on log lines comes
-                    # from ``hermes_logging._session_context`` (set once per turn in
-                    # conversation_loop.py). Without this, post-rotation log lines in
-                    # the same turn keep the STALE old id while the message/DB/gateway
-                    # state carry the new one — breaking log correlation exactly at the
-                    # compaction boundary (see #34089). Guarded separately so a logging
-                    # failure can never regress the routing update above.
-                    try:
-                        from hermes_logging import set_session_context
-
-                        set_session_context(agent.session_id)
-                    except Exception:
-                        pass
-                    agent._session_db_created = False
-                    try:
-                        agent._session_db.create_session(
-                            session_id=agent.session_id,
-                            source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
-                            model=agent.model,
-                            model_config=agent._session_init_model_config,
-                            parent_session_id=old_session_id,
-                        )
-                    except Exception as _cs_err:
-                        # The child row could not be created (e.g. FK constraint,
-                        # contended write). Previously the outer handler simply
-                        # warned and let the agent continue on the NEW id — which
-                        # has no row in state.db, producing an orphan: the parent
-                        # is ended, the child is never indexed, and every
-                        # subsequent message is attributed to a session that
-                        # doesn't exist (#33906/#33907). Roll the live id back to
-                        # the parent so the conversation stays attached to a real,
-                        # indexed session instead of a phantom.
-                        logger.warning(
-                            "Compression child session create failed (%s) — "
-                            "rolling back to parent session %s to avoid an orphan.",
-                            _cs_err, old_session_id,
-                        )
-                        agent.session_id = old_session_id
-                        try:
-                            from gateway.session_context import set_current_session_id
-                            set_current_session_id(agent.session_id)
-                        except Exception:
-                            os.environ["HERMES_SESSION_ID"] = agent.session_id
-                        try:
-                            from hermes_logging import set_session_context
-                            set_session_context(agent.session_id)
-                        except Exception:
-                            pass
-                        # Re-open the parent: it was ended above, but we're
-                        # continuing on it, so it must not stay closed.
-                        try:
-                            agent._session_db.reopen_session(old_session_id)
-                        except Exception:
-                            pass
-                        old_session_id = None  # no rotation happened
-                        # The parent row already exists in state.db, so mark the
-                        # session as created — _ensure_db_session would otherwise
-                        # retry a (harmless INSERT OR IGNORE) create next turn.
-                        agent._session_db_created = True
-                        raise
-                    agent._session_db_created = True
-                    # Carry a persistent /goal onto the continuation session.
-                    # Compression mints a fresh child id; load_goal does a flat
-                    # per-session lookup with no parent walk, so without this an
-                    # active goal silently dies at the boundary (#33618).
-                    try:
-                        from hermes_cli.goals import migrate_goal_to_session
-                        migrate_goal_to_session(old_session_id, agent.session_id, reason="compression")
-                    except Exception as _goal_err:
-                        logger.debug("Could not migrate goal on compression: %s", _goal_err)
-                    # Auto-number the title for the continuation session
-                    if old_title:
-                        try:
-                            new_title = agent._session_db.get_next_title_in_lineage(old_title)
-                            agent._session_db.set_session_title(agent.session_id, new_title)
-                        except (ValueError, Exception) as e:
-                            logger.debug("Could not propagate title on compression: %s", e)
-
-                # Shared post-write steps (both modes target agent.session_id, which
-                # in-place keeps and rotation has already reassigned to the new id):
-                # refresh the stored system prompt and reset the flush cursor so the
-                # next turn re-bases its append diff.
-                agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
-                agent._last_flushed_db_idx = 0
-            except Exception as e:
-                # If the rotation rolled back to the parent (orphan-avoidance
-                # above), agent.session_id is the still-indexed parent and
-                # old_session_id was cleared — so this is recovery, not an
-                # un-indexed orphan. Otherwise an earlier step failed before the
-                # child was created and the warning's original meaning holds.
-                if locals().get("old_session_id") is None and not in_place:
-                    logger.warning(
-                        "Compression rotation aborted and rolled back to the "
-                        "parent session (%s): %s", agent.session_id or "?", e,
-                    )
-                else:
-                    logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
-
-        # Compaction-boundary bookkeeping, computed once. `old_session_id` is only
-        # bound in the rotation branch; in-place leaves it unset. `_boundary_parent`
-        # is the id the boundary notifications attribute the prior state to: the old
-        # id on rotation, the (unchanged) current id in-place.
-        _old_sid = locals().get("old_session_id")
-        _is_boundary = bool(_old_sid) or in_place
-        _boundary_parent = _old_sid or agent.session_id or ""
-
-        # Notify the context engine that a compaction boundary occurred. Plugin
-        # engines (e.g. hermes-lcm) use boundary_reason="compression" to preserve
-        # DAG lineage / checkpoint per-session state across the boundary instead of
-        # re-initializing fresh. See hermes-lcm#68. Built-in ContextCompressor
-        # ignores kwargs. Fires in BOTH modes: rotation passes old→new ids; in-place
-        # passes the SAME id (the boundary is real even though the id didn't move).
-        try:
-            if _is_boundary and hasattr(agent.context_compressor, "on_session_start"):
-                agent.context_compressor.on_session_start(
-                    agent.session_id or "",
-                    boundary_reason="compression",
-                    old_session_id=_boundary_parent,
-                    platform=getattr(agent, "platform", None) or "cli",
-                    conversation_id=getattr(agent, "_gateway_session_key", None),
-                )
-        except Exception as _ce_err:
-            logger.debug("context engine on_session_start (compression): %s", _ce_err)
-
-        # Notify memory providers of the compaction boundary so provider-cached
-        # per-session state (Hindsight's _document_id, accumulated turn buffers,
-        # counters) refreshes. reset=False because the logical conversation
-        # continues. See #6672. Fires in BOTH modes: in-place uses the same id as
-        # parent (the conversation didn't fork, but the buffer must still be told
-        # the transcript was compacted so it doesn't double-count dropped turns).
-        try:
-            if _is_boundary and agent._memory_manager:
-                agent._memory_manager.on_session_switch(
-                    agent.session_id or "",
-                    parent_session_id=_boundary_parent,
-                    reset=False,
-                    reason="compression",
-                )
-        except Exception as _me_err:
-            logger.debug("memory manager on_session_switch (compression): %s", _me_err)
-
-        # Warn on repeated compressions (quality degrades with each pass).
-        # Route through _emit_status (like the other compression warnings above)
-        # so the warning reaches the TUI / Telegram / Discord via status_callback,
-        # not just CLI stdout. _emit_status still _vprints for the CLI, and
-        # storing it on _compression_warning lets replay_compression_warning
-        # re-deliver it once a late-bound gateway status_callback is wired (#36908).
-        _cc = agent.context_compressor.compression_count
-        if _cc >= 2:
-            _cc_msg = (
-                f"{agent.log_prefix}⚠️  Session compressed {_cc} times — "
-                f"accuracy may degrade. Consider /new to start fresh."
-            )
-            agent._compression_warning = _cc_msg
-            agent._emit_status(_cc_msg)
-
-        # Emit session:compress event so hooks (e.g. MemPalace sync) can ingest
-        # the completed old session before its details are lost. In in-place mode
-        # there is no old id (same session); ``in_place=True`` tells hooks the
-        # transcript was compacted on the same id rather than rotated.
-        if getattr(agent, "event_callback", None):
-            try:
-                agent.event_callback("session:compress", {
-                    "platform": agent.platform or "",
-                    "session_id": agent.session_id,
-                    "old_session_id": _old_sid or "",
-                    "in_place": in_place,
-                    "compression_count": agent.context_compressor.compression_count,
-                })
-            except Exception as e:
-                logger.debug("event_callback error on session:compress: %s", e)
-
-        # Surface the compaction mode to the caller (run_conversation / gateway)
-        # via a rotation-independent flag. The gateway uses this — NOT an
-        # id-change diff — to re-baseline transcript handling (history_offset=0 +
-        # rewrite on the same id) when compaction happened in place. See #38763.
-        agent._last_compaction_in_place = compacted_in_place
-
-        # Keep the post-compression rough estimate for diagnostics, but do not
-        # treat it as provider-reported prompt usage. Schema-heavy rough estimates
-        # can remain above threshold even after the next real API request fits.
-        _compressed_est = estimate_request_tokens_rough(
+        return _commit_compressed_transcript(
+            agent,
+            messages,
             compressed,
-            system_prompt=new_system_prompt or "",
-            tools=agent.tools or None,
+            system_message,
+            in_place=in_place,
+            pre_msg_count=_pre_msg_count,
+            made_progress=_compression_made_progress,
+            used_fallback=_compression_used_fallback,
+            summary_error=getattr(
+                agent.context_compressor, "_last_summary_error", None
+            ),
+            aux_failure_model=getattr(
+                agent.context_compressor, "_last_aux_model_failure_model", None
+            ),
+            aux_failure_error=getattr(
+                agent.context_compressor, "_last_aux_model_failure_error", None
+            ),
+            task_id=task_id,
         )
-        agent.context_compressor.last_compression_rough_tokens = _compressed_est
-        agent.context_compressor.last_prompt_tokens = -1
-        agent.context_compressor.last_completion_tokens = 0
-        agent.context_compressor.awaiting_real_usage_after_compression = True
-        # Arm the effectiveness verdict only after a completed rewrite crosses
-        # the full compaction boundary. Exceptions, aborts, and no-op attempts
-        # leave this false, so unrelated later usage cannot be charged to an
-        # attempt that never changed the transcript.
-        if _compression_made_progress:
-            record_boundary = getattr(
-                type(agent.context_compressor),
-                "record_completed_compaction",
-                None,
-            )
-            if callable(record_boundary):
-                record_boundary(
-                    agent.context_compressor,
-                    used_fallback=_compression_used_fallback,
-                )
-            else:
-                agent.context_compressor._verify_compaction_cleared_threshold = True
-
-        # Clear the file-read dedup cache.  After compression the original
-        # read content is summarised away — if the model re-reads the same
-        # file it needs the full content, not a "file unchanged" stub.
-        try:
-            from tools.file_tools import reset_file_dedup
-            reset_file_dedup(task_id)
-        except Exception:
-            pass
-
-        logger.info(
-            "context compression done: session=%s messages=%d->%d rough_tokens=~%s awaiting_real_usage=true",
-            agent.session_id or "none", _pre_msg_count, len(compressed),
-            f"{_compressed_est:,}",
-        )
-        return compressed, new_system_prompt
     finally:
         # Release the lock on the OLD session_id only AFTER rotation completed
         # and all post-rotation bookkeeping (memory manager, context engine,
@@ -1108,6 +867,473 @@ def compress_context(
         # release will see the NEW session_id in state.db / SessionEntry and
         # acquire on that — no race against our just-finished work.
         _release_lock()
+
+
+def _commit_compressed_transcript(
+    agent: Any,
+    messages: list,
+    compressed: list,
+    system_message: str,
+    *,
+    in_place: bool,
+    pre_msg_count: int,
+    made_progress: bool,
+    used_fallback: bool,
+    summary_error: Optional[str],
+    aux_failure_model: Optional[str],
+    aux_failure_error: Optional[str],
+    task_id: str = "default",
+) -> Tuple[list, str]:
+    """Atomically commit an already-compressed transcript.
+
+    This is the single shared "apply" implementation: the synchronous
+    ``compress_context()`` path calls it right after the compressor returns,
+    and the background-candidate path calls it from
+    ``apply_prepared_candidate()`` after revalidation. Callers MUST hold the
+    per-session compression lock (see ``_CompressionLockGuard``) for the
+    whole call and release it only after this returns.
+
+    Everything the historical inline body did is preserved verbatim: memory
+    flush, todo snapshot, the restored-user-turn guard, system prompt
+    invalidation/rebuild, in-place ``archive_and_compact()`` vs legacy
+    rotation (including orphan rollback), the ``_flushed_db_message_ids``
+    rebaseline, goal/title migration, context-engine and memory-manager
+    boundary notifications, repeated-compression warnings, the
+    ``session:compress`` event, ``_last_compaction_in_place``, the rough
+    post-compression estimate + awaiting-real-usage arming, boundary-quality
+    recording and the file-read dedup reset.
+    """
+    compacted_in_place = False
+    if summary_error:
+        if getattr(agent, "_last_compression_summary_warning", None) != summary_error:
+            agent._last_compression_summary_warning = summary_error
+            agent._emit_warning(
+                f"⚠ Compression summary failed: {summary_error}. "
+                "Inserted a fallback context marker."
+            )
+    else:
+        # No hard failure — but did the configured aux model error out
+        # and get recovered by retrying on main?  Surface that so users
+        # know their auxiliary.compression.model setting is broken even
+        # though compression succeeded.
+        _aux_fail_model = aux_failure_model
+        _aux_fail_err = aux_failure_error
+        if _aux_fail_model:
+            # Dedup on (model, error) so we don't spam on every compaction
+            _aux_key = (_aux_fail_model, _aux_fail_err)
+            if getattr(agent, "_last_aux_fallback_warning_key", None) != _aux_key:
+                agent._last_aux_fallback_warning_key = _aux_key
+                agent._emit_warning(
+                    f"ℹ Configured compression model '{_aux_fail_model}' failed "
+                    f"({_aux_fail_err or 'unknown error'}). Recovered using main model — "
+                    "check auxiliary.compression.model in config.yaml."
+                )
+
+    todo_snapshot = agent._todo_store.format_for_injection()
+    if todo_snapshot:
+        compressed.append({"role": "user", "content": todo_snapshot})
+    _ensure_compressed_has_user_turn(messages, compressed)
+
+    agent._invalidate_system_prompt()
+    new_system_prompt = agent._build_system_prompt(system_message)
+    agent._cached_system_prompt = new_system_prompt
+
+    if agent._session_db:
+        try:
+            # Trigger memory extraction on the current session before the
+            # transcript is rewritten (runs in BOTH modes — the logical
+            # conversation's pre-compaction turns are about to be summarized
+            # away regardless of whether the id rotates).
+            agent.commit_memory_session(messages)
+
+            if in_place:
+                # ── In-place compaction: keep the same session_id ──────────
+                # No end_session, no new row, no parent_session_id, no title
+                # renumber, no contextvar/env/logging re-sync. The session's
+                # id, title, cwd, /goal, and gateway routing all stay put.
+                #
+                # Durable, NON-DESTRUCTIVE replace: soft-archive the
+                # pre-compaction turns (active=0, kept on disk + FTS-searchable +
+                # recoverable) and insert `compressed` as the new live (active=1)
+                # set, atomically. `compressed` already carries the surviving
+                # tail (current-turn messages the compressor kept via
+                # protect_last_n), so we DON'T pre-flush here — a flush would
+                # INSERT current-turn rows that archive_and_compact would then
+                # archive alongside the rest (harmless but wasted writes). The
+                # live-context load filters active=1, so a resume reloads ONLY
+                # the compacted set; the original turns remain under the SAME id
+                # for search/recovery (Teknium review — keep one durable id
+                # WITHOUT destroying history, unlike a hard replace_messages).
+                # See #38763.
+                agent._session_db.archive_and_compact(agent.session_id, compressed)
+                # Reset the flush identity set so the next turn's appends are
+                # diffed against the COMPACTED transcript: the compacted dicts
+                # are passed as conversation_history next turn and skipped by
+                # identity, so only genuinely new turn messages get appended
+                # (no dup of the summary, no resurrection of dropped turns).
+                agent._flushed_db_message_ids = set()
+                # Rotation-independent signal: the conversation was compacted in
+                # place (id unchanged). The gateway reads this (NOT an id-change
+                # diff) to re-baseline transcript handling.
+                compacted_in_place = True
+            else:
+                # ── Rotation (legacy): end this session, fork a continuation ─
+                # Flush any un-persisted current-turn messages to the OLD
+                # session before ending it, so they survive in the preserved
+                # parent transcript (#47202). (In-place skips this — see above.)
+                try:
+                    agent._flush_messages_to_session_db(messages)
+                except Exception:
+                    pass  # best-effort — don't block compression on a flush error
+                # Propagate title to the new session with auto-numbering
+                old_title = agent._session_db.get_session_title(agent.session_id)
+                agent._session_db.end_session(agent.session_id, "compression")
+                old_session_id = agent.session_id
+                agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                # Ordering contract: the agent thread updates the contextvar here;
+                # the gateway propagates to SessionEntry after run_in_executor returns.
+                try:
+                    from gateway.session_context import set_current_session_id
+
+                    set_current_session_id(agent.session_id)
+                except Exception:
+                    os.environ["HERMES_SESSION_ID"] = agent.session_id
+                # The gateway/tools session context (ContextVar + env) and the
+                # logging session context are SEPARATE mechanisms. The call above
+                # moves the former; the ``[session_id]`` tag on log lines comes
+                # from ``hermes_logging._session_context`` (set once per turn in
+                # conversation_loop.py). Without this, post-rotation log lines in
+                # the same turn keep the STALE old id while the message/DB/gateway
+                # state carry the new one — breaking log correlation exactly at the
+                # compaction boundary (see #34089). Guarded separately so a logging
+                # failure can never regress the routing update above.
+                try:
+                    from hermes_logging import set_session_context
+
+                    set_session_context(agent.session_id)
+                except Exception:
+                    pass
+                agent._session_db_created = False
+                try:
+                    agent._session_db.create_session(
+                        session_id=agent.session_id,
+                        source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                        model=agent.model,
+                        model_config=agent._session_init_model_config,
+                        parent_session_id=old_session_id,
+                    )
+                except Exception as _cs_err:
+                    # The child row could not be created (e.g. FK constraint,
+                    # contended write). Previously the outer handler simply
+                    # warned and let the agent continue on the NEW id — which
+                    # has no row in state.db, producing an orphan: the parent
+                    # is ended, the child is never indexed, and every
+                    # subsequent message is attributed to a session that
+                    # doesn't exist (#33906/#33907). Roll the live id back to
+                    # the parent so the conversation stays attached to a real,
+                    # indexed session instead of a phantom.
+                    logger.warning(
+                        "Compression child session create failed (%s) — "
+                        "rolling back to parent session %s to avoid an orphan.",
+                        _cs_err, old_session_id,
+                    )
+                    agent.session_id = old_session_id
+                    try:
+                        from gateway.session_context import set_current_session_id
+                        set_current_session_id(agent.session_id)
+                    except Exception:
+                        os.environ["HERMES_SESSION_ID"] = agent.session_id
+                    try:
+                        from hermes_logging import set_session_context
+                        set_session_context(agent.session_id)
+                    except Exception:
+                        pass
+                    # Re-open the parent: it was ended above, but we're
+                    # continuing on it, so it must not stay closed.
+                    try:
+                        agent._session_db.reopen_session(old_session_id)
+                    except Exception:
+                        pass
+                    old_session_id = None  # no rotation happened
+                    # The parent row already exists in state.db, so mark the
+                    # session as created — _ensure_db_session would otherwise
+                    # retry a (harmless INSERT OR IGNORE) create next turn.
+                    agent._session_db_created = True
+                    raise
+                agent._session_db_created = True
+                # Carry a persistent /goal onto the continuation session.
+                # Compression mints a fresh child id; load_goal does a flat
+                # per-session lookup with no parent walk, so without this an
+                # active goal silently dies at the boundary (#33618).
+                try:
+                    from hermes_cli.goals import migrate_goal_to_session
+                    migrate_goal_to_session(old_session_id, agent.session_id, reason="compression")
+                except Exception as _goal_err:
+                    logger.debug("Could not migrate goal on compression: %s", _goal_err)
+                # Auto-number the title for the continuation session
+                if old_title:
+                    try:
+                        new_title = agent._session_db.get_next_title_in_lineage(old_title)
+                        agent._session_db.set_session_title(agent.session_id, new_title)
+                    except (ValueError, Exception) as e:
+                        logger.debug("Could not propagate title on compression: %s", e)
+
+            # Shared post-write steps (both modes target agent.session_id, which
+            # in-place keeps and rotation has already reassigned to the new id):
+            # refresh the stored system prompt and reset the flush cursor so the
+            # next turn re-bases its append diff.
+            agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+            agent._last_flushed_db_idx = 0
+        except Exception as e:
+            # If the rotation rolled back to the parent (orphan-avoidance
+            # above), agent.session_id is the still-indexed parent and
+            # old_session_id was cleared — so this is recovery, not an
+            # un-indexed orphan. Otherwise an earlier step failed before the
+            # child was created and the warning's original meaning holds.
+            if locals().get("old_session_id") is None and not in_place:
+                logger.warning(
+                    "Compression rotation aborted and rolled back to the "
+                    "parent session (%s): %s", agent.session_id or "?", e,
+                )
+            else:
+                logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
+
+    # Compaction-boundary bookkeeping, computed once. `old_session_id` is only
+    # bound in the rotation branch; in-place leaves it unset. `_boundary_parent`
+    # is the id the boundary notifications attribute the prior state to: the old
+    # id on rotation, the (unchanged) current id in-place.
+    _old_sid = locals().get("old_session_id")
+    _is_boundary = bool(_old_sid) or in_place
+    _boundary_parent = _old_sid or agent.session_id or ""
+
+    # Notify the context engine that a compaction boundary occurred. Plugin
+    # engines (e.g. hermes-lcm) use boundary_reason="compression" to preserve
+    # DAG lineage / checkpoint per-session state across the boundary instead of
+    # re-initializing fresh. See hermes-lcm#68. Built-in ContextCompressor
+    # ignores kwargs. Fires in BOTH modes: rotation passes old→new ids; in-place
+    # passes the SAME id (the boundary is real even though the id didn't move).
+    try:
+        if _is_boundary and hasattr(agent.context_compressor, "on_session_start"):
+            agent.context_compressor.on_session_start(
+                agent.session_id or "",
+                boundary_reason="compression",
+                old_session_id=_boundary_parent,
+                platform=getattr(agent, "platform", None) or "cli",
+                conversation_id=getattr(agent, "_gateway_session_key", None),
+            )
+    except Exception as _ce_err:
+        logger.debug("context engine on_session_start (compression): %s", _ce_err)
+
+    # Notify memory providers of the compaction boundary so provider-cached
+    # per-session state (Hindsight's _document_id, accumulated turn buffers,
+    # counters) refreshes. reset=False because the logical conversation
+    # continues. See #6672. Fires in BOTH modes: in-place uses the same id as
+    # parent (the conversation didn't fork, but the buffer must still be told
+    # the transcript was compacted so it doesn't double-count dropped turns).
+    try:
+        if _is_boundary and agent._memory_manager:
+            agent._memory_manager.on_session_switch(
+                agent.session_id or "",
+                parent_session_id=_boundary_parent,
+                reset=False,
+                reason="compression",
+            )
+    except Exception as _me_err:
+        logger.debug("memory manager on_session_switch (compression): %s", _me_err)
+
+    # Warn on repeated compressions (quality degrades with each pass).
+    # Route through _emit_status (like the other compression warnings above)
+    # so the warning reaches the TUI / Telegram / Discord via status_callback,
+    # not just CLI stdout. _emit_status still _vprints for the CLI, and
+    # storing it on _compression_warning lets replay_compression_warning
+    # re-deliver it once a late-bound gateway status_callback is wired (#36908).
+    _cc = agent.context_compressor.compression_count
+    if _cc >= 2:
+        _cc_msg = (
+            f"{agent.log_prefix}⚠️  Session compressed {_cc} times — "
+            f"accuracy may degrade. Consider /new to start fresh."
+        )
+        agent._compression_warning = _cc_msg
+        agent._emit_status(_cc_msg)
+
+    # Emit session:compress event so hooks (e.g. MemPalace sync) can ingest
+    # the completed old session before its details are lost. In in-place mode
+    # there is no old id (same session); ``in_place=True`` tells hooks the
+    # transcript was compacted on the same id rather than rotated.
+    if getattr(agent, "event_callback", None):
+        try:
+            agent.event_callback("session:compress", {
+                "platform": agent.platform or "",
+                "session_id": agent.session_id,
+                "old_session_id": _old_sid or "",
+                "in_place": in_place,
+                "compression_count": agent.context_compressor.compression_count,
+            })
+        except Exception as e:
+            logger.debug("event_callback error on session:compress: %s", e)
+
+    # Surface the compaction mode to the caller (run_conversation / gateway)
+    # via a rotation-independent flag. The gateway uses this — NOT an
+    # id-change diff — to re-baseline transcript handling (history_offset=0 +
+    # rewrite on the same id) when compaction happened in place. See #38763.
+    agent._last_compaction_in_place = compacted_in_place
+
+    # Keep the post-compression rough estimate for diagnostics, but do not
+    # treat it as provider-reported prompt usage. Schema-heavy rough estimates
+    # can remain above threshold even after the next real API request fits.
+    _compressed_est = estimate_request_tokens_rough(
+        compressed,
+        system_prompt=new_system_prompt or "",
+        tools=agent.tools or None,
+    )
+    agent.context_compressor.last_compression_rough_tokens = _compressed_est
+    agent.context_compressor.last_prompt_tokens = -1
+    agent.context_compressor.last_completion_tokens = 0
+    agent.context_compressor.awaiting_real_usage_after_compression = True
+    # Arm the effectiveness verdict only after a completed rewrite crosses
+    # the full compaction boundary. Exceptions, aborts, and no-op attempts
+    # leave this false, so unrelated later usage cannot be charged to an
+    # attempt that never changed the transcript.
+    if made_progress:
+        record_boundary = getattr(
+            type(agent.context_compressor),
+            "record_completed_compaction",
+            None,
+        )
+        if callable(record_boundary):
+            record_boundary(
+                agent.context_compressor,
+                used_fallback=used_fallback,
+            )
+        else:
+            agent.context_compressor._verify_compaction_cleared_threshold = True
+
+    # Clear the file-read dedup cache.  After compression the original
+    # read content is summarised away — if the model re-reads the same
+    # file it needs the full content, not a "file unchanged" stub.
+    try:
+        from tools.file_tools import reset_file_dedup
+        reset_file_dedup(task_id)
+    except Exception:
+        pass
+
+    logger.info(
+        "context compression done: session=%s messages=%d->%d rough_tokens=~%s awaiting_real_usage=true",
+        agent.session_id or "none", pre_msg_count, len(compressed),
+        f"{_compressed_est:,}",
+    )
+    return compressed, new_system_prompt
+
+
+def apply_prepared_candidate(
+    agent: Any,
+    candidate: Any,
+    messages: list,
+    system_message: str,
+    *,
+    controller: Any = None,
+    task_id: str = "default",
+) -> Optional[Tuple[list, str]]:
+    """Apply a background-prepared compression candidate atomically.
+
+    Foreground-only, called between turns. Acquires the same per-session
+    SQLite lock as the synchronous path, revalidates the candidate INSIDE
+    the lock (same session, current generation, prefix digest unchanged, no
+    open tool call), merges the prepared prefix with the live suffix and
+    commits through the shared :func:`_commit_compressed_transcript`.
+
+    Returns ``(new_messages, new_system_prompt)`` on success, or None when
+    the candidate was invalid or the lock was busy — callers fall back to
+    the existing synchronous path in that case. Nothing is rotated or
+    rewritten unless every validation passed.
+    """
+    from agent.async_context_compression import (
+        has_open_tool_call,
+        merge_candidate_with_live_messages,
+        validate_candidate,
+    )
+
+    if candidate is None:
+        return None
+    in_place = bool(getattr(agent, "compression_in_place", False))
+    guard = _CompressionLockGuard(agent)
+    # Quietly step aside when another path is compressing: for the background
+    # apply this is ordinary contention, not a user-facing anomaly.
+    if not guard.acquire(emit_busy_warning=False):
+        return None
+    try:
+        if has_open_tool_call(messages):
+            # Temporal refusal — keep the candidate for a later boundary.
+            return None
+        current_generation = getattr(controller, "generation", None)
+        ok, reason = validate_candidate(
+            candidate,
+            session_id=agent.session_id or "",
+            messages=messages,
+            current_generation=current_generation,
+        )
+        if not ok:
+            if controller is not None:
+                try:
+                    controller.discard(reason)
+                except Exception:
+                    pass
+            logger.info(
+                "background compression candidate rejected under lock: %s (session=%s)",
+                reason, agent.session_id or "none",
+            )
+            return None
+
+        merged = merge_candidate_with_live_messages(candidate, messages)
+
+        # Same pre-rewrite hook as the synchronous path: give the external
+        # memory provider a chance to capture context before it is dropped.
+        if agent._memory_manager:
+            try:
+                agent._memory_manager.on_pre_compress(messages)
+            except Exception:
+                pass
+
+        # The live engine adopts the prepared bookkeeping BEFORE the commit
+        # so compression_count / iterative-summary state are correct for the
+        # boundary notifications and the session:compress event.
+        adopt = getattr(agent.context_compressor, "adopt_prepared_state", None)
+        if callable(adopt):
+            try:
+                adopt(candidate)
+            except Exception as _adopt_err:
+                logger.debug("adopt_prepared_state failed: %s", _adopt_err)
+
+        logger.info(
+            "applying background compression candidate: session=%s prefix=%d "
+            "prepared=%d suffix=%d",
+            agent.session_id or "none",
+            candidate.prefix_message_count,
+            len(candidate.prepared_messages),
+            len(messages) - candidate.prefix_message_count,
+        )
+        result = _commit_compressed_transcript(
+            agent,
+            messages,
+            merged,
+            system_message,
+            in_place=in_place,
+            pre_msg_count=len(messages),
+            made_progress=True,
+            used_fallback=bool(candidate.used_fallback),
+            summary_error=candidate.summary_error,
+            aux_failure_model=None,
+            aux_failure_error=None,
+            task_id=task_id,
+        )
+        if controller is not None:
+            try:
+                controller.mark_applied(candidate)
+            except Exception:
+                pass
+        return result
+    finally:
+        guard.release()
 
 
 def _compress_context_via_codex_app_server(

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -423,6 +423,30 @@ def build_turn_context(
             tools=agent.tools or None,
         )
         _compressor = agent.context_compressor
+        # Background-prepared candidate (compression.background): swap in a
+        # pre-computed compression BEFORE the synchronous preflight chain.
+        # When it applies, the re-estimated tokens fall below threshold and
+        # the sync path below is naturally skipped; in every other case
+        # (feature off, no/invalid candidate, shadow mode) this returns None
+        # and the chain continues unchanged.
+        _bg_result = agent._maybe_apply_prepared_compression(
+            messages, system_message, current_tokens=_preflight_tokens
+        )
+        if _bg_result is not None:
+            messages, active_system_prompt = _bg_result
+            conversation_history = conversation_history_after_compression(
+                agent, messages
+            )
+            _preflight_tokens = estimate_request_tokens_rough(
+                messages,
+                system_prompt=active_system_prompt or "",
+                tools=agent.tools or None,
+            )
+            agent._empty_content_retries = 0
+            agent._thinking_prefill_retries = 0
+            agent._last_content_with_tools = None
+            agent._last_content_tools_all_housekeeping = False
+            agent._mute_post_response = False
         _defer_preflight = getattr(
             _compressor,
             "should_defer_preflight_to_real_usage",

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -506,6 +506,24 @@ def finalize_turn(
         messages=messages,
     )
 
+    # Background compression preparation — the between-turns window is the
+    # only safe place to freeze a prefix: the provider response is complete
+    # and no tool batch is executing. Interrupted/failed turns are skipped
+    # (the transcript may still be settling). Every other trigger condition
+    # (feature flag, thresholds, open tool calls, in-flight work) is
+    # re-checked inside the hook, and a failure here must never affect the
+    # turn result.
+    if not interrupted and not failed:
+        _prepare_bg = getattr(agent, "_maybe_prepare_background_compression", None)
+        if callable(_prepare_bg):
+            try:
+                _prepare_bg(messages)
+            except Exception:
+                logger.debug(
+                    "background compression preparation trigger failed",
+                    exc_info=True,
+                )
+
     # Background memory/skill review — runs AFTER the response is delivered
     # so it never competes with the user's task for model attention.
     if final_response and not interrupted and (_should_review_memory or _should_review_skills):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16407,6 +16407,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "codex_app_server_auto"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
+        # Whole background-compression block: parsed once at agent init
+        # (agent.background_compression_config), so any edit — including the
+        # kill switch `compression.background.enabled false` — must rebuild
+        # the cached agent on the next message.
+        ("compression", "background"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1504,10 +1504,22 @@ DEFAULT_CONFIG = {
             "shadow_only": True,      # Generate + validate candidates and record
                                       # telemetry, but NEVER apply. Rollout gate.
             "prepare_threshold": 0.65,  # Start preparing at this fraction of the
-                                      # context window.
+                                      # context window. Upper bound, not a
+                                      # promise: the effective gate is derived
+                                      # per model from the engine's live sync
+                                      # trigger (min(this, 80% of the trigger))
+                                      # so preparation always starts before
+                                      # synchronous compaction could fire.
             "apply_threshold": 0.82,  # Apply the candidate at this fraction —
-                                      # kept below the sync compaction threshold
-                                      # so the swap lands before the pause would.
+                                      # also an upper bound, clamped to 96% of
+                                      # the effective sync trigger so the swap
+                                      # lands before the pause would for EVERY
+                                      # profile (default 0.50, small-context
+                                      # floor 0.75, Codex autoraise 0.85):
+                                      # prepare < apply < sync always holds.
+                                      # A ready valid candidate additionally
+                                      # preempts a sync run outright on the
+                                      # same preflight.
             "min_delta_tokens": 20000,  # Don't re-prepare until the context grew
                                       # this many tokens past the last candidate.
             "min_frozen_messages": 12,  # Minimum aligned prefix length worth

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1486,6 +1486,42 @@ DEFAULT_CONFIG = {
                                       # session_search and recoverable, not deleted.
                                       # Default False during rollout; will flip on
                                       # after live validation.
+        "background": {               # Background-prepared ("async") compression.
+                                      # Pre-computes a compression candidate on a
+                                      # worker thread so the compaction pause is
+                                      # replaced by an instant swap between turns.
+                                      # Preparation never mutates live state; the
+                                      # candidate only applies after revalidation
+                                      # (same session, unchanged prefix digest, no
+                                      # open tool call) under the same SQLite lock
+                                      # as synchronous compression. Kill switch:
+                                      #   hermes config set compression.background.enabled false
+                                      #   hermes gateway restart   (or just send the
+                                      #   next gateway message — the key is
+                                      #   cache-busting and hot-reloads)
+            "enabled": False,         # Master switch. Off = behavior identical to
+                                      # the synchronous baseline.
+            "shadow_only": True,      # Generate + validate candidates and record
+                                      # telemetry, but NEVER apply. Rollout gate.
+            "prepare_threshold": 0.65,  # Start preparing at this fraction of the
+                                      # context window.
+            "apply_threshold": 0.82,  # Apply the candidate at this fraction —
+                                      # kept below the sync compaction threshold
+                                      # so the swap lands before the pause would.
+            "min_delta_tokens": 20000,  # Don't re-prepare until the context grew
+                                      # this many tokens past the last candidate.
+            "min_frozen_messages": 12,  # Minimum aligned prefix length worth
+                                      # summarising.
+            "max_candidate_age_turns": 12,  # Discard candidates older than this
+                                      # many turns.
+            "max_workers": 1,         # Single worker — no summary storms.
+            "foreground_priority": True,  # Reserved: background work must never
+                                      # compete with the user's turn.
+            "fallback_sync": True,    # Candidate missing/stale/failed → the
+                                      # existing synchronous path runs unchanged.
+            "apply_only_between_turns": True,  # Never swap mid-turn or while a
+                                      # tool call is open.
+        },
     },
 
     # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).

--- a/run_agent.py
+++ b/run_agent.py
@@ -741,6 +741,16 @@ class AIAgent:
         # False for tool-loop follow-ups (#3040).
         self._is_user_initiated_turn = False
 
+        # A session boundary (/new, /reset, model switch) invalidates any
+        # background compression candidate: its frozen prefix belongs to the
+        # previous transcript and must never be applied to the new one.
+        _bg_controller = getattr(self, "background_compression", None)
+        if _bg_controller is not None:
+            try:
+                _bg_controller.reset()
+            except Exception:
+                pass
+
         # Context engine reset/transition (works for built-in compressor and plugins)
         self._transition_context_engine_session(
             old_session_id=old_session_id,
@@ -3600,7 +3610,17 @@ class AIAgent:
         except Exception:
             pass
 
-        # 5. Close the OpenAI/httpx client
+        # 5. Stop background compression work — a hard teardown must not leave
+        # a summariser worker running against a dead session.
+        try:
+            _bg_controller = getattr(self, "background_compression", None)
+            if _bg_controller is not None:
+                _bg_controller.shutdown(wait=False)
+                self.background_compression = None
+        except Exception:
+            pass
+
+        # 6. Close the OpenAI/httpx client
         try:
             client = getattr(self, "client", None)
             if client is not None:
@@ -3609,7 +3629,7 @@ class AIAgent:
         except Exception:
             pass
 
-        # 6. Free conversation history.  Mirrors _release_evicted_agent_soft's
+        # 7. Free conversation history.  Mirrors _release_evicted_agent_soft's
         # soft-eviction clear — close() is the hard teardown for true session
         # boundaries (/new, /reset, session expiry), so the message list won't
         # be reused.  Drops the reference proactively rather than waiting for
@@ -3620,7 +3640,7 @@ class AIAgent:
         except Exception:
             pass
 
-        # 7. Finalize the owned SQLite session row unless this agent is only a
+        # 8. Finalize the owned SQLite session row unless this agent is only a
         # temporary helper that deliberately handed session ownership forward
         # (manual compression helpers that rotate to a continuation session_id,
         # or background-review forks that share the live parent's session_id and
@@ -5965,6 +5985,55 @@ class AIAgent:
             approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic,
             force=force,
         )
+
+    def _maybe_prepare_background_compression(
+        self, messages: list, *, current_tokens: int = None
+    ) -> bool:
+        """Between-turns trigger for background compression preparation.
+
+        Called by the turn finalizer after a completed turn. All trigger
+        conditions (feature flag, thresholds, open tool calls, in-flight
+        work) live in ``agent.async_context_compression``; this wrapper only
+        guarantees a background failure can never surface on the foreground.
+        """
+        try:
+            from agent.async_context_compression import (
+                maybe_prepare_background_compression,
+            )
+            return maybe_prepare_background_compression(
+                self, messages,
+                current_tokens=current_tokens,
+                current_turn=getattr(self, "_user_turn_count", 0),
+            )
+        except Exception:
+            logger.debug(
+                "background compression preparation trigger failed", exc_info=True
+            )
+            return False
+
+    def _maybe_apply_prepared_compression(
+        self, messages: list, system_message: str, *, current_tokens: int = None
+    ):
+        """Preflight apply gate for a background-prepared candidate.
+
+        Returns ``(compressed_messages, new_system_prompt)`` when a valid
+        candidate was applied, or None in every other case — callers then
+        continue with the synchronous compression path unchanged.
+        """
+        try:
+            from agent.async_context_compression import (
+                maybe_apply_prepared_candidate,
+            )
+            return maybe_apply_prepared_candidate(
+                self, messages, system_message,
+                current_tokens=current_tokens,
+                current_turn=getattr(self, "_user_turn_count", 0),
+            )
+        except Exception:
+            logger.debug(
+                "background compression apply gate failed", exc_info=True
+            )
+            return None
 
     def _set_tool_guardrail_halt(self, decision: ToolGuardrailDecision) -> None:
         """Record the first guardrail decision that should stop this turn."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -3537,6 +3537,18 @@ class AIAgent:
         hard teardown for actual session boundaries (/new, /reset, session
         expiry).
         """
+        # Stop background compression work. The candidate and its worker are
+        # bound to THIS instance; the rebuilt agent starts with a fresh
+        # controller, so keeping the old worker alive would only leak a
+        # thread (and a candidate nobody can ever apply).
+        try:
+            _bg_controller = getattr(self, "background_compression", None)
+            if _bg_controller is not None:
+                _bg_controller.shutdown(wait=False)
+                self.background_compression = None
+        except Exception:
+            pass
+
         # Close active child agents (per-turn; no cross-turn persistence).
         try:
             with self._active_children_lock:

--- a/scripts/benchmark_async_compression.py
+++ b/scripts/benchmark_async_compression.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Controlled benchmark for guarded background compression (task 10).
+
+Compares the four operating modes of the plan on REAL persistence machinery
+(AIAgent + SessionDB + apply_prepared_candidate) with a deterministic
+simulated summariser (a sleep standing in for the LLM call — no provider
+traffic, no cost, reproducible):
+
+  1. sync        — current behavior: the turn blocks for summarise + commit;
+  2. shadow      — background candidate generated/validated, never applied:
+                   the compaction pause is unchanged (sync fallback), but
+                   foreground-turn latency during preparation is measured;
+  3. background  — candidate pre-computed between turns; the perceived pause
+                   is only the atomic apply (validate + merge + commit);
+  4. fallback    — background worker fails; the synchronous path runs as if
+                   the feature did not exist.
+
+Approval gates (from the plan):
+  - candidate apply p95 below 500 ms;
+  - >= 90% reduction of the perceived compaction pause vs sync;
+  - foreground-turn p95 during preparation within +10% of baseline;
+  - candidate ready before the apply boundary in >= 95% of runs;
+  - zero unexpected foreground errors ("provider" health);
+  - zero message loss / duplication.
+
+The apply boundary is placed after the preparation window has had time to
+finish, mirroring the real threshold gap: preparation starts at 65% of the
+context window and applies at 82% — tens of thousands of tokens (minutes of
+conversation) later, while a real summarise takes ~40 s. The simulated ratio
+is conservative relative to production.
+
+Usage:
+  python scripts/benchmark_async_compression.py
+  python scripts/benchmark_async_compression.py --iterations 30 --summariser-ms 400
+  python scripts/benchmark_async_compression.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import statistics
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+SUMMARY_MARKER = "[CONTEXT COMPACTION]"
+
+
+def _p(values: List[float], q: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    return ordered[min(len(ordered) - 1, int(len(ordered) * q))]
+
+
+def _make_messages(n_turns: int = 24) -> List[Dict[str, Any]]:
+    msgs = [{"role": "system", "content": "sys"}]
+    for i in range(n_turns):
+        role = "user" if i % 2 == 0 else "assistant"
+        msgs.append({"role": role, "content": f"benchmark message {i} " * 8})
+        if i % 6 == 5:
+            call_id = f"call_{i}"
+            msgs.append({
+                "role": "assistant", "content": None,
+                "tool_calls": [{"id": call_id, "type": "function",
+                                "function": {"name": "read_file",
+                                             "arguments": "{}"}}],
+            })
+            msgs.append({"role": "tool", "tool_call_id": call_id,
+                         "name": "read_file", "content": f"tool output {i} " * 20})
+    return msgs
+
+
+def _make_candidate(messages, session_id, *, generation=1):
+    from agent.async_context_compression import (
+        PreparedCompressionCandidate,
+        align_prefix_boundary,
+        canonical_prefix_digest,
+    )
+    prefix_count = align_prefix_boundary(messages, len(messages) - 5)
+    return PreparedCompressionCandidate(
+        session_id=session_id,
+        generation=generation,
+        prefix_message_count=prefix_count,
+        prefix_digest=canonical_prefix_digest(messages, prefix_count),
+        prepared_messages=(
+            {"role": "user", "content": f"{SUMMARY_MARKER} benchmark summary"},
+            copy.deepcopy(messages[prefix_count - 1]),
+        ),
+        source_prompt_tokens=200_000,
+        created_at_monotonic=time.monotonic(),
+        created_at_turn=1,
+        used_fallback=False,
+        summary_error=None,
+    )
+
+
+def _foreground_turn(messages, turn_work_ms: float) -> float:
+    """One simulated foreground turn: a little CPU + provider-ish wait."""
+    t0 = time.monotonic()
+    json.dumps(messages, default=repr)  # request-assembly-ish CPU work
+    time.sleep(turn_work_ms / 1000.0)
+    return (time.monotonic() - t0) * 1000.0
+
+
+class _Bench:
+    def __init__(self, iterations: int, summariser_ms: float,
+                 turn_work_ms: float):
+        import os
+        os.environ.setdefault("OPENROUTER_API_KEY", "benchmark-offline-key")
+        self.iterations = iterations
+        self.summariser_ms = summariser_ms
+        self.turn_work_ms = turn_work_ms
+        self.errors: List[str] = []
+        self.loss_or_dup = 0
+
+    # -- per-iteration session/agent -------------------------------------
+
+    def _fresh(self, db, tag: str, i: int):
+        from run_agent import AIAgent
+        sid = f"bench-{tag}-{i}"
+        db.create_session(sid, "cli", model="test/model")
+        agent = AIAgent(
+            api_key="benchmark-offline-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=sid,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._compression_feasibility_checked = True
+        agent.compression_in_place = True
+        messages = _make_messages()
+        agent._flush_messages_to_session_db(messages, [])
+        return agent, sid, messages
+
+    def _check_merge(self, cand, messages, new_messages) -> None:
+        prepared_n = len(cand.prepared_messages)
+        live_suffix = messages[cand.prefix_message_count:]
+        got = new_messages[prepared_n:prepared_n + len(live_suffix)]
+        ids = [id(m) for m in got]
+        if (len(got) != len(live_suffix)
+                or any(a is not b for a, b in zip(got, live_suffix))
+                or len(ids) != len(set(ids))):
+            self.loss_or_dup += 1
+
+    # -- modes ------------------------------------------------------------
+
+    def run_sync(self, db) -> Dict[str, List[float]]:
+        """Current path: summarise (blocking) + commit, all in the turn."""
+        from agent.conversation_compression import apply_prepared_candidate
+        pauses = []
+        for i in range(self.iterations):
+            agent, sid, messages = self._fresh(db, "sync", i)
+            try:
+                t0 = time.monotonic()
+                time.sleep(self.summariser_ms / 1000.0)  # blocking summarise
+                cand = _make_candidate(messages, sid)
+                result = apply_prepared_candidate(agent, cand, messages, "sys")
+                pauses.append((time.monotonic() - t0) * 1000.0)
+                if result is None:
+                    self.errors.append(f"sync[{i}]: commit failed")
+                else:
+                    self._check_merge(cand, messages, result[0])
+            finally:
+                agent.close()
+        return {"pause_ms": pauses}
+
+    def run_background(self, db) -> Dict[str, Any]:
+        """Prepared between turns; the pause is only the atomic apply."""
+        from agent.async_context_compression import (
+            BackgroundCompressionConfig,
+            BackgroundCompressionController,
+            CandidateState,
+        )
+        from agent.conversation_compression import apply_prepared_candidate
+        pauses, turn_ms, ready_flags = [], [], []
+        for i in range(self.iterations):
+            agent, sid, messages = self._fresh(db, "bg", i)
+            ctl = BackgroundCompressionController(
+                BackgroundCompressionConfig.from_dict(
+                    {"enabled": True, "shadow_only": False,
+                     "min_frozen_messages": 2, "min_delta_tokens": 0}
+                )
+            )
+            try:
+                def prepare_fn(prefix):
+                    time.sleep(self.summariser_ms / 1000.0)
+                    return [
+                        {"role": "user",
+                         "content": f"{SUMMARY_MARKER} benchmark summary"},
+                        copy.deepcopy(prefix[-1]),
+                    ]
+
+                assert ctl.try_start_preparation(
+                    session_id=sid, messages=messages,
+                    prefix_count=len(messages) - 5, current_turn=1,
+                    source_prompt_tokens=200_000, prepare_fn=prepare_fn,
+                )
+                # Foreground keeps answering while the worker summarises —
+                # the 65%→82% threshold gap gives ample conversation time.
+                deadline = time.monotonic() + (self.summariser_ms / 1000.0) * 3
+                while (ctl.state is CandidateState.PREPARING
+                       and time.monotonic() < deadline):
+                    turn_ms.append(_foreground_turn(messages, self.turn_work_ms))
+                ready_flags.append(ctl.state is CandidateState.READY)
+
+                # Apply boundary: perceived pause = validate + merge + commit.
+                t0 = time.monotonic()
+                cand = ctl.take_valid_candidate(
+                    session_id=sid, messages=messages, current_turn=3
+                )
+                result = (
+                    apply_prepared_candidate(
+                        agent, cand, messages, "sys", controller=ctl
+                    ) if cand is not None else None
+                )
+                pauses.append((time.monotonic() - t0) * 1000.0)
+                if result is None:
+                    self.errors.append(f"background[{i}]: apply failed")
+                else:
+                    self._check_merge(cand, messages, result[0])
+            finally:
+                ctl.shutdown(wait=True)
+                agent.close()
+        return {"pause_ms": pauses, "turn_ms": turn_ms,
+                "ready_rate": (sum(ready_flags) / len(ready_flags))
+                if ready_flags else 0.0}
+
+    def run_shadow(self, db) -> Dict[str, Any]:
+        """Candidate generated + validated, never applied; sync still pays."""
+        from agent.async_context_compression import (
+            BackgroundCompressionConfig,
+            BackgroundCompressionController,
+            CandidateState,
+        )
+        from agent.conversation_compression import apply_prepared_candidate
+        pauses, turn_ms = [], []
+        for i in range(self.iterations):
+            agent, sid, messages = self._fresh(db, "shadow", i)
+            ctl = BackgroundCompressionController(
+                BackgroundCompressionConfig.from_dict(
+                    {"enabled": True, "shadow_only": True,
+                     "min_frozen_messages": 2, "min_delta_tokens": 0}
+                )
+            )
+            try:
+                def prepare_fn(prefix):
+                    time.sleep(self.summariser_ms / 1000.0)
+                    return [
+                        {"role": "user",
+                         "content": f"{SUMMARY_MARKER} shadow summary"},
+                        copy.deepcopy(prefix[-1]),
+                    ]
+
+                assert ctl.try_start_preparation(
+                    session_id=sid, messages=messages,
+                    prefix_count=len(messages) - 5, current_turn=1,
+                    source_prompt_tokens=200_000, prepare_fn=prepare_fn,
+                )
+                deadline = time.monotonic() + (self.summariser_ms / 1000.0) * 3
+                while (ctl.state is CandidateState.PREPARING
+                       and time.monotonic() < deadline):
+                    turn_ms.append(_foreground_turn(messages, self.turn_work_ms))
+                cand = ctl.take_valid_candidate(
+                    session_id=sid, messages=messages, current_turn=3
+                )
+                if cand is not None:
+                    ctl.record_shadow_validation(cand)
+                # Shadow never applies: the compaction pause is the sync one.
+                t0 = time.monotonic()
+                time.sleep(self.summariser_ms / 1000.0)
+                sync_cand = _make_candidate(messages, sid, generation=2)
+                result = apply_prepared_candidate(
+                    agent, sync_cand, messages, "sys"
+                )
+                pauses.append((time.monotonic() - t0) * 1000.0)
+                if result is None:
+                    self.errors.append(f"shadow[{i}]: sync commit failed")
+            finally:
+                ctl.shutdown(wait=True)
+                agent.close()
+        return {"pause_ms": pauses, "turn_ms": turn_ms}
+
+    def run_fallback(self, db) -> Dict[str, List[float]]:
+        """Worker fails → foreground never notices; sync path unchanged."""
+        from agent.async_context_compression import (
+            BackgroundCompressionConfig,
+            BackgroundCompressionController,
+        )
+        from agent.conversation_compression import apply_prepared_candidate
+        pauses = []
+        for i in range(self.iterations):
+            agent, sid, messages = self._fresh(db, "fb", i)
+            ctl = BackgroundCompressionController(
+                BackgroundCompressionConfig.from_dict(
+                    {"enabled": True, "shadow_only": False,
+                     "min_frozen_messages": 2, "min_delta_tokens": 0}
+                )
+            )
+            try:
+                def broken(prefix):
+                    raise RuntimeError("summariser unavailable (benchmark)")
+
+                assert ctl.try_start_preparation(
+                    session_id=sid, messages=messages,
+                    prefix_count=len(messages) - 5, current_turn=1,
+                    source_prompt_tokens=200_000, prepare_fn=broken,
+                )
+                assert ctl.wait_until_settled(timeout=10.0)
+                if ctl.take_valid_candidate(
+                    session_id=sid, messages=messages, current_turn=2
+                ) is not None:
+                    self.errors.append(f"fallback[{i}]: failed worker "
+                                       "produced a candidate")
+                # Sync fallback pays the normal pause.
+                t0 = time.monotonic()
+                time.sleep(self.summariser_ms / 1000.0)
+                cand = _make_candidate(messages, sid, generation=99)
+                result = apply_prepared_candidate(agent, cand, messages, "sys")
+                pauses.append((time.monotonic() - t0) * 1000.0)
+                if result is None:
+                    self.errors.append(f"fallback[{i}]: sync commit failed")
+            finally:
+                ctl.shutdown(wait=True)
+                agent.close()
+        return {"pause_ms": pauses}
+
+
+def run_benchmark(iterations: int = 10, summariser_ms: float = 2000.0,
+                  turn_work_ms: float = 20.0) -> Dict[str, Any]:
+    from hermes_state import SessionDB
+
+    bench = _Bench(iterations, summariser_ms, turn_work_ms)
+    with tempfile.TemporaryDirectory(prefix="hermes-bench-") as tmpdir:
+        db = SessionDB(db_path=Path(tmpdir) / "state.db")
+        # Baseline foreground-turn latency with NO background worker running.
+        baseline_turns = [
+            _foreground_turn(_make_messages(), turn_work_ms)
+            for _ in range(max(10, iterations))
+        ]
+        sync = bench.run_sync(db)
+        shadow = bench.run_shadow(db)
+        background = bench.run_background(db)
+        fallback = bench.run_fallback(db)
+        db.close()
+
+    sync_p95 = _p(sync["pause_ms"], 0.95)
+    bg_p95 = _p(background["pause_ms"], 0.95)
+    turn_baseline_p95 = _p(baseline_turns, 0.95)
+    turn_prepare_p95 = _p(
+        background["turn_ms"] + shadow["turn_ms"], 0.95
+    )
+    pause_reduction = 1.0 - (bg_p95 / sync_p95) if sync_p95 else 0.0
+
+    report = {
+        "params": {"iterations": iterations, "summariser_ms": summariser_ms,
+                   "turn_work_ms": turn_work_ms},
+        "modes": {
+            "sync": {"pause_p50_ms": _p(sync["pause_ms"], 0.50),
+                     "pause_p95_ms": sync_p95},
+            "shadow": {"pause_p50_ms": _p(shadow["pause_ms"], 0.50),
+                       "pause_p95_ms": _p(shadow["pause_ms"], 0.95)},
+            "background": {"pause_p50_ms": _p(background["pause_ms"], 0.50),
+                           "pause_p95_ms": bg_p95,
+                           "ready_rate": background["ready_rate"]},
+            "fallback": {"pause_p50_ms": _p(fallback["pause_ms"], 0.50),
+                         "pause_p95_ms": _p(fallback["pause_ms"], 0.95)},
+        },
+        "foreground_turns": {
+            "baseline_p95_ms": turn_baseline_p95,
+            "during_prepare_p95_ms": turn_prepare_p95,
+        },
+        "gates": {},
+        "errors": bench.errors,
+        "loss_or_dup": bench.loss_or_dup,
+    }
+    turn_ratio = (
+        turn_prepare_p95 / turn_baseline_p95 if turn_baseline_p95 else 1.0
+    )
+    report["gates"] = {
+        "apply_p95_under_500ms": bg_p95 < 500.0,
+        "pause_reduction_at_least_90pct": pause_reduction >= 0.90,
+        "foreground_p95_within_10pct": turn_ratio <= 1.10,
+        "candidate_ready_rate_at_least_95pct":
+            background["ready_rate"] >= 0.95,
+        "no_provider_errors": not bench.errors,
+        "zero_loss_or_duplication": bench.loss_or_dup == 0,
+    }
+    report["pause_reduction"] = pause_reduction
+    report["foreground_turn_ratio"] = turn_ratio
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--iterations", type=int, default=10)
+    parser.add_argument("--summariser-ms", type=float, default=2000.0,
+                        help="simulated summariser latency. The real pause is "
+                             "~40s (41.42s observed upstream); the 2s default "
+                             "is a 20x-scaled-down CONSERVATIVE stand-in — "
+                             "the measured reduction understates production.")
+    parser.add_argument("--turn-work-ms", type=float, default=20.0)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    report = run_benchmark(args.iterations, args.summariser_ms,
+                           args.turn_work_ms)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        m = report["modes"]
+        print(f"iterations={args.iterations} summariser={args.summariser_ms}ms")
+        print(f"  sync       pause p50={m['sync']['pause_p50_ms']:8.1f}ms "
+              f"p95={m['sync']['pause_p95_ms']:8.1f}ms")
+        print(f"  shadow     pause p50={m['shadow']['pause_p50_ms']:8.1f}ms "
+              f"p95={m['shadow']['pause_p95_ms']:8.1f}ms  (unchanged by design)")
+        print(f"  background pause p50={m['background']['pause_p50_ms']:8.1f}ms "
+              f"p95={m['background']['pause_p95_ms']:8.1f}ms  "
+              f"ready_rate={m['background']['ready_rate']:.0%}")
+        print(f"  fallback   pause p50={m['fallback']['pause_p50_ms']:8.1f}ms "
+              f"p95={m['fallback']['pause_p95_ms']:8.1f}ms")
+        ft = report["foreground_turns"]
+        print(f"  foreground turn p95: baseline={ft['baseline_p95_ms']:.1f}ms "
+              f"during_prepare={ft['during_prepare_p95_ms']:.1f}ms "
+              f"(ratio {report['foreground_turn_ratio']:.2f})")
+        print(f"  perceived-pause reduction: {report['pause_reduction']:.1%}")
+        print("  gates:")
+        for gate, ok in report["gates"].items():
+            print(f"    [{'PASS' if ok else 'FAIL'}] {gate}")
+        if report["errors"]:
+            print(f"  errors: {report['errors']}")
+    return 0 if all(report["gates"].values()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/replay_async_compression.py
+++ b/scripts/replay_async_compression.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Offline replay of real session shapes through background compression.
+
+Task 9 of the async-compression plan: exercise the full candidate lifecycle
+(freeze → prepare → validate → apply/fallback) against realistic transcript
+shapes WITHOUT sending any message to a provider and WITHOUT executing any
+tool present in the history. The summariser is a deterministic stand-in, so
+every run is reproducible and free.
+
+Two input sources:
+
+* built-in scenarios covering the plan's matrix (simple, tools, subagent,
+  concurrent arrivals, already-compressed, in-place, legacy rotation,
+  summariser failure, timeout, reset during preparation);
+* sanitized session exports dropped into ``tests/fixtures/async_compression/``
+  as ``*.json`` files (see the README there for the export procedure) — each
+  is replayed through the in-place apply scenario.
+
+Structural gate (the canary blocker): every check below must pass for every
+scenario. Any failure exits non-zero.
+
+  suffix_intact            live suffix survives byte-for-byte (same objects)
+  tool_pairs_valid         no orphaned tool_call / tool result in the result
+  no_duplicates            active DB rows match the final transcript 1:1
+  history_searchable       pre-compaction turns stay archived + FTS-findable
+  summary_within_budget    prepared prefix is smaller than what it replaced
+  sentinels_preserved      IDs, paths, numbers, user corrections survive
+
+Usage:
+  python scripts/replay_async_compression.py            # builtin + fixtures
+  python scripts/replay_async_compression.py --json     # machine-readable
+  python scripts/replay_async_compression.py --scenario tools_closed_groups
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+import tempfile
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "async_compression"
+
+# Sentinel tokens that must survive compression verbatim (the plan's
+# "IDs, caminhos, números e correções do usuário preservados").
+SENTINELS = (
+    "/srv/app/config/settings.py",
+    "ticket #48213",
+    "R$ 1.234,56",
+    "correction: the endpoint is /v2/checkout not /v1/checkout",
+)
+
+SUMMARY_MARKER = "[CONTEXT COMPACTION]"
+
+
+# ── transcript builders ────────────────────────────────────────────────────
+
+
+def _turns(n: int, prefix: str = "message") -> List[Dict[str, Any]]:
+    out = []
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        out.append({"role": role, "content": f"{prefix} {i}"})
+    return out
+
+
+def _tool_group(idx: int, name: str = "read_file", content: str = "") -> List[Dict[str, Any]]:
+    call_id = f"call_{name}_{idx}"
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "name": name,
+            "content": content or f"tool result {idx}",
+        },
+    ]
+
+
+def _sentinel_tail() -> List[Dict[str, Any]]:
+    """Recent-turn messages carrying the must-survive sentinels."""
+    return [
+        {"role": "user",
+         "content": f"please edit {SENTINELS[0]} for {SENTINELS[1]}"},
+        {"role": "assistant",
+         "content": f"done — the refund of {SENTINELS[2]} is configured"},
+        {"role": "user", "content": SENTINELS[3]},
+        {"role": "assistant", "content": "acknowledged, using /v2/checkout"},
+    ]
+
+
+def _simple_conversation() -> List[Dict[str, Any]]:
+    return [{"role": "system", "content": "sys"}] + _turns(14) + _sentinel_tail()
+
+
+def _tools_conversation() -> List[Dict[str, Any]]:
+    msgs = [{"role": "system", "content": "sys"}] + _turns(4)
+    for i in range(4):
+        msgs.extend(_tool_group(i))
+        msgs.append({"role": "assistant", "content": f"analysed result {i}"})
+        msgs.append({"role": "user", "content": f"continue {i}"})
+    return msgs + _sentinel_tail()
+
+
+def _subagent_conversation() -> List[Dict[str, Any]]:
+    msgs = [{"role": "system", "content": "sys"}] + _turns(4)
+    msgs.extend(_tool_group(0, name="delegate_task",
+                            content="subagent finished: refactored 3 files"))
+    msgs.append({"role": "assistant", "content": "subagent work merged"})
+    msgs.extend(_turns(6, prefix="follow-up"))
+    return msgs + _sentinel_tail()
+
+
+def _already_compressed_conversation() -> List[Dict[str, Any]]:
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": f"{SUMMARY_MARKER} earlier summary of turns 1-40"},
+    ]
+    msgs += _turns(12, prefix="post-summary")
+    return msgs + _sentinel_tail()
+
+
+# ── scenario definition ────────────────────────────────────────────────────
+
+
+@dataclass
+class Scenario:
+    name: str
+    messages_builder: Callable[[], List[Dict[str, Any]]]
+    mode: str = "apply"          # apply | failure | timeout | reset
+    in_place: bool = True
+    late_messages: int = 0       # messages arriving between prepare and apply
+    description: str = ""
+
+
+BUILTIN_SCENARIOS: List[Scenario] = [
+    Scenario("simple_operational", _simple_conversation,
+             description="plain user/assistant conversation"),
+    Scenario("tools_closed_groups", _tools_conversation,
+             description="conversation with closed tool-call groups"),
+    Scenario("subagent_delegation", _subagent_conversation,
+             description="conversation containing a delegate_task round"),
+    Scenario("messages_during_execution", _simple_conversation,
+             late_messages=3,
+             description="messages arrive after the prefix was frozen"),
+    Scenario("already_compressed", _already_compressed_conversation,
+             description="transcript already carries a compaction summary"),
+    Scenario("in_place_session", _tools_conversation, in_place=True,
+             description="in-place compaction (same session id)"),
+    Scenario("legacy_rotation_session", _tools_conversation, in_place=False,
+             description="legacy rotation (parent → child session)"),
+    Scenario("summariser_failure", _simple_conversation, mode="failure",
+             description="worker raises; foreground must be untouched"),
+    Scenario("summariser_timeout", _simple_conversation, mode="timeout",
+             description="worker never finishes in time; sync fallback"),
+    Scenario("reset_during_preparation", _simple_conversation, mode="reset",
+             description="/reset lands while the worker is in flight"),
+]
+
+
+@dataclass
+class ReplayResult:
+    name: str
+    ok: bool
+    checks: Dict[str, bool] = field(default_factory=dict)
+    detail: str = ""
+
+
+# ── validations ────────────────────────────────────────────────────────────
+
+
+def _canonical(msgs: List[Dict[str, Any]]) -> str:
+    from agent.async_context_compression import _semantic_view
+    return json.dumps([_semantic_view(m) for m in msgs], sort_keys=True,
+                      ensure_ascii=False, default=repr)
+
+
+def _tool_pairs_valid(msgs: List[Dict[str, Any]]) -> bool:
+    open_ids: set = set()
+    for m in msgs:
+        if not isinstance(m, dict):
+            return False
+        if m.get("role") == "assistant" and m.get("tool_calls"):
+            for tc in m["tool_calls"]:
+                tc_id = tc.get("id") if isinstance(tc, dict) else None
+                if tc_id:
+                    open_ids.add(tc_id)
+        elif m.get("role") == "tool":
+            tc_id = m.get("tool_call_id")
+            if tc_id not in open_ids:
+                return False  # orphan result
+            open_ids.discard(tc_id)
+    return not open_ids  # no orphan calls
+
+
+def _rough_tokens(msgs: List[Dict[str, Any]]) -> int:
+    return max(1, len(json.dumps(msgs, ensure_ascii=False, default=repr)) // 4)
+
+
+def _transcript_text(msgs: List[Dict[str, Any]]) -> str:
+    return "\n".join(str(m.get("content", "")) for m in msgs if isinstance(m, dict))
+
+
+# ── replay core ────────────────────────────────────────────────────────────
+
+
+def _make_agent(session_db, session_id):
+    os.environ.setdefault("OPENROUTER_API_KEY", "replay-offline-key")
+    from run_agent import AIAgent
+    agent = AIAgent(
+        api_key="replay-offline-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        session_db=session_db,
+        session_id=session_id,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._compression_feasibility_checked = True
+    return agent
+
+
+def replay_scenario(scenario: Scenario) -> ReplayResult:
+    """Run one scenario in a throwaway SessionDB. Never touches real state."""
+    from agent.async_context_compression import (
+        BackgroundCompressionConfig,
+        BackgroundCompressionController,
+        CandidateState,
+    )
+    from agent.conversation_compression import apply_prepared_candidate
+    from hermes_state import SessionDB
+
+    checks: Dict[str, bool] = {}
+    with tempfile.TemporaryDirectory(prefix="hermes-replay-") as tmpdir:
+        db = SessionDB(db_path=Path(tmpdir) / "state.db")
+        sid = f"replay-{scenario.name}"
+        db.create_session(sid, "cli", model="test/model")
+        agent = _make_agent(db, sid)
+        agent.compression_in_place = scenario.in_place
+        try:
+            messages = [copy.deepcopy(m) for m in scenario.messages_builder()]
+            agent._flush_messages_to_session_db(messages, [])
+            baseline = copy.deepcopy(messages)
+
+            cfg = BackgroundCompressionConfig.from_dict({
+                "enabled": True, "shadow_only": False,
+                "min_delta_tokens": 0, "min_frozen_messages": 2,
+            })
+            ctl = BackgroundCompressionController(cfg)
+            release = threading.Event()
+
+            def prepare_fn(prefix):
+                if scenario.mode == "failure":
+                    raise RuntimeError("summariser failure (replay)")
+                if scenario.mode in ("timeout", "reset"):
+                    # Deterministic stand-in for a hung/slow provider call.
+                    assert release.wait(timeout=10.0)
+                return [
+                    {"role": "user",
+                     "content": f"{SUMMARY_MARKER} deterministic replay summary"},
+                    copy.deepcopy(prefix[-1]),
+                ]
+
+            prefix_count = len(messages) - 5
+            checks["preparation_started"] = ctl.try_start_preparation(
+                session_id=sid, messages=messages, prefix_count=prefix_count,
+                current_turn=1, source_prompt_tokens=200_000,
+                prepare_fn=prepare_fn,
+            )
+
+            if scenario.mode == "reset":
+                ctl.reset()
+                release.set()
+                checks["settled"] = ctl.wait_until_settled(timeout=10.0)
+                checks["candidate_discarded"] = ctl.peek_candidate() is None
+                checks["transcript_unchanged"] = messages == baseline
+                checks["db_rows_unchanged"] = (
+                    len(db.get_messages(sid)) == len(baseline)
+                )
+            elif scenario.mode == "timeout":
+                # Apply attempt while the worker is still "hung": the loop
+                # must defer and the synchronous fallback stays available.
+                checks["apply_deferred"] = ctl.take_valid_candidate(
+                    session_id=sid, messages=messages, current_turn=2
+                ) is None
+                ctl.cancel()
+                release.set()
+                checks["settled"] = ctl.wait_until_settled(timeout=10.0)
+                checks["late_result_discarded"] = ctl.peek_candidate() is None
+                checks["transcript_unchanged"] = messages == baseline
+                checks["db_rows_unchanged"] = (
+                    len(db.get_messages(sid)) == len(baseline)
+                )
+            elif scenario.mode == "failure":
+                checks["settled"] = ctl.wait_until_settled(timeout=10.0)
+                checks["worker_failed_quietly"] = ctl.state is CandidateState.FAILED
+                checks["no_candidate"] = ctl.take_valid_candidate(
+                    session_id=sid, messages=messages, current_turn=2
+                ) is None
+                checks["transcript_unchanged"] = messages == baseline
+                checks["db_rows_unchanged"] = (
+                    len(db.get_messages(sid)) == len(baseline)
+                )
+            else:  # apply
+                checks["settled"] = ctl.wait_until_settled(timeout=10.0)
+                for i in range(scenario.late_messages):
+                    messages.append({
+                        "role": "user" if i % 2 == 0 else "assistant",
+                        "content": f"arrived during preparation {i} "
+                                   f"(keep {SENTINELS[1]})",
+                    })
+                    agent._flush_messages_to_session_db(messages, [])
+
+                cand = ctl.take_valid_candidate(
+                    session_id=sid, messages=messages, current_turn=2
+                )
+                checks["candidate_valid"] = cand is not None
+                if cand is not None:
+                    live_suffix = messages[cand.prefix_message_count:]
+                    suffix_canon = _canonical(live_suffix)
+                    frozen_tokens = _rough_tokens(
+                        messages[:cand.prefix_message_count]
+                    )
+                    prepared_tokens = _rough_tokens(
+                        list(cand.prepared_messages)
+                    )
+
+                    result = apply_prepared_candidate(
+                        agent, cand, messages, "sys", controller=ctl
+                    )
+                    checks["apply_committed"] = result is not None
+                    if result is not None:
+                        new_messages, _prompt = result
+                        prepared_n = len(cand.prepared_messages)
+                        got_suffix = new_messages[
+                            prepared_n:prepared_n + len(live_suffix)
+                        ]
+                        checks["suffix_intact"] = (
+                            _canonical(got_suffix) == suffix_canon
+                            and all(a is b for a, b in
+                                    zip(got_suffix, live_suffix))
+                        )
+                        checks["tool_pairs_valid"] = _tool_pairs_valid(new_messages)
+                        checks["summary_within_budget"] = (
+                            prepared_tokens < frozen_tokens
+                        )
+                        text = _transcript_text(new_messages)
+                        checks["sentinels_preserved"] = all(
+                            s in text for s in SENTINELS
+                        )
+
+                        if scenario.in_place:
+                            checks["same_session_id"] = agent.session_id == sid
+                            active = db.get_messages(sid)
+                            checks["no_duplicates"] = (
+                                len(active) == len(new_messages)
+                            )
+                            checks["history_archived"] = (
+                                db.has_archived_messages(sid)
+                            )
+                            # Pre-compaction turns must remain searchable —
+                            # probe with the real content of an archived
+                            # (frozen-prefix) message from this transcript.
+                            probe = ""
+                            for m in baseline[1:cand.prefix_message_count]:
+                                if isinstance(m.get("content"), str) and m["content"].strip():
+                                    probe = m["content"].strip()[:40]
+                                    break
+                            hits = db.search_messages(f'"{probe}"', limit=5)
+                            checks["history_searchable"] = any(
+                                h.get("session_id") == sid for h in hits
+                            )
+                        else:
+                            checks["rotated_to_child"] = agent.session_id != sid
+                            child = db.get_session(agent.session_id)
+                            checks["child_linked_to_parent"] = bool(
+                                child and child.get("parent_session_id") == sid
+                            )
+                            parent_rows = db.get_messages(sid)
+                            checks["parent_history_preserved"] = (
+                                len(parent_rows) >= len(baseline)
+                            )
+                checks["lock_released"] = (
+                    db.get_compression_lock_holder(sid) is None
+                )
+
+            ctl.shutdown(wait=True)
+            ok = all(checks.values())
+            return ReplayResult(scenario.name, ok, checks,
+                                scenario.description)
+        finally:
+            try:
+                agent.close()
+            except Exception:
+                pass
+            db.close()
+
+
+def _fixture_scenarios() -> List[Scenario]:
+    out: List[Scenario] = []
+    if not FIXTURES_DIR.is_dir():
+        return out
+    for path in sorted(FIXTURES_DIR.glob("*.json")):
+        def _load(p=path):
+            data = json.loads(p.read_text(encoding="utf-8"))
+            if not isinstance(data, list) or len(data) < 8:
+                raise ValueError(f"fixture {p.name}: expected a list of >=8 messages")
+            # Never execute anything from the history: strip nothing, run
+            # nothing — messages are treated as opaque transcript data.
+            return data + _sentinel_tail()
+        out.append(Scenario(
+            name=f"fixture_{path.stem}", messages_builder=_load,
+            description=f"sanitized export {path.name}",
+        ))
+    return out
+
+
+def run_all(only: Optional[str] = None) -> List[ReplayResult]:
+    scenarios = BUILTIN_SCENARIOS + _fixture_scenarios()
+    if only:
+        scenarios = [s for s in scenarios if s.name == only]
+        if not scenarios:
+            raise SystemExit(f"unknown scenario: {only}")
+    return [replay_scenario(s) for s in scenarios]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--scenario", help="run a single scenario by name")
+    parser.add_argument("--json", action="store_true",
+                        help="machine-readable output")
+    args = parser.parse_args()
+
+    results = run_all(only=args.scenario)
+    if args.json:
+        print(json.dumps(
+            [{"name": r.name, "ok": r.ok, "checks": r.checks,
+              "description": r.detail} for r in results],
+            indent=2, ensure_ascii=False,
+        ))
+    else:
+        for r in results:
+            status = "PASS" if r.ok else "FAIL"
+            print(f"[{status}] {r.name} — {r.detail}")
+            if not r.ok:
+                for check, value in r.checks.items():
+                    if not value:
+                        print(f"        ✗ {check}")
+    failed = [r for r in results if not r.ok]
+    print(f"\n{len(results) - len(failed)}/{len(results)} scenarios passed")
+    if failed:
+        print("STRUCTURAL GATE FAILED — canary is blocked.")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -844,3 +844,99 @@ def test_lease_refresher_stops_on_persistent_raise() -> None:
     _no_sleep(refresher)
     refresher._run()  # must not propagate
     assert db.calls == refresher._max_consecutive_failures
+
+
+def test_background_apply_and_sync_compression_never_double_rotate(
+    tmp_path: Path,
+) -> None:
+    """A background-candidate apply racing a synchronous compression must
+    yield exactly one rotation: both paths contend on the same per-session
+    SQLite lock, and the loser steps aside without touching the DB."""
+    from agent.async_context_compression import (
+        PreparedCompressionCandidate,
+        canonical_prefix_digest,
+    )
+    from agent.conversation_compression import apply_prepared_candidate
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "race-apply-vs-sync"
+    db.create_session(parent_sid, "gateway", model="test/model")
+
+    sync_agent = _build_agent_with_db(db, parent_sid)
+    apply_agent = _build_agent_with_db(db, parent_sid)
+    apply_agent.context_compressor.adopt_prepared_state = lambda c: None
+
+    messages = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"message {i}"}
+        for i in range(12)
+    ]
+    prefix_count = len(messages) - 2
+    candidate = PreparedCompressionCandidate(
+        session_id=parent_sid,
+        generation=1,
+        prefix_message_count=prefix_count,
+        prefix_digest=canonical_prefix_digest(messages, prefix_count),
+        prepared_messages=(
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            dict(messages[prefix_count - 1]),
+        ),
+        source_prompt_tokens=120_000,
+        created_at_monotonic=0.0,
+        created_at_turn=1,
+        used_fallback=False,
+        summary_error=None,
+    )
+
+    # Same determinism trick as test_compression_concurrent_sessions: barrier
+    # INSIDE the lock acquisition so both paths contend simultaneously. (The
+    # lock serializes concurrent rotation; a stale-session-id holder acquiring
+    # AFTER the winner released is the gateway's SessionEntry re-baseline
+    # problem, covered by the gateway suites.)
+    orig_acquire = db.try_acquire_compression_lock
+    acquire_barrier = threading.Barrier(2)
+
+    def _barriered_acquire(sid, holder, **kw):
+        try:
+            acquire_barrier.wait(timeout=5.0)
+        except threading.BrokenBarrierError:
+            pass
+        return orig_acquire(sid, holder, **kw)
+
+    db.try_acquire_compression_lock = _barriered_acquire
+
+    results: dict = {}
+
+    def _sync_path():
+        results["sync"] = sync_agent._compress_context(
+            [dict(m) for m in messages], "sys", approx_tokens=120_000
+        )
+
+    def _apply_path():
+        results["apply"] = apply_prepared_candidate(
+            apply_agent, candidate, [dict(m) for m in messages], "sys"
+        )
+
+    threads = [
+        threading.Thread(target=_sync_path, name="sync_compress"),
+        threading.Thread(target=_apply_path, name="bg_apply"),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15.0)
+
+    children = _count_children(db, parent_sid)
+    sync_rotated = sync_agent.session_id != parent_sid
+    apply_rotated = apply_agent.session_id != parent_sid
+
+    # Exactly one path rotated; the loser returned without touching state.
+    assert children == 1, f"expected exactly 1 child session, got {children}"
+    assert sync_rotated != apply_rotated, (
+        f"exactly one rotation expected (sync={sync_rotated}, "
+        f"apply={apply_rotated})"
+    )
+    if not apply_rotated:
+        assert results["apply"] is None or results["apply"][0] is not None
+    # Lock on the parent id is fully released afterwards.
+    assert db.get_compression_lock_holder(parent_sid) is None
+    db.close()

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -130,6 +130,20 @@ class TestDefaults:
         assert status["last_prompt_tokens"] == 0
         assert status["usage_percent"] >= 0
 
+    def test_default_background_preparation_hooks_are_noop(self):
+        """Engines written before background compression must stay inert:
+        can_prepare_compression defaults False (never scheduled), and the
+        prepare/adopt hooks default to None-returning no-ops."""
+        engine = StubEngine()
+        msgs = [{"role": "user", "content": "hi"}]
+        assert engine.can_prepare_compression(msgs) is False
+        assert engine.can_prepare_compression(msgs, current_tokens=120_000) is False
+        assert engine.prepare_compression(msgs) is None
+        assert engine.prepare_compression(
+            msgs, current_tokens=120_000, focus_topic="x"
+        ) is None
+        assert engine.adopt_prepared_state(object()) is None
+
     def test_on_session_reset(self):
         engine = StubEngine()
         engine.last_prompt_tokens = 999

--- a/tests/fixtures/async_compression/README.md
+++ b/tests/fixtures/async_compression/README.md
@@ -1,0 +1,70 @@
+# Async-compression replay fixtures
+
+Sanitized, read-only copies of real session transcripts used by
+`scripts/replay_async_compression.py` to exercise the background-compression
+candidate lifecycle against real conversation shapes — **without** sending any
+message to a provider and **without** executing any tool present in the
+history. The replay treats every message as opaque transcript data.
+
+## Format
+
+One `*.json` file per session: a JSON **list** of OpenAI-style message dicts
+(at least 8 messages), e.g.
+
+```json
+[
+  {"role": "system", "content": "..."},
+  {"role": "user", "content": "..."},
+  {"role": "assistant", "content": null,
+   "tool_calls": [{"id": "call_1", "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"}}]},
+  {"role": "tool", "tool_call_id": "call_1", "name": "read_file",
+   "content": "..."}
+]
+```
+
+Only the fields the provider sees matter (`role`, `content`, `name`,
+`tool_call_id`, `tool_calls`). Internal persistence metadata (underscore
+keys, `id`, `timestamp`, `active`, …) is ignored by the canonical digest and
+may be stripped.
+
+## Exporting a real session (read-only)
+
+Run against a **copy** of `state.db`, never the live file:
+
+```bash
+cp ~/.hermes/state.db /tmp/state-copy.db
+python - <<'EOF'
+import json, sys
+sys.path.insert(0, "/path/to/hermes-agent")
+from hermes_state import SessionDB
+db = SessionDB(db_path="/tmp/state-copy.db")
+rows = db.get_messages("SESSION_ID", include_inactive=False)
+keep = ("role", "content", "name", "tool_call_id", "tool_calls")
+out = [{k: r.get(k) for k in keep if r.get(k) is not None} for r in rows]
+print(json.dumps(out, ensure_ascii=False, indent=1))
+EOF
+```
+
+## Sanitization checklist (mandatory before committing)
+
+- Remove or mask credentials, API keys, tokens, phone numbers and any
+  personal identifiers (names, addresses, customer data).
+- Remove absolute paths that reveal infrastructure layout when not needed
+  for the scenario.
+- Keep tool_call/result **pairs together** — the replay validates that no
+  pair is ever split.
+- Prefer long sessions (50+ messages) with mixed shapes: tool rounds,
+  subagent delegation, previous `[CONTEXT COMPACTION]` summaries.
+
+## Running
+
+```bash
+python scripts/replay_async_compression.py           # builtin + all fixtures
+python scripts/replay_async_compression.py --json    # machine-readable
+python scripts/replay_async_compression.py --scenario fixture_<name>
+```
+
+The structural gate requires 100% of the checks (suffix intact, tool pairs
+valid, no duplicates, history archived + searchable, summary within budget,
+sentinels preserved). Any failure blocks the canary rollout.

--- a/tests/gateway/test_async_compression_message_race.py
+++ b/tests/gateway/test_async_compression_message_race.py
@@ -1,0 +1,458 @@
+"""Gateway-facing race hardening for background-prepared compression (task 7).
+
+Contract under test:
+
+* background *preparation* never takes the per-session SQLite compression
+  lock — the gateway must NOT see the session as blocked, and new messages
+  flow in normally while a candidate is being prepared;
+* *applying* a candidate holds the same SQLite lock as synchronous
+  compression for a short critical window — the existing #56391 interrupt
+  demotion then queues new messages for the duration of the commit;
+* eviction paths (``_release_evicted_agent_soft`` → ``release_clients``)
+  shut the controller down so no worker outlives its agent instance;
+* the background-review fork (shares the parent's live ``session_id``,
+  ``compression_enabled=False``) can neither prepare nor apply;
+* a deterministic 1,000-run interleaving stress (message arrival, worker
+  completion, reset, session switch, apply) shows zero message loss, zero
+  duplication and zero cross-session application.
+"""
+
+import copy
+import os
+import random
+import tempfile
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.async_context_compression import (
+    BackgroundCompressionConfig,
+    BackgroundCompressionController,
+    CandidateState,
+    maybe_apply_prepared_candidate,
+    maybe_prepare_background_compression,
+    merge_candidate_with_live_messages,
+)
+
+
+def _enabled_config(**overrides) -> BackgroundCompressionConfig:
+    base = {
+        "enabled": True,
+        "shadow_only": False,
+        "prepare_threshold": 0.65,
+        "apply_threshold": 0.82,
+        "min_delta_tokens": 0,
+        "min_frozen_messages": 2,
+        "max_candidate_age_turns": 12,
+        "max_workers": 1,
+    }
+    base.update(overrides)
+    return BackgroundCompressionConfig.from_dict(base)
+
+
+def _make_messages(n_turns: int = 12) -> list:
+    msgs = [{"role": "system", "content": "sys"}]
+    for i in range(n_turns):
+        role = "user" if i % 2 == 0 else "assistant"
+        msgs.append({"role": role, "content": f"message {i}"})
+    return msgs
+
+
+def _summary_prepare_fn(frozen_prefix: list) -> list:
+    return [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        copy.deepcopy(frozen_prefix[-1]),
+    ]
+
+
+def _make_runner_over_db(raw_db, session_id: str):
+    """GatewayRunner shell wired to a REAL SessionDB for the in-flight probe."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    store = MagicMock()
+    store._lock = threading.Lock()
+    store._loaded = True
+    store._entries = {"k": SimpleNamespace(session_id=session_id)}
+    store._ensure_loaded_locked = lambda: None
+    runner.session_store = store
+    runner._session_db = SimpleNamespace(_db=raw_db)
+    return runner
+
+
+def _make_real_agent(session_db, session_id):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._compression_feasibility_checked = True
+    return agent
+
+
+# ── preparation never blocks the session ───────────────────────────────────
+
+
+class TestPreparationDoesNotBlockSession:
+    @pytest.mark.asyncio
+    async def test_in_flight_preparation_holds_no_lock_and_does_not_demote(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "prep-no-lock"
+            db.create_session(sid, "gateway", model="test/model")
+
+            started = threading.Event()
+            release = threading.Event()
+
+            def blocked_prepare(prefix):
+                started.set()
+                assert release.wait(timeout=5.0)
+                return _summary_prepare_fn(prefix)
+
+            ctl = BackgroundCompressionController(_enabled_config())
+            msgs = _make_messages()
+            assert ctl.try_start_preparation(
+                session_id=sid, messages=msgs, prefix_count=len(msgs) - 4,
+                current_turn=1, source_prompt_tokens=180_000,
+                prepare_fn=blocked_prepare,
+            )
+            assert started.wait(timeout=5.0)
+            try:
+                # Mid-preparation: no SQLite lock, gateway sees no compression.
+                assert db.get_compression_lock_holder(sid) is None
+                runner = _make_runner_over_db(db, sid)
+                assert await runner._session_has_compression_in_flight("k") is False
+            finally:
+                release.set()
+                assert ctl.wait_until_settled(timeout=5.0)
+                ctl.shutdown(wait=True)
+            db.close()
+
+    def test_new_message_during_preparation_flows_and_suffix_survives(self):
+        ctl = BackgroundCompressionController(_enabled_config())
+        msgs = _make_messages()
+        assert ctl.try_start_preparation(
+            session_id="sess-1", messages=msgs, prefix_count=len(msgs) - 4,
+            current_turn=1, source_prompt_tokens=180_000,
+            prepare_fn=_summary_prepare_fn,
+        )
+        assert ctl.wait_until_settled(timeout=5.0)
+
+        # Messages arriving while/after preparation enter the live transcript
+        # normally — nothing queues, nothing blocks.
+        late = [
+            {"role": "user", "content": "arrived during preparation"},
+            {"role": "assistant", "content": "answered during preparation"},
+        ]
+        msgs.extend(late)
+
+        cand = ctl.take_valid_candidate(
+            session_id="sess-1", messages=msgs, current_turn=2
+        )
+        assert cand is not None
+        merged = merge_candidate_with_live_messages(cand, msgs)
+        assert merged[-2] is late[0]
+        assert merged[-1] is late[1]
+        ctl.shutdown(wait=True)
+
+
+# ── apply marks a short critical window via the shared SQLite lock ─────────
+
+
+class TestApplyCriticalWindow:
+    @pytest.mark.asyncio
+    async def test_apply_holds_lock_briefly_and_gateway_demotes_to_queue(self):
+        from agent.async_context_compression import (
+            PreparedCompressionCandidate,
+            canonical_prefix_digest,
+        )
+        from agent.conversation_compression import apply_prepared_candidate
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "apply-window"
+            db.create_session(sid, "gateway", model="test/model")
+            agent = _make_real_agent(db, sid)
+            agent.compression_in_place = True
+
+            messages = [
+                {"role": "user" if i % 2 == 0 else "assistant",
+                 "content": f"message {i}"}
+                for i in range(12)
+            ]
+            agent._flush_messages_to_session_db(messages, [])
+
+            prefix_count = len(messages) - 2
+            candidate = PreparedCompressionCandidate(
+                session_id=sid,
+                generation=1,
+                prefix_message_count=prefix_count,
+                prefix_digest=canonical_prefix_digest(messages, prefix_count),
+                prepared_messages=(
+                    {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                    dict(messages[prefix_count - 1]),
+                ),
+                source_prompt_tokens=180_000,
+                created_at_monotonic=0.0,
+                created_at_turn=1,
+                used_fallback=False,
+                summary_error=None,
+            )
+
+            entered = threading.Event()
+            release = threading.Event()
+            orig_archive = db.archive_and_compact
+
+            def blocking_archive(session_id, compressed, *a, **k):
+                entered.set()
+                assert release.wait(timeout=10.0)
+                return orig_archive(session_id, compressed, *a, **k)
+
+            db.archive_and_compact = blocking_archive
+            result_box = {}
+
+            def _apply():
+                result_box["result"] = apply_prepared_candidate(
+                    agent, candidate, messages, "sys"
+                )
+
+            t = threading.Thread(target=_apply, daemon=True)
+            t.start()
+            try:
+                assert entered.wait(timeout=10.0)
+                # Critical window: the same lock synchronous compression
+                # takes is held, so the #56391 demotion queues new messages.
+                assert db.get_compression_lock_holder(sid) is not None
+                runner = _make_runner_over_db(db, sid)
+                assert await runner._session_has_compression_in_flight("k") is True
+            finally:
+                release.set()
+                t.join(timeout=10.0)
+            assert not t.is_alive()
+
+            assert result_box["result"] is not None
+            # Window closed: lock released, gateway unblocked.
+            assert db.get_compression_lock_holder(sid) is None
+            runner = _make_runner_over_db(db, sid)
+            assert await runner._session_has_compression_in_flight("k") is False
+
+            agent.close()
+            db.close()
+
+
+# ── eviction / reset / fork isolation ──────────────────────────────────────
+
+
+class TestLifecycleIsolation:
+    def test_soft_eviction_shuts_down_controller(self):
+        from gateway.run import GatewayRunner
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "evict-soft"
+            db.create_session(sid, "gateway", model="test/model")
+            agent = _make_real_agent(db, sid)
+
+            ctl = BackgroundCompressionController(_enabled_config())
+            msgs = _make_messages()
+            assert ctl.try_start_preparation(
+                session_id=sid, messages=msgs, prefix_count=len(msgs) - 4,
+                current_turn=1, source_prompt_tokens=180_000,
+                prepare_fn=_summary_prepare_fn,
+            )
+            assert ctl.wait_until_settled(timeout=5.0)
+            agent.background_compression_config = ctl.config
+            agent.background_compression = ctl
+
+            runner = GatewayRunner.__new__(GatewayRunner)
+            runner._release_evicted_agent_soft(agent)
+
+            assert agent.background_compression is None
+            assert ctl.peek_candidate() is None
+            agent.close()
+            db.close()
+
+    def test_background_review_fork_can_neither_prepare_nor_apply(self):
+        cfg = _enabled_config()
+        engine = SimpleNamespace(
+            context_length=100_000,
+            last_prompt_tokens=90_000,
+            can_prepare_compression=lambda messages, current_tokens=None: True,
+            prepare_compression=(
+                lambda messages, current_tokens=None, focus_topic=None:
+                    _summary_prepare_fn(messages)
+            ),
+        )
+        # Fork shape (agent/background_review.py): shares the parent's live
+        # session_id but has compression_enabled=False and its own (empty)
+        # controller slot.
+        parent_msgs = _make_messages()
+        parent_ctl = BackgroundCompressionController(cfg)
+        assert parent_ctl.try_start_preparation(
+            session_id="parent-sess", messages=parent_msgs,
+            prefix_count=len(parent_msgs) - 4, current_turn=1,
+            source_prompt_tokens=180_000, prepare_fn=_summary_prepare_fn,
+        )
+        assert parent_ctl.wait_until_settled(timeout=5.0)
+
+        fork = SimpleNamespace(
+            background_compression_config=cfg,
+            background_compression=None,
+            context_compressor=engine,
+            session_id="parent-sess",
+            compression_enabled=False,
+        )
+        assert maybe_prepare_background_compression(
+            fork, parent_msgs, current_tokens=90_000, current_turn=2
+        ) is False
+        assert fork.background_compression is None
+
+        # Even if a future refactor wrongly shared the parent's controller,
+        # the compression_enabled gate keeps the fork from applying.
+        fork.background_compression = parent_ctl
+        assert maybe_apply_prepared_candidate(
+            fork, parent_msgs, "sys", current_tokens=90_000, current_turn=2
+        ) is None
+        assert parent_ctl.peek_candidate() is not None  # untouched
+        parent_ctl.shutdown(wait=True)
+
+
+# ── deterministic interleaving stress ──────────────────────────────────────
+
+
+class TestDeterministicInterleavingStress:
+    """1,000 seeded runs permuting message arrival, worker completion,
+    reset, session switch and apply. Invariants: zero suffix loss, zero
+    duplication, zero cross-session application."""
+
+    N_RUNS = 1000
+
+    def _run_one(self, seed: int) -> dict:
+        rng = random.Random(seed)
+        sid = "sess-stress"
+        current_sid = sid
+        ctl = BackgroundCompressionController(_enabled_config())
+
+        msgs = _make_messages(n_turns=rng.randint(6, 14))
+        base_snapshot = copy.deepcopy(msgs)
+        prefix_request = len(msgs) - rng.randint(2, 4)
+
+        release = threading.Event()
+
+        def gated_prepare(prefix):
+            assert release.wait(timeout=10.0)
+            return _summary_prepare_fn(prefix)
+
+        started = ctl.try_start_preparation(
+            session_id=sid, messages=msgs, prefix_count=prefix_request,
+            current_turn=1, source_prompt_tokens=180_000,
+            prepare_fn=gated_prepare,
+        )
+        assert started is True
+
+        ops = (
+            ["worker_done"]
+            + ["new_message"] * rng.randint(0, 2)
+            + ["apply"] * rng.randint(1, 2)
+        )
+        if rng.random() < 0.30:
+            ops.append("reset")
+        if rng.random() < 0.20:
+            ops.append("session_switch")
+        rng.shuffle(ops)
+
+        appended = []
+        worker_done = False
+        reset_done = False
+        applied = False
+        turn = 1
+
+        for op in ops:
+            turn += 1
+            if op == "worker_done":
+                release.set()
+                assert ctl.wait_until_settled(timeout=10.0)
+                worker_done = True
+            elif op == "new_message":
+                if applied:
+                    continue
+                m = {"role": "user", "content": f"late {seed}-{turn}"}
+                appended.append(m)
+                msgs.append(m)
+            elif op == "reset":
+                ctl.reset()
+                reset_done = True
+            elif op == "session_switch":
+                current_sid = "sess-OTHER"
+            elif op == "apply":
+                cand = ctl.take_valid_candidate(
+                    session_id=current_sid, messages=msgs, current_turn=turn
+                )
+                if cand is None:
+                    continue
+                # Zero cross-session application, ever.
+                assert current_sid == sid, f"seed {seed}: cross-session apply"
+                assert cand.session_id == sid
+                assert not reset_done, f"seed {seed}: applied after reset"
+                assert worker_done, f"seed {seed}: applied unfinished work"
+
+                merged = merge_candidate_with_live_messages(cand, msgs)
+                prepared_n = len(cand.prepared_messages)
+                # Prefix is exactly the prepared set.
+                assert merged[:prepared_n] == list(cand.prepared_messages)
+                # Suffix: same objects, same order, exactly once (no loss,
+                # no duplication).
+                live_suffix = msgs[cand.prefix_message_count:]
+                merged_suffix = merged[prepared_n:]
+                assert len(merged_suffix) == len(live_suffix)
+                assert all(a is b for a, b in zip(merged_suffix, live_suffix))
+                suffix_ids = [id(m) for m in merged_suffix]
+                assert len(suffix_ids) == len(set(suffix_ids))
+                for late_msg in appended:
+                    assert merged.count(late_msg) == 1
+
+                ctl.mark_applied(cand)
+                msgs = merged
+                applied = True
+
+        # Ensure the worker is never left dangling.
+        release.set()
+        ctl.shutdown(wait=True)
+
+        # Preparation never mutated the frozen part of the live transcript.
+        if not applied:
+            assert msgs[: len(base_snapshot)] == base_snapshot
+            for late_msg in appended:
+                assert msgs.count(late_msg) == 1
+        # A second apply after a successful one must be impossible.
+        assert ctl.take_valid_candidate(
+            session_id=sid, messages=msgs, current_turn=turn + 1
+        ) is None
+        return {"applied": applied, "reset": reset_done,
+                "switched": current_sid != sid}
+
+    def test_thousand_deterministic_interleavings(self):
+        outcomes = {"applied": 0, "reset": 0, "switched": 0}
+        for seed in range(self.N_RUNS):
+            result = self._run_one(seed)
+            for key in outcomes:
+                if result[key]:
+                    outcomes[key] += 1
+        # The permutation space must actually exercise every branch.
+        assert outcomes["applied"] > 100
+        assert outcomes["reset"] > 100
+        assert outcomes["switched"] > 50

--- a/tests/run_agent/test_async_context_compression.py
+++ b/tests/run_agent/test_async_context_compression.py
@@ -1,0 +1,504 @@
+"""Safety contract for background-prepared ("async") context compression.
+
+These tests pin the non-negotiable invariants of the candidate lifecycle
+introduced by ``agent/async_context_compression.py`` — a fresh implementation
+of the idea explored in PR #23892, rebuilt against the current compression
+locks and persistence (no code is reused from that PR).
+
+Invariants under test (see the design plan):
+
+  1.  a valid candidate preserves the live suffix byte-for-byte;
+  2.  a diverging prefix digest discards the candidate;
+  3.  a diverging session_id discards the candidate;
+  4.  a stale generation discards the candidate;
+  5.  a candidate is never applied while a tool call is open;
+  6.  cancel and reset clear the candidate;
+  7.  two preparations leave only the newest generation;
+  8.  a worker exception never leaks into the foreground;
+  9.  with the feature disabled nothing is called;
+  10. ``shadow_only`` never touches persistence.
+
+Preparation must never mutate live state: the worker receives a deep copy of
+a frozen prefix and the live ``messages`` list stays untouched.
+"""
+
+import copy
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.async_context_compression import (
+    BackgroundCompressionConfig,
+    BackgroundCompressionController,
+    CandidateState,
+    PreparedCompressionCandidate,
+    PrepareResult,
+    align_prefix_boundary,
+    canonical_prefix_digest,
+    has_open_tool_call,
+    maybe_apply_prepared_candidate,
+    maybe_prepare_background_compression,
+    merge_candidate_with_live_messages,
+    validate_candidate,
+)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_messages(n_turns: int = 16) -> list:
+    msgs = [{"role": "system", "content": "sys"}]
+    for i in range(n_turns):
+        role = "user" if i % 2 == 0 else "assistant"
+        msgs.append({"role": role, "content": f"message {i}"})
+    return msgs
+
+
+def _tool_call_group(idx: int, *, answered: bool = True) -> list:
+    call_id = f"call_{idx}"
+    group = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }
+            ],
+        }
+    ]
+    if answered:
+        group.append(
+            {"role": "tool", "tool_call_id": call_id, "name": "read_file",
+             "content": f"tool result {idx}"}
+        )
+    return group
+
+
+def _enabled_config(**overrides) -> BackgroundCompressionConfig:
+    base = {
+        "enabled": True,
+        "shadow_only": False,
+        "prepare_threshold": 0.65,
+        "apply_threshold": 0.82,
+        "min_delta_tokens": 0,
+        "min_frozen_messages": 2,
+        "max_candidate_age_turns": 12,
+        "max_workers": 1,
+    }
+    base.update(overrides)
+    return BackgroundCompressionConfig.from_dict(base)
+
+
+def _default_prepare_fn(frozen_prefix: list) -> list:
+    """Stand-in summariser: one compaction marker + the last frozen message."""
+    return [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary of frozen prefix"},
+        copy.deepcopy(frozen_prefix[-1]),
+    ]
+
+
+def _prepare_ready_controller(messages, *, session_id="sess-1", config=None,
+                              prepare_fn=_default_prepare_fn, current_turn=3):
+    ctl = BackgroundCompressionController(config or _enabled_config())
+    started = ctl.try_start_preparation(
+        session_id=session_id,
+        messages=messages,
+        prefix_count=len(messages) - 4,
+        current_turn=current_turn,
+        source_prompt_tokens=180_000,
+        prepare_fn=prepare_fn,
+    )
+    assert started is True
+    assert ctl.wait_until_settled(timeout=5.0)
+    return ctl
+
+
+# ── config parsing ─────────────────────────────────────────────────────────
+
+
+class TestBackgroundCompressionConfig:
+    def test_defaults_are_off_and_shadow(self):
+        cfg = BackgroundCompressionConfig.from_dict(None)
+        assert cfg.enabled is False
+        assert cfg.shadow_only is True
+        assert cfg.prepare_threshold == pytest.approx(0.65)
+        assert cfg.apply_threshold == pytest.approx(0.82)
+        assert cfg.min_delta_tokens == 20_000
+        assert cfg.min_frozen_messages == 12
+        assert cfg.max_candidate_age_turns == 12
+        assert cfg.max_workers == 1
+        assert cfg.fallback_sync is True
+        assert cfg.apply_only_between_turns is True
+
+    def test_from_dict_reads_overrides(self):
+        cfg = BackgroundCompressionConfig.from_dict(
+            {"enabled": True, "shadow_only": False, "prepare_threshold": 0.5,
+             "min_delta_tokens": 5}
+        )
+        assert cfg.enabled is True
+        assert cfg.shadow_only is False
+        assert cfg.prepare_threshold == pytest.approx(0.5)
+        assert cfg.min_delta_tokens == 5
+
+
+# ── digest & boundary primitives ───────────────────────────────────────────
+
+
+class TestDigestAndBoundary:
+    def test_digest_is_deterministic_and_prefix_scoped(self):
+        msgs = _make_messages()
+        d1 = canonical_prefix_digest(msgs, len(msgs) - 2)
+        d2 = canonical_prefix_digest(copy.deepcopy(msgs), len(msgs) - 2)
+        assert d1 == d2
+        assert d1 != canonical_prefix_digest(msgs, len(msgs) - 3)
+
+    def test_digest_ignores_internal_persistence_metadata(self):
+        msgs = _make_messages()
+        marked = copy.deepcopy(msgs)
+        for m in marked:
+            m["_db_persisted"] = True
+        assert canonical_prefix_digest(msgs, len(msgs)) == canonical_prefix_digest(
+            marked, len(marked)
+        )
+
+    def test_digest_changes_when_semantic_content_changes(self):
+        msgs = _make_messages()
+        edited = copy.deepcopy(msgs)
+        edited[3]["content"] += " EDITED"
+        assert canonical_prefix_digest(msgs, len(msgs)) != canonical_prefix_digest(
+            edited, len(edited)
+        )
+
+    def test_boundary_never_splits_tool_call_group(self):
+        msgs = [{"role": "system", "content": "sys"},
+                {"role": "user", "content": "u0"}]
+        assistant_idx = len(msgs)
+        msgs.extend(_tool_call_group(0))          # assistant @2, tool @3
+        msgs.append({"role": "user", "content": "u1"})
+
+        # Boundary between the assistant tool_call and its tool result must
+        # retreat to before the assistant message.
+        assert align_prefix_boundary(msgs, assistant_idx + 1) == assistant_idx
+        # A boundary at a safe cut point is left untouched.
+        assert align_prefix_boundary(msgs, assistant_idx) == assistant_idx
+        assert align_prefix_boundary(msgs, len(msgs)) == len(msgs)
+
+    def test_boundary_retreats_across_multiple_tool_results(self):
+        msgs = [{"role": "system", "content": "sys"},
+                {"role": "user", "content": "u0"}]
+        assistant_idx = len(msgs)
+        call_ids = ["call_a", "call_b"]
+        msgs.append({
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": cid, "type": "function",
+                 "function": {"name": "t", "arguments": "{}"}}
+                for cid in call_ids
+            ],
+        })
+        for cid in call_ids:
+            msgs.append({"role": "tool", "tool_call_id": cid, "name": "t",
+                         "content": "r"})
+        # Cutting between the two tool results must retreat before the assistant.
+        assert align_prefix_boundary(msgs, assistant_idx + 2) == assistant_idx
+
+    def test_has_open_tool_call(self):
+        closed = _make_messages(4) + _tool_call_group(0, answered=True)
+        assert has_open_tool_call(closed) is False
+        open_ = _make_messages(4) + _tool_call_group(1, answered=False)
+        assert has_open_tool_call(open_) is True
+
+
+# ── candidate lifecycle ────────────────────────────────────────────────────
+
+
+class TestCandidateLifecycle:
+    def test_valid_candidate_preserves_new_suffix_byte_for_byte(self):
+        msgs = _make_messages()
+        ctl = _prepare_ready_controller(msgs)
+        # New messages arrive after preparation started.
+        msgs.append({"role": "user", "content": "new after prepare"})
+        msgs.append({"role": "assistant", "content": "answer after prepare"})
+
+        cand = ctl.take_valid_candidate(
+            session_id="sess-1", messages=msgs, current_turn=4
+        )
+        assert cand is not None
+        assert isinstance(cand, PreparedCompressionCandidate)
+        merged = merge_candidate_with_live_messages(cand, msgs)
+        suffix = merged[len(cand.prepared_messages):]
+        live_suffix = msgs[cand.prefix_message_count:]
+        # Same content AND the very same objects — byte-for-byte survival.
+        assert suffix == live_suffix
+        assert all(a is b for a, b in zip(suffix, live_suffix))
+        assert merged[: len(cand.prepared_messages)] == list(cand.prepared_messages)
+
+    def test_worker_receives_deep_copy_and_never_touches_live_messages(self):
+        msgs = _make_messages()
+        snapshot = copy.deepcopy(msgs)
+        seen = {}
+
+        def prepare_fn(frozen_prefix):
+            seen["prefix"] = frozen_prefix
+            # A worker mutating its input must never reach the live list.
+            frozen_prefix[0]["content"] = "MUTATED BY WORKER"
+            return _default_prepare_fn(frozen_prefix)
+
+        ctl = _prepare_ready_controller(msgs, prepare_fn=prepare_fn)
+        assert ctl.peek_candidate() is not None
+        assert msgs == snapshot
+        assert all(
+            frozen is not live for frozen, live in zip(seen["prefix"], msgs)
+        )
+
+    def test_diverging_digest_discards_candidate(self):
+        msgs = _make_messages()
+        ctl = _prepare_ready_controller(msgs)
+        msgs[2]["content"] += " EDITED AFTER SNAPSHOT"
+        assert ctl.take_valid_candidate(
+            session_id="sess-1", messages=msgs, current_turn=4
+        ) is None
+        assert ctl.peek_candidate() is None
+        assert ctl.state is CandidateState.STALE
+
+    def test_diverging_session_id_discards_candidate(self):
+        msgs = _make_messages()
+        ctl = _prepare_ready_controller(msgs, session_id="sess-1")
+        assert ctl.take_valid_candidate(
+            session_id="sess-OTHER", messages=msgs, current_turn=4
+        ) is None
+        assert ctl.peek_candidate() is None
+        assert ctl.state is CandidateState.STALE
+
+    def test_stale_generation_discards_candidate(self):
+        msgs = _make_messages()
+        ctl = _prepare_ready_controller(msgs)
+        old = ctl.peek_candidate()
+        assert old is not None
+
+        # A second preparation supersedes the first generation.
+        assert ctl.try_start_preparation(
+            session_id="sess-1",
+            messages=msgs,
+            prefix_count=len(msgs) - 4,
+            current_turn=5,
+            source_prompt_tokens=190_000,
+            prepare_fn=_default_prepare_fn,
+        )
+        assert ctl.wait_until_settled(timeout=5.0)
+        current = ctl.peek_candidate()
+        assert current is not None
+        assert current.generation > old.generation
+
+        ok, reason = validate_candidate(
+            old,
+            session_id="sess-1",
+            messages=msgs,
+            current_generation=ctl.generation,
+        )
+        assert ok is False
+        assert reason == "stale_generation"
+
+    def test_expired_candidate_age_discards_candidate(self):
+        msgs = _make_messages()
+        ctl = _prepare_ready_controller(
+            msgs, config=_enabled_config(max_candidate_age_turns=2), current_turn=3
+        )
+        assert ctl.take_valid_candidate(
+            session_id="sess-1", messages=msgs, current_turn=3 + 2 + 1
+        ) is None
+        assert ctl.state is CandidateState.STALE
+
+    def test_open_tool_call_blocks_apply_but_keeps_candidate(self):
+        msgs = _make_messages()
+        ctl = _prepare_ready_controller(msgs)
+        msgs.extend(_tool_call_group(9, answered=False))
+
+        assert ctl.take_valid_candidate(
+            session_id="sess-1", messages=msgs, current_turn=4
+        ) is None
+        # The candidate is not consumed: once the tool result lands it can apply.
+        assert ctl.state is CandidateState.READY
+        assert ctl.peek_candidate() is not None
+
+        msgs.append({"role": "tool", "tool_call_id": "call_9", "name": "read_file",
+                     "content": "late result"})
+        assert ctl.take_valid_candidate(
+            session_id="sess-1", messages=msgs, current_turn=4
+        ) is not None
+
+    def test_two_preparations_keep_only_newest_generation(self):
+        msgs = _make_messages()
+        ctl = BackgroundCompressionController(_enabled_config())
+        first_started = threading.Event()
+        release_first = threading.Event()
+
+        def slow_prepare(frozen_prefix):
+            first_started.set()
+            assert release_first.wait(timeout=5.0)
+            return [{"role": "user", "content": "[CONTEXT COMPACTION] FIRST"}]
+
+        assert ctl.try_start_preparation(
+            session_id="sess-1", messages=msgs, prefix_count=len(msgs) - 4,
+            current_turn=1, source_prompt_tokens=100_000, prepare_fn=slow_prepare,
+        )
+        assert first_started.wait(timeout=5.0)
+        # Second preparation supersedes the in-flight first one.
+        assert ctl.try_start_preparation(
+            session_id="sess-1", messages=msgs, prefix_count=len(msgs) - 4,
+            current_turn=2, source_prompt_tokens=110_000,
+            prepare_fn=lambda p: [
+                {"role": "user", "content": "[CONTEXT COMPACTION] SECOND"}
+            ],
+        )
+        release_first.set()
+        assert ctl.wait_until_settled(timeout=5.0)
+
+        cand = ctl.peek_candidate()
+        assert cand is not None
+        assert cand.prepared_messages[0]["content"].endswith("SECOND")
+        assert cand.generation == ctl.generation
+
+    def test_cancel_and_reset_clear_candidate(self):
+        msgs = _make_messages()
+
+        # Cancel while preparing: the late worker result must be discarded.
+        ctl = BackgroundCompressionController(_enabled_config())
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocked_prepare(frozen_prefix):
+            started.set()
+            assert release.wait(timeout=5.0)
+            return _default_prepare_fn(frozen_prefix)
+
+        assert ctl.try_start_preparation(
+            session_id="sess-1", messages=msgs, prefix_count=len(msgs) - 4,
+            current_turn=1, source_prompt_tokens=100_000,
+            prepare_fn=blocked_prepare,
+        )
+        assert started.wait(timeout=5.0)
+        ctl.cancel()
+        release.set()
+        assert ctl.wait_until_settled(timeout=5.0)
+        assert ctl.peek_candidate() is None
+        assert ctl.state is CandidateState.CANCELLED
+
+        # Reset after ready: candidate cleared, state back to idle.
+        ctl2 = _prepare_ready_controller(msgs)
+        assert ctl2.peek_candidate() is not None
+        ctl2.reset()
+        assert ctl2.peek_candidate() is None
+        assert ctl2.state is CandidateState.IDLE
+
+    def test_worker_exception_never_leaks_into_foreground(self):
+        msgs = _make_messages()
+        ctl = BackgroundCompressionController(_enabled_config())
+
+        def broken_prepare(frozen_prefix):
+            raise RuntimeError("summariser exploded")
+
+        assert ctl.try_start_preparation(
+            session_id="sess-1", messages=msgs, prefix_count=len(msgs) - 4,
+            current_turn=1, source_prompt_tokens=100_000,
+            prepare_fn=broken_prepare,
+        )
+        # Foreground calls never raise.
+        assert ctl.wait_until_settled(timeout=5.0)
+        assert ctl.state is CandidateState.FAILED
+        assert ctl.peek_candidate() is None
+        assert "summariser exploded" in (ctl.last_error or "")
+        assert ctl.take_valid_candidate(
+            session_id="sess-1", messages=msgs, current_turn=2
+        ) is None
+
+    def test_prepare_result_metadata_is_recorded_on_candidate(self):
+        msgs = _make_messages()
+
+        def fallback_prepare(frozen_prefix):
+            return PrepareResult(
+                messages=_default_prepare_fn(frozen_prefix),
+                used_fallback=True,
+                summary_error="aux provider down",
+            )
+
+        ctl = _prepare_ready_controller(msgs, prepare_fn=fallback_prepare)
+        cand = ctl.peek_candidate()
+        assert cand is not None
+        assert cand.used_fallback is True
+        assert cand.summary_error == "aux provider down"
+
+    def test_candidate_is_immutable(self):
+        msgs = _make_messages()
+        ctl = _prepare_ready_controller(msgs)
+        cand = ctl.peek_candidate()
+        assert isinstance(cand.prepared_messages, tuple)
+        with pytest.raises(Exception):
+            cand.session_id = "other"
+
+
+# ── feature flag & shadow mode ─────────────────────────────────────────────
+
+
+class TestFeatureFlagAndShadow:
+    def test_disabled_feature_changes_no_calls(self):
+        # Controller level: preparation refuses to start.
+        cfg = BackgroundCompressionConfig.from_dict(None)  # enabled=False default
+        ctl = BackgroundCompressionController(cfg)
+        prepare_fn = MagicMock()
+        assert ctl.try_start_preparation(
+            session_id="sess-1", messages=_make_messages(),
+            prefix_count=8, current_turn=1, source_prompt_tokens=200_000,
+            prepare_fn=prepare_fn,
+        ) is False
+        assert ctl.state is CandidateState.IDLE
+        prepare_fn.assert_not_called()
+
+        # Loop-facing helper: nothing on the agent is touched.
+        agent = SimpleNamespace(
+            background_compression_config=cfg,
+            background_compression=None,
+            context_compressor=MagicMock(),
+            session_id="sess-1",
+            compression_enabled=True,
+        )
+        assert maybe_prepare_background_compression(
+            agent, _make_messages(), current_tokens=250_000, current_turn=1
+        ) is False
+        assert agent.background_compression is None
+        assert agent.context_compressor.mock_calls == []
+
+        assert maybe_apply_prepared_candidate(
+            agent, _make_messages(), "sys", current_tokens=250_000, current_turn=1
+        ) is None
+
+    def test_shadow_only_never_calls_persistence(self):
+        msgs = _make_messages()
+        cfg = _enabled_config(shadow_only=True)
+        ctl = _prepare_ready_controller(msgs, config=cfg)
+
+        db = MagicMock()
+        agent = SimpleNamespace(
+            background_compression_config=cfg,
+            background_compression=ctl,
+            context_compressor=MagicMock(),
+            _session_db=db,
+            session_id="sess-1",
+            compression_enabled=True,
+        )
+        result = maybe_apply_prepared_candidate(
+            agent, msgs, "sys", current_tokens=250_000, current_turn=4
+        )
+        # Shadow mode validates and measures but never applies or persists.
+        assert result is None
+        db.archive_and_compact.assert_not_called()
+        db.replace_messages.assert_not_called()
+        db.end_session.assert_not_called()
+        db.create_session.assert_not_called()
+        db.update_system_prompt.assert_not_called()

--- a/tests/run_agent/test_async_context_compression.py
+++ b/tests/run_agent/test_async_context_compression.py
@@ -760,6 +760,122 @@ class TestFinalizeTurnWiring:
         assert result["final_response"] == "done"
 
 
+class TestConfigTelemetryKillSwitch:
+    """Task 8: operable without code edits — config block, telemetry, kill switch."""
+
+    def test_default_config_ships_disabled_shadow_block(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        bg = DEFAULT_CONFIG["compression"]["background"]
+        assert bg["enabled"] is False
+        assert bg["shadow_only"] is True
+        assert bg["prepare_threshold"] == pytest.approx(0.65)
+        assert bg["apply_threshold"] == pytest.approx(0.82)
+        assert bg["min_delta_tokens"] == 20_000
+        assert bg["min_frozen_messages"] == 12
+        assert bg["max_candidate_age_turns"] == 12
+        assert bg["max_workers"] == 1
+        assert bg["foreground_priority"] is True
+        assert bg["fallback_sync"] is True
+        assert bg["apply_only_between_turns"] is True
+        # The shipped defaults and the dataclass defaults must never drift.
+        assert BackgroundCompressionConfig.from_dict(bg) == BackgroundCompressionConfig()
+
+    def test_gateway_cache_signature_busts_on_background_config_edit(self):
+        from gateway.run import GatewayRunner
+
+        on = GatewayRunner._extract_cache_busting_config(
+            {"compression": {"background": {"enabled": True}}}
+        )
+        off = GatewayRunner._extract_cache_busting_config(
+            {"compression": {"background": {"enabled": False}}}
+        )
+        assert "compression.background" in on
+        assert on["compression.background"] != off["compression.background"]
+
+    def test_kill_switch_via_config_set_restores_baseline(self):
+        from hermes_cli.config import _set_nested
+
+        config = {"compression": {"background": {"enabled": True,
+                                                 "shadow_only": False}}}
+        _set_nested(config, "compression.background.enabled", False)
+        cfg = BackgroundCompressionConfig.from_dict(
+            config["compression"]["background"]
+        )
+        assert cfg.enabled is False
+
+        agent = _fake_agent(cfg, _fake_engine())
+        assert maybe_prepare_background_compression(
+            agent, _make_messages(), current_tokens=90_000, current_turn=1
+        ) is False
+        assert agent.background_compression is None
+        assert maybe_apply_prepared_candidate(
+            agent, _make_messages(), "sys", current_tokens=90_000, current_turn=1
+        ) is None
+
+    def test_telemetry_snapshot_counts_lifecycle_events(self):
+        msgs = _make_messages()
+        ctl = _prepare_ready_controller(msgs)
+        snap = ctl.telemetry_snapshot()
+        assert snap["candidate_started"] == 1
+        assert snap["candidate_ready"] == 1
+        assert snap["candidate_failed"] == 0
+        assert snap["state"] == "ready"
+        assert snap["candidate_prepare_ms"]["count"] == 1
+        assert snap["candidate_prepare_ms"]["p50_ms"] >= 0.0
+
+    def test_telemetry_counts_worker_failure_as_provider_error(self):
+        ctl = BackgroundCompressionController(_enabled_config())
+
+        def broken(prefix):
+            raise RuntimeError("provider 500")
+
+        assert ctl.try_start_preparation(
+            session_id="sess-1", messages=_make_messages(),
+            prefix_count=10, current_turn=1, source_prompt_tokens=100_000,
+            prepare_fn=broken,
+        )
+        assert ctl.wait_until_settled(timeout=5.0)
+        snap = ctl.telemetry_snapshot()
+        assert snap["candidate_failed"] == 1
+        assert snap["background_provider_error"] == 1
+
+    def test_apply_records_duration_and_suffix_preserved(self):
+        msgs = _make_messages()
+        cfg = _enabled_config(shadow_only=False)
+        ctl = _prepare_ready_controller(msgs, config=cfg)
+        agent = _fake_agent(cfg, _fake_engine(), controller=ctl)
+
+        with patch(
+            "agent.conversation_compression.apply_prepared_candidate",
+            return_value=(["compressed"], "new-prompt"),
+        ):
+            result = maybe_apply_prepared_candidate(
+                agent, msgs, "sys", current_tokens=90_000, current_turn=4
+            )
+        assert result == (["compressed"], "new-prompt")
+        snap = ctl.telemetry_snapshot()
+        assert snap["candidate_apply_ms"]["count"] == 1
+        # Helper froze len(msgs) - 4 messages; the 4-message suffix survived.
+        assert snap["suffix_messages_preserved"] == 4
+
+    def test_apply_failure_counts_sync_fallback(self):
+        msgs = _make_messages()
+        cfg = _enabled_config(shadow_only=False)
+        ctl = _prepare_ready_controller(msgs, config=cfg)
+        agent = _fake_agent(cfg, _fake_engine(), controller=ctl)
+
+        with patch(
+            "agent.conversation_compression.apply_prepared_candidate",
+            side_effect=RuntimeError("db locked"),
+        ):
+            result = maybe_apply_prepared_candidate(
+                agent, msgs, "sys", current_tokens=90_000, current_turn=4
+            )
+        assert result is None
+        assert ctl.telemetry_snapshot()["sync_fallback_count"] == 1
+
+
 class TestAgentLifecycleIntegration:
     """Real-agent surface: hooks exist, are safe, and honor session boundaries."""
 

--- a/tests/run_agent/test_async_context_compression.py
+++ b/tests/run_agent/test_async_context_compression.py
@@ -23,9 +23,12 @@ a frozen prefix and the live ``messages`` list stays untouched.
 """
 
 import copy
+import os
+import tempfile
 import threading
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -502,3 +505,363 @@ class TestFeatureFlagAndShadow:
         db.end_session.assert_not_called()
         db.create_session.assert_not_called()
         db.update_system_prompt.assert_not_called()
+
+
+# ── loop integration (task 6): prepare between turns, apply in preflight ───
+
+
+def _fake_engine(*, context_length=100_000, last_prompt_tokens=0,
+                 can_prepare=True, prepare_fn=_default_prepare_fn):
+    """Duck-typed ContextEngine exposing exactly the hooks the loop uses."""
+    eng = SimpleNamespace()
+    eng.context_length = context_length
+    eng.last_prompt_tokens = last_prompt_tokens
+    eng.can_prepare_compression = (
+        lambda messages, current_tokens=None: can_prepare
+    )
+    eng.prepare_compression = (
+        lambda messages, current_tokens=None, focus_topic=None: prepare_fn(messages)
+    )
+    return eng
+
+
+def _fake_agent(cfg, engine, *, controller=None, session_id="sess-1"):
+    return SimpleNamespace(
+        background_compression_config=cfg,
+        background_compression=controller,
+        context_compressor=engine,
+        session_id=session_id,
+        compression_enabled=True,
+    )
+
+
+class TestPreparationTriggers:
+    """maybe_prepare_background_compression() trigger conditions (task 6)."""
+
+    def test_prepare_starts_above_threshold_without_mutating_live_messages(self):
+        msgs = _make_messages()
+        snapshot = copy.deepcopy(msgs)
+        agent = _fake_agent(_enabled_config(), _fake_engine())
+
+        started = maybe_prepare_background_compression(
+            agent, msgs, current_tokens=80_000, current_turn=2
+        )
+        assert started is True
+        ctl = agent.background_compression
+        assert isinstance(ctl, BackgroundCompressionController)
+        assert ctl.wait_until_settled(timeout=5.0)
+        assert ctl.state is CandidateState.READY
+        assert ctl.peek_candidate() is not None
+        assert msgs == snapshot
+
+    def test_prepare_skipped_below_prepare_threshold(self):
+        agent = _fake_agent(_enabled_config(), _fake_engine())
+        assert maybe_prepare_background_compression(
+            agent, _make_messages(), current_tokens=30_000, current_turn=2
+        ) is False
+        assert agent.background_compression is None
+
+    def test_prepare_skipped_when_engine_opts_out(self):
+        agent = _fake_agent(_enabled_config(), _fake_engine(can_prepare=False))
+        assert maybe_prepare_background_compression(
+            agent, _make_messages(), current_tokens=80_000, current_turn=2
+        ) is False
+        assert agent.background_compression is None
+
+    def test_prepare_skipped_when_tool_call_open(self):
+        msgs = _make_messages() + _tool_call_group(7, answered=False)
+        agent = _fake_agent(_enabled_config(), _fake_engine())
+        assert maybe_prepare_background_compression(
+            agent, msgs, current_tokens=80_000, current_turn=2
+        ) is False
+
+    def test_prepare_skipped_while_preparation_in_flight(self):
+        msgs = _make_messages()
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocked(prefix):
+            started.set()
+            assert release.wait(timeout=5.0)
+            return _default_prepare_fn(prefix)
+
+        cfg = _enabled_config()
+        agent = _fake_agent(cfg, _fake_engine(prepare_fn=blocked))
+        assert maybe_prepare_background_compression(
+            agent, msgs, current_tokens=80_000, current_turn=2
+        ) is True
+        assert started.wait(timeout=5.0)
+        # In flight — a second trigger must not supersede the running one.
+        assert maybe_prepare_background_compression(
+            agent, msgs, current_tokens=90_000, current_turn=3
+        ) is False
+        release.set()
+        assert agent.background_compression.wait_until_settled(timeout=5.0)
+
+    def test_prepare_respects_min_delta_tokens(self):
+        msgs = _make_messages()
+        cfg = _enabled_config(min_delta_tokens=20_000)
+        agent = _fake_agent(cfg, _fake_engine())
+        assert maybe_prepare_background_compression(
+            agent, msgs, current_tokens=80_000, current_turn=2
+        ) is True
+        assert agent.background_compression.wait_until_settled(timeout=5.0)
+        # Barely grown context: don't re-summarise on every message.
+        assert maybe_prepare_background_compression(
+            agent, msgs, current_tokens=85_000, current_turn=3
+        ) is False
+        # Past the delta: a fresh candidate is worth preparing.
+        assert maybe_prepare_background_compression(
+            agent, msgs, current_tokens=101_000, current_turn=4
+        ) is True
+        assert agent.background_compression.wait_until_settled(timeout=5.0)
+
+
+class TestApplyGate:
+    """maybe_apply_prepared_candidate() must respect apply_threshold."""
+
+    def test_apply_below_threshold_keeps_candidate_warm(self):
+        msgs = _make_messages()
+        cfg = _enabled_config(shadow_only=False)
+        ctl = _prepare_ready_controller(msgs, config=cfg)
+        agent = _fake_agent(cfg, _fake_engine(), controller=ctl)
+
+        result = maybe_apply_prepared_candidate(
+            agent, msgs, "sys", current_tokens=70_000, current_turn=4
+        )
+        assert result is None
+        # Below the gate is a temporal refusal — the candidate survives and
+        # no apply/fallback was even attempted.
+        assert ctl.peek_candidate() is not None
+        assert ctl.state is CandidateState.READY
+        assert "sync_fallback_count" not in ctl.stats
+        assert "candidate_applied" not in ctl.stats
+
+    def test_shadow_above_threshold_records_and_drops(self):
+        msgs = _make_messages()
+        cfg = _enabled_config(shadow_only=True)
+        ctl = _prepare_ready_controller(msgs, config=cfg)
+        agent = _fake_agent(cfg, _fake_engine(), controller=ctl)
+
+        result = maybe_apply_prepared_candidate(
+            agent, msgs, "sys", current_tokens=90_000, current_turn=4
+        )
+        assert result is None
+        assert ctl.peek_candidate() is None
+        assert ctl.stats.get("candidate_shadow_validated") == 1
+
+
+class _FinalizeStubAgent:
+    """Minimal duck-typed agent surface for finalize_turn wiring tests."""
+
+    def __init__(self):
+        self.max_iterations = 10
+        self.iteration_budget = SimpleNamespace(used=1, max_total=10, remaining=9)
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.model = "stub/model"
+        self.provider = "stub"
+        self.base_url = "http://stub"
+        self.session_id = "sess-1"
+        self.quiet_mode = True
+        self.platform = "cli"
+        self._interrupt_requested = False
+        self._interrupt_message = None
+        self._tool_guardrail_halt_decision = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        for attr in (
+            "session_input_tokens", "session_output_tokens",
+            "session_cache_read_tokens", "session_cache_write_tokens",
+            "session_reasoning_tokens", "session_prompt_tokens",
+            "session_completion_tokens", "session_total_tokens",
+            "session_estimated_cost_usd",
+        ):
+            setattr(self, attr, 0)
+        self.session_cost_status = "ok"
+        self.session_cost_source = "stub"
+        self.prepare_calls = []
+
+    def _maybe_prepare_background_compression(self, messages, **kwargs):
+        self.prepare_calls.append(list(messages))
+        return True
+
+    # -- inert surfaces --------------------------------------------------
+    def _save_trajectory(self, *a, **k): pass
+    def _cleanup_task_resources(self, *a, **k): pass
+    def _drop_trailing_empty_response_scaffolding(self, *a, **k): pass
+    def _persist_session(self, *a, **k): pass
+    def _emit_status(self, *a, **k): pass
+    def _safe_print(self, *a, **k): pass
+    def _handle_max_iterations(self, messages, n): return "SUMMARY"
+    def _file_mutation_verifier_enabled(self): return False
+    def _turn_completion_explainer_enabled(self): return False
+    def _drain_pending_steer(self): return None
+    def clear_interrupt(self): pass
+    def _sync_external_memory_for_turn(self, **k): pass
+
+
+def _run_finalize(agent, *, interrupted=False, failed=False,
+                  final_response="done"):
+    from agent.turn_finalizer import finalize_turn
+
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": final_response or "answer"},
+    ]
+    return finalize_turn(
+        agent,
+        final_response=final_response,
+        api_call_count=1,
+        interrupted=interrupted,
+        failed=failed,
+        messages=messages,
+        conversation_history=None,
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="question",
+        original_user_message="question",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+
+class TestFinalizeTurnWiring:
+    """The between-turns finalizer must trigger background preparation."""
+
+    def test_completed_turn_triggers_preparation(self):
+        agent = _FinalizeStubAgent()
+        result = _run_finalize(agent)
+        assert result["final_response"] == "done"
+        assert len(agent.prepare_calls) == 1
+        assert agent.prepare_calls[0][-1]["role"] == "assistant"
+
+    def test_interrupted_turn_does_not_trigger_preparation(self):
+        agent = _FinalizeStubAgent()
+        result = _run_finalize(agent, interrupted=True, final_response=None)
+        assert result["interrupted"] is True
+        assert agent.prepare_calls == []
+
+    def test_preparation_hook_exception_never_breaks_the_turn(self):
+        agent = _FinalizeStubAgent()
+
+        def _boom(messages, **kwargs):
+            raise RuntimeError("background exploded")
+
+        agent._maybe_prepare_background_compression = _boom
+        result = _run_finalize(agent)
+        assert result["final_response"] == "done"
+
+    def test_agent_without_hook_still_finalizes(self):
+        # Backward compatibility: stubs/forks without the hook keep working.
+        agent = _FinalizeStubAgent()
+        agent._maybe_prepare_background_compression = None  # not callable
+        result = _run_finalize(agent)
+        assert result["final_response"] == "done"
+
+
+class TestAgentLifecycleIntegration:
+    """Real-agent surface: hooks exist, are safe, and honor session boundaries."""
+
+    def _make_real_agent(self, session_db, session_id):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id=session_id,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent._compression_feasibility_checked = True
+        return agent
+
+    def test_feature_disabled_by_default_and_hooks_are_noops(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "bg-defaults"
+            db.create_session(sid, "cli", model="test/model")
+            agent = self._make_real_agent(db, sid)
+            try:
+                cfg = agent.background_compression_config
+                assert isinstance(cfg, BackgroundCompressionConfig)
+                assert cfg.enabled is False
+                assert cfg.shadow_only is True
+                assert agent.background_compression is None
+
+                msgs = _make_messages()
+                assert agent._maybe_prepare_background_compression(msgs) is False
+                assert agent._maybe_apply_prepared_compression(msgs, "sys") is None
+                assert agent.background_compression is None
+            finally:
+                agent.close()
+                db.close()
+
+    def test_reset_session_state_invalidates_candidate(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "bg-reset"
+            db.create_session(sid, "cli", model="test/model")
+            agent = self._make_real_agent(db, sid)
+            try:
+                msgs = _make_messages()
+                ctl = _prepare_ready_controller(msgs, session_id=sid)
+                agent.background_compression_config = ctl.config
+                agent.background_compression = ctl
+                assert ctl.peek_candidate() is not None
+
+                agent.reset_session_state()
+                assert ctl.peek_candidate() is None
+                assert ctl.state is CandidateState.IDLE
+            finally:
+                agent.close()
+                db.close()
+
+    def test_close_shuts_down_controller(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "bg-close"
+            db.create_session(sid, "cli", model="test/model")
+            agent = self._make_real_agent(db, sid)
+            msgs = _make_messages()
+            ctl = _prepare_ready_controller(msgs, session_id=sid)
+            agent.background_compression_config = ctl.config
+            agent.background_compression = ctl
+
+            agent.close()
+            assert agent.background_compression is None
+            assert ctl.peek_candidate() is None
+            db.close()
+
+    def test_apply_hook_swallows_controller_exceptions(self):
+        from hermes_state import SessionDB
+
+        class _BrokenController(BackgroundCompressionController):
+            def take_valid_candidate(self, **kwargs):
+                raise RuntimeError("controller exploded")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "bg-broken"
+            db.create_session(sid, "cli", model="test/model")
+            agent = self._make_real_agent(db, sid)
+            try:
+                cfg = _enabled_config(shadow_only=False)
+                agent.background_compression_config = cfg
+                agent.background_compression = _BrokenController(cfg)
+                # Invariant 7: background failures never reach the foreground.
+                assert agent._maybe_apply_prepared_compression(
+                    _make_messages(), "sys", current_tokens=250_000
+                ) is None
+            finally:
+                agent.close()
+                db.close()

--- a/tests/run_agent/test_async_context_compression.py
+++ b/tests/run_agent/test_async_context_compression.py
@@ -44,6 +44,7 @@ from agent.async_context_compression import (
     maybe_apply_prepared_candidate,
     maybe_prepare_background_compression,
     merge_candidate_with_live_messages,
+    resolve_effective_gate_tokens,
     validate_candidate,
 )
 
@@ -617,6 +618,59 @@ class TestPreparationTriggers:
         assert agent.background_compression.wait_until_settled(timeout=5.0)
 
 
+class TestEffectiveGateDerivation:
+    """resolve_effective_gate_tokens(): prepare < apply < sync for every profile."""
+
+    def _engine(self, *, context_length, threshold_tokens):
+        eng = _fake_engine(context_length=context_length)
+        eng.threshold_tokens = threshold_tokens
+        return eng
+
+    def test_defaults_clamp_under_upstream_sync_threshold(self):
+        # Shipped defaults: sync 0.50 of a 400K window → 200K trigger. The
+        # absolute 0.65/0.82 gates (260K/328K) sit past it and must clamp.
+        prepare, apply, sync = resolve_effective_gate_tokens(
+            _enabled_config(),
+            self._engine(context_length=400_000, threshold_tokens=200_000),
+        )
+        assert sync == 200_000
+        assert prepare == pytest.approx(160_000)  # 80% of the sync trigger
+        assert apply == pytest.approx(192_000)    # 96% of the sync trigger
+        assert prepare < apply < sync
+
+    def test_small_context_floor_profile(self):
+        # 100K window under the raise-only 0.75 floor → 75K trigger.
+        prepare, apply, sync = resolve_effective_gate_tokens(
+            _enabled_config(),
+            self._engine(context_length=100_000, threshold_tokens=75_000),
+        )
+        assert prepare == pytest.approx(60_000)
+        assert apply == pytest.approx(72_000)
+        assert prepare < apply < sync
+
+    def test_high_sync_threshold_honors_configured_values(self):
+        # 0.85-style profile (Codex autoraise): 0.65 already fires first and
+        # is honored verbatim; 0.82 clamps marginally to 96% of the trigger.
+        prepare, apply, sync = resolve_effective_gate_tokens(
+            _enabled_config(),
+            self._engine(context_length=100_000, threshold_tokens=85_000),
+        )
+        assert prepare == pytest.approx(65_000)
+        assert apply == pytest.approx(81_600)
+        assert prepare < apply < sync
+
+    def test_inverted_user_config_is_reordered(self):
+        cfg = _enabled_config(prepare_threshold=0.9, apply_threshold=0.6)
+        prepare, apply, _sync = resolve_effective_gate_tokens(
+            cfg, self._engine(context_length=100_000, threshold_tokens=85_000)
+        )
+        assert prepare < apply
+
+    def test_unknown_engine_keeps_gates_silent(self):
+        prepare, apply, sync = resolve_effective_gate_tokens(_enabled_config(), None)
+        assert (prepare, apply, sync) == (0.0, 0.0, 0.0)
+
+
 class TestApplyGate:
     """maybe_apply_prepared_candidate() must respect apply_threshold."""
 
@@ -649,6 +703,43 @@ class TestApplyGate:
         assert result is None
         assert ctl.peek_candidate() is None
         assert ctl.stats.get("candidate_shadow_validated") == 1
+
+    def test_sync_preemption_when_sync_fires_below_apply_gate(self):
+        # ``should_compress`` can fire on non-token triggers (message-count
+        # hygiene) while usage still sits under the apply gate. A ready
+        # candidate must preempt that synchronous run, not stay warm.
+        msgs = _make_messages()
+        cfg = _enabled_config(shadow_only=True)
+        ctl = _prepare_ready_controller(msgs, config=cfg)
+        eng = _fake_engine(context_length=1_000_000)
+        eng.threshold_tokens = 900_000            # apply gate stays at 820K
+        eng.should_compress = lambda tokens: True  # hygiene-style trigger
+        agent = _fake_agent(cfg, eng, controller=ctl)
+
+        result = maybe_apply_prepared_candidate(
+            agent, msgs, "sys", current_tokens=600_000, current_turn=4
+        )
+        assert result is None  # shadow mode: observe, never apply
+        assert ctl.stats.get("candidate_shadow_validated") == 1
+
+    def test_below_gate_and_sync_quiet_still_keeps_candidate_warm(self):
+        # Same engine surface, sync NOT firing: the temporal refusal from
+        # test_apply_below_threshold_keeps_candidate_warm must survive the
+        # preemption backstop.
+        msgs = _make_messages()
+        cfg = _enabled_config(shadow_only=False)
+        ctl = _prepare_ready_controller(msgs, config=cfg)
+        eng = _fake_engine(context_length=1_000_000)
+        eng.threshold_tokens = 900_000
+        eng.should_compress = lambda tokens: tokens >= 900_000
+        agent = _fake_agent(cfg, eng, controller=ctl)
+
+        result = maybe_apply_prepared_candidate(
+            agent, msgs, "sys", current_tokens=600_000, current_turn=4
+        )
+        assert result is None
+        assert ctl.peek_candidate() is not None
+        assert ctl.state is CandidateState.READY
 
 
 class _FinalizeStubAgent:
@@ -978,6 +1069,184 @@ class TestAgentLifecycleIntegration:
                 assert agent._maybe_apply_prepared_compression(
                     _make_messages(), "sys", current_tokens=250_000
                 ) is None
+            finally:
+                agent.close()
+                db.close()
+
+
+# ── E2E preflight ordering with shipped defaults (PR #66619 review) ────────
+
+
+class TestPreflightDefaultsEndToEnd:
+    """The real ``build_turn_context`` preflight must apply a candidate
+    prepared under SHIPPED defaults instead of invoking the synchronous
+    ``_compress_context`` — the hermes-sweeper blocking finding on #66619.
+
+    Everything is real except the summariser LLM call: AIAgent, SessionDB,
+    ContextCompressor threshold math (0.50 config + floors), the background
+    controller, the preflight chain and the atomic apply."""
+
+    _SUMMARY = "[CONTEXT COMPACTION] e2e deterministic summary"
+
+    def _grow_until(self, messages, estimator, target_tokens, *, tag, repeat=30):
+        """Append user/assistant turns until the rough estimate crosses the
+        target. Returns how many USER rows were appended so the caller can
+        advance ``_user_turn_count`` exactly like live turns would."""
+        i = 0
+        users = 0
+        filler = ("conversa longa sobre o projeto, decisões e arquivos. " * repeat).strip()
+        while estimator(messages) < target_tokens:
+            role = "user" if i % 2 == 0 else "assistant"
+            if role == "user":
+                users += 1
+            messages.append({"role": role, "content": f"[{tag} {i}] {filler}"})
+            i += 1
+        return users
+
+    def test_default_candidate_applies_instead_of_sync_compression(self):
+        import agent.conversation_loop as loop_mod
+        import agent.turn_context as turn_ctx_mod
+        from agent.context_compressor import ContextCompressor
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                from run_agent import AIAgent
+
+                db = SessionDB(db_path=Path(tmpdir) / "state.db")
+                sid = "e2e-preflight-defaults"
+                db.create_session(sid, "cli", model="test/model")
+                agent = AIAgent(
+                    api_key="test-key",
+                    base_url="https://openrouter.ai/api/v1",
+                    model="test/model",
+                    quiet_mode=True,
+                    session_db=db,
+                    session_id=sid,
+                    skip_context_files=True,
+                    skip_memory=True,
+                )
+            try:
+                agent._compression_feasibility_checked = True
+                engine = agent.context_compressor
+                # Real engine API + real threshold math on a bounded window;
+                # the shipped compression config (0.50 + raise-only floors)
+                # stays untouched.
+                engine.update_model("test/model", 120_000)
+                sync_trigger = engine.threshold_tokens
+                assert sync_trigger > 0
+
+                # Turn the feature on exactly as an operator would; every
+                # threshold keeps its shipped default (0.65 / 0.82).
+                agent.background_compression_config = (
+                    BackgroundCompressionConfig.from_dict(
+                        {"enabled": True, "shadow_only": False}
+                    )
+                )
+                cfg = agent.background_compression_config
+                prepare_gate, apply_gate, sync_tokens = (
+                    resolve_effective_gate_tokens(cfg, engine)
+                )
+                # The review's invariant, on the real engine with defaults:
+                assert prepare_gate < apply_gate < sync_tokens == sync_trigger
+
+                def _estimate(msgs):
+                    return turn_ctx_mod.estimate_request_tokens_rough(
+                        msgs,
+                        system_prompt="",
+                        tools=agent.tools or None,
+                    )
+
+                # Deterministic summariser: the only stubbed boundary.
+                with patch.object(
+                    ContextCompressor,
+                    "_generate_summary",
+                    return_value=self._SUMMARY,
+                ):
+                    # 1. History lands between the prepare and apply gates →
+                    #    the real between-turn hook starts preparation. The
+                    #    turn counter is hydrated first, exactly as the live
+                    #    loop keeps it across the accumulated turns.
+                    history = []
+                    self._grow_until(
+                        history, _estimate,
+                        int((prepare_gate + apply_gate) / 2), tag="base",
+                    )
+                    agent._user_turn_count = sum(
+                        1 for m in history if m.get("role") == "user"
+                    )
+                    prepare_tokens = _estimate(history)
+                    assert prepare_gate <= prepare_tokens < apply_gate
+                    started = agent._maybe_prepare_background_compression(
+                        history, current_tokens=prepare_tokens
+                    )
+                    assert started is True
+                    ctl = agent.background_compression
+                    assert ctl is not None and ctl.wait_until_settled(timeout=30.0)
+                    assert ctl.state is CandidateState.READY
+                    candidate = ctl.peek_candidate()
+                    assert candidate is not None
+
+                    # 2. Conversation keeps growing (append-only) past the
+                    #    synchronous trigger — agentic-sized turns, with the
+                    #    turn counter advancing like live turns would.
+                    grown_users = self._grow_until(
+                        history, _estimate, int(sync_trigger * 1.05),
+                        tag="growth", repeat=120,
+                    )
+                    agent._user_turn_count += grown_users
+                    tail_before = copy.deepcopy(history[-5:])
+                    agent._flush_messages_to_session_db(history, [])
+
+                    # 3. The REAL preflight, wired exactly like the loop.
+                    sync_spy = MagicMock(
+                        side_effect=lambda msgs, sysm, **kw: (msgs, sysm)
+                    )
+                    with patch.object(agent, "_compress_context", sync_spy):
+                        ctx = turn_ctx_mod.build_turn_context(
+                            agent,
+                            "e segue o baile",
+                            None,
+                            history,
+                            None,
+                            None,
+                            None,
+                            restore_or_build_system_prompt=(
+                                loop_mod._restore_or_build_system_prompt
+                            ),
+                            install_safe_stdio=loop_mod._install_safe_stdio,
+                            sanitize_surrogates=loop_mod._sanitize_surrogates,
+                            summarize_user_message_for_log=(
+                                loop_mod._summarize_user_message_for_log
+                            ),
+                            set_session_context=loop_mod.set_session_context,
+                            set_current_write_origin=(
+                                loop_mod.set_current_write_origin
+                            ),
+                            ra=loop_mod._ra,
+                        )
+
+                # The candidate applied; the synchronous path never ran.
+                assert sync_spy.call_count == 0
+                assert ctl.stats.get("candidate_applied") == 1
+                joined = "\n".join(
+                    str(m.get("content")) for m in ctx.messages
+                )
+                assert self._SUMMARY in joined
+                # Suffix survival across the swap: the merge must keep the
+                # exact live dict objects (identity), and their semantic
+                # content must be untouched (persistence markers aside).
+                merged_tail = ctx.messages[-6:-1]
+                assert all(
+                    a is b for a, b in zip(merged_tail, history[-5:])
+                )
+                assert [
+                    (m.get("role"), m.get("content")) for m in merged_tail
+                ] == [
+                    (m.get("role"), m.get("content")) for m in tail_before
+                ]
+                # And the applied context sits back under the sync trigger.
+                assert not engine.should_compress(_estimate(ctx.messages))
             finally:
                 agent.close()
                 db.close()

--- a/tests/run_agent/test_async_context_compression_plugin_integration.py
+++ b/tests/run_agent/test_async_context_compression_plugin_integration.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 from agent.async_context_compression import (
     BackgroundCompressionConfig,
     PreparedCompressionCandidate,
+    PrepareResult,
     maybe_prepare_background_compression,
 )
 from agent.context_compressor import SUMMARY_PREFIX, ContextCompressor
@@ -154,8 +155,11 @@ class TestBuiltinCompressorPreparation:
         ):
             prepared = comp.prepare_compression(msgs, current_tokens=150_000)
 
-        assert prepared is not None
-        assert len(prepared) < len(msgs)
+        assert isinstance(prepared, PrepareResult)
+        # No aux provider means the deterministic fallback summary was used —
+        # surfaced as candidate metadata, not hidden.
+        assert prepared.used_fallback is True
+        assert len(prepared.messages) < len(msgs)
         # The live input list and its dicts are untouched.
         assert msgs == snapshot
         # The live compressor never ran compress(): every mutable field is

--- a/tests/run_agent/test_async_context_compression_plugin_integration.py
+++ b/tests/run_agent/test_async_context_compression_plugin_integration.py
@@ -1,0 +1,185 @@
+"""Plugin-facing contract for background compression preparation.
+
+Backwards compatibility is the core requirement: the new ContextEngine hooks
+(``can_prepare_compression`` / ``prepare_compression`` / ``adopt_prepared_state``)
+must default to no-ops so existing third-party engines keep working unchanged,
+while the built-in ContextCompressor gains a real implementation that runs on a
+DEDICATED clone — ``compress()`` mutates counters and iterative-summary state,
+so the live instance must never be driven by a background worker.
+"""
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.async_context_compression import (
+    BackgroundCompressionConfig,
+    PreparedCompressionCandidate,
+    maybe_prepare_background_compression,
+)
+from agent.context_compressor import SUMMARY_PREFIX, ContextCompressor
+from agent.context_engine import ContextEngine
+
+
+class MinimalEngine(ContextEngine):
+    """A plugin engine written before the async-compression hooks existed."""
+
+    @property
+    def name(self):
+        return "minimal"
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        return messages
+
+
+def _make_compressor(**overrides) -> ContextCompressor:
+    kwargs = dict(model="test/model", quiet_mode=True, config_context_length=200_000)
+    kwargs.update(overrides)
+    return ContextCompressor(**kwargs)
+
+
+def _make_candidate(prepared, **overrides) -> PreparedCompressionCandidate:
+    fields = dict(
+        session_id="sess-1",
+        generation=1,
+        prefix_message_count=10,
+        prefix_digest="0" * 64,
+        prepared_messages=tuple(prepared),
+        source_prompt_tokens=180_000,
+        created_at_monotonic=0.0,
+        created_at_turn=1,
+        used_fallback=False,
+        summary_error=None,
+    )
+    fields.update(overrides)
+    return PreparedCompressionCandidate(**fields)
+
+
+class TestContextEngineDefaultHooks:
+    def test_defaults_are_noop(self):
+        engine = MinimalEngine()
+        msgs = [{"role": "user", "content": "hi"}]
+        assert engine.can_prepare_compression(msgs) is False
+        assert engine.can_prepare_compression(msgs, current_tokens=100_000) is False
+        assert engine.prepare_compression(msgs) is None
+        assert engine.prepare_compression(
+            msgs, current_tokens=100_000, focus_topic="x"
+        ) is None
+        candidate = _make_candidate(
+            [{"role": "user", "content": f"{SUMMARY_PREFIX}\nsummary"}]
+        )
+        assert engine.adopt_prepared_state(candidate) is None
+
+    def test_legacy_engine_disables_background_preparation(self):
+        """An engine that never opted in must keep the feature inert even when
+        the config block enables it."""
+        agent = SimpleNamespace(
+            background_compression_config=BackgroundCompressionConfig.from_dict(
+                {"enabled": True, "shadow_only": True, "min_delta_tokens": 0,
+                 "min_frozen_messages": 2}
+            ),
+            background_compression=None,
+            context_compressor=MinimalEngine(),
+            session_id="sess-1",
+            compression_enabled=True,
+        )
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+        assert maybe_prepare_background_compression(
+            agent, msgs, current_tokens=250_000, current_turn=1
+        ) is False
+        assert agent.background_compression is None
+
+
+class TestBuiltinCompressorPreparation:
+    def test_builtin_compressor_opts_in(self):
+        comp = _make_compressor()
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(30)]
+        assert comp.can_prepare_compression(msgs, current_tokens=150_000) is True
+
+    def test_builtin_compressor_declines_under_active_cooldown(self):
+        comp = _make_compressor()
+        comp._record_compression_failure_cooldown(60.0, "summary failed")
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(30)]
+        assert comp.can_prepare_compression(msgs, current_tokens=150_000) is False
+
+    def test_clone_for_background_copies_config_and_summary_state(self):
+        comp = _make_compressor()
+        comp._previous_summary = "PREV SUMMARY"
+        comp.threshold_tokens = 123_456
+        comp.protect_first_n = 2
+        comp.protect_last_n = 7
+        comp.tail_token_budget = 999
+
+        clone = comp.clone_for_background()
+        assert clone is not comp
+        assert clone._previous_summary == "PREV SUMMARY"
+        assert clone.threshold_tokens == 123_456
+        assert clone.protect_first_n == 2
+        assert clone.protect_last_n == 7
+        assert clone.tail_token_budget == 999
+        assert clone.context_length == comp.context_length
+
+        # Mutating the clone must never reach the live compressor.
+        clone._previous_summary = "MUTATED"
+        clone.compression_count = 99
+        clone._ineffective_compression_count = 5
+        assert comp._previous_summary == "PREV SUMMARY"
+        assert comp.compression_count == 0
+
+    def test_prepare_compression_runs_on_clone_and_never_mutates_live_state(self):
+        comp = _make_compressor()
+        # Shrink the protected head/tail so a small transcript has a real
+        # compressable middle window.
+        comp.protect_first_n = 1
+        comp.protect_last_n = 2
+        comp.tail_token_budget = 80
+
+        msgs = [{"role": "system", "content": "sys"}]
+        for i in range(30):
+            role = "user" if i % 2 == 0 else "assistant"
+            msgs.append({"role": role, "content": f"turn {i}: " + ("x" * 400)})
+        snapshot = copy.deepcopy(msgs)
+
+        # No aux provider: the clone's compress() falls back to the static
+        # summary and still compacts the middle window.
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=RuntimeError("no provider"),
+        ):
+            prepared = comp.prepare_compression(msgs, current_tokens=150_000)
+
+        assert prepared is not None
+        assert len(prepared) < len(msgs)
+        # The live input list and its dicts are untouched.
+        assert msgs == snapshot
+        # The live compressor never ran compress(): every mutable field is
+        # still pristine.
+        assert comp.compression_count == 0
+        assert comp._previous_summary is None
+        assert comp._last_summary_fallback_used is False
+        assert comp._last_compress_aborted is False
+        assert comp._ineffective_compression_count == 0
+        assert comp.awaiting_real_usage_after_compression is False
+
+    def test_adopt_prepared_state_updates_live_counters(self):
+        comp = _make_compressor()
+        summary_body = "key facts preserved across compaction"
+        candidate = _make_candidate(
+            [
+                {"role": "user", "content": f"{SUMMARY_PREFIX}\n{summary_body}"},
+                {"role": "user", "content": "tail message"},
+            ]
+        )
+        comp.adopt_prepared_state(candidate)
+        assert comp.compression_count == 1
+        assert summary_body in (comp._previous_summary or "")
+        # Mirrors the synchronous post-compression bookkeeping: real usage is
+        # awaited before the next threshold decision.
+        assert comp.awaiting_real_usage_after_compression is True
+        assert comp.last_prompt_tokens == -1

--- a/tests/run_agent/test_benchmark_async_compression.py
+++ b/tests/run_agent/test_benchmark_async_compression.py
@@ -1,0 +1,47 @@
+"""CI wrapper for the controlled benchmark (task 10).
+
+Runs ``scripts/benchmark_async_compression.py`` with light parameters and
+enforces the structural gates. Timing-sensitive thresholds are relaxed vs
+the script's production-scale defaults (2s simulated summariser) so CI
+variance can't flake: at 500ms the apply pause is already an order of
+magnitude smaller than the pause it replaces.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_benchmark_module():
+    spec = importlib.util.spec_from_file_location(
+        "benchmark_async_compression",
+        REPO_ROOT / "scripts" / "benchmark_async_compression.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("benchmark_async_compression", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_benchmark_gates_hold_at_reduced_scale():
+    bench = _load_benchmark_module()
+    report = bench.run_benchmark(iterations=5, summariser_ms=500.0,
+                                 turn_work_ms=10.0)
+
+    modes = report["modes"]
+    # Structural gates — never timing-flaky.
+    assert report["loss_or_dup"] == 0
+    assert report["errors"] == []
+    assert modes["background"]["ready_rate"] == 1.0
+
+    # The apply window must stay far below both the plan's 500ms budget and
+    # the synchronous pause it replaces.
+    assert modes["background"]["pause_p95_ms"] < 500.0
+    assert report["pause_reduction"] >= 0.80  # >=0.90 at production scale
+
+    # Shadow and fallback must pay the SAME pause class as sync (they run
+    # the synchronous path) — the feature never makes the baseline worse.
+    assert modes["shadow"]["pause_p95_ms"] >= 500.0 * 0.9
+    assert modes["fallback"]["pause_p95_ms"] >= 500.0 * 0.9

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -307,3 +307,319 @@ class TestGatewayHistoryOffsetAfterSplit:
         assert len(new_messages) == 0, (
             "Expected 0 messages with stale offset=200 (demonstrates the bug)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Part 3: Background-candidate apply — shared atomic commit
+# ---------------------------------------------------------------------------
+
+class TestApplyPreparedCandidatePersistence:
+    """apply_prepared_candidate() must reuse the exact persistence contract of
+    the synchronous path: same SQLite lock, same in-place archive_and_compact
+    (soft-archive + rebaseline) vs legacy rotation (child session), and no
+    write of any kind when validation fails under the lock."""
+
+    def _make_agent(self, session_db, session_id):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id=session_id,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent._compression_feasibility_checked = True
+        return agent
+
+    def _make_messages(self, n=12):
+        return [
+            {"role": "user" if i % 2 == 0 else "assistant",
+             "content": f"message {i}"}
+            for i in range(n)
+        ]
+
+    def _make_candidate(self, messages, session_id, *, generation=1,
+                        prefix_count=None):
+        from agent.async_context_compression import (
+            PreparedCompressionCandidate,
+            canonical_prefix_digest,
+        )
+        if prefix_count is None:
+            prefix_count = len(messages) - 2
+        prepared = (
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            dict(messages[prefix_count - 1]),
+        )
+        return PreparedCompressionCandidate(
+            session_id=session_id,
+            generation=generation,
+            prefix_message_count=prefix_count,
+            prefix_digest=canonical_prefix_digest(messages, prefix_count),
+            prepared_messages=prepared,
+            source_prompt_tokens=180_000,
+            created_at_monotonic=0.0,
+            created_at_turn=1,
+            used_fallback=False,
+            summary_error=None,
+        )
+
+    def test_apply_in_place_archives_history_and_preserves_suffix(self):
+        import tempfile as _tempfile
+
+        from agent.conversation_compression import apply_prepared_candidate
+        from hermes_state import SessionDB
+
+        with _tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "apply-in-place"
+            db.create_session(sid, "gateway", model="test/model")
+            agent = self._make_agent(db, sid)
+            agent.compression_in_place = True
+
+            messages = self._make_messages()
+            agent._flush_messages_to_session_db(messages, [])
+            pre_rows = db.get_messages(sid)
+            assert len(pre_rows) == len(messages)
+
+            candidate = self._make_candidate(messages, sid)
+            result = apply_prepared_candidate(agent, candidate, messages, "sys")
+
+            assert result is not None
+            new_messages, new_prompt = result
+            assert isinstance(new_prompt, str) and new_prompt
+            # Suffix after the frozen prefix survives as the SAME objects.
+            suffix = new_messages[len(candidate.prepared_messages):]
+            assert [m.get("content") for m in suffix if not str(m.get("content", "")).startswith("[")] \
+                == [m["content"] for m in messages[candidate.prefix_message_count:]]
+            assert all(
+                a is b for a, b in zip(
+                    new_messages[len(candidate.prepared_messages):
+                                 len(candidate.prepared_messages) + 2],
+                    messages[candidate.prefix_message_count:],
+                )
+            )
+
+            # Same session id, in-place semantics.
+            assert agent.session_id == sid
+            assert agent._last_compaction_in_place is True
+            assert agent._flushed_db_message_ids == set()
+
+            # Non-destructive: history soft-archived, compacted set active.
+            assert db.has_archived_messages(sid) is True
+            active = db.get_messages(sid)
+            assert len(active) == len(new_messages)
+            assert any(
+                "[CONTEXT COMPACTION]" in str(r.get("content", "")) for r in active
+            )
+
+            # Lock released after commit.
+            assert db.get_compression_lock_holder(sid) is None
+            db.close()
+
+    def test_apply_rotation_creates_child_session(self):
+        import tempfile as _tempfile
+
+        from agent.conversation_compression import apply_prepared_candidate
+        from hermes_state import SessionDB
+
+        with _tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "apply-rotation"
+            db.create_session(sid, "gateway", model="test/model")
+            agent = self._make_agent(db, sid)
+            agent.compression_in_place = False
+
+            messages = self._make_messages()
+            candidate = self._make_candidate(messages, sid)
+            result = apply_prepared_candidate(agent, candidate, messages, "sys")
+
+            assert result is not None
+            assert agent.session_id != sid
+            assert agent._last_compaction_in_place is False
+            child = db.get_session(agent.session_id)
+            assert child is not None
+            assert child.get("parent_session_id") == sid
+            # Lock keyed on the OLD session id is released.
+            assert db.get_compression_lock_holder(sid) is None
+            db.close()
+
+    def test_apply_digest_mismatch_makes_no_writes(self):
+        import tempfile as _tempfile
+
+        from agent.conversation_compression import apply_prepared_candidate
+        from hermes_state import SessionDB
+
+        with _tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "apply-stale"
+            db.create_session(sid, "gateway", model="test/model")
+            agent = self._make_agent(db, sid)
+            agent.compression_in_place = True
+
+            messages = self._make_messages()
+            agent._flush_messages_to_session_db(messages, [])
+            candidate = self._make_candidate(messages, sid)
+            # Prefix diverges after the candidate was frozen.
+            messages[1]["content"] += " EDITED"
+
+            result = apply_prepared_candidate(agent, candidate, messages, "sys")
+            assert result is None
+            assert agent.session_id == sid
+            assert db.has_archived_messages(sid) is False
+            rows = db.get_messages(sid)
+            assert len(rows) == len(messages)
+            assert db.get_compression_lock_holder(sid) is None
+            db.close()
+
+    def test_apply_steps_aside_when_lock_is_held(self):
+        import tempfile as _tempfile
+
+        from agent.conversation_compression import apply_prepared_candidate
+        from hermes_state import SessionDB
+
+        with _tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "apply-contended"
+            db.create_session(sid, "gateway", model="test/model")
+            agent = self._make_agent(db, sid)
+            agent.compression_in_place = True
+
+            messages = self._make_messages()
+            candidate = self._make_candidate(messages, sid)
+
+            assert db.try_acquire_compression_lock(sid, "other-holder") is True
+            try:
+                result = apply_prepared_candidate(
+                    agent, candidate, messages, "sys"
+                )
+                assert result is None
+                assert agent.session_id == sid
+                assert db.has_archived_messages(sid) is False
+                # The competing holder still owns the lock.
+                assert db.get_compression_lock_holder(sid) == "other-holder"
+            finally:
+                db.release_compression_lock(sid, "other-holder")
+            db.close()
+
+    def test_sync_and_background_paths_commit_equivalently(self):
+        """Equivalence gate: for a deterministic compressor output, the
+        refactored synchronous path and the background apply path must leave
+        the same final message list, the same session:compress event shape
+        and the same active DB rows (in-place mode)."""
+        import tempfile as _tempfile
+        from unittest.mock import MagicMock
+
+        from agent.async_context_compression import canonical_prefix_digest
+        from agent.conversation_compression import (
+            apply_prepared_candidate,
+            compress_context,
+        )
+        from hermes_state import SessionDB
+
+        base_messages = self._make_messages()
+        prefix_count = len(base_messages) - 2
+        prepared = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            dict(base_messages[prefix_count - 1]),
+        ]
+
+        def _run_sync(tmpdir):
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "equiv-sync"
+            db.create_session(sid, "gateway", model="test/model")
+            agent = self._make_agent(db, sid)
+            agent.compression_in_place = True
+            messages = [dict(m) for m in base_messages]
+            agent._flush_messages_to_session_db(messages, [])
+            events = []
+            agent.event_callback = lambda name, payload: events.append(
+                (name, payload)
+            )
+
+            compressor = MagicMock()
+            compressor.compress.side_effect = lambda msgs, **kw: (
+                [dict(m) for m in prepared] + msgs[prefix_count:]
+            )
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            compressor._last_compression_made_progress = True
+            compressor._last_summary_fallback_used = False
+            compressor._last_aux_model_failure_model = None
+            compressor._last_aux_model_failure_error = None
+            agent.context_compressor = compressor
+
+            result, _prompt = compress_context(
+                agent, messages, "sys", approx_tokens=120_000
+            )
+            rows = db.get_messages(sid)
+            db.close()
+            return result, events, rows
+
+        def _run_background(tmpdir):
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            sid = "equiv-sync"  # same id so event payloads match exactly
+            db.create_session(sid, "gateway", model="test/model")
+            agent = self._make_agent(db, sid)
+            agent.compression_in_place = True
+            messages = [dict(m) for m in base_messages]
+            agent._flush_messages_to_session_db(messages, [])
+            events = []
+            agent.event_callback = lambda name, payload: events.append(
+                (name, payload)
+            )
+
+            compressor = MagicMock()
+            compressor.compression_count = 1
+            compressor.adopt_prepared_state = lambda candidate: None
+            agent.context_compressor = compressor
+
+            from agent.async_context_compression import (
+                PreparedCompressionCandidate,
+            )
+            candidate = PreparedCompressionCandidate(
+                session_id=sid,
+                generation=1,
+                prefix_message_count=prefix_count,
+                prefix_digest=canonical_prefix_digest(messages, prefix_count),
+                prepared_messages=tuple(dict(m) for m in prepared),
+                source_prompt_tokens=120_000,
+                created_at_monotonic=0.0,
+                created_at_turn=1,
+                used_fallback=False,
+                summary_error=None,
+            )
+            result = apply_prepared_candidate(agent, candidate, messages, "sys")
+            assert result is not None
+            rows = db.get_messages(sid)
+            db.close()
+            return result[0], events, rows
+
+        with _tempfile.TemporaryDirectory() as d1:
+            sync_list, sync_events, sync_rows = _run_sync(d1)
+        with _tempfile.TemporaryDirectory() as d2:
+            bg_list, bg_events, bg_rows = _run_background(d2)
+
+        def _semantic(msgs):
+            return [
+                {k: v for k, v in m.items() if not k.startswith("_")}
+                for m in msgs
+            ]
+
+        assert _semantic(sync_list) == _semantic(bg_list)
+
+        sync_compress_events = [e for e in sync_events if e[0] == "session:compress"]
+        bg_compress_events = [e for e in bg_events if e[0] == "session:compress"]
+        assert len(sync_compress_events) == len(bg_compress_events) == 1
+        assert sync_compress_events[0][1] == bg_compress_events[0][1]
+
+        def _row_view(rows):
+            return [(r.get("role"), r.get("content")) for r in rows]
+
+        assert _row_view(sync_rows) == _row_view(bg_rows)

--- a/tests/run_agent/test_replay_async_compression.py
+++ b/tests/run_agent/test_replay_async_compression.py
@@ -1,0 +1,52 @@
+"""CI wrapper for the offline replay harness (task 9).
+
+Runs every builtin scenario of ``scripts/replay_async_compression.py`` and
+enforces the structural gate: 100% of the invariants must hold for every
+session shape (simple, tools, subagent, concurrent arrivals, already
+compressed, in-place, legacy rotation, summariser failure, timeout, reset
+during preparation) plus any sanitized fixture exports present in
+``tests/fixtures/async_compression/``.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_replay_module():
+    spec = importlib.util.spec_from_file_location(
+        "replay_async_compression",
+        REPO_ROOT / "scripts" / "replay_async_compression.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("replay_async_compression", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_replay_structural_gate_passes_for_every_scenario():
+    replay = _load_replay_module()
+    results = replay.run_all()
+    names = {r.name for r in results}
+    # The full plan matrix must actually run.
+    expected = {
+        "simple_operational",
+        "tools_closed_groups",
+        "subagent_delegation",
+        "messages_during_execution",
+        "already_compressed",
+        "in_place_session",
+        "legacy_rotation_session",
+        "summariser_failure",
+        "summariser_timeout",
+        "reset_during_preparation",
+    }
+    assert expected.issubset(names)
+
+    failures = {
+        r.name: {check: ok for check, ok in r.checks.items() if not ok}
+        for r in results if not r.ok
+    }
+    assert not failures, f"structural gate failed: {failures}"

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -81,7 +81,10 @@ starts in `shadow_only` mode (see the
 [user guide](/user-guide/configuration#background-asynchronous-compression)
 for the config block and rollout/kill-switch procedure).
 
-**Preparation** (between turns, above `prepare_threshold`): the turn finalizer
+**Preparation** (between turns, above the effective prepare gate — see
+`resolve_effective_gate_tokens()`, which clamps the configured thresholds
+against the live synchronous trigger so `prepare < apply < sync` always
+holds): the turn finalizer
 calls `agent._maybe_prepare_background_compression()`. The controller freezes a
 deep-copied prefix of the conversation (boundary aligned so a tool-call group
 is never split), records its canonical digest, and submits the summarisation to
@@ -91,7 +94,8 @@ on a **dedicated clone** of the live compressor — the live engine, the live
 worker thread, and no SQLite compression lock is taken, so the gateway never
 sees the session as blocked during preparation.
 
-**Apply** (preflight of the next turn, above `apply_threshold`): `turn_context`
+**Apply** (preflight of the next turn, above the effective apply gate, or
+whenever the synchronous path would fire on that same preflight): `turn_context`
 calls `agent._maybe_apply_prepared_compression()` before the synchronous
 preflight chain. `apply_prepared_candidate()` acquires the same per-session
 SQLite lock as synchronous compression, revalidates the candidate **inside the

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -73,6 +73,56 @@ Located in `agent/context_compressor.py`. This is the **primary compression
 system** that runs inside the agent's tool loop with access to accurate,
 API-reported token counts.
 
+## Background (asynchronous) compression
+
+`agent/async_context_compression.py` adds an optional third layer that removes
+the user-visible compaction pause. It is **off by default** and, when enabled,
+starts in `shadow_only` mode (see the
+[user guide](/user-guide/configuration#background-asynchronous-compression)
+for the config block and rollout/kill-switch procedure).
+
+**Preparation** (between turns, above `prepare_threshold`): the turn finalizer
+calls `agent._maybe_prepare_background_compression()`. The controller freezes a
+deep-copied prefix of the conversation (boundary aligned so a tool-call group
+is never split), records its canonical digest, and submits the summarisation to
+a single-worker executor. The worker runs `ContextCompressor.prepare_compression()`
+on a **dedicated clone** of the live compressor — the live engine, the live
+`messages` list, the session id and the database are never touched from the
+worker thread, and no SQLite compression lock is taken, so the gateway never
+sees the session as blocked during preparation.
+
+**Apply** (preflight of the next turn, above `apply_threshold`): `turn_context`
+calls `agent._maybe_apply_prepared_compression()` before the synchronous
+preflight chain. `apply_prepared_candidate()` acquires the same per-session
+SQLite lock as synchronous compression, revalidates the candidate **inside the
+lock** (same session id, current generation, unchanged prefix digest, no open
+tool call), merges the prepared prefix with the live suffix (suffix objects
+preserved verbatim) and commits through the shared
+`_commit_compressed_transcript()` — the exact code path the synchronous
+compressor uses, so persistence semantics (in-place archive vs legacy rotation,
+memory flush, system-prompt rebuild, flush rebaseline) can never diverge. Any
+validation failure discards the candidate and the synchronous path runs as if
+the feature did not exist.
+
+**Invalidation**: `/new`, `/reset`, model switches and session changes reach
+`reset_session_state()` / `close()` / `release_clients()`, all of which reset
+or shut down the controller. The background-review fork shares the parent's
+live session id but has `compression_enabled=False`, which gates both prepare
+and apply.
+
+**Telemetry**: `BackgroundCompressionController.telemetry_snapshot()` returns
+stable-shaped counters and duration distributions:
+
+| Metric | Meaning |
+|---|---|
+| `candidate_started` / `candidate_ready` / `candidate_failed` | Preparation lifecycle |
+| `candidate_discarded_stale` | Candidate rejected (digest/session/generation/age) |
+| `candidate_applied` / `candidate_shadow_validated` | Real applies vs shadow would-have-applied |
+| `candidate_cancelled` | Best-effort cancels (interrupt/reset) |
+| `sync_fallback_count` | Apply attempts that fell back to the synchronous path |
+| `suffix_messages_preserved` | Total live-suffix messages carried across applies |
+| `background_provider_error` | Worker failures (summariser provider errors) |
+| `candidate_prepare_ms` / `candidate_apply_ms` | count/p50/p95/max duration distributions |
 
 ## Configuration
 

--- a/website/docs/developer-guide/context-engine-plugin.md
+++ b/website/docs/developer-guide/context-engine-plugin.md
@@ -97,6 +97,33 @@ These have sensible defaults in the ABC. Override as needed:
 | `handle_tool_call(name, args, **kwargs)` | Returns error JSON | You implement tool handlers |
 | `should_compress_preflight(messages)` | Returns `False` | You can do a cheap pre-API-call estimate |
 | `get_status()` | Standard token/threshold dict | You have custom metrics to expose |
+| `can_prepare_compression(messages, current_tokens)` | Returns `False` | Your engine supports background-prepared compression |
+| `prepare_compression(messages, current_tokens, focus_topic)` | Returns `None` | See background preparation below |
+| `adopt_prepared_state(candidate)` | No-op | See background preparation below |
+
+### Background compression preparation (opt-in)
+
+When `compression.background.enabled` is on, Hermes can pre-compute a
+compression candidate off-thread and swap it in between turns instead of
+pausing the conversation. Engines participate only if they opt in:
+
+- `can_prepare_compression(messages, current_tokens=None)` — return `True`
+  when your engine can produce a candidate right now. Return `False` while
+  in a failure cooldown or otherwise unable to compress. The default is
+  `False`, so engines that predate this feature are never scheduled.
+- `prepare_compression(messages, current_tokens=None, focus_topic=None)` —
+  called on a **background worker thread** with a frozen deep copy of a
+  conversation prefix. It must not mutate the live engine: run on a
+  dedicated instance or state copy (the built-in compressor uses
+  `clone_for_background()`). Return the compressed list, an
+  `agent.async_context_compression.PrepareResult` (adds
+  `used_fallback`/`summary_error` metadata), or `None` when no useful
+  candidate could be produced.
+- `adopt_prepared_state(candidate)` — called on the foreground thread after
+  a `PreparedCompressionCandidate` was committed, so the live engine can
+  adopt bookkeeping (counters, iterative-summary base, token sentinels).
+
+All three default to no-ops; existing plugins keep working unchanged.
 
 ## Engine tools
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -774,8 +774,10 @@ compression:
   background:
     enabled: false                # Master switch — off by default
     shadow_only: true             # Generate + validate + measure, but never apply (rollout gate)
-    prepare_threshold: 0.65       # Start preparing at 65% of the context window
-    apply_threshold: 0.82         # Swap the candidate in at 82% (below the sync threshold)
+    prepare_threshold: 0.65       # Ceiling: start preparing at 65% of the window,
+                                  # clamped to 80% of the live sync trigger
+    apply_threshold: 0.82         # Ceiling: swap in at 82% of the window, clamped
+                                  # to 96% of the live sync trigger
     min_delta_tokens: 20000       # Don't re-prepare until the context grew this much
     min_frozen_messages: 12       # Minimum prefix length worth summarising
     max_candidate_age_turns: 12   # Discard candidates older than this many turns
@@ -784,6 +786,14 @@ compression:
     fallback_sync: true           # Missing/stale candidate → synchronous path as before
     apply_only_between_turns: true  # Never swap mid-turn or during a tool call
 ```
+
+The two thresholds are **ceilings, not promises**: the effective gates are
+derived per model from the compressor's live synchronous trigger (which folds
+in the configured `compression.threshold`, the small-context floor and the
+Codex autoraise), keeping `prepare < apply < synchronous` for every profile —
+with the stock `threshold: 0.50` the real gates land at 40%/48% of the window.
+A ready valid candidate also preempts a synchronous run outright if one would
+fire first (for example on the message-count hygiene trigger).
 
 Rollout is staged: enable with `shadow_only: true` first — candidates are generated and validated and telemetry is recorded, but the conversation is never touched. Only after shadow metrics look clean should `shadow_only` be set to `false`.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -765,6 +765,36 @@ Older configs with `compression.summary_model`, `compression.summary_provider`, 
 
 `protect_first_n` controls how many **non-system** head messages are pinned across every compaction. Default `3` — the opening user/assistant exchange survives every summarizer pass so the original goal stays visible. On long-running rolling-compaction sessions where the opening turn is no longer relevant, set `protect_first_n: 0` to pin nothing but the system prompt + summary + tail. The system prompt itself is always preserved regardless of this setting.
 
+### Background (asynchronous) compression
+
+Normally, when the conversation crosses the compression threshold the next turn pauses while the summarizer runs. Background compression removes that pause: a candidate summary is pre-computed on a worker thread while you keep chatting, and swapped in between turns after strict revalidation (same session, byte-identical frozen prefix, no open tool call) under the same per-session lock as synchronous compression. If anything doesn't match, the candidate is discarded and the normal synchronous path runs — the feature can only make things faster, never different.
+
+```yaml
+compression:
+  background:
+    enabled: false                # Master switch — off by default
+    shadow_only: true             # Generate + validate + measure, but never apply (rollout gate)
+    prepare_threshold: 0.65       # Start preparing at 65% of the context window
+    apply_threshold: 0.82         # Swap the candidate in at 82% (below the sync threshold)
+    min_delta_tokens: 20000       # Don't re-prepare until the context grew this much
+    min_frozen_messages: 12       # Minimum prefix length worth summarising
+    max_candidate_age_turns: 12   # Discard candidates older than this many turns
+    max_workers: 1                # Single worker — no summary storms
+    foreground_priority: true     # Background work never competes with your turn
+    fallback_sync: true           # Missing/stale candidate → synchronous path as before
+    apply_only_between_turns: true  # Never swap mid-turn or during a tool call
+```
+
+Rollout is staged: enable with `shadow_only: true` first — candidates are generated and validated and telemetry is recorded, but the conversation is never touched. Only after shadow metrics look clean should `shadow_only` be set to `false`.
+
+**Kill switch** (restores baseline behavior immediately):
+
+```bash
+hermes config set compression.background.enabled false
+hermes gateway restart   # optional — the key is cache-busting, so the next
+                         # gateway message picks it up without a restart
+```
+
 :::tip Gateway hot-reload of compression and context length
 As of recent releases, editing `model.context_length` or any `compression.*` key in `config.yaml` on a running gateway takes effect on the next message — no gateway restart, no `/reset`, no session rotation required. The cached-agent signature includes these keys, so the gateway transparently rebuilds the agent when it sees a change. API keys and tool/skill config still require the usual reload paths.
 :::


### PR DESCRIPTION
## Resumo
- prepara candidatos de compressão em background sem bloquear turnos
- aplica a troca de contexto de forma atômica e somente entre turnos
- mantém o rollout seguro: `compression.background.enabled: false` e `shadow_only: true` por padrão

## Validação
- `scripts/run_tests.sh tests/run_agent/test_async_context_compression.py tests/gateway/test_async_compression_message_race.py tests/run_agent/test_compression_persistence.py tests/agent/test_compression_concurrent_fork.py`
- 88 testes aprovados, 0 falhas