### PR TITLE
fix(anthropic-adapter): default aliased model names to adaptive thinking (#66244)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -105,6 +105,20 @@ _LEGACY_MANUAL_THINKING_CLAUDE_SUBSTRINGS = (
     "claude-haiku-4-5", "claude-haiku-4.5",
 )
 
+# Non-Claude models that speak the Anthropic Messages protocol (minimax, qwen3,
+# kimi, glm, …).  These do NOT support adaptive thinking and must stay on the
+# legacy manual path (thinking.type="enabled" + budget_tokens).  Case-insensitive
+# substring — keep entries in lowercase.  See test_non_claude_anthropic_models_
+# use_manual_path.
+_NON_CLAUDE_ANTHROPIC_SUBSTRINGS = (
+    "minimax",
+    "qwen3",
+    "moonshot",
+    "kimi",
+    "k1.", "k2.",
+    "glm",
+)
+
 # Older Claude families that DON'T accept the "xhigh" effort level (4.6 only
 # supports low/medium/high/max). xhigh arrived with Opus 4.7. Adaptive models
 # not in this list (4.7, 4.8, fable, future) accept xhigh.
@@ -247,9 +261,32 @@ def _supports_adaptive_thinking(model: str) -> bool:
     only returns False for the explicit legacy list of older Claude families
     that require manual budget-based thinking. Non-Claude Anthropic-Messages
     models (minimax, qwen3, …) return False so they keep the manual path.
+
+    Aliased model names (``"auto"``, ``"default"``, …) routed through a
+    custom Anthropic-Messages-compatible proxy that interprets them as a
+    Claude model group also default to adaptive.  The legacy manual-thinking
+    format (``thinking.type="enabled"`` + ``budget_tokens``) is rejected with
+    HTTP 400 by every Claude 4.6+ model group, while the adaptive format is
+    accepted by every Claude 4.6+ model and ignored by 4.5-and-older — so
+    defaulting unknown aliases to adaptive is fail-open for the modern
+    contract and only fails closed for the (much rarer) legacy-only proxy
+    route.  See #66244.
     """
     if not _is_claude_model(model):
-        return False
+        # Non-Claude Anthropic-Messages models (minimax / qwen3 / kimi / glm)
+        # stay on the manual-thinking path.  Any other non-Claude name (e.g.
+        # an alias like "auto" routed to a Claude model group by a proxy) is
+        # treated as an adaptive Claude alias — see the docstring.
+        m = (model or "").lower()
+        if any(v in m for v in _NON_CLAUDE_ANTHROPIC_SUBSTRINGS):
+            return False
+        # Unknown alias on a custom Anthropic-Messages proxy — default to
+        # the modern (4.6+) adaptive contract.  An empty model is NOT
+        # treated as an alias (callers that intentionally pass "" should go
+        # through the manual path).
+        if not m:
+            return False
+        return True
     m = model.lower()
     return not any(v in m for v in _LEGACY_MANUAL_THINKING_CLAUDE_SUBSTRINGS)
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1615,6 +1615,32 @@ class TestBuildAnthropicKwargs:
             assert _supports_xhigh_effort(m) is False, m
             assert _forbids_sampling_params(m) is False, m
 
+    def test_aliased_model_name_defaults_to_adaptive_thinking(self):
+        """Regression for #66244: an aliased model name routed through a custom
+        Anthropic-Messages-compatible proxy (e.g. ``model: auto`` resolving to
+        a Claude model group server-side) must default to the modern adaptive
+        contract.  Before the fix, the legacy manual-thinking format
+        (``thinking.type="enabled"`` + ``budget_tokens``) was sent
+        unconditionally, which every Claude 4.6+ model group rejects with
+        HTTP 400 — silently breaking ``delegate_task`` subagents whose first
+        API call hit a non-retryable 400.
+        """
+        from agent.anthropic_adapter import _supports_adaptive_thinking
+
+        for m in (
+            "auto",
+            "default",
+            "proxy-claude",
+            "auto-std-00a0c0-10",  # the actual model-group ID from #66244's logs
+        ):
+            assert _supports_adaptive_thinking(m) is True, m
+
+        # Empty / None keep the legacy contract — callers that intentionally
+        # pass "" should not be silently treated as adaptive Claude aliases.
+        assert _supports_adaptive_thinking("") is False
+        assert _supports_adaptive_thinking(None) is False
+
+
     def test_fast_mode_omitted_for_unsupported_model(self):
         """fast_mode=True on Opus 4.7 must NOT inject speed=fast (API 400s)."""
         kwargs = build_anthropic_kwargs(


### PR DESCRIPTION
## Summary

Fixes #66244.

`_supports_adaptive_thinking("auto")` returned `False` because `_is_claude_model` does a strict substring check (`"claude" in model.lower()`). When `model: auto` (or any proxy-routed alias) resolves server-side to a Claude 4.6+ model group, Hermes sends the legacy manual-thinking format (`thinking.type="enabled"` + `budget_tokens`), which the proxy rejects with HTTP 400 — a **non-retryable** error that silently kills `delegate_task` subagents on their first API call.

## Root cause

`_supports_adaptive_thinking` in `agent/anthropic_adapter.py:251` short-circuited to `False` for *any* model name that didn't contain `"claude"` — without distinguishing third-party Anthropic-Messages models (minimax, qwen3, kimi, glm, …) from aliases that resolve to a real Claude model group on a custom proxy.

```
model="auto"
  → _is_claude_model("auto") = False
  → _supports_adaptive_thinking("auto") = False (short-circuit)
  → build_anthropic_kwargs L2652 sends legacy {thinking.type="enabled", budget_tokens}
  → proxy resolves "auto" to a Claude 4.6+ model group
  → HTTP 400: "thinking.type.enabled" is not supported for this model
  → Non-retryable client error → subagent dies
```

## Fix

Add `_NON_CLAUDE_ANTHROPIC_SUBSTRINGS` — an explicit list of known non-Claude Anthropic-Messages model families (`minimax`, `qwen3`, `moonshot`, `kimi`, `k1.`, `k2.`, `glm`).

`_supports_adaptive_thinking` now:

1. Short-circuits to `False` for known non-Claude Anthropic-Messages models — **unchanged behaviour**, keeps those on the manual-thinking path.
2. Short-circuits to `False` for empty string / `None` — **safety guard**, callers that intentionally pass `""` should not be silently treated as adaptive aliases.
3. **Defaults to `True` for any other non-Claude model name** — i.e. unknown aliases on a custom Anthropic-Messages proxy — the fail-open path for the modern (4.6+) adaptive-thinking contract.

The legacy manual format is rejected by **every** Claude 4.6+ model group, while the adaptive format is accepted by 4.6+ and only rejected by the much rarer legacy-only (4.5-and-older) endpoint. Fail-open is the correct default for unknown aliases.

## Why `_is_claude_model` is not changed

`_is_claude_model` is also used by `_forbids_sampling_params` and `_get_anthropic_max_output`. Treating every unknown string as a Claude model would make `_forbids_sampling_params` strip sampling params from non-Claude models (causing its own regressions). The fix is scoped to `_supports_adaptive_thinking` only — the one predicate whose decision must switch for aliases.

## Verification — issue's exact scenario

```python
from agent.anthropic_adapter import _supports_adaptive_thinking

# Aliased names → adaptive (the fix)
assert _supports_adaptive_thinking("auto") is True
assert _supports_adaptive_thinking("default") is True
assert _supports_adaptive_thinking("auto-std-00a0c0-10") is True   # the model-group ID from the issue's logs

# Known non-Claude Anthropic-Messages models → manual (unchanged)
assert _supports_adaptive_thinking("minimax-m2") is False
assert _supports_adaptive_thinking("qwen3-max") is False
assert _supports_adaptive_thinking("moonshotai/kimi-k2.5") is False
assert _supports_adaptive_thinking("glm-4.6") is False

# Empty / None → manual (safety guard)
assert _supports_adaptive_thinking("") is False
assert _supports_adaptive_thinking(None) is False

# Existing Claude families → unchanged
assert _supports_adaptive_thinking("claude-opus-4-8") is True
assert _supports_adaptive_thinking("claude-fable-5") is True
assert _supports_adaptive_thinking("claude-3-5-sonnet") is False
assert _supports_adaptive_thinking("claude-opus-4-6") is True
```

## Tests

- New test `test_aliased_model_name_defaults_to_adaptive_thinking` covers `auto`, `default`, `proxy-claude`, `auto-std-00a0c0-10` (the actual model-group ID from #66244's debug logs), plus empty/None as safety guards.
- Existing `test_non_claude_anthropic_models_use_manual_path` still passes — minimax, qwen3, kimi, glm keep the manual path.
- Existing `test_legacy_claude_stays_on_manual_thinking` and `test_claude_46_is_adaptive_but_not_xhigh_or_no_sampling` still pass.

```
177 passed in 1.94s
```

## Out of scope

A user who proxies a non-Claude model (e.g. minimax) through a *custom* alias that doesn't contain `minimax`, `qwen3`, `kimi`, or `glm` will hit the adaptive path and likely 400. Those users must configure a different alias that contains the model family name, or disable `reasoning_config.enabled`. This is an acceptable trade-off: the known-family list is documented and can be extended as new non-Claude Anthropic-Messages models arrive.

## Checklist

- [x] Reproduces the exact scenario from #66244 (alias on custom Anthropic proxy defaults to adaptive)
- [x] Non-Claude Anthropic-Messages models unchanged (minimax, qwen3, kimi, glm stay on manual)
- [x] Empty / None safety guard retained
- [x] `_is_claude_model` deliberately **not** changed — preserves `_forbids_sampling_params` and `_get_anthropic_max_output` contracts
- [x] 1 new test + 176 existing tests pass
