### PR TITLE
feat: built-in wiki page generation from sessions (holographic plugin)

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -179,6 +179,17 @@ class HolographicMemoryProvider(MemoryProvider):
             hrr_dim=hrr_dim,
         )
         self._session_id = session_id
+        self._session_title = ""
+        self._session_source = kwargs.get("platform", "")
+        self._wiki_builder = None
+        self._wiki_thread = None
+        self._wiki_thread_lock = __import__("threading").Lock()
+        # Initialize wiki builder if auto_wiki is enabled
+        if self._config.get("auto_wiki", True):
+            from .wiki_builder import WikiBuilder
+            self._wiki_builder = WikiBuilder(self._store, self._config)
+            # Process any leftover pending items from previous runs
+            self._schedule_wiki_build()
 
     def system_prompt_block(self) -> str:
         if not self._store:
@@ -235,11 +246,54 @@ class HolographicMemoryProvider(MemoryProvider):
         return tool_error(f"Unknown tool: {tool_name}")
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
-        if not self._config.get("auto_extract", False):
-            return
         if not self._store or not messages:
             return
-        self._auto_extract_facts(messages)
+        # Enqueue for wiki processing (non-blocking)
+        try:
+            self._store.enqueue_wiki_pending(
+                session_id=self._session_id,
+                messages=messages,
+                title=self._session_title,
+                source=self._session_source,
+            )
+            logger.debug("Enqueued session %s for wiki processing", self._session_id)
+            # Trigger background processing
+            self._schedule_wiki_build()
+        except Exception as e:
+            logger.debug("Wiki enqueue failed: %s", e)
+        # Also run legacy auto-extract if configured
+        if self._config.get("auto_extract", False):
+            self._auto_extract_facts(messages)
+
+    def on_session_switch(self, new_session_id: str, **kwargs) -> None:
+        """Capture session title for wiki page generation."""
+        self._session_id = new_session_id
+        self._session_title = kwargs.get("title", "") or ""
+
+    def _schedule_wiki_build(self) -> None:
+        """Start a background thread to process wiki pending queue."""
+        if not self._wiki_builder:
+            return
+        with self._wiki_thread_lock:
+            # Don't start a new thread if one is already running
+            if self._wiki_thread and self._wiki_thread.is_alive():
+                return
+            import threading
+            self._wiki_thread = threading.Thread(
+                target=self._wiki_build_worker,
+                daemon=True,
+                name="wiki-builder",
+            )
+            self._wiki_thread.start()
+
+    def _wiki_build_worker(self) -> None:
+        """Background worker: process pending wiki jobs."""
+        try:
+            count = self._wiki_builder.process_pending()
+            if count:
+                logger.info("WikiBuilder processed %d sessions", count)
+        except Exception as e:
+            logger.error("WikiBuilder worker failed: %s", e)
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes as facts."""
@@ -251,12 +305,11 @@ class HolographicMemoryProvider(MemoryProvider):
                 logger.debug("Holographic memory_write mirror failed: %s", e)
 
     def shutdown(self) -> None:
-        # Release the shared SQLite connection deterministically on the
-        # caller's thread. Dropping the reference alone leaves fd finalization
-        # to GC, which keeps the connection (and its write lock) alive on a
-        # long-running gateway and prolongs the "database is locked" contention
-        # this store's shared-connection refcounting is meant to eliminate.
-        # close() is idempotent and refcount-guarded, so siblings stay safe.
+        # Stop wiki builder thread
+        self._wiki_builder = None
+        if self._wiki_thread and self._wiki_thread.is_alive():
+            self._wiki_thread.join(timeout=5.0)
+        # Release shared SQLite connection
         if self._store is not None:
             try:
                 self._store.close()

--- a/plugins/memory/holographic/plugin.yaml
+++ b/plugins/memory/holographic/plugin.yaml
@@ -1,5 +1,21 @@
 name: holographic
-version: 0.1.0
-description: "Holographic memory — local SQLite fact store with FTS5 search, trust scoring, and HRR-based compositional retrieval."
+version: 0.2.0
+description: "Holographic memory — local SQLite fact store with FTS5 search, trust scoring, HRR-based retrieval, and built-in wiki page generation."
 hooks:
   - on_session_end
+config:
+  - key: auto_wiki
+    description: "Enable automatic wiki page generation from sessions"
+    default: "true"
+  - key: auto_extract
+    description: "Enable legacy regex-based fact extraction"
+    default: "false"
+  - key: db_path
+    description: "Path to memory_store.db"
+    default: "$HERMES_HOME/memory_store.db"
+  - key: default_trust
+    description: "Default trust score for new facts"
+    default: "0.5"
+  - key: hrr_dim
+    description: "HRR vector dimensions"
+    default: "1024"

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -52,18 +52,23 @@ class FactRetriever:
         min_trust: float = 0.3,
         limit: int = 10,
     ) -> list[dict]:
-        """Hybrid search: FTS5 candidates → Jaccard rerank → trust weighting.
+        """Hybrid search: FTS5 candidates (facts + wiki) → Jaccard rerank → trust weighting.
 
         Pipeline:
-        1. FTS5 search: Get limit*3 candidates from SQLite full-text search
-        2. Jaccard boost: Token overlap between query and fact content
+        1. FTS5 search: Get limit*3 candidates from facts_fts AND wiki_fts
+        2. Jaccard boost: Token overlap between query and fact/wiki content
         3. Trust weighting: final_score = relevance * trust_score
         4. Temporal decay (optional): decay = 0.5^(age_days / half_life)
 
         Returns list of dicts with fact data + 'score' field, sorted by score desc.
+        Wiki results include 'source': 'wiki' and 'content' from summary.
         """
         # Stage 1: Get FTS5 candidates (more than limit for reranking headroom)
         candidates = self._fts_candidates(query, category, min_trust, limit * 3)
+
+        # Also search wiki pages
+        wiki_hits = self._wiki_candidates(query, limit * 2)
+        candidates.extend(wiki_hits)
 
         if not candidates:
             return []
@@ -542,6 +547,98 @@ class FactRetriever:
             fact.pop("fts_rank_raw", None)
             fact["fts_rank"] = raw_rank / max_rank  # normalize to [0, 1]
             results.append(fact)
+
+        return results
+
+    def _wiki_candidates(
+        self,
+        query: str,
+        limit: int,
+    ) -> list[dict]:
+        """Search wiki_pages via wiki_fts and return results in fact-compatible format.
+
+        Wiki results are normalized to look like facts so the reranking pipeline
+        can process them uniformly. Key mappings:
+        - page_id → fact_id
+        - summary → content
+        - quality/5.0 → trust_score (quality 3 → 0.6, quality 5 → 1.0)
+        - page_type → category
+        - source='wiki' marker for callers to distinguish
+
+        Uses FTS5 for English tokens and LIKE fallback for CJK queries.
+        """
+        conn = self.store._conn
+
+        # Check if wiki_fts table exists
+        try:
+            conn.execute("SELECT 1 FROM wiki_fts LIMIT 0")
+        except Exception:
+            return []
+
+        match_query = self._sanitize_fts_query(query)
+        rows = []
+
+        # FTS5 search
+        sql = """
+            SELECT wp.page_id, wp.title, wp.summary, wp.quality,
+                   wp.page_type, wp.topics, wp.keywords, wp.slug,
+                   wp.date, wiki_fts.rank as fts_rank_raw
+            FROM wiki_fts
+            JOIN wiki_pages wp ON wp.page_id = wiki_fts.rowid
+            WHERE wiki_fts MATCH ?
+            ORDER BY wiki_fts.rank
+            LIMIT ?
+        """
+        try:
+            rows = conn.execute(sql, [match_query, limit]).fetchall()
+        except Exception:
+            pass
+
+        # LIKE fallback for CJK / short queries with no FTS hits
+        if not rows and len(query) >= 2:
+            like_sql = """
+                SELECT page_id, title, summary, quality,
+                       page_type, topics, keywords, slug, date,
+                       0.0 as fts_rank_raw
+                FROM wiki_pages
+                WHERE summary LIKE ? OR title LIKE ? OR topics LIKE ?
+                LIMIT ?
+            """
+            like_param = f"%{query}%"
+            try:
+                rows = conn.execute(
+                    like_sql, [like_param, like_param, like_param, limit]
+                ).fetchall()
+            except Exception:
+                return []
+
+        if not rows:
+            return []
+
+        raw_ranks = [abs(row["fts_rank_raw"] if row["fts_rank_raw"] else 0.5) for row in rows]
+        max_rank = max(raw_ranks) if raw_ranks else 1.0
+        max_rank = max(max_rank, 1e-6)
+
+        results = []
+        for row, raw_rank in zip(rows, raw_ranks):
+            quality = row["quality"] or 3
+            wiki = {
+                "fact_id": f"wiki_{row['page_id']}",
+                "content": row["summary"] or row["title"],
+                "category": row["page_type"],
+                "tags": f"wiki:{row['slug']}, {row['topics'] or ''}",
+                "trust_score": quality / 5.0,
+                "retrieval_count": 0,
+                "helpful_count": 0,
+                "created_at": row["date"],
+                "updated_at": row["date"],
+                "fts_rank": raw_rank / max_rank,
+                "source": "wiki",
+                "wiki_slug": row["slug"],
+                "wiki_title": row["title"],
+                "wiki_quality": quality,
+            }
+            results.append(wiki)
 
         return results
 

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -73,6 +73,65 @@ CREATE TABLE IF NOT EXISTS memory_banks (
     fact_count INTEGER DEFAULT 0,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Wiki tables (memory-wiki plugin)
+CREATE TABLE IF NOT EXISTS wiki_pages (
+    page_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_type      TEXT NOT NULL,
+    slug           TEXT UNIQUE NOT NULL,
+    title          TEXT NOT NULL,
+    date           TEXT,
+    quality        INTEGER,
+    content_type   TEXT,
+    topics         TEXT,
+    keywords       TEXT,
+    summary        TEXT,
+    full_content   TEXT,
+    source_session_id TEXT,
+    created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS wiki_page_entities (
+    page_id   INTEGER NOT NULL,
+    entity_id INTEGER NOT NULL,
+    PRIMARY KEY (page_id, entity_id),
+    FOREIGN KEY (page_id) REFERENCES wiki_pages(page_id),
+    FOREIGN KEY (entity_id) REFERENCES entities(entity_id)
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS wiki_fts
+    USING fts5(title, summary, topics, keywords, content=wiki_pages, content_rowid=page_id);
+
+CREATE TRIGGER IF NOT EXISTS wiki_ai AFTER INSERT ON wiki_pages BEGIN
+    INSERT INTO wiki_fts(rowid, title, summary, topics, keywords)
+    VALUES (new.page_id, new.title, new.summary, new.topics, new.keywords);
+END;
+
+CREATE TRIGGER IF NOT EXISTS wiki_ad AFTER DELETE ON wiki_pages BEGIN
+    INSERT INTO wiki_fts(wiki_fts, rowid, title, summary, topics, keywords)
+    VALUES ('delete', old.page_id, old.title, old.summary, old.topics, old.keywords);
+END;
+
+CREATE TRIGGER IF NOT EXISTS wiki_au AFTER UPDATE ON wiki_pages BEGIN
+    INSERT INTO wiki_fts(wiki_fts, rowid, title, summary, topics, keywords)
+    VALUES ('delete', old.page_id, old.title, old.summary, old.topics, old.keywords);
+    INSERT INTO wiki_fts(rowid, title, summary, topics, keywords)
+    VALUES (new.page_id, new.title, new.summary, new.topics, new.keywords);
+END;
+
+CREATE TABLE IF NOT EXISTS wiki_pending_queue (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  TEXT NOT NULL,
+    title       TEXT,
+    source      TEXT,
+    message_count INTEGER,
+    messages_json TEXT NOT NULL,
+    enqueued_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    status      TEXT DEFAULT 'pending'
+);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_pending_status ON wiki_pending_queue(status);
 """
 
 # Trust adjustment constants
@@ -607,6 +666,72 @@ class MemoryStore:
                 self._rebuild_bank(category)
 
             return len(rows)
+
+    # ------------------------------------------------------------------
+    # Wiki pending queue
+    # ------------------------------------------------------------------
+
+    def enqueue_wiki_pending(
+        self,
+        session_id: str,
+        messages: list,
+        title: str = "",
+        source: str = "",
+    ) -> int:
+        """Enqueue a session for wiki processing. Returns queue id."""
+        import json as _json
+        messages_json = _json.dumps(messages, ensure_ascii=False)
+        with self._lock:
+            cur = self._conn.execute(
+                """INSERT INTO wiki_pending_queue (session_id, title, source, message_count, messages_json, status)
+                   VALUES (?, ?, ?, ?, ?, 'pending')""",
+                (session_id, title, source, len(messages), messages_json),
+            )
+            self._conn.commit()
+            return cur.lastrowid  # type: ignore[return-value]
+
+    def dequeue_wiki_pending(self, limit: int = 1) -> list:
+        """Get pending wiki jobs and mark them as processing."""
+        import json as _json
+        with self._lock:
+            # Two-step: select pending IDs, then update (compatible with all SQLite versions)
+            rows = self._conn.execute(
+                """SELECT id, session_id, title, source, message_count, messages_json
+                   FROM wiki_pending_queue WHERE status = 'pending'
+                   ORDER BY enqueued_at ASC LIMIT ?""",
+                (limit,),
+            ).fetchall()
+            if not rows:
+                return []
+            ids = [dict(r)["id"] for r in rows]
+            placeholders = ",".join("?" * len(ids))
+            self._conn.execute(
+                f"UPDATE wiki_pending_queue SET status = 'processing' WHERE id IN ({placeholders})",
+                ids,
+            )
+            self._conn.commit()
+        results = []
+        for row in rows:
+            d = dict(row)
+            d["messages"] = _json.loads(d.pop("messages_json"))
+            results.append(d)
+        return results
+
+    def mark_wiki_done(self, queue_id: int, status: str = "done") -> None:
+        """Mark a pending queue item as done or failed."""
+        with self._lock:
+            self._conn.execute(
+                "UPDATE wiki_pending_queue SET status = ? WHERE id = ?",
+                (status, queue_id),
+            )
+            self._conn.commit()
+
+    def wiki_pending_count(self) -> int:
+        """Count pending wiki jobs."""
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM wiki_pending_queue WHERE status = 'pending'"
+        ).fetchone()
+        return row[0] if row else 0
 
     # ------------------------------------------------------------------
     # Utilities

--- a/plugins/memory/holographic/wiki_builder.py
+++ b/plugins/memory/holographic/wiki_builder.py
@@ -1,0 +1,543 @@
+"""
+Wiki Builder — converts pending sessions into structured wiki pages.
+
+Runs as a background daemon thread inside the holographic memory plugin.
+Reads from wiki_pending_queue, calls the LLM for analysis, writes wiki_pages.
+"""
+
+import json
+import logging
+import re
+import sqlite3
+import datetime
+from typing import Any, Dict, List, Optional
+
+# i18n: section headers by language
+_I18N_HEADERS = {
+    "en": {"bg": "Background", "dec": "Key Decisions", "prob": "Problems & Solutions", "res": "Result", "timeline": "Session Timeline", "overview": "Overview"},
+    "zh": {"bg": "背景", "dec": "关键决策", "prob": "问题与解决", "res": "结果", "timeline": "Session 时间线", "overview": "概述"},
+    "ja": {"bg": "背景", "dec": "重要な決定", "prob": "問題と解決", "res": "結果", "timeline": "セッションタイムライン", "overview": "概要"},
+    "ko": {"bg": "배경", "dec": "주요 결정", "prob": "문제와 해결", "res": "결과", "timeline": "세션 타임라인", "overview": "개요"},
+    "de": {"bg": "Hintergrund", "dec": "Wichtige Entscheidungen", "prob": "Probleme & Lösungen", "res": "Ergebnis", "timeline": "Sitzungsverlauf", "overview": "Übersicht"},
+    "fr": {"bg": "Contexte", "dec": "Décisions clés", "prob": "Problèmes et solutions", "res": "Résultat", "timeline": "Chronologie", "overview": "Aperçu"},
+    "es": {"bg": "Contexto", "dec": "Decisiones clave", "prob": "Problemas y soluciones", "res": "Resultado", "timeline": "Cronología", "overview": "Resumen"},
+}
+
+logger = logging.getLogger(__name__)
+
+# Truncation limits
+_MAX_MESSAGE_LEN = 3000
+_MAX_MESSAGES_FOR_LLM = 80  # cap messages sent to LLM
+
+
+class WikiBuilder:
+    """Process pending sessions into wiki pages via LLM analysis."""
+
+    def __init__(self, store, config: dict):
+        self._store = store
+        self._config = config
+        self._conn = store._conn  # shared connection
+        self._lock = store._lock
+
+    def process_pending(self) -> int:
+        """Process all pending wiki jobs. Returns count processed."""
+        processed = 0
+        while True:
+            items = self._store.dequeue_wiki_pending(limit=1)
+            if not items:
+                break
+            item = items[0]
+            try:
+                self._process_session(item)
+                self._store.mark_wiki_done(item["id"], "done")
+                processed += 1
+            except Exception as e:
+                logger.error("WikiBuilder failed for %s: %s", item.get("session_id"), e)
+                self._store.mark_wiki_done(item["id"], "failed")
+        return processed
+
+    def _process_session(self, item: dict) -> None:
+        """Process a single session into wiki page + facts."""
+        session_id = item["session_id"]
+        title = item.get("title", "") or ""
+        source = item.get("source", "")
+        messages = item.get("messages", [])
+
+        # Check if already processed
+        with self._lock:
+            existing = self._conn.execute(
+                "SELECT page_id FROM wiki_pages WHERE source_session_id = ?",
+                (session_id,),
+            ).fetchone()
+        if existing:
+            logger.debug("Session %s already in wiki_pages, skipping", session_id)
+            return
+
+        # Filter to user + assistant only, truncate long messages
+        filtered = []
+        for msg in messages:
+            role = msg.get("role", "")
+            if role not in ("user", "assistant"):
+                continue
+            content = msg.get("content", "")
+            if not content or not isinstance(content, str):
+                continue
+            if len(content) > _MAX_MESSAGE_LEN:
+                content = content[: _MAX_MESSAGE_LEN // 2] + "\n...[truncated]...\n" + content[-_MAX_MESSAGE_LEN // 2 :]
+            filtered.append({"role": role, "content": content})
+
+        if len(filtered) < 2:
+            logger.debug("Session %s too few messages (%d), skipping", session_id, len(filtered))
+            return
+
+        # Cap total messages
+        if len(filtered) > _MAX_MESSAGES_FOR_LLM:
+            filtered = filtered[:_MAX_MESSAGES_FOR_LLM]
+
+        # Call LLM for analysis
+        analysis = self._call_llm(filtered, title, source)
+        if not analysis:
+            logger.warning("LLM returned no analysis for %s, using defaults", session_id)
+            analysis = self._default_analysis(title)
+
+        language = analysis.get("language", "en")
+        quality = analysis.get("quality", 2)
+        if quality < 1 or quality > 5:
+            quality = 2
+
+        # Build date from session_id
+        date = self._extract_date(session_id)
+
+        # Build slug
+        slug = self._build_slug(date, analysis.get("title", title))
+
+        # Build wiki page content
+        full_content = self._build_wiki_page(
+            session_id=session_id,
+            date=date,
+            title=analysis.get("title", title),
+            language=language,
+            quality=quality,
+            content_type=analysis.get("content_type", "discussion"),
+            topics=analysis.get("topics", []),
+            entities=analysis.get("entities", []),
+            keywords=analysis.get("keywords", []),
+            result=analysis.get("result", ""),
+            background=analysis.get("background", ""),
+            decisions=analysis.get("decisions", []),
+            problems=analysis.get("problems", []),
+        )
+
+        summary = analysis.get("result", "")[:200] or analysis.get("background", "")[:200]
+
+        topics = analysis.get("topics", [])
+        entities = analysis.get("entities", [])
+        keywords = analysis.get("keywords", [])
+
+        # Write to SQLite
+        with self._lock:
+            # Insert wiki page
+            cur = self._conn.execute(
+                """INSERT OR REPLACE INTO wiki_pages
+                   (page_type, slug, title, date, quality, content_type,
+                    topics, keywords, summary, full_content, source_session_id)
+                   VALUES ('session', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    slug,
+                    analysis.get("title", title),
+                    date,
+                    quality,
+                    analysis.get("content_type", "discussion"),
+                    json.dumps(topics, ensure_ascii=False),
+                    json.dumps(keywords, ensure_ascii=False),
+                    summary,
+                    full_content,
+                    session_id,
+                ),
+            )
+            page_id = cur.lastrowid
+
+            # Link entities
+            for ename in entities:
+                entity_id = self._ensure_entity(ename)
+                if entity_id:
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO wiki_page_entities (page_id, entity_id) VALUES (?, ?)",
+                        (page_id, entity_id),
+                    )
+
+            # Update topic pages
+            for topic in topics:
+                self._update_topic_page(topic, date, analysis.get("title", title), quality)
+
+            # Extract facts (only for quality >= 3)
+            if quality >= 3:
+                self._extract_facts(analysis, slug, entities)
+
+            self._conn.commit()
+
+        logger.info(
+            "Wiki page created: %s (quality=%d, topics=%s)",
+            slug, quality, topics,
+        )
+
+    def _call_llm(self, messages: list, title: str, source: str) -> Optional[dict]:
+        """Call the configured LLM provider for session analysis."""
+        import os
+        import httpx
+
+        # Get provider config: plugin config → config.yaml → env vars
+        provider = self._config.get("provider", "")
+        model = self._config.get("model", "")
+        api_key = self._config.get("api_key", "")
+        base_url = self._config.get("base_url", "")
+
+        # If not in plugin config, read from config.yaml model section
+        if not model or not provider:
+            try:
+                import yaml
+                from hermes_constants import get_hermes_home
+                cfg_path = get_hermes_home() / "config.yaml"
+                if cfg_path.exists():
+                    with open(cfg_path) as f:
+                        cfg = yaml.safe_load(f) or {}
+                    model_cfg = cfg.get("model", {})
+                    if not model:
+                        model = model_cfg.get("default", "") or model_cfg.get("model", "")
+                    if not provider:
+                        provider = model_cfg.get("provider", "")
+                    if not base_url:
+                        base_url = model_cfg.get("base_url", "")
+            except Exception:
+                pass
+
+        if not model:
+            logger.warning("No model configured for wiki builder, skipping LLM call")
+            return None
+
+        # Resolve base_url from provider
+        if not base_url:
+            base_url = self._resolve_base_url(provider)
+        if not base_url:
+            logger.warning("Cannot resolve base_url for provider %s", provider)
+            return None
+
+        # Resolve API key
+        if not api_key:
+            api_key = self._resolve_api_key(provider)
+        if not api_key:
+            api_key = "no-key"  # some providers don't need a key
+
+        # Build conversation for analysis
+        analysis_messages = [
+            {
+                "role": "system",
+                "content": self._analysis_prompt(),
+            },
+            {
+                "role": "user",
+                "content": self._format_session_for_llm(messages, title, source),
+            },
+        ]
+
+        try:
+            url = f"{base_url.rstrip('/')}/chat/completions"
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            }
+            payload = {
+                "model": model,
+                "messages": analysis_messages,
+                "max_tokens": 2000,
+                "temperature": 0.3,
+            }
+
+            with httpx.Client(timeout=60.0) as client:
+                resp = client.post(url, json=payload, headers=headers)
+                resp.raise_for_status()
+                data = resp.json()
+
+            content = data["choices"][0]["message"]["content"]
+            return self._extract_json(content)
+
+        except Exception as e:
+            logger.error("LLM call failed: %s", e)
+            return None
+
+    def _analysis_prompt(self) -> str:
+        # Use English for broader compatibility
+        return """You are a memory-wiki agent. Analyze the following session and return a JSON analysis.
+
+Return strict JSON only, no extra text:
+{
+  "title": "Session title (≤30 chars, summarize core content)",
+  "language": "en",
+  "quality": 3,
+  "content_type": "troubleshooting",
+  "topics": ["topic-slug-1", "topic-slug-2"],
+  "entities": ["Entity Name 1", "Entity Name 2"],
+  "keywords": ["keyword1", "keyword2"],
+  "result": "One-sentence summary of the final outcome",
+  "background": "Brief user goal and context (≤100 chars)",
+  "decisions": ["Decision 1 and reason", "Decision 2 and reason"],
+  "problems": ["Problem 1 → Solution", "Problem 2 → Solution"]
+}
+
+CRITICAL: Respond in the SAME LANGUAGE as the session content.
+The "language" field must be the ISO 639-1 code (e.g. "en", "zh", "ja", "ko", "de", "fr", "es").
+All text fields (title, result, background, decisions, problems) must be in that language.
+Only topic slugs, entity names, and content_type remain in English."""
+
+    def _format_session_for_llm(self, messages: list, title: str, source: str) -> str:
+        """Format messages into a readable prompt for the LLM."""
+        lines = []
+        if title:
+            lines.append(f"Title: {title}")
+        if source:
+            lines.append(f"Source: {source}")
+        lines.append(f"Messages: {len(messages)}")
+        lines.append("---")
+        for msg in messages:
+            role = msg["role"]
+            content = msg["content"]
+            prefix = "User" if role == "user" else "Assistant"
+            lines.append(f"[{prefix}]: {content[:1500]}")
+        return "\n".join(lines)
+
+    def _extract_json(self, text: str) -> Optional[dict]:
+        """Extract JSON from LLM response, handling markdown code blocks and extra text."""
+        text = text.strip()
+        # Try direct parse first
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+        # Try extracting from markdown code block
+        match = re.search(r"```(?:json)?\s*\n?(.*?)\n?\s*```", text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group(1).strip())
+            except json.JSONDecodeError:
+                pass
+        # Try finding first { ... } block
+        match = re.search(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except json.JSONDecodeError:
+                pass
+        logger.warning("Failed to extract JSON from LLM response: %s...", text[:200])
+        return None
+
+    def _default_analysis(self, title: str) -> dict:
+        """Fallback analysis when LLM is unavailable."""
+        return {
+            "title": title or "Untitled Session",
+            "language": "en",
+            "quality": 2,
+            "content_type": "discussion",
+            "topics": [],
+            "entities": [],
+            "keywords": [],
+            "result": "",
+            "background": "",
+            "decisions": [],
+            "problems": [],
+        }
+
+    def _resolve_base_url(self, provider: str) -> Optional[str]:
+        """Resolve provider name to API base URL using PROVIDER_REGISTRY."""
+        import os
+        # 1. Check env var overrides first
+        for env_key in ("OPENAI_BASE_URL", "CUSTOM_BASE_URL", "XIAOMI_BASE_URL"):
+            val = os.environ.get(env_key, "")
+            if val:
+                return val
+        # 2. Look up PROVIDER_REGISTRY
+        try:
+            from hermes_cli.auth import PROVIDER_REGISTRY
+            cfg = PROVIDER_REGISTRY.get(provider)
+            if cfg and cfg.inference_base_url:
+                # Check provider-specific env var override
+                if cfg.base_url_env_var:
+                    env_val = os.environ.get(cfg.base_url_env_var, "")
+                    if env_val:
+                        return env_val
+                return cfg.inference_base_url
+        except ImportError:
+            pass
+        return None
+
+    def _resolve_api_key(self, provider: str) -> Optional[str]:
+        """Resolve provider name to API key using PROVIDER_REGISTRY."""
+        import os
+        # 1. Check generic env vars
+        for env_key in ("CUSTOM_API_KEY", "OPENAI_API_KEY"):
+            val = os.environ.get(env_key, "")
+            if val:
+                return val
+        # 2. Look up PROVIDER_REGISTRY
+        try:
+            from hermes_cli.auth import PROVIDER_REGISTRY
+            cfg = PROVIDER_REGISTRY.get(provider)
+            if cfg and cfg.api_key_env_vars:
+                for env_var in cfg.api_key_env_vars:
+                    val = os.environ.get(env_var, "")
+                    if val:
+                        return val
+        except ImportError:
+            pass
+        return None
+
+    def _ensure_entity(self, name: str) -> Optional[int]:
+        """Get or create entity, return entity_id."""
+        row = self._conn.execute(
+            "SELECT entity_id FROM entities WHERE name = ?", (name,)
+        ).fetchone()
+        if row:
+            return row[0]
+        try:
+            cur = self._conn.execute(
+                "INSERT INTO entities (name, entity_type, created_at) VALUES (?, 'wiki', ?)",
+                (name, datetime.datetime.now().isoformat()),
+            )
+            return cur.lastrowid
+        except Exception:
+            return None
+
+    def _update_topic_page(self, topic: str, date: str, title: str, quality: int) -> None:
+        """Create or update a topic aggregation page."""
+        existing = self._conn.execute(
+            "SELECT page_id, full_content FROM wiki_pages WHERE slug = ? AND page_type = 'topic'",
+            (topic,),
+        ).fetchone()
+
+        if existing:
+            content = existing["full_content"] or ""
+            new_entry = f"- [{date}] {title} — quality: {quality}"
+            if new_entry not in content:
+                updated = content.replace(
+                    f"## {_I18N_HEADERS['en']['timeline']}\n",
+                    f"## {_I18N_HEADERS['en']['timeline']}\n{new_entry}\n",
+                )
+                self._conn.execute(
+                    "UPDATE wiki_pages SET full_content = ?, updated_at = ? WHERE page_id = ?",
+                    (updated, datetime.datetime.now().isoformat(), existing["page_id"]),
+                )
+        else:
+            topic_content = (
+                f"---\ntopic: {topic}\npage_count: 1\n"
+                f"first_seen: {date}\nlast_updated: {date}\n---\n\n"
+                f"# {topic}\n\n## {_I18N_HEADERS['en']['overview']}\n\n## {_I18N_HEADERS['en']['timeline']}\n"
+                f"- [{date}] {title} — quality: {quality}\n"
+            )
+            self._conn.execute(
+                """INSERT INTO wiki_pages (page_type, slug, title, date, topics, summary, full_content)
+                   VALUES ('topic', ?, ?, ?, ?, ?, ?)""",
+                (topic, topic, date, json.dumps([topic], ensure_ascii=False), f"Topic: {topic}", topic_content),
+            )
+
+    def _extract_facts(self, analysis: dict, slug: str, entities: list) -> None:
+        """Extract stable knowledge from analysis into facts table."""
+        facts_to_add = []
+
+        # Background → general fact
+        bg = analysis.get("background", "")
+        if bg and len(bg) > 20:
+            facts_to_add.append((bg[:80], "general"))
+
+        # Result → reference fact
+        result = analysis.get("result", "")
+        if result and len(result) > 10:
+            facts_to_add.append((result[:80], "reference"))
+
+        # Decisions → reference facts
+        for dec in analysis.get("decisions", [])[:2]:
+            if len(dec) > 10:
+                facts_to_add.append((dec[:80], "reference"))
+
+        for content, category in facts_to_add:
+            # Deduplicate
+            existing = self._conn.execute(
+                "SELECT fact_id FROM facts WHERE content = ?", (content,)
+            ).fetchone()
+            if existing:
+                continue
+            try:
+                now = datetime.datetime.now().isoformat()
+                cur = self._conn.execute(
+                    """INSERT INTO facts (content, category, tags, trust_score, retrieval_count, helpful_count, created_at, updated_at)
+                       VALUES (?, ?, ?, ?, 0, 0, ?, ?)""",
+                    (content, category, f"wiki:{slug}", 0.5, now, now),
+                )
+                fact_id = cur.lastrowid
+                # Link to first entity
+                if entities:
+                    entity_id = self._ensure_entity(entities[0])
+                    if entity_id:
+                        self._conn.execute(
+                            "INSERT OR IGNORE INTO fact_entities (fact_id, entity_id) VALUES (?, ?)",
+                            (fact_id, entity_id),
+                        )
+            except Exception:
+                pass
+
+    def _extract_date(self, session_id: str) -> str:
+        """Extract YYYY-MM-DD from session_id like 20260718_000446_83fbd4."""
+        match = re.match(r"(\d{4})(\d{2})(\d{2})", session_id)
+        if match:
+            return f"{match.group(1)}-{match.group(2)}-{match.group(3)}"
+        return datetime.date.today().isoformat()
+
+    def _build_slug(self, date: str, title: str) -> str:
+        """Build a filesystem-safe slug from date and title."""
+        # Clean title
+        slug = re.sub(r"[^\w\s-]", "", title.lower())
+        slug = re.sub(r"[\s_]+", "-", slug).strip("-")
+        slug = slug[:40]
+        if not slug:
+            slug = "session"
+        return f"{date}_{slug}"
+
+    def _build_wiki_page(self, **kwargs) -> str:
+        """Build full markdown content for a wiki page."""
+        lang = kwargs.get("language", "en")
+        h = _I18N_HEADERS.get(lang, _I18N_HEADERS["en"])
+
+        lines = [
+            "---",
+            f'session_id: "{kwargs["session_id"]}"',
+            f'date: {kwargs["date"]}',
+            f'language: {lang}',
+            f'quality: {kwargs["quality"]}',
+            f'content_type: {kwargs["content_type"]}',
+            f'topics: {json.dumps(kwargs["topics"], ensure_ascii=False)}',
+            f'entities: {json.dumps(kwargs["entities"], ensure_ascii=False)}',
+            f'keywords: {json.dumps(kwargs["keywords"], ensure_ascii=False)}',
+            f'result: "{kwargs["result"]}"',
+            "---",
+            "",
+            f"# {kwargs['title']} ({kwargs['date']})",
+            "",
+        ]
+
+        if kwargs.get("background"):
+            lines += [f"## {h['bg']}", kwargs["background"], ""]
+
+        if kwargs.get("decisions"):
+            lines += [f"## {h['dec']}"]
+            for d in kwargs["decisions"]:
+                lines.append(f"- {d}")
+            lines.append("")
+
+        if kwargs.get("problems"):
+            lines += [f"## {h['prob']}"]
+            for p in kwargs["problems"]:
+                lines.append(f"- {p}")
+            lines.append("")
+
+        if kwargs.get("result"):
+            lines += [f"## {h['res']}", kwargs["result"], ""]
+
+        return "\n".join(lines)


### PR DESCRIPTION
## What

Add automatic session-to-wiki conversion to the holographic memory plugin. Sessions are queued at session end and processed in the background by a daemon thread that calls the configured LLM provider.

## Why

Currently, session knowledge is only available via raw session_search (noisy, full conversation history) or manually-added facts. This change automatically compiles session knowledge into structured wiki pages — the Karpathy LLM Wiki pattern integrated directly into the memory plugin.

## Architecture

```
session end → on_session_end (non-blocking, milliseconds)
  → enqueue to wiki_pending_queue table
  → start background daemon thread

background thread:
  → dequeue pending session
  → call LLM (via PROVIDER_REGISTRY URL + config.yaml model)
  → analyze: quality scoring, topic classification, entity extraction
  → write wiki_pages + wiki_fts + facts
  → fact_store search now returns both facts AND wiki pages
```

## Changes

### wiki_builder.py (new, 543 lines)
- `WikiBuilder` class for LLM-based session analysis
- Provider URL resolution via `PROVIDER_REGISTRY` (no hardcoded URLs)
- Model/provider from `config.yaml` `model.default` / `model.provider`
- 7-language i18n: en/zh/ja/ko/de/fr/es — LLM detects session language and responds accordingly
- Graceful degradation: falls back to default analysis when LLM unavailable
- JSON extraction handles markdown code blocks and surrounding text

### store.py (+125 lines)
- `wiki_pages` table: session/topic/entity pages with frontmatter metadata
- `wiki_fts`: FTS5 full-text search on title/summary/topics/keywords
- `wiki_page_entities`: junction table linking wiki pages to entities
- `wiki_pending_queue`: async queue for session processing
- Queue methods: `enqueue_wiki_pending`, `dequeue_wiki_pending`, `mark_wiki_done`, `wiki_pending_count`

### __init__.py (+71 lines)
- `on_session_end`: enqueues session to pending queue (non-blocking)
- Background daemon thread processes queue after each session end
- `on_session_switch`: captures session title for wiki page metadata
- Thread cleanup with join(timeout) on shutdown

### retrieval.py (+103 lines)
- `_wiki_candidates` method: searches wiki_pages via FTS5 + LIKE fallback for CJK text
- `search()` now returns both facts and wiki pages, merged and ranked together
- Wiki results include `source: 'wiki'` marker for callers to distinguish

### plugin.yaml (+20 lines)
- Version bump to 0.2.0
- `auto_wiki` config option (default: true)

## Compatibility

- SQLite 3.31+ (Python 3.9+) — no RETURNING clause used
- httpx already in pyproject.toml dependencies
- No hardcoded URLs — uses PROVIDER_REGISTRY for resolution
- No personal data or paths in the code
- All code comments and strings in English, wiki output matches session language