### PR TITLE
fix(reasoning): preserve provider replay contracts

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -708,6 +708,11 @@ def apply_reasoning_content_policy(
     if source_msg.get("role") != "assistant":
         return
 
+    def strip_generic_replay() -> None:
+        """Remove generic scratchpad fields, not provider continuation state."""
+        api_msg.pop("reasoning", None)
+        api_msg.pop("reasoning_content", None)
+
     # 1. Explicit reasoning_content already set.
     #
     # When the active provider enforces the thinking-mode echo-back
@@ -729,7 +734,7 @@ def apply_reasoning_content_policy(
     existing = source_msg.get("reasoning_content")
     if isinstance(existing, str):
         if not needs_thinking_pad:
-            api_msg.pop("reasoning_content", None)
+            strip_generic_replay()
         elif existing == "":
             api_msg["reasoning_content"] = " "
         else:
@@ -767,7 +772,7 @@ def apply_reasoning_content_policy(
         if needs_thinking_pad:
             api_msg["reasoning_content"] = normalized_reasoning
         else:
-            api_msg.pop("reasoning_content", None)
+            strip_generic_replay()
         return
 
     # 4. DeepSeek / Kimi thinking mode: all assistant messages need
@@ -784,7 +789,7 @@ def apply_reasoning_content_policy(
 
     # 5. reasoning_content was present but not a string (e.g. None after
     # context compaction).  Don't pass null to the API.
-    api_msg.pop("reasoning_content", None)
+    strip_generic_replay()
 
 
 def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -723,6 +723,11 @@ def apply_reasoning_content_policy(
     if source_msg.get("role") != "assistant":
         return
 
+    def strip_generic_replay() -> None:
+        """Remove generic scratchpad fields, not provider continuation state."""
+        api_msg.pop("reasoning", None)
+        api_msg.pop("reasoning_content", None)
+
     # 1. Explicit reasoning_content already set.
     #
     # When the active provider enforces the thinking-mode echo-back
@@ -744,7 +749,7 @@ def apply_reasoning_content_policy(
     existing = source_msg.get("reasoning_content")
     if isinstance(existing, str):
         if not needs_thinking_pad:
-            api_msg.pop("reasoning_content", None)
+            strip_generic_replay()
         elif existing == "":
             api_msg["reasoning_content"] = " "
         else:
@@ -782,7 +787,7 @@ def apply_reasoning_content_policy(
         if needs_thinking_pad:
             api_msg["reasoning_content"] = normalized_reasoning
         else:
-            api_msg.pop("reasoning_content", None)
+            strip_generic_replay()
         return
 
     # 4. DeepSeek / Kimi thinking mode: all assistant messages need
@@ -799,7 +804,7 @@ def apply_reasoning_content_policy(
 
     # 5. reasoning_content was present but not a string (e.g. None after
     # context compaction).  Don't pass null to the API.
-    api_msg.pop("reasoning_content", None)
+    strip_generic_replay()
 
 
 def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -122,6 +122,37 @@ class TestCopyReasoningContentForApi:
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert "reasoning_content" not in api_msg
 
+    def test_local_qwen_strips_historical_reasoning_replay(self) -> None:
+        """Local Qwen thinking may store reasoning for audit/UI, but must not
+        replay historical scratchpad fields into every next request.
+
+        Provider-native continuation envelopes are separate contracts and
+        must remain untouched by this generic policy.
+        """
+        agent = _make_agent(
+            provider="custom",
+            model="mlx-community/Qwen3.6-35B-A3B-4bit-DWQ",
+            base_url="http://127.0.0.1:10240/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "visible answer",
+            "reasoning": "long prior scratchpad",
+            "reasoning_content": "long provider scratchpad",
+            "reasoning_details": [{"type": "reasoning.summary", "summary": "hidden"}],
+            "codex_reasoning_items": [{"type": "reasoning", "encrypted_content": "blob"}],
+            "codex_message_items": [{"type": "message", "id": "msg_1"}],
+        }
+        api_msg = dict(source)
+
+        agent._copy_reasoning_content_for_api(source, api_msg)
+
+        assert api_msg["content"] == "visible answer"
+        for key in ("reasoning", "reasoning_content"):
+            assert key not in api_msg
+        assert api_msg["reasoning_details"] == source["reasoning_details"]
+        assert api_msg["codex_reasoning_items"] == source["codex_reasoning_items"]
+        assert api_msg["codex_message_items"] == source["codex_message_items"]
 
 
 

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -164,6 +164,41 @@ class TestBuildApiKwargsOpenRouter:
         assert "codex_reasoning_items" in messages[1]
         assert messages[1]["tool_calls"][0]["extra_content"] == {"thought_signature": "opaque"}
 
+    def test_replay_preserves_reasoning_details_end_to_end(self, monkeypatch):
+        """OpenRouter continuation state survives replay and transport cleanup."""
+        agent = _make_agent(monkeypatch, "openrouter")
+        reasoning_details = [
+            {
+                "type": "reasoning.encrypted",
+                "signature": "opaque-signature",
+                "encrypted_content": "opaque-provider-state",
+            }
+        ]
+        stored = {
+            "role": "assistant",
+            "content": "visible answer",
+            "reasoning": "local scratchpad",
+            "reasoning_content": "provider scratchpad",
+            "reasoning_details": reasoning_details,
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "codex-only"}
+            ],
+        }
+        replay = dict(stored)
+
+        agent._copy_reasoning_content_for_api(stored, replay)
+        kwargs = agent._build_api_kwargs(
+            [replay, {"role": "user", "content": "continue"}]
+        )
+
+        outgoing = kwargs["messages"][0]
+        assert outgoing["reasoning_details"] == reasoning_details
+        assert "reasoning" not in outgoing
+        assert "reasoning_content" not in outgoing
+        assert "codex_reasoning_items" not in outgoing
+        assert stored["reasoning"] == "local scratchpad"
+        assert stored["codex_reasoning_items"][0]["encrypted_content"] == "codex-only"
+
     def test_keeps_extra_content_for_gemini_target(self, monkeypatch):
         """Gemini-family targets must keep extra_content (thought_signature) —
         Gemini 3 thinking models 400 without it replayed on the next turn.
@@ -470,6 +505,59 @@ class TestBuildApiKwargsCodex:
         # Responses format has "name" at top level, not nested under "function"
         assert "name" in tools[0]
         assert "function" not in tools[0]
+
+    def test_native_replay_items_survive_policy_and_transport(self, monkeypatch):
+        """Codex Responses keeps its encrypted reasoning and message items."""
+        agent = _make_agent(
+            monkeypatch,
+            "openai-codex",
+            api_mode="codex_responses",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        stored = {
+            "role": "assistant",
+            "content": "visible answer",
+            "reasoning": "local scratchpad",
+            "reasoning_content": "chat-completions scratchpad",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "encrypted_content": "encrypted-codex-state",
+                }
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "id": "msg_1",
+                    "phase": "final_answer",
+                    "content": [
+                        {"type": "output_text", "text": "visible answer"}
+                    ],
+                }
+            ],
+        }
+        replay = dict(stored)
+
+        agent._copy_reasoning_content_for_api(stored, replay)
+        kwargs = agent._build_api_kwargs(
+            [replay, {"role": "user", "content": "continue"}]
+        )
+
+        reasoning_item = next(
+            item for item in kwargs["input"] if item.get("type") == "reasoning"
+        )
+        message_item = next(
+            item
+            for item in kwargs["input"]
+            if item.get("type") == "message" and item.get("role") == "assistant"
+        )
+        assert reasoning_item["encrypted_content"] == "encrypted-codex-state"
+        assert message_item["id"] == "msg_1"
+        assert stored["codex_reasoning_items"][0]["id"] == "rs_1"
+        assert stored["codex_message_items"][0]["id"] == "msg_1"
 
 
 # ── Message conversion tests ────────────────────────────────────────────────
@@ -919,6 +1007,5 @@ class TestReasoningEffortDefaults:
                             base_url="https://chatgpt.com/backend-api/codex")
         kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
         assert kwargs["reasoning"]["effort"] == "medium"
-
 
 


### PR DESCRIPTION
## What changed

- Strip only generic `reasoning` / `reasoning_content` scratchpads before replay to providers that do not require DeepSeek/Kimi/MiMo echo-back.
- Preserve opaque `reasoning_details` for OpenRouter, Anthropic, and OpenAI continuation contracts.
- Leave Codex-native item filtering at the transport boundary: Chat Completions strips those carriers, while Codex Responses replays them.
- Add request-level regressions for both OpenRouter and Codex Responses.

## Root cause

Stored assistant history can retain generic scratchpad text for UI/session audit. Replaying that text into every non-echo request bloats long sessions, but provider-native continuation envelopes are not interchangeable scratchpads and must keep their existing ownership contracts.

## Validation

```text
scripts/run_tests.sh -j 1 \
  tests/agent/test_message_sanitization_policy.py \
  tests/run_agent/test_deepseek_reasoning_content_echo.py \
  tests/run_agent/test_provider_parity.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/agent/transports/test_codex_transport.py

233 passed
```

Ruff and `git diff --check` pass on the rebased branch.