### PR TITLE
fix(gateway): fail-closed session destination ownership + isolated workers

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -155,6 +155,11 @@ class GatewayKanbanWatchersMixin:
                 "kanban notifier: disabled via config kanban.dispatch_in_gateway=false"
             )
             return
+        # Notifications are delivery-only by default. Synthetic creator turns
+        # are conversational side effects and must be explicitly enabled.
+        wake_creator_session = bool(
+            kanban_cfg.get("wake_creator_session", False)
+        )
         from gateway.config import Platform as _Platform
         try:
             from hermes_cli import kanban_db as _kb
@@ -491,7 +496,17 @@ class GatewayKanbanWatchersMixin:
                         task_terminal = task and task.status in {"done", "archived"}
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
                         _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
-                        if _wake_kinds:
+                        if _wake_kinds and wake_creator_session and not sub.get("thread_id"):
+                            # Fail closed even after opt-in: the unthreaded/root
+                            # chat belongs to its foreground session. Workers
+                            # may converse only in an isolated topic/thread.
+                            logger.warning(
+                                "kanban notifier: refusing creator wake for %s "
+                                "on unthreaded %s/%s; configure a distinct "
+                                "subscription thread/topic",
+                                sub["task_id"], platform_str, sub["chat_id"],
+                            )
+                        elif _wake_kinds and wake_creator_session:
                             try:
                                 _session_key = getattr(task, "session_id", None) or ""
                                 if _session_key:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12329,6 +12329,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    total_tokens=agent_result.get("total_tokens"),
+                    estimated_cost_usd=agent_result.get("estimated_cost_usd"),
+                    profile=self._active_profile_name(),
+                    session_id=session_entry.session_id,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
@@ -15383,12 +15387,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return True
 
-    async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
+    async def _await_adapter_send_ready(self, adapter, *, timeout: float = 15.0) -> bool:
+        """Wait until a platform adapter is willing to send, if it exposes that state.
+
+        Telegram polling marks ``_send_path_degraded=True`` until the first
+        successful getUpdates after connect/reconnect. Post-boot lifecycle
+        messages used to fire during that window and fail with
+        ``send_path_degraded``, then drop the notify marker so the user never
+        saw "Gateway restarted successfully."
+        """
+        if adapter is None:
+            return False
+        if not getattr(adapter, "_send_path_degraded", False):
+            return True
+
+        progress = getattr(adapter, "_polling_progress_event", None)
+        if progress is not None:
+            try:
+                await asyncio.wait_for(progress.wait(), timeout=timeout)
+            except (asyncio.TimeoutError, AttributeError, TypeError):
+                pass
+        else:
+            deadline = time.monotonic() + timeout
+            while getattr(adapter, "_send_path_degraded", False) and time.monotonic() < deadline:
+                await asyncio.sleep(0.25)
+        return not getattr(adapter, "_send_path_degraded", False)
+
+    def _schedule_restart_notification_retry(self, attempt: int) -> None:
+        """Retry a chat-originated restart notification after a retryable send failure."""
+        max_attempts = 3
+        if attempt >= max_attempts:
+            return
+
+        async def _retry() -> None:
+            await asyncio.sleep(3.0 * attempt)
+            if not _restart_notification_pending():
+                return
+            await self._send_restart_notification(attempt=attempt + 1)
+
+        try:
+            task = asyncio.create_task(_retry())
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+        except Exception:
+            logger.debug("Failed to schedule restart notification retry", exc_info=True)
+
+    async def _send_restart_notification(
+        self, *, attempt: int = 1
+    ) -> Optional[tuple[str, str, Optional[str]]]:
         """Notify the chat that initiated /restart that the gateway is back."""
         notify_path = _hermes_home / ".restart_notify.json"
         if not notify_path.exists():
             return None
 
+        cleanup = True
         try:
             data = json.loads(notify_path.read_text())
             platform_str = data.get("platform")
@@ -15417,6 +15469,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return None
 
+            # Wait out the post-connect Telegram send-path gate when present.
+            await self._await_adapter_send_ready(adapter, timeout=15.0)
+
             metadata = self._thread_metadata_for_target(
                 platform,
                 chat_id,
@@ -15435,12 +15490,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # we must inspect the result before claiming success — otherwise
             # the log line is misleading and hides real delivery failures.
             if result is not None and getattr(result, "success", True) is False:
+                err = getattr(result, "error", "send returned success=False")
+                retryable = bool(getattr(result, "retryable", False))
                 logger.warning(
                     "Restart notification to %s:%s was not delivered: %s",
                     platform_str,
                     chat_id,
-                    getattr(result, "error", "send returned success=False"),
+                    err,
                 )
+                # Keep the marker for a short deferred retry when the adapter
+                # itself says the failure is transient (e.g. send_path_degraded
+                # before first getUpdates progress). Permanent failures still
+                # clean up so a dead target cannot wedge boot forever.
+                if retryable and attempt < 3:
+                    cleanup = False
+                    self._schedule_restart_notification_retry(attempt)
                 return None
 
             logger.info(
@@ -15453,7 +15517,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Restart notification failed: %s", e)
             return None
         finally:
-            notify_path.unlink(missing_ok=True)
+            if cleanup:
+                notify_path.unlink(missing_ok=True)
 
     async def _send_home_channel_startup_notifications(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2944,6 +2944,28 @@ async def _dispose_unused_adapter(adapter: "BasePlatformAdapter | None") -> None
         )
 
 
+def _require_isolated_handoff_thread(
+    *,
+    platform: Platform,
+    chat_id: str,
+    effective_thread_id: Optional[str],
+) -> str:
+    """Return the thread id or reject a handoff into a root destination.
+
+    A CLI handoff creates a conversational owner. Letting it fall back to an
+    unthreaded home chat can overwrite the root DM's foreground routing state.
+    Handoffs therefore fail closed unless the adapter created a thread/topic or
+    the configured home destination already names one.
+    """
+    if effective_thread_id:
+        return str(effective_thread_id)
+    platform_name = platform.value if isinstance(platform, Platform) else str(platform)
+    raise RuntimeError(
+        "handoff requires a distinct thread/topic; refusing unthreaded "
+        f"destination {platform_name}:{chat_id}"
+    )
+
+
 class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
     Main gateway controller.
@@ -7794,11 +7816,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             new_thread_id = None
 
-        # Use the new thread if the adapter created one; otherwise fall
-        # back to whatever thread (if any) the home channel was configured
-        # with.
+        # Use the new thread if the adapter created one; otherwise accept only
+        # an explicitly configured home thread. Never fall back to the root
+        # chat: a handoff is a new conversational owner and must be isolated.
         effective_thread_id = new_thread_id or (
             str(home.thread_id) if home.thread_id else None
+        )
+        effective_thread_id = _require_isolated_handoff_thread(
+            platform=platform,
+            chat_id=str(home.chat_id),
+            effective_thread_id=effective_thread_id,
         )
 
         # Determine chat_type/user_id for the destination source.
@@ -7815,7 +7842,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             and looks_like_telegram_private_chat_id(home_chat_id)
         )
 
-        if new_thread_id and not is_telegram_private_chat:
+        if effective_thread_id and not is_telegram_private_chat:
             dest_chat_type = "thread"
             dest_user_id = "system:handoff"
         else:
@@ -12322,6 +12349,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _footer_line = ""
             try:
                 from gateway.runtime_footer import build_footer_line as _bfl
+                _footer_session_title = None
+                if self._session_db is not None:
+                    try:
+                        _footer_session_title = await self._session_db.get_session_title(
+                            session_entry.session_id
+                        )
+                    except Exception:
+                        logger.debug("runtime_footer title lookup failed", exc_info=True)
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
@@ -12333,6 +12368,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     estimated_cost_usd=agent_result.get("estimated_cost_usd"),
                     profile=self._active_profile_name(),
                     session_id=session_entry.session_id,
+                    session_title=_footer_session_title,
+                    session_role=(
+                        "foreground"
+                        if not source.thread_id and not getattr(event, "internal", False)
+                        else "background"
+                    ),
+                    thread_id=source.thread_id,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -9,7 +9,7 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, tokens, context_pct, cost, profile, session, cwd]
+        fields: [model, tokens, context_pct, cost, profile, session, title, role, thread, cwd]
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -111,6 +111,9 @@ def format_runtime_footer(
     estimated_cost_usd: Optional[float] = None,
     profile: Optional[str] = None,
     session_id: Optional[str] = None,
+    session_title: Optional[str] = None,
+    session_role: Optional[str] = None,
+    thread_id: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -145,6 +148,15 @@ def format_runtime_footer(
         elif field == "session":
             if session_id:
                 parts.append(f"session:{session_id[:8]}")
+        elif field == "title":
+            if session_title:
+                compact_title = " ".join(str(session_title).split())
+                parts.append(f"title:{compact_title[:48]}")
+        elif field == "role":
+            if session_role:
+                parts.append(str(session_role))
+        elif field == "thread":
+            parts.append(f"thread:{thread_id if thread_id else 'root'}")
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -164,6 +176,9 @@ def build_footer_line(
     estimated_cost_usd: Optional[float] = None,
     profile: Optional[str] = None,
     session_id: Optional[str] = None,
+    session_title: Optional[str] = None,
+    session_role: Optional[str] = None,
+    thread_id: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -183,5 +198,8 @@ def build_footer_line(
         estimated_cost_usd=estimated_cost_usd,
         profile=profile,
         session_id=session_id,
+        session_title=session_title,
+        session_role=session_role,
+        thread_id=thread_id,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -9,7 +9,7 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        fields: [model, tokens, context_pct, cost, profile, session, cwd]
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -53,6 +53,19 @@ def _model_short(model: Optional[str]) -> str:
     return model.rsplit("/", 1)[-1]
 
 
+def _compact_tokens(tokens: Optional[int]) -> str:
+    """Render a token count compactly (``278400`` → ``278.4k tok``)."""
+    if tokens is None or tokens < 0:
+        return ""
+    if tokens >= 1_000_000:
+        value = f"{tokens / 1_000_000:.1f}".rstrip("0").rstrip(".")
+        return f"{value}m tok"
+    if tokens >= 1_000:
+        value = f"{tokens / 1_000:.1f}".rstrip("0").rstrip(".")
+        return f"{value}k tok"
+    return f"{tokens} tok"
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,
@@ -94,6 +107,10 @@ def format_runtime_footer(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    total_tokens: Optional[int] = None,
+    estimated_cost_usd: Optional[float] = None,
+    profile: Optional[str] = None,
+    session_id: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -107,14 +124,27 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "tokens":
+            rendered_tokens = _compact_tokens(total_tokens)
+            if rendered_tokens:
+                parts.append(rendered_tokens)
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
                 parts.append(f"{pct}%")
+        elif field == "cost":
+            if estimated_cost_usd is not None and estimated_cost_usd >= 0:
+                parts.append(f"${estimated_cost_usd:.4f}")
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "profile":
+            if profile:
+                parts.append(f"profile:{profile}")
+        elif field == "session":
+            if session_id:
+                parts.append(f"session:{session_id[:8]}")
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -130,6 +160,10 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    total_tokens: Optional[int] = None,
+    estimated_cost_usd: Optional[float] = None,
+    profile: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -145,5 +179,9 @@ def build_footer_line(
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
+        total_tokens=total_tokens,
+        estimated_cost_usd=estimated_cost_usd,
+        profile=profile,
+        session_id=session_id,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -144,6 +144,10 @@ def _is_session_key_unsafe(value: object) -> bool:
     return len(s) >= 2 and s[0].isalpha() and s[1] == ":"
 
 
+class SessionOwnershipConflict(RuntimeError):
+    """A physical unthreaded DM destination already has another owner."""
+
+
 @dataclass
 class SessionSource:
     """
@@ -1411,6 +1415,61 @@ class SessionStore:
             profile=self._resolve_profile_for_key(source),
         )
 
+    @staticmethod
+    def _unthreaded_destination_identity(
+        source: Optional[SessionSource],
+    ) -> Optional[tuple[str, str]]:
+        """Return the physical destination identity for an unthreaded chat."""
+        if source is None or not source.chat_id or source.thread_id:
+            return None
+        platform = (
+            source.platform.value
+            if isinstance(source.platform, Platform)
+            else str(source.platform)
+        )
+        return platform, str(source.chat_id)
+
+    def _assert_destination_owner_locked(
+        self,
+        source: SessionSource,
+        session_key: str,
+    ) -> None:
+        """Fail closed when a root DM would acquire a second routing owner.
+
+        ``build_session_key`` intentionally includes ``chat_type`` and may also
+        include a participant id.  A synthetic event that mislabels a Telegram
+        DM as ``group`` can therefore create a second logical key for the exact
+        same physical root chat.  That split owner is dangerous: whichever turn
+        runs last can appear to replace the user's foreground conversation.
+
+        Regular group per-user sessions remain valid.  The collision guard only
+        applies when at least one side identifies the unthreaded destination as
+        a DM.  Explicit thread/topic destinations are separate owners.
+
+        Must be called while ``self._lock`` is held.
+        """
+        destination = self._unthreaded_destination_identity(source)
+        if destination is None:
+            return
+
+        for existing_key, existing in self._entries.items():
+            if existing_key == session_key:
+                continue
+            existing_source = existing.origin
+            if self._unthreaded_destination_identity(existing_source) != destination:
+                continue
+            existing_type = (existing_source.chat_type if existing_source else "") or ""
+            incoming_type = (source.chat_type or "")
+            if "dm" not in {existing_type.lower(), incoming_type.lower()}:
+                continue
+            platform, chat_id = destination
+            raise SessionOwnershipConflict(
+                "destination ownership conflict: "
+                f"{platform}:{chat_id} is already owned by {existing_key!r}; "
+                f"refusing second owner {session_key!r}. Use a distinct "
+                "thread/topic for another conversational worker."
+            )
+
     def _create_entry_from_recovered_row(
         self,
         *,
@@ -1921,6 +1980,7 @@ class SessionStore:
         _entry_for_checks = None
         with self._lock:
             self._ensure_loaded_locked()
+            self._assert_destination_owner_locked(source, session_key)
             if force_new:
                 force_new_observed_entry = self._entries.get(session_key)
             if session_key in self._entries and not force_new:
@@ -2032,6 +2092,7 @@ class SessionStore:
                 with self._lock:
                     published = self._entries.get(session_key)
                     if published is None:
+                        self._assert_destination_owner_locked(source, session_key)
                         self._entries[session_key] = recovered
                         published = recovered
                 entry = published
@@ -2055,6 +2116,7 @@ class SessionStore:
                 reset_had_activity=reset_had_activity,
             )
             with self._lock:
+                self._assert_destination_owner_locked(source, session_key)
                 current = self._entries.get(session_key)
                 may_publish = current is None or (
                     force_new and current is force_new_observed_entry

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2787,6 +2787,10 @@ DEFAULT_CONFIG = {
         # only if you run the dispatcher as a separate systemd unit or
         # don't want the gateway to spawn workers.
         "dispatch_in_gateway": True,
+        # A terminal Kanban event is normally notification-only. Set true to
+        # inject a synthetic follow-up turn into the creator session; even then,
+        # the gateway requires a distinct thread/topic and rejects root-chat wake.
+        "wake_creator_session": False,
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,

--- a/tests/gateway/test_handoff_thread_isolation.py
+++ b/tests/gateway/test_handoff_thread_isolation.py
@@ -1,0 +1,35 @@
+import pytest
+
+from gateway.config import Platform
+from gateway.run import _require_isolated_handoff_thread
+
+
+def test_new_handoff_thread_is_used():
+    assert (
+        _require_isolated_handoff_thread(
+            platform=Platform.TELEGRAM,
+            chat_id="8650058832",
+            effective_thread_id="topic-77",
+        )
+        == "topic-77"
+    )
+
+
+def test_explicitly_configured_home_thread_is_allowed():
+    assert (
+        _require_isolated_handoff_thread(
+            platform=Platform.TELEGRAM,
+            chat_id="8650058832",
+            effective_thread_id="88",
+        )
+        == "88"
+    )
+
+
+def test_handoff_fails_closed_when_no_distinct_thread_exists():
+    with pytest.raises(RuntimeError, match="distinct thread/topic"):
+        _require_isolated_handoff_thread(
+            platform=Platform.TELEGRAM,
+            chat_id="8650058832",
+            effective_thread_id=None,
+        )

--- a/tests/gateway/test_kanban_creator_wake_policy.py
+++ b/tests/gateway/test_kanban_creator_wake_policy.py
@@ -1,0 +1,108 @@
+import asyncio
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+
+
+class RecordingAdapter:
+    def __init__(self):
+        self.sent = []
+        self.wakes = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        self.wakes.append(event)
+
+
+def _make_runner(adapter):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._kanban_sub_fail_counts = {}
+    return runner
+
+
+async def _run_one_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _create_wakeable_completion(thread_id=None):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="creator wake policy",
+            assignee="worker",
+            session_id="agent:main:telegram:dm:chat-1",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="telegram",
+            chat_id="chat-1",
+            thread_id=thread_id,
+        )
+        kb.complete_task(conn, task_id, summary="finished")
+        return task_id
+    finally:
+        conn.close()
+
+
+def _configure(monkeypatch, tmp_path, *, wake_creator_session, thread_id=None):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _create_wakeable_completion(thread_id=thread_id)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "wake_creator_session": wake_creator_session,
+            }
+        },
+    )
+
+
+def test_default_policy_delivers_notification_without_waking_creator(tmp_path, monkeypatch):
+    _configure(monkeypatch, tmp_path, wake_creator_session=False)
+    adapter = RecordingAdapter()
+
+    asyncio.run(_run_one_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    assert adapter.wakes == []
+
+
+def test_opt_in_still_refuses_root_chat_without_distinct_thread(tmp_path, monkeypatch):
+    _configure(monkeypatch, tmp_path, wake_creator_session=True, thread_id=None)
+    adapter = RecordingAdapter()
+
+    asyncio.run(_run_one_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    assert adapter.wakes == []
+
+
+def test_opt_in_wakes_only_the_explicit_thread(tmp_path, monkeypatch):
+    _configure(monkeypatch, tmp_path, wake_creator_session=True, thread_id="topic-77")
+    adapter = RecordingAdapter()
+
+    asyncio.run(_run_one_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    assert len(adapter.wakes) == 1
+    assert adapter.wakes[0].internal is True
+    assert adapter.wakes[0].source.thread_id == "topic-77"

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -137,6 +137,38 @@ def test_format_footer_custom_field_order():
     assert out == "50% · gpt-5.4"
 
 
+def test_format_footer_shows_profile_and_short_session_owner():
+    out = format_runtime_footer(
+        model="",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        profile="default",
+        session_id="abcdef1234567890",
+        fields=("profile", "session"),
+    )
+    assert out == "profile:default · session:abcdef12"
+
+
+def test_format_footer_preserves_tokens_cost_and_cwd_fields(monkeypatch):
+    monkeypatch.setenv("HOME", "/root")
+    out = format_runtime_footer(
+        model="openai/gpt-5.6-sol",
+        context_tokens=128_000,
+        context_length=272_000,
+        cwd="/root/hermes-agent",
+        total_tokens=278_400,
+        estimated_cost_usd=0.0,
+        profile="default",
+        session_id="abcdef1234567890",
+        fields=("model", "tokens", "context_pct", "cost", "profile", "session", "cwd"),
+    )
+    assert out == (
+        "gpt-5.6-sol · 278.4k tok · 47% · $0.0000 · "
+        "profile:default · session:abcdef12 · ~/hermes-agent"
+    )
+
+
 def test_format_footer_unknown_field_silently_ignored():
     out = format_runtime_footer(
         model="openai/gpt-5.4",

--- a/tests/gateway/test_runtime_footer_ownership.py
+++ b/tests/gateway/test_runtime_footer_ownership.py
@@ -1,0 +1,41 @@
+from gateway.runtime_footer import build_footer_line, format_runtime_footer
+
+
+def test_footer_exposes_role_full_session_and_root_thread():
+    line = format_runtime_footer(
+        model=None,
+        context_tokens=0,
+        context_length=None,
+        profile="default",
+        session_id="20260718_011205_4d2617",
+        session_role="foreground",
+        thread_id=None,
+        fields=["role", "profile", "session", "thread"],
+    )
+
+    assert line == (
+        "foreground · profile:default · "
+        "session:20260718 · thread:root"
+    )
+
+
+def test_build_footer_exposes_background_topic():
+    line = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["role", "session", "thread"],
+                }
+            }
+        },
+        platform_key="telegram",
+        model=None,
+        context_tokens=0,
+        context_length=None,
+        session_id="session-2",
+        session_role="background",
+        thread_id="topic-77",
+    )
+
+    assert line == "background · session:session- · thread:topic-77"

--- a/tests/gateway/test_session_destination_ownership.py
+++ b/tests/gateway/test_session_destination_ownership.py
@@ -1,0 +1,108 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.session import (
+    SessionOwnershipConflict,
+    SessionSource,
+    SessionStore,
+)
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    result = SessionStore(
+        sessions_dir=tmp_path / "sessions",
+        config=GatewayConfig(write_sessions_json=False),
+    )
+    if result._db is not None:
+        result._db.close()
+    result._db = None
+    result._loaded = True
+    return result
+
+
+def _source(*, chat_type="dm", user_id="8650058832", thread_id=None):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="8650058832",
+        chat_type=chat_type,
+        user_id=user_id,
+        thread_id=thread_id,
+    )
+
+
+def test_unthreaded_dm_rejects_synthetic_group_owner(store):
+    dm = store.get_or_create_session(_source())
+
+    with pytest.raises(SessionOwnershipConflict, match="distinct thread/topic"):
+        store.get_or_create_session(_source(chat_type="group"))
+
+    assert list(store._entries) == [dm.session_key]
+
+
+def test_existing_unthreaded_group_rejects_second_dm_owner(store):
+    group = store.get_or_create_session(_source(chat_type="group"))
+
+    with pytest.raises(SessionOwnershipConflict, match="destination ownership conflict"):
+        store.get_or_create_session(_source())
+
+    assert list(store._entries) == [group.session_key]
+
+
+def test_group_per_user_sessions_remain_allowed_without_dm_owner(store):
+    alice = store.get_or_create_session(_source(chat_type="group", user_id="alice"))
+    bob = store.get_or_create_session(_source(chat_type="group", user_id="bob"))
+
+    assert alice.session_key != bob.session_key
+    assert len(store._entries) == 2
+
+
+def test_distinct_thread_can_own_separate_session(store):
+    root = store.get_or_create_session(_source())
+    topic = store.get_or_create_session(
+        _source(chat_type="dm", thread_id="topic-77")
+    )
+
+    assert root.session_key != topic.session_key
+    assert len(store._entries) == 2
+
+
+def test_same_dm_routing_key_reuses_owner(store):
+    first = store.get_or_create_session(_source())
+    second = store.get_or_create_session(_source())
+
+    assert first is second
+    assert len(store._entries) == 1
+
+
+def test_concurrent_conflicting_publications_create_exactly_one_owner(store):
+    barrier = threading.Barrier(2)
+
+    def synchronized_recovery(**_kwargs):
+        barrier.wait(timeout=5)
+        return None
+
+    store._query_recoverable_session = synchronized_recovery
+    sources = [_source(), _source(chat_type="group")]
+
+    outcomes = []
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(store.get_or_create_session, src) for src in sources]
+        for future in futures:
+            try:
+                outcomes.append(future.result(timeout=10))
+            except BaseException as exc:  # assert the exact conflict below
+                outcomes.append(exc)
+
+    entries = [value for value in outcomes if not isinstance(value, BaseException)]
+    errors = [value for value in outcomes if isinstance(value, BaseException)]
+    assert len(entries) == 1
+    assert len(errors) == 1
+    assert isinstance(errors[0], SessionOwnershipConflict)
+    assert len(store._entries) == 1

--- a/tests/hermes_cli/test_kanban_creator_wake_default.py
+++ b/tests/hermes_cli/test_kanban_creator_wake_default.py
@@ -1,0 +1,5 @@
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+def test_creator_session_wake_is_opt_in_by_default():
+    assert DEFAULT_CONFIG["kanban"]["wake_creator_session"] is False


### PR DESCRIPTION
## Summary
Two commits hardening Telegram (and general platform) session destination ownership and gateway restart/footer behavior, derived from operational soak on a VPS gateway:

1. **`d509ad10e` — fix(gateway): harden restart notice and runtime footer**
   - Await adapter send-ready before restart notification (closes a `send_path_degraded` race where the post-boot "restarted" notice could fire before Telegram was connected).
   - Runtime footer base fields: `total_tokens`, `cost`, `profile`, `session_id`.

2. **`2b110b438` — fix(gateway): fail-closed session destination ownership and isolated workers**
   - `SessionOwnershipConflict` raised on a second unthreaded DM *destination* owner (prevents split-owner routing).
   - Handoff requires a distinct thread/topic (`_require_isolated_handoff_thread`).
   - Kanban creator wake is **opt-in** (`kanban.wake_creator_session: false` default); even when enabled, it **refuses root-chat wake**.
   - Footer fields: `role` / `title` / `thread`.

No behavior change for correctly-configured single-owner setups; these only add fail-closed guards and fix a startup-notify race. Upstream `origin/main` has no equivalent of these contracts.

## Test plan
- Targeted (pre-commit): 69 passed — `tests/gateway/test_session_destination_ownership.py`, `test_handoff_thread_isolation.py`, `test_kanban_creator_wake_policy.py`, `test_runtime_footer_ownership.py`, `tests/hermes_cli/test_kanban_creator_wake_default.py`, `test_runtime_footer.py`, `test_restart_notification.py`
- Broader related: 119 passed (session race guard, restart drain, kanban gates)
- `git status` clean; branch is 2 commits ahead / 0 behind `origin/main`.

## Notes
- This is an operational hardening carry; no schema/config redesign, no unrelated cleanup.
- Authorship preserved as-is from the soak branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)