### PR TITLE
fix(telegram): per-chat send cooldown + skip progress fallback on flood control

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18535,16 +18535,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 )
                                 continue
                             if "flood" in _err or "retry after" in _err:
-                                # Flood control hit — backoff but keep editing.
-                                # Only disable edits for non-recoverable errors.
+                                # Flood control hit. The previous behaviour was
+                                # to fall back to a brand-new
+                                # ``adapter.send()`` here — but that send is
+                                # exactly the kind of burst that triggered the
+                                # penalty in the first place, and re-firing it
+                                # during the penalty window keeps the timer
+                                # pinned at "Retry in 7000+ seconds". Instead,
+                                # drop this tick's update, leave the progress
+                                # message and ``progress_lines`` intact, and
+                                # let the next tick try the edit again once the
+                                # per-chat send cooldown (added in
+                                # ``plugins/platforms/telegram/adapter.py``)
+                                # releases the chat. The user will see a
+                                # short stale-bubble window; that's strictly
+                                # better than escalating the Telegram penalty
+                                # by minutes.
                                 logger.info(
-                                    "[%s] Progress edit flood control, backing off",
+                                    "[%s] Progress edit flood control — skipping "
+                                    "fallback send (would re-trigger penalty); "
+                                    "will retry edit on next tick",
                                     adapter.name,
                                 )
                                 _last_edit_ts = time.monotonic()
-                            else:
-                                can_edit = False
-                            _flood_result = await adapter.send(
+                                continue
+                            can_edit = False
+                            # Non-flood permanent failure (message deleted,
+                            # permission revoked, etc.) — fall back to a fresh
+                            # message bubble so the user still sees the
+                            # progress line. This branch intentionally keeps
+                            # the legacy send() fallback because the failure
+                            # mode here is local, not a Telegram rate-limit
+                            # signal.
+                            _perm_result = await adapter.send(
                                 chat_id=source.chat_id,
                                 content=msg,
                                 reply_to=_progress_reply_to,
@@ -18552,10 +18575,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                             if (
                                 _cleanup_progress
-                                and getattr(_flood_result, "success", False)
-                                and getattr(_flood_result, "message_id", None)
+                                and getattr(_perm_result, "success", False)
+                                and getattr(_perm_result, "message_id", None)
                             ):
-                                _cleanup_msg_ids.append(str(_flood_result.message_id))
+                                _cleanup_msg_ids.append(str(_perm_result.message_id))
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -14,9 +14,10 @@ import inspect
 import json
 import logging
 import os
-import html as _html
 import re
 import threading
+import time
+import html as _html
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
@@ -679,6 +680,44 @@ class TelegramAdapter(BasePlatformAdapter):
             30.0,
             min_value=1.0,
             max_value=300.0,
+        )
+        # Per-chat send-cooldown. Telegram's Bot API enforces ~1 msg/sec/chat
+        # in private DMs and a global ~30 msg/sec budget across all chats for
+        # bots. A single user turn routinely fans out 3-5 sends (status
+        # callbacks, progress bubbles, streaming previews, final answer) and
+        # they were historically fired in parallel from independent code paths
+        # (status callbacks via safe_schedule_threadsafe, progress via the
+        # progress-queue consumer, final via the stream consumer). Even
+        # though each path has its own per-send retry-after handling, the
+        # burst pattern crosses Telegram's threshold and triggers a flood
+        # control penalty that escalates into multi-thousand-second back-offs
+        # ("Retry in 7019 seconds"). The fix is a cross-cutting per-chat gate
+        # that forces every send to honour a minimum gap so the cumulative
+        # send rate stays under the threshold regardless of how many
+        # components fire concurrently.
+        #
+        # Stored as a timestamp-by-chat dict so multiple chats don't
+        # serialise on a single lock. ``_send_cooldown_seconds`` defaults to
+        # 1.1s — comfortably above Telegram's per-chat limit while still
+        # feeling responsive (status bubbles lag by at most ~1s, well below
+        # the user-visible threshold for "did anything happen?").
+        self._send_cooldown_until: Dict[str, float] = {}
+        self._send_cooldown_seconds: float = self._coerce_float_extra(
+            "send_cooldown_seconds",
+            1.1,
+            min_value=0.0,
+            max_value=10.0,
+        )
+        # Hard cap on how long a send will block waiting for its cooldown
+        # to expire. Without this, a 7000-second flood penalty would stall
+        # the whole chat path for two hours. We let the caller observe the
+        # wait via a flood_control-style error so upstream retries can
+        # back off too, instead of silently dropping messages.
+        self._send_cooldown_max_wait: float = self._coerce_float_extra(
+            "send_cooldown_max_wait_seconds",
+            5.0,
+            min_value=0.5,
+            max_value=60.0,
         )
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
@@ -3950,7 +3989,52 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
-        
+
+        # Per-chat send cooldown. Telegram's Bot API enforces ~1 msg/sec/chat
+        # in private DMs and a ~30 msg/sec global budget across all chats for
+        # bots. A single user turn historically fans out 3-5 sends from
+        # independent code paths (status callbacks fired via
+        # safe_schedule_threadsafe, progress bubbles from the progress-queue
+        # consumer, streaming previews from the stream consumer, the final
+        # answer, photo batches). Even though each path does its own
+        # retry-after handling, the burst pattern crosses Telegram's
+        # threshold and triggers a flood-control penalty that escalates
+        # into multi-thousand-second back-offs ("Retry in 7019 seconds").
+        # This gate serialises every outbound send per-chat with a small
+        # minimum gap, so the cumulative rate stays under the threshold
+        # regardless of how many components fire concurrently.
+        #
+        # The wait is bounded by ``_send_cooldown_max_wait``: a 7000-second
+        # Telegram penalty shouldn't stall the chat path for two hours.
+        # When the bounded wait would be exceeded, we return a non-fatal
+        # flood_control-style error so upstream retries can back off too,
+        # instead of silently dropping the message.
+        # getattr() — tests build adapters via object.__new__() (no __init__).
+        _cooldown_until_map = getattr(self, "_send_cooldown_until", None)
+        if _cooldown_until_map is not None:
+            _now_mono = time.monotonic()
+            _chat_key = str(chat_id)
+            _until = _cooldown_until_map.get(_chat_key, 0.0)
+            if _until > _now_mono:
+                _wait = _until - _now_mono
+                _max_wait = getattr(self, "_send_cooldown_max_wait", 5.0)
+                if _wait > _max_wait:
+                    logger.warning(
+                        "[%s] send cooldown for chat %s exceeds max wait (%.1fs > %.1fs); "
+                        "yielding with retryable error so upstream can back off",
+                        self.name, _chat_key, _wait, _max_wait,
+                    )
+                    return SendResult(
+                        success=False,
+                        error=f"flood_control:{_wait:.0f}",
+                        retryable=True,
+                    )
+                logger.debug(
+                    "[%s] send cooldown for chat %s: sleeping %.2fs",
+                    self.name, _chat_key, _wait,
+                )
+                await asyncio.sleep(_wait)
+
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
@@ -3961,6 +4045,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
+                        # Stamp the cooldown on the rich fast-path too so the
+                        # next non-rich send (or another rich one) honours
+                        # the per-chat gate. Without this, the rich path
+                        # would bypass the limiter entirely and a
+                        # rich→markdown sequence would race.
+                        _cooldown_until_map = getattr(self, "_send_cooldown_until", None)
+                        if _cooldown_until_map is not None:
+                            _cooldown_until_map[str(chat_id)] = (
+                                time.monotonic()
+                                + getattr(self, "_send_cooldown_seconds", 1.1)
+                            )
                         # Re-trigger typing like the legacy success path does,
                         # but ONLY for intermediate sends. On the final reply
                         # (metadata["notify"]) the gateway has already torn down
@@ -4011,6 +4106,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 _TimedOut = None  # type: ignore[assignment,misc]
 
             for i, chunk in enumerate(chunks):
+                # Stamp the per-chat cooldown immediately before the Bot API
+                # call so subsequent chunks / sends queue behind this one
+                # for ``_send_cooldown_seconds``. Updating here (rather than
+                # at the top of the gate) means a Telegram retry-after wait
+                # we did NOT spend — i.e. the previous send's actual
+                # wall-clock cost — is what gets credited.
+                _cooldown_until_map = getattr(self, "_send_cooldown_until", None)
+                if _cooldown_until_map is not None:
+                    _cooldown_until_map[str(chat_id)] = (
+                        time.monotonic() + getattr(self, "_send_cooldown_seconds", 1.1)
+                    )
                 retried_thread_not_found = False
                 metadata_reply_to = self._metadata_reply_to_message_id(metadata)
                 private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)

--- a/tests/gateway/test_run_progress_interrupt.py
+++ b/tests/gateway/test_run_progress_interrupt.py
@@ -233,7 +233,7 @@ async def test_progress_suppressed_when_agent_is_interrupted(monkeypatch, tmp_pa
     )
     assert result["final_response"] == "interrupted"
 
-    rendered = " ".join(c["content"] for c in adapter.sent) + " " + " ".join(
+    rendered = " ".join(c["content"] for c in adapter.sent) + " ".join(
         c["content"] for c in adapter.edits
     )
 
@@ -249,3 +249,158 @@ async def test_progress_suppressed_when_agent_is_interrupted(monkeypatch, tmp_pa
             f"event '{leaked_query}' leaked into the UI after interrupt — "
             f"progress_callback / drain loop is not checking is_interrupted"
         )
+
+
+# ============================================================
+# Flood-control fallback regression
+# ============================================================
+#
+# Bug: when the progress bubble's edit call fails with a Telegram
+# flood-control error, the gateway's send_progress_messages()
+# handler used to "fall back" to a fresh adapter.send() in the
+# same chat. That fallback is exactly the burst pattern that
+# triggers the Telegram penalty in the first place — re-firing
+# it during the penalty window keeps the timer pinned at
+# "Retry in 7000+ seconds" and escalates the penalty by minutes
+# each tick.
+#
+# Fix: when the edit fails with a flood-control error, drop the
+# tick and let the per-chat send cooldown (added in
+# plugins/platforms/telegram/adapter.py) release the chat before
+# the next tick retries the edit. No fresh send() during the
+# penalty window.
+
+
+class FloodControlEditAdapter(ProgressCaptureAdapter):
+    """Adapter whose edit_message() fails with a Telegram flood-control
+    error for the first ``edit_failures_remaining`` calls, then
+    succeeds. Used to verify the progress handler does NOT call
+    send() as a fallback when the edit fails with flood-control.
+    """
+
+    def __init__(self, *args, edit_failures_remaining=3, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.edit_failures_remaining = edit_failures_remaining
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append({"message_id": message_id, "content": content})
+        if self.edit_failures_remaining > 0:
+            self.edit_failures_remaining -= 1
+            return SendResult(
+                success=False,
+                error="flood control exceeded. Retry in 7000 seconds",
+                retryable=False,
+            )
+        return SendResult(success=True, message_id=message_id)
+
+
+class FloodControlProgressAgent:
+    """Fires a handful of tool.started events so the progress consumer
+    has enough work to drain past the throttle interval and observe
+    the flood-edit failure."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+        self._interrupt_requested = False
+
+    @property
+    def is_interrupted(self) -> bool:
+        return self._interrupt_requested
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        for _ in range(3):
+            self.tool_progress_callback("tool.started", "web_search", "first hit", {})
+            time.sleep(0.05)
+        # Let the drain loop observe the flood-control edit failure
+        # and (under the fix) skip the fallback send. The 1.5s
+        # progress-edit throttle means we need at least that long.
+        time.sleep(2.0)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+@pytest.mark.asyncio
+async def test_progress_flood_control_does_not_trigger_fallback_send(
+    monkeypatch, tmp_path
+):
+    """When edit_message fails with a Telegram flood-control error, the
+    progress handler must NOT issue a fresh adapter.send() in the
+    same chat. Issuing one re-triggers the Telegram penalty and
+    extends it from minutes to hours. The fix is to drop the tick
+    and let the per-chat send cooldown release the chat.
+    """
+    adapter = FloodControlEditAdapter(edit_failures_remaining=3)
+    # Tiny cooldown so the test runs fast — the actual cooldown
+    # doesn't matter for this test, only that one is set.
+    adapter._send_cooldown_seconds = 0.05
+    adapter._send_cooldown_max_wait = 1.0
+    runner = _make_runner(adapter)
+
+    import importlib
+    gateway_run = importlib.import_module("gateway.run")
+
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FloodControlProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***"},
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-flood",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+
+    # The handler should have tried (and failed) at least one edit —
+    # the flood-control-failing edit_message is the signal we need
+    # to react to.
+    assert any("first hit" in e["content"] for e in adapter.edits), (
+        "expected at least one edit attempt against the progress bubble; "
+        "without it the flood-control path is not exercised"
+    )
+
+    # The fix: no fresh send() fallback on flood-control. Filter out
+    # any final-response send (which is unrelated to the progress
+    # path) — we only care about progress-driven fallback sends,
+    # which would appear with content matching the progress line.
+    #
+    # Note: a single progress send is EXPECTED here — the first
+    # progress bubble has to be sent (not edited) because no
+    # previous progress message exists yet. The bug we are
+    # regressing on is the SECOND and onward sends that the legacy
+    # code issued as a fallback when the edit hit flood control.
+    # With the fix, the edit failures drop the tick instead of
+    # firing a fresh send, so the count should stay at 1.
+    progress_sends = [s for s in adapter.sent if "first hit" in s["content"]]
+    assert len(progress_sends) <= 1, (
+        f"progress handler issued {len(progress_sends)} progress-bubble "
+        f"send(s) — at most 1 is expected (the initial bubble). "
+        f"Multiple sends here means the flood-control fallback bug "
+        f"is back: every extra send re-triggers Telegram's penalty "
+        f"and extends it from minutes to hours. "
+        f"Sent: {progress_sends!r}"
+    )
+
+

--- a/tests/gateway/test_telegram_send_cooldown.py
+++ b/tests/gateway/test_telegram_send_cooldown.py
@@ -1,0 +1,233 @@
+"""TelegramAdapter per-chat send-cooldown gate.
+
+Cross-cutting rate-limiter for outbound ``send()`` calls. Telegram's
+Bot API enforces ~1 msg/sec/chat in private DMs and a global ~30
+msg/sec budget across all chats for bots. A single user turn
+historically fans out 3-5 sends from independent code paths
+(status callbacks, progress bubbles, streaming previews, final
+answer) and they were fired in parallel — a burst pattern that
+crosses Telegram's threshold and triggers a flood-control penalty
+that escalates into multi-thousand-second back-offs.
+
+The fix is a per-chat minimum-gap gate in ``send()`` so the
+cumulative send rate stays under the threshold regardless of how
+many components fire concurrently. These tests pin the gate's
+behaviour:
+
+  - successful sends stamp the cooldown so the next send to the
+    same chat waits for ``_send_cooldown_seconds``
+  - a different chat has an independent cooldown
+  - the wait is bounded by ``_send_cooldown_max_wait`` so a
+    7000-second Telegram penalty doesn't stall the chat path
+  - a send that arrives just after the cooldown expires goes
+    through without an extra delay
+"""
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    mod.error.RetryAfter = type(
+        "RetryAfter",
+        (Exception,),
+        {"__init__": lambda self, retry_after=1: setattr(self, "retry_after", retry_after)},
+    )
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(
+        return_value=MagicMock(message_id=42),
+    )
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_first_send_stamps_cooldown_for_same_chat(monkeypatch):
+    """A successful send records a cooldown timestamp so the next send to
+    the same chat can be gated by ``send()``."""
+    adapter = _make_adapter()
+    adapter._send_cooldown_seconds = 1.1
+    adapter._send_cooldown_max_wait = 5.0
+
+    fake_now = {"t": 1000.0}
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic",
+        lambda: fake_now["t"],
+    )
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is True
+    # Stamped roughly +1.1s from the start of the call. Allow a small
+    # floating-point slack because the gate reads monotonic() multiple
+    # times during the request.
+    stamped = adapter._send_cooldown_until["123"]
+    assert 1000.0 <= stamped <= 1001.5
+
+
+@pytest.mark.asyncio
+async def test_second_send_within_window_blocks(monkeypatch):
+    """A second send to the same chat within the cooldown window waits for
+    the gate before issuing its Bot API call. We assert via the elapsed
+    ``time.monotonic()`` — by advancing a fake clock while the gate sleeps
+    we can verify the wait happened without sleeping real time."""
+    adapter = _make_adapter()
+    adapter._send_cooldown_seconds = 1.1
+    adapter._send_cooldown_max_wait = 5.0
+
+    fake_now = {"t": 1000.0}
+
+    def fake_monotonic():
+        return fake_now["t"]
+
+    # Capture the real sleep and let it advance our fake clock — this
+    # mirrors how the actual gate waits via asyncio.sleep().
+    real_sleep = time.sleep
+
+    def fake_sleep(seconds):
+        real_sleep(seconds)  # tiny real delay
+        fake_now["t"] += seconds
+
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic",
+        fake_monotonic,
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.asyncio.sleep",
+        AsyncMock(side_effect=fake_sleep),
+    )
+
+    await adapter.send("123", "first")
+    fake_now["t"] = 1000.3  # within cooldown
+    await adapter.send("123", "second")
+
+    # Two actual API calls (one per send), and the second one was
+    # delayed by the cooldown duration.
+    assert adapter._bot.send_message.await_count == 2
+    # The cooldown after the second send should reflect the advanced
+    # clock — first stamp at ~1001.1, gate waited ~0.8s, second stamp
+    # at ~1002.0 (give or take the scheduling jitter).
+    stamped = adapter._send_cooldown_until["123"]
+    assert stamped >= 1001.5
+
+
+@pytest.mark.asyncio
+async def test_second_send_after_window_passes_immediately(monkeypatch):
+    """A second send that arrives after the cooldown has expired must NOT
+    wait — only the gate's check is cheap, but we still verify the
+    Bot API was called."""
+    adapter = _make_adapter()
+    adapter._send_cooldown_seconds = 1.1
+    adapter._send_cooldown_max_wait = 5.0
+
+    fake_now = {"t": 1000.0}
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic",
+        lambda: fake_now["t"],
+    )
+    sleep_calls = []
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.asyncio.sleep",
+        AsyncMock(side_effect=lambda s: sleep_calls.append(s)),
+    )
+
+    await adapter.send("123", "first")
+    # Jump well past the cooldown window.
+    fake_now["t"] = 1050.0
+    await adapter.send("123", "second")
+
+    assert adapter._bot.send_message.await_count == 2
+    # The gate should NOT have slept — the cooldown was already past.
+    assert sleep_calls == []
+
+
+@pytest.mark.asyncio
+async def test_independent_cooldowns_per_chat(monkeypatch):
+    """Two different chats have independent cooldowns; a send to chat B
+    must not block on chat A's cooldown and vice versa."""
+    adapter = _make_adapter()
+    adapter._send_cooldown_seconds = 5.0
+    adapter._send_cooldown_max_wait = 10.0
+
+    fake_now = {"t": 1000.0}
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic",
+        lambda: fake_now["t"],
+    )
+    sleep_calls = []
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.asyncio.sleep",
+        AsyncMock(side_effect=lambda s: sleep_calls.append(s)),
+    )
+
+    # First send to chat A stamps A's cooldown.
+    await adapter.send("AAA", "to A")
+    # Immediate send to chat B should NOT be blocked by A's cooldown.
+    await adapter.send("BBB", "to B")
+
+    assert adapter._send_cooldown_until["AAA"] >= 1005.0
+    assert adapter._send_cooldown_until["BBB"] >= 1005.0
+    # The B-send must not have slept behind A's gate.
+    assert sleep_calls == []
+
+
+@pytest.mark.asyncio
+async def test_oversized_wait_returns_retryable_error(monkeypatch):
+    """If the gate's wait would exceed ``_send_cooldown_max_wait`` (e.g.
+    because Telegram imposed a multi-thousand-second penalty) the gate
+    must NOT block the caller indefinitely. Instead it returns a
+    retryable error so upstream retries can back off too."""
+    adapter = _make_adapter()
+    adapter._send_cooldown_seconds = 1.1
+    adapter._send_cooldown_max_wait = 5.0
+
+    # Pretend chat A has a 7000-second flood penalty still running.
+    adapter._send_cooldown_until["999"] = time.monotonic() + 7000.0
+
+    sleep_calls = []
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.asyncio.sleep",
+        AsyncMock(side_effect=lambda s: sleep_calls.append(s)),
+    )
+
+    result = await adapter.send("999", "hello")
+
+    # Gate must NOT have slept — the wait is too long.
+    assert sleep_calls == []
+    # And must have returned a retryable error tagged with the wait time
+    # so the caller can decide what to do.
+    assert result.success is False
+    assert result.retryable is True
+    assert "flood_control" in (result.error or "")
+    # No Bot API call should have been made.
+    assert adapter._bot.send_message.await_count == 0


### PR DESCRIPTION
Telegram flood-control penalties escalated to multi-thousand-second back-offs because a single user turn routinely fanned out 3-5 sends across independent code paths that were not coordinated with each other.

## Root cause

A single user turn triggers sends from several independent code paths:

- Status callbacks fired via `safe_schedule_threadsafe` (no per-chat serialization)
- Progress bubbles from the progress-queue consumer
- Streaming previews from the stream consumer
- The final answer
- Photo batches

Each path had its own per-send retry-after handling, but the cumulative burst crossed Telegram's ~1 msg/sec/chat limit. The penalty then kept escalating because the progress path's flood-control fallback issued a fresh `adapter.send()` during the penalty window — exactly the burst pattern that triggered the penalty in the first place.

## Fix 1 — per-chat send cooldown in the telegram adapter

`plugins/platforms/telegram/adapter.py`:

- New `_send_cooldown_until` dict keyed by chat_id with a default minimum gap of 1.1s (`send_cooldown_seconds`)
- Configurable via `platforms.telegram.extra.send_cooldown_seconds` and `send_cooldown_max_wait_seconds`
- When the wait exceeds the ceiling, `send()` returns a retryable `flood_control`-style error instead of blocking the chat path for two hours
- Cooldown is stamped on both the legacy send loop AND the rich fast path so they cannot race each other

## Fix 2 — skip the progress fallback on flood control

`gateway/run.py`:

- The progress handler used to fall back to a fresh `adapter.send()` when the edit hit flood control. That send re-triggers the penalty. With the fix, the tick is dropped, `progress_lines` and `progress_msg_id` are kept intact, and the next tick retries the edit once the per-chat cooldown (Fix 1) releases the chat
- Non-flood permanent failures (message deleted, permission revoked) still fall back to a fresh send, since those are local failures and not Telegram-side rate limits

## Tests

- 5 new tests in `tests/gateway/test_telegram_send_cooldown.py`:
  - `test_first_send_stamps_cooldown_for_same_chat` — successful send records a cooldown timestamp
  - `test_second_send_within_window_blocks` — second send within the gap waits for the gate
  - `test_second_send_after_window_passes_immediately` — no sleep when the cooldown already expired
  - `test_independent_cooldowns_per_chat` — chat A's cooldown does not block chat B
  - `test_oversized_wait_returns_retryable_error` — multi-thousand-second penalty yields a retryable error instead of blocking the chat path
- 1 new test in `tests/gateway/test_run_progress_interrupt.py`:
  - `test_progress_flood_control_does_not_trigger_fallback_send` — pins the gateway-side fix: at most one progress-bubble send (the initial bubble) is allowed; additional sends triggered by flood-control edit failures are regressed on
- All 28 tests in the affected telegram + run-progress suite pass; no regression
