### PR TITLE
fix(web-search): honor the site:<domain> operator natively

### DIFF
--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -125,12 +125,28 @@ class ExaWebSearchProvider(WebSearchProvider):
             if is_interrupted():
                 return {"success": False, "error": "Interrupted"}
 
-            logger.info("Exa search: '%s' (limit=%d)", query, limit)
-            response = _get_exa_client().search(
-                query,
-                num_results=limit,
-                contents={"highlights": True},
+            # ``site:<domain>`` is an operator, not a literal term. Exa has a
+            # native domain filter (``include_domains``), so parse the operator
+            # out and apply it natively. Otherwise the ``site:`` token is sent
+            # verbatim and results come back with empty highlights.
+            from tools.web_tools import parse_site_operator
+
+            domains, residual = parse_site_operator(query)
+            effective_query = residual if domains else query
+
+            logger.info(
+                "Exa search: '%s' (limit=%d, include_domains=%s)",
+                effective_query,
+                limit,
+                domains or None,
             )
+            search_kwargs: Dict[str, Any] = {
+                "num_results": limit,
+                "contents": {"highlights": True},
+            }
+            if domains:
+                search_kwargs["include_domains"] = domains
+            response = _get_exa_client().search(effective_query, **search_kwargs)
 
             web_results = []
             for i, result in enumerate(response.results or []):

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -158,16 +158,30 @@ class TavilyWebSearchProvider(WebSearchProvider):
             if is_interrupted():
                 return {"success": False, "error": "Interrupted"}
 
-            logger.info("Tavily search: '%s' (limit=%d)", query, limit)
-            raw = _tavily_request(
-                "search",
-                {
-                    "query": query,
-                    "max_results": min(limit, 20),
-                    "include_raw_content": False,
-                    "include_images": False,
-                },
+            # ``site:<domain>`` is an operator, not a literal term. Tavily has
+            # a native domain filter (``include_domains``), so parse the
+            # operator out and apply it natively instead of sending the
+            # ``site:`` token verbatim as a search term.
+            from tools.web_tools import parse_site_operator
+
+            domains, residual = parse_site_operator(query)
+            effective_query = residual if domains else query
+
+            logger.info(
+                "Tavily search: '%s' (limit=%d, include_domains=%s)",
+                effective_query,
+                limit,
+                domains or None,
             )
+            payload: Dict[str, Any] = {
+                "query": effective_query,
+                "max_results": min(limit, 20),
+                "include_raw_content": False,
+                "include_images": False,
+            }
+            if domains:
+                payload["include_domains"] = domains
+            raw = _tavily_request("search", payload)
             return _normalize_tavily_search_results(raw)
         except ValueError as exc:
             return {"success": False, "error": str(exc)}

--- a/tests/tools/test_web_tools_site_operator.py
+++ b/tests/tools/test_web_tools_site_operator.py
@@ -1,0 +1,161 @@
+"""Tests for the ``site:<domain>`` search operator handling.
+
+Background: ``site:nature.com CRISPR`` style queries used to be passed to
+web-search providers verbatim, so providers with a native domain-filter
+parameter never used it and the ``site:`` token reached the backend as a
+literal search term.
+
+These tests pin the shared ``parse_site_operator`` helper plus the
+provider-specific wiring: both Exa and Tavily receive the residual query
+plus their native domain filter (``include_domains``).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ─── parse_site_operator (shared helper) ─────────────────────────────────────
+
+
+class TestParseSiteOperator:
+    def test_single_operator_leading(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator("site:nature.com CRISPR")
+        assert domains == ["nature.com"]
+        assert residual == "CRISPR"
+
+    def test_no_operator_passthrough(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator("CRISPR gene editing")
+        assert domains == []
+        assert residual == "CRISPR gene editing"
+
+    def test_operator_midquery(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator("CRISPR site:nature.com review")
+        assert domains == ["nature.com"]
+        assert residual == "CRISPR review"
+
+    def test_multiple_operators(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator(
+            "site:nature.com site:science.org foo bar"
+        )
+        assert domains == ["nature.com", "science.org"]
+        assert residual == "foo bar"
+
+    def test_strips_scheme_and_dedups(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator(
+            "site:https://nature.com site:nature.com foo"
+        )
+        assert domains == ["nature.com"]
+        assert residual == "foo"
+
+    def test_empty_query(self):
+        from tools.web_tools import parse_site_operator
+
+        domains, residual = parse_site_operator("")
+        assert domains == []
+        assert residual == ""
+
+
+# ─── Exa: include_domains + residual query ───────────────────────────────────
+
+
+class TestExaSiteOperator:
+    def _mock_client(self):
+        client = MagicMock()
+        resp = MagicMock()
+        resp.results = []
+        client.search.return_value = resp
+        return client
+
+    def test_site_query_uses_include_domains_and_residual(self):
+        from plugins.web.exa.provider import ExaWebSearchProvider
+
+        client = self._mock_client()
+        with patch.dict(os.environ, {"EXA_API_KEY": "exa-key"}):
+            with patch(
+                "plugins.web.exa.provider._get_exa_client", return_value=client
+            ):
+                ExaWebSearchProvider().search("site:nature.com CRISPR", limit=5)
+
+        client.search.assert_called_once()
+        call = client.search.call_args
+        # residual query passed positionally, site: token stripped
+        assert call.args[0] == "CRISPR"
+        assert call.kwargs.get("include_domains") == ["nature.com"]
+
+    def test_plain_query_omits_include_domains(self):
+        from plugins.web.exa.provider import ExaWebSearchProvider
+
+        client = self._mock_client()
+        with patch.dict(os.environ, {"EXA_API_KEY": "exa-key"}):
+            with patch(
+                "plugins.web.exa.provider._get_exa_client", return_value=client
+            ):
+                ExaWebSearchProvider().search("CRISPR gene editing", limit=5)
+
+        call = client.search.call_args
+        assert call.args[0] == "CRISPR gene editing"
+        assert call.kwargs.get("include_domains") is None
+
+
+# ─── Tavily: include_domains + residual query ────────────────────────────────
+
+
+class TestTavilySiteOperator:
+    @staticmethod
+    def _search(query, limit=5):
+        from plugins.web.tavily.provider import TavilyWebSearchProvider
+
+        captured = {}
+
+        def fake_request(endpoint, payload):
+            captured["endpoint"] = endpoint
+            captured["payload"] = payload
+            return {"results": []}
+
+        with patch(
+            "plugins.web.tavily.provider._tavily_request", side_effect=fake_request
+        ):
+            TavilyWebSearchProvider().search(query, limit=limit)
+
+        return captured["payload"]
+
+    def test_site_query_uses_include_domains_and_residual(self):
+        payload = self._search("site:nature.com CRISPR")
+
+        assert payload["include_domains"] == ["nature.com"]
+        # The operator is translated, not forwarded as a literal term.
+        assert payload["query"] == "CRISPR"
+        assert "site:" not in payload["query"]
+
+    def test_site_query_keeps_default_depth(self):
+        """Scoped queries must not silently upgrade to the 2-credit tier."""
+        payload = self._search("site:nature.com CRISPR")
+
+        assert "search_depth" not in payload
+
+    def test_multiple_operators_forwarded(self):
+        payload = self._search("site:nature.com site:science.org CRISPR")
+
+        assert payload["include_domains"] == ["nature.com", "science.org"]
+        assert payload["query"] == "CRISPR"
+
+    def test_plain_query_omits_include_domains(self):
+        payload = self._search("CRISPR gene editing")
+
+        assert "include_domains" not in payload
+        assert "search_depth" not in payload
+        assert payload["query"] == "CRISPR gene editing"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -103,6 +103,39 @@ import sys
 logger = logging.getLogger(__name__)
 
 
+# ─── Query Operators ──────────────────────────────────────────────────────────
+
+# Matches a ``site:<domain>`` search operator token. The domain runs to the
+# next whitespace; an optional ``http(s)://`` scheme is tolerated and stripped
+# by :func:`parse_site_operator`.
+_SITE_OPERATOR_RE = re.compile(r"\bsite:(\S+)", re.IGNORECASE)
+
+
+def parse_site_operator(query: str) -> tuple[list[str], str]:
+    """Split ``site:<domain>`` operators out of a web-search query.
+
+    Returns ``(domains, residual_query)`` where ``domains`` is the
+    order-preserving, de-duplicated list of domains referenced by ``site:``
+    tokens (scheme stripped, lower-cased) and ``residual_query`` is the query
+    with those tokens removed and whitespace collapsed.
+
+    When no ``site:`` operator is present, ``domains`` is empty and
+    ``residual_query`` is the whitespace-collapsed input. This lets providers
+    with a native domain filter (e.g. Exa ``include_domains``) apply it
+    natively instead of shipping ``site:`` to the backend as a literal term.
+    """
+    if not query:
+        return [], ""
+    domains: list[str] = []
+    for match in _SITE_OPERATOR_RE.finditer(query):
+        dom = match.group(1).strip().strip("\"'").rstrip("/")
+        dom = re.sub(r"^https?://", "", dom, flags=re.IGNORECASE).lower()
+        if dom and dom not in domains:
+            domains.append(dom)
+    residual = " ".join(_SITE_OPERATOR_RE.sub("", query).split())
+    return domains, residual
+
+
 def _web_extract_url(value: Any) -> Optional[str]:
     """Return a usable URL from a model-supplied extract item.
 


### PR DESCRIPTION
Noticed `site:nature.com CRISPR`-style queries were going to the search providers as a literal string instead of being treated as an operator.

For Exa, that means the `site:` token gets sent as part of the search text and the native `include_domains` filter never gets used — results come back with empty/degraded highlights. For Tavily, the operator is honored inline but the default `basic` search depth frequently returns empty `content` snippets for domain-scoped queries.

Added a small shared `parse_site_operator()` helper in `tools/web_tools.py` that pulls `site:` tokens out of a query into a domain list plus the residual query text. Exa now passes the residual query + `include_domains` natively. Tavily keeps sending the full query as before (it already parses `site:` inline fine) but bumps to `search_depth="advanced"` only when a site scope is present, so ordinary queries are untouched.

Test file covers the parser itself (leading/mid-query/multiple operators, scheme-stripping, dedup) plus both providers' wiring.