### PR TITLE
chore(i18n): add check_locales.py to surface locale catalog drift

### DIFF
--- a/scripts/check_locales.py
+++ b/scripts/check_locales.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Check locale catalogs for missing translation keys.
+
+Compares every locale against its English baseline and reports keys that
+exist in English but not in the locale:
+
+  * CLI/gateway catalogs:  locales/*.yaml         (baseline: locales/en.yaml)
+  * Desktop catalogs:      apps/desktop/src/i18n/*.ts  (baseline: en.ts)
+  * Desktop JSON catalogs: apps/desktop/src/locales/*.json  (baseline: en.json;
+    checked only when the directory exists)
+
+Missing keys never break the build — YAML lookups and `defineLocale()` both
+fall back to English — so gaps accumulate silently until users see mixed
+English/localized UI. This script makes the drift visible.
+
+Usage:
+  python scripts/check_locales.py               # summary table
+  python scripts/check_locales.py --list zh-hant  # list missing keys
+  python scripts/check_locales.py --strict      # exit 1 if anything missing
+
+Stdlib only, so it can run in CI without installing the project.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Desktop files that are i18n machinery rather than locale catalogs.
+TS_NON_CATALOG = {
+    "catalog.ts",
+    "context.tsx",
+    "define-locale.ts",
+    "index.ts",
+    "languages.ts",
+    "runtime.ts",
+    "types.ts",
+}
+
+_YAML_KEY = re.compile(r"^(\s*)([A-Za-z0-9_.-]+):(.*)$")
+_TS_KEY = re.compile(r"^(\s*)([A-Za-z0-9_$]+|'[^']+'):\s*(.*)$")
+
+
+def yaml_leaf_keys(path: Path) -> set[str]:
+    """Dotted paths of every key with a scalar value in a simple YAML mapping.
+
+    Handles the subset of YAML these catalogs use: nested mappings with
+    scalar leaves (including quoted and block scalars). Lists of mappings
+    would need a real parser, but no locale file uses them.
+    """
+    keys: set[str] = set()
+    stack: list[tuple[int, str]] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        m = _YAML_KEY.match(raw)
+        if not m:
+            continue
+        indent, key, value = len(m.group(1)), m.group(2), m.group(3).strip()
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        dotted = ".".join([k for _, k in stack] + [key])
+        stack.append((indent, key))
+        if value and not value.startswith("#"):
+            keys.add(dotted)
+    return keys
+
+
+_INLINE_KEY = re.compile(r"(?:^|[,{]\s*)([A-Za-z0-9_$]+|'[^']+')\s*:")
+
+
+def _inline_object_keys(prefix: str, value: str, keys: set[str]) -> None:
+    """Add dotted keys for a single-line object literal like `{ label: 'x', help: 'y' }`.
+
+    Only scans depth-1 of the inline literal; string contents are stripped
+    first so colons inside translations don't produce phantom keys.
+    """
+    body = value.strip().rstrip(",").strip()
+    if not (body.startswith("{") and body.endswith("}")):
+        return
+    # Drop quoted strings and template literals, keeping quoted keys intact
+    # (quoted keys are immediately followed by a colon).
+    scrubbed = re.sub(r"('[^']*'|\"[^\"]*\"|`[^`]*`)(?!\s*:)", "''", body[1:-1])
+    depth = 0
+    top_level = []
+    for ch in scrubbed:
+        if ch in "{([":
+            depth += 1
+        elif ch in "})]":
+            depth -= 1
+        top_level.append(ch if depth == 0 else " ")
+    for m in _INLINE_KEY.finditer("{" + "".join(top_level)):
+        keys.add(f"{prefix}.{m.group(1).strip(chr(39))}")
+
+
+def ts_leaf_keys(path: Path) -> set[str]:
+    """Dotted paths of every leaf entry in a desktop i18n catalog.
+
+    The catalogs are plain nested object literals (string, template-function,
+    or array values). Indentation-based like the YAML walker: a line whose
+    value is exactly `{` opens a nested scope, a single-line `{ ... }` object
+    contributes its inner keys, and anything else is a leaf.
+    """
+    keys: set[str] = set()
+    stack: list[tuple[int, str]] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+        m = _TS_KEY.match(raw)
+        if not m:
+            continue
+        indent = len(m.group(1))
+        key = m.group(2).strip("'")
+        value = m.group(3).strip()
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        dotted = ".".join([k for _, k in stack] + [key])
+        stack.append((indent, key))
+        if value == "{":
+            continue
+        if value.startswith("{"):
+            _inline_object_keys(dotted, value, keys)
+        else:
+            # Includes `key:` with the value continued on the next line —
+            # in an object literal a bare key line is still a leaf.
+            keys.add(dotted)
+    return keys
+
+
+def json_leaf_keys(path: Path) -> set[str]:
+    """Dotted paths of every leaf value in a JSON catalog.
+
+    Works for both flat dot-notation catalogs (`"a.b.c": "..."`) and nested
+    objects; the two spellings of the same key produce the same dotted path.
+    """
+    keys: set[str] = set()
+
+    def walk(prefix: str, node: object) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                walk(f"{prefix}.{key}" if prefix else str(key), value)
+        else:
+            keys.add(prefix)
+
+    walk("", json.loads(path.read_text(encoding="utf-8")))
+    return keys
+
+
+def collect(root: Path = REPO_ROOT) -> dict[str, tuple[set[str], set[str]]]:
+    """Map of catalog label -> (baseline keys, locale keys)."""
+    results: dict[str, tuple[set[str], set[str]]] = {}
+
+    yaml_dir = root / "locales"
+    en_yaml = yaml_leaf_keys(yaml_dir / "en.yaml")
+    for path in sorted(yaml_dir.glob("*.yaml")):
+        if path.name == "en.yaml":
+            continue
+        results[f"locales/{path.name}"] = (en_yaml, yaml_leaf_keys(path))
+
+    ts_dir = root / "apps" / "desktop" / "src" / "i18n"
+    en_ts = ts_leaf_keys(ts_dir / "en.ts")
+    for path in sorted(ts_dir.glob("*.ts")):
+        if path.name in TS_NON_CATALOG or path.name == "en.ts" or path.name.endswith(".test.ts"):
+            continue
+        results[f"desktop/{path.name}"] = (en_ts, ts_leaf_keys(path))
+
+    # Hybrid JSON catalogs (proposed in #38846); skipped until that lands.
+    json_dir = root / "apps" / "desktop" / "src" / "locales"
+    if (json_dir / "en.json").is_file():
+        en_json = json_leaf_keys(json_dir / "en.json")
+        for path in sorted(json_dir.glob("*.json")):
+            if path.name == "en.json":
+                continue
+            results[f"desktop-json/{path.name}"] = (en_json, json_leaf_keys(path))
+
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--strict", action="store_true", help="exit 1 if any locale is missing keys")
+    parser.add_argument("--list", metavar="LOCALE", help="list missing keys for one locale (e.g. zh-hant, ja)")
+    args = parser.parse_args()
+
+    results = collect()
+
+    if args.list:
+        wanted = args.list.lower()
+        matched = False
+        for label, (baseline, keys) in results.items():
+            stem = label.split("/")[-1].rsplit(".", 1)[0].lower()
+            if stem != wanted:
+                continue
+            matched = True
+            missing = sorted(baseline - keys)
+            print(f"{label}: {len(missing)} missing")
+            for key in missing:
+                print(f"  {key}")
+        if not matched:
+            print(f"no catalog named {args.list!r}", file=sys.stderr)
+            return 2
+        return 0
+
+    width = max(len(label) for label in results)
+    any_missing = False
+    for label, (baseline, keys) in results.items():
+        missing = len(baseline - keys)
+        extra = len(keys - baseline)
+        status = "OK" if missing == 0 else f"{missing} missing"
+        if extra:
+            status += f", {extra} extra"
+        if missing:
+            any_missing = True
+        print(f"{label:<{width}}  {status}")
+
+    if any_missing:
+        print("\nRun with --list <locale> to see the missing keys.")
+    return 1 if (args.strict and any_missing) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_check_locales.py
+++ b/tests/ci/test_check_locales.py
@@ -1,0 +1,126 @@
+"""Tests for scripts/check_locales.py.
+
+The checker's job is surfacing catalog drift that the runtime hides:
+YAML lookups and defineLocale() both fall back to English, so a missing
+key is invisible until a user sees mixed-language UI. These tests pin the
+key-extraction behavior for each catalog format and the collect() layout,
+including the not-yet-merged hybrid JSON catalogs (#38846) staying absent
+until their directory exists.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_locales.py"
+_spec = importlib.util.spec_from_file_location("check_locales", _PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError("Failed to load check_locales.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def test_yaml_leaf_keys_nested_mappings(tmp_path: Path) -> None:
+    catalog = tmp_path / "en.yaml"
+    catalog.write_text(
+        "\n".join(
+            [
+                "# comment",
+                "greeting: hello",
+                "menu:",
+                "  file:",
+                "    open: Open",
+                "    close: 'Close: now'",
+                "  edit: Edit",
+                "empty:",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    assert _mod.yaml_leaf_keys(catalog) == {
+        "greeting",
+        "menu.file.open",
+        "menu.file.close",
+        "menu.edit",
+    }
+
+
+def test_ts_leaf_keys_nested_inline_and_quoted(tmp_path: Path) -> None:
+    catalog = tmp_path / "en.ts"
+    catalog.write_text(
+        "\n".join(
+            [
+                "export const en = {",
+                "  title: 'Hermes',",
+                "  // comment",
+                "  panel: {",
+                "    'quoted-key': 'value: with colon',",
+                "    inline: { label: 'x', help: 'y' },",
+                "    count: (n: number) => `${n} items`,",
+                "  },",
+                "}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    keys = _mod.ts_leaf_keys(catalog)
+    assert "title" in keys
+    assert "panel.quoted-key" in keys
+    assert "panel.inline.label" in keys
+    assert "panel.inline.help" in keys
+    assert "panel.count" in keys
+    assert "panel" not in keys
+
+
+def test_json_leaf_keys_flat_and_nested_agree(tmp_path: Path) -> None:
+    flat = tmp_path / "flat.json"
+    flat.write_text('{"menu.file.open": "Open", "greeting": "hi"}', encoding="utf-8")
+    nested = tmp_path / "nested.json"
+    nested.write_text(
+        '{"menu": {"file": {"open": "Open"}}, "greeting": "hi"}', encoding="utf-8"
+    )
+    expected = {"menu.file.open", "greeting"}
+    assert _mod.json_leaf_keys(flat) == expected
+    assert _mod.json_leaf_keys(nested) == expected
+
+
+def _fake_repo(root: Path, with_json: bool) -> None:
+    yaml_dir = root / "locales"
+    yaml_dir.mkdir(parents=True)
+    (yaml_dir / "en.yaml").write_text("a: x\nb: y\n", encoding="utf-8")
+    (yaml_dir / "zz.yaml").write_text("a: x\n", encoding="utf-8")
+
+    ts_dir = root / "apps" / "desktop" / "src" / "i18n"
+    ts_dir.mkdir(parents=True)
+    (ts_dir / "en.ts").write_text("export const en = {\n  a: 'x',\n}\n", encoding="utf-8")
+    (ts_dir / "zz.ts").write_text("export const zz = {\n  a: 'x',\n}\n", encoding="utf-8")
+    (ts_dir / "index.ts").write_text("export {}\n", encoding="utf-8")
+
+    if with_json:
+        json_dir = root / "apps" / "desktop" / "src" / "locales"
+        json_dir.mkdir(parents=True)
+        (json_dir / "en.json").write_text('{"a": "x", "b": "y"}', encoding="utf-8")
+        (json_dir / "zz.json").write_text('{"a": "x"}', encoding="utf-8")
+
+
+def test_collect_skips_json_catalogs_until_directory_exists(tmp_path: Path) -> None:
+    _fake_repo(tmp_path, with_json=False)
+    labels = set(_mod.collect(tmp_path))
+    assert labels == {"locales/zz.yaml", "desktop/zz.ts"}
+
+
+def test_collect_reports_json_drift_when_present(tmp_path: Path) -> None:
+    _fake_repo(tmp_path, with_json=True)
+    results = _mod.collect(tmp_path)
+    assert set(results) == {"locales/zz.yaml", "desktop/zz.ts", "desktop-json/zz.json"}
+    baseline, keys = results["desktop-json/zz.json"]
+    assert baseline - keys == {"b"}
+
+
+def test_collect_excludes_machinery_and_baselines(tmp_path: Path) -> None:
+    _fake_repo(tmp_path, with_json=True)
+    labels = set(_mod.collect(tmp_path))
+    for baseline_label in ("locales/en.yaml", "desktop/en.ts", "desktop-json/en.json"):
+        assert baseline_label not in labels
+    assert "desktop/index.ts" not in labels


### PR DESCRIPTION
## What does this PR do?

> **Draft decision gate:** #65425 still needs a maintainer decision on CI enforcement (blocking vs informational) and implementation home (`scripts/` vs the JS test suite). This PR preserves the working spike without treating those questions as settled.

Adds `scripts/check_locales.py`, a stdlib-only checker that diffs the leaf keys of every locale catalog against its English baseline and reports what's missing. Locale gaps never break the build — YAML lookups and `defineLocale()` both fall back to English by design — so drift accumulates silently until users see mixed English/localized UI. This makes the drift visible in one command (found while working on the zh-Hant catch-up in #65402 / #65405).

Covers all three catalog families:

- CLI/gateway: `locales/*.yaml` (baseline `en.yaml`)
- Desktop: `apps/desktop/src/i18n/*.ts` (baseline `en.ts`, machinery files excluded)
- Desktop hybrid JSON: `apps/desktop/src/locales/*.json` (baseline `en.json`) — activates automatically once #38846 lands, no-op until then (per @iaendi's suggestion on the issue)

Current drift on `main`:

```
$ python scripts/check_locales.py
locales/af.yaml       OK
... (all 15 YAML catalogs OK)
desktop/ja.ts         299 missing, 111 extra
desktop/zh-hant.ts    299 missing, 111 extra
desktop/zh.ts         4 missing, 130 extra
```

Deliberately **not** wired into CI in this PR: the issue's open question is whether maintainers want a blocking `--strict` job or a friendlier informational job that comments the table. The `--strict` flag (exit 1 on any missing key) is ready for whichever you pick — happy to add the workflow as a follow-up once there's a preference.

## Related Issue

Related to #65425. The issue remains open as the decision thread; this draft must not auto-close it.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `scripts/check_locales.py` — the checker: `yaml_leaf_keys()` / `ts_leaf_keys()` / `json_leaf_keys()` extract dotted leaf-key sets; `collect()` maps catalog label → (baseline, locale) key sets. Flags: `--list <locale>` prints the exact missing keys, `--strict` exits 1 for CI. No dependencies, so CI can run it without installing the project.
- `tests/ci/test_check_locales.py` — 6 tests following the existing `tests/ci/` importlib pattern: YAML nesting, TS inline-object/quoted-key/template-value parsing, flat-vs-nested JSON equivalence, and `collect()` layout (JSON catalogs skipped until their directory exists; baselines and i18n machinery excluded).

## How to Test

1. `python scripts/check_locales.py` — summary table; desktop `ja`/`zh-hant`/`zh` currently show drift, all 15 YAML catalogs OK.
2. `python scripts/check_locales.py --list zh-hant && python scripts/check_locales.py --strict; echo $?` — lists the exact missing keys; strict mode exits `1` while drift exists.
3. `python -m pytest tests/ci/test_check_locales.py -q` — 6 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suite: `pytest tests/ci/ -q` passes (this PR only adds two new files and touches no production code)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module docstring documents usage; N/A beyond that
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib `pathlib` + explicit `encoding="utf-8"` everywhere, no shell/subprocess
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ python scripts/check_locales.py --strict; echo "exit=$?"
locales/af.yaml       OK
locales/de.yaml       OK
locales/es.yaml       OK
locales/fr.yaml       OK
locales/ga.yaml       OK
locales/hu.yaml       OK
locales/it.yaml       OK
locales/ja.yaml       OK
locales/ko.yaml       OK
locales/pt.yaml       OK
locales/ru.yaml       OK
locales/tr.yaml       OK
locales/uk.yaml       OK
locales/zh-hant.yaml  OK
locales/zh.yaml       OK
desktop/ja.ts         299 missing, 111 extra
desktop/zh-hant.ts    299 missing, 111 extra
desktop/zh.ts         4 missing, 130 extra

Run with --list <locale> to see the missing keys.
exit=1

$ python -m pytest tests/ci/test_check_locales.py -q
......                                                                   [100%]
6 passed in 0.07s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
