### PR TITLE
fix(batch): repair mojibake warning emoji in final checkpoint save message

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1010,7 +1010,7 @@ class BatchRunner:
             checkpoint_data["completed_prompts"] = sorted(completed_prompts_set)
             self._save_checkpoint(checkpoint_data, lock=checkpoint_lock)
         except Exception as ckpt_err:
-            print(f"âš ï¸  Warning: Failed to save final checkpoint: {ckpt_err}")
+            print(f"⚠️  Warning: Failed to save final checkpoint: {ckpt_err}")
         
         # Calculate success rates
         for tool_name in total_tool_stats:


### PR DESCRIPTION
## Summary
The final-checkpoint failure warning in `batch_runner.py` printed the UTF-8 bytes of the warning emoji mis-decoded as cp1252 (`âš ï¸`), garbling console output. This restores the proper `⚠️`, matching every other warning message in the file.

Supersedes the stale, untouched #11799. Closes #11799.

## Testing
- `scripts/run_tests.sh tests/test_batch_runner_checkpoint.py` — 16 passed
- `scripts/check-windows-footguns.py --all` — clean
- `ruff check` — clean
