### PR TITLE
fix(cli): sanitize terminal escapes in the /resume recent-sessions list

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6853,6 +6853,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return False
 
         from hermes_cli.main import _relative_time
+        # Stored session titles and previews are untrusted for display: a title
+        # or a preview (a snippet of stored message content) can carry raw
+        # CSI/OSC/control bytes — pasted content, gateway-origin text, or model
+        # output echoing an injected tool result — so a crafted session shown in
+        # this /resume list could clear the screen, retitle the window, move the
+        # cursor, or restyle the terminal. Scrub both before printing, matching
+        # the /resume + /status recap and /history replay paths. (Sanitizing
+        # first also keeps the column widths honest — an escape byte is no
+        # longer counted toward the padded field width.)
+        from tools.ansi_strip import sanitize_display_text as _sanitize_display_text
 
         _cli_visible_print()
         if reason == "history":
@@ -6863,8 +6873,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         _cli_visible_print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
         _cli_visible_print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
         for idx, session in enumerate(sessions, start=1):
-            title = session.get("title") or "—"
-            preview = (session.get("preview") or "")[:38]
+            title = _sanitize_display_text(session.get("title") or "—")
+            preview = _sanitize_display_text(session.get("preview") or "")[:38]
             last_active = _relative_time(session.get("last_active"))
             _cli_visible_print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
         _cli_visible_print()

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -39,6 +39,34 @@ class TestCliResumeCommand:
         assert "/resume 2" in output
         assert "/resume <session title>" in output
 
+    def test_show_recent_sessions_sanitizes_terminal_escapes(self, capsys):
+        """A stored title/preview carrying raw terminal escapes (pasted content,
+        gateway-origin text, or model output echoing an injected tool result)
+        must not clear/retitle/restyle the terminal when the /resume list is
+        rendered. Escapes/control bytes are stripped; the visible text survives.
+        """
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[
+            {
+                "id": "sess_evil",
+                # OSC window-retitle + BEL, then CSI clear-screen, around text.
+                "title": "ok\x1b]0;PWNED\x07\x1b[2Jtitle",
+                "preview": "hi\x1b[31m\x07\x1b[2Jbye",
+                "last_active": None,
+            },
+        ])
+
+        shown = cli_obj._show_recent_sessions(reason="resume")
+        output = capsys.readouterr().out
+
+        assert shown is True
+        # No raw ESC / BEL bytes reach the terminal...
+        assert "\x1b" not in output
+        assert "\x07" not in output
+        # ...but the visible characters survive.
+        assert "oktitle" in output
+        assert "hibye" in output
+
     def test_show_recent_sessions_uses_prompt_toolkit_safe_print(self):
         cli_obj = _make_cli()
         cli_obj._list_recent_sessions = MagicMock(return_value=[


### PR DESCRIPTION
## What does this PR do?

`HermesCLI._show_recent_sessions` renders each recent session's stored `title` and `preview` straight to the terminal via `_cli_visible_print` with **no escape stripping**. Both are untrusted for display:

- `title` — a stored session title.
- `preview` — a snippet of stored **message content** (`hermes_state.py` builds it by truncating the raw message text; no sanitization).

Stored content can carry raw CSI/OSC/control bytes — pasted content, gateway-origin text, or model output echoing an injected tool result — so a crafted session shown in this list (`/resume` with no arg, or the "no messages yet — here are recent sessions" prompt) could clear the screen, retitle the window, move the cursor, or restyle the terminal UI.

This is the one remaining stored-content terminal-replay path that didn't sanitize — the `/resume` + `/status` recap (`session_recap.py`) and the `/history` replay already do.

## Related Issue

No separate issue — completes the display-layer terminal-escape sanitization for the recent-sessions (`/resume`) list. Complements #40105 (title-only, source-side, open), which does not cover the `preview`.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `cli.py` — in `_show_recent_sessions`, route each `title` and `preview` through `tools.ansi_strip.sanitize_display_text` before building the `_cli_visible_print` row. Sanitizing before the padded-column format also keeps the alignment honest (an escape byte no longer counts toward a field width).
- `tests/cli/test_cli_resume_command.py` — add `test_show_recent_sessions_sanitizes_terminal_escapes`.

## How to Test

1. Have (or mock) a recent session whose title/preview contains a terminal escape, e.g. `ok\x1b]0;PWNED\x07\x1b[2Jtitle`.
2. Run `/resume` with no argument (or open a chat with no messages so the recent-sessions prompt shows).
3. Before this change the raw escapes reach the terminal (retitle/clear); after it, only the visible text (`oktitle`) is printed.

Automated:

```
pytest tests/cli/test_cli_resume_command.py -q
# 19 passed
```

The new test fails without the source change (raw `\x1b`/`\x07` present in the captured output) and passes with it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant test suite and it passes
- [x] I've added tests for my changes
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] Docs / docstrings — N/A (inline comment added)
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform impact considered — N/A (pure string sanitization)