### PR TITLE
fix(auxiliary): resolve key_env in _resolve_task_provider_model (#66641)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6253,6 +6253,13 @@ def _resolve_task_provider_model(
         cfg_model = str(task_config.get("model", "")).strip() or None
         cfg_base_url = str(task_config.get("base_url", "")).strip() or None
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
+        # Resolve key_env → env var when api_key is not set directly
+        if not cfg_api_key:
+            cfg_key_env = str(
+                task_config.get("key_env") or task_config.get("api_key_env") or ""
+            ).strip()
+            if cfg_key_env:
+                cfg_api_key = os.getenv(cfg_key_env, "").strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
     # 'auto' is a sentinel meaning "inherit from main runtime / auto-detect", not


### PR DESCRIPTION
## Summary

`_resolve_task_provider_model()` read `api_key` from the auxiliary task config but never consulted `key_env` (or `api_key_env`). When a user configured an auxiliary task with `key_env` instead of a plaintext `api_key`, the resolved API key was `None`, causing 401 on every call.

**Root cause:** `cfg_api_key` was only read from `task_config.get("api_key", "")`. The `key_env` → `os.getenv()` resolution pattern already existed in two other places in the same file (`_fallback_entry_api_key()` and named custom provider resolution) but was missing from the top-level `_resolve_task_provider_model()`.

## Change

- Added `key_env`/`api_key_env` → `os.getenv()` fallback in `_resolve_task_provider_model()` right after reading `cfg_api_key`, matching the existing pattern used elsewhere in the file.

```diff
agent/auxiliary_client.py | 7 +++++++
 1 file changed, 7 insertions(+)
```

## Verification

- `python3 -m py_compile agent/auxiliary_client.py` passes cleanly
- The fix mirrors the same `key_env`/`api_key_env` fallback pattern already proven in `_fallback_entry_api_key()` (L4291) and named custom provider resolution (L5047)

Closes #66641

/cc @hanjunwp
