### PR TITLE
fix(cron): read jobs.json with utf-8-sig to tolerate BOM (#66607)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -835,13 +835,13 @@ def load_jobs() -> List[Dict[str, Any]]:
     _strict_retry = False  # track whether we used the strict=False fallback
 
     try:
-        with open(jobs_file, 'r', encoding='utf-8') as f:
+        with open(jobs_file, 'r', encoding='utf-8-sig') as f:
             data = json.load(f)
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         _strict_retry = True
         try:
-            with open(jobs_file, 'r', encoding='utf-8') as f:
+            with open(jobs_file, 'r', encoding='utf-8-sig') as f:
                 data = json.loads(f.read(), strict=False)
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -167,7 +167,7 @@ def _cron_summary(hermes_home: Path) -> str:
     if not jobs_file.exists():
         return "0"
     try:
-        with open(jobs_file, encoding="utf-8") as f:
+        with open(jobs_file, encoding="utf-8-sig") as f:
             data = json.load(f)
         jobs = data.get("jobs", [])
         active = sum(1 for j in jobs if j.get("enabled", True))

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -529,7 +529,7 @@ def show_status(args):
     if jobs_file.exists():
         import json
         try:
-            with open(jobs_file, encoding="utf-8") as f:
+            with open(jobs_file, encoding="utf-8-sig") as f:
                 data = json.load(f)
                 jobs = data.get("jobs", [])
                 enabled_jobs = [j for j in jobs if j.get("enabled", True)]


### PR DESCRIPTION
## Summary

Fixes #66607 — `load_jobs()` crashes with RuntimeError when `jobs.json` has a UTF-8 BOM.

## Root cause

Four readers of `~/.hermes/cron/jobs.json` open with plain `encoding='utf-8'`. Python's `json.load` rejects a leading BOM (`EF BB BF`) under plain UTF-8.

## Fix

Switch all four readers to `encoding='utf-8-sig'`:
- `cron/jobs.py:838` — `load_jobs` primary open
- `cron/jobs.py:844` — `load_jobs` strict=False retry
- `hermes_cli/dump.py:170` — `_cron_summary`
- `hermes_cli/status.py:532` — `show_status`

Writers remain on plain `utf-8` so saves stay BOM-free.

## Testing

```bash
TMP=$(mktemp -d)
mkdir -p "$TMP/cron"
printf 'ï»¿{"jobs": []}
' > "$TMP/cron/jobs.json"
HERMES_HOME="$TMP" python -c 'from cron.jobs import load_jobs; print(load_jobs())'
rm -rf "$TMP"
```

- `py_compile` passes on all 3 modified files
- No behavioral change for non-BOM files
