### PR TITLE
feat(desktop): auto-connect OAuth catalog installs and render post_install notes

### DIFF
--- a/apps/desktop/src/app/skills/mcp-tab.test.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.test.tsx
@@ -77,7 +77,20 @@ afterEach(() => {
 })
 
 describe('McpCatalog install → OAuth chaining', () => {
-  it('chains an oauth+http install straight into the desktop OAuth flow', async () => {
+  it('refreshes immediately, then refreshes again after OAuth succeeds', async () => {
+    const approvedFlow = {
+      flow_id: 'f1',
+      server_name: 'linear',
+      status: 'approved',
+      authorization_url: null,
+      error: null,
+      tools: [{ name: 'create_issue', description: 'Create an issue' }]
+    }
+
+    let approve: ((flow: typeof approvedFlow) => void) | undefined
+    completeMcpDesktopOAuth.mockImplementation(
+      () => new Promise<typeof approvedFlow>(resolve => (approve = resolve))
+    )
     const { McpCatalog } = await import('./mcp-tab')
     const onInstalled = vi.fn()
     render(<McpCatalog entries={[entry()]} loading={false} onInstalled={onInstalled} />)
@@ -90,7 +103,27 @@ describe('McpCatalog install → OAuth chaining', () => {
     await waitFor(() =>
       expect(completeMcpDesktopOAuth).toHaveBeenCalledWith(expect.objectContaining({ serverName: 'linear' }))
     )
-    await waitFor(() => expect(onInstalled).toHaveBeenCalled())
+    await waitFor(() => expect(onInstalled).toHaveBeenCalledTimes(1))
+    expect((screen.getByRole('button', { name: 'Install' }) as HTMLButtonElement).disabled).toBe(false)
+
+    approve?.(approvedFlow)
+
+    await waitFor(() => expect(onInstalled).toHaveBeenCalledTimes(2))
+  })
+
+  it('does not hold install completion behind persistent authorization_required polling', async () => {
+    // Models completeMcpDesktopOAuth continuing to poll an authorization_required
+    // flow after the user closes or abandons the browser.
+    completeMcpDesktopOAuth.mockImplementation(() => new Promise(() => undefined))
+    const { McpCatalog } = await import('./mcp-tab')
+    const onInstalled = vi.fn()
+    render(<McpCatalog entries={[entry()]} loading={false} onInstalled={onInstalled} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install' }))
+
+    await waitFor(() => expect(completeMcpDesktopOAuth).toHaveBeenCalled())
+    await waitFor(() => expect(onInstalled).toHaveBeenCalledTimes(1))
+    expect((screen.getByRole('button', { name: 'Install' }) as HTMLButtonElement).disabled).toBe(false)
   })
 
   it('does not launch OAuth for a non-oauth entry', async () => {

--- a/apps/desktop/src/app/skills/mcp-tab.test.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.test.tsx
@@ -1,0 +1,172 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as HermesApi from '@/hermes'
+import type { McpCatalogEntry } from '@/types/hermes'
+
+const installMcpCatalogEntry = vi.fn()
+const getActionStatus = vi.fn()
+const authMcpServer = vi.fn()
+const getMcpOAuthFlow = vi.fn()
+const completeMcpDesktopOAuth = vi.fn()
+const notify = vi.fn()
+const notifyError = vi.fn()
+
+// Partial-mock @/hermes: only the four calls the install→OAuth chain exercises
+// are stubbed. The rest stay real because sibling modules (e.g. @/store/profile)
+// touch other exports at import time — a full mock would drop those and crash.
+vi.mock('@/hermes', async importOriginal => {
+  const actual = await importOriginal<typeof HermesApi>()
+
+  return {
+    ...actual,
+    authMcpServer: (name: string) => authMcpServer(name),
+    getActionStatus: (name: string, lines?: number) => getActionStatus(name, lines),
+    getMcpOAuthFlow: (flowId: string) => getMcpOAuthFlow(flowId),
+    installMcpCatalogEntry: (name: string, env?: Record<string, string>) => installMcpCatalogEntry(name, env)
+  }
+})
+
+vi.mock('@/lib/mcp-dashboard-oauth', () => ({
+  completeMcpDesktopOAuth: (opts: unknown) => completeMcpDesktopOAuth(opts)
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: (input: unknown) => notify(input),
+  notifyError: (err: unknown, title?: string) => notifyError(err, title)
+}))
+
+function entry(overrides: Partial<McpCatalogEntry> = {}): McpCatalogEntry {
+  return {
+    name: 'linear',
+    description: 'Linear issue tracker',
+    source: 'nous',
+    transport: 'http',
+    auth_type: 'oauth',
+    required_env: [],
+    command: null,
+    args: [],
+    url: 'https://mcp.linear.app/mcp',
+    install_url: null,
+    install_ref: null,
+    bootstrap: [],
+    default_enabled: null,
+    post_install: '',
+    needs_install: false,
+    installed: false,
+    enabled: false,
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  installMcpCatalogEntry.mockResolvedValue({ ok: true, background: false })
+  completeMcpDesktopOAuth.mockResolvedValue({
+    flow_id: 'f1',
+    server_name: 'linear',
+    status: 'approved',
+    authorization_url: null,
+    error: null,
+    tools: [{ name: 'create_issue', description: 'Create an issue' }]
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('McpCatalog install → OAuth chaining', () => {
+  it('chains an oauth+http install straight into the desktop OAuth flow', async () => {
+    const { McpCatalog } = await import('./mcp-tab')
+    const onInstalled = vi.fn()
+    render(<McpCatalog entries={[entry()]} loading={false} onInstalled={onInstalled} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install' }))
+
+    await waitFor(() => expect(installMcpCatalogEntry).toHaveBeenCalledWith('linear', {}))
+    // The auth flow is launched for the just-installed server, reusing the same
+    // completeMcpDesktopOAuth machinery the Servers tab uses for re-auth.
+    await waitFor(() =>
+      expect(completeMcpDesktopOAuth).toHaveBeenCalledWith(expect.objectContaining({ serverName: 'linear' }))
+    )
+    await waitFor(() => expect(onInstalled).toHaveBeenCalled())
+  })
+
+  it('does not launch OAuth for a non-oauth entry', async () => {
+    const { McpCatalog } = await import('./mcp-tab')
+    const onInstalled = vi.fn()
+    render(
+      <McpCatalog
+        entries={[entry({ name: 'postgres', auth_type: 'api_key', transport: 'stdio', url: null })]}
+        loading={false}
+        onInstalled={onInstalled}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install' }))
+
+    await waitFor(() => expect(installMcpCatalogEntry).toHaveBeenCalledWith('postgres', {}))
+    await waitFor(() => expect(onInstalled).toHaveBeenCalled())
+    expect(completeMcpDesktopOAuth).not.toHaveBeenCalled()
+  })
+
+  it('does not launch OAuth for an oauth entry on a non-http transport', async () => {
+    const { McpCatalog } = await import('./mcp-tab')
+    const onInstalled = vi.fn()
+    render(
+      <McpCatalog
+        entries={[entry({ name: 'stdio-oauth', transport: 'stdio' })]}
+        loading={false}
+        onInstalled={onInstalled}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install' }))
+
+    await waitFor(() => expect(installMcpCatalogEntry).toHaveBeenCalledWith('stdio-oauth', {}))
+    await waitFor(() => expect(onInstalled).toHaveBeenCalled())
+    expect(completeMcpDesktopOAuth).not.toHaveBeenCalled()
+  })
+
+  it('keeps the install successful when the chained OAuth fails', async () => {
+    completeMcpDesktopOAuth.mockRejectedValue(new Error('user cancelled'))
+    const { McpCatalog } = await import('./mcp-tab')
+    const onInstalled = vi.fn()
+    render(<McpCatalog entries={[entry()]} loading={false} onInstalled={onInstalled} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install' }))
+
+    // OAuth was attempted and threw...
+    await waitFor(() => expect(completeMcpDesktopOAuth).toHaveBeenCalled())
+    // ...yet the install still resolves: onInstalled fires and the error goes to
+    // notify (connect-later), never to notifyError (which is the install-failed path).
+    await waitFor(() => expect(onInstalled).toHaveBeenCalled())
+    expect(notifyError).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ kind: 'info' }))
+  })
+})
+
+describe('McpCatalog post_install rendering', () => {
+  it('renders setup notes when post_install is present', async () => {
+    const { McpCatalog } = await import('./mcp-tab')
+    render(
+      <McpCatalog
+        entries={[entry({ post_install: 'Grant the OAuth scopes in your Linear settings.' })]}
+        loading={false}
+        onInstalled={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByText('Setup notes')).toBeTruthy()
+    expect(screen.getByText('Grant the OAuth scopes in your Linear settings.')).toBeTruthy()
+  })
+
+  it('omits the setup-notes block when post_install is empty', async () => {
+    const { McpCatalog } = await import('./mcp-tab')
+    render(<McpCatalog entries={[entry({ post_install: '' })]} loading={false} onInstalled={vi.fn()} />)
+
+    await screen.findByRole('button', { name: 'Install' })
+    expect(screen.queryByText('Setup notes')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -1335,7 +1335,7 @@ function CatalogTag({ children }: { children: string }) {
 // The Nous-approved MCP catalog: one-click installs of curated servers, with an
 // inline prompt for any required credentials (never shows stored values). On
 // install the parent refetches config + catalog and reloads live sessions.
-function McpCatalog({
+export function McpCatalog({
   entries,
   loading,
   onInstalled
@@ -1394,6 +1394,36 @@ function McpCatalog({
 
       notify({ kind: 'success', title: m.catalogInstallStarted(entry.name), message: '' })
       setEnvOpenFor(null)
+
+      // An OAuth-over-HTTP connector isn't usable straight after install — the
+      // catalog install only writes config/env, it never mints a token. Chain
+      // straight into the SAME desktop OAuth flow the Servers tab uses for
+      // re-auth (see `authenticate`), so "Install" actually connects. Best-effort:
+      // a cancelled/failed auth leaves the install intact — surface a connect-later
+      // state and let the user finish from the Servers tab's Authenticate action.
+      // The strict `=== 'http'` / `=== 'oauth'` checks are inherently version-skew
+      // safe: a missing/renamed field on an older runtime's catalog just fails the
+      // predicate, so the chain no-ops rather than crashing.
+      if (entry.auth_type === 'oauth' && entry.transport === 'http') {
+        try {
+          const flow = await completeMcpDesktopOAuth({
+            serverName: entry.name,
+            start: authMcpServer,
+            status: getMcpOAuthFlow,
+            openExternal: url => window.hermesDesktop.openExternal(url)
+          })
+
+          notify({
+            kind: 'success',
+            title: m.authenticatedTitle,
+            message: m.authenticatedMessage(entry.name, flow.tools?.length ?? 0)
+          })
+        } catch {
+          // Never fail the install over an auth hiccup — it already succeeded.
+          notify({ kind: 'info', title: m.catalogConnectPending(entry.name), message: '' })
+        }
+      }
+
       onInstalled()
     } catch (err) {
       notifyError(err, m.catalogInstallFailed(entry.name))
@@ -1463,6 +1493,15 @@ function McpCatalog({
                       </label>
                     ))}
                   </div>
+                )}
+                {/* Post-install setup notes (e.g. "grant scopes in the provider
+                    console"). Mirrors the web dashboard's McpPage render. Guarded
+                    for the version-skew case: older runtimes omit `post_install`. */}
+                {entry.post_install && (
+                  <details className="mt-1.5 text-[0.66rem] text-muted-foreground/70">
+                    <summary className="cursor-pointer select-none">{m.catalogSetupNotes}</summary>
+                    <p className="mt-1 whitespace-pre-wrap">{entry.post_install.trim()}</p>
+                  </details>
                 )}
               </div>
               <Button

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -1350,6 +1350,29 @@ export function McpCatalog({
   const [envDrafts, setEnvDrafts] = useState<Record<string, Record<string, string>>>({})
   const [envOpenFor, setEnvOpenFor] = useState<null | string>(null)
 
+  const connectAfterInstall = async (entry: McpCatalogEntry) => {
+    try {
+      const flow = await completeMcpDesktopOAuth({
+        serverName: entry.name,
+        start: authMcpServer,
+        status: getMcpOAuthFlow,
+        openExternal: url => window.hermesDesktop.openExternal(url)
+      })
+
+      notify({
+        kind: 'success',
+        title: m.authenticatedTitle,
+        message: m.authenticatedMessage(entry.name, flow.tools?.length ?? 0)
+      })
+      // OAuth persists post-install auth config, so reconcile catalog/config
+      // once more after approval without holding the install lifecycle open.
+      onInstalled()
+    } catch {
+      // Never fail the install over an auth hiccup: it already succeeded.
+      notify({ kind: 'info', title: m.catalogConnectPending(entry.name), message: '' })
+    }
+  }
+
   const install = async (entry: McpCatalogEntry) => {
     const required = entry.required_env.filter(env => env.required)
     const draft = envDrafts[entry.name] ?? {}
@@ -1395,36 +1418,21 @@ export function McpCatalog({
       notify({ kind: 'success', title: m.catalogInstallStarted(entry.name), message: '' })
       setEnvOpenFor(null)
 
+      // Refresh installed catalog/config immediately and release the row. The
+      // browser OAuth handoff can remain authorization_required for minutes.
+      onInstalled()
+
       // An OAuth-over-HTTP connector isn't usable straight after install — the
       // catalog install only writes config/env, it never mints a token. Chain
       // straight into the SAME desktop OAuth flow the Servers tab uses for
-      // re-auth (see `authenticate`), so "Install" actually connects. Best-effort:
-      // a cancelled/failed auth leaves the install intact — surface a connect-later
-      // state and let the user finish from the Servers tab's Authenticate action.
+      // re-auth (see `authenticate`), so "Install" actually connects. Run it as
+      // a non-blocking follow-up so closing the browser cannot strand the row.
       // The strict `=== 'http'` / `=== 'oauth'` checks are inherently version-skew
       // safe: a missing/renamed field on an older runtime's catalog just fails the
       // predicate, so the chain no-ops rather than crashing.
       if (entry.auth_type === 'oauth' && entry.transport === 'http') {
-        try {
-          const flow = await completeMcpDesktopOAuth({
-            serverName: entry.name,
-            start: authMcpServer,
-            status: getMcpOAuthFlow,
-            openExternal: url => window.hermesDesktop.openExternal(url)
-          })
-
-          notify({
-            kind: 'success',
-            title: m.authenticatedTitle,
-            message: m.authenticatedMessage(entry.name, flow.tools?.length ?? 0)
-          })
-        } catch {
-          // Never fail the install over an auth hiccup — it already succeeded.
-          notify({ kind: 'info', title: m.catalogConnectPending(entry.name), message: '' })
-        }
+        void connectAfterInstall(entry)
       }
-
-      onInstalled()
     } catch (err) {
       notifyError(err, m.catalogInstallFailed(entry.name))
     } finally {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -694,6 +694,8 @@ export const en: Translations = {
       catalogInstalling: 'Installing...',
       catalogInstallStarted: name => `Installing ${name}... applies to new sessions when done.`,
       catalogInstallFailed: name => `Failed to install ${name}`,
+      catalogConnectPending: name => `Installed ${name} — open it in Servers to finish connecting.`,
+      catalogSetupNotes: 'Setup notes',
       catalogEnvPrompt: name => `${name} requires credentials`,
       catalogEnvRequired: 'Fill in the required values before installing.',
       capabilitySummary: (tools, prompts, resources) =>

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -597,6 +597,8 @@ export interface Translations {
       catalogInstalling: string
       catalogInstallStarted: (name: string) => string
       catalogInstallFailed: (name: string) => string
+      catalogConnectPending: (name: string) => string
+      catalogSetupNotes: string
       catalogEnvPrompt: (name: string) => string
       catalogEnvRequired: string
       capabilitySummary: (tools: number, prompts: number, resources: number) => string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -883,6 +883,8 @@ export const zh: Translations = {
       catalogInstalling: '安装中…',
       catalogInstallStarted: name => `正在安装 ${name}… 完成后对新会话生效。`,
       catalogInstallFailed: name => `安装 ${name} 失败`,
+      catalogConnectPending: name => `已安装 ${name} — 请在“服务器”中打开以完成连接。`,
+      catalogSetupNotes: '设置说明',
       catalogEnvPrompt: name => `${name} 需要凭据`,
       catalogEnvRequired: '安装前请填写必需的值。',
       capabilitySummary: (tools, prompts, resources) =>


### PR DESCRIPTION
Two additive fixes to the desktop MCP catalog so an installed OAuth connector actually connects and shows its setup notes — both reusing machinery that already exists on `main`.\n>\n> **1. Install → OAuth auto-launch.** Today `install()` in `apps/desktop/src/app/skills/mcp-tab.tsx` calls `installMcpCatalogEntry` → `POST /api/mcp/catalog/install`, which only writes config/env. For an OAuth-over-HTTP connector that mints no token, so the user has to go find the Servers tab and trigger auth separately. This chains straight into the **existing** desktop OAuth flow — the same `completeMcpDesktopOAuth` the Servers tab already uses for re-auth (`mcp-tab.tsx:583`) — when `entry.auth_type === 'oauth' && entry.transport === 'http'`. Best-effort: a cancelled/failed auth leaves the install intact and surfaces a \"connect to finish\" notification instead of crashing. No new OAuth code; success is persisted server-side and picked up by the existing `onInstalled()` refetch.\n>\n> **2. Render `post_install`.** The desktop catalog card never showed `entry.post_install` even though the type carries it and the API returns it — the web dashboard already renders it (`web/src/pages/McpPage.tsx:860`). Added a truthy-guarded \"Setup notes\" block mirroring that render.\n>\n> Both changes are additive, guard every new field read for the version-skew case (Desktop newer than the runtime it talks to), and touch neither the install API contract nor the OAuth machinery. Complements the connector-catalog work in #66653; independent of the presentation PRs #59692 / #59872.\n>\n> Tests (vitest): oauth+http install chains into the OAuth launch (asserts `completeMcpDesktopOAuth` called with the entry's server name); non-oauth and oauth-on-non-http installs do **not** launch OAuth; an OAuth-launch failure leaves the install succeeded (no throw, routes to the connect-later notify, `onInstalled` still fires); `post_install` renders when present and is absent when empty. `tsc -p apps/desktop --noEmit` clean, eslint clean.