### PR TITLE
fix(skills): do not recreate deleted skills from descriptions

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -473,6 +473,8 @@ class TestSyncSkills:
     def test_user_deleted_skill_not_re_added(self, tmp_path):
         """Skill in manifest but not on disk = user deleted it. Don't re-add."""
         bundled = self._setup_bundled(tmp_path)
+        # A per-skill DESCRIPTION must not recreate the deleted directory.
+        (bundled / "old-skill" / "DESCRIPTION.md").write_text("Skill desc")
         skills_dir = tmp_path / "user_skills"
         manifest_file = skills_dir / ".bundled_manifest"
         skills_dir.mkdir(parents=True)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -693,8 +693,14 @@ def sync_skills(quiet: bool = False) -> dict:
     for name in cleaned:
         del manifest[name]
 
-    # Also copy DESCRIPTION.md files for categories (if not already present)
+    # Also copy DESCRIPTION.md files for categories (if not already present).
+    # Some skill directories carry their own DESCRIPTION.md. Copying those
+    # independently would recreate a deliberately deleted/suppressed skill as
+    # a DESCRIPTION-only directory, which the next update misclassifies as a
+    # user-modified bundled skill.
     for desc_md in bundled_dir.rglob("DESCRIPTION.md"):
+        if (desc_md.parent / "SKILL.md").exists():
+            continue
         rel = desc_md.relative_to(bundled_dir)
         dest_desc = SKILLS_DIR / rel
         if not dest_desc.exists():


### PR DESCRIPTION
## Summary

- copy only category-level `DESCRIPTION.md` files during bundled skill sync
- skip `DESCRIPTION.md` files that belong to a skill directory containing `SKILL.md`
- add a regression case proving a user-deleted bundled skill is not recreated as a description-only directory

## Why

A deliberately deleted or curator-suppressed bundled skill could be recreated as a directory containing only its per-skill `DESCRIPTION.md`. On the next update, that incomplete directory was classified as a user-modified bundled skill and kept indefinitely.

## Test

```text
python -m pytest tests/tools/test_skills_sync.py -o addopts= -q
69 passed
```