### PR TITLE
fix(session): don't double-prefix group session keys

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1897,6 +1897,7 @@ from gateway.session import (
     SessionStore,
     SessionSource,
     SessionContext,
+    GROUP_PREFIXED_CHAT_ID_PLATFORMS,
     build_session_context,
     build_session_context_prompt,
     build_session_key,
@@ -2654,13 +2655,26 @@ def _parse_session_key(session_key: str) -> "dict | None":
     it is unambiguous (``dm`` and ``thread``).  For group/channel sessions
     the suffix may be a user_id (per-user isolation) rather than a
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
+
+    Signal/SimpleX/Yuanbao chat_ids carry the chat_type as a literal
+    ``group:`` prefix that ``build_session_key`` strips (it would otherwise
+    duplicate the chat_type segment); it is restored here, because those
+    adapters send to a group only when the prefix is present and would
+    otherwise deliver a group reply to a single direct recipient.
     """
     parts = session_key.split(":")
     if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+        chat_id = parts[4]
+        if (
+            parts[2] in GROUP_PREFIXED_CHAT_ID_PLATFORMS
+            and parts[3] == "group"
+            and not chat_id.startswith("group:")
+        ):
+            chat_id = f"group:{chat_id}"
         result = {
             "platform": parts[2],
             "chat_type": parts[3],
-            "chat_id": parts[4],
+            "chat_id": chat_id,
         }
         if len(parts) > 5 and parts[3] in {"dm", "thread"}:
             result["thread_id"] = parts[5]

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -341,6 +341,18 @@ that requires raw IDs).  Discord is excluded because mentions use ``<@user_id>``
 and the LLM needs the real ID to tag users."""
 
 
+GROUP_PREFIXED_CHAT_ID_PLATFORMS = frozenset({"signal", "simplex", "yuanbao"})
+"""Platform values whose adapters bake the chat_type into chat_id itself as a
+literal ``group:<id>`` (gateway/platforms/signal.py,
+plugins/platforms/simplex/adapter.py, gateway/platforms/yuanbao.py) and route
+outbound sends on that prefix.
+
+:func:`build_session_key` strips the redundant segment for these platforms so
+the key isn't doubled, and ``_parse_session_key`` in gateway/run.py restores it
+when rebuilding a source from a key alone.  Both sides gate on this set and on
+``chat_type == "group"``, which is what keeps the transform reversible."""
+
+
 def _discord_tools_loaded() -> bool:
     """True iff the agent will actually have Discord tools this session.
 
@@ -964,7 +976,19 @@ def build_session_key(
     key_parts = [ns, platform, source.chat_type]
 
     if source.chat_id:
-        key_parts.append(source.chat_id)
+        # Signal, SimpleX and Yuanbao already bake the chat_type into chat_id
+        # itself ("group:<id>"), and key_parts above supplies that segment
+        # once already.  Drop the redundant copy so the key doesn't double up
+        # ("agent:main:signal:group:group:<id>"), which also made the fifth
+        # segment read back as a bare "group" in _parse_session_key.
+        chat_id_for_key = source.chat_id
+        if (
+            platform in GROUP_PREFIXED_CHAT_ID_PLATFORMS
+            and source.chat_type == "group"
+            and chat_id_for_key.startswith("group:")
+        ):
+            chat_id_for_key = chat_id_for_key[len("group:"):]
+        key_parts.append(chat_id_for_key)
     if source.thread_id:
         key_parts.append(source.thread_id)
 

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -556,3 +556,54 @@ def test_parse_session_key_too_short():
 def test_parse_session_key_wrong_prefix():
     assert _parse_session_key("cron:main:telegram:dm:123") is None
     assert _parse_session_key("agent:cron:telegram:dm:123") is None
+
+
+def test_parse_session_key_restores_signal_group_prefix():
+    """Signal chat_ids carry the chat_type as a literal prefix, and send()
+    routes to a group only when it is present, so parsing must restore it."""
+    result = _parse_session_key("agent:main:signal:group:AbCdEf123456")
+    assert result == {
+        "platform": "signal",
+        "chat_type": "group",
+        "chat_id": "group:AbCdEf123456",
+    }
+
+
+def test_parse_session_key_leaves_unprefixed_platforms_alone():
+    """Only the platforms that use the prefix convention get it back."""
+    result = _parse_session_key("agent:main:discord:group:guild-123")
+    assert result["chat_id"] == "guild-123"
+
+
+# ---------------------------------------------------------------------------
+# Async-delegation routing enrichment
+# ---------------------------------------------------------------------------
+
+def test_enrich_async_delegation_routing_keeps_signal_group_routable(
+    monkeypatch, tmp_path
+):
+    """A background/async-delegation completion carries only session_key.
+
+    Its reconstructed source has to stay addressed to the group: a bare id
+    would be handed to Signal's direct-recipient branch and the group's reply
+    would be delivered to one person.
+    """
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+
+    evt = {
+        "type": "async_delegation",
+        "session_id": "proc_async",
+        "session_key": "agent:main:signal:group:AbCdEf123456",
+    }
+
+    runner._enrich_async_delegation_routing(evt)
+
+    assert evt["platform"] == "signal"
+    assert evt["chat_type"] == "group"
+    assert evt["chat_id"] == "group:AbCdEf123456"
+
+    source = runner._build_process_event_source(evt)
+    assert source is not None
+    assert source.platform == Platform.SIGNAL
+    assert source.chat_id == "group:AbCdEf123456"
+    assert source.chat_type == "group"

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -2017,3 +2017,125 @@ class TestGatewayRoutingTable:
         )
         assert entry.session_key not in rows
         restarted._db.close()
+
+
+class TestGroupChatIdDoublePrefix:
+    """Regression: Signal, SimpleX and Yuanbao bake the chat_type into chat_id
+    itself ("group:<id>") before handing it to build_session_key, which also
+    appends chat_type as its own key segment.  That double-prefixes the key
+    ("agent:main:signal:group:group:<id>"), and _parse_session_key reads the
+    fifth segment as the chat_id, so a key-only reconstruction used to come
+    back with a bare "group".
+    """
+
+    def test_signal_group_key_has_single_group_prefix(self):
+        source = SessionSource(
+            platform=Platform.SIGNAL,
+            chat_id="group:AbCdEf123456",
+            chat_type="group",
+            user_name="alice",
+        )
+        key = build_session_key(source, group_sessions_per_user=False)
+        assert key == "agent:main:signal:group:AbCdEf123456"
+
+    def test_simplex_group_key_has_single_group_prefix(self):
+        """SimpleX uses the same prefix convention
+        (plugins/platforms/simplex/adapter.py)."""
+        source = SessionSource(
+            platform=Platform("simplex"),
+            chat_id="group:42",
+            chat_type="group",
+        )
+        key = build_session_key(source, group_sessions_per_user=False)
+        assert key == "agent:main:simplex:group:42"
+
+    def test_signal_dm_key_unaffected(self):
+        """Signal DM chat_ids are bare phone numbers, never prefixed."""
+        source = SessionSource(
+            platform=Platform.SIGNAL,
+            chat_id="+15551234567",
+            chat_type="dm",
+        )
+        assert build_session_key(source) == "agent:main:signal:dm:+15551234567"
+
+    def test_discord_group_key_unaffected(self):
+        """Platforms whose chat_id never carries a chat_type prefix (Discord's
+        bare guild id) must be byte-identical to before.  The strip only
+        applies to the platforms that use the prefix convention."""
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-123",
+            chat_type="group",
+            user_id="alice",
+            user_name="Alice",
+        )
+        assert (
+            build_session_key(source, group_sessions_per_user=False)
+            == "agent:main:discord:group:guild-123"
+        )
+
+
+class TestGroupChatIdKeyRoundTrip:
+    """Session-key-only routing must reconstruct a routable chat_id.
+
+    Async-delegation completions carry only ``session_key`` and are rebuilt by
+    ``_parse_session_key`` in gateway/run.py.  Signal's ``send()`` treats a
+    chat_id as a group only when it starts with "group:" and otherwise sends to
+    a direct recipient (gateway/platforms/signal.py), and SimpleX does the same
+    (plugins/platforms/simplex/adapter.py), so the prefix has to survive the
+    round trip or a group reply is delivered to one individual.
+    """
+
+    def test_signal_group_key_round_trips_to_prefixed_chat_id(self):
+        from gateway.run import _parse_session_key
+
+        source = SessionSource(
+            platform=Platform.SIGNAL,
+            chat_id="group:AbCdEf123456",
+            chat_type="group",
+        )
+        key = build_session_key(source, group_sessions_per_user=False)
+        parsed = _parse_session_key(key)
+        assert parsed is not None
+        assert parsed["chat_id"] == "group:AbCdEf123456"
+        assert parsed["platform"] == "signal"
+        assert parsed["chat_type"] == "group"
+
+    def test_signal_group_per_user_key_round_trips(self):
+        """Per-user isolation appends a user_id segment; the chat_id segment
+        still has to come back prefixed."""
+        from gateway.run import _parse_session_key
+
+        source = SessionSource(
+            platform=Platform.SIGNAL,
+            chat_id="group:AbCdEf123456",
+            chat_type="group",
+            user_id="+15551234567",
+        )
+        key = build_session_key(source, group_sessions_per_user=True)
+        assert key == "agent:main:signal:group:AbCdEf123456:+15551234567"
+        assert _parse_session_key(key)["chat_id"] == "group:AbCdEf123456"
+
+    def test_simplex_group_key_round_trips(self):
+        from gateway.run import _parse_session_key
+
+        source = SessionSource(
+            platform=Platform("simplex"),
+            chat_id="group:42",
+            chat_type="group",
+        )
+        key = build_session_key(source, group_sessions_per_user=False)
+        assert _parse_session_key(key)["chat_id"] == "group:42"
+
+    def test_discord_group_key_round_trip_stays_bare(self):
+        """Discord chat_ids carry no prefix, so parsing must not invent one."""
+        from gateway.run import _parse_session_key
+
+        parsed = _parse_session_key("agent:main:discord:group:guild-123")
+        assert parsed["chat_id"] == "guild-123"
+
+    def test_signal_dm_key_round_trip_stays_bare(self):
+        from gateway.run import _parse_session_key
+
+        parsed = _parse_session_key("agent:main:signal:dm:+15551234567")
+        assert parsed["chat_id"] == "+15551234567"


### PR DESCRIPTION
Noticed while looking at session-key handling for a Signal group chat — the session key came out as `agent:main:signal:group:group:<id>`, double-prefixed.

`build_session_key` appends `chat_type` ("group") as its own segment, but Signal's adapter already sets `chat_id = f"group:{group_id}"` before handing it off, so the group prefix ends up in the key twice. Traced the same pattern in the yuanbao and simplex adapters — they build their group `chat_id` the same way, so they hit it too.

Fix strips a redundant leading `"<chat_type>:"` from `chat_id` before appending it — only kicks in when chat_id actually starts with that prefix, so it's a no-op for every adapter that doesn't do this (added a Discord test to confirm that explicitly). Ran the full `test_session.py` suite plus the yuanbao/simplex test files locally — all green, no regressions.