### PR TITLE
fix(cli): reject stale update cache when Git HEAD is unresolved

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -396,6 +396,8 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir = None
+    local_git_rev = None
 
     # Docker images have no working tree to count commits against — the
     # published image excludes `.git` (see .dockerignore) and sets no
@@ -411,6 +413,20 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         pass
 
+    if not embedded_rev:
+        repo_dir = _resolve_repo_dir()
+        if repo_dir is not None:
+            local_git_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
+    cache_rev = embedded_rev or local_git_rev
+    # A source checkout has a trustworthy cache identity only when HEAD was
+    # resolved. Packaged installs have no checkout, while Nix identifies the
+    # running build through HERMES_REVISION.
+    cache_rev_known = (
+        embedded_rev is not None
+        or local_git_rev is not None
+        or repo_dir is None
+    )
+
     # Read cache — invalidate if the embedded rev OR installed version has
     # changed since the last check.
     now = time.time()
@@ -419,7 +435,8 @@ def check_for_updates() -> Optional[int]:
             cached = json.loads(cache_file.read_text(encoding="utf-8"))
             if (
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
+                and cache_rev_known
+                and cached.get("rev") == cache_rev
                 and cached.get("ver") == VERSION
             ):
                 return cached.get("behind")
@@ -429,13 +446,7 @@ def check_for_updates() -> Optional[int]:
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
+        if repo_dir is None:
             # No git checkout and no embedded revision — can't determine
             # update status. This is the Docker path (already short-circuited
             # above) or an unsupported install without a source tree.
@@ -445,7 +456,7 @@ def check_for_updates() -> Optional[int]:
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+            json.dumps({"ts": now, "behind": behind, "rev": cache_rev, "ver": VERSION}),
             encoding="utf-8",
         )
     except Exception:

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -287,6 +287,8 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir = None
+    local_git_rev = None
 
     # Docker images have no working tree to count commits against — the
     # published image excludes `.git` (see .dockerignore) and sets no
@@ -302,6 +304,20 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         pass
 
+    if not embedded_rev:
+        repo_dir = _resolve_repo_dir()
+        if repo_dir is not None:
+            local_git_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
+    cache_rev = embedded_rev or local_git_rev
+    # A source checkout has a trustworthy cache identity only when HEAD was
+    # resolved. Packaged installs have no checkout, while Nix identifies the
+    # running build through HERMES_REVISION.
+    cache_rev_known = (
+        embedded_rev is not None
+        or local_git_rev is not None
+        or repo_dir is None
+    )
+
     # Read cache — invalidate if the embedded rev OR installed version has
     # changed since the last check.
     now = time.time()
@@ -310,7 +326,8 @@ def check_for_updates() -> Optional[int]:
             cached = json.loads(cache_file.read_text(encoding="utf-8"))
             if (
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
+                and cache_rev_known
+                and cached.get("rev") == cache_rev
                 and cached.get("ver") == VERSION
             ):
                 return cached.get("behind")
@@ -320,13 +337,7 @@ def check_for_updates() -> Optional[int]:
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
+        if repo_dir is None:
             # No git checkout and no embedded revision — can't determine
             # update status. This is the Docker path (already short-circuited
             # above) or an unsupported install without a source tree.
@@ -336,7 +347,7 @@ def check_for_updates() -> Optional[int]:
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+            json.dumps({"ts": now, "behind": behind, "rev": cache_rev, "ver": VERSION}),
             encoding="utf-8",
         )
     except Exception:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -13,9 +13,8 @@ import pytest
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
-    from hermes_cli.banner import check_for_updates
-    from hermes_cli import __version__
+    """A fresh cache stamped with the current HEAD skips the remote check."""
+    import hermes_cli.banner as banner
 
     # Create a fake git repo and fresh cache
     repo_dir = tmp_path / "hermes-agent"
@@ -23,14 +22,140 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 3,
+        "rev": "current-head",
+        "ver": banner.VERSION,
+    }))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
-        result = check_for_updates()
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with (
+        patch("hermes_cli.banner._resolve_repo_dir", return_value=repo_dir),
+        patch("hermes_cli.banner._git_stdout", return_value="current-head"),
+        patch("hermes_cli.banner._check_via_local_git") as mock_git_check,
+    ):
+        result = banner.check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    mock_git_check.assert_not_called()
+
+
+def test_check_for_updates_invalidates_cache_when_head_changes(tmp_path, monkeypatch):
+    """A branch switch or external pull must invalidate a fresh cache."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 4,
+        "rev": "old-head",
+        "ver": banner.VERSION,
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with (
+        patch("hermes_cli.banner._resolve_repo_dir", return_value=repo_dir),
+        patch("hermes_cli.banner._git_stdout", return_value="new-head"),
+        patch(
+            "hermes_cli.banner._check_via_local_git", return_value=0
+        ) as mock_git_check,
+    ):
+        result = banner.check_for_updates()
+
+    assert result == 0
+    mock_git_check.assert_called_once_with(repo_dir)
+    written = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert written["behind"] == 0
+    assert written["rev"] == "new-head"
+
+
+def test_check_for_updates_does_not_trust_cache_when_head_is_unknown(
+    tmp_path, monkeypatch
+):
+    """A checkout whose HEAD cannot be resolved has no valid cache identity."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 4,
+        "rev": "previous-head",
+        "ver": banner.VERSION,
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with (
+        patch("hermes_cli.banner._resolve_repo_dir", return_value=repo_dir),
+        patch("hermes_cli.banner._git_stdout", return_value=None),
+        patch(
+            "hermes_cli.banner._check_via_local_git", return_value=0
+        ) as mock_git_check,
+    ):
+        result = banner.check_for_updates()
+
+    assert result == 0
+    mock_git_check.assert_called_once_with(repo_dir)
+
+
+def test_check_for_updates_keeps_embedded_revision_cache(tmp_path, monkeypatch):
+    """Nix builds keep using HERMES_REVISION without probing a checkout."""
+    import hermes_cli.banner as banner
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 0,
+        "rev": "embedded-revision",
+        "ver": banner.VERSION,
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_REVISION", "embedded-revision")
+    with (
+        patch("hermes_cli.banner._resolve_repo_dir") as mock_resolve,
+        patch("hermes_cli.banner._check_via_rev") as mock_rev_check,
+    ):
+        result = banner.check_for_updates()
+
+    assert result == 0
+    mock_resolve.assert_not_called()
+    mock_rev_check.assert_not_called()
+
+
+def test_check_for_updates_keeps_cache_without_checkout(tmp_path, monkeypatch):
+    """A packaged install with no git identity keeps its time-based cache."""
+    import hermes_cli.banner as banner
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": None,
+        "rev": None,
+        "ver": banner.VERSION,
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with (
+        patch("hermes_cli.banner._resolve_repo_dir", return_value=None),
+        patch("hermes_cli.banner._git_stdout") as mock_git_stdout,
+        patch("hermes_cli.banner._check_via_local_git") as mock_git_check,
+    ):
+        result = banner.check_for_updates()
+
+    assert result is None
+    mock_git_stdout.assert_not_called()
+    mock_git_check.assert_not_called()
 
 
 
@@ -56,7 +181,5 @@ def test_prefetch_non_blocking():
         # Wait for the background thread to finish
         banner._update_check_done.wait(timeout=5)
         assert banner._update_result == 5
-
-
 
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -13,9 +13,8 @@ import pytest
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
-    from hermes_cli.banner import check_for_updates
-    from hermes_cli import __version__
+    """A fresh cache stamped with the current HEAD skips the remote check."""
+    import hermes_cli.banner as banner
 
     # Create a fake git repo and fresh cache
     repo_dir = tmp_path / "hermes-agent"
@@ -23,14 +22,140 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 3,
+        "rev": "current-head",
+        "ver": banner.VERSION,
+    }))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
-        result = check_for_updates()
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with (
+        patch("hermes_cli.banner._resolve_repo_dir", return_value=repo_dir),
+        patch("hermes_cli.banner._git_stdout", return_value="current-head"),
+        patch("hermes_cli.banner._check_via_local_git") as mock_git_check,
+    ):
+        result = banner.check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    mock_git_check.assert_not_called()
+
+
+def test_check_for_updates_invalidates_cache_when_head_changes(tmp_path, monkeypatch):
+    """A branch switch or external pull must invalidate a fresh cache."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 4,
+        "rev": "old-head",
+        "ver": banner.VERSION,
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with (
+        patch("hermes_cli.banner._resolve_repo_dir", return_value=repo_dir),
+        patch("hermes_cli.banner._git_stdout", return_value="new-head"),
+        patch(
+            "hermes_cli.banner._check_via_local_git", return_value=0
+        ) as mock_git_check,
+    ):
+        result = banner.check_for_updates()
+
+    assert result == 0
+    mock_git_check.assert_called_once_with(repo_dir)
+    written = json.loads(cache_file.read_text())
+    assert written["behind"] == 0
+    assert written["rev"] == "new-head"
+
+
+def test_check_for_updates_does_not_trust_cache_when_head_is_unknown(
+    tmp_path, monkeypatch
+):
+    """A checkout whose HEAD cannot be resolved has no valid cache identity."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 4,
+        "rev": "previous-head",
+        "ver": banner.VERSION,
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with (
+        patch("hermes_cli.banner._resolve_repo_dir", return_value=repo_dir),
+        patch("hermes_cli.banner._git_stdout", return_value=None),
+        patch(
+            "hermes_cli.banner._check_via_local_git", return_value=0
+        ) as mock_git_check,
+    ):
+        result = banner.check_for_updates()
+
+    assert result == 0
+    mock_git_check.assert_called_once_with(repo_dir)
+
+
+def test_check_for_updates_keeps_embedded_revision_cache(tmp_path, monkeypatch):
+    """Nix builds keep using HERMES_REVISION without probing a checkout."""
+    import hermes_cli.banner as banner
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 0,
+        "rev": "embedded-revision",
+        "ver": banner.VERSION,
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_REVISION", "embedded-revision")
+    with (
+        patch("hermes_cli.banner._resolve_repo_dir") as mock_resolve,
+        patch("hermes_cli.banner._check_via_rev") as mock_rev_check,
+    ):
+        result = banner.check_for_updates()
+
+    assert result == 0
+    mock_resolve.assert_not_called()
+    mock_rev_check.assert_not_called()
+
+
+def test_check_for_updates_keeps_cache_without_checkout(tmp_path, monkeypatch):
+    """A packaged install with no git identity keeps its time-based cache."""
+    import hermes_cli.banner as banner
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": None,
+        "rev": None,
+        "ver": banner.VERSION,
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with (
+        patch("hermes_cli.banner._resolve_repo_dir", return_value=None),
+        patch("hermes_cli.banner._git_stdout") as mock_git_stdout,
+        patch("hermes_cli.banner._check_via_local_git") as mock_git_check,
+    ):
+        result = banner.check_for_updates()
+
+    assert result is None
+    mock_git_stdout.assert_not_called()
+    mock_git_check.assert_not_called()
 
 
 
@@ -56,7 +181,5 @@ def test_prefetch_non_blocking():
         # Wait for the background thread to finish
         banner._update_check_done.wait(timeout=5)
         assert banner._update_result == 5
-
-
 
 


### PR DESCRIPTION
## Current scope

Reconciled with main `ee4452991d17534aa561f31ee55596d082aa94e7` using a non-forced merge; the previous branch history is preserved. HEAD-keyed invalidation is now native, so this PR retains only the remaining unresolved-HEAD gap rather than reintroducing the old implementation.

When a checkout exists but `rev-parse HEAD` fails, a fresh positive cache with a missing/null `head` field must not be trusted. Return an inconclusive result instead of displaying a stale update count. The patch does not add a network request to this failure path.

## Tests

- Two parameterized regression cases fail on unchanged main (`7` instead of `None`) and pass with this patch.
- **23 targeted update-check/banner tests pass**, with isolated imports checked against the exact candidate sources.
- Current mock Git runner accepts only the local system/global `safe.directory` read probes in addition to its existing commands; the no-fetch/no-ls-remote assertions remain.
- Ruff error checks and whitespace checks pass.
- This is targeted validation, not a claim of a complete upstream CI run. CI/maintainer gates remain authoritative.

Earlier consolidation references: #9670, #11210. The rest of their HEAD-cache behavior has since landed in main.
