### PR TITLE
fix(cli): load explicit skills in one-shot mode

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12972,6 +12972,7 @@ def _try_termux_fast_cli_launch() -> bool:
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                skills=getattr(args, "skills", None),
                 usage_file=getattr(args, "usage_file", None),
             )
         )
@@ -15129,6 +15130,7 @@ def main():
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                skills=getattr(args, "skills", None),
                 usage_file=getattr(args, "usage_file", None),
             )
         )

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -49,6 +49,25 @@ def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
     return [item for item in normalized if item] or None
 
 
+def _normalize_skills(skills: object = None) -> list[str]:
+    if not skills:
+        return []
+
+    raw_items = [skills] if isinstance(skills, str) else skills
+    if not isinstance(raw_items, (list, tuple)):
+        raw_items = [raw_items]
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in raw_items:
+        for part in str(item).split(","):
+            name = part.strip()
+            if name and name not in seen:
+                seen.add(name)
+                normalized.append(name)
+    return normalized
+
+
 def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | None, str | None]:
     normalized = _normalize_toolsets(toolsets)
     if normalized is None:
@@ -171,6 +190,7 @@ def run_oneshot(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
+    skills: object = None,
     usage_file: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
@@ -182,6 +202,8 @@ def run_oneshot(
         provider: Optional provider override. Falls back to config.yaml's
             model.provider, then "auto".
         toolsets: Optional comma-separated string or iterable of toolsets.
+        skills: Optional skill name, comma-separated names, or iterable to
+            preload into the one-shot system prompt.
         usage_file: Optional path; when set, a JSON usage report (estimated
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
@@ -238,6 +260,7 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    skills=skills,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -306,6 +329,7 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    skills: object = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -421,6 +445,30 @@ def _run_agent(
     agent.suppress_status_output = True
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
+
+    requested_skills = _normalize_skills(skills)
+    if requested_skills:
+        from agent.skill_commands import build_preloaded_skills_prompt
+
+        skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
+            requested_skills,
+            task_id=getattr(agent, "session_id", None),
+        )
+        if missing_skills and not loaded_skills:
+            raise ValueError(f"Unknown skill(s): {', '.join(missing_skills)}")
+        if missing_skills:
+            logging.warning(
+                "Unknown skill(s) requested, skipping: %s. Continuing with: %s.",
+                ", ".join(missing_skills),
+                ", ".join(loaded_skills),
+            )
+        if skills_prompt:
+            agent.system_prompt = "\n\n".join(
+                part
+                for part in (getattr(agent, "system_prompt", ""), skills_prompt)
+                if part
+            ).strip()
+        agent.preloaded_skills = loaded_skills
 
     result = agent.run_conversation(prompt)
     return (result.get("final_response") or "", result)

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -413,6 +413,8 @@ def _run_agent(
     # Read the effective fallback chain from profile config so oneshot workers
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
+    agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+    configured_system_prompt = str(agent_cfg.get("system_prompt") or "").strip()
 
     agent = AIAgent(
         api_key=runtime.get("api_key"),
@@ -423,6 +425,7 @@ def _run_agent(
         enabled_toolsets=toolsets_list,
         quiet_mode=True,
         platform="cli",
+        ephemeral_system_prompt=configured_system_prompt or None,
         session_db=session_db,
         credential_pool=runtime.get("credential_pool"),
         fallback_model=_fb or None,
@@ -463,9 +466,12 @@ def _run_agent(
                 ", ".join(loaded_skills),
             )
         if skills_prompt:
-            agent.system_prompt = "\n\n".join(
+            agent.ephemeral_system_prompt = "\n\n".join(
                 part
-                for part in (getattr(agent, "system_prompt", ""), skills_prompt)
+                for part in (
+                    getattr(agent, "ephemeral_system_prompt", ""),
+                    skills_prompt,
+                )
                 if part
             ).strip()
         agent.preloaded_skills = loaded_skills

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -353,7 +353,10 @@ def test_termux_fast_cli_launch_oneshot_uses_light_parser(monkeypatch, main_mod)
     monkeypatch.setattr(
         sys,
         "argv",
-        ["hermes", "-z", "hello", "--model", "gpt-test", "--provider", "openai"],
+        [
+            "hermes", "-z", "hello", "--model", "gpt-test",
+            "--provider", "openai", "--skills", "memory-consolidation",
+        ],
     )
     monkeypatch.setattr(
         main_mod, "_prepare_agent_startup", lambda args: prepared.append(args.command)
@@ -379,6 +382,7 @@ def test_termux_fast_cli_launch_oneshot_uses_light_parser(monkeypatch, main_mod)
         "model": "gpt-test",
         "provider": "openai",
         "toolsets": None,
+        "skills": ["memory-consolidation"],
         "usage_file": None,
     }
 
@@ -571,13 +575,18 @@ def test_read_git_revision_fingerprint_unresolved_ref_is_stable(tmp_path, main_m
     assert fingerprint == "git:refs/heads/missing:unresolved"
 
 
-def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
+def test_main_top_level_oneshot_accepts_toolsets_and_skills(monkeypatch, main_mod):
     captured = {}
 
     import hermes_cli.config as config_mod
 
     monkeypatch.setattr(
-        sys, "argv", ["hermes", "-z", "hello", "--toolsets", "web,terminal"]
+        sys,
+        "argv",
+        [
+            "hermes", "-z", "hello", "--toolsets", "web,terminal",
+            "--skills", "memory-consolidation",
+        ],
     )
     monkeypatch.setitem(
         sys.modules,
@@ -618,8 +627,26 @@ def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
         "model": None,
         "provider": None,
         "toolsets": "web,terminal",
+        "skills": ["memory-consolidation"],
         "usage_file": None,
     }
+
+
+def test_oneshot_forwards_skills_to_run_agent(monkeypatch, capsys):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+
+    captured = {}
+
+    def fake_run(prompt, **kwargs):
+        captured.update({"prompt": prompt, **kwargs})
+        return "done", {}
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", fake_run)
+
+    assert oneshot_mod.run_oneshot("hello", skills=["alpha", "beta"]) == 0
+    assert captured["skills"] == ["alpha", "beta"]
+    assert capsys.readouterr().out == "done\n"
 
 
 def _stub_plugin_discovery(monkeypatch):
@@ -828,12 +855,16 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     class FakeAgent:
         def __init__(self, **kwargs):
             captured.update(kwargs)
+            self.session_id = "oneshot-test"
+            self.system_prompt = "base prompt"
             self.suppress_status_output = False
             self.stream_delta_callback = object()
             self.tool_gen_callback = object()
 
         def run_conversation(self, prompt, **_kwargs):
             captured["prompt"] = prompt
+            captured["system_prompt"] = self.system_prompt
+            captured["preloaded_skills"] = self.preloaded_skills
             return {"final_response": "ok", "failed": False, "partial": False}
 
     class FakeSessionDB:
@@ -877,13 +908,27 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
         "hermes_cli.tools_config",
         mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: {"session_search"}),
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.skill_commands",
+        mod(
+            "agent.skill_commands",
+            build_preloaded_skills_prompt=lambda names, task_id=None: (
+                "loaded skill body",
+                names,
+                [],
+            ),
+        ),
+    )
 
-    text, result = _run_agent("recall this")
+    text, result = _run_agent("recall this", skills=["memory-consolidation"])
     assert text == "ok"
     assert not result.get("failed")
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
     assert captured["prompt"] == "recall this"
+    assert captured["system_prompt"] == "base prompt\n\nloaded skill body"
+    assert captured["preloaded_skills"] == ["memory-consolidation"]
 
 
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -856,14 +856,14 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
         def __init__(self, **kwargs):
             captured.update(kwargs)
             self.session_id = "oneshot-test"
-            self.system_prompt = "base prompt"
+            self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
             self.suppress_status_output = False
             self.stream_delta_callback = object()
             self.tool_gen_callback = object()
 
         def run_conversation(self, prompt, **_kwargs):
             captured["prompt"] = prompt
-            captured["system_prompt"] = self.system_prompt
+            captured["ephemeral_system_prompt_at_run"] = self.ephemeral_system_prompt
             captured["preloaded_skills"] = self.preloaded_skills
             return {"final_response": "ok", "failed": False, "partial": False}
 
@@ -882,7 +882,13 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.config",
-        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {
+                "model": {"default": "m"},
+                "agent": {"system_prompt": "base prompt"},
+            },
+        ),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -927,7 +933,9 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
     assert captured["prompt"] == "recall this"
-    assert captured["system_prompt"] == "base prompt\n\nloaded skill body"
+    assert captured["ephemeral_system_prompt_at_run"] == (
+        "base prompt\n\nloaded skill body"
+    )
     assert captured["preloaded_skills"] == ["memory-consolidation"]
 
 


### PR DESCRIPTION
## What changed

- Propagate top-level `--skills` selections through both fast and normal one-shot entrypoints.
- Normalize repeated and comma-separated skill names.
- Preload selected skills through the canonical skill prompt builder.
- Append skill context without replacing a configured `agent.system_prompt`.
- Fail when every requested skill is missing and warn while loading valid entries from a partial selection.

## Root cause

The CLI parser accepted `--skills`, but one-shot execution dropped the value before agent construction. The requested skills therefore never reached the prompt outside the interactive TUI path.

## Impact

Explicit skill selection behaves consistently in scripted and interactive use while preserving configured system guidance.

## Validation

```text
scripts/run_tests.sh -j 1 tests/hermes_cli/test_tui_resume_flow.py
50 passed
```

Ruff and `git diff --check` pass on the branch diff.
