### PR TITLE
fix(model-picker): show exhausted-pool providers in the aux-task and vision pickers too

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3487,6 +3487,12 @@ def _aux_select_for_task(task: str) -> None:
             current_provider=current_provider,
             current_model=current_model,
             current_base_url=current_base_url,
+            # Interactive picker: also show providers whose credential pool is
+            # entirely rate-limited (exhausted). Rate limits are per-model, and
+            # this persists an aux-task config the user will use later once the
+            # cooldown clears, so hiding the provider here is wrong — same
+            # rationale as the /model picker (#66584).
+            for_picker=True,
         )
     except Exception as exc:
         print(f"Could not detect authenticated providers: {exc}")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3589,7 +3589,11 @@ def _configure_vision_provider_model(config: dict, vision_cfg: dict) -> None:
         return
 
     try:
-        providers = list_authenticated_providers(max_models=40)
+        # Interactive picker: include providers whose credential pool is
+        # entirely rate-limited (exhausted) so the user can still route vision
+        # here — rate limits are per-model and this persists a config used
+        # later. Same rationale as the /model picker (#66584).
+        providers = list_authenticated_providers(max_models=40, for_picker=True)
     except Exception as exc:
         _print_warning(f"  Could not detect providers: {exc}")
         providers = []

--- a/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
+++ b/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
@@ -114,3 +114,61 @@ def test_picker_shows_exhausted_pool_provider(monkeypatch):
         "Picker must show exhausted-pool providers so the user can select "
         "a different model under the same provider"
     )
+
+
+class _StopPicker(BaseException):
+    """Aborts a picker right after it requests its provider list, before any
+    interactive prompt. Subclasses BaseException so the picker's own
+    ``except Exception`` guards don't swallow it."""
+
+
+def _spy_list_authenticated(recorded: dict):
+    def _spy(*_args, **kwargs):
+        recorded.update(kwargs)
+        raise _StopPicker
+    return _spy
+
+
+def test_aux_task_picker_requests_exhausted_pool_visibility(monkeypatch):
+    """The ``hermes model`` auxiliary-task picker (``_aux_select_for_task``)
+    must request exhausted-pool visibility (``for_picker=True``) like the
+    ``/model`` picker (#66584).
+
+    The aux picker writes a *persistent* per-task provider/model config that
+    the user runs later — long after a momentary rate-limit cooldown clears —
+    so silently hiding a provider whose keys are all exhausted is exactly the
+    bug the #66584 picker fix addressed, one interactive picker over.
+    """
+    import hermes_cli.main as main
+
+    recorded: dict = {}
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        _spy_list_authenticated(recorded),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+
+    with pytest.raises(_StopPicker):
+        main._aux_select_for_task("compression")
+
+    assert recorded.get("for_picker") is True, (
+        "aux-task picker must pass for_picker=True so exhausted-pool providers "
+        "stay selectable (before the fix it omitted the flag → hidden)"
+    )
+
+
+def test_vision_provider_picker_requests_exhausted_pool_visibility(monkeypatch):
+    """The vision provider/model picker (``_configure_vision_provider_model``)
+    must also request exhausted-pool visibility — same rationale as #66584."""
+    import hermes_cli.tools_config as tc
+
+    recorded: dict = {}
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        _spy_list_authenticated(recorded),
+    )
+
+    with pytest.raises(_StopPicker):
+        tc._configure_vision_provider_model({}, {})
+
+    assert recorded.get("for_picker") is True


### PR DESCRIPTION
## What

#66584 taught the interactive `/model` picker to keep showing a provider whose credential pool has entries but is entirely **rate-limited (exhausted)** — rate limits are per-model (e.g. Google Gemini), so an exhausted key for model-A may still serve model-B, and the user should stay able to select it. That fix wired `for_picker=True` into `list_picker_providers`.

The two sibling interactive pickers reached from `hermes model` still called `list_authenticated_providers()` **without** `for_picker=True`, so they kept hiding exhausted-pool providers:

- `_aux_select_for_task` (`hermes_cli/main.py`) — the auxiliary-task provider/model picker
- `_configure_vision_provider_model` (`hermes_cli/tools_config.py`) — the vision provider/model picker

Both persist a per-task config the user runs **later** (once the momentary cooldown clears), so hiding an exhausted-pool provider here is exactly the #66584 bug, one picker over.

## Fix

Pass `for_picker=True` at both call sites.

## Tests

`tests/hermes_cli/test_authenticated_providers_exhausted_pool.py` — two regressions asserting each picker requests `for_picker=True` (both omitted it before the fix). Existing picker/exhausted-pool suite unchanged.

```
pytest tests/hermes_cli/test_authenticated_providers_exhausted_pool.py -q
# 6 passed
```