### PR TITLE
fix(qqbot): add return_exceptions=True to asyncio.gather in chunked upload

### DIFF
--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -599,4 +599,7 @@ async def _run_with_concurrency(
         async with sem:
             await thunk()
 
-    await asyncio.gather(*(_wrap(t) for t in tasks))
+    results = await asyncio.gather(*(_wrap(t) for t in tasks), return_exceptions=True)
+    errors = [r for r in results if isinstance(r, BaseException)]
+    if errors:
+        raise errors[0]


### PR DESCRIPTION
## Summary

Add `return_exceptions=True` to the `asyncio.gather()` call in `_run_with_concurrency` used by the QQBot chunked file upload pipeline.

## Problem

The `asyncio.gather()` at gateway/platforms/qqbot/chunked_upload.py:602 had no `return_exceptions=True`. When uploading a multi-part file, if any single part upload failed (network error, server rejection, etc.), `gather()` would cancel all other concurrent uploads rather than letting them finish, wasting bandwidth and potentially leaving the upload in an inconsistent state. This is the same pattern already fixed in trajectory_compressor (PR #65932), context_references (PR #62902), and feishu (PR #64864).

## Fix

- Pass `return_exceptions=True` to `asyncio.gather()` so each part upload runs to completion regardless of sibling failures.
- Collect any exceptions from results and re-raise the first one, preserving the existing `-> None` return contract of `_run_with_concurrency`.

## Testing
- Syntax check passed (py_compile)
- Behavior verified