### PR TITLE
fix(auxiliary): keep local compression timeouts local

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4624,6 +4624,45 @@ def _fallback_destination(
     return _complete_fallback_destination(provider, base_url, api_mode, model)
 
 
+def _resolve_fallback_timeout(
+    *,
+    task: Optional[str],
+    fb_label: str,
+    destination: _FallbackDestination,
+    effective_timeout: float,
+    timeout_override: Optional[float],
+) -> float:
+    """Resolve a fallback deadline without leaking the primary route policy."""
+    entry_timeout = _fallback_entry_timeout(task, fb_label)
+    if entry_timeout is not None:
+        if entry_timeout != effective_timeout:
+            logger.info(
+                "Auxiliary %s: %s using its configured timeout %.0fs "
+                "(task-level was %.0fs)",
+                task or "call", fb_label, entry_timeout, effective_timeout,
+            )
+        return entry_timeout
+
+    if task != "compression" or timeout_override is not None:
+        return effective_timeout
+
+    destination_timeout = _effective_aux_timeout(
+        task,
+        None,
+        base_url=destination.base_url,
+    )
+    if destination_timeout != effective_timeout:
+        logger.info(
+            "Auxiliary %s: %s resolved endpoint timeout %.0fs "
+            "(primary was %.0fs)",
+            task,
+            fb_label,
+            destination_timeout,
+            effective_timeout,
+        )
+    return destination_timeout
+
+
 def _replan_synchronous_cache_sections(
     messages: list,
     tools: Optional[list],
@@ -4654,6 +4693,7 @@ def _call_fallback_candidate_sync(
     max_tokens: Optional[int],
     tools: Optional[list],
     effective_timeout: float,
+    timeout_override: Optional[float] = None,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
 ) -> Optional[Any]:
@@ -4672,20 +4712,18 @@ def _call_fallback_candidate_sync(
     expired token), mark the provider unhealthy and return ``None`` so the
     caller can continue to the next fallback layer. Non-auth errors raise.
 
-    ``effective_timeout`` is the task-level deadline; a configured-chain
-    candidate with its own ``timeout`` entry gets that instead, so a
-    fallback tuned differently from the primary is allowed its own budget
-    (#62452).
+    ``effective_timeout`` is the primary route's deadline. A configured-chain
+    candidate with its own ``timeout`` entry gets that exact value; otherwise
+    implicit compression timeouts are recalculated for the fallback endpoint.
     """
-    fb_timeout = _fallback_entry_timeout(task, fb_label)
-    if fb_timeout is not None and fb_timeout != effective_timeout:
-        logger.info(
-            "Auxiliary %s: %s using its configured timeout %.0fs "
-            "(task-level was %.0fs)",
-            task or "call", fb_label, fb_timeout, effective_timeout,
-        )
-        effective_timeout = fb_timeout
     destination = _fallback_destination(task, fb_client, fb_model, fb_label)
+    effective_timeout = _resolve_fallback_timeout(
+        task=task,
+        fb_label=fb_label,
+        destination=destination,
+        effective_timeout=effective_timeout,
+        timeout_override=timeout_override,
+    )
     fallback_messages, fallback_tools = _replan_synchronous_cache_sections(
         messages,
         tools,
@@ -4779,19 +4817,19 @@ async def _call_fallback_candidate_async(
     max_tokens: Optional[int],
     tools: Optional[list],
     effective_timeout: float,
+    timeout_override: Optional[float] = None,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
 ) -> Optional[Any]:
     """Async mirror of :func:`_call_fallback_candidate_sync`."""
-    fb_timeout = _fallback_entry_timeout(task, fb_label)
-    if fb_timeout is not None and fb_timeout != effective_timeout:
-        logger.info(
-            "Auxiliary %s: %s using its configured timeout %.0fs "
-            "(task-level was %.0fs)",
-            task or "call", fb_label, fb_timeout, effective_timeout,
-        )
-        effective_timeout = fb_timeout
     destination = _fallback_destination(task, fb_client, fb_model, fb_label)
+    effective_timeout = _resolve_fallback_timeout(
+        task=task,
+        fb_label=fb_label,
+        destination=destination,
+        effective_timeout=effective_timeout,
+        timeout_override=timeout_override,
+    )
     fallback_messages, fallback_tools = _replan_synchronous_cache_sections(
         messages,
         tools,
@@ -7538,19 +7576,42 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     return default
 
 
-def _effective_aux_timeout(task: str, timeout: Optional[float]) -> float:
+def _is_local_aux_base_url(base_url: Optional[str]) -> bool:
+    """Return whether an auxiliary endpoint is bound to the local machine."""
+    try:
+        host = base_url_hostname(str(base_url or ""))
+    except Exception:
+        return False
+    return (host or "").strip().lower().strip("[]") in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "0.0.0.0",
+    }
+
+
+def _effective_aux_timeout(
+    task: str,
+    timeout: Optional[float],
+    *,
+    base_url: Optional[str] = None,
+) -> float:
     """Resolve the effective timeout for an auxiliary LLM call.
 
     Uses the caller-provided ``timeout`` when given; otherwise reads
     ``auxiliary.{task}.timeout`` from config via :func:`_get_task_timeout`.
     For the ``compression`` task only, applies a bounded floor so a reasoning
     model summarising a large context is not cut off by the default timeout
-    (#54915).  The floor is intentionally skipped when the caller passes an
-    explicit ``timeout=`` — explicit per-call deadlines are always honoured —
-    and it is a minimum (``max``), so a config value already above it is kept.
+    (#54915). The floor is skipped for local endpoints and when the caller
+    passes an explicit ``timeout=``; a configured value above the floor is
+    kept unchanged.
     """
     effective = timeout if timeout is not None else _get_task_timeout(task)
-    if timeout is None and task == "compression":
+    if (
+        timeout is None
+        and task == "compression"
+        and not _is_local_aux_base_url(base_url)
+    ):
         effective = max(effective, _COMPRESSION_TIMEOUT_FLOOR_SECONDS)
     return effective
 
@@ -8715,7 +8776,6 @@ def _call_llm_impl(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = _effective_aux_timeout(task, timeout)
     _set_relay_auxiliary_route(
         resolved_provider,
         final_model,
@@ -8724,6 +8784,11 @@ def _call_llm_impl(
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
+    effective_timeout = _effective_aux_timeout(
+        task,
+        timeout,
+        base_url=_base_info or resolved_base_url,
+    )
     if task:
         logger.info("Auxiliary %s: using %s (%s)%s",
                      task, resolved_provider or "auto", final_model or "default",
@@ -9245,6 +9310,7 @@ def _call_llm_impl(
                     task=task, messages=messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, effective_timeout=effective_timeout,
+                    timeout_override=timeout,
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config)
                 if fb_resp is not None:
@@ -9260,6 +9326,7 @@ def _call_llm_impl(
                         task=task, messages=messages,
                         temperature=temperature, max_tokens=max_tokens,
                         tools=tools, effective_timeout=effective_timeout,
+                        timeout_override=timeout,
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config)
                     if fb_resp is not None:
@@ -9474,7 +9541,6 @@ async def _async_call_llm_impl(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = _effective_aux_timeout(task, timeout)
     _set_relay_auxiliary_route(
         resolved_provider,
         final_model,
@@ -9485,6 +9551,11 @@ async def _async_call_llm_impl(
     # endpoint-specific temperature overrides can distinguish
     # api.moonshot.ai vs api.kimi.com/coding even on auto-detected routes.
     _client_base = str(getattr(client, "base_url", "") or "")
+    effective_timeout = _effective_aux_timeout(
+        task,
+        timeout,
+        base_url=_client_base or resolved_base_url,
+    )
     kwargs = _build_call_kwargs(
         resolved_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
@@ -9886,6 +9957,7 @@ async def _async_call_llm_impl(
                     task=task, messages=messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, effective_timeout=effective_timeout,
+                    timeout_override=timeout,
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config)
                 if fb_resp is not None:
@@ -9903,6 +9975,7 @@ async def _async_call_llm_impl(
                         task=task, messages=messages,
                         temperature=temperature, max_tokens=max_tokens,
                         tools=tools, effective_timeout=effective_timeout,
+                        timeout_override=timeout,
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config)
                     if fb_resp is not None:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4988,6 +4988,45 @@ def _fallback_destination(
     return _complete_fallback_destination(provider, base_url, api_mode, model)
 
 
+def _resolve_fallback_timeout(
+    *,
+    task: Optional[str],
+    fb_label: str,
+    destination: _FallbackDestination,
+    effective_timeout: float,
+    timeout_override: Optional[float],
+) -> float:
+    """Resolve a fallback deadline without leaking the primary route policy."""
+    entry_timeout = _fallback_entry_timeout(task, fb_label)
+    if entry_timeout is not None:
+        if entry_timeout != effective_timeout:
+            logger.info(
+                "Auxiliary %s: %s using its configured timeout %.0fs "
+                "(task-level was %.0fs)",
+                task or "call", fb_label, entry_timeout, effective_timeout,
+            )
+        return entry_timeout
+
+    if task != "compression" or timeout_override is not None:
+        return effective_timeout
+
+    destination_timeout = _effective_aux_timeout(
+        task,
+        None,
+        base_url=destination.base_url,
+    )
+    if destination_timeout != effective_timeout:
+        logger.info(
+            "Auxiliary %s: %s resolved endpoint timeout %.0fs "
+            "(primary was %.0fs)",
+            task,
+            fb_label,
+            destination_timeout,
+            effective_timeout,
+        )
+    return destination_timeout
+
+
 def _replan_synchronous_cache_sections(
     messages: list,
     tools: Optional[list],
@@ -5027,6 +5066,7 @@ def _call_fallback_candidate_sync(
     max_tokens: Optional[int],
     tools: Optional[list],
     effective_timeout: float,
+    timeout_override: Optional[float] = None,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
 ) -> Optional[Any]:
@@ -5045,20 +5085,18 @@ def _call_fallback_candidate_sync(
     expired token), mark the provider unhealthy and return ``None`` so the
     caller can continue to the next fallback layer. Non-auth errors raise.
 
-    ``effective_timeout`` is the task-level deadline; a configured-chain
-    candidate with its own ``timeout`` entry gets that instead, so a
-    fallback tuned differently from the primary is allowed its own budget
-    (#62452).
+    ``effective_timeout`` is the primary route's deadline. A configured-chain
+    candidate with its own ``timeout`` entry gets that exact value; otherwise
+    implicit compression timeouts are recalculated for the fallback endpoint.
     """
-    fb_timeout = _fallback_entry_timeout(task, fb_label)
-    if fb_timeout is not None and fb_timeout != effective_timeout:
-        logger.info(
-            "Auxiliary %s: %s using its configured timeout %.0fs "
-            "(task-level was %.0fs)",
-            task or "call", fb_label, fb_timeout, effective_timeout,
-        )
-        effective_timeout = fb_timeout
     destination = _fallback_destination(task, fb_client, fb_model, fb_label)
+    effective_timeout = _resolve_fallback_timeout(
+        task=task,
+        fb_label=fb_label,
+        destination=destination,
+        effective_timeout=effective_timeout,
+        timeout_override=timeout_override,
+    )
     fallback_messages, fallback_tools = _replan_synchronous_cache_sections(
         messages,
         tools,
@@ -5152,19 +5190,19 @@ async def _call_fallback_candidate_async(
     max_tokens: Optional[int],
     tools: Optional[list],
     effective_timeout: float,
+    timeout_override: Optional[float] = None,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
 ) -> Optional[Any]:
     """Async mirror of :func:`_call_fallback_candidate_sync`."""
-    fb_timeout = _fallback_entry_timeout(task, fb_label)
-    if fb_timeout is not None and fb_timeout != effective_timeout:
-        logger.info(
-            "Auxiliary %s: %s using its configured timeout %.0fs "
-            "(task-level was %.0fs)",
-            task or "call", fb_label, fb_timeout, effective_timeout,
-        )
-        effective_timeout = fb_timeout
     destination = _fallback_destination(task, fb_client, fb_model, fb_label)
+    effective_timeout = _resolve_fallback_timeout(
+        task=task,
+        fb_label=fb_label,
+        destination=destination,
+        effective_timeout=effective_timeout,
+        timeout_override=timeout_override,
+    )
     fallback_messages, fallback_tools = _replan_synchronous_cache_sections(
         messages,
         tools,
@@ -8092,19 +8130,42 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     return default
 
 
-def _effective_aux_timeout(task: str, timeout: Optional[float]) -> float:
+def _is_local_aux_base_url(base_url: Optional[str]) -> bool:
+    """Return whether an auxiliary endpoint is bound to the local machine."""
+    try:
+        host = base_url_hostname(str(base_url or ""))
+    except Exception:
+        return False
+    return (host or "").strip().lower().strip("[]") in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "0.0.0.0",
+    }
+
+
+def _effective_aux_timeout(
+    task: str,
+    timeout: Optional[float],
+    *,
+    base_url: Optional[str] = None,
+) -> float:
     """Resolve the effective timeout for an auxiliary LLM call.
 
     Uses the caller-provided ``timeout`` when given; otherwise reads
     ``auxiliary.{task}.timeout`` from config via :func:`_get_task_timeout`.
     For the ``compression`` task only, applies a bounded floor so a reasoning
     model summarising a large context is not cut off by the default timeout
-    (#54915).  The floor is intentionally skipped when the caller passes an
-    explicit ``timeout=`` — explicit per-call deadlines are always honoured —
-    and it is a minimum (``max``), so a config value already above it is kept.
+    (#54915). The floor is skipped for local endpoints and when the caller
+    passes an explicit ``timeout=``; a configured value above the floor is
+    kept unchanged.
     """
     effective = timeout if timeout is not None else _get_task_timeout(task)
-    if timeout is None and task == "compression":
+    if (
+        timeout is None
+        and task == "compression"
+        and not _is_local_aux_base_url(base_url)
+    ):
         effective = max(effective, _COMPRESSION_TIMEOUT_FLOOR_SECONDS)
     return effective
 
@@ -9301,7 +9362,6 @@ def _call_llm_impl(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = _effective_aux_timeout(task, timeout)
     request_provider = effective_provider or resolved_provider
     _set_relay_auxiliary_route(
         request_provider,
@@ -9314,6 +9374,11 @@ def _call_llm_impl(
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
+    effective_timeout = _effective_aux_timeout(
+        task,
+        timeout,
+        base_url=_base_info or resolved_base_url,
+    )
     if task:
         logger.info("Auxiliary %s: using %s (%s)%s",
                      task, request_provider or "auto", final_model or "default",
@@ -9838,6 +9903,7 @@ def _call_llm_impl(
                     task=task, messages=messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, effective_timeout=effective_timeout,
+                    timeout_override=timeout,
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config)
                 if fb_resp is not None:
@@ -9856,6 +9922,7 @@ def _call_llm_impl(
                         task=task, messages=messages,
                         temperature=temperature, max_tokens=max_tokens,
                         tools=tools, effective_timeout=effective_timeout,
+                        timeout_override=timeout,
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config)
                     if fb_resp is not None:
@@ -10087,7 +10154,6 @@ async def _async_call_llm_impl(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = _effective_aux_timeout(task, timeout)
     request_provider = effective_provider or resolved_provider
     _set_relay_auxiliary_route(
         request_provider,
@@ -10102,6 +10168,11 @@ async def _async_call_llm_impl(
     # endpoint-specific temperature overrides can distinguish
     # api.moonshot.ai vs api.kimi.com/coding even on auto-detected routes.
     _client_base = str(getattr(client, "base_url", "") or "")
+    effective_timeout = _effective_aux_timeout(
+        task,
+        timeout,
+        base_url=_client_base or resolved_base_url,
+    )
     kwargs = _build_call_kwargs(
         request_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
@@ -10508,6 +10579,7 @@ async def _async_call_llm_impl(
                     task=task, messages=messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, effective_timeout=effective_timeout,
+                    timeout_override=timeout,
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config)
                 if fb_resp is not None:
@@ -10530,6 +10602,7 @@ async def _async_call_llm_impl(
                         task=task, messages=messages,
                         temperature=temperature, max_tokens=max_tokens,
                         tools=tools, effective_timeout=effective_timeout,
+                        timeout_override=timeout,
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config)
                     if fb_resp is not None:

--- a/tests/agent/test_auxiliary_compression_timeout_floor.py
+++ b/tests/agent/test_auxiliary_compression_timeout_floor.py
@@ -42,16 +42,16 @@ def _ok_response():
     return {"ok": True}
 
 
-def _client_sync():
+def _client_sync(base_url="https://api.openai.com/v1"):
     client = MagicMock()
-    client.base_url = "https://api.openai.com/v1"
+    client.base_url = base_url
     client.chat.completions.create.return_value = _ok_response()
     return client
 
 
-def _client_async():
+def _client_async(base_url="https://api.openai.com/v1"):
     client = MagicMock()
-    client.base_url = "https://api.openai.com/v1"
+    client.base_url = base_url
     client.chat.completions.create = AsyncMock(return_value=_ok_response())
     return client
 
@@ -110,6 +110,74 @@ class TestCompressionTimeoutFloorSync:
             f"non-compression task timeout must stay {low}, got {timeout}"
         )
 
+    def test_local_primary_uses_short_timeout_but_remote_fallback_keeps_floor(self):
+        primary = _client_sync("http://127.0.0.1:10243/v1")
+        primary.chat.completions.create.side_effect = TimeoutError("local timeout")
+        fallback = _client_sync("https://openrouter.ai/api/v1")
+        local_timeout = 60.0
+        chain = [{
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+        }]
+        p1, p2, p3, p4 = _patches(primary, task_timeout=local_timeout)
+        with (
+            p1, p2, p3, p4,
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"fallback_chain": chain},
+            ),
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(
+                    fallback,
+                    "fallback-model",
+                    "fallback_chain[0](openrouter)",
+                ),
+            ),
+        ):
+            assert call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarise"}],
+            ) == _ok_response()
+
+        primary_timeout = primary.chat.completions.create.call_args.kwargs["timeout"]
+        fallback_timeout = fallback.chat.completions.create.call_args.kwargs["timeout"]
+        assert primary_timeout == local_timeout
+        assert fallback_timeout >= COMPRESSION_TIMEOUT_FLOOR
+
+    def test_explicit_call_timeout_survives_remote_fallback(self):
+        primary = _client_sync("http://localhost:10243/v1")
+        primary.chat.completions.create.side_effect = TimeoutError("local timeout")
+        fallback = _client_sync("https://openrouter.ai/api/v1")
+        explicit = 45.0
+        chain = [{
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+        }]
+        p1, p2, p3, p4 = _patches(primary, task_timeout=60.0)
+        with (
+            p1, p2, p3, p4,
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"fallback_chain": chain},
+            ),
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(
+                    fallback,
+                    "fallback-model",
+                    "fallback_chain[0](openrouter)",
+                ),
+            ),
+        ):
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarise"}],
+                timeout=explicit,
+            )
+
+        assert fallback.chat.completions.create.call_args.kwargs["timeout"] == explicit
+
 
 
 class TestCompressionTimeoutFloorAsync:
@@ -156,3 +224,43 @@ class TestCompressionTimeoutFloorAsync:
             )
         timeout = client.chat.completions.create.call_args.kwargs["timeout"]
         assert timeout == low
+
+    @pytest.mark.asyncio
+    async def test_local_primary_uses_short_timeout_but_remote_fallback_keeps_floor(self):
+        primary = _client_async("http://[::1]:10243/v1")
+        primary.chat.completions.create.side_effect = TimeoutError("local timeout")
+        fallback = _client_async("https://openrouter.ai/api/v1")
+        local_timeout = 60.0
+        chain = [{
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+        }]
+        p1, p2, p3, p4 = _patches(primary, task_timeout=local_timeout)
+        with (
+            p1, p2, p3, p4,
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"fallback_chain": chain},
+            ),
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(
+                    fallback,
+                    "fallback-model",
+                    "fallback_chain[0](openrouter)",
+                ),
+            ),
+            patch(
+                "agent.auxiliary_client._to_async_client",
+                return_value=(fallback, "fallback-model"),
+            ),
+        ):
+            assert await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarise"}],
+            ) == _ok_response()
+
+        primary_timeout = primary.chat.completions.create.call_args.kwargs["timeout"]
+        fallback_timeout = fallback.chat.completions.create.call_args.kwargs["timeout"]
+        assert primary_timeout == local_timeout
+        assert fallback_timeout >= COMPRESSION_TIMEOUT_FLOOR

--- a/tests/agent/test_compression_fallback_budget.py
+++ b/tests/agent/test_compression_fallback_budget.py
@@ -70,6 +70,34 @@ def test_fallback_candidate_call_uses_entry_timeout():
     assert seen.get("timeout") == 240.0
 
 
+def test_entry_timeout_equal_to_primary_remains_explicit():
+    """Equality must not make an explicit entry timeout look implicit."""
+    seen = {}
+
+    class _FakeCompletions:
+        def create(self, **kwargs):
+            seen.update(kwargs)
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+            )
+
+    fb_client = SimpleNamespace(
+        base_url="https://example.invalid/v1",
+        chat=SimpleNamespace(completions=_FakeCompletions()),
+    )
+    chain = [{"provider": "custom", "timeout": 60}]
+    with _patch_task_config(chain):
+        _call_fallback_candidate_sync(
+            fb_client, "model", "fallback_chain[0](custom)",
+            task="compression", messages=[{"role": "user", "content": "hi"}],
+            temperature=None, max_tokens=None, tools=None,
+            effective_timeout=60.0,
+            effective_extra_body={}, reasoning_config=None,
+        )
+
+    assert seen.get("timeout") == 60.0
+
+
 
 
 # ---------------------------------------------------------------------------
@@ -128,5 +156,4 @@ def test_non_timeout_transient_errors_keep_flat_cooldown():
 
     # And it does not advance the timeout streak.
     assert getattr(c, "_consecutive_timeout_failures", 0) == 0
-
 


### PR DESCRIPTION
## What changed

- Detect local auxiliary endpoints (`localhost`, loopback addresses, and `0.0.0.0`).
- Keep implicit local compression calls at their configured timeout.
- Preserve the 300-second floor for implicit remote compression calls.
- Recalculate the timeout for each sync/async fallback destination.
- Preserve exact per-call and per-fallback-entry timeout overrides.

## Root cause

The reasoning-model timeout floor was applied to every compression endpoint. The first version exempted a local primary but passed that shortened deadline into remote fallbacks. Timeout policy must follow each destination, not the primary route.

## Review resolution

The fallback timeout policy is now centralized in `_resolve_fallback_timeout()`. A local primary configured for 60 seconds can fall back to a remote provider with the 300-second floor, while explicit overrides remain exact.

## Validation

- regression-first sync and async local-primary → remote-fallback tests
- timeout/fallback suites: 12 passed
- full auxiliary client file: 169 passed
- Ruff, byte compilation, and `git diff --check`: passed