### PR TITLE
fix(files): preserve path-aware file globs

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -466,6 +466,38 @@ class TestSearchFilesFallbackHiddenPaths:
         assert result.error is None
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
 
+    def test_rg_preserves_directory_components_in_glob(self, tmp_path, monkeypatch):
+        root = tmp_path / "workspace"
+        wanted = root / "reference-alpha" / "audit-report.md"
+        other = root / "target-gamma" / "audit-report.md"
+        for file_path in (wanted, other):
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.write_text("x")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "rg")
+        result = ops._search_files(
+            "**/reference-alpha/**", str(root), limit=50, offset=0
+        )
+
+        assert result.error is None
+        assert result.files == [str(wanted)]
+
+    def test_find_fallback_rejects_path_glob_instead_of_matching_everything(
+        self, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "workspace"
+        root.mkdir()
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+        result = ops._search_files(
+            "**/reference-alpha/**", str(root), limit=50, offset=0
+        )
+
+        assert result.error is not None
+        assert "Set `path`" in result.error
+
 
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -478,6 +478,38 @@ class TestSearchFilesFallbackHiddenPaths:
         assert result.error is None
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
 
+    def test_rg_preserves_directory_components_in_glob(self, tmp_path, monkeypatch):
+        root = tmp_path / "workspace"
+        wanted = root / "reference-alpha" / "audit-report.md"
+        other = root / "target-gamma" / "audit-report.md"
+        for file_path in (wanted, other):
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.write_text("x")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "rg")
+        result = ops._search_files(
+            "**/reference-alpha/**", str(root), limit=50, offset=0
+        )
+
+        assert result.error is None
+        assert result.files == [str(wanted)]
+
+    def test_find_fallback_rejects_path_glob_instead_of_matching_everything(
+        self, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "workspace"
+        root.mkdir()
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+        result = ops._search_files(
+            "**/reference-alpha/**", str(root), limit=50, offset=0
+        )
+
+        assert result.error is not None
+        assert "Set `path`" in result.error
+
 
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -450,7 +450,7 @@ class TestSearchFilesFallbackHiddenPaths:
 
         for p in [visible_file, nested_hidden_file, visible_nested_file, hidden_dir_file]:
             p.parent.mkdir(parents=True, exist_ok=True)
-            p.write_text("x")
+            p.write_text("x", encoding="utf-8")
 
         ops = ShellFileOperations(self._make_env())
         monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
@@ -469,7 +469,7 @@ class TestSearchFilesFallbackHiddenPaths:
 
         for p in [visible_file, visible_nested_file, hidden_dir_file]:
             p.parent.mkdir(parents=True, exist_ok=True)
-            p.write_text("x")
+            p.write_text("x", encoding="utf-8")
 
         ops = ShellFileOperations(self._make_env())
         monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
@@ -484,7 +484,7 @@ class TestSearchFilesFallbackHiddenPaths:
         other = root / "target-gamma" / "audit-report.md"
         for file_path in (wanted, other):
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            file_path.write_text("x")
+            file_path.write_text("x", encoding="utf-8")
 
         ops = ShellFileOperations(self._make_env())
         monkeypatch.setattr(ops, "_has_command", lambda command: command == "rg")
@@ -638,7 +638,7 @@ class TestAtomicWriteNewFilePermissions:
             os.umask(old_umask)
 
         assert result.error is None, f"write failed: {result.error}"
-        assert dest.read_text() == "test content\n"
+        assert dest.read_text(encoding="utf-8") == "test content\n"
         expected_mode = 0o666 & ~test_umask
         actual_mode = dest.stat().st_mode & 0o777
         assert actual_mode == expected_mode, (
@@ -651,13 +651,13 @@ class TestAtomicWriteNewFilePermissions:
         mode preservation (e.g. an executable script stays 0755)."""
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         dest = tmp_path / "existing.sh"
-        dest.write_text("#!/bin/sh\n")
+        dest.write_text("#!/bin/sh\n", encoding="utf-8")
         dest.chmod(0o755)
 
         result = ops.write_file(str(dest), "#!/bin/sh\necho updated\n")
 
         assert result.error is None, f"write failed: {result.error}"
-        assert dest.read_text() == "#!/bin/sh\necho updated\n"
+        assert dest.read_text(encoding="utf-8") == "#!/bin/sh\necho updated\n"
         assert dest.stat().st_mode & 0o777 == 0o755
 
 
@@ -672,7 +672,7 @@ class TestAtomicWriteThroughSymlink:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         real = tmp_path / "real.txt"
         link = tmp_path / "link.txt"
-        real.write_text("original\n")
+        real.write_text("original\n", encoding="utf-8")
         link.symlink_to(real)
 
         result = ops.write_file(str(link), "newcontent\n")
@@ -681,7 +681,7 @@ class TestAtomicWriteThroughSymlink:
         # The link must survive as a symlink...
         assert link.is_symlink(), "symlink was replaced by a plain file"
         # ...and the real target must carry the new content.
-        assert real.read_text() == "newcontent\n"
+        assert real.read_text(encoding="utf-8") == "newcontent\n"
         assert os.path.realpath(link) == str(real)
 
     def test_write_through_broken_symlink_falls_back(self, tmp_path):
@@ -695,7 +695,7 @@ class TestAtomicWriteThroughSymlink:
 
         assert result.error is None, f"write failed: {result.error}"
         assert target.exists()
-        assert target.read_text() == "data\n"
+        assert target.read_text(encoding="utf-8") == "data\n"
 
 
 class TestReadNonUtf8IsBinary:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2372,12 +2372,6 @@ class ShellFileOperations(FileOperations):
 
     def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name pattern (glob-like)."""
-        # Auto-prepend **/ for recursive search if not already present
-        if not pattern.startswith('**/') and '/' not in pattern:
-            search_pattern = pattern
-        else:
-            search_pattern = pattern.split('/')[-1]
-
         search_root = Path(path)
         has_hidden_path_ancestor = any(
             part not in {".", ".."} and part.startswith(".")
@@ -2388,7 +2382,7 @@ class ShellFileOperations(FileOperations):
         # default, and has parallel directory traversal (~200x faster than
         # find on wide trees).  Mirrors _search_content which already uses rg.
         if self._has_command('rg'):
-            return self._search_files_rg(search_pattern, path, limit, offset)
+            return self._search_files_rg(pattern, path, limit, offset)
 
         # Fallback: find (slower, no .gitignore awareness)
         if not self._has_command('find'):
@@ -2397,6 +2391,17 @@ class ShellFileOperations(FileOperations):
                       "Install ripgrep for best results: "
                       "https://github.com/BurntSushi/ripgrep#installation"
             )
+
+        if '/' in pattern:
+            return SearchResult(
+                error=(
+                    "Path-aware file globs require ripgrep. Set `path` to the "
+                    "directory to search and use a basename glob such as `*.py`, "
+                    "or install ripgrep."
+                )
+            )
+
+        search_pattern = pattern
 
         # Exclude hidden directories (matching ripgrep's default behavior).
         hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2840,12 +2840,6 @@ class ShellFileOperations(FileOperations):
 
     def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name pattern (glob-like)."""
-        # Auto-prepend **/ for recursive search if not already present
-        if not pattern.startswith('**/') and '/' not in pattern:
-            search_pattern = pattern
-        else:
-            search_pattern = pattern.split('/')[-1]
-
         search_root = Path(path)
         has_hidden_path_ancestor = any(
             part not in {".", ".."} and part.startswith(".")
@@ -2856,7 +2850,7 @@ class ShellFileOperations(FileOperations):
         # default, and has parallel directory traversal (~200x faster than
         # find on wide trees).  Mirrors _search_content which already uses rg.
         if self._has_command('rg'):
-            return self._search_files_rg(search_pattern, path, limit, offset)
+            return self._search_files_rg(pattern, path, limit, offset)
 
         # Fallback: find (slower, no .gitignore awareness)
         if not self._has_command('find'):
@@ -2865,6 +2859,17 @@ class ShellFileOperations(FileOperations):
                       "Install ripgrep for best results: "
                       "https://github.com/BurntSushi/ripgrep#installation"
             )
+
+        if '/' in pattern:
+            return SearchResult(
+                error=(
+                    "Path-aware file globs require ripgrep. Set `path` to the "
+                    "directory to search and use a basename glob such as `*.py`, "
+                    "or install ripgrep."
+                )
+            )
+
+        search_pattern = pattern
 
         # Exclude hidden directories (matching ripgrep's default behavior).
         hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2241,11 +2241,11 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*', '**/reference/**'). Prefer setting `path` to the directory scope and using a basename glob when the directory is known. Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {
-            "pattern": {"type": "string", "description": "Regex pattern for content search, or glob pattern (e.g., '*.py') for file search"},
+            "pattern": {"type": "string", "description": "Regex pattern for content search, or glob pattern (e.g., '*.py' or '**/reference/**') for file search"},
             "target": {"type": "string", "enum": ["content", "files"], "description": "'content' searches inside file contents, 'files' searches for files by name", "default": "content"},
             "path": {"type": "string", "description": "Directory or file to search in (default: current working directory)", "default": "."},
             "file_glob": {"type": "string", "description": "Filter files by pattern in grep mode (e.g., '*.py' to only search Python files)"},

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2734,11 +2734,11 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*', '**/reference/**'). Prefer setting `path` to the directory scope and using a basename glob when the directory is known. Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {
-            "pattern": {"type": "string", "description": "Regex pattern for content search, or glob pattern (e.g., '*.py') for file search"},
+            "pattern": {"type": "string", "description": "Regex pattern for content search, or glob pattern (e.g., '*.py' or '**/reference/**') for file search"},
             "target": {"type": "string", "enum": ["content", "files"], "description": "'content' searches inside file contents, 'files' searches for files by name", "default": "content"},
             "path": {"type": "string", "description": "Directory or file to search in (default: current working directory)", "default": "."},
             "file_glob": {"type": "string", "description": "Filter files by pattern in grep mode (e.g., '*.py' to only search Python files)"},


### PR DESCRIPTION
## What changed

- Pass complete path-aware glob expressions to ripgrep.
- Stop reducing a scoped glob to its final basename component.
- Make the `find` fallback reject path-aware globs it cannot implement faithfully instead of returning false positives.
- Clarify path-scoped glob examples in the tool schema.

## Root cause

The file search helper split glob expressions on `/` and retained only the last component. For example, `**/reference/**` became `**`, silently expanding the search to every file.

## Impact

Scoped searches stay inside the requested directory pattern, and fallback behavior fails explicitly rather than violating scope.

## Validation

```text
scripts/run_tests.sh -j 1 tests/tools/test_file_operations.py
96 passed
```

Ruff and `git diff --check` pass on the branch diff. The broader `tests/tools/test_file_tools.py` suite has three pre-existing macOS `/tmp` versus `/private/tmp` assertions that reproduce unchanged on current `main`.
