### PR TITLE
fix(vision): scope the top-level supports_vision override to the active model

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -199,12 +199,23 @@ def _supports_vision_override(
     if not isinstance(cfg, dict):
         return None
 
-    # 1. Top-level shortcut
+    # 1. Top-level shortcut — declares the capability of the ACTIVE model
+    # (``model.default``), the model it sits beside in config. It must not
+    # leak onto a *different* model: after a per-session ``/model`` switch, or
+    # in a multi-session gateway routing several models, the resolved model can
+    # differ from ``model.default`` — and applying the default's declaration
+    # there would, e.g., route an image natively into a text-only model (or
+    # suppress native vision on a capable one). Apply it only when the queried
+    # model is the active one; skip only when they are provably different so a
+    # single-model setup (and the unknown-default case) is unaffected.
     model_cfg_raw = cfg.get("model")
     model_cfg: Dict[str, Any] = model_cfg_raw if isinstance(model_cfg_raw, dict) else {}
-    top = _coerce_capability_bool(model_cfg.get("supports_vision"))
-    if top is not None:
-        return top
+    _active_model = str(model_cfg.get("default") or "").strip().lower()
+    _queried_model = str(model or "").strip().lower()
+    if not (_active_model and _queried_model and _active_model != _queried_model):
+        top = _coerce_capability_bool(model_cfg.get("supports_vision"))
+        if top is not None:
+            return top
 
     # 2. Per-provider, per-model. Named custom providers (e.g. "my-vllm")
     # get rewritten to provider="custom" at runtime

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -228,6 +228,32 @@ class TestSupportsVisionOverride:
         cfg = {"model": {"default": "my-llava"}}
         assert _supports_vision_override(cfg, "custom", "my-llava") is None
 
+    def test_top_level_override_scoped_to_active_model(self):
+        # ``model.supports_vision`` declares the ACTIVE model's capability (the
+        # model it sits beside as ``model.default``). It must apply to that
+        # model but must NOT leak onto a *different* one — a per-session
+        # ``/model`` switch, or a multi-session gateway routing several models,
+        # can query a model other than ``model.default``. Leaking the default's
+        # ``true`` declaration there would route an image natively into a
+        # text-only model.
+        cfg = {"model": {"default": "my-vision-vllm", "supports_vision": True}}
+        # Active model → the declaration applies.
+        assert _supports_vision_override(cfg, "custom", "my-vision-vllm") is True
+        # A different model → no leak; fall through to the normal lookup.
+        assert _supports_vision_override(cfg, "openai", "gpt-3.5-text-only") is None
+
+    def test_top_level_override_scoping_is_case_insensitive(self):
+        cfg = {"model": {"default": "My-Vision-VLLM", "supports_vision": True}}
+        assert _supports_vision_override(cfg, "custom", "my-vision-vllm") is True
+
+    def test_top_level_false_override_does_not_leak_to_other_model(self):
+        # The ``false`` direction leaks too: a text-only main's ``false``
+        # declaration would otherwise suppress native vision on a genuinely
+        # capable other model.
+        cfg = {"model": {"default": "text-only-main", "supports_vision": False}}
+        assert _supports_vision_override(cfg, "custom", "text-only-main") is False
+        assert _supports_vision_override(cfg, "anthropic", "claude-sonnet-4") is None
+
     def test_malformed_sections_are_ignored(self):
         # User accidentally wrote a string where a section was expected —
         # don't blow up, just fall through.


### PR DESCRIPTION
## What

`model.supports_vision` in config.yaml declares the vision capability of the **active** model (the escape hatch for custom/local models not in models.dev). It sits beside `model.default`, so it describes *that* model.

`_supports_vision_override` returned it for **any** model it was queried with, never checking the queried model is the active one. When the routed model differs from `model.default` — a per-session `/model` switch, or a multi-session gateway routing several models — the default's declaration leaked onto the other model:

- a `true` default routed images **natively into a text-only model** (which gets an image part it can't inspect / the provider 400s), and
- a `false` default **suppressed native vision on a genuinely capable** other model.

## Fix

Apply the top-level shortcut only when the queried model equals `model.default` (case-insensitive). Skip it only when they are provably different, so a single-model setup and the unknown-default case keep the historical behaviour. Per-provider / per-model overrides already match by model and are unchanged.

## Tests

`tests/agent/test_image_routing.py::TestSupportsVisionOverride` — the override applies for the active model, does not leak to a different one (both `true` and `false` directions), and is case-insensitive.

```
pytest tests/agent/test_image_routing.py::TestSupportsVisionOverride -q
# 15 passed  (2 new fail without the fix)
```