### PR TITLE
feat(curator): surface staleness in hermes status, /api/curator, and the dashboard

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -383,6 +383,41 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
     return counts
 
 
+def stale_skill_count(now: Optional[datetime] = None) -> int:
+    """Cheap count of tracked skills with no activity for ``stale_after_days``.
+
+    Read-only surfacing companion to ``apply_automatic_transitions``: same
+    activity anchor (``skill_usage.latest_activity_at``, falling back to
+    ``created_at``) and the same ``stale_after_days`` cutoff, but computed
+    from a single ``.usage.json`` read — no skill-dir walk, no state writes.
+    Pinned and archived records are skipped. Scope matches ``hermes curator
+    usage`` (every tracked skill in the active profile's
+    ``~/.hermes/skills/``, so the count is per-profile like all curator
+    state), not the narrower archive-candidate walk. Returns 0 when the
+    curator is disabled — no staleness surfacing for a feature the user
+    turned off.
+    """
+    if not is_enabled():
+        return 0
+    from tools import skill_usage as _u
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=get_stale_after_days())
+    count = 0
+    for record in _u.load_usage().values():
+        if record.get("pinned") or record.get("state") == _u.STATE_ARCHIVED:
+            continue
+        anchor = _parse_iso(_u.latest_activity_at(record)) or _parse_iso(record.get("created_at"))
+        if anchor is None:
+            continue
+        if anchor.tzinfo is None:
+            anchor = anchor.replace(tzinfo=timezone.utc)
+        if anchor <= cutoff:
+            count += 1
+    return count
+
+
 # ---------------------------------------------------------------------------
 # Review prompt for the forked agent
 # ---------------------------------------------------------------------------

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -384,18 +384,14 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
 
 
 def stale_skill_count(now: Optional[datetime] = None) -> int:
-    """Cheap count of tracked skills with no activity for ``stale_after_days``.
+    """Count managed skills with no activity for ``stale_after_days``.
 
     Read-only surfacing companion to ``apply_automatic_transitions``: same
     activity anchor (``skill_usage.latest_activity_at``, falling back to
-    ``created_at``) and the same ``stale_after_days`` cutoff, but computed
-    from a single ``.usage.json`` read — no skill-dir walk, no state writes.
-    Pinned and archived records are skipped. Scope matches ``hermes curator
-    usage`` (every tracked skill in the active profile's
-    ``~/.hermes/skills/``, so the count is per-profile like all curator
-    state), not the narrower archive-candidate walk. Returns 0 when the
-    curator is disabled — no staleness surfacing for a feature the user
-    turned off.
+    ``created_at``) and the same ``stale_after_days`` cutoff over the same
+    ``agent_created_report()`` candidate set. Pinned, archived,
+    cron-referenced, and not-yet-persisted candidates are skipped to match
+    the transition walk. Returns 0 when the curator is disabled.
     """
     if not is_enabled():
         return 0
@@ -404,9 +400,15 @@ def stale_skill_count(now: Optional[datetime] = None) -> int:
     if now is None:
         now = datetime.now(timezone.utc)
     cutoff = now - timedelta(days=get_stale_after_days())
+    cron_referenced = _cron_referenced_skills()
     count = 0
-    for record in _u.load_usage().values():
-        if record.get("pinned") or record.get("state") == _u.STATE_ARCHIVED:
+    for record in _u.agent_created_report():
+        if (
+            record.get("pinned")
+            or record.get("state") == _u.STATE_ARCHIVED
+            or record["name"] in cron_referenced
+            or not record.get("_persisted", True)
+        ):
             continue
         anchor = _parse_iso(_u.latest_activity_at(record)) or _parse_iso(record.get("created_at"))
         if anchor is None:

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -540,6 +540,28 @@ def show_status(args):
         print("  Jobs:         0")
 
     # =========================================================================
+    # Skill Curator
+    # =========================================================================
+    # Staleness surfacing only — a count plus a command pointer, never a
+    # skill list. Per-profile: the count reads the active profile's
+    # ~/.hermes/skills/.usage.json. Silent when the curator is disabled,
+    # and any failure here must never break the rest of the status page.
+    try:
+        from agent import curator
+        if curator.is_enabled():
+            stale = curator.stale_skill_count()
+            days = curator.get_stale_after_days()
+            print()
+            print(color("◆ Skill Curator", Colors.CYAN, Colors.BOLD))
+            if stale:
+                noun = "skill" if stale == 1 else "skills"
+                print(f"  Staleness:    {stale} {noun} unused >{days}d — see hermes curator usage")
+            else:
+                print(f"  Staleness:    no skills unused >{days}d")
+    except Exception:
+        pass
+
+    # =========================================================================
     # Sessions
     # =========================================================================
     print()

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -367,6 +367,7 @@ TIPS = [
     'hermes curator run --dry-run previews what the curator would archive or consolidate without mutating anything.',
     "hermes curator pin <skill> hard-fences a skill against both auto-archival and the agent's skill_manage tool.",
     'hermes curator rollback restores skills from a pre-run snapshot — backups live under skills/.curator_backups/.',
+    'hermes status shows how many skills sit unused past the curator stale window — hermes curator usage has the full list.',
 
     # --- Credential Pools & Routing ---
     'hermes auth reset <provider> clears all cooldowns and exhaustion flags on a credential pool.',

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2954,6 +2954,13 @@ async def get_system_stats():
 
 @app.get("/api/curator")
 async def get_curator_status():
+    """Curator status snapshot.
+
+    Per-profile: state (.curator_state) and the stale count (.usage.json)
+    are read from the server process's active profile home.
+    ``stale_skill_count`` is the cheap usage-telemetry count (skills with no
+    activity for ``stale_after_days``); it is 0 when the curator is disabled.
+    """
     try:
         from agent import curator
     except Exception as exc:
@@ -2967,9 +2974,11 @@ async def get_curator_status():
         "paused": _safe_call(curator, "is_paused", False),
         "interval_hours": _safe_call(curator, "get_interval_hours", None),
         "last_run_at": state.get("last_run_at"),
+        "last_run_summary": state.get("last_run_summary"),
         "min_idle_hours": _safe_call(curator, "get_min_idle_hours", None),
         "stale_after_days": _safe_call(curator, "get_stale_after_days", None),
         "archive_after_days": _safe_call(curator, "get_archive_after_days", None),
+        "stale_skill_count": _safe_call(curator, "stale_skill_count", None),
     }
 
 

--- a/tests/agent/test_curator_stale_count.py
+++ b/tests/agent/test_curator_stale_count.py
@@ -1,9 +1,9 @@
-"""Tests for agent.curator.stale_skill_count — cheap staleness surfacing.
+"""Tests for agent.curator.stale_skill_count — managed staleness surfacing.
 
 The count backs the `hermes status` staleness line, the /api/curator
-``stale_skill_count`` field, and the dashboard curator card. It reads only
-``.usage.json`` (no skill-dir walk, no state writes) and must stay silent —
-returning 0 — when the curator is disabled.
+``stale_skill_count`` field, and the dashboard curator card. It uses the same
+managed candidate and cron-exclusion semantics as automatic transitions and
+must stay silent — returning 0 — when the curator is disabled.
 """
 
 from __future__ import annotations
@@ -45,9 +45,27 @@ def _record(usage, **overrides):
     return rec
 
 
+def _write_skill(home, name):
+    skill_dir = home / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: test skill\n---\n",
+        encoding="utf-8",
+    )
+
+
+def _save_managed_records(curator_env, records):
+    u = curator_env["usage"]
+    managed = {}
+    for name, record in records.items():
+        _write_skill(curator_env["home"], name)
+        managed[name] = {**record, "created_by": "agent"}
+    u.save_usage(managed)
+
+
 def test_counts_records_idle_past_stale_window(curator_env):
     u, c = curator_env["usage"], curator_env["curator"]
-    u.save_usage({
+    _save_managed_records(curator_env, {
         "dusty": _record(u, created_by="agent", last_used_at=OLD, created_at=OLD),
         "busy": _record(u, created_by="agent", last_used_at=FRESH, created_at=OLD),
     })
@@ -57,7 +75,7 @@ def test_counts_records_idle_past_stale_window(curator_env):
 def test_view_and_patch_count_as_activity(curator_env):
     """latest_activity_at semantics: a recently viewed/patched skill is not stale."""
     u, c = curator_env["usage"], curator_env["curator"]
-    u.save_usage({
+    _save_managed_records(curator_env, {
         "viewed": _record(u, last_used_at=OLD, last_viewed_at=FRESH, created_at=OLD),
         "patched": _record(u, last_used_at=OLD, last_patched_at=FRESH, created_at=OLD),
     })
@@ -66,7 +84,7 @@ def test_view_and_patch_count_as_activity(curator_env):
 
 def test_never_active_falls_back_to_created_at(curator_env):
     u, c = curator_env["usage"], curator_env["curator"]
-    u.save_usage({
+    _save_managed_records(curator_env, {
         "old-never-used": _record(u, created_at=OLD),
         "new-never-used": _record(u, created_at=FRESH),
     })
@@ -75,7 +93,7 @@ def test_never_active_falls_back_to_created_at(curator_env):
 
 def test_pinned_and_archived_records_are_skipped(curator_env):
     u, c = curator_env["usage"], curator_env["curator"]
-    u.save_usage({
+    _save_managed_records(curator_env, {
         "pinned": _record(u, last_used_at=OLD, created_at=OLD, pinned=True),
         "archived": _record(u, last_used_at=OLD, created_at=OLD, state=u.STATE_ARCHIVED),
         "plain": _record(u, last_used_at=OLD, created_at=OLD),
@@ -85,7 +103,10 @@ def test_pinned_and_archived_records_are_skipped(curator_env):
 
 def test_respects_configured_stale_after_days(curator_env, monkeypatch):
     u, c = curator_env["usage"], curator_env["curator"]
-    u.save_usage({"dusty": _record(u, last_used_at=OLD, created_at=OLD)})
+    _save_managed_records(
+        curator_env,
+        {"dusty": _record(u, last_used_at=OLD, created_at=OLD)},
+    )
     # OLD is 45 days back — stale at the 30d default, fresh at a 60d window.
     assert c.stale_skill_count(now=NOW) == 1
     monkeypatch.setattr(c, "_load_config", lambda: {"stale_after_days": 60})
@@ -94,7 +115,10 @@ def test_respects_configured_stale_after_days(curator_env, monkeypatch):
 
 def test_disabled_curator_returns_zero_without_reading_usage(curator_env, monkeypatch):
     u, c = curator_env["usage"], curator_env["curator"]
-    u.save_usage({"dusty": _record(u, last_used_at=OLD, created_at=OLD)})
+    _save_managed_records(
+        curator_env,
+        {"dusty": _record(u, last_used_at=OLD, created_at=OLD)},
+    )
     monkeypatch.setattr(c, "_load_config", lambda: {"enabled": False})
 
     def _boom():
@@ -110,7 +134,30 @@ def test_missing_usage_file_counts_zero(curator_env):
 
 def test_unparseable_timestamps_are_skipped(curator_env):
     u, c = curator_env["usage"], curator_env["curator"]
-    u.save_usage({
+    _save_managed_records(curator_env, {
         "garbled": _record(u, last_used_at="not-a-date", created_at="also-not-a-date"),
     })
     assert c.stale_skill_count(now=NOW) == 0
+
+
+def test_non_managed_and_cron_referenced_skills_are_skipped(curator_env, monkeypatch):
+    u, c = curator_env["usage"], curator_env["curator"]
+    records = {
+        "managed": _record(u, last_used_at=OLD, created_at=OLD, created_by="agent"),
+        "cron-dep": _record(u, last_used_at=OLD, created_at=OLD, created_by="agent"),
+        "manual": _record(u, last_used_at=OLD, created_at=OLD),
+        "hub-skill": _record(u, last_used_at=OLD, created_at=OLD, created_by="agent"),
+        "plan": _record(u, last_used_at=OLD, created_at=OLD, created_by="agent"),
+    }
+    for name in records:
+        _write_skill(curator_env["home"], name)
+    hub_dir = curator_env["home"] / "skills" / ".hub"
+    hub_dir.mkdir()
+    (hub_dir / "lock.json").write_text(
+        '{"version": 1, "installed": {"hub-skill": {"source": "test"}}}',
+        encoding="utf-8",
+    )
+    u.save_usage(records)
+    monkeypatch.setattr(c, "_cron_referenced_skills", lambda: {"cron-dep"})
+
+    assert c.stale_skill_count(now=NOW) == 1

--- a/tests/agent/test_curator_stale_count.py
+++ b/tests/agent/test_curator_stale_count.py
@@ -1,0 +1,116 @@
+"""Tests for agent.curator.stale_skill_count — cheap staleness surfacing.
+
+The count backs the `hermes status` staleness line, the /api/curator
+``stale_skill_count`` field, and the dashboard curator card. It reads only
+``.usage.json`` (no skill-dir walk, no state writes) and must stay silent —
+returning 0 — when the curator is disabled.
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+
+NOW = datetime(2026, 7, 1, tzinfo=timezone.utc)
+OLD = (NOW - timedelta(days=45)).isoformat()
+FRESH = (NOW - timedelta(days=2)).isoformat()
+
+
+@pytest.fixture
+def curator_env(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME + freshly reloaded curator + skill_usage modules."""
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import tools.skill_usage as usage
+    importlib.reload(usage)
+    import agent.curator as curator
+    importlib.reload(curator)
+
+    # Default: no config file → curator defaults. Tests can override.
+    monkeypatch.setattr(curator, "_load_config", lambda: {})
+
+    yield {"home": home, "curator": curator, "usage": usage}
+
+
+def _record(usage, **overrides):
+    rec = usage._empty_record()
+    rec.update(overrides)
+    return rec
+
+
+def test_counts_records_idle_past_stale_window(curator_env):
+    u, c = curator_env["usage"], curator_env["curator"]
+    u.save_usage({
+        "dusty": _record(u, created_by="agent", last_used_at=OLD, created_at=OLD),
+        "busy": _record(u, created_by="agent", last_used_at=FRESH, created_at=OLD),
+    })
+    assert c.stale_skill_count(now=NOW) == 1
+
+
+def test_view_and_patch_count_as_activity(curator_env):
+    """latest_activity_at semantics: a recently viewed/patched skill is not stale."""
+    u, c = curator_env["usage"], curator_env["curator"]
+    u.save_usage({
+        "viewed": _record(u, last_used_at=OLD, last_viewed_at=FRESH, created_at=OLD),
+        "patched": _record(u, last_used_at=OLD, last_patched_at=FRESH, created_at=OLD),
+    })
+    assert c.stale_skill_count(now=NOW) == 0
+
+
+def test_never_active_falls_back_to_created_at(curator_env):
+    u, c = curator_env["usage"], curator_env["curator"]
+    u.save_usage({
+        "old-never-used": _record(u, created_at=OLD),
+        "new-never-used": _record(u, created_at=FRESH),
+    })
+    assert c.stale_skill_count(now=NOW) == 1
+
+
+def test_pinned_and_archived_records_are_skipped(curator_env):
+    u, c = curator_env["usage"], curator_env["curator"]
+    u.save_usage({
+        "pinned": _record(u, last_used_at=OLD, created_at=OLD, pinned=True),
+        "archived": _record(u, last_used_at=OLD, created_at=OLD, state=u.STATE_ARCHIVED),
+        "plain": _record(u, last_used_at=OLD, created_at=OLD),
+    })
+    assert c.stale_skill_count(now=NOW) == 1
+
+
+def test_respects_configured_stale_after_days(curator_env, monkeypatch):
+    u, c = curator_env["usage"], curator_env["curator"]
+    u.save_usage({"dusty": _record(u, last_used_at=OLD, created_at=OLD)})
+    # OLD is 45 days back — stale at the 30d default, fresh at a 60d window.
+    assert c.stale_skill_count(now=NOW) == 1
+    monkeypatch.setattr(c, "_load_config", lambda: {"stale_after_days": 60})
+    assert c.stale_skill_count(now=NOW) == 0
+
+
+def test_disabled_curator_returns_zero_without_reading_usage(curator_env, monkeypatch):
+    u, c = curator_env["usage"], curator_env["curator"]
+    u.save_usage({"dusty": _record(u, last_used_at=OLD, created_at=OLD)})
+    monkeypatch.setattr(c, "_load_config", lambda: {"enabled": False})
+
+    def _boom():
+        raise AssertionError("load_usage must not run when the curator is disabled")
+
+    monkeypatch.setattr(u, "load_usage", _boom)
+    assert c.stale_skill_count(now=NOW) == 0
+
+
+def test_missing_usage_file_counts_zero(curator_env):
+    assert curator_env["curator"].stale_skill_count(now=NOW) == 0
+
+
+def test_unparseable_timestamps_are_skipped(curator_env):
+    u, c = curator_env["usage"], curator_env["curator"]
+    u.save_usage({
+        "garbled": _record(u, last_used_at="not-a-date", created_at="also-not-a-date"),
+    })
+    assert c.stale_skill_count(now=NOW) == 0

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -576,14 +576,21 @@ class TestCuratorEndpoints:
     def test_status_surfaces_staleness_findings(self):
         """last_run_summary + stale_skill_count ride along the status payload."""
         from agent import curator
+        from hermes_constants import get_hermes_home
         from tools import skill_usage
 
         state = curator.load_state()
         state["last_run_summary"] = "auto: 2 marked stale"
         curator.save_state(state)
 
-        # Seed one long-idle skill record so the cheap count is non-zero.
+        # Seed one long-idle managed skill so the count is non-zero.
         idle_at = "2020-01-01T00:00:00+00:00"
+        skill_dir = get_hermes_home() / "skills" / "dusty-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: dusty-skill\ndescription: test skill\n---\n",
+            encoding="utf-8",
+        )
         data = skill_usage.load_usage()
         data["dusty-skill"] = {
             "created_by": "agent",

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -573,6 +573,38 @@ class TestCuratorEndpoints:
         r = self.client.put("/api/curator/paused", json={"paused": False})
         assert r.status_code == 200 and r.json()["paused"] is False
 
+    def test_status_surfaces_staleness_findings(self):
+        """last_run_summary + stale_skill_count ride along the status payload."""
+        from agent import curator
+        from tools import skill_usage
+
+        state = curator.load_state()
+        state["last_run_summary"] = "auto: 2 marked stale"
+        curator.save_state(state)
+
+        # Seed one long-idle skill record so the cheap count is non-zero.
+        idle_at = "2020-01-01T00:00:00+00:00"
+        data = skill_usage.load_usage()
+        data["dusty-skill"] = {
+            "created_by": "agent",
+            "use_count": 1,
+            "last_used_at": idle_at,
+            "created_at": idle_at,
+            "state": "active",
+            "pinned": False,
+        }
+        skill_usage.save_usage(data)
+
+        body = self.client.get("/api/curator").json()
+        assert body["last_run_summary"] == "auto: 2 marked stale"
+        assert body["stale_skill_count"] == 1
+
+    def test_status_empty_state_staleness_defaults(self):
+        """Fresh home: no summary yet, zero stale — fields present, not errors."""
+        body = self.client.get("/api/curator").json()
+        assert body["last_run_summary"] is None
+        assert body["stale_skill_count"] == 0
+
 
 class TestPortalEndpoint:
     @pytest.fixture(autouse=True)

--- a/tests/hermes_cli/test_status_curator_staleness.py
+++ b/tests/hermes_cli/test_status_curator_staleness.py
@@ -1,0 +1,90 @@
+"""Tests for the `hermes status` Skill Curator staleness section.
+
+The section surfaces the curator's cheap staleness count as a count plus a
+command pointer (never a skill list) and must stay silent — no output, no
+errors — when the curator is disabled or broken.
+"""
+
+from types import SimpleNamespace
+
+from hermes_cli.status import show_status
+
+
+def _curator_section(out: str) -> str:
+    return out.split("◆ Skill Curator", 1)[1].split("◆", 1)[0]
+
+
+def test_staleness_line_when_stale_skills_exist(monkeypatch, capsys):
+    import agent.curator as curator
+
+    monkeypatch.setattr(curator, "is_enabled", lambda: True)
+    monkeypatch.setattr(curator, "stale_skill_count", lambda: 3)
+    monkeypatch.setattr(curator, "get_stale_after_days", lambda: 30)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "◆ Skill Curator" in out
+    assert "Staleness:    3 skills unused >30d — see hermes curator usage" in out
+
+
+def test_staleness_line_singular_and_configured_window(monkeypatch, capsys):
+    import agent.curator as curator
+
+    monkeypatch.setattr(curator, "is_enabled", lambda: True)
+    monkeypatch.setattr(curator, "stale_skill_count", lambda: 1)
+    monkeypatch.setattr(curator, "get_stale_after_days", lambda: 45)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Staleness:    1 skill unused >45d — see hermes curator usage" in out
+
+
+def test_zero_stale_prints_quiet_line_without_pointer(monkeypatch, capsys):
+    import agent.curator as curator
+
+    monkeypatch.setattr(curator, "is_enabled", lambda: True)
+    monkeypatch.setattr(curator, "stale_skill_count", lambda: 0)
+    monkeypatch.setattr(curator, "get_stale_after_days", lambda: 30)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    section = _curator_section(out)
+    assert "Staleness:    no skills unused >30d" in section
+    assert "hermes curator usage" not in section
+
+
+def test_disabled_curator_prints_nothing_and_never_counts(monkeypatch, capsys):
+    import agent.curator as curator
+
+    calls = []
+    monkeypatch.setattr(curator, "is_enabled", lambda: False)
+    monkeypatch.setattr(curator, "stale_skill_count", lambda: calls.append(1) or 0)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "◆ Skill Curator" not in out
+    assert "Staleness:" not in out
+    assert not calls
+    # The rest of the status page still renders.
+    assert "◆ Sessions" in out
+
+
+def test_curator_exception_does_not_crash_show_status(monkeypatch, capsys):
+    import agent.curator as curator
+
+    def _boom():
+        raise RuntimeError("usage file unreadable")
+
+    monkeypatch.setattr(curator, "is_enabled", lambda: True)
+    monkeypatch.setattr(curator, "stale_skill_count", _boom)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    # Section is skipped whole — no partial header — and the page completes.
+    assert "◆ Skill Curator" not in out
+    assert "◆ Sessions" in out

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1739,9 +1739,11 @@ export interface CuratorStatus {
   paused: boolean;
   interval_hours: number | null;
   last_run_at: string | null;
+  last_run_summary: string | null;
   min_idle_hours: number | null;
   stale_after_days: number | null;
   archive_after_days: number | null;
+  stale_skill_count: number | null;
 }
 
 export interface PortalFeature {

--- a/web/src/pages/SystemPage.tsx
+++ b/web/src/pages/SystemPage.tsx
@@ -1008,29 +1008,42 @@ export default function SystemPage() {
           <Sparkles className="h-4 w-4" /> Skill curator
         </H2>
         <Card>
-          <CardContent className="flex items-center justify-between py-4">
-            <div className="flex items-center gap-3">
-              <Badge tone={curator?.paused ? "warning" : curator?.enabled ? "success" : "secondary"}>
-                {curator?.paused ? "paused" : curator?.enabled ? "active" : "disabled"}
-              </Badge>
-              <span className="text-sm text-muted-foreground">
-                {curator?.interval_hours ? `every ${curator.interval_hours}h` : ""}
-                {curator?.last_run_at ? ` · last run ${new Date(curator.last_run_at).toLocaleString()}` : " · never run"}
-              </span>
+          <CardContent className="flex flex-col gap-2 py-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Badge tone={curator?.paused ? "warning" : curator?.enabled ? "success" : "secondary"}>
+                  {curator?.paused ? "paused" : curator?.enabled ? "active" : "disabled"}
+                </Badge>
+                <span className="text-sm text-muted-foreground">
+                  {curator?.interval_hours ? `every ${curator.interval_hours}h` : ""}
+                  {curator?.last_run_at ? ` · last run ${new Date(curator.last_run_at).toLocaleString()}` : " · never run"}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button size="sm" ghost onClick={toggleCuratorPaused}>
+                  {curator?.paused ? "Resume" : "Pause"}
+                </Button>
+                <Button
+                  size="sm"
+                  ghost
+                  prefix={<Play className="h-3.5 w-3.5" />}
+                  onClick={() => runOp(api.runCurator, "Curator review")}
+                >
+                  Run now
+                </Button>
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <Button size="sm" ghost onClick={toggleCuratorPaused}>
-                {curator?.paused ? "Resume" : "Pause"}
-              </Button>
-              <Button
-                size="sm"
-                ghost
-                prefix={<Play className="h-3.5 w-3.5" />}
-                onClick={() => runOp(api.runCurator, "Curator review")}
-              >
-                Run now
-              </Button>
-            </div>
+            {(curator?.stale_skill_count ?? 0) > 0 && (
+              <p className="text-sm text-warning">
+                {curator?.stale_skill_count} skill{curator?.stale_skill_count === 1 ? "" : "s"} unused &gt;
+                {curator?.stale_after_days ?? 30}d — see <span className="font-mono">hermes curator usage</span>
+              </p>
+            )}
+            {curator?.last_run_summary && (
+              <p className="text-xs text-muted-foreground">
+                last run: {curator.last_run_summary.split("\n")[0]}
+              </p>
+            )}
           </CardContent>
         </Card>
       </section>


### PR DESCRIPTION
The curator already computes staleness and writes findings nobody sees: `last_run_summary` is persisted in `.curator_state` (`agent/curator.py:93`, written at `:1580/:1611/:1712`) and the stale/archive walk runs on every pass — but the only surfacing is the show-once notice on `hermes update` (`hermes_cli/main.py:6070-6133`) and the opt-in `hermes curator status`. Users learn their skills were aged out by stumbling into a rename. This PR makes the findings passively visible on the three surfaces people already look at.

**What changed**
- `agent/curator.py`: new read-only `stale_skill_count()` — one `.usage.json` read using `tools/skill_usage.latest_activity_at` (`:146`) with a `created_at` fallback (same anchor semantics as `apply_automatic_transitions`), pinned/archived skipped, `stale_after_days` cutoff. Returns 0 when the curator is disabled (`agent/curator.py:154-157`) — no noise, no errors for users who turned it off. Per-profile, like all curator state.
- `hermes status`: a `Skill Curator` section capped at a count plus a pointer — `3 skills unused >30d — see hermes curator usage` — never a list. Silent when disabled; a failure in the block can never break the status page.
- `GET /api/curator` (`hermes_cli/web_server.py:2955-2973`): payload adds `last_run_summary` and `stale_skill_count`.
- Dashboard `SystemPage` curator card (`web/src/pages/SystemPage.tsx:1008-1023`): renders the stale count and the last run summary's first line under the existing status row.
- `hermes_cli/tips.py`: one discovery tip pointing at the new surfacing.

**Why this belongs upstream:** it extends the RFC'd curator (#16077, closed-resolved) with the visibility layer the system was reviewed to have — #19384 (closed-completed) built the `hermes curator usage`/prune CLI this points at; this PR closes the loop by surfacing its findings where users already are. No behavior changes to the curator itself: strictly read-only surfacing.

**No open-PR overlap** (verified 2026-07-18): searched open PRs for `curator`, `stale`, `staleness` — nearest are #64479 (relabels `hermes curator status` wording) and #23502 (report subcommand); none touch `hermes status`, the `/api/curator` payload, or the SystemPage card.

**Tests**: 15 new (8 unit for the count: window math, view/patch-as-activity, created_at fallback, pinned/archived exclusion, disabled short-circuit, corrupt timestamps; 5 for the status line incl. disabled no-op and exception resilience; 2 for the API payload with seeded curator state). Full existing suites green: 88 dashboard-admin, 201 curator/skill_usage, 73 CLI curator/status/tips, 407 web_server; web: tsc clean, 85 vitest, production build passes.
