### PR TITLE
fix(docker): stop tini -g legacy entrypoint boot loop (#66679)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,17 +73,19 @@ RUN set -eu; \
     tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz; \
     tar -C / -Jxpf /tmp/s6-overlay-arch.tar.xz; \
     tar -C / -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz; \
-    rm /tmp/s6-overlay-*.tar.xz /tmp/s6-overlay.sha256; \
-    # #34192: backward-compat shim for orchestration templates that still\
-    # reference the legacy /usr/bin/tini entrypoint (e.g. Hostinger's\
-    # 'Hermes WebUI' catalog). The image has moved to s6-overlay /init\
-    # as PID 1 (see ENTRYPOINT below + the migration comment at the top\
-    # of this file), but external wrappers pinned to /usr/bin/tini will\
-    # crash with 'tini: No such file or directory' on startup. The shim\
-    # symlinks /usr/bin/tini -> /init so legacy wrappers exec the right\
-    # PID-1 reaper without behavior change for users on the current\
-    # ENTRYPOINT. Safe to drop once the affected catalogs are updated.\
-    ln -sf /init /usr/bin/tini
+    rm /tmp/s6-overlay-*.tar.xz /tmp/s6-overlay.sha256
+
+# #34192 / #66679: backward-compat shim for orchestration templates that
+# still reference the legacy /usr/bin/tini entrypoint (Hostinger's
+# 'Hermes WebUI' catalog, NAS compose projects that preserve an old
+# entrypoint on image update, etc.). A plain symlink to /init made the
+# path exist, but forwarded tini flags like `-g` into s6-overlay's
+# rc.init as the container CMD (`rc.init: 91: -g: not found`) and
+# boot-looped any `restart: unless-stopped` deploy. The shim strips the
+# tini CLI surface, then exec's /init + main-wrapper — see
+# docker/tini-shim.sh. Safe to drop once the affected catalogs are
+# updated.
+COPY --chmod=0755 docker/tini-shim.sh /usr/bin/tini
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime
 RUN useradd -u 10000 -m -d /opt/data hermes

--- a/docker/tini-shim.sh
+++ b/docker/tini-shim.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# shellcheck shell=sh
+# /usr/bin/tini — compatibility shim for legacy orchestration templates.
+#
+# Background
+# ----------
+# The published image used to ship real `tini` as PID 1. After the
+# s6-overlay migration, PID 1 is `/init`. Downstream catalogs (Hostinger
+# Hermes WebUI, NAS "update" flows that preserve an old entrypoint, etc.)
+# still pin entrypoints like:
+#
+#   ["/usr/bin/tini", "-g", "--"]
+#   ["/usr/bin/tini", "-g", "--", "gateway", "run"]
+#
+# A plain `ln -sf /init /usr/bin/tini` (#34192) made the binary exist, but
+# forwarded tini's own flags into s6-overlay. `/init` then handed `-g` to
+# `rc.init` as the container CMD, which fails with:
+#
+#   /run/s6/basedir/scripts/rc.init: 91: -g: not found
+#
+# …and with `restart: unless-stopped` the container boot-loops forever
+# (#66679).
+#
+# This shim strips the tini CLI surface, then exec's `/init` with the
+# image's main-wrapper so privilege drop + arg routing still apply.
+#
+# Tini flags we discard (see krallin/tini --help):
+#   -g / --kill-process-group, -s / --subreaper, -w, -v (repeatable),
+#   -h / --help, -l, --version, -p SIGNAL, -e EXIT_CODE, and `--`.
+# s6-overlay already reaps zombies and forwards signals as PID 1; the
+# flag semantics are intentionally no-ops here.
+#
+# Test hook: HERMES_TINI_SHIM_TARGET overrides the `/init` path (and
+# HERMES_TINI_SHIM_WRAPPER the main-wrapper path) so unit tests can
+# record argv without a real s6 tree.
+
+set -e
+
+INIT_TARGET="${HERMES_TINI_SHIM_TARGET:-/init}"
+WRAPPER="${HERMES_TINI_SHIM_WRAPPER:-/opt/hermes/docker/main-wrapper.sh}"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --)
+            shift
+            break
+            ;;
+        -g|--kill-process-group|-s|--subreaper|-w|-l|-h|--help|--version)
+            shift
+            ;;
+        -v)
+            # tini allows repeated -v; drop them all.
+            shift
+            ;;
+        -p|-e)
+            # These take a mandatory argument.
+            shift
+            if [ "$#" -gt 0 ]; then
+                shift
+            fi
+            ;;
+        -*)
+            # Unknown short/long option from an older/newer tini — drop
+            # rather than forwarding into /init (would recreate #66679).
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# No program left (entrypoint was just `tini -g --`) → same as the
+# image's default ENTRYPOINT + empty CMD.
+if [ "$#" -eq 0 ]; then
+    exec "$INIT_TARGET" "$WRAPPER"
+fi
+
+# Caller already supplied the wrapper or /init — don't double-wrap.
+case "$1" in
+    /init|"$INIT_TARGET")
+        exec "$@"
+        ;;
+    "$WRAPPER"|*/main-wrapper.sh)
+        exec "$INIT_TARGET" "$@"
+        ;;
+esac
+
+exec "$INIT_TARGET" "$WRAPPER" "$@"

--- a/tests/docker/test_tini_compat_shim.py
+++ b/tests/docker/test_tini_compat_shim.py
@@ -1,33 +1,42 @@
-"""Runtime smoke test for the Docker tini compatibility shim (#34192).
+"""Runtime smoke test for the Docker tini compatibility shim (#34192, #66679).
 
 Build the real image and verify:
 
-  1. /usr/bin/tini exists and is a symlink to /init (the compat shim
-     for orchestration templates that still reference /usr/bin/tini)
+  1. /usr/bin/tini exists as an executable shim (not a bare symlink to
+     /init — that forwarded tini's ``-g`` into s6 and boot-looped)
   2. The actual ENTRYPOINT is /init (s6-overlay), not /usr/bin/tini
+  3. Legacy ``tini -g -- <cmd>`` entrypoints boot without
+     ``rc.init: -g: not found``
 """
 from __future__ import annotations
 
 import subprocess
 
 
-def test_tini_compat_symlink_exists(built_image: str) -> None:
-    """/usr/bin/tini must exist as a symlink to /init.
+def test_tini_compat_shim_exists(built_image: str) -> None:
+    """/usr/bin/tini must be an executable shim script.
 
-    Regression for #34192: orchestration templates (e.g. Hostinger's
-    'Hermes WebUI' catalog) still pin /usr/bin/tini as the entrypoint.
-    The shim symlinks it to /init so legacy wrappers exec the right
-    PID-1 reaper without behavior change.
+    Regression for #34192 / #66679: orchestration templates (e.g.
+    Hostinger's 'Hermes WebUI' catalog, NAS compose projects that keep
+    an old entrypoint across image updates) still pin /usr/bin/tini as
+    the entrypoint, often with ``-g --``. The shim must exist *and*
+    strip those flags before exec'ing /init.
     """
     r = subprocess.run(
         ["docker", "run", "--rm", "--entrypoint", "sh",
          built_image, "-c",
-         'test -L /usr/bin/tini && '
-         'test "$(readlink -f /usr/bin/tini)" = "/init"'],
+         'test -x /usr/bin/tini && '
+         # Must NOT be a raw symlink to /init — that reintroduces #66679.
+         'if [ -L /usr/bin/tini ]; then '
+         '  target="$(readlink -f /usr/bin/tini)"; '
+         '  test "$target" != "/init"; '
+         'fi && '
+         'head -n1 /usr/bin/tini | grep -q "^#!"'],
         capture_output=True, text=True, timeout=60,
     )
     assert r.returncode == 0, (
-        f"/usr/bin/tini is not a symlink to /init: {r.stderr[-500:]}"
+        f"/usr/bin/tini is not a usable tini shim: "
+        f"stdout={r.stdout[-500:]!r} stderr={r.stderr[-500:]!r}"
     )
 
 
@@ -51,4 +60,31 @@ def test_entrypoint_is_init_not_tini(built_image: str) -> None:
     # /usr/bin/tini should NOT be in the entrypoint.
     assert "tini" not in entrypoint.lower(), (
         f"ENTRYPOINT references tini instead of /init: {entrypoint!r}"
+    )
+
+
+def test_legacy_tini_g_entrypoint_does_not_boot_loop(built_image: str) -> None:
+    """``docker run --entrypoint /usr/bin/tini … -g -- --help`` must work.
+
+    Exact failure from #66679: after update, NAS templates still invoke
+    ``/usr/bin/tini -g -- …``. The old symlink turned that into
+    ``/init -g -- …``, rc.init tried to exec ``-g``, and the container
+    restart-looped. The shim must strip ``-g`` / ``--`` and reach hermes.
+    """
+    r = subprocess.run(
+        [
+            "docker", "run", "--rm",
+            "--entrypoint", "/usr/bin/tini",
+            built_image,
+            "-g", "--", "--help",
+        ],
+        capture_output=True, text=True, timeout=120,
+    )
+    combined = r.stdout + r.stderr
+    assert "-g: not found" not in combined, (
+        f"tini -g leaked into rc.init (boot-loop regression):\n{combined[-3000:]}"
+    )
+    assert r.returncode == 0, (
+        f"legacy tini -g -- --help failed (exit {r.returncode}):\n"
+        f"stdout={r.stdout[-2000:]!r}\nstderr={r.stderr[-2000:]!r}"
     )

--- a/tests/test_tini_shim.py
+++ b/tests/test_tini_shim.py
@@ -1,0 +1,107 @@
+"""Unit tests for docker/tini-shim.sh argument stripping (#66679).
+
+These run without Docker: the shim's HERMES_TINI_SHIM_TARGET /
+HERMES_TINI_SHIM_WRAPPER hooks let us record the argv that would be
+handed to /init.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHIM = REPO_ROOT / "docker" / "tini-shim.sh"
+
+
+@pytest.fixture
+def recorder(tmp_path: Path) -> tuple[Path, Path]:
+    """Fake /init + wrapper that print argv, one token per line."""
+    init = tmp_path / "fake-init"
+    wrapper = tmp_path / "fake-wrapper"
+    init.write_text("#!/bin/sh\nprintf '%s\\n' \"$@\"\n")
+    wrapper.write_text("#!/bin/sh\nprintf 'wrapper\\n'\n")
+    init.chmod(0o755)
+    wrapper.chmod(0o755)
+    return init, wrapper
+
+
+def _run_shim(
+    recorder: tuple[Path, Path],
+    args: list[str],
+) -> subprocess.CompletedProcess[str]:
+    init, wrapper = recorder
+    env = os.environ.copy()
+    env["HERMES_TINI_SHIM_TARGET"] = str(init)
+    env["HERMES_TINI_SHIM_WRAPPER"] = str(wrapper)
+    return subprocess.run(
+        ["sh", str(SHIM), *args],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+        check=False,
+    )
+
+
+def test_shim_script_is_executable_bit_friendly() -> None:
+    assert SHIM.is_file()
+    text = SHIM.read_text()
+    assert text.startswith("#!/bin/sh")
+    assert "HERMES_TINI_SHIM_TARGET" in text
+
+
+def test_strips_g_and_double_dash(recorder: tuple[Path, Path]) -> None:
+    """Legacy `tini -g -- gateway run` must not forward `-g` to /init."""
+    r = _run_shim(recorder, ["-g", "--", "gateway", "run"])
+    assert r.returncode == 0, r.stderr
+    lines = [ln for ln in r.stdout.splitlines() if ln]
+    init, wrapper = recorder
+    assert lines[0] == str(wrapper)
+    assert lines[1:] == ["gateway", "run"]
+    assert "-g" not in lines
+    assert "--" not in lines
+
+
+def test_strips_g_without_double_dash(recorder: tuple[Path, Path]) -> None:
+    r = _run_shim(recorder, ["-g", "gateway", "run"])
+    assert r.returncode == 0, r.stderr
+    lines = [ln for ln in r.stdout.splitlines() if ln]
+    init, wrapper = recorder
+    assert lines == [str(wrapper), "gateway", "run"]
+
+
+def test_empty_args_after_flags_uses_wrapper_only(
+    recorder: tuple[Path, Path],
+) -> None:
+    """entrypoint `tini -g --` with empty CMD → /init main-wrapper."""
+    r = _run_shim(recorder, ["-g", "--"])
+    assert r.returncode == 0, r.stderr
+    lines = [ln for ln in r.stdout.splitlines() if ln]
+    _, wrapper = recorder
+    assert lines == [str(wrapper)]
+
+
+def test_does_not_double_wrap_existing_wrapper(
+    recorder: tuple[Path, Path],
+) -> None:
+    _, wrapper = recorder
+    r = _run_shim(recorder, ["-g", "--", str(wrapper), "gateway", "run"])
+    assert r.returncode == 0, r.stderr
+    lines = [ln for ln in r.stdout.splitlines() if ln]
+    assert lines == [str(wrapper), "gateway", "run"]
+
+
+def test_strips_p_and_e_with_arguments(recorder: tuple[Path, Path]) -> None:
+    r = _run_shim(
+        recorder,
+        ["-p", "SIGKILL", "-e", "143", "-v", "-v", "--", "sleep", "infinity"],
+    )
+    assert r.returncode == 0, r.stderr
+    lines = [ln for ln in r.stdout.splitlines() if ln]
+    _, wrapper = recorder
+    assert lines == [str(wrapper), "sleep", "infinity"]
+    assert "SIGKILL" not in lines
+    assert "143" not in lines


### PR DESCRIPTION
## Summary
- Replace the `/usr/bin/tini` → `/init` symlink with a flag-stripping shim so legacy entrypoints like `tini -g -- …` (NAS/Hostinger catalogs that keep the old entrypoint after image update) no longer hand `-g` to s6-overlay's `rc.init`.
- That failure (`rc.init: 91: -g: not found`) exited the container immediately; with `restart: unless-stopped` it boot-looped forever after update ([#66679](https://github.com/NousResearch/hermes-agent/issues/66679)).
- Add unit + image tests covering `-g` / `--` stripping and the legacy entrypoint boot path.

## Test plan
- [x] `scripts/run_tests.sh tests/test_tini_shim.py -q`
- [ ] `scripts/run_tests.sh tests/docker/test_tini_compat_shim.py -q` (needs Docker daemon + image build)
- [ ] Manual: `docker run --rm --entrypoint /usr/bin/tini <image> -g -- --help` exits 0 and does **not** print `-g: not found`
- [ ] Manual: compose/NAS-style `entrypoint: ["/usr/bin/tini", "-g", "--"]` + `command: ["gateway", "run"]` stays up (no restart loop)



## Infographic

![tini-compat-shim-boot-loop-fix](https://v3b.fal.media/files/b/0aa2b892/YsD_kB2-DE5MotPcnglvs_tMSun2Ck.png)
