### PR TITLE
fix(gateway): scope PID ownership check to active profile home

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1451,7 +1451,15 @@ def get_running_pid(
     lock_active = is_gateway_runtime_lock_active(resolved_lock_path)
     if not lock_active:
         if pid_path is None:
-            runtime_pid = get_runtime_status_running_pid()
+            # The runtime-status fallback must validate ownership against the
+            # active profile.  Without this scope, a stale default
+            # gateway_state.json can point at a live named-profile gateway and
+            # make ``gateway start`` report "already running" for the wrong
+            # profile (the PID itself is alive and the command is gateway-like,
+            # so an unscoped check cannot distinguish the two).
+            runtime_pid = get_runtime_status_running_pid(
+                expected_home=Path(_get_runtime_status_path()).parent
+            )
             if runtime_pid is not None:
                 return runtime_pid
         _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
@@ -1478,7 +1486,9 @@ def get_running_pid(
 
     _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
     if pid_path is None:
-        runtime_pid = get_runtime_status_running_pid()
+        runtime_pid = get_runtime_status_running_pid(
+            expected_home=Path(_get_runtime_status_path()).parent
+        )
         if runtime_pid is not None:
             return runtime_pid
     return None

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -53,6 +53,32 @@ class TestGatewayPidState:
         assert status.get_running_pid() is None
         assert not pid_path.exists()
 
+    def test_get_running_pid_rejects_other_profile_runtime_pid(self, tmp_path, monkeypatch):
+        """A stale default runtime record must not claim a named gateway PID.
+
+        This is the start-path regression: with no active default lock/PID file,
+        ``get_running_pid()`` falls back to gateway_state.json.  That fallback
+        must apply the same profile ownership check used by profile listing;
+        otherwise ``gateway start`` can refuse recovery because another profile
+        happens to be alive.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "gateway_state.json").write_text(json.dumps({
+            "pid": 30184,
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "gateway_state": "running",
+        }))
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda pid: "hermes --profile research gateway run --replace",
+        )
+
+        assert status.get_running_pid() is None
+
     def test_get_running_pid_cleans_stale_record_from_dead_process(self, tmp_path, monkeypatch):
         # Simulates the aftermath of a crash: the PID file still points at a
         # process that no longer exists. The next gateway startup must be
@@ -546,7 +572,7 @@ class TestGatewayRuntimeStatus:
         for cmdline in (
             "hermes -p coder gateway run --replace",
             "/opt/hermes/.venv/bin/hermes --profile coder gateway run --replace",
-            "hermes_home=/opt/data/profiles/coder hermes gateway run --replace",
+            f"hermes_home={str(coder_home).lower()} hermes gateway run --replace",
         ):
             monkeypatch.setattr(status, "_read_process_cmdline", lambda pid, c=cmdline: c)
             assert (


### PR DESCRIPTION
## What does this PR do?

Fixes a multi-profile gateway PID ownership bug on Windows/profile installs.

When the default profile's gateway was stopped, a stale `gateway_state.json` could still point at a live named-profile gateway PID. `get_running_pid()` fell back to that runtime status **without** scoping ownership to the active profile home, so `hermes --profile default gateway start` reported `Gateway already running (PID: <other-profile>)` and blocked recovery — even though `gateway list` correctly showed default stopped.

This PR scopes both runtime-status fallbacks in `get_running_pid()` to the active profile home so another profile's live gateway cannot satisfy default (or any other profile's) liveness.

## Related Issue

Incident path (2026-07-17 multi-profile Windows): default stopped, research running; default start refused with research PID. No public issue number yet.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `gateway/status.py` — pass `expected_home=Path(_get_runtime_status_path()).parent` into both `get_runtime_status_running_pid()` fallbacks inside `get_running_pid()`
- `tests/gateway/test_status.py` — add `test_get_running_pid_rejects_other_profile_runtime_pid` regression; normalize Windows fixture path for `hermes_home=` cmdline case

## How to Test

1. **Unit (required):**
   ```bash
   pytest tests/gateway/test_status.py -q -k 'get_running_pid' --disable-warnings
   # expect: 13 passed
   pytest tests/gateway/test_status.py -q --disable-warnings
   # expect: 95 passed
   pytest tests/hermes_cli/test_profiles.py -q -k 'gateway_running_check' --disable-warnings
   # expect: 6 passed
   ```
2. **Live smoke (multi-profile):** with default + one named profile gateways:
   ```bash
   hermes --profile default gateway status
   hermes --profile <named> gateway status
   hermes gateway list
   ```
   Confirm each profile reports its own PID (or stopped) independently; a running named-profile gateway must not make default `get_running_pid()` return that PID when default is stopped.
3. **Regression scenario:** leave a stale default `gateway_state.json` pointing at another profile's live PID with no default lock/pidfile; `get_running_pid()` for default must return `None` so start can recover.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(gateway): …`)
- [x] I searched for existing PRs (related ownership/status work exists; this is a narrow profile-home scope fix for the runtime-status fallback)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run targeted pytest suites above (full tree not re-run in this agent session)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (git-bash), multi-profile default + research

### Documentation and Housekeeping

- [x] I've updated relevant documentation — N/A (behavior fix; comments in code + regression test document the contract)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — ownership check uses existing profile-home/cmdline helpers already used by list/status paths
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Local evidence after this commit (`5d284fdec`):
- `tests/gateway/test_status.py` → 95 passed
- `get_running_pid` filter → 13 passed
- profile gateway checks → 6 passed
- Live smoke: default and named-profile status report distinct PIDs; list does not misattribute ownership

## Follow-ups (out of this PR's minimal fix)

Sibling fleet work (not blocking this mergeable root-cause fix):
- Align start/status/list callers more explicitly on shared PID utility usage (consistency tests)
- Non-secret gateway self-health diagnostics (CLI/HTTP) for operator visibility
