### PR TITLE
fix(slack): 修复缺少 Slack 凭证时的无限重连循环

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -986,10 +986,30 @@ class SlackAdapter(BasePlatformAdapter):
             app_token = os.getenv("SLACK_APP_TOKEN")
 
         if not raw_token:
-            logger.error("[Slack] SLACK_BOT_TOKEN not set")
+            logger.error(
+                "[Slack] SLACK_BOT_TOKEN not set — this is a permanent config "
+                "error; add SLACK_BOT_TOKEN to the active profile's .env or "
+                "hermes_cli/config.yaml and restart the gateway.",
+            )
+            self._set_fatal_error(
+                "missing_slack_bot_token",
+                "SLACK_BOT_TOKEN not configured. Add it to the active profile's .env "
+                "or hermes_cli/config.yaml, then restart the gateway.",
+                retryable=False,
+            )
             return False
         if not app_token:
-            logger.error("[Slack] SLACK_APP_TOKEN not set")
+            logger.error(
+                "[Slack] SLACK_APP_TOKEN not set — this is a permanent config "
+                "error; add SLACK_APP_TOKEN to the active profile's .env or "
+                "hermes_cli/config.yaml and restart the gateway.",
+            )
+            self._set_fatal_error(
+                "missing_slack_app_token",
+                "SLACK_APP_TOKEN not configured. Add it to the active profile's .env "
+                "or hermes_cli/config.yaml, then restart the gateway.",
+                retryable=False,
+            )
             return False
 
         proxy_url = _resolve_slack_proxy_url()

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -988,26 +988,30 @@ class SlackAdapter(BasePlatformAdapter):
         if not raw_token:
             logger.error(
                 "[Slack] SLACK_BOT_TOKEN not set — this is a permanent config "
-                "error; add SLACK_BOT_TOKEN to the active profile's .env or "
-                "hermes_cli/config.yaml and restart the gateway.",
+                "error; set SLACK_BOT_TOKEN via `hermes gateway setup` "
+                "or in the active profile's ~/.hermes/.env file, then restart "
+                "the gateway.",
             )
             self._set_fatal_error(
                 "missing_slack_bot_token",
-                "SLACK_BOT_TOKEN not configured. Add it to the active profile's .env "
-                "or hermes_cli/config.yaml, then restart the gateway.",
+                "SLACK_BOT_TOKEN not configured. Use `hermes gateway setup` "
+                "or add it to your active profile's ~/.hermes/.env file, "
+                "then restart the gateway.",
                 retryable=False,
             )
             return False
         if not app_token:
             logger.error(
                 "[Slack] SLACK_APP_TOKEN not set — this is a permanent config "
-                "error; add SLACK_APP_TOKEN to the active profile's .env or "
-                "hermes_cli/config.yaml and restart the gateway.",
+                "error; set SLACK_APP_TOKEN via `hermes gateway setup` "
+                "or in the active profile's ~/.hermes/.env file, then restart "
+                "the gateway.",
             )
             self._set_fatal_error(
                 "missing_slack_app_token",
-                "SLACK_APP_TOKEN not configured. Add it to the active profile's .env "
-                "or hermes_cli/config.yaml, then restart the gateway.",
+                "SLACK_APP_TOKEN not configured. Use `hermes gateway setup` "
+                "or add it to your active profile's ~/.hermes/.env file, "
+                "then restart the gateway.",
                 retryable=False,
             )
             return False

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4927,3 +4927,63 @@ class TestThreadContextUnverifiedTagging:
         # Renders successfully without trust tag (exception → unknown trust).
         assert "U_X: hello" in content
         assert "[unverified]" not in content
+
+
+# ---------------------------------------------------------------------------
+# Missing-credential handling — fatal-error contract
+# ---------------------------------------------------------------------------
+
+
+class TestMissingCredentials:
+    """Missing SLACK_BOT_TOKEN or SLACK_APP_TOKEN must set a non-retryable fatal error."""
+
+    @pytest.mark.asyncio
+    async def test_missing_bot_token_sets_fatal_error(self):
+        """When SLACK_BOT_TOKEN is absent from both config and env, connect()
+        must set fatal_error with code 'missing_slack_bot_token' and retryable=False."""
+        config = PlatformConfig(enabled=True, token=None)  # no bot token
+        adapter = SlackAdapter(config)
+
+        fatal_errors = []
+
+        def capture_fatal(code, message, *, retryable):
+            fatal_errors.append({"code": code, "message": message, "retryable": retryable})
+
+        with (
+            patch.object(adapter, "_set_fatal_error", side_effect=capture_fatal),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            result = await adapter.connect()
+
+        assert result is False
+        assert len(fatal_errors) == 1
+        assert fatal_errors[0]["code"] == "missing_slack_bot_token"
+        assert fatal_errors[0]["retryable"] is False
+        assert "SLACK_BOT_TOKEN" in fatal_errors[0]["message"]
+        assert "hermes gateway setup" in fatal_errors[0]["message"].lower() or ".env" in fatal_errors[0]["message"]
+
+    @pytest.mark.asyncio
+    async def test_missing_app_token_sets_fatal_error(self):
+        """When SLACK_APP_TOKEN is absent but SLACK_BOT_TOKEN is present,
+        connect() must set fatal_error with code 'missing_slack_app_token'
+        and retryable=False."""
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+
+        fatal_errors = []
+
+        def capture_fatal(code, message, *, retryable):
+            fatal_errors.append({"code": code, "message": message, "retryable": retryable})
+
+        with (
+            patch.object(adapter, "_set_fatal_error", side_effect=capture_fatal),
+            patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-fake"}, clear=True),
+        ):
+            result = await adapter.connect()
+
+        assert result is False
+        assert len(fatal_errors) == 1
+        assert fatal_errors[0]["code"] == "missing_slack_app_token"
+        assert fatal_errors[0]["retryable"] is False
+        assert "SLACK_APP_TOKEN" in fatal_errors[0]["message"]
+        assert "hermes gateway setup" in fatal_errors[0]["message"].lower() or ".env" in fatal_errors[0]["message"]


### PR DESCRIPTION
## 背景

修复 #66696: Gateway Slack reconnect loop when default env lacks SLACK_APP_TOKEN

当默认 gateway 环境中缺少 SLACK_BOT_TOKEN 或 SLACK_APP_TOKEN 时，Slack adapter 的 connect() 方法仅记录错误并返回 False。gateway 的重连 watcher 会将该 platform 加入重试队列，以指数退避（30s → 300s cap）无限重试，导致 gateway 陷入永久重连循环。

## 根因分析

在 `plugins/platforms/slack/adapter.py` 的 `connect()` 方法中：
- 当 `SLACK_BOT_TOKEN` 缺失时，仅 `logger.error("[Slack] SLACK_BOT_TOKEN not set")` 后 return False
- 当 `SLACK_APP_TOKEN` 缺失时，仅 `logger.error("[Slack] SLACK_APP_TOKEN not set")` 后 return False
- 没有调用 `_set_fatal_error()` 标记为非可重试错误
- gateway 的 `_platform_reconnect_watcher` 将此类失败视为 retryable，持续入队重试

参考其他 adapter（Discord、Telegram）的处理方式，它们对缺失凭证都调用了 `_set_fatal_error(code, message, retryable=False)` 来标记为不可重试。

## 修复方式

1. 在 `connect()` 中检测到 `SLACK_BOT_TOKEN` 缺失时，调用 `_set_fatal_error("missing_slack_bot_token", ..., retryable=False)`
2. 在 `connect()` 中检测到 `SLACK_APP_TOKEN` 缺失时，调用 `_set_fatal_error("missing_slack_app_token", ..., retryable=False)`
3. 错误日志中包含明确的修复指引（告知用户应添加哪个环境变量到哪个配置文件）

gateway 的重连 watcher 在检测到 `fatal_error_retryable=False` 时会立即从重试队列中移除该 platform，标记为 "fatal" 状态，不再无限重试。

## 验证

- [x] 代码变更已在本地验证（语法检查通过）
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更 — 仅在 connect() 失败路径上增加 _set_fatal_error 调用
- [x] 与其他 adapter 的行为一致（Discord、Telegram 已有类似模式）

Closes #66696