### PR TITLE
fix(telegram): pass httpx limits to TelegramFallbackTransport inner transports

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2312,17 +2312,31 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 # Keep request/update pools separate to reduce contention during
                 # polling reconnect + bot API bootstrap/delete_webhook calls.
+                # httpx ignores the client-level `limits` kwarg when a custom
+                # `transport` is supplied (#58790).  Unlike the proxy/direct
+                # branches (which inject limits at the client level via
+                # `_with_limits`), this branch MUST pass the tuned limits
+                # directly into TelegramFallbackTransport so its inner
+                # AsyncHTTPTransport instances honour keepalive_expiry — do not
+                # route this through `_with_limits`, httpx would discard it.
+                _transport_kwargs: dict = {}
+                if _pool_limits is not None:
+                    _transport_kwargs["limits"] = _pool_limits
                 request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs=_with_limits(
-                        {"transport": TelegramFallbackTransport(fallback_ips)}
-                    ),
+                    httpx_kwargs={
+                        "transport": TelegramFallbackTransport(
+                            fallback_ips, **_transport_kwargs
+                        )
+                    },
                 )
                 get_updates_request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs=_with_limits(
-                        {"transport": TelegramFallbackTransport(fallback_ips)}
-                    ),
+                    httpx_kwargs={
+                        "transport": TelegramFallbackTransport(
+                            fallback_ips, **_transport_kwargs
+                        )
+                    },
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -58,14 +58,15 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
     ``curl --resolve api.telegram.org:443:<ip>``.
     """
 
-    def __init__(self, fallback_ips: Iterable[str], **transport_kwargs):
+    def __init__(self, fallback_ips: Iterable[str], limits: Optional[httpx.Limits] = None, **transport_kwargs):
         self._fallback_ips = list(dict.fromkeys(_normalize_fallback_ips(fallback_ips)))
         proxy_url = _resolve_proxy_url(target_hosts=[_TELEGRAM_API_HOST, *self._fallback_ips])
         if proxy_url and "proxy" not in transport_kwargs:
             transport_kwargs["proxy"] = proxy_url
-        self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
+        self._limits = limits
+        self._primary = httpx.AsyncHTTPTransport(limits=limits, **transport_kwargs)
         self._fallbacks = {
-            ip: httpx.AsyncHTTPTransport(**transport_kwargs) for ip in self._fallback_ips
+            ip: httpx.AsyncHTTPTransport(limits=limits, **transport_kwargs) for ip in self._fallback_ips
         }
         self._sticky_ip: Optional[str] = None
         self._sticky_lock = asyncio.Lock()


### PR DESCRIPTION
## What does this PR do?

The `TelegramFallbackTransport` class creates inner `httpx.AsyncHTTPTransport` instances (one for the primary DNS path and one per fallback IP) without any explicit `httpx.Limits`. These transports fall back to httpcore defaults (`max_keepalive_connections=5`, `keepalive_expiry=5.0`), causing CLOSE-WAIT socket accumulation when the Telegram API server initiates TCP FIN on keepalive connections.

Over time, all 10 pool slots fill with stuck CLOSE-WAIT connections, and every new outbound request hits `telegram.error.TimedOut: Pool timeout: All connections in the connection pool are occupied`.

The outer `HTTPXRequest` already computed tuned limits via `platform_httpx_limits()` (`keepalive_expiry=2.0`, `max_keepalive=10`), but httpx silently ignores client-level `limits` when a custom `transport` is supplied (#58790).

## Related Issue

No existing issue. Discovered and reproduced in production: 101 CLOSE-WAIT sockets, 163 PoolTimeout errors over 7 days.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **telegram_network.py** — `TelegramFallbackTransport.__init__` now accepts an optional `limits: Optional[httpx.Limits]` parameter and forwards it to every inner `AsyncHTTPTransport` (primary + per-fallback-IP).
- **adapter.py** — Builds `_transport_kwargs` with the pre-computed `_pool_limits` and passes them via `**` spread to `TelegramFallbackTransport`, bypassing `_with_limits()` entirely (which would only set useless outer-client limits per #58790).

## How to Test

1. Before fix: monitor CLOSE-WAIT sockets via `ss -tna | grep 149.154` — expect 10+ within hours under load.
2. After fix: restart gateway (`systemctl --user restart hermes-gateway.service`).
3. Verify CLOSE-WAIT stays near 0 under continued load.
4. Verify no `telegram.error.TimedOut: Pool timeout` errors in journalctl.

Tested on: Ubuntu 24.04, Linux x86_64.
