### PR TITLE
fix(background-review): seed fork write markers before AIAgent.__init__

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1318,8 +1318,15 @@ def init_agent(
     # fall back to stateless continuity.  See
     # agent/conversation_loop.py's invalid_encrypted_content retry branch.
     agent._codex_reasoning_replay_enabled = True
-    agent._memory_write_origin = "assistant_tool"
-    agent._memory_write_context = "foreground"
+    # Honor a pre-seeded write origin/context (the background_review fork sets
+    # them before __init__ so the LCM engine's auxiliary-frame detection can
+    # see them during on_session_start) instead of clobbering to the defaults.
+    agent._memory_write_origin = (
+        getattr(agent, "_memory_write_origin", "") or "assistant_tool"
+    )
+    agent._memory_write_context = (
+        getattr(agent, "_memory_write_context", "") or "foreground"
+    )
     
     # Cached system prompt -- built once per session, only rebuilt on compression
     agent._cached_system_prompt: Optional[str] = None

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -709,7 +709,22 @@ def _run_review_in_thread(
             # _cached_system_prompt below.
             if not _routed:
                 _fork_kwargs["reasoning_config"] = getattr(agent, "reasoning_config", None)
-            review_agent = AIAgent(
+
+            # The background_review markers must exist BEFORE __init__ runs:
+            # a plugin context engine's on_session_start fires inside
+            # agent_init with the fork's fresh session_id, and
+            # auxiliary-frame detection (e.g. hermes-lcm's) reads
+            # _memory_write_origin off the constructing agent. Set only
+            # after construction (as before), the fork's fresh session_id
+            # gets bound as a real engine session and the whole conversation
+            # snapshot is bulk-ingested as a new wrong-timestamped session.
+            class _ReviewAgent(AIAgent):
+                def __init__(self, *args, **kwargs):
+                    self._memory_write_origin = "background_review"
+                    self._memory_write_context = "background_review"
+                    super().__init__(*args, **kwargs)
+
+            review_agent = _ReviewAgent(
                 model=_rt.get("model") or agent.model,
                 max_iterations=16,
                 quiet_mode=True,

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -473,3 +473,45 @@ def test_skill_patch_off_silent_verbose_shows_diff():
     )
     assert len(verbose) == 1
     assert "demo" in verbose[0] and "→" in verbose[0]
+
+
+def test_background_review_fork_seeds_write_markers_before_init(monkeypatch):
+    """The fork's write markers must be visible DURING AIAgent.__init__.
+
+    A plugin context engine's on_session_start fires inside agent init with
+    the fork's fresh session_id and classifies auxiliary frames by reading
+    _memory_write_origin off the constructing agent. Markers set only after
+    construction arrive too late: the fork's session gets bound as a real
+    engine session and the replayed snapshot is bulk-ingested as a new
+    wrong-timestamped session.
+    """
+    seen = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            seen["origin_at_init"] = getattr(self, "_memory_write_origin", None)
+            seen["context_at_init"] = getattr(self, "_memory_write_context", None)
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert seen["origin_at_init"] == "background_review"
+    assert seen["context_at_init"] == "background_review"


### PR DESCRIPTION
## Problem

When a plugin context engine is active (e.g. hermes-lcm), its `on_session_start` fires during `AIAgent.__init__` with the fork's fresh `session_id`. Auxiliary-frame detection reads `_memory_write_origin` off the constructing agent at that moment. The background-review fork sets its markers only **after** construction (`background_review.py`, after the `review_agent = AIAgent(...)` call), and `init_agent` unconditionally clobbers any pre-set value.

Result: the fork's fresh session id gets bound as a real engine session, and the replayed conversation snapshot is bulk-ingested as a new wrong-timestamped session. Downstream, "last session" recall queries return the review fork's duplicate instead of the user's actual last session.

## Fix

- `agent/background_review.py`: construct the fork through a tiny `AIAgent` subclass that sets `_memory_write_origin` / `_memory_write_context` to `"background_review"` **before** `super().__init__`, so any engine hook that fires during init sees them. The post-construction assignments stay (idempotent, keeps behavior for engines that read them later).
- `agent/agent_init.py`: honor a pre-seeded marker instead of overwriting it with the defaults.

## Test

`test_background_review_fork_seeds_write_markers_before_init` asserts the markers are visible during `__init__` via the existing FakeReviewAgent/ImmediateThread harness. Verified red on the unpatched tree, green with the fix.

This has been running in production as a downstream patch since v2026.6.19 (same template as #42406).

🤖 Generated with [Claude Code](https://claude.com/claude-code)