### PR TITLE
fix(media): derive cached image suffix from magic bytes

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -684,21 +684,26 @@ def get_image_cache_dir() -> Path:
     return d
 
 
+def _detect_image_extension(data: bytes) -> str:
+    """Return the extension implied by *data*'s magic bytes, or ``""``."""
+    if len(data) < 4:
+        return ""
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return ".png"
+    if data[:3] == b"\xff\xd8\xff":
+        return ".jpg"
+    if data[:6] in {b"GIF87a", b"GIF89a"}:
+        return ".gif"
+    if data[:2] == b"BM":
+        return ".bmp"
+    if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
+        return ".webp"
+    return ""
+
+
 def _looks_like_image(data: bytes) -> bool:
     """Return True if *data* starts with a known image magic-byte sequence."""
-    if len(data) < 4:
-        return False
-    if data[:8] == b"\x89PNG\r\n\x1a\n":
-        return True
-    if data[:3] == b"\xff\xd8\xff":
-        return True
-    if data[:6] in {b"GIF87a", b"GIF89a"}:
-        return True
-    if data[:2] == b"BM":
-        return True
-    if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
-        return True
-    return False
+    return bool(_detect_image_extension(data))
 
 
 def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
@@ -724,7 +729,10 @@ def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
             f"(starts with: {snippet!r})"
         )
     cache_dir = get_image_cache_dir()
-    filename = f"img_{uuid.uuid4().hex[:12]}{ext}"
+    # Trust the payload over caller metadata. Platform APIs can return WebP or
+    # PNG bytes under a misleading .jpg filename, which breaks some decoders.
+    detected_ext = _detect_image_extension(data)
+    filename = f"img_{uuid.uuid4().hex[:12]}{detected_ext or ext}"
     filepath = cache_dir / filename
     filepath.write_bytes(data)
     return str(filepath)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -912,21 +912,26 @@ def get_image_cache_dir() -> Path:
     return d
 
 
+def _detect_image_extension(data: bytes) -> str:
+    """Return the extension implied by *data*'s magic bytes, or ``""``."""
+    if len(data) < 4:
+        return ""
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return ".png"
+    if data[:3] == b"\xff\xd8\xff":
+        return ".jpg"
+    if data[:6] in {b"GIF87a", b"GIF89a"}:
+        return ".gif"
+    if data[:2] == b"BM":
+        return ".bmp"
+    if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
+        return ".webp"
+    return ""
+
+
 def _looks_like_image(data: bytes) -> bool:
     """Return True if *data* starts with a known image magic-byte sequence."""
-    if len(data) < 4:
-        return False
-    if data[:8] == b"\x89PNG\r\n\x1a\n":
-        return True
-    if data[:3] == b"\xff\xd8\xff":
-        return True
-    if data[:6] in {b"GIF87a", b"GIF89a"}:
-        return True
-    if data[:2] == b"BM":
-        return True
-    if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
-        return True
-    return False
+    return bool(_detect_image_extension(data))
 
 
 def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
@@ -952,7 +957,10 @@ def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
             f"(starts with: {snippet!r})"
         )
     cache_dir = get_image_cache_dir()
-    filename = f"img_{uuid.uuid4().hex[:12]}{ext}"
+    # Trust the payload over caller metadata. Platform APIs can return WebP or
+    # PNG bytes under a misleading .jpg filename, which breaks some decoders.
+    detected_ext = _detect_image_extension(data)
+    filename = f"img_{uuid.uuid4().hex[:12]}{detected_ext or ext}"
     filepath = cache_dir / filename
     filepath.write_bytes(data)
     return str(filepath)

--- a/tests/gateway/test_media_download_retry.py
+++ b/tests/gateway/test_media_download_retry.py
@@ -104,6 +104,16 @@ class TestCacheImageFromBytes:
         path = cache_image_from_bytes(b"\x89PNG\r\n\x1a\n fake png data", ".png")
         assert path.endswith(".png")
 
+    def test_magic_bytes_override_misleading_extension(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        from gateway.platforms.base import cache_image_from_bytes
+
+        path = cache_image_from_bytes(
+            b"RIFF\x00\x00\x00\x00WEBP fake webp data", ".jpg"
+        )
+
+        assert path.endswith(".webp")
+
     def test_rejects_html_content(self, tmp_path, monkeypatch):
         monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
         from gateway.platforms.base import cache_image_from_bytes
@@ -614,7 +624,7 @@ class TestSlackDownloadSlackFile:
                 )
 
         path = asyncio.run(run())
-        assert path.endswith(".jpg")
+        assert path.endswith(".png")
         mock_client.get.assert_called_once()
 
     def test_rejects_html_response(self, tmp_path, monkeypatch):
@@ -673,7 +683,7 @@ class TestSlackDownloadSlackFile:
                 )
 
         path = asyncio.run(run())
-        assert path.endswith(".jpg")
+        assert path.endswith(".png")
         assert mock_client.get.call_count == 2
         mock_sleep.assert_called_once()
 

--- a/tests/gateway/test_media_download_retry.py
+++ b/tests/gateway/test_media_download_retry.py
@@ -100,6 +100,16 @@ class TestCacheImageFromBytes:
         assert path.endswith(".jpg")
 
 
+    def test_magic_bytes_override_misleading_extension(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        from gateway.platforms.base import cache_image_from_bytes
+
+        path = cache_image_from_bytes(
+            b"RIFF\x00\x00\x00\x00WEBP fake webp data", ".jpg"
+        )
+
+        assert path.endswith(".webp")
+
     def test_rejects_html_content(self, tmp_path, monkeypatch):
         monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
         from gateway.platforms.base import cache_image_from_bytes
@@ -410,7 +420,7 @@ class TestSlackDownloadSlackFile:
                 )
 
         path = asyncio.run(run())
-        assert path.endswith(".jpg")
+        assert path.endswith(".png")
         mock_client.get.assert_called_once()
 
     def test_rejects_html_response(self, tmp_path, monkeypatch):
@@ -441,7 +451,6 @@ class TestSlackDownloadSlackFile:
         img_dir = tmp_path / "img"
         if img_dir.exists():
             assert list(img_dir.iterdir()) == []
-
 
 # ---------------------------------------------------------------------------
 # SlackAdapter._download_slack_file_bytes
@@ -556,4 +565,3 @@ class TestMattermostSendUrlAsFile:
         adapter.send.assert_called_once()
         text_arg = adapter.send.call_args[0][1]
         assert "http://cdn.example.com/img.png" in text_arg
-


### PR DESCRIPTION
## Summary

- detect PNG, JPEG, GIF, BMP, and WebP suffixes from payload magic bytes
- use the detected suffix when platform metadata or filenames are misleading
- keep existing non-image validation behavior

Some messaging APIs return WebP or PNG bytes under a `.jpg` filename. Saving
those bytes with the caller-provided suffix can make downstream image decoders
select the wrong format.

## Current-main verification

- rebased onto `73f68362b` (2026-09-02)
- focused cache-image tests: 3 passed
- full media-download module: 12 passed; 3 existing `files.slack.com` DNS/SSRF
  environment failures reproduced independently of this change
- Ruff and `git diff --check`: passed
