### PR TITLE
fix(sanitize): preserve assistant messages with tool_calls when stripping images

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -396,9 +396,11 @@ def _strip_images_from_messages(messages: list) -> bool:
         with a plaintext placeholder, NOT deleted — deleting them would leave
         the paired ``tool_call_id`` on the prior assistant message unmatched,
         which providers reject with HTTP 400.
-      * Non-tool messages whose content becomes empty are dropped.  In
-        practice this only hits synthetic image-only user messages appended
-        for attachment delivery; real user turns always include text.
+      * Assistant messages carrying ``tool_calls`` are likewise replaced, not
+        deleted — dropping them would orphan their tool responses.
+      * Other messages whose content becomes empty are dropped.  In practice
+        this only hits synthetic image-only user messages appended for
+        attachment delivery; real user turns always include text.
 
     Returns True if any image parts were removed.
     """
@@ -419,13 +421,15 @@ def _strip_images_from_messages(messages: list) -> bool:
         if len(new_parts) < len(content):
             if new_parts:
                 msg["content"] = new_parts
-            elif msg.get("role") == "tool":
-                # Preserve tool_call_id linkage — providers require every
-                # assistant tool_call to have a matching tool response.
+            elif msg.get("role") == "tool" or msg.get("tool_calls"):
+                # Preserve message linkage — providers require every assistant
+                # tool_call to have a matching tool response, and an assistant
+                # message carrying tool_calls must survive even if its content
+                # was entirely images.
                 msg["content"] = "[image content removed — server does not support images]"
             else:
-                # Synthetic image-only user/assistant message with no text;
-                # safe to drop.
+                # Synthetic image-only user/assistant message with no text and
+                # no tool_calls; safe to drop.
                 to_delete.append(i)
     for i in reversed(to_delete):
         del messages[i]

--- a/tests/run_agent/test_image_rejection_fallback.py
+++ b/tests/run_agent/test_image_rejection_fallback.py
@@ -113,6 +113,37 @@ class TestStripImagesPreservesAlternation:
         assert msgs[2]["content"] == [{"type": "text", "text": "Captured 1024x768"}]
         assert msgs[2]["tool_call_id"] == "call_1"
 
+    def test_assistant_with_tool_calls_and_image_only_content_preserved(self):
+        """Assistant messages carrying tool_calls must NEVER be deleted —
+        dropping them would orphan the paired tool responses, which providers
+        reject with unmatched tool_call_id errors.
+        """
+        msgs = [
+            {"role": "user", "content": "annotate this screenshot"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
+                ],
+                "tool_calls": [{
+                    "id": "call_xyz",
+                    "type": "function",
+                    "function": {"name": "annotate", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_xyz", "content": "done"},
+        ]
+        changed = _strip_images_from_messages(msgs)
+        assert changed is True
+        # Length preserved — assistant message with tool_calls NOT deleted
+        assert len(msgs) == 3
+        assert msgs[1]["tool_calls"][0]["id"] == "call_xyz"
+        # Content replaced with text placeholder (now a string, not a list)
+        assert isinstance(msgs[1]["content"], str)
+        assert "image content removed" in msgs[1]["content"].lower()
+        # Paired tool response still matches
+        assert msgs[2]["tool_call_id"] == "call_xyz"
+
     def test_image_only_user_message_dropped(self):
         """Synthetic image-only user messages (gateway injection pattern) are
         safe to drop — no tool_call_id linkage to preserve."""


### PR DESCRIPTION
## Summary
`_strip_images_from_messages()` deletes any non-tool message whose content becomes empty after image removal. An assistant message whose content was entirely images but which carries `tool_calls` was therefore dropped, orphaning its paired tool responses — the next request fails with unmatched `tool_call_id` errors (HTTP 400).

Such messages are now replaced with the existing plaintext placeholder, exactly like tool-role messages, preserving the alternation invariant. The docstring is updated to document the new rule.

Supersedes the stale, untouched #40463. Closes #40463.

## Testing
- New regression test `test_assistant_with_tool_calls_and_image_only_content_preserved`. Verified it fails on current `main` and passes with the fix.
- `scripts/run_tests.sh tests/run_agent/test_image_rejection_fallback.py` — 17 passed
- `scripts/run_tests.sh tests/agent/test_close_interrupted_tool_sequence.py` — 7 passed
- `ruff check` / `scripts/check-windows-footguns.py --all` — clean
