### PR TITLE
fix(env): detect and convert UTF-16 .env files to UTF-8 (#66474)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -187,6 +187,32 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
     except ImportError:
         return  # early bootstrap — config module not available yet
 
+    # Detect and convert UTF-16 encoded .env files (e.g. Windows Notepad
+    # "Unicode" save) to UTF-8 so downstream readers don't mangle the
+    # content.  Must run before the UTF-8-sig read below.
+    try:
+        raw = path.read_bytes()
+        if raw[:2] in (b"\xff\xfe", b"\xfe\xff"):  # UTF-16 LE / BE BOM
+            import tempfile
+            decoded = raw.decode("utf-16")
+            fd, tmp = tempfile.mkstemp(
+                dir=str(path.parent), suffix=".tmp", prefix=".env_"
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as tf:
+                    tf.write(decoded)
+                    tf.flush()
+                    os.fsync(tf.fileno())
+                atomic_replace(tmp, path)
+            except BaseException:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+    except Exception:
+        pass  # best-effort — fall through to normal read
+
     read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
     try:
         with open(path, **read_kw) as f:


### PR DESCRIPTION
## Summary

Fixes #66474 — UTF-16 `.env` files silently corrupt the first env key, and the sanitizer persists the corruption to disk.

## Root cause

`_sanitize_env_file_if_needed` reads with `encoding="utf-8-sig"`. A UTF-16 LE BOM (`FF FE`) is invalid UTF-8 and gets replaced with U+FFFD characters. The sanitizer then writes the mangled content back, permanently corrupting the file.

## Fix

Add UTF-16 BOM detection at the top of `_sanitize_env_file_if_needed`:
1. Read raw bytes, check for UTF-16 LE/BE BOM
2. Decode as `utf-16` (Python auto-detects variant)
3. Write back as clean UTF-8 using atomic replace
4. Fall through to existing UTF-8-sig sanitizer

## Testing

```python
import codecs, os, tempfile
from pathlib import Path
from hermes_cli.env_loader import load_hermes_dotenv

home = Path(tempfile.mkdtemp())
env = home / ".env"
content = "HERMES_TEST_KEY=hello_utf16
SECOND_KEY=world
"
env.write_bytes(codecs.BOM_UTF16_LE + content.encode("utf-16-le"))

os.environ.pop("HERMES_TEST_KEY", None)
os.environ.pop("SECOND_KEY", None)
load_hermes_dotenv(hermes_home=home)

print("HERMES_TEST_KEY:", os.environ.get("HERMES_TEST_KEY"))
print("SECOND_KEY:", os.environ.get("SECOND_KEY"))
```

- Before fix: `HERMES_TEST_KEY=None`, mangled key `��HERMES_TEST_KEY` exists
- After fix: `HERMES_TEST_KEY=hello_utf16`, `SECOND_KEY=world`
- `py_compile` passes