### PR TITLE
fix(config): quote .env values with internal whitespace (#66482)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7778,6 +7778,7 @@ def _quote_env_value(value: str) -> str:
         or '"' in value
         or "'" in value
         or value != value.strip()
+        or any(c.isspace() for c in value)
     )
     if not needs_quoting:
         return value

--- a/tests/tools/test_quote_env_value.py
+++ b/tests/tools/test_quote_env_value.py
@@ -1,0 +1,70 @@
+"""Tests for `_quote_env_value` / `save_env_value` (issue #66482).
+
+Spaced paths (e.g. macOS `~/Library/Application Support/...`) must be
+double-quoted on write so shell `set -a; . ~/.hermes/.env` round-trips
+identically to python-dotenv.  Prior to the fix, internal whitespace
+did not trigger quoting, breaking POSIX-shell sourcing.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from hermes_cli.config import _quote_env_value, save_env_value
+
+
+class TestQuoteEnvValue:
+    def test_simple_value_not_quoted(self):
+        assert _quote_env_value("simple") == "simple"
+        assert _quote_env_value("path/to/file") == "path/to/file"
+        assert _quote_env_value("value_with_underscores-123") == "value_with_underscores-123"
+
+    def test_hash_triggers_quoting(self):
+        out = _quote_env_value("a#b")
+        assert out.startswith('"') and out.endswith('"')
+
+    def test_double_quote_triggers_quoting(self):
+        out = _quote_env_value('a"b')
+        assert out.startswith('"') and out.endswith('"')
+        assert '\\"' in out, "embedded double-quote must be backslash-escaped"
+
+    def test_single_quote_triggers_quoting(self):
+        out = _quote_env_value("a'b")
+        assert out.startswith('"') and out.endswith('"')
+
+    def test_leading_trailing_whitespace_triggers_quoting(self):
+        assert _quote_env_value(" leading").startswith('"')
+        assert _quote_env_value("trailing ").startswith('"')
+
+    def test_internal_space_triggers_quoting(self):
+        """Regression for #66482 — spaced paths must be quoted."""
+        spaced = "/Users/me/Library/Application Support/hermes/keys/id_ed25519"
+        out = _quote_env_value(spaced)
+        assert out != spaced, f"spaced path should be quoted, got: {out}"
+        assert out.startswith('"') and out.endswith('"'), f"must be double-quoted: {out}"
+        # No transformation of the inner content when no escapes are needed
+        assert "Application Support" in out, "whitespace content preserved"
+
+    def test_internal_tab_triggers_quoting(self):
+        out = _quote_env_value("a\tb")
+        assert out.startswith('"') and out.endswith('"')
+
+    def test_empty_string_returned_unchanged(self):
+        assert _quote_env_value("") == ""
+
+    def test_idempotent_save(self, tmp_path, monkeypatch):
+        """Re-saving the same value does not double-quote."""
+        from hermes_cli.config import get_env_path
+
+        orig_path = get_env_path()
+        env_path = tmp_path / "hermes" / ".env"
+        env_path.parent.mkdir(parents=True)
+        monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: env_path)
+        save_env_value("HERMES_TEST_KEY", "/path/with spaces/to/key")
+        save_env_value("HERMES_TEST_KEY", "/path/with spaces/to/key")
+        text = env_path.read_text()
+        lines = [ln for ln in text.splitlines() if ln.startswith("HERMES_TEST_KEY=")]
+        assert len(lines) == 1, f"expected one HERMES_TEST_KEY entry, got {lines}"
+        line = lines[0]
+        assert line.count('"') == 2, f"expected exactly 2 double-quotes, line: {line}"


### PR DESCRIPTION
## Summary

Fixes #66482.

`save_env_value` / `_quote_env_value` in `hermes_cli/config.py` did not quote values containing **internal** whitespace. Paths like `/Users/me/Library/Application Support/hermes/keys/id_ed25519` (common on macOS) were written verbatim to `~/.hermes/.env`.

- python-dotenv: OK — treats unquoted RHS as running to EOL (masks the bug for Hermes' own load).
- POSIX shell `set -a; . ~/.hermes/.env`: word-splits after the first space → `TERMINAL_SSH_KEY` ends up empty / truncated, with `Support/hermes/keys/id_ed25519: No such file or directory` from the shell.

## Root cause

`hermes_cli/config.py:7772` predicate:

```python
needs_quoting = (
    "#" in value
    or '"' in value
    or "'" in value
    or value != value.strip()
)
```

Internal whitespace (space/tab between non-space chars) does **not** trigger quoting. Only `#`, quotes, and leading/trailing whitespace do.

## Fix

One-line extension to the predicate — escape algorithm and idempotency unchanged:

```python
needs_quoting = (
    "#" in value
    or '"' in value
    or "'" in value
    or value != value.strip()
    or any(c.isspace() for c in value)
)
```

After the fix, the spaced path serializes as:
```
TERMINAL_SSH_KEY="/Users/me/Library/Application Support/hermes/keys/id_ed25519"
```

Both python-dotenv and POSIX `set -a; . file; set +a` round-trip identically.

## Tests

New `tests/tools/test_quote_env_value.py` (9 tests, all pass):

- `test_simple_value_not_quoted` — `simple`, `path/to/file`, `value_with_underscores-123` remain unquoted
- `test_internal_space_triggers_quoting` — regression for #66482, spaced path is double-quoted
- `test_internal_tab_triggers_quoting`
- `test_hash_triggers_quoting`
- `test_double_quote_triggers_quoting` — verifies `\"` backslash escape
- `test_single_quote_triggers_quoting`
- `test_leading_trailing_whitespace_triggers_quoting`
- `test_empty_string_returned_unchanged`
- `test_idempotent_save` — re-saving the same spaced value does not double-wrap; exactly 2 double-quotes on the line

## Out of scope

- The sibling installer-surface bug (`#57249`/`#57449`) — different write path, separate PR.
- Mass re-quoting of pre-existing unquoted spaced `.env` keys: not done automatically; users re-save a key to upgrade its serialization.

## Checklist

- [x] Reproduces on current `origin/main`
- [x] 1-line behavior change, escape algorithm unchanged
- [x] New tests pass (`pytest tests/tools/test_quote_env_value.py`)
- [x] Idempotent re-save verified (no nested quotes)
- [x] No behavior change for already-safe values (no spaces / no special chars)
