### PR TITLE
feat(platforms): Rabbit R1 as a platform plugin (zero core changes)

### DIFF
--- a/plugins/platforms/rabbit_r1/README.md
+++ b/plugins/platforms/rabbit_r1/README.md
@@ -1,0 +1,95 @@
+# Rabbit R1 platform plugin
+
+This plugin connects Hermes Agent to a [Rabbit R1][r1] hardware device. The
+R1 is a pocket AI companion with a 2.88-inch touchscreen and voice output; this
+adapter lets it talk to your own Hermes agent instead of the stock cloud
+assistant.
+
+It ships as a self-contained platform plugin under
+`plugins/platforms/rabbit_r1/` and wires itself into the gateway entirely
+through `ctx.register_platform(...)` — **no core files are modified**.
+
+## Architecture
+
+Unlike webhook or long-poll channels, the R1 dials *in*: the adapter runs a
+**WebSocket server** that the device connects to and speaks the
+OpenClaw/clawdbot-gateway protocol. An optional tunnel (Tailscale Funnel or
+Cloudflare) publishes that server so the R1 can reach it from anywhere, not
+just the home LAN. A QR code printed on startup carries the public URL + auth
+token for one-scan pairing.
+
+```
+                       wss:// (clawdbot-gateway proto)
+┌──────────────────┐  ◄──────────────────────────────►  ┌──────────────────────┐
+│  Rabbit R1        │   pair / message / keepalive        │  RabbitR1Adapter     │
+│  (hardware)       │                                     │  WebSocket server    │
+└──────────────────┘                                      └──────────┬───────────┘
+        ▲   scans QR (public URL + token)                            │ MessageEvent
+        │                                                            ▼
+┌──────────────────┐        Tailscale Funnel /            ┌──────────────────────┐
+│  Terminal QR PNG  │ ◄───── Cloudflare tunnel ─────────► │  Hermes gateway       │
+│  ~/.hermes/…qr.png│           (public URL)              │  (agent core)         │
+└──────────────────┘                                      └──────────────────────┘
+```
+
+- **Inbound**: the device opens a WebSocket, authenticates with a hex token
+  (timing-safe compare + per-IP rate limiting on failures), and streams
+  messages. The adapter normalizes each one into a `MessageEvent` for the
+  gateway.
+- **Outbound**: the agent's reply is sent back over the same socket. Responses
+  are capped at 2000 chars to stay readable on the small screen, and a
+  server→device keepalive (default every 300 s) holds the connection open
+  under the R1's ~30-minute inactivity timeout.
+
+## First-time setup
+
+```bash
+# Optional guided prompts (token, tunnel, port, allowed devices):
+hermes setup rabbit_r1
+
+# Start the gateway — a pairing QR code is printed on startup:
+hermes gateway start
+```
+
+Scan the printed QR code with your R1 to pair. The token is auto-generated if
+you leave it blank; the QR PNG is also saved to `~/.hermes/rabbit_r1_qr.png` so
+you can re-open or share it later.
+
+## Dependencies
+
+```
+websockets   # required — the WebSocket server
+qrcode       # optional — terminal QR code display for pairing
+```
+
+Install with `pip install websockets qrcode`. If `websockets` is missing the
+platform stays hidden from `hermes status`.
+
+## Configuration
+
+All settings are optional and read from the environment (surfaced in
+`hermes setup` / `hermes config` via `plugin.yaml`). Only `RABBIT_R1_TOKEN` is
+a secret.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RABBIT_R1_TOKEN` | auto-generated | 64-char hex auth token the R1 presents when pairing. |
+| `RABBIT_R1_PORT` | `18789` | Local WebSocket server listen port. |
+| `RABBIT_R1_TUNNEL` | `tailscale` | Public tunnel mode: `tailscale`, `cloudflare`, or `none`. |
+| `RABBIT_R1_PUBLIC_URL` | *(auto)* | Explicit `wss://` URL to advertise in the QR code (overrides tunnel auto-detection). |
+| `RABBIT_R1_KEEPALIVE_INTERVAL` | `300` | Seconds between server→device keepalive heartbeats. |
+| `RABBIT_R1_ALLOWED_USERS` | *(any)* | Comma-separated device IDs allowed to talk to the bot. |
+| `RABBIT_R1_ALLOW_ALL_USERS` | `false` | Allow any device without allowlisting (token still required; dev only). |
+| `RABBIT_R1_HOME_CHANNEL` | *(unset)* | Default device ID for cron / notification delivery. |
+
+## Security notes
+
+- **Token auth** is timing-safe (`secrets.compare_digest`) with per-IP rate
+  limiting (5 failures / 300 s) to blunt brute-force attempts.
+- **Device IDs** (64-char hex) are redacted in this adapter's own logs, so the
+  plugin declares `pii_safe=False` to the registry.
+- Cron/out-of-process delivery returns a descriptive error: the R1 is only
+  reachable from the live gateway process that owns the WebSocket server, not
+  from a standalone `hermes` invocation.
+
+[r1]: https://www.rabbit.tech/

--- a/plugins/platforms/rabbit_r1/__init__.py
+++ b/plugins/platforms/rabbit_r1/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/rabbit_r1/adapter.py
+++ b/plugins/platforms/rabbit_r1/adapter.py
@@ -1,0 +1,901 @@
+"""
+Rabbit R1 platform adapter for Hermes Agent (bundled plugin form).
+
+Speaks the OpenClaw/clawdbot-gateway WebSocket protocol so a Rabbit R1
+hardware device can talk to Hermes (full memory, skills, crons) from
+anywhere - not just the home WiFi.
+
+Unlike the official OpenClaw setup (LAN-only), this adapter runs on a VM or
+always-on server behind a tunnel (Tailscale Funnel or Cloudflare Tunnel) so
+the R1 works from any network: home, cellular, travelling.
+
+Architecture::
+
+    R1 (anywhere with internet)
+        v  wss://yourname.ts.net  (TLS via Tailscale Funnel)
+    VM / always-on server
+        v
+    adapter.py  (this file - BasePlatformAdapter subclass)
+        v
+    Hermes gateway -> Claude / local model (full memory, skills, crons)
+
+Protocol reference::
+
+    QR payload:  {"type":"clawdbot-gateway","version":1,"ips":[...],
+                  "port":18789,"token":"<hex32>","protocol":"ws"}
+    Handshake:   connect.challenge -> connect -> node.pair.approved -> connect.ok
+    Chat:        chat.send (R1->server) / chat event (server->R1)
+
+Tunnel options (RABBIT_R1_TUNNEL)::
+
+    tailscale    Tailscale Funnel (default, no extra account)
+    cloudflare   Cloudflare Quick Tunnel (free account, stable URL)
+    none         LAN only (home network)
+
+This adapter registers itself through ``register(ctx)`` and requires **zero
+changes to core Hermes code**. Every integration point the older built-in
+version patched (platform enum, env overrides, auth maps, cron delivery,
+send routing, prompt hint, status/setup/channel-directory) is now supplied
+via ``ctx.register_platform()`` keyword arguments and ``plugin.yaml``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import secrets
+import socket
+import subprocess
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    import websockets
+    from websockets.server import WebSocketServerProtocol
+    WEBSOCKETS_AVAILABLE = True
+except ImportError:
+    WEBSOCKETS_AVAILABLE = False
+    WebSocketServerProtocol = Any  # type: ignore
+
+try:
+    import qrcode
+    QRCODE_AVAILABLE = True
+except ImportError:
+    QRCODE_AVAILABLE = False
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_PORT = 18789
+DEFAULT_KEEPALIVE_INTERVAL = 300  # 5 min - well under the R1's ~30 min idle cap
+DEFAULT_TUNNEL = "tailscale"
+
+# R1 has no hard message length limit, but keep responses readable on the
+# small 2.88-inch screen.
+R1_MAX_MESSAGE_LENGTH = 2000
+
+# 64-char hex device IDs - redacted from this adapter's own log output.
+_R1_DEVICE_ID_RE = re.compile(r"(?<![A-Za-z0-9])[a-f0-9]{64}(?![A-Za-z0-9])")
+
+
+def _redact(text: str) -> str:
+    """Mask 64-char hex device IDs in log strings (plugin-local redaction)."""
+    return _R1_DEVICE_ID_RE.sub("[R1_DEVICE_ID]", str(text))
+
+
+# ---------------------------------------------------------------------------
+# Dependency check
+# ---------------------------------------------------------------------------
+
+def check_requirements() -> bool:
+    """Return True if the required dependencies are available."""
+    if not WEBSOCKETS_AVAILABLE:
+        logger.warning(
+            "Rabbit R1: 'websockets' package not installed. Run: pip install websockets"
+        )
+        return False
+    return True
+
+
+def validate_config(config) -> bool:
+    """Rabbit R1 needs no external credential - the token is auto-generated.
+
+    We just require the websockets dependency to be importable so the
+    adapter can actually stand up its server.
+    """
+    return WEBSOCKETS_AVAILABLE
+
+
+def is_connected(config) -> bool:
+    """Surface in ``hermes status`` / ``get_connected_platforms`` when enabled.
+
+    The platform is considered connected/enabled whenever its dependency is
+    present, since it stands up its own server rather than dialing out to a
+    credentialed service.
+    """
+    return WEBSOCKETS_AVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Tunnel helpers
+# ---------------------------------------------------------------------------
+
+def _get_tailscale_funnel_url(port: int) -> Optional[str]:
+    """Start a Tailscale Funnel on *port* and return the public wss:// URL.
+
+    Returns None if Tailscale is unavailable or the command fails.
+    """
+    try:
+        # Enable funnel for the port (idempotent - safe to call repeatedly).
+        subprocess.run(
+            ["tailscale", "funnel", str(port)],
+            check=True,
+            capture_output=True,
+            timeout=15,
+        )
+        # Get the stable public hostname.
+        result = subprocess.run(
+            ["tailscale", "status", "--json"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        status = json.loads(result.stdout)
+        dns_name = status["Self"]["DNSName"].rstrip(".")
+        return f"wss://{dns_name}"
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+            KeyError, json.JSONDecodeError, FileNotFoundError):
+        return None
+
+
+def _get_cloudflare_tunnel_url(port: int) -> Optional[str]:
+    """Start a Cloudflare Quick Tunnel (trycloudflare.com) and return wss:// URL.
+
+    This is a temporary URL - use Tailscale or a named Cloudflare tunnel for
+    stability.
+    """
+    try:
+        proc = subprocess.Popen(
+            ["cloudflared", "tunnel", "--url", f"http://localhost:{port}"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        # Parse the tunnel URL from cloudflared's stderr output.
+        for _ in range(30):
+            line = proc.stderr.readline()
+            if not line:
+                break
+            match = re.search(r"https://[a-z0-9\-]+\.trycloudflare\.com", line)
+            if match:
+                return match.group(0).replace("https://", "wss://")
+        return None
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+def _now_ms() -> int:
+    """Current time in milliseconds."""
+    return int(time.time() * 1000)
+
+
+def _get_lan_ip() -> str:
+    """Best-effort LAN IP detection for the QR code fallback."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except Exception:
+        return "127.0.0.1"
+
+
+def _resolve_token(config) -> str:
+    """Resolve the auth token from env, config, or auto-generate one."""
+    extra = getattr(config, "extra", {}) or {}
+    return (
+        os.getenv("RABBIT_R1_TOKEN")
+        or getattr(config, "token", None)
+        or extra.get("token")
+        or secrets.token_hex(32)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main adapter
+# ---------------------------------------------------------------------------
+
+class RabbitR1Adapter(BasePlatformAdapter):
+    """
+    Rabbit R1 platform adapter.
+
+    Runs a WebSocket server that speaks the clawdbot-gateway protocol. On
+    startup it optionally opens a Tailscale Funnel or Cloudflare Tunnel so
+    the R1 can reach it from anywhere, then prints a pairing QR code.
+
+    Config env vars:
+        RABBIT_R1_TOKEN     - hex32 auth token (auto-generated if not set)
+        RABBIT_R1_PORT      - WebSocket server port (default: 18789)
+        RABBIT_R1_TUNNEL    - "tailscale" | "cloudflare" | "none"
+        RABBIT_R1_PUBLIC_URL - explicit public wss:// URL (overrides tunnel)
+        RABBIT_R1_KEEPALIVE_INTERVAL - seconds between heartbeats (default 300)
+    """
+
+    MAX_MESSAGE_LENGTH = R1_MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform("rabbit_r1"))
+
+        extra = getattr(config, "extra", {}) or {}
+
+        self._port: int = int(
+            os.getenv("RABBIT_R1_PORT") or extra.get("port") or DEFAULT_PORT
+        )
+        self._tunnel_mode: str = str(
+            os.getenv("RABBIT_R1_TUNNEL") or extra.get("tunnel") or DEFAULT_TUNNEL
+        ).lower()
+
+        self._token: str = _resolve_token(config)
+
+        # Runtime state
+        self._server = None
+        self._public_url: Optional[str] = None
+
+        # device_id -> websocket for connected R1 devices
+        self._clients: Dict[str, WebSocketServerProtocol] = {}
+
+        # Server->R1 keepalive: prevents the R1 from timing out the session
+        # due to inactivity. Default 5 minutes keeps us well under the R1's
+        # ~30-minute inactivity threshold.
+        self._keepalive_interval: int = int(
+            os.getenv("RABBIT_R1_KEEPALIVE_INTERVAL")
+            or extra.get("keepalive_interval")
+            or DEFAULT_KEEPALIVE_INTERVAL
+        )
+        self._keepalive_tasks: Dict[str, asyncio.Task] = {}
+
+        # Rate limiting: track failed auth attempts per IP.
+        self._auth_failures: Dict[str, List[float]] = {}
+        self._max_auth_failures = 5      # max failures per window
+        self._auth_window_secs = 300.0   # 5-minute window
+
+    # ------------------------------------------------------------------
+    # BasePlatformAdapter - required methods
+    # ------------------------------------------------------------------
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Start the WebSocket server and (optionally) open the tunnel."""
+        if not check_requirements():
+            return False
+
+        # Start the tunnel first so we know the public URL for the QR code.
+        self._public_url = await self._start_tunnel()
+
+        # Start the WebSocket server.
+        try:
+            self._server = await websockets.serve(
+                self._handle_connection,
+                "0.0.0.0",
+                self._port,
+            )
+            logger.info("Rabbit R1: WebSocket server listening on port %s", self._port)
+        except OSError as e:
+            logger.error("Rabbit R1: Failed to start WebSocket server: %s", e)
+            return False
+
+        self._mark_connected()
+
+        # Print pairing instructions + QR code to the console.
+        await self._print_pairing_info()
+        return True
+
+    async def disconnect(self) -> None:
+        """Stop the WebSocket server and cancel keepalive tasks."""
+        for device_id in list(self._keepalive_tasks):
+            self._stop_keepalive(device_id)
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        self._clients.clear()
+        self._mark_disconnected()
+        logger.info("Rabbit R1: disconnected")
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a text reply back to the R1 device identified by *chat_id*."""
+        ws = self._clients.get(chat_id)
+        if not ws:
+            return SendResult(success=False, error="Device not connected")
+
+        run_id = str(uuid.uuid4())
+        payload = {
+            "type": "event",
+            "event": "chat",
+            "payload": {
+                "runId": run_id,
+                "sessionKey": "main",
+                "seq": 1,
+                "state": "final",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": content}],
+                    "timestamp": _now_ms(),
+                    "stopReason": "stop",
+                    "usage": {"input": 0, "output": 0, "totalTokens": 0},
+                },
+            },
+        }
+        try:
+            await ws.send(json.dumps(payload))
+            return SendResult(success=True, message_id=run_id)
+        except Exception as e:
+            logger.warning("Rabbit R1: send failed for %s: %s", _redact(chat_id), e)
+            return SendResult(success=False, error=str(e))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Return metadata about the chat (device) identified by *chat_id*."""
+        return {
+            "name": "Rabbit R1",
+            "type": "dm",
+            "chat_id": chat_id,
+            "connected": chat_id in self._clients,
+        }
+
+    def format_message(self, content: str) -> str:
+        """Strip markdown for the R1's small screen (plain-text rendering)."""
+        # Bold / italic
+        content = re.sub(r'\*{1,3}(.+?)\*{1,3}', r'\1', content)
+        content = re.sub(r'_{1,3}(.+?)_{1,3}', r'\1', content)
+        # Links [text](url) -> text (url)
+        content = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'\1 (\2)', content)
+        # Headers
+        content = re.sub(r'^#{1,6}\s+', '', content, flags=re.MULTILINE)
+        # Code fences / inline code
+        content = re.sub(r'```\w*\n?', '', content)
+        content = re.sub(r'`([^`]+)`', r'\1', content)
+        return content.strip()
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """Send a 'thinking' state to the R1 - shows a loading indicator."""
+        ws = self._clients.get(chat_id)
+        if not ws:
+            return
+        payload = {
+            "type": "event",
+            "event": "chat",
+            "payload": {
+                "runId": str(uuid.uuid4()),
+                "sessionKey": "main",
+                "seq": 0,
+                "state": "thinking",
+                "message": {
+                    "role": "assistant",
+                    "content": [],
+                    "timestamp": _now_ms(),
+                },
+            },
+        }
+        try:
+            await ws.send(json.dumps(payload))
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # WebSocket connection handling
+    # ------------------------------------------------------------------
+
+    async def _handle_connection(self, ws, path: str = "/") -> None:
+        """Handle a new WebSocket connection from an R1 device."""
+        remote = f"{ws.remote_address[0]}:{ws.remote_address[1]}"
+        logger.debug("Rabbit R1: new connection from %s", remote)
+
+        # Step 1 - send the challenge immediately.
+        nonce = str(uuid.uuid4())
+        await self._send(ws, {
+            "type": "event",
+            "event": "connect.challenge",
+            "payload": {"nonce": nonce, "ts": _now_ms()},
+        })
+
+        device_id: Optional[str] = None
+        try:
+            async for raw in ws:
+                try:
+                    msg = json.loads(raw)
+                except json.JSONDecodeError:
+                    logger.warning("Rabbit R1: invalid JSON from %s", remote)
+                    continue
+
+                method = msg.get("method") or msg.get("type", "")
+
+                # Pairing / auth handshake
+                if method in ("connect", "gateway.connect"):
+                    device_id = await self._handle_connect(ws, msg, remote)
+                    if device_id is None:
+                        break  # auth failed - connection closed inside handler
+                    continue
+
+                # Drop everything until the device is authenticated.
+                if device_id is None:
+                    logger.warning(
+                        "Rabbit R1: unauthenticated message from %s, ignoring", remote
+                    )
+                    continue
+
+                if method == "chat.send":
+                    await self._handle_chat_send(ws, msg, device_id)
+
+                elif method == "system-presence":
+                    # Heartbeat - just acknowledge it.
+                    await self._send(ws, {
+                        "type": "res",
+                        "id": msg.get("id"),
+                        "ok": True,
+                        "payload": {"ts": _now_ms()},
+                    })
+
+                elif method == "chat.abort":
+                    # Abort an in-progress generation.
+                    await self.cancel_background_tasks()
+                    await self._send(ws, {"type": "res", "id": msg.get("id"), "ok": True})
+
+        except websockets.exceptions.ConnectionClosed:
+            pass
+        finally:
+            if device_id:
+                self._stop_keepalive(device_id)
+                if device_id in self._clients:
+                    del self._clients[device_id]
+                    logger.info("Rabbit R1: device disconnected: %s", _redact(device_id))
+
+    async def _handle_connect(
+        self,
+        ws: WebSocketServerProtocol,
+        msg: dict,
+        remote: str,
+    ) -> Optional[str]:
+        """Validate the token and complete the pairing handshake.
+
+        Returns the device_id on success, None on failure.
+        """
+        msg_id = msg.get("id")
+
+        # Rate-limit: reject if too many recent failures from this IP.
+        ip = remote.rsplit(":", 1)[0]
+        now = time.time()
+        failures = [t for t in self._auth_failures.get(ip, [])
+                    if now - t < self._auth_window_secs]
+        self._auth_failures[ip] = failures
+        if len(failures) >= self._max_auth_failures:
+            logger.warning(
+                "Rabbit R1: rate-limited %s (%d failures in %ss)",
+                remote, len(failures), self._auth_window_secs,
+            )
+            await self._send(ws, {
+                "type": "res",
+                "id": msg_id,
+                "ok": False,
+                "error": {"code": 429, "message": "Too many failed attempts"},
+            })
+            await ws.close()
+            return None
+
+        params = msg.get("params", {})
+
+        # Extract token - R1 sends it at params.auth.token.
+        client_token = (
+            params.get("auth", {}).get("token")
+            or params.get("authToken")
+            or msg.get("token")
+        )
+        # Extract device ID.
+        device_id = (
+            params.get("device", {}).get("id")
+            or params.get("deviceId")
+            or f"r1-{remote}"
+        )
+
+        if not secrets.compare_digest(
+            (client_token or "").encode(), self._token.encode()
+        ):
+            logger.warning("Rabbit R1: auth failed from %s (bad token)", remote)
+            self._auth_failures.setdefault(ip, []).append(now)
+            await self._send(ws, {
+                "type": "res",
+                "id": msg_id,
+                "ok": False,
+                "error": {"code": 401, "message": "Invalid token"},
+            })
+            await ws.close()
+            return None
+
+        # Auth passed - register the device.
+        self._clients[device_id] = ws
+        self._start_keepalive(device_id, ws)
+        logger.info("Rabbit R1: device paired: %s from %s", _redact(device_id), remote)
+
+        await self._send(ws, {
+            "type": "event",
+            "event": "node.pair.approved",
+            "payload": {"deviceId": device_id, "token": str(uuid.uuid4())},
+        })
+        await self._send(ws, {
+            "type": "res",
+            "id": msg_id,
+            "ok": True,
+            "payload": {"status": "paired", "ts": _now_ms()},
+        })
+        await self._send(ws, {
+            "type": "event",
+            "event": "connect.ok",
+            "payload": {"deviceId": device_id, "ts": _now_ms()},
+        })
+        return device_id
+
+    async def _handle_chat_send(
+        self,
+        ws: WebSocketServerProtocol,
+        msg: dict,
+        device_id: str,
+    ) -> None:
+        """Route an incoming chat.send message into the Hermes pipeline."""
+        params = msg.get("params", {})
+        text = (params.get("message") or "").strip()
+        if not text:
+            return
+
+        # Acknowledge immediately so the R1 doesn't time out.
+        await self._send(ws, {"type": "res", "id": msg.get("id"), "ok": True})
+
+        source = self.build_source(
+            chat_id=device_id,
+            chat_name="Rabbit R1",
+            chat_type="dm",
+            user_id=device_id,
+            user_name="R1 User",
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=params.get("idempotencyKey") or str(uuid.uuid4()),
+        )
+        await self.handle_message(event)
+
+    # ------------------------------------------------------------------
+    # Server->R1 keepalive
+    # ------------------------------------------------------------------
+
+    def _start_keepalive(self, device_id: str, ws: WebSocketServerProtocol) -> None:
+        """Start a background task that sends periodic heartbeats to the R1."""
+        self._stop_keepalive(device_id)  # cancel any existing task
+        self._keepalive_tasks[device_id] = asyncio.ensure_future(
+            self._keepalive_loop(device_id, ws)
+        )
+
+    def _stop_keepalive(self, device_id: str) -> None:
+        """Cancel the keepalive task for a device."""
+        task = self._keepalive_tasks.pop(device_id, None)
+        if task and not task.done():
+            task.cancel()
+
+    async def _keepalive_loop(self, device_id: str, ws: WebSocketServerProtocol) -> None:
+        """Send system-presence heartbeats every *_keepalive_interval* seconds."""
+        try:
+            while True:
+                await asyncio.sleep(self._keepalive_interval)
+                await self._send(ws, {
+                    "type": "event",
+                    "event": "system-presence",
+                    "payload": {"ts": _now_ms(), "deviceId": device_id},
+                })
+                logger.debug("Rabbit R1: keepalive sent to %s", _redact(device_id))
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.debug("Rabbit R1: keepalive stopped for %s: %s", _redact(device_id), e)
+
+    # ------------------------------------------------------------------
+    # Tunnel helpers
+    # ------------------------------------------------------------------
+
+    async def _start_tunnel(self) -> Optional[str]:
+        """Start the configured tunnel and return the public wss:// URL."""
+        # Allow hardcoding the public URL via env var - useful when running
+        # as a systemd service where subprocess tunnel detection may fail.
+        explicit_url = os.getenv("RABBIT_R1_PUBLIC_URL")
+        if explicit_url:
+            logger.info("Rabbit R1: using explicit public URL: %s", explicit_url)
+            return explicit_url
+
+        if self._tunnel_mode == "none":
+            return None
+
+        loop = asyncio.get_event_loop()
+
+        if self._tunnel_mode == "tailscale":
+            url = await loop.run_in_executor(None, _get_tailscale_funnel_url, self._port)
+            if url:
+                logger.info("Rabbit R1: Tailscale Funnel active at %s", url)
+            else:
+                logger.warning(
+                    "Rabbit R1: Tailscale Funnel unavailable - R1 will only work "
+                    "on the local network. Run 'tailscale funnel %s' manually or "
+                    "set RABBIT_R1_TUNNEL=none.", self._port,
+                )
+            return url
+
+        if self._tunnel_mode == "cloudflare":
+            url = await loop.run_in_executor(None, _get_cloudflare_tunnel_url, self._port)
+            if url:
+                logger.info("Rabbit R1: Cloudflare Tunnel active at %s", url)
+            else:
+                logger.warning("Rabbit R1: Cloudflare Tunnel unavailable")
+            return url
+
+        logger.warning(
+            "Rabbit R1: Unknown tunnel mode %r, skipping tunnel", self._tunnel_mode
+        )
+        return None
+
+    # ------------------------------------------------------------------
+    # QR code / pairing info
+    # ------------------------------------------------------------------
+
+    def _build_qr_payload(self) -> str:
+        """Build the clawdbot-gateway QR payload JSON string."""
+        if self._public_url:
+            # Strip scheme - the payload uses host + port separately.
+            host = self._public_url.replace("wss://", "").replace("ws://", "")
+            port = 443  # Tailscale/Cloudflare terminate TLS on 443
+        else:
+            host = _get_lan_ip()
+            port = self._port
+        return json.dumps({
+            "type": "clawdbot-gateway",
+            "version": 1,
+            "ips": [host],
+            "port": port,
+            "token": self._token,
+            "protocol": "wss" if self._public_url else "ws",
+        })
+
+    async def _print_pairing_info(self) -> None:
+        """Print pairing instructions and save/print the QR code."""
+        qr_data = self._build_qr_payload()
+
+        # Save QR code as PNG for easy access (avoids terminal truncation).
+        qr_png_path = None
+        if QRCODE_AVAILABLE:
+            try:
+                qr_png_path = os.path.expanduser("~/.hermes/rabbit_r1_qr.png")
+                os.makedirs(os.path.dirname(qr_png_path), exist_ok=True)
+                qrcode.make(qr_data).save(qr_png_path)
+                logger.info("Rabbit R1: QR code saved to %s", qr_png_path)
+            except Exception as e:
+                logger.warning("Rabbit R1: failed to save QR PNG: %s", e)
+                qr_png_path = None
+
+        print("\n" + "=" * 60)
+        print("  Rabbit R1 - Hermes Gateway")
+        print("=" * 60)
+        if self._public_url:
+            print(f"  Public URL : {self._public_url}")
+            print("  Works from : anywhere (home, cellular, travelling)")
+        else:
+            host = _get_lan_ip()
+            print(f"  Local URL  : ws://{host}:{self._port}")
+            print("  Works from : home network only")
+        masked = self._token[:6] + "..." + self._token[-4:]
+        print(f"  Token      : {masked}  (full token in RABBIT_R1_TOKEN env var)")
+        if qr_png_path:
+            print(f"  QR image   : {qr_png_path}")
+        print()
+        print("  Scan the QR code below with your Rabbit R1:")
+        print("  (If the QR code is cut off, open the PNG file above instead)")
+        print()
+
+        if QRCODE_AVAILABLE:
+            qr = qrcode.QRCode(border=1)
+            qr.add_data(qr_data)
+            qr.make(fit=True)
+            qr.print_ascii(invert=True)
+        else:
+            print(f"  QR payload : {qr_data}")
+            print()
+            print("  (Install 'qrcode' for a visual QR code: pip install qrcode)")
+
+        print("=" * 60 + "\n")
+
+    # ------------------------------------------------------------------
+    # Low-level send
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _send(ws: WebSocketServerProtocol, data: dict) -> None:
+        """Send a JSON message, ignoring closed connections."""
+        try:
+            await ws.send(json.dumps(data))
+        except websockets.exceptions.ConnectionClosed:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Plugin hooks
+# ---------------------------------------------------------------------------
+
+def _env_enablement() -> Optional[Dict[str, Any]]:
+    """Auto-seed PlatformConfig.extra from env-only setups.
+
+    Lets ``hermes status`` reflect a Rabbit R1 configuration that lives
+    entirely in ``.env`` without a ``platforms.rabbit_r1`` block in
+    ``config.yaml``. The R1 needs no external credential, so the presence
+    of any RABBIT_R1_* var is treated as an intent to enable.
+    """
+    keys = (
+        "RABBIT_R1_TOKEN", "RABBIT_R1_PORT", "RABBIT_R1_TUNNEL",
+        "RABBIT_R1_PUBLIC_URL", "RABBIT_R1_KEEPALIVE_INTERVAL",
+        "RABBIT_R1_HOME_CHANNEL",
+    )
+    if not any(os.getenv(k) for k in keys):
+        return None
+
+    seeded: Dict[str, Any] = {}
+    if os.getenv("RABBIT_R1_TOKEN"):
+        seeded["token"] = os.environ["RABBIT_R1_TOKEN"]
+    if os.getenv("RABBIT_R1_PORT"):
+        try:
+            seeded["port"] = int(os.environ["RABBIT_R1_PORT"])
+        except ValueError:
+            pass
+    if os.getenv("RABBIT_R1_TUNNEL"):
+        seeded["tunnel"] = os.environ["RABBIT_R1_TUNNEL"]
+    if os.getenv("RABBIT_R1_PUBLIC_URL"):
+        seeded["public_url"] = os.environ["RABBIT_R1_PUBLIC_URL"]
+    if os.getenv("RABBIT_R1_KEEPALIVE_INTERVAL"):
+        try:
+            seeded["keepalive_interval"] = int(os.environ["RABBIT_R1_KEEPALIVE_INTERVAL"])
+        except ValueError:
+            pass
+    if os.getenv("RABBIT_R1_HOME_CHANNEL"):
+        seeded["home_channel"] = os.environ["RABBIT_R1_HOME_CHANNEL"]
+    return seeded or {}
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[List[str]] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    """Out-of-process delivery for cron jobs detached from the gateway.
+
+    The Rabbit R1 adapter is a WebSocket *server*: messages can only be
+    pushed to a device over a live connection owned by the running gateway.
+    A detached cron process holds no such connection, so there is nothing to
+    push to. We return a descriptive error instead of silently failing.
+
+    To deliver to an R1 from cron, run the cron job in the gateway process
+    (the scheduler routes through the live adapter's ``send()`` there).
+    """
+    return {
+        "error": (
+            "Rabbit R1 delivery requires the gateway process (the device "
+            "connects to the gateway's WebSocket server). Run the cron job "
+            "with the gateway active, or use deliver='origin'."
+        )
+    }
+
+
+def interactive_setup() -> None:
+    """Minimal stdin wizard for ``hermes setup rabbit_r1``."""
+    print()
+    print("Rabbit R1 setup")
+    print("---------------")
+    print("The Rabbit R1 adapter runs a WebSocket server your R1 connects to.")
+    print("A tunnel (Tailscale Funnel or Cloudflare) makes it reachable from")
+    print("anywhere. On startup a QR code is printed - scan it with your R1 to")
+    print("pair. The auth token is auto-generated if you leave it blank.")
+    print()
+
+    try:
+        from hermes_cli.config import get_env_var, set_env_var
+    except ImportError:
+        print("hermes_cli.config not available; set RABBIT_R1_* vars manually "
+              "in ~/.hermes/.env")
+        return
+
+    def _prompt(var: str, prompt: str, *, secret: bool = False) -> None:
+        existing = get_env_var(var) if callable(get_env_var) else None
+        suffix = " [keep current]" if existing else ""
+        try:
+            if secret:
+                from hermes_cli.secret_prompt import masked_secret_prompt
+                value = masked_secret_prompt(f"{prompt}{suffix}: ")
+            else:
+                value = input(f"{prompt}{suffix}: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if value:
+            set_env_var(var, value)
+
+    _prompt("RABBIT_R1_TOKEN", "Auth token (blank = auto-generate)", secret=True)
+    _prompt("RABBIT_R1_TUNNEL", "Tunnel mode (tailscale/cloudflare/none)")
+    _prompt("RABBIT_R1_PORT", "WebSocket port (blank = 18789)")
+    _prompt("RABBIT_R1_ALLOWED_USERS", "Allowed device IDs (comma-separated; blank = any)")
+    print("Done. Start the gateway and scan the printed QR code with your R1.")
+
+
+def register(ctx) -> None:
+    """Plugin entry point - called by the Hermes plugin system at startup."""
+    ctx.register_platform(
+        name="rabbit_r1",
+        label="Rabbit R1",
+        adapter_factory=lambda cfg: RabbitR1Adapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=[],
+        install_hint="pip install websockets qrcode",
+        setup_fn=interactive_setup,
+        # Env-driven auto-configuration: seeds PlatformConfig.extra + home
+        # channel from RABBIT_R1_* vars so env-only setups show in status.
+        env_enablement_fn=_env_enablement,
+        # Cron home-channel delivery target.
+        cron_deliver_env_var="RABBIT_R1_HOME_CHANNEL",
+        # Out-of-process cron delivery (returns a descriptive error - the R1
+        # can only be reached from the live gateway process).
+        standalone_sender_fn=_standalone_send,
+        # Auth env vars for _is_user_authorized() integration.
+        allowed_users_env="RABBIT_R1_ALLOWED_USERS",
+        allow_all_env="RABBIT_R1_ALLOW_ALL_USERS",
+        # Keep responses readable on the small 2.88-inch screen.
+        max_message_length=R1_MAX_MESSAGE_LENGTH,
+        # Device IDs are redacted in this adapter's own logs.
+        pii_safe=False,
+        allow_update_command=True,
+        emoji="🐰",
+        platform_hint=(
+            "The user is on a Rabbit R1 device with a small 2.88-inch "
+            "touchscreen. Keep responses concise and conversational - no "
+            "markdown, no long lists. The device has voice output so short "
+            "spoken-style answers work best. Aim for 1-3 sentences unless the "
+            "user asks for detail. If the user asks for the R1 QR code or needs "
+            "to reconnect their R1, the pairing QR code PNG is saved at "
+            "~/.hermes/rabbit_r1_qr.png - send or share that file. The R1 "
+            "auto-reconnects using the same QR code as long as the token has "
+            "not changed."
+        ),
+    )

--- a/plugins/platforms/rabbit_r1/plugin.yaml
+++ b/plugins/platforms/rabbit_r1/plugin.yaml
@@ -1,0 +1,51 @@
+name: rabbit_r1-platform
+label: Rabbit R1
+kind: platform
+version: 1.0.0
+description: >
+  Rabbit R1 gateway adapter for Hermes Agent. Runs a WebSocket server that
+  speaks the OpenClaw/clawdbot-gateway protocol so a Rabbit R1 hardware
+  device can talk to Hermes from anywhere - not just the home LAN. An
+  optional tunnel (Tailscale Funnel or Cloudflare) makes the server
+  reachable over the internet, and a QR code is printed on startup for
+  pairing. Auth uses a hex token with timing-safe comparison, per-IP rate
+  limiting on failed attempts, and a server->device keepalive that
+  prevents the R1's ~30-minute inactivity timeout.
+author: Hermes Agent contributors
+# ``requires_env`` and ``optional_env`` entries are surfaced in the
+# ``hermes config`` / ``hermes setup`` UI via the platform-plugin env var
+# injector in ``hermes_cli/config.py``.
+requires_env: []
+optional_env:
+  - name: RABBIT_R1_TOKEN
+    description: "64-char hex auth token the R1 presents when pairing. Auto-generated on startup if unset (printed in the QR payload)."
+    prompt: "Rabbit R1 auth token (leave empty to auto-generate)"
+    password: true
+  - name: RABBIT_R1_PORT
+    description: "WebSocket server listen port (default: 18789)"
+    prompt: "WebSocket port"
+    password: false
+  - name: RABBIT_R1_TUNNEL
+    description: "Public tunnel mode: tailscale | cloudflare | none (default: tailscale)"
+    prompt: "Tunnel mode (tailscale/cloudflare/none)"
+    password: false
+  - name: RABBIT_R1_PUBLIC_URL
+    description: "Explicit public wss:// URL to advertise in the QR code (overrides tunnel auto-detection; useful under systemd/reverse proxy)"
+    prompt: "Public wss:// URL (optional)"
+    password: false
+  - name: RABBIT_R1_KEEPALIVE_INTERVAL
+    description: "Seconds between server->R1 keepalive heartbeats (default: 300; keeps well under the R1's ~30-min inactivity threshold)"
+    prompt: "Keepalive interval (seconds)"
+    password: false
+  - name: RABBIT_R1_ALLOWED_USERS
+    description: "Comma-separated R1 device IDs allowed to talk to the bot (empty = any device with the correct token)"
+    prompt: "Allowed device IDs (comma-separated)"
+    password: false
+  - name: RABBIT_R1_ALLOW_ALL_USERS
+    description: "Allow any device to talk to the bot without device-ID allowlisting (token still required; dev only)"
+    prompt: "Allow all devices? (true/false)"
+    password: false
+  - name: RABBIT_R1_HOME_CHANNEL
+    description: "Default device ID for cron / notification delivery"
+    prompt: "Home device ID (or empty)"
+    password: false

--- a/plugins/platforms/rabbit_r1/plugin.yaml
+++ b/plugins/platforms/rabbit_r1/plugin.yaml
@@ -11,7 +11,7 @@ description: >
   pairing. Auth uses a hex token with timing-safe comparison, per-IP rate
   limiting on failed attempts, and a server->device keepalive that
   prevents the R1's ~30-minute inactivity timeout.
-author: Hermes Agent contributors
+author: Michael Potter (@mpotter2002) with Claude Code
 # ``requires_env`` and ``optional_env`` entries are surfaced in the
 # ``hermes config`` / ``hermes setup`` UI via the platform-plugin env var
 # injector in ``hermes_cli/config.py``.

--- a/tests/gateway/test_rabbit_r1_plugin.py
+++ b/tests/gateway/test_rabbit_r1_plugin.py
@@ -1,0 +1,419 @@
+"""Tests for the Rabbit R1 platform adapter plugin.
+
+The Rabbit R1 adapter is a bundled platform plugin
+(``plugins/platforms/rabbit_r1/``) that runs a WebSocket server speaking the
+clawdbot-gateway protocol. These tests validate its logic without a real R1
+device or a live gateway:
+
+1. register() metadata + hook wiring (zero core-file integration points)
+2. check_requirements / validate_config / is_connected
+3. _env_enablement seeding from RABBIT_R1_* env vars
+4. _standalone_send returns a descriptive error (server-only platform)
+5. adapter init (token resolution, port/tunnel/keepalive config)
+6. format_message markdown stripping for the small screen
+7. QR payload construction (LAN vs public URL)
+8. auth: timing-safe token comparison + per-IP rate limiting
+9. device-ID redaction in log strings
+10. send / send_typing behavior over a mocked WebSocket
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+# Load plugins/platforms/rabbit_r1/adapter.py under a unique module name so it
+# cannot collide with sibling platform-plugin tests in the same xdist worker.
+_r1 = load_plugin_adapter("rabbit_r1")
+
+RabbitR1Adapter = _r1.RabbitR1Adapter
+register = _r1.register
+check_requirements = _r1.check_requirements
+validate_config = _r1.validate_config
+is_connected = _r1.is_connected
+_env_enablement = _r1._env_enablement
+_standalone_send = _r1._standalone_send
+_redact = _r1._redact
+
+
+# All RABBIT_R1_* env vars this plugin reads — cleared before each test so
+# the environment can't leak configuration into assertions.
+_R1_ENV_VARS = (
+    "RABBIT_R1_TOKEN",
+    "RABBIT_R1_PORT",
+    "RABBIT_R1_TUNNEL",
+    "RABBIT_R1_PUBLIC_URL",
+    "RABBIT_R1_KEEPALIVE_INTERVAL",
+    "RABBIT_R1_ALLOWED_USERS",
+    "RABBIT_R1_ALLOW_ALL_USERS",
+    "RABBIT_R1_HOME_CHANNEL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_r1_env(monkeypatch):
+    for var in _R1_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def _make_config(**extra):
+    from gateway.config import PlatformConfig
+    return PlatformConfig(enabled=True, extra=extra or {})
+
+
+# ---------------------------------------------------------------------------
+# 1. register() metadata + hook wiring
+# ---------------------------------------------------------------------------
+
+class _FakeCtx:
+    def __init__(self):
+        self.kwargs = None
+
+    def register_platform(self, **kw):
+        self.kwargs = kw
+
+
+class TestRegister:
+    def test_register_calls_register_platform(self):
+        ctx = _FakeCtx()
+        register(ctx)
+        assert ctx.kwargs is not None
+        assert ctx.kwargs["name"] == "rabbit_r1"
+        assert ctx.kwargs["label"] == "Rabbit R1"
+
+    def test_register_requires_no_credential_env(self):
+        ctx = _FakeCtx()
+        register(ctx)
+        # The R1 auto-generates its token; nothing is a hard requirement.
+        assert ctx.kwargs["required_env"] == []
+
+    def test_register_wires_allowlist_envs(self):
+        ctx = _FakeCtx()
+        register(ctx)
+        assert ctx.kwargs["allowed_users_env"] == "RABBIT_R1_ALLOWED_USERS"
+        assert ctx.kwargs["allow_all_env"] == "RABBIT_R1_ALLOW_ALL_USERS"
+
+    def test_register_wires_cron_home_channel(self):
+        ctx = _FakeCtx()
+        register(ctx)
+        assert ctx.kwargs["cron_deliver_env_var"] == "RABBIT_R1_HOME_CHANNEL"
+
+    def test_register_provides_hooks(self):
+        ctx = _FakeCtx()
+        register(ctx)
+        assert callable(ctx.kwargs["standalone_sender_fn"])
+        assert callable(ctx.kwargs["env_enablement_fn"])
+        assert callable(ctx.kwargs["setup_fn"])
+        assert callable(ctx.kwargs["check_fn"])
+        assert callable(ctx.kwargs["validate_config"])
+        assert callable(ctx.kwargs["is_connected"])
+
+    def test_register_provides_platform_hint(self):
+        ctx = _FakeCtx()
+        register(ctx)
+        hint = ctx.kwargs["platform_hint"]
+        assert "Rabbit R1" in hint
+        # The hint should steer the model away from markdown on the small screen.
+        assert "markdown" in hint.lower()
+
+    def test_register_sets_message_length(self):
+        ctx = _FakeCtx()
+        register(ctx)
+        assert ctx.kwargs["max_message_length"] == RabbitR1Adapter.MAX_MESSAGE_LENGTH
+
+    def test_register_factory_yields_r1_adapter(self):
+        ctx = _FakeCtx()
+        register(ctx)
+        ad = ctx.kwargs["adapter_factory"](_make_config())
+        assert isinstance(ad, RabbitR1Adapter)
+
+
+# ---------------------------------------------------------------------------
+# 2. check_requirements / validate_config / is_connected
+# ---------------------------------------------------------------------------
+
+class TestRequirements:
+    def test_check_requirements_returns_bool(self):
+        assert isinstance(check_requirements(), bool)
+
+    def test_validate_config_returns_bool(self):
+        assert isinstance(validate_config(_make_config()), bool)
+
+    def test_is_connected_returns_bool(self):
+        assert isinstance(is_connected(_make_config()), bool)
+
+    def test_check_requirements_false_without_websockets(self, monkeypatch):
+        monkeypatch.setattr(_r1, "WEBSOCKETS_AVAILABLE", False)
+        assert check_requirements() is False
+
+    def test_validate_config_gated_on_websockets(self, monkeypatch):
+        monkeypatch.setattr(_r1, "WEBSOCKETS_AVAILABLE", False)
+        assert validate_config(_make_config()) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. _env_enablement
+# ---------------------------------------------------------------------------
+
+class TestEnvEnablement:
+    def test_returns_none_without_any_env(self):
+        assert _env_enablement() is None
+
+    def test_seeds_token(self, monkeypatch):
+        monkeypatch.setenv("RABBIT_R1_TOKEN", "abc123")
+        assert _env_enablement() == {"token": "abc123"}
+
+    def test_seeds_port_and_tunnel(self, monkeypatch):
+        monkeypatch.setenv("RABBIT_R1_PORT", "9000")
+        monkeypatch.setenv("RABBIT_R1_TUNNEL", "cloudflare")
+        result = _env_enablement()
+        assert result["port"] == 9000
+        assert result["tunnel"] == "cloudflare"
+
+    def test_ignores_invalid_port(self, monkeypatch):
+        monkeypatch.setenv("RABBIT_R1_TUNNEL", "none")
+        monkeypatch.setenv("RABBIT_R1_PORT", "not-a-number")
+        result = _env_enablement()
+        assert "port" not in result
+        assert result["tunnel"] == "none"
+
+    def test_seeds_home_channel(self, monkeypatch):
+        monkeypatch.setenv("RABBIT_R1_HOME_CHANNEL", "device-42")
+        assert _env_enablement()["home_channel"] == "device-42"
+
+
+# ---------------------------------------------------------------------------
+# 4. _standalone_send — server-only platform, returns descriptive error
+# ---------------------------------------------------------------------------
+
+class TestStandaloneSend:
+    def test_returns_error(self):
+        result = asyncio.run(_standalone_send(_make_config(), "device-1", "hi"))
+        assert "error" in result
+        assert "gateway" in result["error"].lower()
+
+    def test_accepts_optional_kwargs(self):
+        # Signature parity with other plugins — extra kwargs must not raise.
+        result = asyncio.run(
+            _standalone_send(
+                _make_config(), "device-1", "hi",
+                thread_id="t", media_files=["/tmp/x"], force_document=True,
+            )
+        )
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# 5. Adapter init
+# ---------------------------------------------------------------------------
+
+class TestAdapterInit:
+    def test_token_autogenerated_when_absent(self):
+        ad = RabbitR1Adapter(_make_config())
+        # 32 bytes hex == 64 chars.
+        assert len(ad._token) == 64
+
+    def test_token_from_env_wins(self, monkeypatch):
+        monkeypatch.setenv("RABBIT_R1_TOKEN", "envtoken")
+        ad = RabbitR1Adapter(_make_config(token="extratoken"))
+        assert ad._token == "envtoken"
+
+    def test_token_from_extra_when_no_env(self):
+        ad = RabbitR1Adapter(_make_config(token="extratoken"))
+        assert ad._token == "extratoken"
+
+    def test_defaults(self):
+        ad = RabbitR1Adapter(_make_config())
+        assert ad._port == _r1.DEFAULT_PORT
+        assert ad._tunnel_mode == _r1.DEFAULT_TUNNEL
+        assert ad._keepalive_interval == _r1.DEFAULT_KEEPALIVE_INTERVAL
+
+    def test_env_overrides_config(self, monkeypatch):
+        monkeypatch.setenv("RABBIT_R1_PORT", "12345")
+        monkeypatch.setenv("RABBIT_R1_TUNNEL", "NONE")
+        monkeypatch.setenv("RABBIT_R1_KEEPALIVE_INTERVAL", "60")
+        ad = RabbitR1Adapter(_make_config(port=1, tunnel="tailscale", keepalive_interval=999))
+        assert ad._port == 12345
+        assert ad._tunnel_mode == "none"  # lowercased
+        assert ad._keepalive_interval == 60
+
+    def test_config_extra_when_no_env(self):
+        ad = RabbitR1Adapter(_make_config(port=7777, tunnel="cloudflare", keepalive_interval=120))
+        assert ad._port == 7777
+        assert ad._tunnel_mode == "cloudflare"
+        assert ad._keepalive_interval == 120
+
+
+# ---------------------------------------------------------------------------
+# 6. format_message — markdown stripping
+# ---------------------------------------------------------------------------
+
+class TestFormatMessage:
+    def setup_method(self):
+        self.ad = RabbitR1Adapter(_make_config())
+
+    def test_strips_bold_italic(self):
+        assert self.ad.format_message("**bold** and _italic_") == "bold and italic"
+
+    def test_links_become_text_and_url(self):
+        assert self.ad.format_message("[docs](https://x.com)") == "docs (https://x.com)"
+
+    def test_strips_headers(self):
+        assert self.ad.format_message("# Title\nbody") == "Title\nbody"
+
+    def test_strips_code_fences(self):
+        out = self.ad.format_message("```python\ncode\n```")
+        assert "```" not in out
+        assert "code" in out
+
+    def test_strips_inline_code(self):
+        assert self.ad.format_message("run `ls` now") == "run ls now"
+
+
+# ---------------------------------------------------------------------------
+# 7. QR payload construction
+# ---------------------------------------------------------------------------
+
+class TestQrPayload:
+    def test_lan_payload(self, monkeypatch):
+        ad = RabbitR1Adapter(_make_config())
+        ad._public_url = None
+        monkeypatch.setattr(_r1, "_get_lan_ip", lambda: "192.168.1.5")
+        payload = json.loads(ad._build_qr_payload())
+        assert payload["type"] == "clawdbot-gateway"
+        assert payload["protocol"] == "ws"
+        assert payload["ips"] == ["192.168.1.5"]
+        assert payload["port"] == ad._port
+        assert payload["token"] == ad._token
+
+    def test_public_url_payload(self):
+        ad = RabbitR1Adapter(_make_config())
+        ad._public_url = "wss://me.ts.net"
+        payload = json.loads(ad._build_qr_payload())
+        assert payload["protocol"] == "wss"
+        assert payload["ips"] == ["me.ts.net"]
+        assert payload["port"] == 443
+
+
+# ---------------------------------------------------------------------------
+# 8. Auth: timing-safe comparison + per-IP rate limiting
+# ---------------------------------------------------------------------------
+
+class TestAuth:
+    def _make_ws(self):
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+        ws.remote_address = ("10.0.0.9", 5555)
+        return ws
+
+    def test_valid_token_pairs_device(self):
+        ad = RabbitR1Adapter(_make_config(token="secret-token"))
+        ws = self._make_ws()
+        msg = {"id": "1", "method": "connect",
+               "params": {"auth": {"token": "secret-token"},
+                          "device": {"id": "dev-1"}}}
+        device_id = asyncio.run(ad._handle_connect(ws, msg, "10.0.0.9:5555"))
+        assert device_id == "dev-1"
+        assert ad._clients["dev-1"] is ws
+        ad._stop_keepalive("dev-1")
+
+    def test_bad_token_rejected(self):
+        ad = RabbitR1Adapter(_make_config(token="secret-token"))
+        ws = self._make_ws()
+        msg = {"id": "1", "method": "connect",
+               "params": {"auth": {"token": "wrong"}, "device": {"id": "dev-1"}}}
+        device_id = asyncio.run(ad._handle_connect(ws, msg, "10.0.0.9:5555"))
+        assert device_id is None
+        assert ad._clients == {}
+        ws.close.assert_awaited()
+
+    def test_rate_limit_after_repeated_failures(self):
+        ad = RabbitR1Adapter(_make_config(token="secret-token"))
+        remote = "10.0.0.9:5555"
+
+        async def _run():
+            # 5 bad attempts trip the limiter; the 6th is rejected as 429.
+            for _ in range(ad._max_auth_failures):
+                ws = self._make_ws()
+                msg = {"id": "x", "method": "connect",
+                       "params": {"auth": {"token": "bad"}, "device": {"id": "d"}}}
+                await ad._handle_connect(ws, msg, remote)
+            ws = self._make_ws()
+            msg = {"id": "x", "method": "connect",
+                   "params": {"auth": {"token": "secret-token"}, "device": {"id": "d"}}}
+            result = await ad._handle_connect(ws, msg, remote)
+            # Even a *correct* token is refused once the IP is rate-limited.
+            sent = json.loads(ws.send.call_args[0][0])
+            return result, sent
+
+        result, sent = asyncio.run(_run())
+        assert result is None
+        assert sent["error"]["code"] == 429
+
+
+# ---------------------------------------------------------------------------
+# 9. Device-ID redaction
+# ---------------------------------------------------------------------------
+
+class TestRedaction:
+    def test_masks_64_char_hex(self):
+        device_id = "a" * 64
+        assert _redact(f"paired {device_id} ok") == "paired [R1_DEVICE_ID] ok"
+
+    def test_leaves_short_ids_alone(self):
+        assert _redact("device r1-10.0.0.9:5555") == "device r1-10.0.0.9:5555"
+
+
+# ---------------------------------------------------------------------------
+# 10. send / send_typing over a mocked WebSocket
+# ---------------------------------------------------------------------------
+
+class TestSend:
+    def _make_ws(self):
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        return ws
+
+    def test_send_to_unknown_device_fails(self):
+        ad = RabbitR1Adapter(_make_config())
+        result = asyncio.run(ad.send("nope", "hi"))
+        assert result.success is False
+
+    def test_send_delivers_final_chat_event(self):
+        ad = RabbitR1Adapter(_make_config())
+        ws = self._make_ws()
+        ad._clients["dev-1"] = ws
+        result = asyncio.run(ad.send("dev-1", "hello there"))
+        assert result.success is True
+        sent = json.loads(ws.send.call_args[0][0])
+        assert sent["event"] == "chat"
+        assert sent["payload"]["state"] == "final"
+        assert sent["payload"]["message"]["content"][0]["text"] == "hello there"
+
+    def test_send_typing_emits_thinking_state(self):
+        ad = RabbitR1Adapter(_make_config())
+        ws = self._make_ws()
+        ad._clients["dev-1"] = ws
+        asyncio.run(ad.send_typing("dev-1"))
+        sent = json.loads(ws.send.call_args[0][0])
+        assert sent["payload"]["state"] == "thinking"
+
+    def test_send_typing_noop_for_unknown_device(self):
+        ad = RabbitR1Adapter(_make_config())
+        # Should not raise when the device isn't connected.
+        asyncio.run(ad.send_typing("nope"))
+
+    def test_get_chat_info(self):
+        ad = RabbitR1Adapter(_make_config())
+        ad._clients["dev-1"] = self._make_ws()
+        info = asyncio.run(ad.get_chat_info("dev-1"))
+        assert info["type"] == "dm"
+        assert info["connected"] is True
+        assert asyncio.run(ad.get_chat_info("other"))["connected"] is False


### PR DESCRIPTION
## Summary

Re-platforms the previously submitted Rabbit R1 support (#3119, closed) as a
self-contained **platform plugin** under `plugins/platforms/rabbit_r1/`, wired
entirely through `ctx.register_platform(...)` with **zero core-file changes**,
per the maintainer feedback on the closed PR. The `line` plugin was used as the
template.

> Closing for the same structural reason as other pre-plugin-era platform PRs:
> platform adapters now ship via `plugins/platforms/<name>/` with zero
> core-file changes … a re-platform as `plugins/platforms/rabbit_r1/` would be
> welcome — the line plugin is a good template.

This PR is that re-platform.

## What the Rabbit R1 adapter does

The [Rabbit R1](https://www.rabbit.tech/) is a pocket AI device with a
2.88-inch touchscreen and voice output. This adapter lets an R1 talk to your
own Hermes agent instead of the stock cloud assistant.

The R1 dials *in*: the adapter runs a **WebSocket server** the device connects
to, speaking the OpenClaw/clawdbot-gateway protocol. An optional tunnel
(Tailscale Funnel or Cloudflare) publishes the server so the R1 can reach it
from anywhere, and a QR code printed on startup carries the public URL + auth
token for one-scan pairing.

## What changed vs. the closed PR

The original wired into **10 core files** (platform enum, `gateway/run.py`
adapter factory + auth maps, `agent/prompt_builder.py` hints, `redact.py`,
cron delivery, etc.). Every one of those integration points is now expressed as
a `register_platform(...)` kwarg instead:

| Old core edit | Now |
|---|---|
| `Platform` enum member | resolved via `Platform._missing_()` — no edit |
| adapter factory in `gateway/run.py` | `adapter_factory=` |
| auth allow-list / allow-all maps | `allowed_users_env=`, `allow_all_env=` |
| prompt hint in `prompt_builder.py` | `platform_hint=` |
| cron home-channel delivery | `cron_deliver_env_var=`, `standalone_sender_fn=` |
| PII redaction in `redact.py` | self-contained `_redact()` in the adapter (`pii_safe=False`) |
| env-var config UI | `plugin.yaml` `optional_env` |
| message length cap | `max_message_length=2000` |
| connect/status/setup | `check_fn=`, `validate_config=`, `is_connected=`, `env_enablement_fn=`, `setup_fn=` |

`git diff --stat` against `main` touches **no tracked files** — only new files
are added under `plugins/platforms/rabbit_r1/` and `tests/`.

## Files

- `plugins/platforms/rabbit_r1/plugin.yaml` — metadata + `optional_env` for the
  `RABBIT_R1_*` settings (surfaced in `hermes setup` / `hermes config`).
- `plugins/platforms/rabbit_r1/adapter.py` — `RabbitR1Adapter(BasePlatformAdapter)`
  with timing-safe token auth + per-IP rate limiting, server→device keepalive
  (holds the connection under the R1's ~30-min inactivity timeout), tunnel URL
  detection, QR pairing, self-contained device-ID redaction, and `register()`.
- `plugins/platforms/rabbit_r1/README.md` — architecture, setup, config, security.
- `tests/gateway/test_rabbit_r1_plugin.py` — 43 tests (register/hooks,
  requirements, env-enablement, standalone send, format, QR, auth timing-safe +
  rate-limit, redaction, send/typing).

## Conformance & tests

- `connect()` accepts `*, is_reconnect: bool = False` to satisfy the gateway
  reconnect contract (`test_adapter_connect_is_reconnect_contract.py`).
- Passes `test_plugin_platform_interface.py` and the reconnect contract suite.
- `python -m pytest tests/gateway/test_rabbit_r1_plugin.py` → 43 passed.

## Testing status

Full test suite is green for the plugin and conformance checks. I have **not**
yet validated against physical R1 hardware — feedback from anyone with a device
is welcome. Opening as a draft while that hands-on validation happens.

## Credit

Original work by @mpotter2002 (closed PR #3119), re-platformed to the plugin
system with Claude Code.
