### PR TITLE
fix(qqbot): accept is_reconnect kwarg in QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,16 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        Args:
+            is_reconnect: True when called by the gateway reconnect loop.
+                QQAdapter has its own _reconnect() for WebSocket-level
+                reconnection, so this parameter is accepted for signature
+                compatibility but not used — the full connect() flow
+                (token refresh, gateway URL fetch, WS open) runs regardless.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)


### PR DESCRIPTION
## Problem

Hermes gateway now calls `adapter.connect(is_reconnect=True)` during platform reconnection, but `QQAdapter.connect()` only accepts `self`, causing:

```
TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

The QQ adapter enters a permanent retry loop and never connects.

## Fix

Add `*, is_reconnect: bool = False` parameter to `QQAdapter.connect()` to match the updated `BasePlatformAdapter.connect()` signature. QQAdapter has its own `_reconnect()` for WebSocket-level reconnection, so `is_reconnect` is accepted for signature compatibility but not used — the full connect() flow (token refresh, gateway URL fetch, WS open) runs regardless.

## Verification

- All 161 QQ Bot tests pass
- Gateway restart confirms qqbot platform transitions to `connected` state