### PR TITLE
fix(agent): close _codex_session in AIAgent.close() to prevent subprocess leaks (#66671)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3620,7 +3620,18 @@ class AIAgent:
         except Exception:
             pass
 
-        # 7. Finalize the owned SQLite session row unless this agent is only a
+        # 7. Close the Codex app-server session so the subprocess tree is
+        # reaped rather than orphaned on close (#66671).  Idempotent:
+        # CodexAppServerSession.close() is already guarded by self._closed.
+        try:
+            codex = getattr(self, "_codex_session", None)
+            if codex is not None:
+                codex.close()
+                self._codex_session = None
+        except Exception:
+            pass
+
+        # 8. Finalize the owned SQLite session row unless this agent is only a
         # temporary helper that deliberately handed session ownership forward
         # (manual compression helpers that rotate to a continuation session_id,
         # or background-review forks that share the live parent's session_id and


### PR DESCRIPTION
## Summary

`AIAgent.close()` cleans up background processes, terminal sandboxes, browser daemons, child agents, HTTP clients, message history, and the SQLite session row — but never closes `self._codex_session`. This permanently orphans the Codex app-server subprocess tree (plus its MCP children) whenever a Codex-route session is closed via `session.close` or any other path that tears down the agent.

## Fix

Add a guarded, idempotent `_codex_session` close step to `AIAgent.close()`, matching the existing crash-path cleanup in `agent/codex_runtime.py`. `CodexAppServerSession.close()` is already guarded by `self._closed`, so repeated calls are safe.

## Testing

- All 40 existing Codex-related tests pass (5 persistence + 29 integration + 6 compaction).
- Verified syntax with `python3 -c "import ast; ast.parse(...)"`.

Fixes #66671