### PR TITLE
fix(feishu): prevent str(None) leaking as literal text in message extraction

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4324,6 +4324,8 @@ class FeishuAdapter(BasePlatformAdapter):
         if normalized.text_content:
             return normalized.text_content
         placeholder = normalized.metadata.get("placeholder_text") if isinstance(normalized.metadata, dict) else None
+        if not placeholder:
+            return None
         return str(placeholder).strip() or None
 
     @staticmethod

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -760,6 +760,18 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(media_urls, ["/tmp/feishu-audio.ogg"])
         self.assertEqual(media_types, ["audio/ogg"])
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_text_from_raw_content_image_no_placeholder_returns_none(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        result = adapter._extract_text_from_raw_content(
+            msg_type="image",
+            raw_content='{"image_key":"img_v3_xyz"}',
+        )
+        self.assertIsNone(result)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_extract_text_message_starting_with_slash_becomes_command(self):


### PR DESCRIPTION
## Summary

- Fix `_extract_text_from_raw_content` returning the literal string `"None"` instead of Python `None` when a message has no `placeholder_text` in its metadata
- `str(None)` produces `"None"` (truthy), which downstream callers treat as real message content — e.g. reply-to context shows "None" for image messages

## Root cause

Introduced in `ca4907dfb` (feat(gateway): add Feishu/Lark platform support #3817). The code path:

```python
placeholder = normalized.metadata.get("placeholder_text") ...
return str(placeholder).strip() or None  # str(None) == "None" — truthy!
```

## Fix

Add an early return when `placeholder` is falsy:

```python
if not placeholder:
    return None
return str(placeholder).strip() or None
```

## Test plan

- Quote-reply to a pure image message (no alt text) → reply_to_text should be None, not "None"
- Quote-reply to sticker/share_chat → same behavior
- Messages with actual placeholder_text (file/audio/media) → still return the correct placeholder string