### PR TITLE
feat(gateway): admin-gated cross-source session listing in /resume --all

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3944,8 +3944,23 @@ class GatewaySlashCommandsMixin:
             name = name[1:-1].strip()
 
         async def _list_titled_sessions() -> list[dict]:
-            user_source = source.platform.value if source.platform else None
-            sessions = await self._session_db.list_sessions_rich(source=user_source, limit=10)
+            # Cross-origin FETCH is gated exactly like `/sessions all` (the
+            # enumeration half of the /resume IDOR): `--all` only widens the
+            # query for a configured admin, and _resume_row_visible still
+            # screens every row after the fetch. For everyone else the
+            # listing stays scoped to the caller's own platform, so desktop
+            # (tui/cli) sessions become resumable from a phone only when the
+            # operator explicitly configured allow_admin_from (#41220).
+            cross_origin = allow_all and self._resume_caller_is_admin(source)
+            user_source = (
+                None if cross_origin
+                else (source.platform.value if source.platform else None)
+            )
+            sessions = await self._session_db.list_sessions_rich(
+                source=user_source,
+                exclude_sources=["tool"] if cross_origin else None,
+                limit=10,
+            )
             return [s for s in sessions if s.get("title")][:10]
 
         if not name:
@@ -3961,12 +3976,17 @@ class GatewaySlashCommandsMixin:
                         return t("gateway.resume.matrix_no_named_sessions")
                     return t("gateway.resume.no_named_sessions")
                 lines = [t("gateway.resume.list_header")]
+                caller_source = source.platform.value if source.platform else None
                 for idx, s in enumerate(titled[:10], start=1):
                     title = s["title"]
                     if source.platform == Platform.MATRIX and allow_all:
                         origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
                         if origin:
                             title = f"{title} — {origin.chat_name or origin.chat_id}"
+                    elif allow_all and s.get("source") and s.get("source") != caller_source:
+                        # Cross-origin rows label their surface so an admin can
+                        # tell a desktop (tui/cli) session from a local one.
+                        title = f"{title} — {s['source']}"
                     preview = s.get("preview", "")[:40]
                     preview_part = t("gateway.resume.list_preview_suffix", preview=preview) if preview else ""
                     lines.append(t("gateway.resume.list_item_numbered", index=idx, title=title, preview_part=preview_part))

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -1001,3 +1001,73 @@ class TestSameMatrixRoomThreadScoping:
         row = {"id": "sid_thread_b"}
         caller_thread_a = self._msrc(thread_id="thread-a")
         assert await runner._resume_row_visible(caller_thread_a, row, allow_all=False) is False
+
+
+class TestResumeCrossSourceListing:
+    """#41220: the /resume listing FETCH is platform-scoped unless a configured
+    admin passes --all. The widened fetch is gated on the exact predicate
+    /sessions all uses, and _resume_row_visible still screens every row, so a
+    default install (no allow_admin_from) behaves byte-identically."""
+
+    @staticmethod
+    def _seed_cross_source_db(tmp_path):
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("tg_session", "telegram", user_id="12345", chat_id="67890")
+        db.set_session_title("tg_session", "Telegram Chat")
+        db.create_session("desktop_session", "tui", user_id=None)
+        db.set_session_title("desktop_session", "Desktop Deep Work")
+        db.create_session("tool_session", "tool")
+        db.set_session_title("tool_session", "Tool Noise")
+        db.create_session("current_session_001", "telegram", user_id="12345", chat_id="67890")
+        return db
+
+    @pytest.mark.asyncio
+    async def test_non_admin_all_stays_platform_scoped(self, tmp_path):
+        db = self._seed_cross_source_db(tmp_path)
+        event = _make_event(text="/resume --all")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001",
+                              event=event)
+        runner._resume_caller_is_admin = lambda src: False
+        result = await runner._handle_resume_command(event)
+        assert "Telegram Chat" in result
+        assert "Desktop Deep Work" not in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_admin_without_all_stays_platform_scoped(self, tmp_path):
+        db = self._seed_cross_source_db(tmp_path)
+        event = _make_event(text="/resume")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001",
+                              event=event)
+        runner._resume_caller_is_admin = lambda src: True
+        result = await runner._handle_resume_command(event)
+        assert "Telegram Chat" in result
+        assert "Desktop Deep Work" not in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_admin_all_lists_cross_source_with_label(self, tmp_path):
+        db = self._seed_cross_source_db(tmp_path)
+        event = _make_event(text="/resume --all")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001",
+                              event=event)
+        runner._resume_caller_is_admin = lambda src: True
+        result = await runner._handle_resume_command(event)
+        assert "Telegram Chat" in result
+        assert "Desktop Deep Work" in result
+        # Cross rows are labelled with their surface; same-platform rows aren't.
+        assert "Desktop Deep Work — tui" in result
+        assert "Telegram Chat — " not in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_admin_all_excludes_tool_rows(self, tmp_path):
+        db = self._seed_cross_source_db(tmp_path)
+        event = _make_event(text="/resume --all")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001",
+                              event=event)
+        runner._resume_caller_is_admin = lambda src: True
+        result = await runner._handle_resume_command(event)
+        assert "Tool Noise" not in result
+        db.close()


### PR DESCRIPTION
Fixes #41220.

## Problem

Telegram `/resume` only lists sessions created on Telegram: the no-arg listing hard-filters `list_sessions_rich(source=<caller platform>)` (`gateway/slash_commands.py`, `_list_titled_sessions`), so desktop (tui/cli) sessions living in the same `state.db` are invisible from a phone. #41220 documents the asymmetry precisely: Telegram→Desktop visible, Desktop→Telegram hidden — no way to pick a desktop conversation up from your phone.

## Fix — widen the fetch behind the gate that already exists

The security layer was already in place: `_resume_row_visible` returns True only for a **configured admin** passing `--all`, and `/sessions all` gates its cross-origin fetch on the same predicate (`cross_origin = include_all and self._resume_caller_is_admin(source)`) with the IDOR rationale documented at that site. Only the `/resume` fetch stayed narrow. This PR widens it behind the **identical** predicate:

- Default installs are byte-identical: with no `allow_admin_from` configured the policy's `enabled = bool(admin_ids)` (`gateway/slash_access.py:188`) can never open the gate.
- The cross fetch excludes `source='tool'` rows, matching `/sessions` hygiene.
- Cross rows are labelled with their surface (`Deep Work — tui`) so an admin can tell a desktop session from a local one — mirroring the existing Matrix origin-label precedent in the same renderer. Same-platform rows are unlabelled.
- `_resume_row_visible` still screens every fetched row, and the numeric pick shares the same closure, so the displayed numbering and the resolution can never diverge.

Pairs with the deep-link direction (#66647): `/resume --all` from the phone brings a desktop session to Telegram; a `hermes://session/<id>` link sends it back to the desktop.

## Tests

4 new cases in `tests/gateway/test_resume_command.py` (real `SessionDB`, seeded telegram + tui + tool rows): non-admin `--all` stays platform-scoped; admin without `--all` stays scoped; admin `--all` lists the cross row **with** the source label and local rows without; tool rows excluded. Full resume suite: **56 passed** (52 pre-existing IDOR/visibility tests untouched). With the shared listing suite: **125 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)