### PR TITLE
fix(desktop): stage node-pty without fs.cpSync/fs.rmSync (non-ASCII Windows paths)

### DIFF
--- a/apps/desktop/scripts/before-pack.mjs
+++ b/apps/desktop/scripts/before-pack.mjs
@@ -59,7 +59,7 @@
  */
 import { existsSync, rmSync } from 'node:fs'
 import { Arch } from 'electron-builder'
-import { stageNodePty } from './stage-native-deps.mjs'
+import { removeDirSync, stageNodePty } from './stage-native-deps.mjs'
 
 export function cleanStaleAppOutDir(appOutDir) {
   if (!appOutDir || typeof appOutDir !== 'string') {
@@ -72,6 +72,13 @@ export function cleanStaleAppOutDir(appOutDir) {
   // can't block the wipe. retry/maxRetries rides out transient EBUSY on
   // Windows where an AV/indexer may briefly hold a handle.
   rmSync(appOutDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  // Node's native rmSync silently deletes nothing on non-ASCII Windows
+  // paths (nodejs/node#56049, fixed in v24.13.1) — without this check the
+  // stale tree survives and the "removed" log below lies. Fall back to
+  // the libuv-backed walk, which handles those paths on every version.
+  if (existsSync(appOutDir)) {
+    removeDirSync(appOutDir)
+  }
   return true
 }
 

--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -14,12 +14,13 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import {
   chmodSync,
-  cpSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
   readFileSync,
-  rmSync,
+  rmdirSync,
+  unlinkSync,
   writeFileSync
 } from 'node:fs'
 import { spawnSync } from 'node:child_process'
@@ -31,6 +32,52 @@ const require = createRequire(import.meta.url)
 
 function makeExecutable(filePath) {
   chmodSync(filePath, 0o755)
+}
+
+// ─── libuv-safe fs primitives ────────────────────────────────────────
+//
+// Node 24's native rewrite of fs.cpSync/fs.rmSync mishandles non-ASCII
+// Windows paths (observed on v24.11.1 with an accented Windows user name,
+// i.e. a default %LOCALAPPDATA%\hermes home): a recursive cpSync fails
+// with EIO "Access is denied" or hard-crashes the process, an overwriting
+// cpSync fails with a bogus errno-0 unlink error, and rmSync silently
+// deletes nothing — leaving a half-staged tree that breaks every retry.
+// copyFileSync/unlinkSync/rmdirSync/readdirSync go through libuv and
+// handle those paths correctly, so staging uses them exclusively.
+
+/** Recursively copy a directory without fs.cpSync. */
+function copyDirSync(srcDir, destDir) {
+  mkdirSync(destDir, { recursive: true })
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    const src = join(srcDir, entry.name)
+    const dest = join(destDir, entry.name)
+    if (entry.isDirectory()) {
+      copyDirSync(src, dest)
+    } else {
+      copyFileSync(src, dest)
+    }
+  }
+}
+
+/**
+ * Recursively delete a directory without fs.rmSync (missing dir is fine),
+ * then verify the tree is actually gone — a silent no-op here surfaces
+ * later as an inexplicable staging failure, so fail loudly instead.
+ */
+function removeDirSync(dir) {
+  if (!existsSync(dir)) return
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      removeDirSync(full)
+    } else {
+      unlinkSync(full)
+    }
+  }
+  rmdirSync(dir)
+  if (existsSync(dir)) {
+    throw new Error(`[stage-native-deps] failed to remove ${dir}`)
+  }
 }
 
 function patchUnixTerminalAsarPaths(destRoot) {
@@ -74,7 +121,7 @@ function copyGlobByExt(srcDir, destDir, extensions) {
     }
     if (extensions.some((ext) => entry.name.endsWith(ext))) {
       mkdirSync(destDir, { recursive: true })
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name))
+      copyFileSync(join(srcDir, entry.name), join(destDir, entry.name))
     }
   }
 }
@@ -96,12 +143,12 @@ function copyBuildRelease(srcDir, destDir) {
   mkdirSync(destDir, { recursive: true })
   for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name), { recursive: true })
+      copyDirSync(join(srcDir, entry.name), join(destDir, entry.name))
       continue
     }
     if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
       const destFile = join(destDir, entry.name)
-      cpSync(join(srcDir, entry.name), destFile)
+      copyFileSync(join(srcDir, entry.name), destFile)
       if (entry.name === 'spawn-helper') {
         makeExecutable(destFile)
       }
@@ -240,12 +287,12 @@ function validateStagedBinaries(destRoot, targetPlatform) {
 export function stageNodePtyInto(srcRoot, destRoot, { platform = process.platform, arch = process.arch } = {}) {
   const hostMatch = platform === process.platform && arch === process.arch
 
-  rmSync(destRoot, { recursive: true, force: true })
+  removeDirSync(destRoot)
   mkdirSync(destRoot, { recursive: true })
 
   // package.json — needed so `require('node-pty')` resolves the package
   // (reads "main") rather than treating it as a directory with no entry.
-  cpSync(join(srcRoot, 'package.json'), join(destRoot, 'package.json'))
+  copyFileSync(join(srcRoot, 'package.json'), join(destRoot, 'package.json'))
 
   // lib/**/*.js — the JS surface node-pty's `main` points into.
   copyGlobByExt(join(srcRoot, 'lib'), join(destRoot, 'lib'), ['.js'])
@@ -261,16 +308,16 @@ export function stageNodePtyInto(srcRoot, destRoot, { platform = process.platfor
     mkdirSync(destPrebuild, { recursive: true })
     for (const entry of readdirSync(prebuildDir, { withFileTypes: true })) {
       if (entry.name === 'conpty' && entry.isDirectory()) {
-        cpSync(join(prebuildDir, 'conpty'), join(destPrebuild, 'conpty'), { recursive: true })
+        copyDirSync(join(prebuildDir, 'conpty'), join(destPrebuild, 'conpty'))
         continue
       }
       if (entry.isFile() && /\.(node|dll|exe)$/.test(entry.name)) {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
+        copyFileSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
         continue
       }
       if (entry.name === 'spawn-helper') {
         const destFile = join(destPrebuild, entry.name)
-        cpSync(join(prebuildDir, entry.name), destFile)
+        copyFileSync(join(prebuildDir, entry.name), destFile)
         makeExecutable(destFile)
       }
     }

--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -16,6 +16,7 @@ import {
   chmodSync,
   copyFileSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -36,14 +37,17 @@ function makeExecutable(filePath) {
 
 // ─── libuv-safe fs primitives ────────────────────────────────────────
 //
-// Node 24's native rewrite of fs.cpSync/fs.rmSync mishandles non-ASCII
-// Windows paths (observed on v24.11.1 with an accented Windows user name,
-// i.e. a default %LOCALAPPDATA%\hermes home): a recursive cpSync fails
-// with EIO "Access is denied" or hard-crashes the process, an overwriting
-// cpSync fails with a bogus errno-0 unlink error, and rmSync silently
-// deletes nothing — leaving a half-staged tree that breaks every retry.
-// copyFileSync/unlinkSync/rmdirSync/readdirSync go through libuv and
-// handle those paths correctly, so staging uses them exclusively.
+// Node's native (non-libuv) rewrite of fs.cpSync/fs.rmSync mishandles
+// non-ASCII Windows paths (observed on v24.11.1 with an accented Windows
+// user name, i.e. a default %LOCALAPPDATA%\hermes home): a recursive
+// cpSync fails with EIO "Access is denied" or hard-crashes the process,
+// an overwriting cpSync fails with a bogus errno-0 unlink error, and
+// rmSync silently deletes nothing — leaving a half-staged tree that
+// breaks every retry. Fixed upstream (nodejs/node#61878 → v24.15.0;
+// nodejs/node#56049 → v24.13.1), but the installer builds on whatever
+// Node the user already has, so staging sticks to libuv-backed
+// primitives (copyFileSync/unlinkSync/rmdirSync/readdirSync), which
+// handle those paths correctly on every affected version.
 
 /** Recursively copy a directory without fs.cpSync. */
 function copyDirSync(srcDir, destDir) {
@@ -60,12 +64,25 @@ function copyDirSync(srcDir, destDir) {
 }
 
 /**
- * Recursively delete a directory without fs.rmSync (missing dir is fine),
- * then verify the tree is actually gone — a silent no-op here surfaces
- * later as an inexplicable staging failure, so fail loudly instead.
+ * Recursively delete a path without fs.rmSync — missing paths are fine,
+ * a plain file or symlink at the path is unlinked (rm -rf semantics).
+ * Verifies the tree is actually gone afterwards: a silent no-op here
+ * surfaces later as an inexplicable staging failure, so fail loudly.
+ *
+ * Also used by before-pack.mjs as the fallback when the native rmSync
+ * silently leaves the stale unpacked dir behind.
  */
-function removeDirSync(dir) {
-  if (!existsSync(dir)) return
+export function removeDirSync(dir) {
+  let stats
+  try {
+    stats = lstatSync(dir)
+  } catch {
+    return
+  }
+  if (!stats.isDirectory()) {
+    unlinkSync(dir)
+    return
+  }
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name)
     if (entry.isDirectory()) {

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -345,6 +345,19 @@ test.skipIf(process.platform === 'win32')(
 // This test stages into an accented src/dest tree — twice, so the
 // restage exercises the delete-then-recopy path — to keep it that way.
 
+test('non-ASCII paths: staging never calls fs.cpSync/fs.rmSync', () => {
+  // The Node bug is Windows-only while CI runs on Linux, so the accented
+  // staging test below cannot catch a reintroduction there. Guard at the
+  // source level instead: no cpSync/rmSync call may come back into the
+  // staging path.
+  const source = fs.readFileSync(new URL('./stage-native-deps.mjs', import.meta.url), 'utf8')
+  assert.doesNotMatch(
+    source,
+    /(?:cpSync|rmSync)\(/,
+    'stage-native-deps.mjs must stay on libuv-backed fs primitives (see the banner comment)'
+  )
+})
+
 test('non-ASCII paths: staging into an accented tree works and restages cleanly', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
   try {

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -336,6 +336,48 @@ test.skipIf(process.platform === 'win32')(
   }
 )
 
+// ─── non-ASCII path regression tests ───────────────────────────────
+//
+// Node 24's native fs.cpSync/fs.rmSync mishandle non-ASCII Windows paths
+// (accented user-profile dirs): recursive copies fail or crash, overwrite
+// copies fail with a bogus errno-0 unlink error, and rmSync silently
+// deletes nothing. Staging therefore uses libuv-backed primitives only.
+// This test stages into an accented src/dest tree — twice, so the
+// restage exercises the delete-then-recopy path — to keep it that way.
+
+test('non-ASCII paths: staging into an accented tree works and restages cleanly', () => {
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+  try {
+    const accented = join(tmp, 'áccentéd ünïcødé-pŕöfílé')
+    const srcRoot = join(accented, 'node-pty')
+    const destRoot = join(accented, 'dest')
+
+    makeFakeNodePty(srcRoot, {
+      prebuildPlatform: process.platform,
+      prebuildArch: process.arch
+    })
+    // Windows prebuilds ship a nested conpty/ payload — cover the
+    // recursive-directory branch on every platform.
+    const conptyDir = join(srcRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'conpty')
+    fs.mkdirSync(conptyDir, { recursive: true })
+    fs.writeFileSync(join(conptyDir, 'conpty.dll'), 'fake dll')
+    fs.writeFileSync(join(conptyDir, 'OpenConsole.exe'), 'fake exe')
+
+    for (let pass = 1; pass <= 2; pass++) {
+      stageNodePtyInto(srcRoot, destRoot, { platform: process.platform, arch: process.arch })
+
+      const stagedPrebuild = join(destRoot, 'prebuilds', `${process.platform}-${process.arch}`)
+      assert.equal(existsSync(join(destRoot, 'package.json')), true, `pass ${pass}: package.json staged`)
+      assert.equal(existsSync(join(destRoot, 'lib', 'index.js')), true, `pass ${pass}: lib staged`)
+      assert.equal(existsSync(join(stagedPrebuild, 'pty.node')), true, `pass ${pass}: prebuild staged`)
+      assert.equal(existsSync(join(stagedPrebuild, 'conpty', 'conpty.dll')), true, `pass ${pass}: conpty dir staged`)
+      assert.equal(existsSync(join(stagedPrebuild, 'conpty', 'OpenConsole.exe')), true, `pass ${pass}: conpty exe staged`)
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
 test('validation rejects a staged binary with the wrong platform magic', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
   try {


### PR DESCRIPTION
## Problem

On Windows, `hermes-setup` bricks at the desktop build stage for **every user whose profile path contains non-ASCII characters** (accented user names — common across Central/Eastern Europe, and any non-Latin locale), because the default install home is `%LOCALAPPDATA%\hermes`, i.e. inside the user profile.

Node's native (non-libuv) rewrite of `fs.cpSync`/`fs.rmSync` mishandles such paths. This is a known upstream regression — [nodejs/node#61878](https://github.com/nodejs/node/issues/61878) (cpSync, fixed in v24.15.0) and [nodejs/node#56049](https://github.com/nodejs/node/issues/56049) (rmSync silent no-op, fixed in v24.13.1) — but the installer builds with whatever Node the user already has, and affected versions (e.g. the v24.11.x line) will be in the wild for a long time. Reproduced on stock `node.exe` v24.11.1:

- recursive `cpSync` fails with `EIO, Access is denied` (errno 5, syscall `cp`, from `fsBinding.cpSyncCopyDir`) — or hard-crashes the process with `0xC0000409` after creating a mojibake (double-encoded) sibling directory,
- `cpSync` over an existing file fails with a bogus `errno: 0, code: '', syscall: 'unlink', "The operation completed successfully"` (from `fsBinding.cpSyncOverrideFile`),
- `rmSync({recursive: true, force: true})` **silently deletes nothing**.

In `apps/desktop/scripts/stage-native-deps.mjs` this plays out as: the first `npm run pack` dies copying the `conpty` prebuild dir; the silent `rmSync` no-op then leaves the half-staged `dist/node_modules/node-pty` tree in place, so **every retry fails earlier** (on the `package.json` overwrite) — including the bootstrap installer's automatic retry, which then misdiagnoses the failure as a blocked Electron download. Net effect: fresh installs fail at `stage=desktop`, updates fail at `stage=rebuild`, and no `Hermes.exe` is ever produced.

Real-world failure (bootstrap-installer.log, accented profile, fresh install):

```
Error: EIO, Access is denied. '\\?\C:\Users\<áccented user>\AppData\Local\hermes\hermes-agent\apps\desktop\dist\node_modules\node-pty\prebuilds\win32-x64\conpty'
    at stageNodePtyInto (.../scripts/stage-native-deps.mjs:264:9)
...retry...
Error: , The operation completed successfully. '\\?\...\dist\node_modules\node-pty\package.json'
  errno: 0, code: '', syscall: 'unlink'
```

## Fix

**`stage-native-deps.mjs`** — replace all `cpSync`/`rmSync` uses with libuv-backed primitives, which handle these paths correctly on every affected Node version:

- single-file copies → `copyFileSync` (drop-in, preserves the source mode),
- recursive directory copies (the `conpty` payload, nested `build/Release` dirs) → a small `copyDirSync` walk (`mkdirSync` + `readdirSync` + `copyFileSync`),
- the dest-tree cleanup → an exported `removeDirSync` walk (`lstatSync`/`unlinkSync`/`rmdirSync`, rm -rf semantics for a stray file/symlink at the path), **verified with `existsSync` afterwards** so a silent no-op fails loudly instead of poisoning every subsequent build.

**`before-pack.mjs`** — `cleanStaleAppOutDir` keeps its retrying `rmSync` (the `maxRetries` EBUSY resilience is worth keeping) but now verifies the tree is actually gone and falls back to `removeDirSync` when the native `rmSync` silently no-ops; previously it logged `removed stale unpacked dir` while the stale tree survived.

No behavior change on ASCII paths; the staged tree, validation, and `spawn-helper` chmod handling are untouched.

## Verification

- A/B on an affected machine (`node.exe` v24.11.1, accented profile path): the unpatched script fails with the byte-identical `EIO ... conpty` error from the production log (and in a clean scratch dir, hard-crashes with `0xC0000409`, leaving a partial dest plus a double-encoded mojibake directory); the patched script stages twice in a row cleanly (the restage exercises the delete-then-recopy path).
- `npx vitest run scripts/stage-native-deps.test.mjs scripts/before-pack.test.mjs`: 21 passed, 1 skipped (the POSIX-only helper test, on win32).
- New regression test stages a fake node-pty tree — including a nested `conpty/` payload — into an accented src/dest path, twice.
- New source-level guard test asserts no `cpSync(`/`rmSync(` call comes back into `stage-native-deps.mjs` — CI runs on Linux where the native implementations happen to work, so the accented staging test alone could not catch a reintroduction there.

## Notes

- Known, deliberate divergences from `rmSync`/`cpSync` semantics, all outside what a real node-pty tree contains: no chmod-retry for read-only files or Windows directory junctions inside the dest tree (fails loudly instead), and symlinks are dereferenced on copy rather than copied verbatim (npm-published trees cannot contain symlinks).
- The installer's "Electron download from GitHub looks blocked" retry message is a red herring in this failure mode (no download was attempted) — happy to file a separate issue for that misdiagnosis if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
