### PR TITLE
fix(update): install nested Ink workspace dependencies

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2021,13 +2021,24 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if not os.environ.get("HERMES_QUIET"):
             print("Installing TUI dependencies…")
         npm_cwd = _workspace_root(tui_dir)
-        # --workspace ui-tui avoids resolving apps/desktop (Electron + node-pty).
-        # See #38772.
+        # Scope the install to the TUI and its nested @hermes/ink workspace so
+        # npm does not resolve apps/desktop (Electron + node-pty). Selecting
+        # only ui-tui leaves @hermes/ink's runtime dependencies uninstalled on
+        # npm 11, and the subsequent esbuild step cannot resolve them.
         # When ui-tui/ has its own package-lock.json (e.g. curl install),
         # _workspace_root() returns tui_dir itself.  Passing --workspace in
         # that case fails because npm cannot find a workspace named "ui-tui"
         # inside ui-tui/.  See #42973.
-        npm_workspace_args: tuple[str, ...] = () if npm_cwd == tui_dir else ("--workspace", "ui-tui")
+        npm_workspace_args: tuple[str, ...] = (
+            ()
+            if npm_cwd == tui_dir
+            else (
+                "--workspace",
+                "ui-tui",
+                "--workspace",
+                "ui-tui/packages/hermes-ink",
+            )
+        )
         if termux_startup:
             npm_cwd, npm_workspace_args = _termux_workspace_install_context(
                 tui_dir,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2096,13 +2096,24 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if not os.environ.get("HERMES_QUIET"):
             print("Installing TUI dependencies…")
         npm_cwd = _workspace_root(tui_dir)
-        # --workspace ui-tui avoids resolving apps/desktop (Electron + node-pty).
-        # See #38772.
+        # Scope the install to the TUI and its nested @hermes/ink workspace so
+        # npm does not resolve apps/desktop (Electron + node-pty). Selecting
+        # only ui-tui leaves @hermes/ink's runtime dependencies uninstalled on
+        # npm 11, and the subsequent esbuild step cannot resolve them.
         # When ui-tui/ has its own package-lock.json (e.g. curl install),
         # _workspace_root() returns tui_dir itself.  Passing --workspace in
         # that case fails because npm cannot find a workspace named "ui-tui"
         # inside ui-tui/.  See #42973.
-        npm_workspace_args: tuple[str, ...] = () if npm_cwd == tui_dir else ("--workspace", "ui-tui")
+        npm_workspace_args: tuple[str, ...] = (
+            ()
+            if npm_cwd == tui_dir
+            else (
+                "--workspace",
+                "ui-tui",
+                "--workspace",
+                "ui-tui/packages/hermes-ink",
+            )
+        )
         if termux_startup:
             npm_cwd, npm_workspace_args = _termux_workspace_install_context(
                 tui_dir,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2059,7 +2059,7 @@ def _update_node_dependencies() -> list[str]:
                 (_m().PROJECT_ROOT / workspace / "package.json").exists()
                 for workspace in ("ui-tui", "web")
             ):
-                failed.append("ui-tui, web workspaces")
+                failed.append("ui-tui, @hermes/ink, web workspaces")
             return failed
         return []
 
@@ -2116,9 +2116,18 @@ def _update_node_dependencies() -> list[str]:
             print(f"    {stderr.splitlines()[-1]}")
         return _partial_update_failure("repo root")
 
-    # Step 2: install only the workspaces update needs (ui-tui, web).
+    # Step 2: install only the workspaces update needs (ui-tui, its nested
+    # @hermes/ink package, and web).
     # --workspace selects specific workspaces; the rest (desktop) are skipped.
-    ws_args = [*extra_args, "--workspace", "ui-tui", "--workspace", "web"]
+    ws_args = [
+        *extra_args,
+        "--workspace",
+        "ui-tui",
+        "--workspace",
+        "ui-tui/packages/hermes-ink",
+        "--workspace",
+        "web",
+    ]
     ws_result = _m()._run_npm_install_deterministic(
         npm,
         _m().PROJECT_ROOT,
@@ -2128,14 +2137,14 @@ def _update_node_dependencies() -> list[str]:
     )
     if ws_result.returncode == 0:
         _record_npm_lockfile_hash(shared_hermes_root)
-        print("  ✓ repo root + ui-tui, web workspaces (desktop skipped)")
+        print("  ✓ repo root + ui-tui, @hermes/ink, web workspaces (desktop skipped)")
         return []
 
     print("  ⚠ npm workspace install failed")
     stderr = (ws_result.stderr or "").strip() if ws_result.stderr else ""
     if stderr:
         print(f"    {stderr.splitlines()[-1]}")
-    return _partial_update_failure("ui-tui, web workspaces")
+    return _partial_update_failure("ui-tui, @hermes/ink, web workspaces")
 
 def _log_only_write(text: str) -> None:
     """Write ``text`` to ``~/.hermes/logs/update.log`` only, never the terminal.

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2259,7 +2259,7 @@ def _repair_node_deps_on_current_checkout(print_completion) -> None:
 
 
 def _update_node_dependencies() -> list[str]:
-    """Refresh Node deps for the ui-tui and web workspaces.
+    """Refresh Node deps for the ui-tui, nested Ink, and web workspaces.
 
     Returns the list of labels whose npm install failed (empty on success),
     so the caller can treat a Node refresh failure as a partial update rather
@@ -2286,7 +2286,7 @@ def _update_node_dependencies() -> list[str]:
                 (_m().PROJECT_ROOT / workspace / "package.json").exists()
                 for workspace in ("ui-tui", "web")
             ):
-                failed.append("ui-tui, web workspaces")
+                failed.append("ui-tui, @hermes/ink, web workspaces")
             return failed
         return []
 
@@ -2318,7 +2318,8 @@ def _update_node_dependencies() -> list[str]:
     # @streamdown/math is a desktop-only import now declared in
     # apps/desktop/package.json. That means a plain workspace-scoped install
     # can never prune anything root-only, so we only need to name the
-    # workspaces the CLI/TUI/web build actually requires. apps/desktop pulls
+    # workspaces the CLI/TUI/web build actually requires, including the nested
+    # @hermes/ink runtime package. apps/desktop pulls
     # in Electron as a devDependency with a ~200MB postinstall download, so
     # it's deliberately never named here — desktop deps install on demand
     # (see _desktop_build_needed).
@@ -2332,8 +2333,16 @@ def _update_node_dependencies() -> list[str]:
         return list(labels)
 
     install_args = [
-        "--no-fund", "--no-audit", "--prefer-offline", "--progress=false",
-        "--workspace", "ui-tui", "--workspace", "web",
+        "--no-fund",
+        "--no-audit",
+        "--prefer-offline",
+        "--progress=false",
+        "--workspace",
+        "ui-tui",
+        "--workspace",
+        "ui-tui/packages/hermes-ink",
+        "--workspace",
+        "web",
         # Root package.json's own devDependencies (the shared ESLint flat
         # config every workspace's eslint.config.mjs imports) are otherwise
         # pruned by this scoped install, same as agent-browser/@streamdown
@@ -2361,14 +2370,14 @@ def _update_node_dependencies() -> list[str]:
     )
     if result.returncode == 0:
         _record_npm_lockfile_hash(shared_hermes_root)
-        print("  ✓ ui-tui, web workspaces installed (desktop skipped)")
+        print("  ✓ ui-tui, @hermes/ink, web workspaces installed (desktop skipped)")
         failures: list[str] = []
     else:
         print("  ⚠ npm install failed")
         stderr = (result.stderr or "").strip() if result.stderr else ""
         if stderr:
             print(f"    {stderr.splitlines()[-1]}")
-        failures = _partial_update_failure("ui-tui, web workspaces")
+        failures = _partial_update_failure("ui-tui, @hermes/ink, web workspaces")
 
     return failures
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postinstall": "echo '✅ Browser tools ready. Run: python run_agent.py --help'",
     "install:root": "npm install --workspaces=false",
     "install:web": "npm install --workspace web",
-    "install:tui": "npm install --workspace ui-tui",
+    "install:tui": "npm install --workspace ui-tui --workspace ui-tui/packages/hermes-ink",
     "install:desktop": "npm install --workspace apps/desktop",
     "audit:root": "npm audit --workspaces=false",
     "audit:web": "npm audit --workspace web",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postinstall": "echo '\u2705 Node dependencies installed. Run: python run_agent.py --help'",
     "install:root": "npm install --workspaces=false",
     "install:web": "npm install --workspace web",
-    "install:tui": "npm install --workspace ui-tui",
+    "install:tui": "npm install --workspace ui-tui --workspace ui-tui/packages/hermes-ink",
     "install:desktop": "npm install --workspace apps/desktop",
     "audit:root": "npm audit --workspaces=false",
     "audit:web": "npm audit --workspace web",

--- a/tests-js/package-json-lazy-deps.test.ts
+++ b/tests-js/package-json-lazy-deps.test.ts
@@ -87,3 +87,11 @@ test('root lockfile has no camofox entries', () => {
       '@askjo/camofox-browser). Regenerate the lockfile.'
   )
 })
+
+test('install:tui includes the nested Ink workspace without desktop', () => {
+  const scripts = (rootPackageJson().scripts ?? {}) as Record<string, string>
+  const command = scripts['install:tui'] ?? ''
+  assert.match(command, /--workspace\s+ui-tui(?:\s|$)/)
+  assert.match(command, /--workspace\s+ui-tui\/packages\/hermes-ink(?:\s|$)/)
+  assert.doesNotMatch(command, /apps\/desktop/)
+})

--- a/tests-js/package-json-lazy-deps.test.ts
+++ b/tests-js/package-json-lazy-deps.test.ts
@@ -145,3 +145,11 @@ test('root lockfile has no agent-browser entry (#43564)', () => {
       '--ignore-scripts --no-fund --no-audit`.'
   )
 })
+
+test('install:tui includes the nested Ink workspace without desktop', () => {
+  const scripts = (rootPackageJson().scripts ?? {}) as Record<string, string>
+  const command = scripts['install:tui'] ?? ''
+  assert.match(command, /--workspace\s+ui-tui(?:\s|$)/)
+  assert.match(command, /--workspace\s+ui-tui\/packages\/hermes-ink(?:\s|$)/)
+  assert.doesNotMatch(command, /apps\/desktop/)
+})

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -110,6 +110,33 @@ class TestCmdUpdateNpmLockfileCache:
         )
         assert hm._npm_lockfile_changed(tmp_path) is True
 
+    def test_update_installs_nested_ink_workspace(self, tmp_path, monkeypatch):
+        """The updater must install the nested Ink workspace without desktop."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        (tmp_path / "package.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_resolve_node_runtime_npm", lambda: "/usr/bin/npm")
+        monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda _root: True)
+        monkeypatch.setattr(update_cmd, "_record_npm_lockfile_hash", lambda _root: None)
+
+        calls = []
+
+        def fake_install(*args, **kwargs):
+            calls.append((args, kwargs))
+            return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        monkeypatch.setattr(hm, "_run_npm_install_deterministic", fake_install)
+
+        assert hm._update_node_dependencies() == []
+        assert len(calls) == 2
+        workspace_args = calls[1][1]["extra_args"]
+        assert "ui-tui" in workspace_args
+        assert "ui-tui/packages/hermes-ink" in workspace_args
+        assert "web" in workspace_args
+        assert "apps/desktop" not in workspace_args
+
 
 
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -101,12 +101,14 @@ class TestCmdUpdateNpmLockfileCache:
         from hermes_cli import main as hm
 
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
-        (tmp_path / "package-lock.json").write_text('{"lockfileVersion": 3}')
+        (tmp_path / "package-lock.json").write_text(
+            '{"lockfileVersion": 3}', encoding="utf-8"
+        )
 
         hm._record_npm_lockfile_hash(tmp_path)
 
         assert (
-            self._cache_file(tmp_path, tmp_path).read_text()
+            self._cache_file(tmp_path, tmp_path).read_text(encoding="utf-8")
             == hm._npm_manifests_digest()
         )
 
@@ -117,8 +119,12 @@ class TestCmdUpdateNpmLockfileCache:
         from hermes_cli import main as hm
 
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
-        (tmp_path / "package-lock.json").write_text('{"lockfileVersion": 3}')
-        (tmp_path / "package.json").write_text('{"dependencies": {}}')
+        (tmp_path / "package-lock.json").write_text(
+            '{"lockfileVersion": 3}', encoding="utf-8"
+        )
+        (tmp_path / "package.json").write_text(
+            '{"dependencies": {}}', encoding="utf-8"
+        )
         (tmp_path / "node_modules").mkdir()
         hm._record_npm_lockfile_hash(tmp_path)
         assert hm._npm_lockfile_changed(tmp_path) is False
@@ -133,7 +139,7 @@ class TestCmdUpdateNpmLockfileCache:
         from hermes_cli import main as hm
         from hermes_cli import update_cmd
 
-        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_resolve_node_runtime_npm", lambda: "/usr/bin/npm")
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda _root: True)
@@ -170,7 +176,7 @@ class TestCmdUpdateNpmLockfileCache:
 
         checkout = tmp_path / "checkout"
         checkout.mkdir()
-        (checkout / "package.json").write_text("{}")
+        (checkout / "package.json").write_text("{}", encoding="utf-8")
         shared_root = tmp_path / ".hermes"
         named_profile = shared_root / "profiles" / "work"
         named_profile.mkdir(parents=True)
@@ -779,7 +785,7 @@ class TestNodeRuntimeNpmResolution:
     ):
         from hermes_cli import main as hm
 
-        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_resolve_node_runtime_npm", lambda: "/usr/bin/npm")
         monkeypatch.setattr(
@@ -1023,8 +1029,8 @@ class TestUpdateNodeDependencies:
         """
         from hermes_cli import main as hm
 
-        (tmp_path / "package.json").write_text("{}")
-        (tmp_path / "package-lock.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
         popen_calls = []
@@ -1060,8 +1066,8 @@ class TestUpdateNodeDependencies:
         review)."""
         from hermes_cli import main as hm
 
-        (tmp_path / "package.json").write_text("{}")
-        (tmp_path / "package-lock.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
         popen_calls = []
@@ -1081,8 +1087,8 @@ class TestUpdateNodeDependencies:
         """--no-fund, --no-audit, --progress=false must survive."""
         from hermes_cli import main as hm
 
-        (tmp_path / "package.json").write_text("{}")
-        (tmp_path / "package-lock.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
         popen_calls = []
@@ -1102,8 +1108,8 @@ class TestUpdateNodeDependencies:
         """When _npm_lockfile_changed reports no change, npm must not be called."""
         from hermes_cli import main as hm
 
-        (tmp_path / "package.json").write_text("{}")
-        (tmp_path / "package-lock.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: False)
 
@@ -1119,8 +1125,8 @@ class TestUpdateNodeDependencies:
         """When _npm_lockfile_changed reports a change, npm must run."""
         from hermes_cli import main as hm
 
-        (tmp_path / "package.json").write_text("{}")
-        (tmp_path / "package-lock.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
         popen_calls = []
@@ -1138,8 +1144,8 @@ class TestUpdateNodeDependencies:
         run retries instead of wrongly believing deps are up to date)."""
         from hermes_cli import main as hm
 
-        (tmp_path / "package.json").write_text("{}")
-        (tmp_path / "package-lock.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
         recorded = []
@@ -1159,8 +1165,8 @@ class TestUpdateNodeDependencies:
         it's independent of ui-tui/web dependency state (#43564)."""
         from hermes_cli import main as hm
 
-        (tmp_path / "package.json").write_text("{}")
-        (tmp_path / "package-lock.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
         mock_popen.side_effect = self._make_popen([], returncode=1, stderr_lines=["npm ERR!\n"])
@@ -1178,7 +1184,7 @@ class TestUpdateNodeDependencies:
         """No npm on PATH → return without calling subprocess."""
         from hermes_cli import main as hm
 
-        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
 
         hm._update_node_dependencies()
@@ -1203,8 +1209,8 @@ class TestUpdateNodeDependencies:
         """npm install must execute from PROJECT_ROOT, not a workspace subdir."""
         from hermes_cli import main as hm
 
-        (tmp_path / "package.json").write_text("{}")
-        (tmp_path / "package-lock.json").write_text("{}")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
 
         popen_calls = []

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -128,6 +128,33 @@ class TestCmdUpdateNpmLockfileCache:
         )
         assert hm._npm_lockfile_changed(tmp_path) is True
 
+    def test_update_installs_nested_ink_workspace(self, tmp_path, monkeypatch):
+        """The updater must install the nested Ink workspace without desktop."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        (tmp_path / "package.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_resolve_node_runtime_npm", lambda: "/usr/bin/npm")
+        monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda _root: True)
+        monkeypatch.setattr(update_cmd, "_record_npm_lockfile_hash", lambda _root: None)
+
+        calls = []
+
+        def fake_install(*args, **kwargs):
+            calls.append((args, kwargs))
+            return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        monkeypatch.setattr(hm, "_run_npm_install_deterministic", fake_install)
+
+        assert hm._update_node_dependencies() == []
+        assert len(calls) == 1
+        workspace_args = calls[0][1]["extra_args"]
+        assert "ui-tui" in workspace_args
+        assert "ui-tui/packages/hermes-ink" in workspace_args
+        assert "web" in workspace_args
+        assert "apps/desktop" not in workspace_args
+
 
 
 
@@ -765,7 +792,7 @@ class TestNodeRuntimeNpmResolution:
             "tools.browser_tool.warm_agent_browser_npx_cache", return_value=True
         ):
             failed = hm._update_node_dependencies()
-        assert failed == ["ui-tui, web workspaces"]
+        assert failed == ["ui-tui, @hermes/ink, web workspaces"]
         out = capsys.readouterr().out
         assert "mixed state" in out
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -176,3 +176,33 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     assert install_cmd[:2] == ["/bin/npm", "install"]
     # cwd must be tui_dir (standalone), not parent
     assert calls[0][1]["cwd"] == str(tui_dir)
+
+
+def test_make_tui_argv_installs_nested_ink_workspace(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """A root-workspace install must include @hermes/ink's dependencies."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    install_cmd = calls[0][0][0]
+    assert install_cmd.count("--workspace") == 2
+    assert "ui-tui" in install_cmd
+    assert "ui-tui/packages/hermes-ink" in install_cmd
+    assert "apps/desktop" not in install_cmd

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -17,13 +17,13 @@ def main_mod():
 def _touch_ink(root: Path) -> None:
     ink = root / "node_modules" / "@hermes" / "ink" / "package.json"
     ink.parent.mkdir(parents=True, exist_ok=True)
-    ink.write_text("{}")
+    ink.write_text("{}", encoding="utf-8")
 
 
 def _touch_tui_entry(root: Path) -> None:
     entry = root / "dist" / "entry.js"
     entry.parent.mkdir(parents=True, exist_ok=True)
-    entry.write_text("console.log('tui')")
+    entry.write_text("console.log('tui')", encoding="utf-8")
 
 
 def _assert_utf8_replace_capture(kwargs: dict) -> None:
@@ -62,7 +62,7 @@ def test_make_tui_argv_uses_bundled_tui_when_workspace_missing(
 
     bundled_entry = tmp_path / "bundled" / "entry.js"
     bundled_entry.parent.mkdir(parents=True)
-    bundled_entry.write_text("// bundled TUI")
+    bundled_entry.write_text("// bundled TUI", encoding="utf-8")
     monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: bundled_entry)
 
     def which(name: str) -> str | None:
@@ -148,11 +148,11 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     """
     tui_dir = tmp_path / "ui-tui"
     tui_dir.mkdir()
-    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "package.json").write_text("{}", encoding="utf-8")
     # Simulate curl-install layout: tui_dir has its own lockfile
-    (tui_dir / "package-lock.json").write_text("{}")
+    (tui_dir / "package-lock.json").write_text("{}", encoding="utf-8")
     # Parent also has lockfile (but _workspace_root prefers tui_dir's own)
-    (tmp_path / "package-lock.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
 
     monkeypatch.delenv("TERMUX_VERSION", raising=False)
     monkeypatch.setenv("PREFIX", "/usr")
@@ -184,8 +184,8 @@ def test_make_tui_argv_installs_nested_ink_workspace(
     """A root-workspace install must include @hermes/ink's dependencies."""
     tui_dir = tmp_path / "ui-tui"
     tui_dir.mkdir()
-    (tui_dir / "package.json").write_text("{}")
-    (tmp_path / "package-lock.json").write_text("{}")
+    (tui_dir / "package.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
 
     monkeypatch.delenv("TERMUX_VERSION", raising=False)
     monkeypatch.setenv("PREFIX", "/usr")


### PR DESCRIPTION
## What changed

- Include the nested `ui-tui/packages/hermes-ink` workspace when installing TUI dependencies.
- Apply the same workspace selection to TUI launch repair and `hermes update`.
- Continue skipping the desktop workspace and unrelated packages.

## Root cause

With npm 11, selecting only the top-level `ui-tui` workspace does not install runtime dependencies owned by the nested `@hermes/ink` workspace. Fresh builds could then fail on packages such as `chalk`, `wrap-ansi`, or `react-reconciler`.

## Impact

Source checkouts can install and rebuild the Ink TUI reliably without pulling in desktop dependencies.

## Validation

```text
scripts/run_tests.sh -j 1 tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_tui_npm_install.py
82 passed
```

Ruff and `git diff --check` pass on the branch diff.
