### PR TITLE
fix(claw): default cleanup archive prompt to No and warn about impact

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -670,7 +670,13 @@ def _cmd_cleanup(args):
         elif not auto_yes and not sys.stdin.isatty():
             print_info(f"Non-interactive session — would archive: {source_dir}")
             print_info("To execute, re-run with: hermes claw cleanup --yes")
-        elif auto_yes or prompt_yes_no(f"Archive {source_dir}?", default=True):
+        # Archiving renames the directory, which leaves any remaining OpenClaw
+        # install unable to start until it is renamed back — default to No.
+        elif auto_yes or prompt_yes_no(
+            f"Archive {source_dir}? (OpenClaw will stop working until the "
+            "directory is renamed back)",
+            default=False,
+        ):
             try:
                 archive_path = _archive_directory(source_dir)
                 print_success(f"Archived: {source_dir} → {archive_path}")

--- a/tests/hermes_cli/test_claw.py
+++ b/tests/hermes_cli/test_claw.py
@@ -588,6 +588,26 @@ class TestCmdCleanup:
         assert "Skipped" in captured.out
         assert openclaw.is_dir()
 
+    def test_interactive_prompt_defaults_to_no_and_warns(self, tmp_path):
+        openclaw = tmp_path / ".openclaw"
+        openclaw.mkdir()
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+
+        args = Namespace(source=None, dry_run=False, yes=False)
+        with (
+            patch.object(claw_mod, "_find_openclaw_dirs", return_value=[openclaw]),
+            patch.object(claw_mod, "prompt_yes_no", return_value=False) as mock_prompt,
+            patch("sys.stdin", mock_stdin),
+        ):
+            claw_mod._cmd_cleanup(args)
+
+        assert mock_prompt.call_count == 1
+        question = mock_prompt.call_args[0][0]
+        assert "stop working" in question
+        assert mock_prompt.call_args.kwargs.get("default") is False
+
     def test_explicit_source(self, tmp_path, capsys):
         custom_dir = tmp_path / "my-openclaw"
         custom_dir.mkdir()


### PR DESCRIPTION
## Summary
`hermes claw cleanup` archives an OpenClaw directory by renaming it, which leaves any remaining OpenClaw install unable to start until the directory is renamed back. The interactive confirmation defaulted to **Yes**, so a bare Enter silently broke OpenClaw.

This defaults the prompt to **No** and states the consequence in the question itself. `--yes` and the non-interactive path are unchanged, so scripted cleanups behave exactly as before.

Adds `test_interactive_prompt_defaults_to_no_and_warns` asserting the prompt is called with `default=False` and includes the warning.

Supersedes the stale, untouched #8611. Closes #8611.

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_claw.py` — 49 passed (incl. the new test)
- `scripts/run_tests.sh tests/hermes_cli/test_setup_openclaw_migration.py` — 33 passed
- `ruff check` — clean
