### PR TITLE
fix(gateway): skip check_fn for env-bridged already-enabled platforms

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2316,12 +2316,19 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             # awaits this synchronously) — even when the user configured none
             # of them.  That blocked startup until every install finished and
             # caused the desktop app to time out and boot-loop (stuck at 94%).
-            try:
-                if not entry.check_fn():
+            # Skip ``check_fn`` for platforms already enabled by the env-var
+            # bridge at _enable_from_env() — Matrix, Slack, Teams, etc. set
+            # ``enabled=True`` there, then re-running their ``check_fn`` here
+            # triggers a synchronous pip install on every ``/api/status`` poll.
+            # The lazy install still runs at start_gateway() when the adapter
+            # is instantiated. (#66127)
+            if not (existing_cfg is not None and existing_cfg.enabled):
+                try:
+                    if not entry.check_fn():
+                        continue
+                except Exception as e:
+                    logger.debug("check_fn for %s raised: %s", entry.name, e)
                     continue
-            except Exception as e:
-                logger.debug("check_fn for %s raised: %s", entry.name, e)
-                continue
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()
             config.platforms[platform].enabled = True

--- a/tests/gateway/test_startup_no_eager_platform_install.py
+++ b/tests/gateway/test_startup_no_eager_platform_install.py
@@ -98,3 +98,25 @@ def test_failed_install_does_not_enable_configured_platform(isolated_registry):
 
     check_fn.assert_called_once()
     assert not config.platforms.get(Platform.DISCORD, PlatformConfig()).enabled
+
+
+def test_env_var_bridged_platform_does_not_re_run_check_fn(isolated_registry):
+    # Regression for #66127: a platform already enabled by _enable_from_env()
+    # (e.g. Matrix via MATRIX_HOMESERVER + MATRIX_ACCESS_TOKEN) must NOT re-run
+    # its check_fn here — check_fn is the lazy SDK installer and re-running
+    # it on every load_gateway_config() pip-installed mautrix/aiosqlite/
+    # asyncpg/aiohttp-socks on every /api/status poll.
+    check_fn = MagicMock(return_value=True)
+    _register_fake_platform(
+        "matrix", check_fn=check_fn, is_connected=lambda cfg: True
+    )
+
+    config = GatewayConfig()
+    config.platforms[Platform.MATRIX] = PlatformConfig(
+        enabled=True, extra={"token": "redacted"}
+    )
+
+    _apply_env_overrides(config)
+
+    check_fn.assert_not_called()
+    assert config.platforms[Platform.MATRIX].enabled is True


### PR DESCRIPTION
## Summary

When a platform is enabled via env-var bridge (`_enable_from_env()` sets `enabled=True` early in `load_gateway_config()`), `_apply_env_overrides()` was unconditionally re-running `entry.check_fn()` on every call. For Matrix, Slack, Teams, and other adapter plugins, `check_fn` IS the lazy SDK installer — it does `pip install mautrix[encryption] aiosqlite asyncpg aiohttp-socks` (Matrix) or equivalents.

`load_gateway_config()` is awaited synchronously by `GET /api/status` (the dashboard status refresh). Result: every 5s status poll triggered a fresh pip install. The dashboard hung for 30–300s on each poll until install finished.

## Root cause

`gateway/config.py` had two gaps:
1. **Earlier fix** (lines 2309–2318): skip `check_fn` for platforms not configured at all. Pinned by `test_unconfigured_platform_is_not_probed_for_install`.
2. **This fix**: also skip `check_fn` for platforms **already enabled** by the env-var bridge (e.g. `_enable_from_env(Platform.MATRIX)` at lines 1747–1773 sets `enabled=True` before the plugin sweep). The earlier gate at lines 2234–2239 covers explicit user-disable via `_enabled_explicit`, so we know anything past line 2309 is not user-disabled.

## Fix

`gateway/config.py:2319` — guard `entry.check_fn()` with a `not (existing_cfg and existing_cfg.enabled)` check. One-line guard, preserves the existing 2309–2318 comment and the test fixture.

The lazy install still runs at `start_gateway()` time when `MatrixAdapter.__init__()` calls `check_matrix_requirements()` via the `_import` importer — so end-to-end install behavior is preserved; only the eager synchronous install on every status poll is removed.

## Reproduction (before the fix)

```bash
# In ~/.hermes/.env:
#   MATRIX_HOMESERVER=https://matrix.example.com
#   MATRIX_ACCESS_TOKEN=syt_...

# Dashboard is running on port 9119. Each call hangs:
curl http://127.0.0.1:9119/api/status    # 30–300s, then returns 200
curl http://127.0.0.1:9119/api/status    # 30–300s, then returns 200
```

`ps` shows `python -m pip install mautrix[encryption]...` as a child of the dashboard Python process for the duration of each call.

## Test plan

- [x] New test `test_env_var_bridged_platform_does_not_re_run_check_fn` — fails on main, passes after the guard
- [x] All 3 existing tests in `tests/gateway/test_startup_no_eager_platform_install.py` still pass (no regression in the unconfigured / configured / failed-install paths)
- [ ] CI green (will run on PR open)

## Verification

After the fix:
- `scripts/run_tests.sh tests/gateway/test_startup_no_eager_platform_install.py` → 4/4 pass in 0.9s
- No `pip install` children spawned on `/api/status` calls

Closes #66127