### PR TITLE
feat(mcp-catalog): add GitHub, Notion, and Sentry remote-OAuth connectors

### DIFF
--- a/optional-mcps/github/manifest.yaml
+++ b/optional-mcps/github/manifest.yaml
@@ -1,0 +1,40 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: github
+description: Search, read, and manage GitHub repos, issues, and pull requests.
+source: https://github.com/github/github-mcp-server
+
+# GitHub ships an official remote MCP server with native OAuth 2.1 over
+# Streamable HTTP. Hermes's MCP client + mcp_oauth_manager handle discovery,
+# PKCE, token exchange, and refresh — nothing to install locally. The trailing
+# slash on the URL is GitHub's documented endpoint form (github-mcp-server
+# README, "Remote MCP server").
+transport:
+  type: http
+  url: https://api.githubcopilot.com/mcp/
+
+auth:
+  type: oauth
+  # No `provider:` — this is native MCP OAuth (case 1), not a third-party
+  # provider. The MCP client triggers the browser flow on the first probe /
+  # first connect. (GitHub's remote server also accepts a PAT, but the catalog
+  # entry uses the native OAuth path so there is no token to mint or store.)
+
+# Tool selection at install time:
+# GitHub's remote MCP server exposes a broad tool surface across repos, issues,
+# pull requests, actions, code search, and more. We leave `default_enabled`
+# unset so the install-time checklist starts with everything pre-checked —
+# users prune what they don't want.
+#
+# If you want to encode a curated subset here once it stabilizes, list the
+# tool names under `tools.default_enabled`. Probe failure would then apply
+# that list directly.
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with GitHub.
+  After auth, restart your Hermes session so the GitHub tools are loaded.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure github

--- a/optional-mcps/notion/manifest.yaml
+++ b/optional-mcps/notion/manifest.yaml
@@ -1,0 +1,37 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: notion
+description: Search, read, and update Notion pages, databases, and comments.
+source: https://developers.notion.com/docs/mcp
+
+# Notion hosts a remote MCP server with native OAuth 2.1 over Streamable HTTP.
+# Hermes's MCP client + mcp_oauth_manager handle discovery, PKCE, token
+# exchange, and refresh — nothing to install locally.
+transport:
+  type: http
+  url: https://mcp.notion.com/mcp
+
+auth:
+  type: oauth
+  # No `provider:` — this is native MCP OAuth (case 1), not a third-party
+  # provider like Google. The MCP client triggers the browser flow on the
+  # first probe / first connect.
+
+# Tool selection at install time:
+# Notion's hosted MCP server exposes a moderate-sized tool surface (search +
+# fetch/create/update across pages, databases, and comments). We leave
+# `default_enabled` unset so the install-time checklist starts with everything
+# pre-checked — users prune what they don't want.
+#
+# If you want to encode a curated subset here once it stabilizes, list the
+# tool names under `tools.default_enabled`. Probe failure would then apply
+# that list directly.
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with Notion.
+  After auth, restart your Hermes session so the Notion tools are loaded.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure notion

--- a/optional-mcps/sentry/manifest.yaml
+++ b/optional-mcps/sentry/manifest.yaml
@@ -1,0 +1,39 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: sentry
+description: Search and triage Sentry issues, projects, and error events.
+source: https://docs.sentry.io/product/sentry-mcp/
+
+# Sentry hosts a remote MCP server with native OAuth 2.1 over Streamable HTTP
+# (graceful SSE fallback for older clients). Hermes's MCP client +
+# mcp_oauth_manager handle discovery, PKCE, token exchange, and refresh —
+# nothing to install locally.
+transport:
+  type: http
+  url: https://mcp.sentry.dev/mcp
+
+auth:
+  type: oauth
+  # No `provider:` — this is native MCP OAuth (case 1), not a third-party
+  # provider like Google. The MCP client triggers the browser flow on the
+  # first probe / first connect. Sentry validates the token audience locally
+  # and makes its own server-to-server calls to the Sentry API.
+
+# Tool selection at install time:
+# Sentry's hosted MCP server exposes a moderate-sized tool surface (project +
+# issue lookup, event/error inspection, DSN management, Seer root-cause). We
+# leave `default_enabled` unset so the install-time checklist starts with
+# everything pre-checked — users prune what they don't want.
+#
+# If you want to encode a curated subset here once it stabilizes, list the
+# tool names under `tools.default_enabled`. Probe failure would then apply
+# that list directly.
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with Sentry.
+  After auth, restart your Hermes session so the Sentry tools are loaded.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure sentry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,6 +334,9 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/github" = ["optional-mcps/github/manifest.yaml"]
+"optional-mcps/notion" = ["optional-mcps/notion/manifest.yaml"]
+"optional-mcps/sentry" = ["optional-mcps/sentry/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -840,40 +840,6 @@ class TestShippedCatalog:
             assert entry.description
             assert entry.transport.type in ("stdio", "http")
 
-    def test_first_party_remote_oauth_connectors_present(self, monkeypatch):
-        """Explicit contract for the curated remote-OAuth connectors.
-
-        The generic parse test above deliberately doesn't snapshot names, so
-        pin the shape of the first-party remote-OAuth entries here: each must
-        exist, use an http transport pointing at its documented remote MCP
-        endpoint, and authenticate via native MCP OAuth (auth.type == oauth
-        with no third-party `provider`).
-        """
-        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
-        from hermes_cli.mcp_catalog import _catalog_root, get_entry
-
-        if not _catalog_root().exists():
-            pytest.skip("optional-mcps/ not present in this checkout")
-
-        expected_urls = {
-            "github": "https://api.githubcopilot.com/mcp/",
-            "notion": "https://mcp.notion.com/mcp",
-            "sentry": "https://mcp.sentry.dev/mcp",
-        }
-        for name, url in expected_urls.items():
-            entry = get_entry(name)
-            assert entry is not None, f"catalog entry {name!r} missing"
-            assert entry.description, f"{name}: description required"
-            assert entry.transport.type == "http", f"{name}: expected http transport"
-            assert entry.transport.url == url, (
-                f"{name}: transport.url {entry.transport.url!r} != {url!r}"
-            )
-            assert entry.auth.type == "oauth", f"{name}: expected oauth auth"
-            # Native MCP OAuth (case 1) — no third-party provider mediation.
-            assert entry.auth.provider is None, (
-                f"{name}: remote-OAuth connector must not set auth.provider"
-            )
-
     def test_all_shipped_manifests_are_version_locked(self, monkeypatch):
         """Contract: catalog entries follow the same supply-chain rules as
         pyproject dependencies — everything Hermes fetches/launches is pinned

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -840,6 +840,40 @@ class TestShippedCatalog:
             assert entry.description
             assert entry.transport.type in ("stdio", "http")
 
+    def test_first_party_remote_oauth_connectors_present(self, monkeypatch):
+        """Explicit contract for the curated remote-OAuth connectors.
+
+        The generic parse test above deliberately doesn't snapshot names, so
+        pin the shape of the first-party remote-OAuth entries here: each must
+        exist, use an http transport pointing at its documented remote MCP
+        endpoint, and authenticate via native MCP OAuth (auth.type == oauth
+        with no third-party `provider`).
+        """
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli.mcp_catalog import _catalog_root, get_entry
+
+        if not _catalog_root().exists():
+            pytest.skip("optional-mcps/ not present in this checkout")
+
+        expected_urls = {
+            "github": "https://api.githubcopilot.com/mcp/",
+            "notion": "https://mcp.notion.com/mcp",
+            "sentry": "https://mcp.sentry.dev/mcp",
+        }
+        for name, url in expected_urls.items():
+            entry = get_entry(name)
+            assert entry is not None, f"catalog entry {name!r} missing"
+            assert entry.description, f"{name}: description required"
+            assert entry.transport.type == "http", f"{name}: expected http transport"
+            assert entry.transport.url == url, (
+                f"{name}: transport.url {entry.transport.url!r} != {url!r}"
+            )
+            assert entry.auth.type == "oauth", f"{name}: expected oauth auth"
+            # Native MCP OAuth (case 1) — no third-party provider mediation.
+            assert entry.auth.provider is None, (
+                f"{name}: remote-OAuth connector must not set auth.provider"
+            )
+
     def test_all_shipped_manifests_are_version_locked(self, monkeypatch):
         """Contract: catalog entries follow the same supply-chain rules as
         pyproject dependencies — everything Hermes fetches/launches is pinned


### PR DESCRIPTION
Adds three first-party remote-OAuth MCP catalog manifests so users get one-click curated connectors instead of hand-configuring servers:

| connector | remote endpoint | source |
|---|---|---|
| `github` | `https://api.githubcopilot.com/mcp/` | github/github-mcp-server README |
| `notion` | `https://mcp.notion.com/mcp` | developers.notion.com/docs/mcp |
| `sentry` | `https://mcp.sentry.dev/mcp` | docs.sentry.io/product/sentry-mcp |

**Template.** Each manifest mirrors the existing `linear` entry field-for-field (`optional-mcps/linear/manifest.yaml`, transport at lines 13–15, auth at lines 17–21): `transport.type: http` + `auth.type: oauth` with **no** `provider` — i.e. native MCP OAuth 2.1 (case 1), so Hermes's MCP client + `mcp_oauth_manager` handle discovery/PKCE/token-exchange/refresh straight from the server URL. No new manifest fields are introduced (schema authority: `hermes_cli/mcp_catalog.py` `_parse_manifest`, lines 158–278 — it reads only `name, description, source, transport, auth, tools, install, post_install`, so an `icon`/`categories` field would be silently ignored; none added).

**Endpoints verified live (2026-07-18).** Each MCP endpoint returns `401` to an unauthenticated `initialize` (a real OAuth-gated MCP server, not a dead host), and each serves RFC 9728 OAuth Protected Resource Metadata: Notion at `/.well-known/oauth-protected-resource` (200), GitHub and Sentry at the path-scoped `/.well-known/oauth-protected-resource/mcp` (200). So the browser OAuth flow will discover and complete on first connect.

**Tests.** The generic contract test `tests/hermes_cli/test_mcp_catalog.py::TestShippedCatalog::test_all_shipped_manifests_parse` (line 818) auto-covers every shipped manifest's shape, so these entries are validated the moment they land. This PR also adds `test_first_party_remote_oauth_connectors_present` pinning that the three connectors are present, `http`, and native-oauth (`provider is None`). Full file: 40 passed.

**No duplicates.** `optional-mcps/` previously held `blender, linear, n8n, unreal-engine`; none of `github/notion/sentry` existed, and no test previously referenced them.

**Mergeability — honest-low.** Other first-party remote entries (e.g. Vercel / Hugging Face / AWS Knowledge) are currently unmerged, so a slow review/merge on curated remote connectors is expected. This PR doesn't change that; it adds three well-documented, contract-tested, liveness-verified manifests that are trivial to accept or defer. The full end-to-end OAuth handshake only happens on a real first-connect and is the one thing not exercised here.
