### PR TITLE
fix(ci): make timings report fork-safe (missed by #66577)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,10 @@ jobs:
 
       - name: Collect timings and generate report
         env:
-          GITHUB_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT }}
+          # Forks get no repo secrets (AUTOFIX_BOT_PAT is empty); fall back to
+          # the built-in read-only token so the timings API read still works
+          # there instead of hard-failing this advisory job on every fork PR.
+          GITHUB_TOKEN: ${{ secrets.AUTOFIX_BOT_PAT || github.token }}
         run: |
           python3 scripts/ci/timings_report.py \
             --baseline ci-timings-baseline.json \

--- a/scripts/ci/timings_report.py
+++ b/scripts/ci/timings_report.py
@@ -923,11 +923,17 @@ def main():
         with open(args.from_json, encoding="utf-8") as f:
             timings = json.load(f)
     else:
-        token = expect_env("GITHUB_TOKEN")
         repo = expect_env("GITHUB_REPOSITORY")
         run_id = expect_env("GITHUB_RUN_ID")
         head_sha = expect_env("GITHUB_SHA")
         try:
+            # A missing token (e.g. an empty PAT on a fork PR, where repo
+            # secrets are unavailable) is a degraded run, not a hard error:
+            # route it through the same soft-fail path so this advisory job
+            # never reddens the PR.
+            token = os.environ.get("GITHUB_TOKEN")
+            if not token:
+                raise TimingsUnavailable("GITHUB_TOKEN is empty")
             timings = collect_timings(token, repo, run_id, head_sha)
         except TimingsUnavailable as e:
             # Observability job: a missing report must never redden the PR.


### PR DESCRIPTION
## What does this PR do?

Fixes the last remaining fork-PR CI failure from the `AUTOFIX_BOT_PAT` migration. The **CI timing report** job still hard-fails on every fork PR because it wasn't covered by the #66577 fallback fix.

## Background

- #66373 swapped `GITHUB_TOKEN` / `github.token` → `secrets.AUTOFIX_BOT_PAT` across all workflows.
- Forks get no repo secrets, so `AUTOFIX_BOT_PAT` is **empty** on fork PRs.
- #66577 restored the `${{ secrets.AUTOFIX_BOT_PAT || github.token }}` fork fallback for `detect-changes` and the `ci-review` / `mcp-catalog-reviewed` label gates — **but missed the `ci-timings` step.**

That step still passes a bare `AUTOFIX_BOT_PAT`, so `scripts/ci/timings_report.py` crashes at `expect_env("GITHUB_TOKEN")` before it can reach its own "degraded run must never redden the PR" soft-fail path. Result: a red run on every fork PR (e.g. #66573).

```
ValueError: missing environment variable GITHUB_TOKEN
```

## Changes made

- **`.github/workflows/ci.yml`** — apply the same `secrets.AUTOFIX_BOT_PAT || github.token` fallback to the timings step, matching #66577's established pattern. `github.token` has `actions: read`, which is sufficient to read the run's job/step durations on forks.
- **`scripts/ci/timings_report.py`** — treat a missing/empty `GITHUB_TOKEN` as a degraded run (`TimingsUnavailable`) instead of a hard `ValueError`. This closes the whole bug class: even if a future workflow drops the token, this advisory job degrades gracefully instead of reddening the PR. It still writes no JSON, so no empty baseline is ever cached.

## Verification

- Syntax check + degraded-path simulation with an empty `GITHUB_TOKEN`: script exits **0**, emits the placeholder HTML report, and correctly writes **no** JSON (so no empty baseline gets cached).
- Same-repo (main) behavior unchanged: the PAT is still used when present.

## Type of change

- [x] Bug fix (CI)