### PR TITLE
fix(gateway): preserve session lineage in list RPC

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7176,6 +7176,26 @@ def test_session_list_returns_clean_error_when_state_db_is_unavailable(monkeypat
     assert "state.db unavailable: locking protocol" in resp["error"]["message"]
 
 
+def test_session_list_preserves_lineage_root_id(monkeypatch):
+    class _DB:
+        def list_sessions_rich(self, **_kwargs):
+            return [
+                {
+                    "id": "tip-1",
+                    "_lineage_root_id": "root-1",
+                    "source": "desktop",
+                }
+            ]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.list", "params": {}}
+    )
+
+    assert resp["result"]["sessions"][0]["_lineage_root_id"] == "root-1"
+
+
 # --------------------------------------------------------------------------
 # session.delete — TUI resume picker `d` key
 # --------------------------------------------------------------------------

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5694,6 +5694,7 @@ def _(rid, params: dict) -> dict:
                 "sessions": [
                     {
                         "id": s["id"],
+                        "_lineage_root_id": s.get("_lineage_root_id"),
                         "title": s.get("title") or "",
                         "preview": s.get("preview") or "",
                         "started_at": s.get("started_at") or 0,


### PR DESCRIPTION
## What does this PR do?

Preserves `_lineage_root_id` in the `session.list` RPC projection so desktop clients can deduplicate compressed conversations.

## Related Issue

Fixes #66663

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Forward the lineage root from `SessionDB` through `session.list`.
- Add a regression test for the RPC response contract.

## How to Test

1. Run `scripts/run_tests.sh tests/test_tui_gateway_server.py -q -k test_session_list_preserves_lineage_root_id`.
2. Confirm the returned session keeps its `_lineage_root_id`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

The focused regression passes. The full gateway test file has one unrelated pre-existing failure in `test_verification_status_returns_recorded_evidence`, reproduced unchanged without this diff.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
