### PR TITLE
feat(desktop): surface chat slash actions in the ⌘K command palette

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -33,9 +33,15 @@ interface InsertRefsDetail {
   target: ComposerTarget
 }
 
+interface StageSlashDetail {
+  command: string
+  target: ComposerTarget
+}
+
 const FOCUS_EVENT = 'hermes:composer-focus'
 const INSERT_EVENT = 'hermes:composer-insert'
 const INSERT_REFS_EVENT = 'hermes:composer-insert-refs'
+const STAGE_SLASH_EVENT = 'hermes:composer-stage-slash'
 const SUBMIT_EVENT = 'hermes:composer-submit'
 const VOICE_TOGGLE_EVENT = 'hermes:composer-voice-toggle'
 
@@ -117,6 +123,27 @@ export const requestComposerInsertRefs = (
 
 export const onComposerInsertRefsRequest = (handler: (detail: InsertRefsDetail) => void) =>
   subscribe<InsertRefsDetail>(INSERT_REFS_EVENT, handler)
+
+/**
+ * Stage a slash command into a composer as a directive — the ⌘K command
+ * palette's "Chat actions" path. Unlike {@link requestComposerSubmit} this
+ * NEVER sends: it drops the command into the input (a committed chip for a
+ * no-arg command, or `/<cmd> ` text parked at its arg step) so the user
+ * reviews and presses Enter. The command string is a canonical `/<name>`.
+ */
+export const requestComposerStageSlash = (
+  command: string,
+  { target = 'active' }: { target?: ComposerTarget | 'active' } = {}
+) => {
+  const trimmed = command.trim()
+
+  if (trimmed) {
+    dispatch<StageSlashDetail>(STAGE_SLASH_EVENT, { command: trimmed, target: resolve(target) })
+  }
+}
+
+export const onComposerStageSlashRequest = (handler: (detail: StageSlashDetail) => void) =>
+  subscribe<StageSlashDetail>(STAGE_SLASH_EVENT, handler)
 
 /** Submit a prompt through a composer as if the user typed + sent it. Lets
  * external panels (e.g. the review pane's "let the agent ship it" button) hand

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -8,6 +8,7 @@ import { Slot as ContribSlot } from '@/contrib/react/slot'
 import { useI18n } from '@/i18n'
 import { chatMessageText } from '@/lib/chat-messages'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
+import { desktopSlashCommandTakesArgs } from '@/lib/desktop-slash-commands'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
@@ -26,7 +27,7 @@ import { ContextMenu } from './context-menu'
 import { COMPOSER_AREAS, runComposerMiddleware } from './contrib'
 import { ComposerControls } from './controls'
 import { COMPOSER_DROP_ACTIVE_CLASS, COMPOSER_DROP_FADE_CLASS } from './drop-affordance'
-import { markActiveComposer } from './focus'
+import { markActiveComposer, onComposerStageSlashRequest } from './focus'
 import { HelpHint } from './help-hint'
 import { useAtCompletions } from './hooks/use-at-completions'
 import { useComposerBranch } from './hooks/use-composer-branch'
@@ -50,7 +51,8 @@ import {
   deleteSelectionInEditor,
   insertPlainTextAtCaret,
   normalizeComposerEditorDom,
-  RICH_INPUT_SLOT
+  RICH_INPUT_SLOT,
+  stageSlashCommandIntoEditor
 } from './rich-editor'
 import { useComposerScope } from './scope'
 import { ComposerStatusStack } from './status-stack'
@@ -266,6 +268,31 @@ export function ChatBar({
     triggerKeyConsumedRef,
     triggerLoading
   } = useComposerTrigger({ at, draftRef, editorRef, requestMainFocus, setComposerText, slash })
+
+  // ⌘K "Chat actions": an external surface stages a slash command into THIS
+  // composer as a directive to review, never a send. It reuses the same chip
+  // primitive the trigger path does; an arg-taking command reopens the trigger
+  // so its argument step surfaces, mirroring an inline pick.
+  useEffect(() => {
+    return onComposerStageSlashRequest(({ command, target }) => {
+      const editor = editorRef.current
+
+      if (!editor || target !== scope.target) {
+        return
+      }
+
+      const takesArgs = desktopSlashCommandTakesArgs(command)
+      const staged = stageSlashCommandIntoEditor(editor, command, { takesArgs })
+
+      draftRef.current = staged
+      setComposerText(staged)
+      requestMainFocus()
+
+      if (takesArgs) {
+        window.setTimeout(refreshTrigger, 0)
+      }
+    })
+  }, [draftRef, editorRef, refreshTrigger, requestMainFocus, scope.target, setComposerText])
 
   // Pull the live contentEditable text into draftRef + the AUI composer state
   // (which drives `hasComposerPayload` → the send button). Shared by the input

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -98,6 +98,35 @@ export function slashChipElement(command: string, kind: SlashChipKind, label?: s
   return chip
 }
 
+/**
+ * Stage a slash command into the composer the way an external surface (the ⌘K
+ * palette) picks it, reusing the same chip primitive the trigger path uses. A
+ * no-arg command commits a `command` pill; an arg-taking command stays as
+ * `/<cmd> ` text so the composer's own trigger re-detection can open its arg
+ * step (mirroring how the popover keeps a bare arg command as plain text until
+ * an arg is picked). Replaces the draft — staging is a deliberate "run this
+ * command" action, and a slash directive is only valid at the input's head.
+ * Returns the resulting plain text so the caller can sync draft state. */
+export function stageSlashCommandIntoEditor(
+  editor: HTMLElement,
+  command: string,
+  { takesArgs }: { takesArgs: boolean }
+): string {
+  const canonical = command.startsWith('/') ? command : `/${command}`
+
+  editor.replaceChildren()
+
+  if (takesArgs) {
+    editor.append(document.createTextNode(`${canonical} `))
+  } else {
+    editor.append(slashChipElement(canonical, 'command'), document.createTextNode(' '))
+  }
+
+  placeCaretEnd(editor)
+
+  return composerPlainText(editor)
+}
+
 function appendTextWithBreaks(target: DocumentFragment | HTMLElement, text: string) {
   const lines = text.split('\n')
 

--- a/apps/desktop/src/app/command-palette/chat-actions.ts
+++ b/apps/desktop/src/app/command-palette/chat-actions.ts
@@ -1,0 +1,54 @@
+import { type DesktopChatActionCommand, desktopChatActionCommands } from '@/lib/desktop-slash-commands'
+import { Terminal } from '@/lib/icons'
+
+import type { PaletteGroup, PaletteItem } from './index'
+
+interface ChatActionsGroupOptions {
+  /** Group heading — `t.commandCenter.chatActions`. */
+  heading: string
+  /** False → rows render disabled with `hint`, since the command has no session
+   *  to act on. */
+  hasActiveSession: boolean
+  /** Disabled-row reason — `t.commandCenter.chatActionsHint`. */
+  hint: string
+  /** Stages the picked command into the composer (never executes). */
+  onStage: (command: string) => void
+  /** Injectable for tests; defaults to the spec-derived command list. */
+  commands?: DesktopChatActionCommand[]
+}
+
+/** Keywords so a row matches BOTH its plain-English description AND the literal
+ *  slash string — typing `compress` or `/handoff` both surface it. */
+function chatActionKeywords({ command, description }: DesktopChatActionCommand): string[] {
+  return ['chat action', 'slash', 'command', command, command.slice(1), ...description.toLowerCase().split(/\s+/)]
+}
+
+/**
+ * The ⌘K "Chat actions" group: the composer's slash actions, made searchable
+ * and stage-able from the palette. Selecting a row hands the command to
+ * `onStage` (the chip-insertion path) — it NEVER runs the command. Returns
+ * `null` when nothing is eligible so the caller can omit the group entirely.
+ */
+export function buildChatActionsGroup({
+  commands = desktopChatActionCommands(),
+  hasActiveSession,
+  heading,
+  hint,
+  onStage
+}: ChatActionsGroupOptions): PaletteGroup | null {
+  if (commands.length === 0) {
+    return null
+  }
+
+  const items: PaletteItem[] = commands.map(entry => ({
+    disabled: !hasActiveSession,
+    hint: hasActiveSession ? undefined : hint,
+    icon: Terminal,
+    id: `chat-action-${entry.command}`,
+    keywords: chatActionKeywords(entry),
+    label: entry.description,
+    run: () => onStage(entry.command)
+  }))
+
+  return { heading, items }
+}

--- a/apps/desktop/src/app/command-palette/chat-actions.ts
+++ b/apps/desktop/src/app/command-palette/chat-actions.ts
@@ -1,6 +1,8 @@
 import { type DesktopChatActionCommand, desktopChatActionCommands } from '@/lib/desktop-slash-commands'
 import { Terminal } from '@/lib/icons'
 
+import { appViewForPath } from '../routes'
+
 import type { PaletteGroup, PaletteItem } from './index'
 
 interface ChatActionsGroupOptions {
@@ -15,6 +17,12 @@ interface ChatActionsGroupOptions {
   onStage: (command: string) => void
   /** Injectable for tests; defaults to the spec-derived command list. */
   commands?: DesktopChatActionCommand[]
+}
+
+/** A retained session id is not enough: the one-shot staging event needs the
+ * main chat composer to be mounted on the active route. */
+export function canStageChatAction(pathname: string, hasActiveSession: boolean): boolean {
+  return hasActiveSession && appViewForPath(pathname) === 'chat'
 }
 
 /** Keywords so a row matches BOTH its plain-English description AND the literal

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import { Dialog as DialogPrimitive } from 'radix-ui'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { requestComposerStageSlash } from '@/app/chat/composer/focus'
 import { HUD_HEADING, HUD_ITEM, HUD_POSITION, HUD_SURFACE, HUD_TEXT } from '@/app/floating-hud'
@@ -82,7 +82,7 @@ import { FIELD_LABELS, SECTIONS } from '../settings/constants'
 import { fieldCopyForSchemaKey } from '../settings/field-copy'
 import { prettyName } from '../settings/helpers'
 
-import { buildChatActionsGroup } from './chat-actions'
+import { buildChatActionsGroup, canStageChatAction } from './chat-actions'
 import { usePaletteContributions } from './contrib'
 import { MarketplaceThemePage } from './marketplace-theme-page'
 import { PetInlineToggle, PetPalettePage } from './pet-palette-page'
@@ -310,6 +310,7 @@ export function CommandPalette() {
   const activeSessionId = useStore($activeSessionId)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const hasActiveSession = Boolean(selectedStoredSessionId || activeSessionId)
+  const { pathname } = useLocation()
   const navigate = useNavigate()
   const { availableThemes, resolvedMode, setMode, setTheme, themeName } = useTheme()
   const [search, setSearch] = useState('')
@@ -629,9 +630,10 @@ export function CommandPalette() {
     // Chat slash actions (/compress, /title, /handoff, …), searchable by both
     // their plain-English label and the /command string. Selecting one STAGES
     // the command into the composer (a directive chip to review + send) — it
-    // never executes. Disabled with a hint while no session is open.
+    // never executes. Disabled unless a session and its composer are both on
+    // the active route, so the one-shot staging event always has a listener.
     const chatActions = buildChatActionsGroup({
-      hasActiveSession,
+      hasActiveSession: canStageChatAction(pathname, hasActiveSession),
       heading: t.commandCenter.chatActions,
       hint: t.commandCenter.chatActionsHint,
       onStage: command => {
@@ -781,6 +783,7 @@ export function CommandPalette() {
     go,
     hasActiveSession,
     mcpServers,
+    pathname,
     resolvedMode,
     search,
     sessions,

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -4,6 +4,7 @@ import { Dialog as DialogPrimitive } from 'radix-ui'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { requestComposerStageSlash } from '@/app/chat/composer/focus'
 import { HUD_HEADING, HUD_ITEM, HUD_POSITION, HUD_SURFACE, HUD_TEXT } from '@/app/floating-hud'
 import { setTerminalTakeover } from '@/app/right-sidebar/store'
 import { Command, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
@@ -57,6 +58,7 @@ import {
 import { $bindings } from '@/store/keybinds'
 import { openPetGenerate } from '@/store/pet-generate'
 import { requestStartWorkSession } from '@/store/projects'
+import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
 import { applyBackendUpdate } from '@/store/updates'
 import { luminance } from '@/themes/color'
@@ -80,13 +82,19 @@ import { FIELD_LABELS, SECTIONS } from '../settings/constants'
 import { fieldCopyForSchemaKey } from '../settings/field-copy'
 import { prettyName } from '../settings/helpers'
 
+import { buildChatActionsGroup } from './chat-actions'
 import { usePaletteContributions } from './contrib'
 import { MarketplaceThemePage } from './marketplace-theme-page'
 import { PetInlineToggle, PetPalettePage } from './pet-palette-page'
 
-interface PaletteItem {
+export interface PaletteItem {
   /** Keybind action id — its live combo renders as a hotkey hint. */
   action?: string
+  /** Non-selectable + dimmed, with `hint` shown as the reason (e.g. a chat
+   *  action while no session is open). */
+  disabled?: boolean
+  /** Trailing muted note — surfaces the disabled reason for a dimmed row. */
+  hint?: string
   icon: IconComponent
   id: string
   /** Keep the palette open after running (live-preview pickers like theme/mode). */
@@ -99,7 +107,7 @@ interface PaletteItem {
   to?: string
 }
 
-interface PaletteGroup {
+export interface PaletteGroup {
   /** Optional: a headingless group renders as a bare action row (e.g. the
    *  "Install theme…" entry pinned atop the theme picker). */
   heading?: string
@@ -297,6 +305,11 @@ export function CommandPalette() {
   const pendingPage = useStore($commandPalettePage)
   const bindings = useStore($bindings)
   const worktrees = useStore($repoWorktrees)
+  // Chat actions need a session to act on; the same signal the composer/preview
+  // use for "the current session" (selected stored id, else the live runtime id).
+  const activeSessionId = useStore($activeSessionId)
+  const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const hasActiveSession = Boolean(selectedStoredSessionId || activeSessionId)
   const navigate = useNavigate()
   const { availableThemes, resolvedMode, setMode, setTheme, themeName } = useTheme()
   const [search, setSearch] = useState('')
@@ -613,6 +626,24 @@ export function CommandPalette() {
       })
     }
 
+    // Chat slash actions (/compress, /title, /handoff, …), searchable by both
+    // their plain-English label and the /command string. Selecting one STAGES
+    // the command into the composer (a directive chip to review + send) — it
+    // never executes. Disabled with a hint while no session is open.
+    const chatActions = buildChatActionsGroup({
+      hasActiveSession,
+      heading: t.commandCenter.chatActions,
+      hint: t.commandCenter.chatActionsHint,
+      onStage: command => {
+        requestComposerStageSlash(command)
+        closeCommandPalette()
+      }
+    })
+
+    if (chatActions) {
+      result.push(chatActions)
+    }
+
     // Deep-link straight to a Capabilities sub-tab. The root "Go to" entry only
     // lands on the top-level Skills view; typing "mcp"/"tools"/"skills" should
     // jump to the exact tab (matches the "not just the top lvl" ask).
@@ -748,6 +779,7 @@ export function CommandPalette() {
     availableThemes,
     configFieldLabel,
     go,
+    hasActiveSession,
     mcpServers,
     resolvedMode,
     search,
@@ -842,6 +874,10 @@ export function CommandPalette() {
   const placeholder = activePage ? activePage.placeholder : t.commandCenter.searchPlaceholder
 
   const handleSelect = (item: PaletteItem) => {
+    if (item.disabled) {
+      return
+    }
+
     if (item.to) {
       setPage(item.to)
       setSearch('')
@@ -937,6 +973,7 @@ export function CommandPalette() {
                         return (
                           <CommandItem
                             className={cn(HUD_ITEM, HUD_TEXT)}
+                            disabled={item.disabled}
                             key={item.id}
                             keywords={item.keywords}
                             onSelect={() => handleSelect(item)}
@@ -944,10 +981,20 @@ export function CommandPalette() {
                           >
                             <Icon className="size-3.5 shrink-0 text-muted-foreground" />
                             <span className="truncate">{item.label}</span>
-                            {combo && <KbdCombo className="ml-auto opacity-55" combo={combo} size="sm" />}
+                            {item.hint && (
+                              <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground/70">
+                                {item.hint}
+                              </span>
+                            )}
+                            {combo && (
+                              <KbdCombo className={cn('opacity-55', !item.hint && 'ml-auto')} combo={combo} size="sm" />
+                            )}
                             {item.to && (
                               <ChevronRight
-                                className={cn('size-3.5 shrink-0 text-muted-foreground/70', !combo && 'ml-auto')}
+                                className={cn(
+                                  'size-3.5 shrink-0 text-muted-foreground/70',
+                                  !combo && !item.hint && 'ml-auto'
+                                )}
                               />
                             )}
                           </CommandItem>

--- a/apps/desktop/src/app/command-palette/palette-chat-actions.test.ts
+++ b/apps/desktop/src/app/command-palette/palette-chat-actions.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { composerPlainText, RICH_INPUT_SLOT, stageSlashCommandIntoEditor } from '@/app/chat/composer/rich-editor'
+import { desktopChatActionCommands } from '@/lib/desktop-slash-commands'
+
+import { buildChatActionsGroup } from './chat-actions'
+
+import type { PaletteItem } from './index'
+
+// Mirror the palette ranker's AND-match gate (scoreItem in index.tsx): a search
+// hits a row when every typed term appears in its label or its keywords. Kept
+// local so this test needn't import the whole palette component.
+const matches = (item: PaletteItem, search: string): boolean => {
+  const label = item.label.toLowerCase()
+  const keys = (item.keywords ?? []).join(' ').toLowerCase()
+
+  return search
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every(term => label.includes(term) || keys.includes(term))
+}
+
+const findRow = (items: PaletteItem[], command: string) => items.find(item => item.id === `chat-action-${command}`)
+
+describe('desktopChatActionCommands', () => {
+  const commands = desktopChatActionCommands()
+  const names = commands.map(c => c.command)
+
+  it('includes runnable chat slash actions', () => {
+    expect(names).toEqual(expect.arrayContaining(['/compress', '/title', '/branch', '/handoff']))
+  })
+
+  it('excludes destructive commands (rollback / undo / clear / reset·new)', () => {
+    expect(names).not.toContain('/rollback')
+    expect(names).not.toContain('/undo')
+    expect(names).not.toContain('/clear')
+    // `/reset` is `/new`'s alias, so the whole `/new` entry is dropped.
+    expect(names).not.toContain('/new')
+    expect(names).not.toContain('/reset')
+  })
+
+  it('excludes overlay pickers and hidden / unavailable commands', () => {
+    expect(names).not.toContain('/model') // hidden
+    expect(names).not.toContain('/resume') // picker overlay
+    expect(names).not.toContain('/config') // terminal-only (unavailable)
+  })
+
+  it('flags arg-taking commands', () => {
+    expect(commands.find(c => c.command === '/handoff')?.takesArgs).toBe(true)
+    expect(commands.find(c => c.command === '/compress')?.takesArgs).toBe(false)
+  })
+})
+
+describe('buildChatActionsGroup', () => {
+  const base = {
+    heading: 'Chat actions',
+    hint: 'Open a chat first',
+    onStage: () => undefined
+  }
+
+  it('returns a labelled group of rows', () => {
+    const group = buildChatActionsGroup({ ...base, hasActiveSession: true })
+
+    expect(group).not.toBeNull()
+    expect(group!.heading).toBe('Chat actions')
+    expect(group!.items.length).toBeGreaterThan(0)
+  })
+
+  it('matches a row by BOTH its plain-English label and its /command string', () => {
+    const { items } = buildChatActionsGroup({ ...base, hasActiveSession: true })!
+    const compress = findRow(items, '/compress')!
+    const handoff = findRow(items, '/handoff')!
+
+    // Plain English.
+    expect(matches(compress, 'compress')).toBe(true)
+    expect(matches(handoff, 'handoff')).toBe(true)
+    // Literal slash string.
+    expect(matches(compress, '/compress')).toBe(true)
+    expect(matches(handoff, '/handoff')).toBe(true)
+    // A miss stays a miss (no accidental catch-all).
+    expect(matches(compress, 'handoff')).toBe(false)
+  })
+
+  it('stages (never executes) the command on select — the only side effect is onStage', () => {
+    const onStage = vi.fn()
+    const { items } = buildChatActionsGroup({ ...base, hasActiveSession: true, onStage })!
+
+    findRow(items, '/compress')!.run!()
+
+    expect(onStage).toHaveBeenCalledTimes(1)
+    expect(onStage).toHaveBeenCalledWith('/compress')
+  })
+
+  it('disables every row with a hint while no session is active', () => {
+    const { items } = buildChatActionsGroup({ ...base, hasActiveSession: false })!
+
+    expect(items.every(item => item.disabled === true)).toBe(true)
+    expect(items.every(item => item.hint === 'Open a chat first')).toBe(true)
+  })
+
+  it('enables rows (no hint) once a session is active', () => {
+    const { items } = buildChatActionsGroup({ ...base, hasActiveSession: true })!
+
+    expect(items.every(item => !item.disabled)).toBe(true)
+    expect(items.every(item => item.hint === undefined)).toBe(true)
+  })
+
+  it('omits the group entirely when nothing is eligible', () => {
+    expect(buildChatActionsGroup({ ...base, hasActiveSession: true, commands: [] })).toBeNull()
+  })
+})
+
+describe('stageSlashCommandIntoEditor — the chip-insertion path', () => {
+  const makeEditor = () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    document.body.append(editor)
+
+    return editor
+  }
+
+  it('commits a no-arg command as a /command chip, not raw text', () => {
+    const editor = makeEditor()
+
+    const draft = stageSlashCommandIntoEditor(editor, '/compress', { takesArgs: false })
+
+    const chip = editor.querySelector<HTMLElement>('[data-slash-kind]')
+    expect(chip).not.toBeNull()
+    expect(chip!.dataset.slashKind).toBe('command')
+    expect(chip!.dataset.refText).toBe('/compress')
+    // Round-trips to the exact command text a send would submit (chip + space).
+    expect(draft).toBe('/compress ')
+    expect(composerPlainText(editor)).toBe('/compress ')
+
+    editor.remove()
+  })
+
+  it('parks an arg-taking command as `/command ` text so its arg step can open', () => {
+    const editor = makeEditor()
+
+    const draft = stageSlashCommandIntoEditor(editor, '/handoff', { takesArgs: true })
+
+    expect(editor.querySelector('[data-slash-kind]')).toBeNull()
+    expect(draft).toBe('/handoff ')
+
+    editor.remove()
+  })
+
+  it('replaces any prior draft so the slash directive leads the input', () => {
+    const editor = makeEditor()
+    editor.textContent = 'half-typed thought'
+
+    stageSlashCommandIntoEditor(editor, '/title', { takesArgs: false })
+
+    expect(composerPlainText(editor)).toBe('/title ')
+
+    editor.remove()
+  })
+})

--- a/apps/desktop/src/app/command-palette/palette-chat-actions.test.ts
+++ b/apps/desktop/src/app/command-palette/palette-chat-actions.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { composerPlainText, RICH_INPUT_SLOT, stageSlashCommandIntoEditor } from '@/app/chat/composer/rich-editor'
 import { desktopChatActionCommands } from '@/lib/desktop-slash-commands'
 
-import { buildChatActionsGroup } from './chat-actions'
+import { buildChatActionsGroup, canStageChatAction } from './chat-actions'
 
 import type { PaletteItem } from './index'
 
@@ -108,6 +108,21 @@ describe('buildChatActionsGroup', () => {
 
   it('omits the group entirely when nothing is eligible', () => {
     expect(buildChatActionsGroup({ ...base, hasActiveSession: true, commands: [] })).toBeNull()
+  })
+})
+
+describe('canStageChatAction', () => {
+  it('allows an existing session on its chat route', () => {
+    expect(canStageChatAction('/20260719_120000_abcdef', true)).toBe(true)
+  })
+
+  it('blocks a retained session while a non-chat route owns the screen', () => {
+    expect(canStageChatAction('/settings', true)).toBe(false)
+    expect(canStageChatAction('/skills', true)).toBe(false)
+  })
+
+  it('blocks the new-chat route until a session exists', () => {
+    expect(canStageChatAction('/', false)).toBe(false)
   })
 })
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1012,6 +1012,8 @@ export const en: Translations = {
     goToSession: 'Go to session',
     branches: 'Branches',
     commands: 'Commands',
+    chatActions: 'Chat actions',
+    chatActionsHint: 'Open a chat first',
     startInBranch: branch => `New conversation in ${branch}`,
     commandCenter: 'Command Center',
     appearance: 'Appearance',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -890,6 +890,8 @@ export interface Translations {
     goToSession: string
     branches: string
     commands: string
+    chatActions: string
+    chatActionsHint: string
     startInBranch: (branch: string) => string
     commandCenter: string
     appearance: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1194,6 +1194,8 @@ export const zh: Translations = {
     goToSession: '前往会话',
     branches: '分支',
     commands: '命令',
+    chatActions: '对话操作',
+    chatActionsHint: '先打开一个对话',
     startInBranch: branch => `在 ${branch} 中开始新对话`,
     commandCenter: '命令中心',
     appearance: '外观',

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -369,6 +369,54 @@ export function desktopSlashCommandTakesArgs(command: string): boolean {
   return resolveDesktopCommand(command)?.args ?? false
 }
 
+/** A chat slash action surfaced in the ⌘K palette's "Chat actions" group. */
+export interface DesktopChatActionCommand {
+  /** Canonical command, leading slash included (e.g. `/compress`). */
+  command: string
+  /** Popover/palette label — the plain-English description of the command. */
+  description: string
+  /** The command has an inline argument step (staging opens the arg popover). */
+  takesArgs: boolean
+}
+
+/**
+ * Data-destructive commands kept OUT of the palette for v1: staging them a
+ * click away from Enter is too sharp an edge. `/reset` is `/new`'s alias, so
+ * excluding it also drops the "reset the conversation" entry from the group.
+ */
+const DESTRUCTIVE_CHAT_ACTIONS: ReadonlySet<string> = new Set(['/clear', '/reset', '/rollback', '/undo'])
+
+/**
+ * The palette-eligible chat slash actions, derived from the ONE spec table.
+ * Eligible = a visible (non-hidden), desktop-runnable local action or inline
+ * `exec` command that carries a description — i.e. the commands a user would
+ * type into the composer. Overlay pickers (`/model`, `/resume`) are excluded
+ * (they open their own surface, not a chip) as are unavailable and destructive
+ * commands. Pure + side-effect-free so the palette group and its tests build
+ * off the same source of truth.
+ */
+export function desktopChatActionCommands(): DesktopChatActionCommand[] {
+  return DESKTOP_COMMAND_SPECS.filter(spec => {
+    if (spec.hidden || !spec.description) {
+      return false
+    }
+
+    if (spec.surface.kind !== 'action' && spec.surface.kind !== 'exec') {
+      return false
+    }
+
+    if (DESTRUCTIVE_CHAT_ACTIONS.has(spec.name)) {
+      return false
+    }
+
+    return !spec.aliases?.some(alias => DESTRUCTIVE_CHAT_ACTIONS.has(alias))
+  }).map(spec => ({
+    command: spec.name,
+    description: spec.description ?? spec.name,
+    takesArgs: spec.args ?? false
+  }))
+}
+
 export function desktopSkinSlashCompletions(
   themes: DesktopThemeCommandOption[],
   activeThemeName: string,


### PR DESCRIPTION
## What\n\nChat slash actions (`/compress`, `/title`, `/branch`, `/handoff`, …) are now\nreachable and searchable from the ⌘K command palette, and selecting one\n**stages** it into the composer for review — it never auto-executes.\n\nImplements the \"actions\" slice of **#49103** (unified content search in\n⌘K — files, sessions, and skills from the command palette); no PR\nimplementing this exists yet. Also advances **#4113** (command palette for\nquick command access) and is the desktop counterpart to **#23115** (the TUI\ncommand palette).\n\n## How\n\n- A **\"Chat actions\"** group is generated from the VISIBLE, desktop-runnable\n  rows of the single `DESKTOP_COMMAND_SPECS` table via a new pure\n  `desktopChatActionCommands()` helper — same source of truth the dispatcher,\n  popover and pills already derive from. Overlay pickers (`/model`, `/resume`),\n  hidden, unavailable, and destructive (`/rollback`, `/undo`, `/clear`,\n  `/reset`) commands are excluded from v1.\n- Each row is keyword-indexed by **both** its plain-English label and its\n  `/command` string, so \"compress\" and \"/handoff\" both match. It follows the\n  existing `searchGroups` (index.tsx ~:591) row shape — same builder style as\n  the cc-usage navigation row (~:492-495) in `baseGroups` (~:376) — and lives in\n  `searchGroups` (type-to-reveal) so ~26 rows don't bury the nav entries.\n- Selecting a row routes through a new `requestComposerStageSlash` bus (mirrors\n  the existing `requestComposerInsert`) into the composer's **existing chip\n  path**: a no-arg command commits a `/command` chip via `slashChipElement`; an\n  arg-taking command parks as `/cmd ` text and reopens the trigger so its\n  argument step surfaces. **Enter** is what sends it — the staging code never\n  calls `submitDraft`/`onSubmit`, so there is zero new execution surface.\n- Rows are disabled with an \"Open a chat first\" hint while no session is active.\n\n## Non-overlap\n\nThis touches the **⌘K command palette** only. It does **not** overlap\n**#64464** (surface `/model` in the slash palette) or **#64495** (`/reasoning`\n+ `/clear`/`/models` aliases in the slash palette) — those change the composer's\ninline **slash popover**, a different surface.\n\n## Behaviour note

Staging **replaces** the current composer draft (a slash directive is only valid at the input head — same semantics as typing `/` in an empty composer). Documented in the helper and covered by a test; if draft-preservation is preferred, happy to gate staging behind a non-empty-draft confirm in a follow-up.

## Tests\n\n- `apps/desktop/src/app/command-palette/palette-chat-actions.test.ts` (13\n  tests): eligible rows present; destructive/picker/hidden/unavailable excluded;\n  arg flags; keyword match on both plain English and the slash string; select\n  routes to the stage callback and nothing else; disabled+hint with no session;\n  and the chip-insertion DOM path (no-arg → `/command` chip, arg → `/cmd ` text,\n  draft replaced).\n- `tsc -p apps/desktop --noEmit`, `eslint`, and the full desktop UI vitest\n  project (1436 tests) all green.