### PR TITLE
fix(hooks): key sys.modules on hook directory name to prevent collisions

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -122,7 +122,11 @@ class HookRegistry:
                 # in the handler). Without this, a handler that declares a
                 # Pydantic BaseModel for webhook/event payloads fails at first
                 # dispatch with "TypeAdapter ... is not fully defined".
-                module_name = f"hermes_hook_{hook_name}"
+                #
+                # Key on the directory name (unique on the filesystem), not the
+                # manifest 'name' field: two hooks declaring the same name would
+                # otherwise overwrite each other's entry in sys.modules.
+                module_name = f"hermes_hook_{hook_dir.name}"
                 spec = importlib.util.spec_from_file_location(
                     module_name, handler_path
                 )

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -1,5 +1,7 @@
 """Tests for gateway/hooks.py — event hook system."""
 
+import sys
+
 from unittest.mock import patch
 
 import pytest
@@ -44,6 +46,31 @@ class TestDiscoverAndLoad:
         assert len(reg.loaded_hooks) == 1
         assert reg.loaded_hooks[0]["name"] == "my-hook"
         assert "agent:start" in reg.loaded_hooks[0]["events"]
+
+    def test_same_manifest_name_does_not_collide_in_sys_modules(self, tmp_path):
+        """Two hooks sharing a HOOK.yaml 'name' keep distinct sys.modules entries."""
+        for dir_name, marker in (("hook-a", "A"), ("hook-b", "B")):
+            hook_dir = tmp_path / dir_name
+            hook_dir.mkdir(parents=True)
+            (hook_dir / "HOOK.yaml").write_text(
+                "name: shared-name\n"
+                "description: Test hook\n"
+                'events: ["agent:start"]\n'
+            )
+            (hook_dir / "handler.py").write_text(
+                f"def handle(event_type, context):\n    return {marker!r}\n"
+            )
+
+        reg = HookRegistry()
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
+            reg.discover_and_load()
+
+        assert len(reg.loaded_hooks) == 2
+        mod_a = sys.modules.get("hermes_hook_hook-a")
+        mod_b = sys.modules.get("hermes_hook_hook-b")
+        assert mod_a is not None and mod_b is not None
+        assert mod_a.handle("agent:start", {}) == "A"
+        assert mod_b.handle("agent:start", {}) == "B"
 
     def test_skips_missing_hook_yaml(self, tmp_path):
         hook_dir = tmp_path / "bad-hook"


### PR DESCRIPTION
## Summary
Hook handler modules are registered in `sys.modules` as `hermes_hook_<manifest name>`. Two hooks declaring the same `name:` in their `HOOK.yaml` overwrite each other's entry, which breaks forward-reference resolution (Pydantic / dataclasses under `from __future__ import annotations`) for the first hook's handler at dispatch time.

This keys the module name on the hook **directory** name instead, which is guaranteed unique on the filesystem.

Supersedes the stale, untouched #40462. Closes #40462.

## Testing
- New regression test `test_same_manifest_name_does_not_collide_in_sys_modules` loads two hooks sharing a manifest name and asserts both keep distinct, working `sys.modules` entries. Verified it fails on current `main` and passes with the fix.
- `scripts/run_tests.sh tests/gateway/test_hooks.py` — 22 passed
- `ruff check` / `scripts/check-windows-footguns.py --all` — clean
