### PR TITLE
fix(config): quote .env values containing internal whitespace (#66482)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7777,6 +7777,8 @@ def _quote_env_value(value: str) -> str:
         or '"' in value
         or "'" in value
         or value != value.strip()
+        or " " in value
+        or "	" in value
     )
     if not needs_quoting:
         return value


### PR DESCRIPTION
## Summary

Fixes #66482 — `save_env_value` writes unquoted values containing internal spaces, breaking shell-sourcing of `.env`.

## Root cause

`_quote_env_value` only checked for `#`, quotes, and leading/trailing whitespace. Internal spaces and tabs were written unquoted, causing shell word-splitting when `.env` is sourced.

## Fix

Add `" " in value` and `"\t" in value` to the `needs_quoting` condition in `_quote_env_value`.

## Impact

Fixes shell-sourcing for paths with spaces:
- macOS `~/Library/Application Support/...`
- Windows `Program Files/...`
- Keys: `TERMINAL_SSH_KEY`, `GOOGLE_CHAT_SERVICE_ACCOUNT_JSON`

## Testing

- `py_compile` passes
- No behavioral change for values without internal whitespace
- Values with spaces now correctly quoted: `KEY="path with spaces"`