### PR TITLE
fix(agent): unwrap nested OpenAI-compat response envelopes

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -182,8 +182,43 @@ def build_keepalive_http_client(
         # Generous read=None for SSE streaming endpoints.
         timeout = httpx.Timeout(connect=15.0, read=None, write=15.0, pool=10.0)
 
-        transport_cls = httpx.AsyncHTTPTransport if async_mode else httpx.HTTPTransport
         client_cls = httpx.AsyncClient if async_mode else httpx.Client
+
+        # Some OpenAI-compat gateways (api.cline.bot) wrap non-streaming
+        # completions in {data, success}. Unwrap on JSON only so the OpenAI
+        # SDK sees top-level choices. Streaming SSE is untouched.
+        from agent.response_envelope_transport import (
+            build_envelope_unwrap_transport,
+            is_envelope_unwrap_host,
+        )
+
+        if is_envelope_unwrap_host(base_url):
+            if proxy is None:
+                mounts = {
+                    "http://": build_envelope_unwrap_transport(
+                        async_mode=async_mode, verify=verify
+                    ),
+                    "https://": build_envelope_unwrap_transport(
+                        async_mode=async_mode, verify=verify
+                    ),
+                }
+                return client_cls(
+                    limits=limits,
+                    timeout=timeout,
+                    mounts=mounts,
+                    verify=verify,
+                )
+            transport = build_envelope_unwrap_transport(
+                async_mode=async_mode, verify=verify, proxy=proxy
+            )
+            return client_cls(
+                limits=limits,
+                timeout=timeout,
+                transport=transport,
+                verify=verify,
+            )
+
+        transport_cls = httpx.AsyncHTTPTransport if async_mode else httpx.HTTPTransport
         mounts = {}
         if proxy is None:
             mounts = {

--- a/agent/response_envelope_transport.py
+++ b/agent/response_envelope_transport.py
@@ -1,0 +1,152 @@
+"""Wire-level unwrap for OpenAI-compat gateways that nest completions.
+
+Some OpenAI-compatible gateways wrap non-streaming Chat Completions in::
+
+    {"data": {<openai chat completion>}, "success": true}
+
+instead of returning the completion at the top level. The OpenAI SDK then
+parses ``choices is None``, which breaks every non-streaming consumer
+(auxiliary titles, summaries, compaction, memory). Streaming SSE is already
+standard and must pass through unchanged.
+
+This module provides sync and async httpx transports that unwrap that
+envelope on JSON responses when the client targets a known host. Other hosts
+keep the default transport. The transports honor the same ``verify`` / proxy
+kwargs the keepalive builders already pass for TLS and proxy policy.
+
+This is HTTP response normalization in core client construction. It is not a
+provider plugin, catalog entry, or product onboarding path. A standalone
+model-provider plugin cannot inject an httpx transport into the keepalive
+builders, so the envelope cannot be fixed out-of-tree.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import urlparse
+
+# Hosts known to wrap non-streaming Chat Completions in {data, success}.
+# Compared as exact hostnames only (not substring of the full URL) so
+# lookalikes like api.cline.bot.example never opt in.
+ENVELOPE_UNWRAP_HOSTS = frozenset({"api.cline.bot"})
+
+
+def is_envelope_unwrap_host(base_url: Any) -> bool:
+    """True if ``base_url``'s hostname is on the envelope-unwrap allowlist.
+
+    Parses the URL and compares the normalized hostname. Substring matches on
+    the raw string (userinfo, path, sibling domains) do not count.
+    """
+    raw = str(base_url or "").strip()
+    if not raw:
+        return False
+    # Bare host or host/path without a scheme still has to resolve.
+    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    host = (parsed.hostname or "").lower()
+    return host in ENVELOPE_UNWRAP_HOSTS
+
+
+def _unwrap_envelope_bytes(raw: bytes) -> bytes:
+    """Return the inner completion bytes if ``raw`` is a nested envelope.
+
+    Only unwraps ``{"data": {... "choices": ...}, ...}`` shapes where the top
+    level carries no ``choices`` of its own. Error envelopes
+    (``{"error": ..., "success": false}``) and already-standard bodies pass
+    through unchanged.
+    """
+    try:
+        body = json.loads(raw)
+    except Exception:
+        return raw
+    if (
+        isinstance(body, dict)
+        and "choices" not in body
+        and isinstance(body.get("data"), dict)
+        and "choices" in body["data"]
+    ):
+        try:
+            return json.dumps(body["data"]).encode("utf-8")
+        except Exception:
+            return raw
+    return raw
+
+
+def _is_json_response(response: Any) -> bool:
+    ctype = ""
+    try:
+        ctype = response.headers.get("content-type", "") or ""
+    except Exception:
+        return False
+    return "application/json" in ctype.lower()
+
+
+def _rebuild_response(
+    httpx_mod: Any, response: Any, request: Any, new_bytes: bytes
+) -> Any:
+    """Build a fresh httpx.Response carrying the (decoded, unwrapped) body.
+
+    Strips length/encoding headers because ``new_bytes`` is already-decoded
+    identity content. httpx recomputes Content-Length from the body.
+    """
+    headers = httpx_mod.Headers(response.headers)
+    for stale in ("content-length", "content-encoding", "transfer-encoding"):
+        if stale in headers:
+            del headers[stale]
+    return httpx_mod.Response(
+        status_code=response.status_code,
+        headers=headers,
+        content=new_bytes,
+        request=request,
+        extensions=getattr(response, "extensions", None) or {},
+    )
+
+
+def build_envelope_unwrap_transport(
+    *,
+    async_mode: bool,
+    verify: Any = True,
+    proxy: Any = None,
+) -> Any:
+    """Return an httpx transport that unwraps nested completion envelopes.
+
+    ``verify`` and ``proxy`` mirror the kwargs used by the keepalive client
+    builders so TLS and proxy behavior stay identical apart from the unwrap.
+    """
+    import httpx
+
+    transport_kwargs: dict[str, Any] = {"verify": verify}
+    if proxy is not None:
+        transport_kwargs["proxy"] = proxy
+
+    if async_mode:
+
+        class _EnvelopeUnwrapAsyncTransport(httpx.AsyncHTTPTransport):
+            async def handle_async_request(self, request: Any) -> Any:
+                response = await super().handle_async_request(request)
+                if not _is_json_response(response):
+                    return response
+                await response.aread()
+                return _rebuild_response(
+                    httpx,
+                    response,
+                    request,
+                    _unwrap_envelope_bytes(response.content),
+                )
+
+        return _EnvelopeUnwrapAsyncTransport(**transport_kwargs)
+
+    class _EnvelopeUnwrapTransport(httpx.HTTPTransport):
+        def handle_request(self, request: Any) -> Any:
+            response = super().handle_request(request)
+            if not _is_json_response(response):
+                return response
+            response.read()
+            return _rebuild_response(
+                httpx,
+                response,
+                request,
+                _unwrap_envelope_bytes(response.content),
+            )
+
+    return _EnvelopeUnwrapTransport(**transport_kwargs)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4112,6 +4112,40 @@ class AIAgent:
                 pool=10.0,
             )
 
+            # Some OpenAI-compat gateways (api.cline.bot) wrap non-streaming
+            # completions in {data, success}. Unwrap on JSON only so the
+            # OpenAI SDK sees top-level choices. Streaming SSE is untouched.
+            from agent.response_envelope_transport import (
+                build_envelope_unwrap_transport,
+                is_envelope_unwrap_host,
+            )
+
+            if is_envelope_unwrap_host(base_url):
+                if _proxy is None:
+                    _mounts = {
+                        "http://": build_envelope_unwrap_transport(
+                            async_mode=False, verify=verify
+                        ),
+                        "https://": build_envelope_unwrap_transport(
+                            async_mode=False, verify=verify
+                        ),
+                    }
+                    return _httpx.Client(
+                        limits=_limits,
+                        timeout=_timeout,
+                        mounts=_mounts,
+                        verify=verify,
+                    )
+                _transport = build_envelope_unwrap_transport(
+                    async_mode=False, verify=verify, proxy=_proxy
+                )
+                return _httpx.Client(
+                    limits=_limits,
+                    timeout=_timeout,
+                    transport=_transport,
+                    verify=verify,
+                )
+
             # When _proxy is None (NO_PROXY bypass or no proxy configured),
             # mount plain transports to prevent httpx from reading env proxy
             # vars and creating an HTTPProxy mount that would bypass our

--- a/tests/agent/test_response_envelope_transport.py
+++ b/tests/agent/test_response_envelope_transport.py
@@ -1,0 +1,181 @@
+"""Unit tests for OpenAI-compat response-envelope unwrap transport.
+
+Some gateways wrap non-streaming Chat Completions in
+``{"data": {...}, "success": true}``. The transport unwraps that on JSON
+responses so the OpenAI SDK sees top-level ``choices``, while leaving SSE
+streams and non-enveloped bodies untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from agent.process_bootstrap import build_keepalive_http_client
+from agent.response_envelope_transport import (
+    _unwrap_envelope_bytes,
+    build_envelope_unwrap_transport,
+    is_envelope_unwrap_host,
+)
+
+ENVELOPED = (
+    b'{"data":{"id":"gen_1","object":"chat.completion","model":"deepseek/x",'
+    b'"choices":[{"index":0,"message":{"role":"assistant","content":"hi"},'
+    b'"finish_reason":"stop"}],"usage":{"total_tokens":3}},"success":true}'
+)
+STANDARD = (
+    b'{"id":"gen_1","object":"chat.completion",'
+    b'"choices":[{"index":0,"message":{"role":"assistant","content":"hi"}}]}'
+)
+ERROR_ENVELOPE = b'{"error":"Not Found","success":false}'
+
+
+class TestHostDetection:
+    def test_matches_known_host(self):
+        assert is_envelope_unwrap_host("https://api.cline.bot/api/v1") is True
+        assert is_envelope_unwrap_host("https://API.CLINE.BOT/api/v1") is True
+        assert is_envelope_unwrap_host("https://api.cline.bot:443/api/v1") is True
+        assert is_envelope_unwrap_host("http://api.cline.bot/v1") is True
+        # Bare host / host+path without scheme still match on hostname.
+        assert is_envelope_unwrap_host("api.cline.bot/api/v1") is True
+
+    def test_rejects_others(self):
+        assert is_envelope_unwrap_host("https://openrouter.ai/api/v1") is False
+        assert is_envelope_unwrap_host("https://api.mistral.ai/v1") is False
+        assert is_envelope_unwrap_host(None) is False
+        assert is_envelope_unwrap_host("") is False
+
+    def test_rejects_substring_false_positives(self):
+        # Old check was `host in str(base_url)`, which opted these in.
+        assert is_envelope_unwrap_host("https://api.cline.bot.example/v1") is False
+        assert is_envelope_unwrap_host("https://evil.example/api.cline.bot/v1") is False
+        assert is_envelope_unwrap_host("https://evil.example/?next=api.cline.bot") is False
+        assert is_envelope_unwrap_host("https://user:api.cline.bot@evil.example/v1") is False
+        assert is_envelope_unwrap_host("https://not-api.cline.bot/v1") is False
+
+
+class TestUnwrapBytes:
+    def test_unwraps_envelope(self):
+        import json
+
+        out = _unwrap_envelope_bytes(ENVELOPED)
+        body = json.loads(out)
+        assert "data" not in body
+        assert body["choices"][0]["message"]["content"] == "hi"
+
+    def test_leaves_standard_body(self):
+        assert _unwrap_envelope_bytes(STANDARD) == STANDARD
+
+    def test_leaves_error_envelope(self):
+        # No data.choices: the 404/error body must reach the SDK intact.
+        assert _unwrap_envelope_bytes(ERROR_ENVELOPE) == ERROR_ENVELOPE
+
+    def test_leaves_non_json(self):
+        assert _unwrap_envelope_bytes(b"not json at all") == b"not json at all"
+
+    def test_leaves_data_without_choices(self):
+        raw = b'{"data":{"ok":true},"success":true}'
+        assert _unwrap_envelope_bytes(raw) == raw
+
+
+class TestSyncTransport:
+    def _transport_returning(self, monkeypatch, *, content, content_type):
+        def fake_handle(self, request):
+            return httpx.Response(
+                200,
+                headers={"content-type": content_type},
+                content=content,
+                request=request,
+            )
+
+        monkeypatch.setattr(httpx.HTTPTransport, "handle_request", fake_handle)
+        return build_envelope_unwrap_transport(async_mode=False)
+
+    def test_unwraps_json_response(self, monkeypatch):
+        t = self._transport_returning(
+            monkeypatch, content=ENVELOPED, content_type="application/json"
+        )
+        resp = t.handle_request(
+            httpx.Request(
+                "POST", "https://api.cline.bot/api/v1/chat/completions"
+            )
+        )
+        body = resp.json()
+        assert "data" not in body
+        assert body["choices"][0]["message"]["content"] == "hi"
+
+    def test_passes_through_sse(self, monkeypatch):
+        sse = b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+        t = self._transport_returning(
+            monkeypatch, content=sse, content_type="text/event-stream"
+        )
+        resp = t.handle_request(
+            httpx.Request(
+                "POST", "https://api.cline.bot/api/v1/chat/completions"
+            )
+        )
+        assert resp.headers["content-type"] == "text/event-stream"
+        assert resp.read() == sse
+
+    def test_error_envelope_survives(self, monkeypatch):
+        t = self._transport_returning(
+            monkeypatch, content=ERROR_ENVELOPE, content_type="application/json"
+        )
+        resp = t.handle_request(
+            httpx.Request("GET", "https://api.cline.bot/api/v1/models")
+        )
+        assert resp.json() == {"error": "Not Found", "success": False}
+
+
+class TestAsyncTransport:
+    def test_unwraps_json_response(self, monkeypatch):
+        async def fake_handle(self, request):
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/json"},
+                content=ENVELOPED,
+                request=request,
+            )
+
+        monkeypatch.setattr(
+            httpx.AsyncHTTPTransport, "handle_async_request", fake_handle
+        )
+        t = build_envelope_unwrap_transport(async_mode=True)
+
+        async def go():
+            resp = await t.handle_async_request(
+                httpx.Request(
+                    "POST", "https://api.cline.bot/api/v1/chat/completions"
+                )
+            )
+            return resp.json()
+
+        body = asyncio.run(go())
+        assert "data" not in body
+        assert body["choices"][0]["message"]["content"] == "hi"
+
+
+class TestClientBuilderWiring:
+    def test_known_host_uses_unwrap_transport(self):
+        client = build_keepalive_http_client(
+            "https://api.cline.bot/api/v1", verify=True
+        )
+        assert isinstance(client, httpx.Client)
+        # Mounts carry the unwrap transport class for both schemes.
+        mounts = client._mounts
+        assert mounts
+        names = {type(transport).__name__ for transport in mounts.values()}
+        assert names == {"_EnvelopeUnwrapTransport"}
+        client.close()
+
+    def test_other_host_keeps_default_transport(self):
+        client = build_keepalive_http_client(
+            "https://openrouter.ai/api/v1", verify=True
+        )
+        assert isinstance(client, httpx.Client)
+        mounts = client._mounts
+        assert mounts
+        names = {type(transport).__name__ for transport in mounts.values()}
+        assert names == {"HTTPTransport"}
+        client.close()


### PR DESCRIPTION
Normalize successful nested Chat Completions from api.cline.bot through synchronous and asynchronous HTTPX response hooks. Preserve the refactored shared transport pools, proxy/TLS configuration and connection limits. Leave SSE streams, other hosts, standard responses and error envelopes unchanged.

Fixes #66750

Validation: 14 SDK and shared-transport tests passed through scripts/run_tests.sh. Real OpenAI sync/async clients parse compressed wrapped completions, consume SSE lazily, and leave sibling clients usable after closure. Error and host-boundary cases remain unchanged.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
