### PR TITLE
fix(ci): timing report crashes on every fork PR (missing token secret)

### DIFF
--- a/scripts/ci/timings_report.py
+++ b/scripts/ci/timings_report.py
@@ -923,11 +923,21 @@ def main():
         with open(args.from_json, encoding="utf-8") as f:
             timings = json.load(f)
     else:
-        token = expect_env("GITHUB_TOKEN")
+        # GITHUB_TOKEN is wired from a repo secret (AUTOFIX_BOT_PAT), which
+        # fork-originated PR runs never receive — so a missing token is the
+        # NORMAL case for community PRs, not a configuration error. Route it
+        # through the same degraded path as any other unavailable-timings
+        # condition instead of crashing (which reddened every fork PR and
+        # spammed contributors with failure mail).
+        token = os.environ.get("GITHUB_TOKEN")
         repo = expect_env("GITHUB_REPOSITORY")
         run_id = expect_env("GITHUB_RUN_ID")
         head_sha = expect_env("GITHUB_SHA")
         try:
+            if not token:
+                raise TimingsUnavailable(
+                    "GITHUB_TOKEN not set (secrets are unavailable to fork PR runs)"
+                )
             timings = collect_timings(token, repo, run_id, head_sha)
         except TimingsUnavailable as e:
             # Observability job: a missing report must never redden the PR.

--- a/tests/ci/test_timings_report.py
+++ b/tests/ci/test_timings_report.py
@@ -1,0 +1,89 @@
+"""Tests for scripts/ci/timings_report.py.
+
+The timing report is an observability job: per its own contract ("a missing
+report must never redden the PR"), any unavailable-timings condition must
+degrade to a placeholder report and exit 0. The load-bearing case is a
+fork-originated PR run, where the AUTOFIX_BOT_PAT-backed GITHUB_TOKEN secret
+is never provided — that must not crash.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "timings_report.py"
+_spec = importlib.util.spec_from_file_location("timings_report", _PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError("Failed to load timings_report.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def _run_main(tmp_path, monkeypatch, argv_extra=()):
+    out_html = tmp_path / "report.html"
+    out_json = tmp_path / "timings.json"
+    out_summary = tmp_path / "summary.md"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "timings_report.py",
+            "--baseline", str(tmp_path / "baseline.json"),
+            "--output", str(out_html),
+            "--json-out", str(out_json),
+            "--summary-out", str(out_summary),
+            *argv_extra,
+        ],
+    )
+    return out_html, out_json, out_summary
+
+
+class TestForkPrTokenAbsence:
+    def test_missing_token_degrades_and_exits_zero(self, tmp_path, monkeypatch):
+        # Fork PR shape: repo/run/sha present, token secret absent.
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_REPOSITORY", "NousResearch/hermes-agent")
+        monkeypatch.setenv("GITHUB_RUN_ID", "123")
+        monkeypatch.setenv("GITHUB_SHA", "deadbeef")
+        out_html, out_json, out_summary = _run_main(tmp_path, monkeypatch)
+
+        with pytest.raises(SystemExit) as excinfo:
+            _mod.main()
+
+        assert excinfo.value.code == 0, (
+            "observability job must never redden the PR when the token secret "
+            "is unavailable (the normal case for fork PR runs)"
+        )
+        # Degraded artifacts are written so the workflow's upload steps succeed.
+        assert "unavailable" in out_html.read_text(encoding="utf-8")
+        assert "unavailable" in out_summary.read_text(encoding="utf-8")
+        # No JSON on purpose: an empty timings file must never be cached as
+        # the main baseline.
+        assert not out_json.exists()
+
+    def test_empty_token_treated_like_missing(self, tmp_path, monkeypatch):
+        # The workflow env-wires the secret even when empty: GITHUB_TOKEN="".
+        monkeypatch.setenv("GITHUB_TOKEN", "")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "NousResearch/hermes-agent")
+        monkeypatch.setenv("GITHUB_RUN_ID", "123")
+        monkeypatch.setenv("GITHUB_SHA", "deadbeef")
+        _run_main(tmp_path, monkeypatch)
+
+        with pytest.raises(SystemExit) as excinfo:
+            _mod.main()
+
+        assert excinfo.value.code == 0
+
+    def test_other_missing_env_still_raises(self, tmp_path, monkeypatch):
+        # Only the token is expected to be absent on forks; a missing
+        # GITHUB_REPOSITORY is a real configuration error and must stay loud.
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        monkeypatch.setenv("GITHUB_RUN_ID", "123")
+        monkeypatch.setenv("GITHUB_SHA", "deadbeef")
+        _run_main(tmp_path, monkeypatch)
+
+        with pytest.raises(ValueError, match="GITHUB_REPOSITORY"):
+            _mod.main()


### PR DESCRIPTION
## Problem

Every fork-originated PR gets a red **CI timing report** job and a failure email. The job wires `GITHUB_TOKEN` from the `AUTOFIX_BOT_PAT` repo secret (`.github/workflows/ci.yml:229`), which fork PR runs never receive, and `expect_env("GITHUB_TOKEN")` (`scripts/ci/timings_report.py:926`) raises **before** reaching the script's own graceful path — the one whose comment says *"a missing report must never redden the PR"* (`:935-943`). Observed on #66646, #66653, #66656 (and presumably every community PR): the required-checks gate passes, but the timing job reddens the run and mails the contributor.

## Fix

Treat a missing/empty token as `TimingsUnavailable` and route it through the existing degraded path: placeholder HTML + summary note, exit 0, and deliberately no JSON (an empty timings file must never be cached as the main baseline — preserving `:941-943`'s invariant). Other missing env vars (`GITHUB_REPOSITORY`, `GITHUB_RUN_ID`, `GITHUB_SHA`) still raise: those are real configuration errors, not the normal fork shape.

## Tests

`tests/ci/test_timings_report.py` (new, follows the `test_classify_changes.py` loader pattern): fork shape (no token) exits 0 with degraded artifacts and no JSON; empty-string token treated as missing (the workflow env-wires the secret even when empty); missing `GITHUB_REPOSITORY` stays loud. Full `tests/ci`: **41 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)