### PR TITLE
feat(desktop): open sessions from hermes://session/<id> deep links

### DIFF
--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -46,6 +46,7 @@ import {
   Wrench,
   Zap
 } from '@/lib/icons'
+import { SESSION_ID_RE } from '@/lib/session-ids'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { $repoWorktrees } from '@/store/coding-status'
@@ -207,10 +208,6 @@ const rankGroups = (groups: PaletteGroup[], search: string): PaletteGroup[] => {
 // cmdk selection values must be unique; labels alone can repeat (the same
 // theme lists under both Light and Dark). The id suffix disambiguates.
 const paletteValue = (item: PaletteItem): string => `${item.label}\u0001${item.id}`
-
-// Hermes session ids: <YYYYMMDD>_<HHMMSS>_<6 hex>. Used to offer a direct
-// "Go to session ‹id›" jump for ids that aren't in the recent-200 list.
-const SESSION_ID_RE = /^\d{8}_\d{6}_[a-f0-9]{6}$/
 
 type SessionRow = Awaited<ReturnType<typeof listAllProfileSessions>>['sessions'][number]
 

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.ts
@@ -1,0 +1,152 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useDesktopIntegrations } from './use-desktop-integrations'
+
+const requestComposerFocus = vi.fn()
+const requestComposerInsert = vi.fn()
+
+vi.mock('@/app/chat/close-tab', () => ({ closeActiveTab: vi.fn() }))
+vi.mock('@/store/native-notifications', () => ({ respondToApprovalAction: vi.fn() }))
+vi.mock('@/store/session', () => ({
+  getRememberedRoute: vi.fn(() => null),
+  getRememberedSessionId: vi.fn(() => null),
+  setRememberedRoute: vi.fn(),
+  setRememberedSessionId: vi.fn()
+}))
+vi.mock('@/store/session-sync', () => ({ onSessionsChanged: vi.fn(() => () => {}) }))
+vi.mock('@/store/updates', () => ({
+  openUpdatesWindow: vi.fn(),
+  startUpdatePoller: vi.fn(),
+  stopUpdatePoller: vi.fn()
+}))
+vi.mock('@/store/windows', () => ({ isSecondaryWindow: vi.fn(() => true) }))
+vi.mock('@/app/chat/composer/focus', () => ({
+  requestComposerFocus: (...args: unknown[]) => requestComposerFocus(...args),
+  requestComposerInsert: (...args: unknown[]) => requestComposerInsert(...args)
+}))
+
+interface DeepLinkPayload {
+  kind: string
+  name: string
+  params: Record<string, string>
+}
+
+let deepLinkListeners: Array<(payload: DeepLinkPayload) => void> = []
+let listenersAtReadySignal = -1
+
+// Snapshot how many deep-link listeners were live at the moment the renderer
+// signalled readiness — electron/main.ts flushes a cold-start-queued link as
+// soon as this resolves, so every kind's listener must already be mounted.
+const signalDeepLinkReady = vi.fn(async () => {
+  listenersAtReadySignal = deepLinkListeners.length
+
+  return { ok: true }
+})
+
+beforeEach(() => {
+  deepLinkListeners = []
+  listenersAtReadySignal = -1
+  ;(window as { hermesDesktop?: unknown }).hermesDesktop = {
+    onDeepLink: (callback: (payload: DeepLinkPayload) => void) => {
+      deepLinkListeners.push(callback)
+
+      return () => {
+        deepLinkListeners = deepLinkListeners.filter(listener => listener !== callback)
+      }
+    },
+    signalDeepLinkReady
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+function mountIntegrations() {
+  const navigate = vi.fn()
+
+  renderHook(() =>
+    useDesktopIntegrations({
+      chatOpen: true,
+      hasPreview: false,
+      locationPathname: '/skills',
+      navigate,
+      refreshSessions: vi.fn(),
+      resumeExhaustedSessionId: null,
+      routedSessionId: null,
+      runtimeIdByStoredSessionId: { current: new Map() }
+    })
+  )
+
+  return navigate
+}
+
+// Fan a payload out exactly like the preload bridge does: every subscribed
+// listener sees every 'hermes:deep-link' IPC message.
+function emitDeepLink(payload: DeepLinkPayload) {
+  act(() => {
+    for (const listener of [...deepLinkListeners]) {
+      listener(payload)
+    }
+  })
+}
+
+describe('useDesktopIntegrations deep links', () => {
+  it('opens the session for a well-formed hermes://session/<id> link', () => {
+    const navigate = mountIntegrations()
+
+    emitDeepLink({ kind: 'session', name: '20260718_101530_ab12cd', params: {} })
+
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith('/20260718_101530_ab12cd')
+  })
+
+  it('ignores malformed session ids silently', () => {
+    const navigate = mountIntegrations()
+
+    emitDeepLink({ kind: 'session', name: '', params: {} })
+    emitDeepLink({ kind: 'session', name: 'not-a-session-id', params: {} })
+    emitDeepLink({ kind: 'session', name: '20260718_101530_ab12cd/../oops', params: {} })
+    emitDeepLink({ kind: 'session', name: '20260718_101530_AB12CD', params: {} })
+
+    expect(navigate).not.toHaveBeenCalled()
+    expect(requestComposerInsert).not.toHaveBeenCalled()
+  })
+
+  it('leaves blueprint links to the composer handler, untouched by the session one', () => {
+    const navigate = mountIntegrations()
+
+    emitDeepLink({ kind: 'blueprint', name: 'morning-brief', params: { time: '08:00' } })
+
+    expect(requestComposerInsert).toHaveBeenCalledWith('/blueprint morning-brief time=08:00', {
+      mode: 'block',
+      target: 'main'
+    })
+    expect(requestComposerFocus).toHaveBeenCalledWith('main')
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('ignores unknown kinds entirely', () => {
+    const navigate = mountIntegrations()
+
+    emitDeepLink({ kind: 'skill', name: '20260718_101530_ab12cd', params: {} })
+
+    expect(navigate).not.toHaveBeenCalled()
+    expect(requestComposerInsert).not.toHaveBeenCalled()
+  })
+
+  it('mounts both deep-link listeners before signalling ready, so a cold-start-queued link flushes into them', () => {
+    const navigate = mountIntegrations()
+
+    expect(signalDeepLinkReady).toHaveBeenCalledTimes(1)
+    expect(listenersAtReadySignal).toBe(2)
+
+    // The flush replays the queued link through the same channel.
+    emitDeepLink({ kind: 'session', name: '20260101_000000_0a0b0c', params: {} })
+
+    expect(navigate).toHaveBeenCalledWith('/20260101_000000_0a0b0c')
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
-import { storedSessionIdForNotification } from '@/lib/session-ids'
+import { SESSION_ID_RE, storedSessionIdForNotification } from '@/lib/session-ids'
 import { respondToApprovalAction } from '@/store/native-notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
@@ -141,6 +141,23 @@ export function useDesktopIntegrations({
 
     return () => unsubscribe?.()
   }, [])
+
+  // hermes://session/<id> deep links -> jump straight to that session, via the
+  // same navigate(sessionRoute(...)) the session list rows use. Malformed ids
+  // are ignored silently; other kinds fall through to their own listeners.
+  // Declared before the blueprint effect below so this listener is mounted
+  // when signalDeepLinkReady flushes a link queued during cold start.
+  useEffect(() => {
+    const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
+      if (!payload || payload.kind !== 'session' || !SESSION_ID_RE.test(payload.name)) {
+        return
+      }
+
+      navigate(sessionRoute(payload.name))
+    })
+
+    return () => unsubscribe?.()
+  }, [navigate])
 
   // hermes:// deep links -> a reviewable /blueprint command in the composer.
   useEffect(() => {

--- a/apps/desktop/src/lib/session-ids.ts
+++ b/apps/desktop/src/lib/session-ids.ts
@@ -1,3 +1,10 @@
+// Hermes stored session ids: <YYYYMMDD>_<HHMMSS>_<6 hex> — the shape the
+// gateway mints for every persisted session. Shared by the surfaces that accept
+// a raw id from outside the session list (the command palette's "Go to session
+// ‹id›" jump, the hermes://session/<id> deep link) so malformed ids are
+// rejected by one definition of "well-formed".
+export const SESSION_ID_RE = /^\d{8}_\d{6}_[a-f0-9]{6}$/
+
 // The gateway tags every event — and therefore every native notification —
 // with the *runtime* session id (the key under which the session lives in the
 // gateway's in-memory `_sessions` map). The chat route, however, is keyed by


### PR DESCRIPTION
Part of #4335 (deep-link surface). #54981 closed the desktop→platform direction — the app registers `hermes://`, handles macOS `open-url`, routes Win/Linux second-instance argv, and queues links that arrive before the renderer is ready (`apps/desktop/electron/main.ts`). What's missing is the pointer INTO desktop: the renderer only listens for `kind === 'blueprint'`, so a `hermes://session/<id>` link from a chat surface foregrounds the app and then goes nowhere.

This adds the session listener beside the blueprint one (`apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts`), mirroring it line for line. A well-formed id navigates via the same `navigate(sessionRoute(id))` the session-switcher rows and notification clicks already use, which triggers the app's normal resume flow. Malformed ids are dropped silently; other kinds fall through untouched. The listener mounts before `signalDeepLinkReady`, so a link queued during cold start flushes into it — warm and cold both work with zero main-process changes.

"Well-formed" reuses the command palette's existing id shape (`<YYYYMMDD>_<HHMMSS>_<6 hex>`, the gateway's mint at `tui_gateway/server.py:5076`), now shared as `SESSION_ID_RE` in `apps/desktop/src/lib/session-ids.ts` instead of duplicated in the palette.

**Security posture: unchanged.** The link carries only a session id into the local renderer's router; opening a session this way is identical to clicking a sidebar row, and lands on the same guard-free local-trust `session.resume` RPC the whole app already uses (`tui_gateway/server.py:5901+`). No new IPC surface, no parameters beyond the id, and the strict id regex rejects path-shaped input before it reaches the router.

**Tests:** 5 new vitest cases (valid id navigates; malformed ids ignored; blueprint behaviour byte-identical; unknown kinds untouched; both listeners mounted before the ready signal + queued-link flush navigates). Full desktop suite 219 files / 1864 tests green; `tsc --noEmit` and eslint clean.

**Overlap.** No open PR touches the deep-link handler in `use-desktop-integrations.ts`. The manual `open "hermes://session/<id>"` check was not run here (the only Hermes Desktop on the build machine is a live production install); cold/warm delivery is asserted through the existing queue contract in the new tests.
