### PR TITLE
fix(state): set _lineage_root_id on uncompressed sessions for desktop dedup (#66664)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3628,6 +3628,47 @@ class SessionDB:
             current = child_id
         return current
 
+    def _compression_lineage_root(self, session_id: str) -> str:
+        """Return the oldest compression-chain ancestor of ``session_id``.
+
+        Walks ``parent_session_id`` upward while each parent ended with
+        ``compression`` and the child is not a marked branch/delegate and not
+        a ``tool``-source child, so every session in one compression chain
+        resolves to the same root. Unlike :meth:`get_compression_tip` — which
+        uses a ``started_at >= ended_at`` timing guard to find the live tip —
+        the backward walk keys on branch/delegate markers: a ``/branch``
+        spawned after its parent was compression-ended would pass the timing
+        guard but must stay its own lineage, so markers are the correct stop
+        signal here. Sessions outside any compression chain resolve to
+        themselves. Used to populate ``_lineage_root_id`` on uncompressed
+        surfaced rows so downstream dedup (desktop lineage grouping) treats
+        every conversation uniformly, not just projected tips. See #66664.
+        """
+        current = session_id
+        seen: set = set()
+        for _ in range(100):
+            if not current or current in seen:
+                return current
+            seen.add(current)
+            with self._lock:
+                row = self._conn.execute(
+                    """
+                    SELECT parent.id AS root_id
+                    FROM sessions child
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE child.id = ?
+                      AND parent.end_reason = 'compression'
+                      AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                      AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                      AND COALESCE(child.source, '') != 'tool'
+                    """,
+                    (current,),
+                ).fetchone()
+            if row is None:
+                return current
+            current = row["root_id"]
+        return current
+
     # Columns excluded from compact_rows projections: only the payload-heavy
     # blob no list consumer renders. Everything else — including gateway
     # routing fields and desktop sidebar fields like git_branch — stays, and
@@ -3965,6 +4006,18 @@ class SessionDB:
                 merged["_lineage_root_id"] = s["id"]
                 projected.append(merged)
             sessions = projected
+
+            # Populate ``_lineage_root_id`` on every remaining surfaced row so
+            # downstream lineage dedup (desktop mergeSessionPage) groups
+            # uncompressed conversations the same way it groups projected
+            # tips. Projected tips already carry it; raw uncompressed rows
+            # resolve to themselves (or their chain root) via the backward
+            # compression-chain walk. Compression-ended roots that did not
+            # project (broken chains with no continuation) stay raw, preserving
+            # the admin/debug contract. See #66664.
+            for s in sessions:
+                if "_lineage_root_id" not in s and s.get("end_reason") != "compression":
+                    s["_lineage_root_id"] = self._compression_lineage_root(s["id"])
 
         return sessions
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4479,6 +4479,85 @@ class TestCompressionChainProjection:
         assert "_lineage_root_id" not in row
         assert row["end_reason"] == "compression"
 
+    def test_uncompressed_sessions_carry_lineage_root_id(self, db):
+        """Sessions that were never compressed must still carry
+        ``_lineage_root_id`` (resolved to themselves) so the desktop's
+        lineage dedup can group every surfaced row uniformly — not just
+        projected compression tips. Regression for #66664.
+        """
+        db.create_session("soloA", "cli")
+        db.append_message("soloA", "user", "first standalone")
+        db.create_session("soloB", "cli")
+        db.append_message("soloB", "user", "second standalone")
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        by_id = {s["id"]: s for s in sessions}
+        assert "soloA" in by_id and "soloB" in by_id
+        # Every uncompressed row resolves to its own lineage root.
+        assert by_id["soloA"]["_lineage_root_id"] == "soloA"
+        assert by_id["soloB"]["_lineage_root_id"] == "soloB"
+
+    def test_lineage_root_id_covers_uncompressed_and_projected(self, db):
+        """A mix of projected compression tips and uncompressed sessions:
+        every surfaced row must carry ``_lineage_root_id`` — tips resolve to
+        the chain root, uncompressed sessions to themselves. Regression for
+        #66664.
+        """
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+        db.create_session("solo", "cli")
+        db.append_message("solo", "user", "standalone")
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        by_id = {s["id"]: s for s in sessions}
+        # Projected tip resolves to the chain root (existing behaviour).
+        assert by_id["tip1"]["_lineage_root_id"] == "root1"
+        # Uncompressed session resolves to itself (the #66664 fix).
+        assert by_id["solo"]["_lineage_root_id"] == "solo"
+
+    def test_compression_lineage_root_walks_to_oldest_ancestor(self, db):
+        """``_compression_lineage_root`` walks ``parent_session_id`` up while
+        each parent ended with ``compression`` (skipping marked branch/delegate
+        children), returning the oldest chain ancestor. A multi-hop chain
+        resolves to the original root.
+        """
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+        # root1 -> mid1 -> tip1 : tip1 resolves all the way back to root1.
+        assert db._compression_lineage_root("tip1") == "root1"
+        assert db._compression_lineage_root("mid1") == "root1"
+        # root1 has no compression parent -> resolves to itself.
+        assert db._compression_lineage_root("root1") == "root1"
+
+    def test_compression_lineage_root_stops_at_marked_branch(self, db):
+        """A branch child (carrying ``_branched_from``) whose parent was later
+        compressed is its own lineage: the marker stops the backward walk so
+        the branch does not collapse into the parent's compression chain.
+        Mirrors the marker-based exclusion ``get_compression_tip`` uses.
+        """
+        import time as _time
+        t0 = _time.time() - 3600
+        db.create_session("proot", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "proot"))
+        # proot is later compressed.
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason='compression' WHERE id=?",
+            (t0 + 100, "proot"),
+        )
+        # A marked branch of proot — this surfaces in list_sessions_rich.
+        db.create_session(
+            "br", "cli", parent_session_id="proot",
+            model_config={"_branched_from": "proot"},
+        )
+        db._conn.commit()
+        # The branch resolves to itself, not to proot.
+        assert db._compression_lineage_root("br") == "br"
+        # An uncompressed session with no parent resolves to itself.
+        db.create_session("lonely", "cli")
+        assert db._compression_lineage_root("lonely") == "lonely"
+
 
 # =========================================================================
 # Session source exclusion (--source flag for third-party isolation)


### PR DESCRIPTION
## What

`_lineage_root_id` was only populated during compression projection (root→tip merge), so every session that was **not** a projected compression tip — i.e. ordinary uncompressed conversations and branches — was returned by `list_sessions_rich` without the field. The desktop's lineage dedup (`mergeSessionPage`, `apps/desktop/src/store/session.ts:199-209`) groups surfaced sessions by `_lineage_root_id`, so these sessions each appeared as their own lineage instead of being grouped.

Closes #66664.

## Fix (backend-only, `hermes_state.py`)

1. **New private helper `_compression_lineage_root(session_id)`** walks `parent_session_id` upward while each parent ended with `compression` and the child is not a marked branch/delegate and not a `tool`-source child, returning the oldest chain ancestor (or `self` for sessions outside any chain).
2. **Fill-in pass** after projection: every remaining surfaced row that lacks `_lineage_root_id` and is not a compression-ended orphan now resolves to its chain root.

### Why markers, not `get_compression_tip`'s timing guard

`get_compression_tip` (forward walk) uses `child.started_at >= parent.ended_at` to find the live tip. The backward lineage walk deliberately keys on **branch/delegate markers** instead: a `/branch` spawned *after* its parent was compression-ended would pass the timing guard but must remain its own lineage. Markers are the correct stop signal for the reverse direction. (The `seen`-set + 100-hop bound guards against cycles.)

## Contracts preserved (no regressions)

- `project_compression_tips=False` (admin/debug raw view) stays raw — no `_lineage_root_id`. ✅
- Broken-chain orphan (compression root with no continuation) stays raw. ✅
- Projected tips keep `_lineage_root_id = <chain root>`. ✅

## Verification

RED on `upstream/main` (d59b79fad), before the fix:
- `test_uncompressed_sessions_carry_lineage_root_id` → `KeyError: '_lineage_root_id'`
- `test_lineage_root_id_covers_uncompressed_and_projected` → `KeyError: '_lineage_root_id'`
- `test_compression_lineage_root_walks_to_oldest_ancestor` → `AttributeError` (helper absent)
- `test_compression_lineage_root_stops_at_marked_branch` → `AttributeError` (helper absent)

GREEN on this branch (commit 8e065de6, rebased on `upstream/main` bf517f93):
- 4 new production-path regression tests pass
- `tests/test_hermes_state.py` — **374 passed**
- `tests/test_tui_gateway_server.py -k "session or compression or lineage or list"` — **111 passed**
- `ruff check` clean, `git diff --check` clean
- Branch is exactly **1 commit ahead** of `upstream/main` (`git rev-list --left-right --count` = `0 1`)

## Duplicate / competitor check

No open PR addresses the backend lineage-key derivation for uncompressed rows:
- `repo:NousResearch/hermes-agent 66664 state:open` → only unrelated openclaw anthropic `max_tokens` ports.
- Topic-overlap search (`_lineage_root_id`, `project_compression_tips`, lineage dedup) → empty.
- PR #66675 addresses the **related but distinct** #66663 (RPC response projection in `tui_gateway/server.py`), not the backend derivation here. These are complementary, not competing.

## Scope

Backend-only (`hermes_state.py` + tests). Both REST and RPC consumers of `list_sessions_rich` benefit.

---

Auto-published by Moonsong via Path B automated pipeline. Reviewed against the hermes-agent bugfix-cycle checklist (CONTRIBUTING compliance, root-cause + whole-bug-class coverage, RED→GREEN proof, competitor evaluation, pre-publication gating).
