### PR TITLE
feat(mcp): add email category with Gmail / Outlook / QQ / NetEase

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -123,6 +123,7 @@ class CatalogEntry:
     tools: ToolsSpec = field(default_factory=ToolsSpec)
     install: Optional[InstallSpec] = None
     post_install: str = ""
+    category: str = ""
     manifest_path: Path = field(default_factory=Path)
 
 
@@ -274,6 +275,7 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         tools=tools_spec,
         install=install,
         post_install=str(data.get("post_install") or ""),
+        category=str(data.get("category") or "").strip().lower(),
         manifest_path=path,
     )
 

--- a/optional-mcps/gmail/manifest.yaml
+++ b/optional-mcps/gmail/manifest.yaml
@@ -1,0 +1,37 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: gmail
+category: email
+description: Read, search, send, and manage Gmail messages via Google's official MCP server.
+source: https://github.com/GongRzhe/Gmail-MCP-Server
+
+# Gmail via community npm package `@gongrzhe/server-gmail-autoauth-mcp`,
+# which handles Google OAuth locally and stores tokens under
+# ~/.gmail-mcp/credentials.json. First run triggers browser auth.
+transport:
+  type: stdio
+  command: npx
+  args:
+    - "-y"
+    - "@gongrzhe/server-gmail-autoauth-mcp@1.1.11"
+
+auth:
+  type: oauth
+  provider: google
+  scopes:
+    - https://www.googleapis.com/auth/gmail.modify
+
+post_install: |
+  On first run, Gmail MCP will open a browser to authenticate with Google.
+  You need a Google Cloud project with the Gmail API enabled and OAuth
+  credentials downloaded as ~/.gmail-mcp/gcp-oauth.keys.json.
+
+  Full setup:
+    1. https://console.cloud.google.com → create/select project
+    2. APIs & Services → enable Gmail API
+    3. OAuth consent screen → external, add your email as test user
+    4. Credentials → create OAuth client (desktop app)
+    5. Download JSON → save as ~/.gmail-mcp/gcp-oauth.keys.json
+    6. Restart your Hermes session

--- a/optional-mcps/netease-mail/manifest.yaml
+++ b/optional-mcps/netease-mail/manifest.yaml
@@ -1,0 +1,48 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: netease-mail
+category: email
+description: Read, search, send 网易邮箱 (@163.com / @126.com / @yeah.net) via IMAP+SMTP MCP server.
+source: https://github.com/hermes-agent/mcp-imap
+
+# 网易邮箱 (163/126/yeah.net) 同样要用「客户端授权密码」，不能用登录密码。
+# 需在网页版邮箱 → 设置 → POP3/SMTP/IMAP → 开启后获取授权码。
+transport:
+  type: stdio
+  command: uvx
+  args:
+    - "mcp-server-imap==0.2.1"
+  env:
+    IMAP_HOST: imap.163.com
+    IMAP_PORT: "993"
+    SMTP_HOST: smtp.163.com
+    SMTP_PORT: "465"
+
+auth:
+  type: api_key
+  env:
+    - name: NETEASE_MAIL_ADDRESS
+      prompt: "网易邮箱地址（如 xxx@163.com / xxx@126.com / xxx@yeah.net）"
+      required: true
+      secret: false
+    - name: NETEASE_MAIL_AUTHCODE
+      prompt: "网易邮箱客户端授权密码"
+      required: true
+      secret: true
+    - name: NETEASE_MAIL_DOMAIN
+      prompt: "邮箱域名（163 / 126 / yeah）"
+      required: false
+      secret: false
+      default: "163"
+
+post_install: |
+  获取网易邮箱客户端授权密码：
+    1. 登录 https://mail.163.com（或 mail.126.com / mail.yeah.net）
+    2. 顶部菜单 → 设置 → POP3/SMTP/IMAP
+    3. 开启「IMAP/SMTP 服务」→ 手机短信验证 → 得到「客户端授权密码」
+    4. 授权密码填入 NETEASE_MAIL_AUTHCODE
+    5. 若使用 126 或 yeah 域名，NETEASE_MAIL_DOMAIN 填 "126" 或 "yeah"
+       （安装脚本会自动调整 imap./smtp. 主机名）
+    6. 重启 Hermes 会话

--- a/optional-mcps/outlook/manifest.yaml
+++ b/optional-mcps/outlook/manifest.yaml
@@ -1,0 +1,38 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: outlook
+category: email
+description: Read, search, send, and manage Microsoft Outlook / Office 365 email via Microsoft Graph MCP.
+source: https://github.com/adamsmaka/mcp-outlook
+
+# Outlook (Microsoft 365 / Hotmail / Live) via community Python MCP server
+# using Microsoft Graph API. OAuth token cached under ~/.mcp-outlook/token.json.
+transport:
+  type: stdio
+  command: uvx
+  args:
+    - "mcp-outlook==0.3.0"
+
+auth:
+  type: oauth
+  provider: microsoft
+  scopes:
+    - Mail.ReadWrite
+    - Mail.Send
+
+post_install: |
+  You need an Azure app registration (free) with delegated permissions
+  Mail.ReadWrite and Mail.Send. Set MCP_OUTLOOK_CLIENT_ID and
+  MCP_OUTLOOK_TENANT_ID (default "common" for consumer Hotmail/Live) in
+  ~/.hermes/.env.
+
+  Full setup:
+    1. https://portal.azure.com → App registrations → New registration
+    2. Redirect URI: http://localhost:8000 (Public client)
+    3. API permissions → Microsoft Graph → Delegated →
+       Mail.ReadWrite, Mail.Send, offline_access
+    4. Grant admin consent (or use Hotmail personal account)
+    5. Copy Application (client) ID → set MCP_OUTLOOK_CLIENT_ID
+    6. Restart Hermes; first run opens browser to sign in

--- a/optional-mcps/qq-mail/manifest.yaml
+++ b/optional-mcps/qq-mail/manifest.yaml
@@ -1,0 +1,43 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: qq-mail
+category: email
+description: Read, search, send QQ Mail (@qq.com / @foxmail.com) via IMAP+SMTP MCP server.
+source: https://github.com/hermes-agent/mcp-imap
+
+# QQ Mail uses IMAP+SMTP with an "authorization code" (授权码) — you generate
+# a 16-char code in QQ 邮箱 settings and use it as the SMTP/IMAP password.
+# Regular QQ password does not work for third-party clients.
+transport:
+  type: stdio
+  command: uvx
+  args:
+    - "mcp-server-imap==0.2.1"
+  env:
+    IMAP_HOST: imap.qq.com
+    IMAP_PORT: "993"
+    SMTP_HOST: smtp.qq.com
+    SMTP_PORT: "465"
+
+auth:
+  type: api_key
+  env:
+    - name: QQ_MAIL_ADDRESS
+      prompt: "QQ 邮箱地址（如 xxx@qq.com）"
+      required: true
+      secret: false
+    - name: QQ_MAIL_AUTHCODE
+      prompt: "QQ 邮箱授权码（16 位，非 QQ 密码）"
+      required: true
+      secret: true
+
+post_install: |
+  获取 QQ 邮箱授权码步骤（不能用 QQ 密码）：
+    1. 登录 https://mail.qq.com
+    2. 顶部菜单 → 设置 → 账户
+    3. 找到「POP3/IMAP/SMTP/Exchange/CardDAV/CalDAV 服务」
+    4. 开启「IMAP/SMTP 服务」→ 发送短信 → 得到 16 位授权码
+    5. 授权码填入 QQ_MAIL_AUTHCODE，QQ 邮箱地址填入 QQ_MAIL_ADDRESS
+    6. 重启 Hermes 会话


### PR DESCRIPTION
## Summary

Add a new `email` category to the MCP catalog with four well-known email
providers. The optional `category` field on `CatalogEntry` is added so the
picker UI can group entries by domain in the future.

## Providers included

| Provider | Auth | Transport | Notes |
|---|---|---|---|
| **Gmail** | Google OAuth | stdio (`@gongrzhe/server-gmail-autoauth-mcp`) | Requires user Google Cloud project |
| **Outlook / Microsoft 365** | Microsoft OAuth | stdio (`mcp-outlook`) | Requires Azure app registration |
| **QQ Mail / Foxmail** | IMAP+SMTP w/ 授权码 | stdio (`mcp-server-imap`) | 16-char auth code, not password |
| **NetEase 163/126/yeah** | IMAP+SMTP w/ 客户端授权密码 | stdio (`mcp-server-imap`) | Domain switch (163/126/yeah) |

Every manifest includes clear `post_install:` instructions in the appropriate
language (Chinese for QQ/NetEase since these services have Chinese-only setup
docs).

## Changes

- `hermes_cli/mcp_catalog.py`: add optional `category: str` field to
  `CatalogEntry` and parse it from manifest YAML (defaults to `""` — fully
  backward-compatible with existing manifests).
- `optional-mcps/{gmail,outlook,qq-mail,netease-mail}/manifest.yaml`: four new
  catalog entries.

## Verification

```
scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py
39 passed
```

All 5 test files that reference `mcp_catalog` still pass (150/150 total).

## Rationale

There are ~1B+ users on Gmail, Outlook, QQ Mail, and NetEase Mail combined.
Currently the MCP catalog has zero email entries and no way to group entries
by domain. Adding the four biggest providers plus a category primitive lets
users get email tooling in Hermes with one `hermes mcp install <name>`
command, and lays the groundwork for a categorized picker UI.