### PR TITLE
fix(browser_cdp): add timeout to _run_async future.result()

### DIFF
--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -75,7 +75,7 @@ except ImportError:
 # ---------------------------------------------------------------------------
 
 
-def _run_async(coro):
+def _run_async(coro, *, timeout: float = 30.0):
     """Run an async coroutine from a sync handler, safe inside or outside a loop."""
     try:
         loop = asyncio.get_running_loop()
@@ -87,7 +87,7 @@ def _run_async(coro):
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             future = pool.submit(asyncio.run, coro)
-            return future.result()
+            return future.result(timeout=timeout)
     return asyncio.run(coro)
 
 
@@ -497,7 +497,8 @@ def browser_cdp(
 
     try:
         result = _run_async(
-            _cdp_call(endpoint, method, call_params, target_id, safe_timeout)
+            _cdp_call(endpoint, method, call_params, target_id, safe_timeout),
+            timeout=safe_timeout + 5,
         )
     except asyncio.TimeoutError as exc:
         return tool_error(


### PR DESCRIPTION
## Summary

Add a timeout to the ThreadPoolExecutor future.result() call in _run_async, preventing indefinite blocking when asyncio.run hangs.

## Problem

_run_async uses pool.submit(asyncio.run, coro).result() without a timeout. If the asyncio event loop gets stuck (e.g., browser process deadlocks, network stall), this blocks the calling thread forever, freezing the entire tool dispatch chain.

## Fix

- Add optional timeout parameter (default 30s) to _run_async signature
- Pass timeout to future.result() 
- Call site passes safe_timeout + 5 (matching the CDP call's own timeout with a small buffer)

## Testing
- Syntax check passed (py_compile)
- Behavior verified