### PR TITLE
fix(kanban): guard dependency block after successor creation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4934,6 +4934,16 @@ def block_task(
         # here (rather than ``blocked``) is what keeps a cron from ever seeing
         # a dependency-wait as something to "unblock".
         if kind == "dependency":
+            child_row = conn.execute(
+                "SELECT child_id FROM task_links WHERE parent_id = ? LIMIT 1",
+                (task_id,),
+            ).fetchone()
+            if child_row is not None:
+                raise ValueError(
+                    "dependency block is invalid after successor creation; "
+                    f"complete parent task {task_id} because successor "
+                    f"{child_row['child_id']} already exists"
+                )
             cur = conn.execute(
                 """
                 UPDATE tasks

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -162,6 +162,29 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
         assert kb.get_task(conn, child).status == "ready"
 
 
+def test_dependency_block_refuses_after_successor_creation(kanban_home: Path) -> None:
+    """A parent with a created successor must complete, not dependency-park."""
+    with kb.connect_closing() as conn:
+        parent = _running_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", assignee="worker", parents=[parent])
+
+        with pytest.raises(ValueError, match="complete parent task .* successor"):
+            kb.block_task(conn, parent, reason="wait", kind="dependency")
+
+        parent_task = kb.get_task(conn, parent)
+        child_task = kb.get_task(conn, child)
+        assert parent_task is not None
+        assert child_task is not None
+        assert parent_task.status == "running"
+        assert child_task.status == "todo"
+
+        kb.complete_task(conn, parent, result="done")
+        kb.recompute_ready(conn)
+        child_task = kb.get_task(conn, child)
+        assert child_task is not None
+        assert child_task.status == "ready"
+
+
 # ---------------------------------------------------------------------------
 # Completion resets loop memory
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- guard dependency blocks after a successor child has already been created, forcing the parent to complete instead of parking itself in `todo`
- keep the parent running and successor todo when the invalid block is attempted, then verify parent completion promotes the child normally
- preserve existing no-successor dependency wait behavior

## Scope
- `hermes_cli/kanban_db.py`
- `tests/hermes_cli/test_kanban_block_kinds.py`

## Verification
- `git verify-commit HEAD`
- `git diff --check origin/main...HEAD`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_block_kinds.py -k test_dependency_block_refuses_after_successor_creation`

Upstream QA acceptance was recorded by Merlin for exact signed commit `81fa11a5c0fa434e0ec65f0990d697072154a5a9`.