### PR TITLE
MUL-292: fix(desktop): restore per-profile sessions on agent switch (BRI-290)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react'
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
 import { respondToApprovalAction } from '@/store/native-notifications'
+import { $activeGatewayProfile } from '@/store/profile'
 import { getRememberedRoute, getRememberedSessionId, setRememberedRoute, setRememberedSessionId } from '@/store/session'
 import { onSessionsChanged } from '@/store/session-sync'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/updates'
@@ -60,10 +61,11 @@ export function useDesktopIntegrations({
   // Remember the open chat (session id for notifications/resume) AND the last
   // non-overlay route (a page like /skills, or a session route) so a relaunch
   // lands where you were. Overlays (settings/command-center/…) aren't stored —
-  // you don't want to boot into a modal.
+  // you don't want to boot into a modal. Key the session by the live gateway
+  // profile so switching agents and back restores the right chat (BRI-290).
   useEffect(() => {
     if (routedSessionId) {
-      setRememberedSessionId(routedSessionId)
+      setRememberedSessionId(routedSessionId, $activeGatewayProfile.get())
     }
 
     if (!isOverlayView(appViewForPath(locationPathname))) {
@@ -75,7 +77,8 @@ export function useDesktopIntegrations({
 
   // Restore once on cold start — only when the renderer booted at the default
   // route (a hidden-then-shown window keeps its own route). Prefer the full
-  // remembered route (covers pages); fall back to the last session id.
+  // remembered route (covers pages); fall back to the last session id for the
+  // active gateway profile.
   useEffect(() => {
     if (restoredRef.current || locationPathname !== NEW_CHAT_ROUTE) {
       restoredRef.current = true
@@ -92,7 +95,7 @@ export function useDesktopIntegrations({
       return
     }
 
-    const last = getRememberedSessionId()
+    const last = getRememberedSessionId($activeGatewayProfile.get())
 
     if (last) {
       navigate(sessionRoute(last), { replace: true })
@@ -100,8 +103,8 @@ export function useDesktopIntegrations({
   }, [locationPathname, navigate])
 
   useEffect(() => {
-    if (resumeExhaustedSessionId && getRememberedSessionId() === resumeExhaustedSessionId) {
-      setRememberedSessionId(null)
+    if (resumeExhaustedSessionId && getRememberedSessionId($activeGatewayProfile.get()) === resumeExhaustedSessionId) {
+      setRememberedSessionId(null, $activeGatewayProfile.get())
     }
   }, [resumeExhaustedSessionId])
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -30,7 +30,7 @@ import { latestSessionTodos } from '@/lib/todos'
 import { setCronFocusJobId } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $filePreviewTarget, $previewTarget } from '@/store/preview'
-import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActiveProfile } from '@/store/profile'
+import { $activeGatewayProfile, $freshSessionRequest, $profileScope, $sessionRestoreRequest, refreshActiveProfile } from '@/store/profile'
 import { $startWorkSessionRequest, followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
 import {
   $activeSessionId,
@@ -419,6 +419,21 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     lastFreshRef.current = freshSessionRequest
     startFreshSessionDraft()
   }, [freshSessionRequest, startFreshSessionDraft])
+
+  // Profile rail switch with a remembered chat: navigate to that stored session
+  // instead of a blank draft so switching agents and back restores the prior
+  // conversation (BRI-290). resumeSession (via the route) rebinds the gateway.
+  const sessionRestoreRequest = useStore($sessionRestoreRequest)
+  const lastRestoreSeqRef = useRef(sessionRestoreRequest?.seq ?? 0)
+
+  useEffect(() => {
+    if (!sessionRestoreRequest || sessionRestoreRequest.seq === lastRestoreSeqRef.current) {
+      return
+    }
+
+    lastRestoreSeqRef.current = sessionRestoreRequest.seq
+    navigate(sessionRoute(sessionRestoreRequest.id))
+  }, [navigate, sessionRestoreRequest])
 
   // Swapping the live gateway to another profile must re-pull that profile's
   // global model + active-profile pill (both are nanostores — the blanket

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -18,8 +18,18 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ queryClient: { invalidateQueries: vi.fn() } }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, $profiles, ensureGatewayProfile, refreshProfiles } = await import('./profile')
-const { $connection } = await import('./session')
+const {
+  $activeGatewayProfile,
+  $freshSessionRequest,
+  $profiles,
+  $sessionRestoreRequest,
+  $showAllProfiles,
+  ensureGatewayProfile,
+  refreshProfiles,
+  selectProfile
+} = await import('./profile')
+const { $connection, $selectedStoredSessionId, getRememberedSessionId, setRememberedSessionId } =
+  await import('./session')
 const { queryClient } = await import('@/lib/query-client')
 const { getProfiles } = await import('@/hermes')
 
@@ -41,6 +51,17 @@ const localConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
 
 const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnection>>()
 
+const memoryStorage = () => {
+  const map = new Map<string, string>()
+
+  return {
+    clear: () => map.clear(),
+    getItem: (key: string) => map.get(key) ?? null,
+    removeItem: (key: string) => void map.delete(key),
+    setItem: (key: string, value: string) => void map.set(key, value)
+  }
+}
+
 beforeEach(() => {
   getConnection.mockReset()
   ensureGatewayForProfile.mockClear()
@@ -48,7 +69,11 @@ beforeEach(() => {
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
   $profiles.set([])
-  vi.stubGlobal('window', { hermesDesktop: { getConnection } })
+  $showAllProfiles.set(false)
+  $selectedStoredSessionId.set(null)
+  $sessionRestoreRequest.set(null)
+  $freshSessionRequest.set(0)
+  vi.stubGlobal('window', { hermesDesktop: { getConnection }, localStorage: memoryStorage() })
   vi.mocked(queryClient.invalidateQueries).mockClear()
   resetStarmapGraph.mockClear()
 })
@@ -132,5 +157,45 @@ describe('refreshProfiles shared rail list (#49289)', () => {
     await expect(refreshProfiles()).rejects.toThrow('backend unavailable')
 
     expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'test1'])
+  })
+})
+
+describe('selectProfile session restore (BRI-290)', () => {
+  it('remembers the open chat under the leaving profile and restores the destination profile chat', () => {
+    $activeGatewayProfile.set('architect-agent')
+    $selectedStoredSessionId.set('sess-arch-1')
+    setRememberedSessionId('sess-builder-1', 'builder-agent')
+    const freshBefore = $freshSessionRequest.get()
+
+    selectProfile('builder-agent')
+
+    expect(getRememberedSessionId('architect-agent')).toBe('sess-arch-1')
+    expect($sessionRestoreRequest.get()?.id).toBe('sess-builder-1')
+    expect($freshSessionRequest.get()).toBe(freshBefore)
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('builder-agent')
+  })
+
+  it('falls back to a fresh draft when the destination profile has no remembered chat', () => {
+    $activeGatewayProfile.set('architect-agent')
+    $selectedStoredSessionId.set('sess-arch-1')
+    const freshBefore = $freshSessionRequest.get()
+
+    selectProfile('builder-agent')
+
+    expect(getRememberedSessionId('architect-agent')).toBe('sess-arch-1')
+    expect($sessionRestoreRequest.get()).toBeNull()
+    expect($freshSessionRequest.get()).toBe(freshBefore + 1)
+  })
+
+  it('is a no-op for chat restore when re-selecting the already-active profile', () => {
+    $activeGatewayProfile.set('architect-agent')
+    $selectedStoredSessionId.set('sess-arch-1')
+    const freshBefore = $freshSessionRequest.get()
+    const restoreBefore = $sessionRestoreRequest.get()
+
+    selectProfile('architect-agent')
+
+    expect($freshSessionRequest.get()).toBe(freshBefore)
+    expect($sessionRestoreRequest.get()).toBe(restoreBefore)
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -12,7 +12,12 @@ import {
   storedStringRecord
 } from '@/lib/storage'
 import { $gateway, ensureGatewayForProfile } from '@/store/gateway'
-import { setConnection } from '@/store/session'
+import {
+  $selectedStoredSessionId,
+  getRememberedSessionId,
+  setConnection,
+  setRememberedSessionId
+} from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
 
@@ -164,6 +169,23 @@ export function requestFreshSession(): void {
   $freshSessionRequest.set($freshSessionRequest.get() + 1)
 }
 
+// Bumped when a profile switch should restore a prior stored session for the
+// destination profile instead of minting a blank draft (BRI-290). Wiring
+// navigates to the session route; resume rebinds the gateway if needed.
+export const $sessionRestoreRequest = atom<{ id: string; seq: number } | null>(null)
+
+export function requestRestoreSession(storedSessionId: string): void {
+  const id = storedSessionId.trim()
+
+  if (!id) {
+    requestFreshSession()
+
+    return
+  }
+
+  $sessionRestoreRequest.set({ id, seq: ($sessionRestoreRequest.get()?.seq ?? 0) + 1 })
+}
+
 // Route profile-scoped REST settings (config/env/skills/tools/model/…) to the
 // profile the live gateway is currently on, and drop cached settings from the
 // previous profile so pages refetch against the right backend. Fires once
@@ -300,14 +322,31 @@ export const $profileScope = computed([$showAllProfiles, $activeGatewayProfile],
 // $activeGatewayProfile → name, so $profileScope follows).
 export function selectProfile(name: string): void {
   const target = normalizeProfileKey(name)
-  // Switching profiles (or coming back from the all-profiles browse view) starts
-  // fresh; re-tapping the profile you're already in leaves your session be.
-  const switching = $showAllProfiles.get() || target !== normalizeProfileKey($activeGatewayProfile.get())
+  const current = normalizeProfileKey($activeGatewayProfile.get())
+  // Switching profiles (or coming back from the all-profiles browse view)
+  // changes context; re-tapping the profile you're already in leaves your
+  // session be.
+  const switching = $showAllProfiles.get() || target !== current
   $showAllProfiles.set(false)
   $newChatProfile.set(target)
 
   if (switching) {
-    requestFreshSession()
+    // Remember the chat we are leaving under the *current* profile so a later
+    // switch-back restores it. Without this, rail switches always land on a
+    // blank draft and the prior conversation looks deleted (BRI-290).
+    const openId = $selectedStoredSessionId.get()
+
+    if (openId) {
+      setRememberedSessionId(openId, current)
+    }
+
+    const restoreId = getRememberedSessionId(target)
+
+    if (restoreId) {
+      requestRestoreSession(restoreId)
+    } else {
+      requestFreshSession()
+    }
   }
 
   void ensureGatewayProfile(target)

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -4,7 +4,16 @@ import { lastVisibleMessageIsUser } from '@/app/chat/thread-loading'
 import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
-import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
+import {
+  persistBoolean,
+  persistString,
+  persistStringRecord,
+  readJson,
+  storedBoolean,
+  storedString,
+  storedStringRecord,
+  writeJson
+} from '@/lib/storage'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
@@ -23,12 +32,75 @@ const COMPOSER_MODEL_SOURCE_KEY = 'hermes.desktop.composer.model-source'
 const COMPOSER_EFFORT_KEY = 'hermes.desktop.composer.reasoning-effort'
 const COMPOSER_FAST_KEY = 'hermes.desktop.composer.fast'
 
-// The last chat the user had open, so a relaunch lands back on it instead of an
-// empty new-chat. Stored (not runtime) id — the route is keyed by stored id.
+// Last open chat, keyed PER PROFILE. Switching agents/profiles must restore the
+// conversation you left on that profile — a single global id made the previous
+// chat look "disappeared" when the rail switched (BRI-290 / hermes#60095 class).
+// Legacy key kept for migration + as a fallback for single-profile cold start.
 const LAST_SESSION_KEY = 'hermes.desktop.lastSessionId'
+const LAST_SESSION_BY_PROFILE_KEY = 'hermes.desktop.lastSessionByProfile.v1'
 
-export const getRememberedSessionId = (): null | string => storedString(LAST_SESSION_KEY)
-export const setRememberedSessionId = (id: null | string) => persistString(LAST_SESSION_KEY, id)
+function normalizeRememberedProfileKey(name: string | null | undefined): string {
+  const value = (name ?? '').trim()
+
+  return value || 'default'
+}
+
+function loadLastSessionByProfile(): Record<string, string> {
+  const fromRecord = storedStringRecord(LAST_SESSION_BY_PROFILE_KEY)
+
+  if (Object.keys(fromRecord).length > 0) {
+    return fromRecord
+  }
+
+  // Older builds wrote a single global id. Promote it into the default slot so
+  // a one-time upgrade still restores the last chat after relaunch.
+  const legacy = storedString(LAST_SESSION_KEY)
+
+  if (legacy) {
+    return { default: legacy }
+  }
+
+  // Tolerate a prior writeJson shape if present.
+  const parsed = readJson<Record<string, string>>(LAST_SESSION_BY_PROFILE_KEY)
+
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    return Object.fromEntries(
+      Object.entries(parsed).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+    )
+  }
+
+  return {}
+}
+
+/** Remembered stored-session id for a profile (defaults to \"default\"). */
+export function getRememberedSessionId(profile?: string | null): null | string {
+  const key = normalizeRememberedProfileKey(profile)
+  const map = loadLastSessionByProfile()
+
+  return map[key] ?? (key === 'default' ? storedString(LAST_SESSION_KEY) : null)
+}
+
+/** Persist the last open stored-session id for a profile. null clears it. */
+export function setRememberedSessionId(id: null | string, profile?: string | null): void {
+  const key = normalizeRememberedProfileKey(profile)
+  const map = loadLastSessionByProfile()
+
+  if (id) {
+    map[key] = id
+  } else {
+    delete map[key]
+  }
+
+  if (Object.keys(map).length === 0) {
+    writeJson(LAST_SESSION_BY_PROFILE_KEY, null)
+    persistString(LAST_SESSION_KEY, null)
+  } else {
+    persistStringRecord(LAST_SESSION_BY_PROFILE_KEY, map)
+    // Mirror the most-recent write into the legacy key so older restore paths
+    // and single-profile cold starts still find something sensible.
+    persistString(LAST_SESSION_KEY, id ?? map[key] ?? Object.values(map)[0] ?? null)
+  }
+}
 
 // The last non-overlay route (a page like /skills, or a session route), so a
 // relaunch lands back where you were instead of a bare new-chat.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3055,10 +3055,35 @@ class SessionDB:
         """
         if not session_id or not task:
             return
-        # FK on session_model_usage.session_id → sessions.id: ensure the row
-        # exists (same INSERT OR IGNORE guard update_token_counts uses — the
-        # initial create_session() can fail under concurrent SQLite locking).
-        self._insert_session_row(session_id, "unknown")
+        # FK on session_model_usage.session_id → sessions.id. Do NOT invent a
+        # ghost sessions row here: when the agent is bound to the wrong profile
+        # DB after a desktop profile switch, INSERT OR IGNORE would plant an
+        # empty source="unknown" shell that steals auto-title and makes the
+        # real conversation look deleted (BRI-290). Drop the aux counters
+        # instead when the owning session row is missing.
+        try:
+            conn = self._conn
+            if conn is None:
+                return
+            with self._lock:
+                exists = conn.execute(
+                    "SELECT 1 FROM sessions WHERE id = ? LIMIT 1",
+                    (session_id,),
+                ).fetchone()
+        except Exception:
+            logger.debug(
+                "record_auxiliary_usage: session existence check failed for %s",
+                session_id,
+                exc_info=True,
+            )
+            return
+        if not exists:
+            logger.debug(
+                "record_auxiliary_usage: skip ghost insert for missing session %s (task=%s)",
+                session_id,
+                task,
+            )
+            return
 
         def _do(conn):
             self._record_model_usage(

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -110,11 +110,16 @@ class TestRecordAuxiliaryUsage:
         db.record_auxiliary_usage("s1", "", input_tokens=5)
         assert _usage_rows(db, "s1") == []
 
-    def test_creates_session_row_if_missing(self, db):
-        """FK safety: recording against a not-yet-created session must not fail."""
+    def test_skips_missing_session_without_creating_ghost(self, db):
+        """BRI-290: never plant an empty source=unknown row for aux usage.
+
+        When the agent is bound to the wrong profile DB after a desktop profile
+        switch, inventing a ghost session steals auto-title and makes the real
+        conversation look deleted. Prefer dropping the aux counters.
+        """
         db.record_auxiliary_usage("ghost", "vision", model="m", input_tokens=5)
-        rows = _usage_rows(db, "ghost")
-        assert len(rows) == 1
+        assert _usage_rows(db, "ghost") == []
+        assert db.get_session("ghost") is None
 
 
 class TestSchemaMigrationV22:


### PR DESCRIPTION
Closes MUL-292

Migrates per-profile session restore, ghost-row fixes, and desktop wiring to upstream hermes-agent.

Original diagnosis and fix (BRI-290/BRI-292) by Brian Spencer.

## Summary
- Remember open chat per profile and restore it on rail switch
- Fix transcript append retry with lock/matcher/cap  
- Stop record_auxiliary_usage from inventing empty ghost rows

## Problem
Switching profiles always forced a blank draft and remembered only one global last-session id, so mid-work chats looked "deleted" when the rail switched.

## Solution
- Store last-session-id per profile and restore it on agent switch
- Fix transcript append retry with proper locking and caps
- Stop auxiliary usage accounting from creating ghost rows in wrong profile DBs

## Files Changed
- `apps/desktop/src/store/session.ts` - per-profile session restore
- `apps/desktop/src/store/profile.ts` - profile store wiring
- `apps/desktop/src/app/contrib/wiring.tsx` - desktop wiring
- `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts` - hooks wiring
- `hermes_state.py` - ghost-row fix
- `tests/hermes_state/test_aux_usage_accounting.py` - test coverage
- `apps/desktop/src/store/profile.test.ts` - test coverage

Fixes sessions appearing "deleted" when switching agents/profiles in Desktop.