### PR TITLE
MiniMax OAuth: source-aware shared-profile refresh

### DIFF
--- a/agent/credential_persistence.py
+++ b/agent/credential_persistence.py
@@ -100,7 +100,9 @@ def _normalize_key(key: Any) -> str:
     return raw.lower().replace("-", "_").replace(".", "_")
 
 
-def is_borrowed_credential_source(source: Any, provider_id: Any = None, payload: Mapping[str, Any] | None = None) -> bool:
+def is_borrowed_credential_source(
+    source: Any, provider_id: Any = None, payload: Mapping[str, Any] | None = None
+) -> bool:
     """Return True when ``source`` points at a borrowed/reference-only secret."""
     normalized_source = str(source or "").strip().lower()
     if not normalized_source:
@@ -141,7 +143,14 @@ def _fingerprint_value(value: Any) -> str | None:
 
 
 def _credential_secret_fingerprint(payload: Mapping[str, Any]) -> str | None:
-    for key in ("agent_key", "access_token", "refresh_token", "api_key", "token", "secret"):
+    for key in (
+        "agent_key",
+        "access_token",
+        "refresh_token",
+        "api_key",
+        "token",
+        "secret",
+    ):
         fingerprint = _fingerprint_value(payload.get(key))
         if fingerprint:
             return fingerprint
@@ -170,14 +179,14 @@ def sanitize_borrowed_credential_payload(
     fingerprint, but raw secret value fields are removed.
     """
     result = dict(payload)
-    if not is_borrowed_credential_source(result.get("source"), provider_id, payload=result):
+    if not is_borrowed_credential_source(
+        result.get("source"), provider_id, payload=result
+    ):
         return result
 
     fingerprint = _credential_secret_fingerprint(result)
     sanitized = {
-        key: value
-        for key, value in result.items()
-        if not _is_secret_payload_key(key)
+        key: value for key, value in result.items() if not _is_secret_payload_key(key)
     }
     if fingerprint:
         sanitized["secret_fingerprint"] = fingerprint

--- a/agent/credential_persistence.py
+++ b/agent/credential_persistence.py
@@ -100,7 +100,7 @@ def _normalize_key(key: Any) -> str:
     return raw.lower().replace("-", "_").replace(".", "_")
 
 
-def is_borrowed_credential_source(source: Any, provider_id: Any = None) -> bool:
+def is_borrowed_credential_source(source: Any, provider_id: Any = None, payload: Mapping[str, Any] | None = None) -> bool:
     """Return True when ``source`` points at a borrowed/reference-only secret."""
     normalized_source = str(source or "").strip().lower()
     if not normalized_source:
@@ -108,6 +108,16 @@ def is_borrowed_credential_source(source: Any, provider_id: Any = None) -> bool:
     if normalized_source == "manual" or normalized_source.startswith("manual:"):
         return False
     normalized_provider = str(provider_id or "").strip().lower()
+    # A MiniMax OAuth entry that carries source_auth_path was seeded from the
+    # global-root fallback; the active profile does not own the grant and must
+    # not persist the secret pair locally.
+    if (
+        normalized_provider == "minimax-oauth"
+        and normalized_source == "oauth"
+        and isinstance(payload, Mapping)
+        and payload.get("source_auth_path")
+    ):
+        return True
     return (normalized_provider, normalized_source) not in _PERSISTABLE_PROVIDER_SOURCES
 
 
@@ -160,7 +170,7 @@ def sanitize_borrowed_credential_payload(
     fingerprint, but raw secret value fields are removed.
     """
     result = dict(payload)
-    if not is_borrowed_credential_source(result.get("source"), provider_id):
+    if not is_borrowed_credential_source(result.get("source"), provider_id, payload=result):
         return result
 
     fingerprint = _credential_secret_fingerprint(result)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -24,18 +24,22 @@ from agent.credential_persistence import (
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import (
     CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    MINIMAX_OAUTH_REFRESH_SKEW_SECONDS,
     PROVIDER_REGISTRY,
     _auth_store_lock,
     _codex_access_token_is_expiring,
     _decode_jwt_claims,
+    _is_terminal_minimax_oauth_refresh_error,
     _load_auth_store,
     _load_provider_state,
+    _minimax_oauth_quarantine_on_terminal_refresh,
     _resolve_kimi_base_url,
     _resolve_zai_base_url,
     _save_auth_store,
     _save_provider_state,
     _store_provider_state,
     read_credential_pool,
+    refresh_minimax_oauth_pure,
     write_credential_pool,
 )
 
@@ -963,6 +967,70 @@ class CredentialPool:
             logger.debug("Failed to sync Nous entry from auth.json: %s", exc)
         return entry
 
+    def _sync_minimax_oauth_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
+        """Sync a MiniMax OAuth pool entry from auth.json if tokens differ.
+
+        MiniMax OAuth refresh tokens are single-use.  When another Hermes
+        process (or another profile sharing the same auth.json singleton)
+        refreshes the token, it writes the new pair to
+        ``providers["minimax-oauth"]`` under ``_auth_store_lock``.  Without
+        this resync, our in-memory pool entry keeps the consumed
+        refresh_token and the next ``_refresh_entry`` call would replay it
+        and get a ``refresh_token_reused``-style 4xx.
+
+        Only applies to entries seeded from the auth-store singleton
+        (``oauth``); manually added entries are independent credentials with
+        their own refresh-token lifecycle.
+        """
+        if self.provider != "minimax-oauth" or entry.source != "oauth":
+            return entry
+        try:
+            with _auth_store_lock():
+                auth_store = _load_auth_store()
+                state = _load_provider_state(auth_store, "minimax-oauth")
+            if not isinstance(state, dict):
+                return entry
+            store_access = state.get("access_token", "")
+            store_refresh = state.get("refresh_token", "")
+            entry_access = entry.access_token or ""
+            entry_refresh = entry.refresh_token or ""
+            if store_access and (
+                store_access != entry_access
+                or (store_refresh and store_refresh != entry_refresh)
+            ):
+                logger.debug(
+                    "Pool entry %s: syncing MiniMax OAuth tokens from auth.json "
+                    "(refreshed by another process)",
+                    entry.id,
+                )
+                field_updates: Dict[str, Any] = {
+                    "last_status": None,
+                    "last_status_at": None,
+                    "last_error_code": None,
+                    "last_error_reason": None,
+                    "last_error_message": None,
+                    "last_error_reset_at": None,
+                }
+                if store_access:
+                    field_updates["access_token"] = store_access
+                if store_refresh:
+                    field_updates["refresh_token"] = store_refresh
+                # Refresh token-level expiry into the pool's expires_at field
+                # so _entry_needs_refresh() sees the freshest lifetime.
+                raw_expires = state.get("expires_at")
+                if raw_expires:
+                    field_updates["expires_at"] = raw_expires
+                base_url = state.get("inference_base_url")
+                if isinstance(base_url, str) and base_url:
+                    field_updates["base_url"] = base_url.rstrip("/")
+                updated = replace(entry, **field_updates)
+                self._replace_entry(entry, updated)
+                self._persist()
+                return updated
+        except Exception as exc:
+            logger.debug("Failed to sync MiniMax OAuth entry from auth.json: %s", exc)
+        return entry
+
     def _sync_device_code_entry_to_auth_store(self, entry: PooledCredential) -> None:
         """Write refreshed pool entry tokens back to auth.json providers.
 
@@ -973,14 +1041,14 @@ class CredentialPool:
         re-seeding a consumed single-use refresh token.
 
         Applies to any OAuth provider whose singleton lives in auth.json
-        (currently Nous, OpenAI Codex, and xAI Grok OAuth).
+        (currently Nous, OpenAI Codex, xAI Grok OAuth, and MiniMax OAuth).
 
         ``set_active=False`` on every write: a pool sync-back is a
         token-rotation side effect, not the user choosing a provider.
         Using ``_save_provider_state`` (which sets ``active_provider``)
-        here would mean every Nous/Codex/xAI refresh in a multi-provider
-        setup silently flips the ``active_provider`` flag — the next
-        ``hermes`` invocation that defaults to the active provider
+        here would mean every Nous/Codex/xAI/MiniMax refresh in a
+        multi-provider setup silently flips the ``active_provider`` flag —
+        the next ``hermes`` invocation that defaults to the active provider
         (e.g. setup wizard, ``hermes auth status``) would land on
         whatever provider happened to refresh last, not whatever the
         user actually chose.
@@ -988,8 +1056,11 @@ class CredentialPool:
         # Only sync entries that were seeded *from* a singleton.  Manually
         # added pool entries (source="manual:*") are independent credentials
         # and must not write back to the singleton.  All singleton-seeded
-        # device-code sources (nous, openai-codex, xAI) use ``device_code``.
-        if entry.source != "device_code":
+        # device-code sources (nous, openai-codex, xAI) use ``device_code``;
+        # MiniMax OAuth uses ``oauth``.
+        if entry.source != "device_code" and not (
+            self.provider == "minimax-oauth" and entry.source == "oauth"
+        ):
             return
         try:
             with _auth_store_lock():
@@ -1009,6 +1080,7 @@ class CredentialPool:
                     "nous": "nous",
                     "openai-codex": "openai-codex",
                     "xai-oauth": "xai-oauth",
+                    "minimax-oauth": "minimax-oauth",
                 }.get(self.provider)
                 write_through_to_root = bool(_wt_provider_id) and not (
                     isinstance(auth_store.get("providers"), dict)
@@ -1067,6 +1139,31 @@ class CredentialPool:
                         state["last_refresh"] = entry.last_refresh
                     _store_provider_state(auth_store, "xai-oauth", state, set_active=False)
 
+                elif self.provider == "minimax-oauth":
+                    # MiniMax OAuth stores its singleton state flat (not
+                    # nested under ``tokens``), mirroring nous.  Re-hydrate
+                    # the full persisted block so we only rotate the fields
+                    # a refresh actually changed, then write it back with
+                    # ``set_active=False`` (a pool refresh is a token
+                    # rotation, not a provider switch).
+                    state = _load_provider_state(auth_store, "minimax-oauth")
+                    if not isinstance(state, dict):
+                        state = {}
+                    state["access_token"] = entry.access_token
+                    if entry.refresh_token:
+                        state["refresh_token"] = entry.refresh_token
+                    if entry.expires_at:
+                        state["expires_at"] = entry.expires_at
+                    for extra_key in ("obtained_at", "expires_in"):
+                        val = entry.extra.get(extra_key)
+                        if val is not None:
+                            state[extra_key] = val
+                    if entry.base_url:
+                        state["inference_base_url"] = entry.base_url
+                    _store_provider_state(
+                        auth_store, "minimax-oauth", state, set_active=False
+                    )
+
                 else:
                     return
 
@@ -1084,7 +1181,7 @@ class CredentialPool:
                 self._mark_exhausted(entry, None)
             return None
 
-        # Codex and xAI OAuth refresh tokens are single-use.  The
+        # Codex, xAI, and MiniMax OAuth refresh tokens are single-use.  The
         # sync→POST→write-back sequence below must run atomically across Hermes
         # processes: otherwise two processes can both adopt the same on-disk
         # token, both POST it, and the loser gets ``refresh_token_reused``.
@@ -1093,12 +1190,13 @@ class CredentialPool:
         # resolve_codex_runtime_credentials()).  When a waiter finally acquires
         # the lock, the in-lock re-sync below picks up the rotated token the
         # winner persisted and skips the POST.
-        if self.provider in ("openai-codex", "xai-oauth"):
-            sync_entry = (
-                self._sync_codex_entry_from_auth_store
-                if self.provider == "openai-codex"
-                else self._sync_xai_oauth_entry_from_pool_store
-            )
+        if self.provider in ("openai-codex", "xai-oauth", "minimax-oauth"):
+            if self.provider == "openai-codex":
+                sync_entry = self._sync_codex_entry_from_auth_store
+            elif self.provider == "xai-oauth":
+                sync_entry = self._sync_xai_oauth_entry_from_pool_store
+            else:
+                sync_entry = self._sync_minimax_oauth_entry_from_auth_store
             with _auth_store_lock(
                 timeout_seconds=self._single_use_refresh_lock_timeout()
             ):
@@ -1109,6 +1207,11 @@ class CredentialPool:
                         if not force and not self._entry_needs_refresh(entry):
                             return entry
                     return self._refresh_entry_impl(entry, force=force)
+                # xai-oauth and minimax-oauth: if another process already
+                # rotated the single-use refresh token while we waited for
+                # the lock, adopt the persisted pair and return WITHOUT
+                # re-POSTing.  This collapses concurrent refreshes to exactly
+                # one token-endpoint exchange (issue #48415).
                 if (
                     synced.access_token != entry.access_token
                     or synced.refresh_token != entry.refresh_token
@@ -1125,12 +1228,15 @@ class CredentialPool:
         resolves.  Reads the provider's ``HERMES_*_REFRESH_TIMEOUT_SECONDS``
         override.
         """
-        env_var = (
-            "HERMES_CODEX_REFRESH_TIMEOUT_SECONDS"
-            if self.provider == "openai-codex"
-            else "HERMES_XAI_REFRESH_TIMEOUT_SECONDS"
-        )
-        refresh_timeout_seconds = auth_mod.env_float(env_var, 20)
+        if self.provider == "openai-codex":
+            env_var = "HERMES_CODEX_REFRESH_TIMEOUT_SECONDS"
+        elif self.provider == "xai-oauth":
+            env_var = "HERMES_XAI_REFRESH_TIMEOUT_SECONDS"
+        else:
+            # MiniMax OAuth (and any future single-use provider): default
+            # 15s matches ``_refresh_minimax_oauth_state``.
+            env_var = "HERMES_MINIMAX_REFRESH_TIMEOUT_SECONDS"
+        refresh_timeout_seconds = auth_mod.env_float(env_var, 15 if self.provider == "minimax-oauth" else 20)
         return max(
             float(auth_mod.AUTH_LOCK_TIMEOUT_SECONDS),
             float(refresh_timeout_seconds) + 5.0,
@@ -1211,6 +1317,57 @@ class CredentialPool:
                     force_refresh=force,
                 )
                 updated = self._sync_nous_entry_from_auth_store(entry)
+            elif self.provider == "minimax-oauth":
+                # Re-adopt fresher tokens from auth.json before spending the
+                # refresh_token — single-use tokens consumed by another Hermes
+                # process sharing the same singleton would otherwise trigger
+                # ``refresh_token_reused`` on the next POST.  Only meaningful
+                # for singleton-seeded (oauth) entries.
+                synced = self._sync_minimax_oauth_entry_from_auth_store(entry)
+                if synced is not entry:
+                    entry = synced
+                # Build the auth-state dict the pure refresh helper expects
+                # from the pool entry.  portal_base_url / client_id live in
+                # the singleton state and are not carried on the pool entry,
+                # so re-read them from the store when missing.
+                refresh_state: Dict[str, Any] = {
+                    "access_token": entry.access_token,
+                    "refresh_token": entry.refresh_token,
+                    "client_id": getattr(entry, "client_id", None),
+                    "portal_base_url": getattr(entry, "portal_base_url", None),
+                    "inference_base_url": entry.base_url,
+                    "expires_at": entry.expires_at,
+                }
+                # The pool entry does not carry client_id/portal_base_url (they
+                # are routing metadata, not secret material), so pull them
+                # from the persisted singleton if the entry lacks them.
+                if not refresh_state["client_id"] or not refresh_state["portal_base_url"]:
+                    try:
+                        persisted_state = auth_mod.get_provider_auth_state("minimax-oauth")
+                        if isinstance(persisted_state, dict):
+                            refresh_state["client_id"] = (
+                                refresh_state["client_id"]
+                                or persisted_state.get("client_id")
+                            )
+                            refresh_state["portal_base_url"] = (
+                                refresh_state["portal_base_url"]
+                                or persisted_state.get("portal_base_url")
+                            )
+                    except Exception:
+                        pass
+                refreshed_fields = refresh_minimax_oauth_pure(refresh_state)
+                extra_updates = dict(entry.extra)
+                if refreshed_fields.get("obtained_at"):
+                    extra_updates["obtained_at"] = refreshed_fields["obtained_at"]
+                if refreshed_fields.get("expires_in") is not None:
+                    extra_updates["expires_in"] = refreshed_fields["expires_in"]
+                updated = replace(
+                    entry,
+                    access_token=refreshed_fields["access_token"],
+                    refresh_token=refreshed_fields["refresh_token"],
+                    expires_at=refreshed_fields.get("expires_at"),
+                    extra=extra_updates,
+                )
             else:
                 return entry
         except Exception as exc:
@@ -1464,6 +1621,112 @@ class CredentialPool:
                         self._current_id = None
                     self._persist(removed_ids=removed_ids)
                     return None
+            # For minimax-oauth: same race as Codex/xAI/nous — another Hermes
+            # process may have consumed the single-use refresh token between
+            # our proactive sync and the HTTP call.  Re-check auth.json and
+            # adopt the fresh tokens if they have rotated since.  Only
+            # meaningful for singleton-seeded (oauth) entries.
+            if self.provider == "minimax-oauth":
+                synced = self._sync_minimax_oauth_entry_from_auth_store(entry)
+                if synced.refresh_token != entry.refresh_token:
+                    logger.debug(
+                        "MiniMax OAuth refresh failed but auth.json has newer "
+                        "tokens — adopting"
+                    )
+                    updated = replace(
+                        synced,
+                        last_status=STATUS_OK,
+                        last_status_at=None,
+                        last_error_code=None,
+                        last_error_reason=None,
+                        last_error_message=None,
+                        last_error_reset_at=None,
+                    )
+                    self._replace_entry(synced, updated)
+                    self._persist()
+                    self._sync_device_code_entry_to_auth_store(updated)
+                    return updated
+                # Terminal error: auth.json has no newer tokens — the stored
+                # refresh_token is dead.  Reuse the shared quarantine helper so
+                # the pool path and the eager-resolve path stay consistent,
+                # then remove all singleton-seeded MiniMax entries from the
+                # in-memory pool.  Mirrors the Codex/xAI/Nous quarantine paths.
+                if _is_terminal_minimax_oauth_refresh_error(exc):
+                    logger.debug(
+                        "MiniMax OAuth refresh token is terminally invalid; "
+                        "clearing local token state"
+                    )
+                    try:
+                        with _auth_store_lock():
+                            auth_store = _load_auth_store()
+                            # Decide whether this profile owns the grant
+                            # (own providers block) or reads it from the
+                            # global-root fallback.  A profile reading from
+                            # root MUST propagate the quarantine to root —
+                            # otherwise root keeps the dead refresh token
+                            # and every other profile reading root replays
+                            # the same terminal failure.  Mirrors the
+                            # write-through decision in
+                            # _sync_device_code_entry_to_auth_store.
+                            owns_block = (
+                                isinstance(auth_store.get("providers"), dict)
+                                and isinstance(
+                                    auth_store["providers"].get("minimax-oauth"),
+                                    dict,
+                                )
+                            )
+                            state = _load_provider_state(
+                                auth_store, "minimax-oauth"
+                            ) or {}
+                            if isinstance(state, dict):
+                                store_refresh = str(
+                                    state.get("refresh_token") or ""
+                                ).strip()
+                                entry_refresh = str(
+                                    entry.refresh_token or ""
+                                ).strip()
+                                if (
+                                    not store_refresh
+                                    or store_refresh == entry_refresh
+                                ):
+                                    # Reuse the eager-resolve quarantine helper
+                                    # so both paths wipe the same fields and
+                                    # write the same diagnostic blob.
+                                    _minimax_oauth_quarantine_on_terminal_refresh(
+                                        state,
+                                        exc,  # type: ignore[arg-type]
+                                    )
+                                    _store_provider_state(
+                                        auth_store,
+                                        "minimax-oauth",
+                                        state,
+                                        set_active=False,
+                                    )
+                                    _save_auth_store(auth_store)
+                                    # Write-through the quarantine to the
+                                    # global root when this profile borrows
+                                    # the grant from root fallback.
+                                    if not owns_block:
+                                        _write_through_provider_state_to_global_root(
+                                            "minimax-oauth", state
+                                        )
+                    except Exception as clear_exc:
+                        logger.debug(
+                            "Failed to clear terminal MiniMax OAuth state: %s",
+                            clear_exc,
+                        )
+                    removed_ids = [
+                        item.id for item in self._entries
+                        if item.source == "oauth"
+                    ]
+                    self._entries = [
+                        item for item in self._entries
+                        if item.source != "oauth"
+                    ]
+                    if self._current_id == entry.id:
+                        self._current_id = None
+                    self._persist(removed_ids=removed_ids)
+                    return None
             self._mark_exhausted(entry, None)
             return None
 
@@ -1506,6 +1769,19 @@ class CredentialPool:
             # runtime credentials are actually resolved, not merely when the pool
             # is enumerated for listing, migration, or selection.
             return False
+        if self.provider == "minimax-oauth":
+            # MiniMax issues short-lived access tokens.  Refresh proactively
+            # when the token is within the configured skew of expiry, mirroring
+            # the eager-resolve path's ``_refresh_minimax_oauth_state`` check.
+            if not entry.expires_at:
+                return False
+            try:
+                expires_at = datetime.fromisoformat(
+                    str(entry.expires_at).replace("Z", "+00:00")
+                ).timestamp()
+            except Exception:
+                return False
+            return (expires_at - time.time()) <= MINIMAX_OAUTH_REFRESH_SKEW_SECONDS
         return False
 
     def select(self) -> Optional[PooledCredential]:
@@ -1569,6 +1845,17 @@ class CredentialPool:
                     and entry.source == "device_code"
                     and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
                 synced = self._sync_xai_oauth_entry_from_auth_store(entry)
+                if synced is not entry:
+                    entry = synced
+                    cleared_any = True
+            # For minimax-oauth singleton-seeded entries, identical pattern:
+            # an entry frozen as exhausted may simply be holding stale tokens
+            # that another process (or a fresh `hermes model` -> MiniMax OAuth
+            # login) has since rotated in auth.json.
+            if (self.provider == "minimax-oauth"
+                    and entry.source == "oauth"
+                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
+                synced = self._sync_minimax_oauth_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
                     cleared_any = True

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1331,44 +1331,83 @@ class CredentialPool:
                 "minimax-oauth",
                 timeout_seconds=lock_timeout,
             ) as (_auth_store, source_state, source_path):
-                if isinstance(source_state, dict):
-                    store_access = str(source_state.get("access_token") or "").strip()
-                    store_refresh = str(source_state.get("refresh_token") or "").strip()
-                    entry_access = str(entry.access_token or "").strip()
-                    entry_refresh = str(entry.refresh_token or "").strip()
-                    if store_access and (
-                        store_access != entry_access
-                        or (store_refresh and store_refresh != entry_refresh)
-                    ):
-                        # Another process already rotated the single-use token
-                        # while we waited for the lock.  Adopt the persisted
-                        # pair and return without re-POSTing.
-                        logger.debug(
-                            "Pool entry %s: adopting MiniMax OAuth tokens from "
-                            "source %s (rotated by another process)",
-                            entry.id,
-                            source_path,
-                        )
-                        field_updates: Dict[str, Any] = {
-                            "access_token": store_access,
-                            "refresh_token": store_refresh or entry.refresh_token,
-                            "last_status": STATUS_OK,
-                            "last_status_at": None,
-                            "last_error_code": None,
-                            "last_error_reason": None,
-                            "last_error_message": None,
-                            "last_error_reset_at": None,
-                        }
-                        raw_expires = source_state.get("expires_at")
-                        if raw_expires:
-                            field_updates["expires_at"] = raw_expires
-                        base_url = source_state.get("inference_base_url")
-                        if isinstance(base_url, str) and base_url:
-                            field_updates["base_url"] = base_url.rstrip("/")
-                        updated = replace(entry, **field_updates)
-                        self._replace_entry(entry, updated)
-                        self._persist()
-                        return updated
+                authoritative_state = (
+                    source_state if isinstance(source_state, dict) else {}
+                )
+                store_access = str(
+                    authoritative_state.get("access_token") or ""
+                ).strip()
+                store_refresh = str(
+                    authoritative_state.get("refresh_token") or ""
+                ).strip()
+                entry_access = str(entry.access_token or "").strip()
+                entry_refresh = str(entry.refresh_token or "").strip()
+
+                # The in-lock source re-read is authoritative.  A borrower may
+                # have resolved a root-owned grant before waiting for the root
+                # lock, then find that the owner removed or quarantined it while
+                # the borrower waited.  Never POST the stale in-memory refresh
+                # token or write a successful response back to the old source
+                # path: either action would resurrect a grant the owner removed.
+                # Also reject a partial rotated state whose refresh token no
+                # longer matches but has no access token pair we can adopt.
+                source_grant_missing = not store_refresh
+                source_pair_incomplete = (
+                    store_refresh != entry_refresh and not store_access
+                )
+                if entry.source == "oauth" and (
+                    source_grant_missing or source_pair_incomplete
+                ):
+                    logger.debug(
+                        "Pool entry %s: MiniMax OAuth source %s disappeared or "
+                        "lost its usable refresh grant while waiting; failing closed",
+                        entry.id,
+                        source_path,
+                    )
+                    removed_ids = [
+                        item.id for item in self._entries if item.source == "oauth"
+                    ]
+                    self._entries = [
+                        item for item in self._entries if item.source != "oauth"
+                    ]
+                    if self._current_id in removed_ids:
+                        self._current_id = None
+                    self._persist(removed_ids=removed_ids)
+                    return None
+
+                if store_access and (
+                    store_access != entry_access
+                    or (store_refresh and store_refresh != entry_refresh)
+                ):
+                    # Another process already rotated the single-use token
+                    # while we waited for the lock.  Adopt the persisted
+                    # pair and return without re-POSTing.
+                    logger.debug(
+                        "Pool entry %s: adopting MiniMax OAuth tokens from "
+                        "source %s (rotated by another process)",
+                        entry.id,
+                        source_path,
+                    )
+                    field_updates: Dict[str, Any] = {
+                        "access_token": store_access,
+                        "refresh_token": store_refresh or entry.refresh_token,
+                        "last_status": STATUS_OK,
+                        "last_status_at": None,
+                        "last_error_code": None,
+                        "last_error_reason": None,
+                        "last_error_message": None,
+                        "last_error_reset_at": None,
+                    }
+                    raw_expires = authoritative_state.get("expires_at")
+                    if raw_expires:
+                        field_updates["expires_at"] = raw_expires
+                    base_url = authoritative_state.get("inference_base_url")
+                    if isinstance(base_url, str) and base_url:
+                        field_updates["base_url"] = base_url.rstrip("/")
+                    updated = replace(entry, **field_updates)
+                    self._replace_entry(entry, updated)
+                    self._persist()
+                    return updated
                 updated = self._refresh_entry_impl(entry, force=force)
                 if updated is None:
                     return None

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -33,6 +33,7 @@ from hermes_cli.auth import (
     _is_terminal_minimax_oauth_refresh_error,
     _load_auth_store,
     _load_provider_state,
+    _load_provider_state_with_source,
     _minimax_oauth_quarantine_on_terminal_refresh,
     _provider_state_transaction,
     _resolve_kimi_base_url,
@@ -244,6 +245,14 @@ class PooledCredential:
         for k, v in self.extra.items():
             if v is not None:
                 result[k] = v
+        # A borrowed-root MiniMax OAuth entry must never persist its secret
+        # values into the active profile's credential pool.  Mark the payload
+        # so the credential-persistence sanitizer strips it.
+        if self.provider == "minimax-oauth" and getattr(self, "source_auth_path", None):
+            result["source_auth_path"] = self.source_auth_path
+            # Ensure the sanitizer sees this as a borrowed/reference-only source.
+            result["source"] = self.source
+            return sanitize_borrowed_credential_payload(result, self.provider)
         return sanitize_borrowed_credential_payload(result, self.provider)
 
     @property
@@ -2611,7 +2620,8 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # always refreshes on expiry, so instead read raw state here to avoid
         # surprise network calls during provider discovery.
         try:
-            state, source_path = auth_mod._load_provider_state_with_source(
+            auth_store = _load_auth_store()
+            state, source_path = _load_provider_state_with_source(
                 auth_store, "minimax-oauth"
             )
             if state and state.get("access_token"):
@@ -2633,13 +2643,6 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                         "source": source_name,
                         "auth_type": AUTH_TYPE_OAUTH,
                         "access_token": state["access_token"],
-                        "refresh_token": state.get("refresh_token"),
-                        # Populate BOTH expires_at (ISO string, consumed by
-                        # _entry_needs_refresh) and expires_at_ms (epoch ms,
-                        # consumed by the anthropic-style check and listing
-                        # display). The previous shape only populated
-                        # expires_at_ms, so proactive refresh never fired for
-                        # normally seeded entries (Review A MUST-FIX #3).
                         "expires_at": raw_expires or None,
                         "expires_at_ms": expires_at_ms,
                         "base_url": base_url,
@@ -2647,20 +2650,17 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                             state.get("access_token", ""), source_name
                         ),
                     }
-                    # Record where the singleton was sourced from.  When the
-                    # entry was read from the global-root fallback (not the
-                    # active profile store), the refresh path uses this to
-                    # write rotated tokens back to root rather than creating a
-                    # profile-local shadow (Review A MUST-FIX #2).
-                    try:
-                        active_path = auth_mod._auth_file_path()
-                        if (
-                            source_path is not None
-                            and not auth_mod._same_path(source_path, active_path)
-                        ):
-                            payload["source_auth_path"] = str(source_path)
-                    except Exception:
-                        pass
+                    # Record whether this seeded entry is borrowed from the
+                    # global-root fallback.  The credential-pool disk boundary
+                    # uses this to avoid persisting root-owned secret values
+                    # into the profile credential pool.
+                    active_path = auth_mod._auth_file_path()
+                    borrowed_root = bool(
+                        source_path is not None
+                        and not auth_mod._same_path(source_path, active_path)
+                    )
+                    if borrowed_root:
+                        payload["source_auth_path"] = str(source_path)
                     changed |= _upsert_entry(
                         entries,
                         provider,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -25,6 +25,7 @@ import hermes_cli.auth as auth_mod
 from hermes_cli.auth import (
     CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
     MINIMAX_OAUTH_REFRESH_SKEW_SECONDS,
+    MINIMAX_OAUTH_REFRESH_TIMEOUT_SECONDS,
     PROVIDER_REGISTRY,
     _auth_store_lock,
     _codex_access_token_is_expiring,
@@ -33,6 +34,7 @@ from hermes_cli.auth import (
     _load_auth_store,
     _load_provider_state,
     _minimax_oauth_quarantine_on_terminal_refresh,
+    _provider_state_transaction,
     _resolve_kimi_base_url,
     _resolve_zai_base_url,
     _save_auth_store,
@@ -151,6 +153,7 @@ _EXTRA_KEYS = frozenset({
     "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
     "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
     "agent_key_obtained_at", "tls", "secret_source", "secret_fingerprint",
+    "source_auth_path",
 })
 
 
@@ -1175,6 +1178,62 @@ class CredentialPool:
         except Exception as exc:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
+    def _sync_minimax_oauth_entry_to_source(
+        self,
+        entry: PooledCredential,
+        auth_store: Dict[str, Any],
+        source_path: Optional[Path],
+    ) -> None:
+        """Persist a rotated MiniMax OAuth entry back to its source store.
+
+        Called from inside ``_provider_state_transaction`` so the source lock
+        is already held.  For borrowed-root grants (``source_path`` points at
+        the global root, not the active profile) this writes directly to root
+        without creating a profile-local ``providers.minimax-oauth`` shadow.
+        A profile that materializes a local shadow after the first refresh
+        would be mistaken for the owner on the next refresh and stop writing
+        to root, stranding every other profile still borrowing the grant
+        (Review A MUST-FIX #2).
+        """
+        source_state, _resolved_path = auth_mod._load_provider_state_with_source(
+            auth_store, "minimax-oauth"
+        )
+        if not isinstance(source_state, dict):
+            source_state = {}
+        state = dict(source_state)
+        # Rotate token fields; pop them when the entry no longer carries them
+        # (quarantine path passes an entry with cleared tokens).
+        for field in ("access_token", "refresh_token", "expires_at"):
+            val = getattr(entry, field, None)
+            if val:
+                state[field] = val
+            else:
+                state.pop(field, None)
+        for extra_key in ("obtained_at", "expires_in"):
+            val = entry.extra.get(extra_key)
+            if val is not None:
+                state[extra_key] = val
+            else:
+                state.pop(extra_key, None)
+        if entry.base_url:
+            state["inference_base_url"] = entry.base_url
+        active_path = auth_mod._auth_file_path()
+        if source_path is not None and not auth_mod._same_path(source_path, active_path):
+            # Borrowed-from-root grant: persist to root directly, never shadow
+            # it locally.
+            try:
+                auth_mod._persist_provider_state_to_store(
+                    "minimax-oauth", state, source_path, set_active=False
+                )
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.debug(
+                    "MiniMax OAuth pool: write-through to source %s failed: %s",
+                    source_path, exc,
+                )
+        else:
+            _store_provider_state(auth_store, "minimax-oauth", state, set_active=False)
+            _save_auth_store(auth_store)
+
     def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
             if force:
@@ -1190,13 +1249,67 @@ class CredentialPool:
         # resolve_codex_runtime_credentials()).  When a waiter finally acquires
         # the lock, the in-lock re-sync below picks up the rotated token the
         # winner persisted and skips the POST.
-        if self.provider in ("openai-codex", "xai-oauth", "minimax-oauth"):
+        if self.provider == "minimax-oauth":
+            # Source-aware transaction: for borrowed-root grants this holds
+            # both the active profile lock AND the global-root source lock, so
+            # two distinct profiles sharing one root grant cannot both POST the
+            # same single-use refresh token (Review A MUST-FIX #1). The in-lock
+            # re-read of the source store lets the loser adopt the winner's
+            # rotated pair without re-POSTing.
+            lock_timeout = self._single_use_refresh_lock_timeout()
+            with _provider_state_transaction(
+                "minimax-oauth",
+                timeout_seconds=lock_timeout,
+            ) as (_auth_store, source_state, source_path):
+                if isinstance(source_state, dict):
+                    store_access = str(source_state.get("access_token") or "").strip()
+                    store_refresh = str(source_state.get("refresh_token") or "").strip()
+                    entry_access = str(entry.access_token or "").strip()
+                    entry_refresh = str(entry.refresh_token or "").strip()
+                    if store_access and (
+                        store_access != entry_access
+                        or (store_refresh and store_refresh != entry_refresh)
+                    ):
+                        # Another process already rotated the single-use token
+                        # while we waited for the lock.  Adopt the persisted
+                        # pair and return without re-POSTing.
+                        logger.debug(
+                            "Pool entry %s: adopting MiniMax OAuth tokens from "
+                            "source %s (rotated by another process)",
+                            entry.id,
+                            source_path,
+                        )
+                        field_updates: Dict[str, Any] = {
+                            "access_token": store_access,
+                            "refresh_token": store_refresh or entry.refresh_token,
+                            "last_status": STATUS_OK,
+                            "last_status_at": None,
+                            "last_error_code": None,
+                            "last_error_reason": None,
+                            "last_error_message": None,
+                            "last_error_reset_at": None,
+                        }
+                        raw_expires = source_state.get("expires_at")
+                        if raw_expires:
+                            field_updates["expires_at"] = raw_expires
+                        base_url = source_state.get("inference_base_url")
+                        if isinstance(base_url, str) and base_url:
+                            field_updates["base_url"] = base_url.rstrip("/")
+                        updated = replace(entry, **field_updates)
+                        self._replace_entry(entry, updated)
+                        self._persist()
+                        return updated
+                updated = self._refresh_entry_impl(entry, force=force)
+                if updated is None:
+                    return None
+                # Persist back to the source we read from (profile or root).
+                self._sync_minimax_oauth_entry_to_source(updated, _auth_store, source_path)
+                return updated
+        if self.provider in ("openai-codex", "xai-oauth"):
             if self.provider == "openai-codex":
                 sync_entry = self._sync_codex_entry_from_auth_store
-            elif self.provider == "xai-oauth":
-                sync_entry = self._sync_xai_oauth_entry_from_pool_store
             else:
-                sync_entry = self._sync_minimax_oauth_entry_from_auth_store
+                sync_entry = self._sync_xai_oauth_entry_from_pool_store
             with _auth_store_lock(
                 timeout_seconds=self._single_use_refresh_lock_timeout()
             ):
@@ -1207,11 +1320,11 @@ class CredentialPool:
                         if not force and not self._entry_needs_refresh(entry):
                             return entry
                     return self._refresh_entry_impl(entry, force=force)
-                # xai-oauth and minimax-oauth: if another process already
-                # rotated the single-use refresh token while we waited for
-                # the lock, adopt the persisted pair and return WITHOUT
-                # re-POSTing.  This collapses concurrent refreshes to exactly
-                # one token-endpoint exchange (issue #48415).
+                # xai-oauth: if another process already rotated the single-use
+                # refresh token while we waited for the lock, adopt the
+                # persisted pair and return WITHOUT re-POSTing.  This collapses
+                # concurrent refreshes to exactly one token-endpoint exchange
+                # (issue #48415).
                 if (
                     synced.access_token != entry.access_token
                     or synced.refresh_token != entry.refresh_token
@@ -1225,18 +1338,20 @@ class CredentialPool:
 
         Covers the configured refresh POST timeout plus a margin so a slow
         token endpoint cannot make the flock give up before the refresh
-        resolves.  Reads the provider's ``HERMES_*_REFRESH_TIMEOUT_SECONDS``
-        override.
+        resolves.  Codex and xAI read a ``HERMES_*_REFRESH_TIMEOUT_SECONDS``
+        override; MiniMax OAuth uses the internal
+        ``MINIMAX_OAUTH_REFRESH_TIMEOUT_SECONDS`` constant (15s) rather than
+        introducing a new user-facing env var, per the repo policy that
+        non-secret behavioral settings belong in config.yaml, not .env.
         """
         if self.provider == "openai-codex":
             env_var = "HERMES_CODEX_REFRESH_TIMEOUT_SECONDS"
+            refresh_timeout_seconds = auth_mod.env_float(env_var, 20)
         elif self.provider == "xai-oauth":
             env_var = "HERMES_XAI_REFRESH_TIMEOUT_SECONDS"
+            refresh_timeout_seconds = auth_mod.env_float(env_var, 20)
         else:
-            # MiniMax OAuth (and any future single-use provider): default
-            # 15s matches ``_refresh_minimax_oauth_state``.
-            env_var = "HERMES_MINIMAX_REFRESH_TIMEOUT_SECONDS"
-        refresh_timeout_seconds = auth_mod.env_float(env_var, 15 if self.provider == "minimax-oauth" else 20)
+            refresh_timeout_seconds = MINIMAX_OAUTH_REFRESH_TIMEOUT_SECONDS
         return max(
             float(auth_mod.AUTH_LOCK_TIMEOUT_SECONDS),
             float(refresh_timeout_seconds) + 5.0,
@@ -1644,72 +1759,82 @@ class CredentialPool:
                     )
                     self._replace_entry(synced, updated)
                     self._persist()
-                    self._sync_device_code_entry_to_auth_store(updated)
+                    # No write-back needed: the adopted tokens already came FROM
+                    # the source store (another process rotated and persisted
+                    # them).  Calling _sync_device_code_entry_to_auth_store here
+                    # would create a profile-local shadow for borrowed-root
+                    # grants, breaking future write-throughs.
                     return updated
                 # Terminal error: auth.json has no newer tokens — the stored
-                # refresh_token is dead.  Reuse the shared quarantine helper so
-                # the pool path and the eager-resolve path stay consistent,
-                # then remove all singleton-seeded MiniMax entries from the
-                # in-memory pool.  Mirrors the Codex/xAI/Nous quarantine paths.
+                # refresh_token is dead.  Quarantine through a source-aware
+                # transaction so borrowed-root grants propagate the quarantine
+                # to root, and persist with set_active=False so a background
+                # pool failure never flips active_provider (Review A MUST-FIX #4).
+                # Mirrors the Codex/xAI/Nous quarantine paths.
                 if _is_terminal_minimax_oauth_refresh_error(exc):
                     logger.debug(
                         "MiniMax OAuth refresh token is terminally invalid; "
                         "clearing local token state"
                     )
                     try:
-                        with _auth_store_lock():
-                            auth_store = _load_auth_store()
-                            # Decide whether this profile owns the grant
-                            # (own providers block) or reads it from the
-                            # global-root fallback.  A profile reading from
-                            # root MUST propagate the quarantine to root —
-                            # otherwise root keeps the dead refresh token
-                            # and every other profile reading root replays
-                            # the same terminal failure.  Mirrors the
-                            # write-through decision in
-                            # _sync_device_code_entry_to_auth_store.
-                            owns_block = (
-                                isinstance(auth_store.get("providers"), dict)
-                                and isinstance(
-                                    auth_store["providers"].get("minimax-oauth"),
-                                    dict,
+                        with _provider_state_transaction(
+                            "minimax-oauth",
+                            timeout_seconds=self._single_use_refresh_lock_timeout(),
+                        ) as (_auth_store, source_state, source_path):
+                            if not isinstance(source_state, dict):
+                                source_state = {}
+                            store_refresh = str(
+                                source_state.get("refresh_token") or ""
+                            ).strip()
+                            entry_refresh = str(
+                                entry.refresh_token or ""
+                            ).strip()
+                            if (
+                                not store_refresh
+                                or store_refresh == entry_refresh
+                            ):
+                                # Reuse the eager-resolve quarantine helper so
+                                # both paths wipe the same fields and write the
+                                # same diagnostic blob — but persist=False so we
+                                # control the save path (source-aware, set_active
+                                # =False) instead of the helper's own
+                                # _minimax_save_auth_state (which would set
+                                # active_provider).
+                                quarantined = dict(source_state)
+                                _minimax_oauth_quarantine_on_terminal_refresh(
+                                    quarantined,
+                                    exc,  # type: ignore[arg-type]
+                                    persist=False,
                                 )
-                            )
-                            state = _load_provider_state(
-                                auth_store, "minimax-oauth"
-                            ) or {}
-                            if isinstance(state, dict):
-                                store_refresh = str(
-                                    state.get("refresh_token") or ""
-                                ).strip()
-                                entry_refresh = str(
-                                    entry.refresh_token or ""
-                                ).strip()
+                                # Persist the quarantined state (tokens removed,
+                                # diagnostic blob added) back to the source store
+                                # with set_active=False.  For borrowed-root
+                                # grants source_path is the root, so this also
+                                # quarantines root — preventing every other
+                                # profile reading root from replaying the dead
+                                # refresh token.
+                                active_path = auth_mod._auth_file_path()
                                 if (
-                                    not store_refresh
-                                    or store_refresh == entry_refresh
+                                    source_path is not None
+                                    and not auth_mod._same_path(source_path, active_path)
                                 ):
-                                    # Reuse the eager-resolve quarantine helper
-                                    # so both paths wipe the same fields and
-                                    # write the same diagnostic blob.
-                                    _minimax_oauth_quarantine_on_terminal_refresh(
-                                        state,
-                                        exc,  # type: ignore[arg-type]
-                                    )
-                                    _store_provider_state(
-                                        auth_store,
-                                        "minimax-oauth",
-                                        state,
-                                        set_active=False,
-                                    )
-                                    _save_auth_store(auth_store)
-                                    # Write-through the quarantine to the
-                                    # global root when this profile borrows
-                                    # the grant from root fallback.
-                                    if not owns_block:
-                                        _write_through_provider_state_to_global_root(
-                                            "minimax-oauth", state
+                                    try:
+                                        auth_mod._persist_provider_state_to_store(
+                                            "minimax-oauth", quarantined,
+                                            source_path, set_active=False,
                                         )
+                                    except Exception as exc2:  # pragma: no cover
+                                        logger.debug(
+                                            "MiniMax OAuth quarantine write-through "
+                                            "to source %s failed: %s",
+                                            source_path, exc2,
+                                        )
+                                else:
+                                    _store_provider_state(
+                                        _auth_store, "minimax-oauth",
+                                        quarantined, set_active=False,
+                                    )
+                                    _save_auth_store(_auth_store)
                     except Exception as clear_exc:
                         logger.debug(
                             "Failed to clear terminal MiniMax OAuth state: %s",
@@ -1743,8 +1868,13 @@ class CredentialPool:
         self._persist()
         # Sync refreshed tokens back to auth.json providers so that
         # _seed_from_singletons() on the next load_pool() sees fresh state
-        # instead of re-seeding stale/consumed tokens.
-        self._sync_device_code_entry_to_auth_store(updated)
+        # instead of re-seeding stale/consumed tokens.  MiniMax OAuth is
+        # handled by the caller (_refresh_entry) via the source-aware
+        # _sync_minimax_oauth_entry_to_source, which writes to the correct
+        # source store (profile or root) without creating a profile-local
+        # shadow for borrowed-root grants.
+        if self.provider != "minimax-oauth":
+            self._sync_device_code_entry_to_auth_store(updated)
         return updated
 
     def _entry_needs_refresh(self, entry: PooledCredential) -> bool:
@@ -2481,36 +2611,61 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # always refreshes on expiry, so instead read raw state here to avoid
         # surprise network calls during provider discovery.
         try:
-            from hermes_cli.auth import get_provider_auth_state
-            state = get_provider_auth_state("minimax-oauth")
+            state, source_path = auth_mod._load_provider_state_with_source(
+                auth_store, "minimax-oauth"
+            )
             if state and state.get("access_token"):
                 source_name = "oauth"
                 if not _is_suppressed(provider, source_name):
                     active_sources.add(source_name)
                     expires_at_ms = None
-                    try:
-                        from datetime import datetime as _dt
-                        raw = state.get("expires_at", "")
-                        if raw:
-                            expires_at_ms = int(_dt.fromisoformat(raw).timestamp() * 1000)
-                    except Exception:
-                        expires_at_ms = None
+                    raw_expires = state.get("expires_at", "")
+                    if raw_expires:
+                        try:
+                            from datetime import datetime as _dt
+                            expires_at_ms = int(
+                                _dt.fromisoformat(raw_expires).timestamp() * 1000
+                            )
+                        except Exception:
+                            expires_at_ms = None
                     base_url = str(state.get("inference_base_url", "") or "").rstrip("/")
+                    payload = {
+                        "source": source_name,
+                        "auth_type": AUTH_TYPE_OAUTH,
+                        "access_token": state["access_token"],
+                        "refresh_token": state.get("refresh_token"),
+                        # Populate BOTH expires_at (ISO string, consumed by
+                        # _entry_needs_refresh) and expires_at_ms (epoch ms,
+                        # consumed by the anthropic-style check and listing
+                        # display). The previous shape only populated
+                        # expires_at_ms, so proactive refresh never fired for
+                        # normally seeded entries (Review A MUST-FIX #3).
+                        "expires_at": raw_expires or None,
+                        "expires_at_ms": expires_at_ms,
+                        "base_url": base_url,
+                        "label": state.get("label", "") or label_from_token(
+                            state.get("access_token", ""), source_name
+                        ),
+                    }
+                    # Record where the singleton was sourced from.  When the
+                    # entry was read from the global-root fallback (not the
+                    # active profile store), the refresh path uses this to
+                    # write rotated tokens back to root rather than creating a
+                    # profile-local shadow (Review A MUST-FIX #2).
+                    try:
+                        active_path = auth_mod._auth_file_path()
+                        if (
+                            source_path is not None
+                            and not auth_mod._same_path(source_path, active_path)
+                        ):
+                            payload["source_auth_path"] = str(source_path)
+                    except Exception:
+                        pass
                     changed |= _upsert_entry(
                         entries,
                         provider,
                         source_name,
-                        {
-                            "source": source_name,
-                            "auth_type": AUTH_TYPE_OAUTH,
-                            "access_token": state["access_token"],
-                            "refresh_token": state.get("refresh_token"),
-                            "expires_at_ms": expires_at_ms,
-                            "base_url": base_url,
-                            "label": state.get("label", "") or label_from_token(
-                                state.get("access_token", ""), source_name
-                            ),
-                        },
+                        payload,
                     )
         except Exception as exc:
             logger.debug("MiniMax OAuth token seed failed: %s", exc)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2864,6 +2864,13 @@ def _seed_from_singletons(
                         "source": source_name,
                         "auth_type": AUTH_TYPE_OAUTH,
                         "access_token": state["access_token"],
+                        # Keep the owning singleton's refresh grant in memory so
+                        # an expired entry loaded through the normal runtime path
+                        # can enter the source-aware refresh transaction.  For a
+                        # borrowed-root entry, source_auth_path below marks the
+                        # payload reference-only and to_dict() strips both tokens
+                        # before any profile credential-pool persistence.
+                        "refresh_token": state.get("refresh_token"),
                         "expires_at": raw_expires or None,
                         "expires_at_ms": expires_at_ms,
                         "base_url": base_url,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -83,12 +83,12 @@ STATUS_DEAD = "dead"
 # server-side and cannot be recovered by retry/refresh.  Sourced from
 # OpenAI Codex Responses API, Anthropic, xAI, and Google OAuth spec.
 _TERMINAL_AUTH_REASONS = frozenset({
-    "token_invalidated",   # OpenAI Codex: "Your authentication token has been invalidated."
-    "token_revoked",        # OAuth 2.0 RFC 7009: token explicitly revoked
-    "invalid_token",        # RFC 6750: bearer token is malformed/expired/revoked
-    "invalid_grant",        # RFC 6749: refresh_token rejected during refresh
+    "token_invalidated",  # OpenAI Codex: "Your authentication token has been invalidated."
+    "token_revoked",  # OAuth 2.0 RFC 7009: token explicitly revoked
+    "invalid_token",  # RFC 6750: bearer token is malformed/expired/revoked
+    "invalid_grant",  # RFC 6749: refresh_token rejected during refresh
     "unauthorized_client",  # RFC 6749: client no longer authorized
-    "refresh_token_reused", # Single-use refresh token consumed by another process
+    "refresh_token_reused",  # Single-use refresh token consumed by another process
 })
 
 # How long a DEAD manual credential is preserved before being pruned.
@@ -125,9 +125,9 @@ SUPPORTED_POOL_STRATEGIES = {
 # Transient 401 auth failures cool down briefly so single-key setups can recover.
 # 429 (rate-limited), 402 (billing/quota), and other failures cool down after 1 hour.
 # Provider-supplied reset_at timestamps override these defaults.
-EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
-EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
-EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
+EXHAUSTED_TTL_401_SECONDS = 5 * 60  # 5 minutes
+EXHAUSTED_TTL_429_SECONDS = 60 * 60  # 1 hour
+EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60  # 1 hour
 
 # Throttle window for the "no available entries" INFO line. Credential
 # selection runs on a hot path (every model call, plus auxiliary tasks like
@@ -151,9 +151,19 @@ CUSTOM_POOL_PREFIX = "custom:"
 
 # Fields that are only round-tripped through JSON — never used for logic as attributes.
 _EXTRA_KEYS = frozenset({
-    "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
-    "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
-    "agent_key_obtained_at", "tls", "secret_source", "secret_fingerprint",
+    "token_type",
+    "scope",
+    "client_id",
+    "portal_base_url",
+    "obtained_at",
+    "expires_in",
+    "agent_key_id",
+    "agent_key_expires_in",
+    "agent_key_reused",
+    "agent_key_obtained_at",
+    "tls",
+    "secret_source",
+    "secret_fingerprint",
     "source_auth_path",
 })
 
@@ -207,7 +217,9 @@ class PooledCredential:
     def __getattr__(self, name: str):
         if name in _EXTRA_KEYS:
             return self.extra.get(name)
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute {name!r}")
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute {name!r}"
+        )
 
     @classmethod
     def from_dict(cls, provider: str, payload: Dict[str, Any]) -> "PooledCredential":
@@ -216,7 +228,11 @@ class PooledCredential:
         # Rehydrated last_status_at may be an ISO string from to_dict() — normalize to float epoch
         if "last_status_at" in data and isinstance(data["last_status_at"], str):
             data["last_status_at"] = _parse_absolute_timestamp(data["last_status_at"])
-        extra = {k: payload[k] for k in _EXTRA_KEYS if k in payload and payload[k] is not None}
+        extra = {
+            k: payload[k]
+            for k in _EXTRA_KEYS
+            if k in payload and payload[k] is not None
+        }
         data["extra"] = extra
         data.setdefault("id", uuid.uuid4().hex[:6])
         data.setdefault("label", payload.get("source", provider))
@@ -344,15 +360,23 @@ def _parse_absolute_timestamp(value: Any) -> Optional[float]:
 def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     if not message:
         return None
-    delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
+    delay_match = re.search(
+        r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE
+    )
     if delay_match:
         value = float(delay_match.group(1))
         return value / 1000.0 if delay_match.group(2).lower() == "ms" else value
-    sec_match = re.search(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
+    sec_match = re.search(
+        r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
+        message,
+        re.IGNORECASE,
+    )
     if sec_match:
         return float(sec_match.group(1))
     # "Resets in 4hr 5min" format used by OpenCode Go weekly usage limits
-    hr_min_match = re.search(r"resets?\s+in\s+(\d+)\s*hr\s+(\d+)\s*min", message, re.IGNORECASE)
+    hr_min_match = re.search(
+        r"resets?\s+in\s+(\d+)\s*hr\s+(\d+)\s*min", message, re.IGNORECASE
+    )
     if hr_min_match:
         return int(hr_min_match.group(1)) * 3600 + int(hr_min_match.group(2)) * 60
     hr_only_match = re.search(r"resets?\s+in\s+(\d+)\s*hr\b", message, re.IGNORECASE)
@@ -431,7 +455,9 @@ def _iter_custom_providers(config: Optional[dict] = None):
         yield _normalize_custom_pool_name(name), entry
 
 
-def get_custom_provider_pool_key(base_url: Optional[str], provider_name: Optional[str] = None) -> Optional[str]:
+def get_custom_provider_pool_key(
+    base_url: Optional[str], provider_name: Optional[str] = None
+) -> Optional[str]:
     """Look up the custom_providers list in config.yaml and return 'custom:<name>' for a matching base_url.
 
     When provider_name is given, prefer matching by name first (solving the case where
@@ -465,7 +491,8 @@ def list_custom_pool_providers() -> List[str]:
     """Return all 'custom:*' pool keys that have entries in auth.json."""
     pool_data = read_credential_pool(None)
     return sorted(
-        key for key in pool_data
+        key
+        for key in pool_data
         if key.startswith(CUSTOM_POOL_PREFIX)
         and isinstance(pool_data.get(key), list)
         and pool_data[key]
@@ -476,7 +503,7 @@ def _get_custom_provider_config(pool_key: str) -> Optional[Dict[str, Any]]:
     """Return the custom_providers config entry matching a pool key like 'custom:together.ai'."""
     if not pool_key.startswith(CUSTOM_POOL_PREFIX):
         return None
-    suffix = pool_key[len(CUSTOM_POOL_PREFIX):]
+    suffix = pool_key[len(CUSTOM_POOL_PREFIX) :]
     for norm_name, entry in _iter_custom_providers():
         if norm_name == suffix:
             return entry
@@ -624,7 +651,9 @@ class CredentialPool:
     def current(self) -> Optional[PooledCredential]:
         if not self._current_id:
             return None
-        return next((entry for entry in self._entries if entry.id == self._current_id), None)
+        return next(
+            (entry for entry in self._entries if entry.id == self._current_id), None
+        )
 
     def _replace_entry(self, old: PooledCredential, new: PooledCredential) -> None:
         """Swap an entry in-place by id, preserving sort order."""
@@ -694,7 +723,9 @@ class CredentialPool:
         self._persist()
         return updated
 
-    def _sync_anthropic_entry_from_credentials_file(self, entry: PooledCredential) -> PooledCredential:
+    def _sync_anthropic_entry_from_credentials_file(
+        self, entry: PooledCredential
+    ) -> PooledCredential:
         """Sync a claude_code pool entry from ~/.claude/.credentials.json if tokens differ.
 
         OAuth refresh tokens are single-use. When something external (e.g.
@@ -706,6 +737,7 @@ class CredentialPool:
             return entry
         try:
             from agent.anthropic_adapter import read_claude_code_credentials
+
             creds = read_claude_code_credentials()
             if not creds:
                 return entry
@@ -746,7 +778,9 @@ class CredentialPool:
             logger.debug("Failed to sync from credentials file: %s", exc)
         return entry
 
-    def _sync_codex_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
+    def _sync_codex_entry_from_auth_store(
+        self, entry: PooledCredential
+    ) -> PooledCredential:
         """Sync a Codex device_code pool entry from auth.json if tokens differ.
 
         When a Codex OAuth access token expires (or the ChatGPT account hits
@@ -810,7 +844,9 @@ class CredentialPool:
             logger.debug("Failed to sync Codex entry from auth.json: %s", exc)
         return entry
 
-    def _sync_xai_oauth_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
+    def _sync_xai_oauth_entry_from_auth_store(
+        self, entry: PooledCredential
+    ) -> PooledCredential:
         """Sync an xAI OAuth pool entry from auth.json if tokens differ.
 
         xAI OAuth refresh tokens are single-use.  When another Hermes process
@@ -907,7 +943,9 @@ class CredentialPool:
             logger.debug("Failed to sync xAI OAuth entry from credential pool: %s", exc)
         return entry
 
-    def _sync_nous_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
+    def _sync_nous_entry_from_auth_store(
+        self, entry: PooledCredential
+    ) -> PooledCredential:
         """Sync a Nous pool entry from auth.json if tokens differ.
 
         Nous OAuth refresh tokens are single-use.  When another process
@@ -961,13 +999,20 @@ class CredentialPool:
                 if state.get("agent_key"):
                     field_updates["agent_key"] = state["agent_key"]
                 if state.get("agent_key_expires_at"):
-                    field_updates["agent_key_expires_at"] = state["agent_key_expires_at"]
+                    field_updates["agent_key_expires_at"] = state[
+                        "agent_key_expires_at"
+                    ]
                 if state.get("inference_base_url"):
                     field_updates["inference_base_url"] = state["inference_base_url"]
                 extra_updates = dict(entry.extra)
-                for extra_key in ("obtained_at", "expires_in", "agent_key_id",
-                                  "agent_key_expires_in", "agent_key_reused",
-                                  "agent_key_obtained_at"):
+                for extra_key in (
+                    "obtained_at",
+                    "expires_in",
+                    "agent_key_id",
+                    "agent_key_expires_in",
+                    "agent_key_reused",
+                    "agent_key_obtained_at",
+                ):
                     val = state.get(extra_key)
                     if val is not None:
                         extra_updates[extra_key] = val
@@ -979,7 +1024,9 @@ class CredentialPool:
             logger.debug("Failed to sync Nous entry from auth.json: %s", exc)
         return entry
 
-    def _sync_minimax_oauth_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
+    def _sync_minimax_oauth_entry_from_auth_store(
+        self, entry: PooledCredential
+    ) -> PooledCredential:
         """Sync a MiniMax OAuth pool entry from auth.json if tokens differ.
 
         MiniMax OAuth refresh tokens are single-use.  When another Hermes
@@ -1096,9 +1143,7 @@ class CredentialPool:
                 }.get(self.provider)
                 write_through_to_root = bool(_wt_provider_id) and not (
                     isinstance(auth_store.get("providers"), dict)
-                    and isinstance(
-                        auth_store["providers"].get(_wt_provider_id), dict
-                    )
+                    and isinstance(auth_store["providers"].get(_wt_provider_id), dict)
                 )
                 if self.provider == "nous":
                     state = _load_provider_state(auth_store, "nous")
@@ -1113,9 +1158,14 @@ class CredentialPool:
                         state["agent_key"] = entry.agent_key
                     if entry.agent_key_expires_at:
                         state["agent_key_expires_at"] = entry.agent_key_expires_at
-                    for extra_key in ("obtained_at", "expires_in", "agent_key_id",
-                                      "agent_key_expires_in", "agent_key_reused",
-                                      "agent_key_obtained_at"):
+                    for extra_key in (
+                        "obtained_at",
+                        "expires_in",
+                        "agent_key_id",
+                        "agent_key_expires_in",
+                        "agent_key_reused",
+                        "agent_key_obtained_at",
+                    ):
                         val = entry.extra.get(extra_key)
                         if val is not None:
                             state[extra_key] = val
@@ -1135,7 +1185,9 @@ class CredentialPool:
                         tokens["refresh_token"] = entry.refresh_token
                     if entry.last_refresh:
                         state["last_refresh"] = entry.last_refresh
-                    _store_provider_state(auth_store, "openai-codex", state, set_active=False)
+                    _store_provider_state(
+                        auth_store, "openai-codex", state, set_active=False
+                    )
 
                 elif self.provider == "xai-oauth":
                     state = _load_provider_state(auth_store, "xai-oauth")
@@ -1149,7 +1201,9 @@ class CredentialPool:
                         tokens["refresh_token"] = entry.refresh_token
                     if entry.last_refresh:
                         state["last_refresh"] = entry.last_refresh
-                    _store_provider_state(auth_store, "xai-oauth", state, set_active=False)
+                    _store_provider_state(
+                        auth_store, "xai-oauth", state, set_active=False
+                    )
 
                 elif self.provider == "minimax-oauth":
                     # MiniMax OAuth stores its singleton state flat (not
@@ -1181,11 +1235,13 @@ class CredentialPool:
 
                 _save_auth_store(auth_store)
                 if write_through_to_root and _wt_provider_id:
-                    _write_through_provider_state_to_global_root(
-                        _wt_provider_id, state
-                    )
+                    _write_through_provider_state_to_global_root(_wt_provider_id, state)
         except Exception as exc:
-            logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
+            logger.debug(
+                "Failed to sync %s pool entry back to auth store: %s",
+                self.provider,
+                exc,
+            )
 
     def _sync_minimax_oauth_entry_to_source(
         self,
@@ -1227,7 +1283,9 @@ class CredentialPool:
         if entry.base_url:
             state["inference_base_url"] = entry.base_url
         active_path = auth_mod._auth_file_path()
-        if source_path is not None and not auth_mod._same_path(source_path, active_path):
+        if source_path is not None and not auth_mod._same_path(
+            source_path, active_path
+        ):
             # Borrowed-from-root grant: persist to root directly, never shadow
             # it locally.
             try:
@@ -1237,13 +1295,16 @@ class CredentialPool:
             except Exception as exc:  # pragma: no cover - best effort
                 logger.debug(
                     "MiniMax OAuth pool: write-through to source %s failed: %s",
-                    source_path, exc,
+                    source_path,
+                    exc,
                 )
         else:
             _store_provider_state(auth_store, "minimax-oauth", state, set_active=False)
             _save_auth_store(auth_store)
 
-    def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
+    def _refresh_entry(
+        self, entry: PooledCredential, *, force: bool
+    ) -> Optional[PooledCredential]:
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
             if force:
                 self._mark_exhausted(entry, None)
@@ -1312,7 +1373,9 @@ class CredentialPool:
                 if updated is None:
                     return None
                 # Persist back to the source we read from (profile or root).
-                self._sync_minimax_oauth_entry_to_source(updated, _auth_store, source_path)
+                self._sync_minimax_oauth_entry_to_source(
+                    updated, _auth_store, source_path
+                )
                 return updated
         if self.provider in ("openai-codex", "xai-oauth"):
             if self.provider == "openai-codex":
@@ -1388,14 +1451,20 @@ class CredentialPool:
                 # see the latest tokens.
                 if entry.source == "claude_code":
                     try:
-                        from agent.anthropic_adapter import _write_claude_code_credentials
+                        from agent.anthropic_adapter import (
+                            _write_claude_code_credentials,
+                        )
+
                         _write_claude_code_credentials(
                             refreshed["access_token"],
                             refreshed["refresh_token"],
                             refreshed["expires_at_ms"],
                         )
                     except Exception as wexc:
-                        logger.debug("Failed to write refreshed token to credentials file: %s", wexc)
+                        logger.debug(
+                            "Failed to write refreshed token to credentials file: %s",
+                            wexc,
+                        )
             elif self.provider == "openai-codex":
                 # Adopt fresher tokens from auth.json before spending the
                 # refresh_token — single-use tokens consumed by another Hermes
@@ -1465,18 +1534,21 @@ class CredentialPool:
                 # The pool entry does not carry client_id/portal_base_url (they
                 # are routing metadata, not secret material), so pull them
                 # from the persisted singleton if the entry lacks them.
-                if not refresh_state["client_id"] or not refresh_state["portal_base_url"]:
+                if (
+                    not refresh_state["client_id"]
+                    or not refresh_state["portal_base_url"]
+                ):
                     try:
-                        persisted_state = auth_mod.get_provider_auth_state("minimax-oauth")
+                        persisted_state = auth_mod.get_provider_auth_state(
+                            "minimax-oauth"
+                        )
                         if isinstance(persisted_state, dict):
-                            refresh_state["client_id"] = (
-                                refresh_state["client_id"]
-                                or persisted_state.get("client_id")
-                            )
-                            refresh_state["portal_base_url"] = (
-                                refresh_state["portal_base_url"]
-                                or persisted_state.get("portal_base_url")
-                            )
+                            refresh_state["client_id"] = refresh_state[
+                                "client_id"
+                            ] or persisted_state.get("client_id")
+                            refresh_state["portal_base_url"] = refresh_state[
+                                "portal_base_url"
+                            ] or persisted_state.get("portal_base_url")
                     except Exception:
                         pass
                 refreshed_fields = refresh_minimax_oauth_pure(refresh_state)
@@ -1495,16 +1567,21 @@ class CredentialPool:
             else:
                 return entry
         except Exception as exc:
-            logger.debug("Credential refresh failed for %s/%s: %s", self.provider, entry.id, exc)
+            logger.debug(
+                "Credential refresh failed for %s/%s: %s", self.provider, entry.id, exc
+            )
             # For anthropic claude_code entries: the refresh token may have been
             # consumed by another process. Check if ~/.claude/.credentials.json
             # has a newer token pair and retry once.
             if self.provider == "anthropic" and entry.source == "claude_code":
                 synced = self._sync_anthropic_entry_from_credentials_file(entry)
                 if synced.refresh_token != entry.refresh_token:
-                    logger.debug("Retrying refresh with synced token from credentials file")
+                    logger.debug(
+                        "Retrying refresh with synced token from credentials file"
+                    )
                     try:
                         from agent.anthropic_adapter import refresh_anthropic_oauth_pure
+
                         refreshed = refresh_anthropic_oauth_pure(
                             synced.refresh_token,
                             use_json=synced.source.endswith("hermes_pkce"),
@@ -1521,20 +1598,28 @@ class CredentialPool:
                         self._replace_entry(synced, updated)
                         self._persist()
                         try:
-                            from agent.anthropic_adapter import _write_claude_code_credentials
+                            from agent.anthropic_adapter import (
+                                _write_claude_code_credentials,
+                            )
+
                             _write_claude_code_credentials(
                                 refreshed["access_token"],
                                 refreshed["refresh_token"],
                                 refreshed["expires_at_ms"],
                             )
                         except Exception as wexc:
-                            logger.debug("Failed to write refreshed token to credentials file (retry path): %s", wexc)
+                            logger.debug(
+                                "Failed to write refreshed token to credentials file (retry path): %s",
+                                wexc,
+                            )
                         return updated
                     except Exception as retry_exc:
                         logger.debug("Retry refresh also failed: %s", retry_exc)
                 elif not self._entry_needs_refresh(synced):
                     # Credentials file had a valid (non-expired) token — use it directly
-                    logger.debug("Credentials file has valid token, using without refresh")
+                    logger.debug(
+                        "Credentials file has valid token, using without refresh"
+                    )
                     return synced
             # For xai-oauth: same race as nous — another process may have
             # consumed the refresh token between our proactive sync and the
@@ -1576,9 +1661,16 @@ class CredentialPool:
                             if isinstance(state, dict):
                                 tokens = state.get("tokens") or {}
                                 if isinstance(tokens, dict):
-                                    store_refresh = str(tokens.get("refresh_token") or "").strip()
-                                    entry_refresh = str(entry.refresh_token or "").strip()
-                                    if not store_refresh or store_refresh == entry_refresh:
+                                    store_refresh = str(
+                                        tokens.get("refresh_token") or ""
+                                    ).strip()
+                                    entry_refresh = str(
+                                        entry.refresh_token or ""
+                                    ).strip()
+                                    if (
+                                        not store_refresh
+                                        or store_refresh == entry_refresh
+                                    ):
                                         tokens.pop("access_token", None)
                                         tokens.pop("refresh_token", None)
                                         state["tokens"] = tokens
@@ -1588,21 +1680,25 @@ class CredentialPool:
                                             "message": str(exc),
                                             "reason": "credential_pool_refresh_failure",
                                             "relogin_required": True,
-                                            "at": datetime.now(timezone.utc).isoformat(),
+                                            "at": datetime.now(
+                                                timezone.utc
+                                            ).isoformat(),
                                         }
-                                        _save_provider_state(auth_store, "xai-oauth", state)
+                                        _save_provider_state(
+                                            auth_store, "xai-oauth", state
+                                        )
                                         _save_auth_store(auth_store)
                     except Exception as clear_exc:
                         logger.debug(
                             "Failed to clear terminal xAI OAuth state: %s", clear_exc
                         )
                     removed_ids = [
-                        item.id for item in self._entries
+                        item.id
+                        for item in self._entries
                         if item.source == "device_code"
                     ]
                     self._entries = [
-                        item for item in self._entries
-                        if item.source != "device_code"
+                        item for item in self._entries if item.source != "device_code"
                     ]
                     if self._current_id == entry.id:
                         self._current_id = None
@@ -1642,13 +1738,22 @@ class CredentialPool:
                     try:
                         with _auth_store_lock():
                             auth_store = _load_auth_store()
-                            state = _load_provider_state(auth_store, "openai-codex") or {}
+                            state = (
+                                _load_provider_state(auth_store, "openai-codex") or {}
+                            )
                             if isinstance(state, dict):
                                 tokens = state.get("tokens") or {}
                                 if isinstance(tokens, dict):
-                                    store_refresh = str(tokens.get("refresh_token") or "").strip()
-                                    entry_refresh = str(entry.refresh_token or "").strip()
-                                    if not store_refresh or store_refresh == entry_refresh:
+                                    store_refresh = str(
+                                        tokens.get("refresh_token") or ""
+                                    ).strip()
+                                    entry_refresh = str(
+                                        entry.refresh_token or ""
+                                    ).strip()
+                                    if (
+                                        not store_refresh
+                                        or store_refresh == entry_refresh
+                                    ):
                                         tokens.pop("access_token", None)
                                         tokens.pop("refresh_token", None)
                                         state["tokens"] = tokens
@@ -1658,21 +1763,25 @@ class CredentialPool:
                                             "message": str(exc),
                                             "reason": "credential_pool_refresh_failure",
                                             "relogin_required": True,
-                                            "at": datetime.now(timezone.utc).isoformat(),
+                                            "at": datetime.now(
+                                                timezone.utc
+                                            ).isoformat(),
                                         }
-                                        _save_provider_state(auth_store, "openai-codex", state)
+                                        _save_provider_state(
+                                            auth_store, "openai-codex", state
+                                        )
                                         _save_auth_store(auth_store)
                     except Exception as clear_exc:
                         logger.debug(
                             "Failed to clear terminal Codex OAuth state: %s", clear_exc
                         )
                     removed_ids = [
-                        item.id for item in self._entries
+                        item.id
+                        for item in self._entries
                         if item.source == "device_code"
                     ]
                     self._entries = [
-                        item for item in self._entries
-                        if item.source != "device_code"
+                        item for item in self._entries if item.source != "device_code"
                     ]
                     if self._current_id == entry.id:
                         self._current_id = None
@@ -1684,7 +1793,9 @@ class CredentialPool:
             if self.provider == "nous":
                 synced = self._sync_nous_entry_from_auth_store(entry)
                 if synced.refresh_token != entry.refresh_token:
-                    logger.debug("Nous refresh failed but auth.json has newer tokens — adopting")
+                    logger.debug(
+                        "Nous refresh failed but auth.json has newer tokens — adopting"
+                    )
                     updated = replace(
                         synced,
                         last_status=STATUS_OK,
@@ -1699,7 +1810,9 @@ class CredentialPool:
                     self._sync_device_code_entry_to_auth_store(updated)
                     return updated
                 if auth_mod._is_terminal_nous_refresh_error(exc):
-                    logger.debug("Nous refresh token is terminally invalid; clearing local token state")
+                    logger.debug(
+                        "Nous refresh token is terminally invalid; clearing local token state"
+                    )
                     try:
                         with _auth_store_lock():
                             auth_store = _load_auth_store()
@@ -1711,7 +1824,9 @@ class CredentialPool:
                                 "scope": entry.scope,
                                 "tls": entry.tls,
                             }
-                            store_refresh = str(state.get("refresh_token") or "").strip()
+                            store_refresh = str(
+                                state.get("refresh_token") or ""
+                            ).strip()
                             entry_refresh = str(entry.refresh_token or "").strip()
                             if not store_refresh or store_refresh == entry_refresh:
                                 auth_mod._quarantine_nous_oauth_state(
@@ -1727,18 +1842,22 @@ class CredentialPool:
                                 _save_provider_state(auth_store, "nous", state)
                                 _save_auth_store(auth_store)
                     except Exception as clear_exc:
-                        logger.debug("Failed to clear terminal Nous OAuth state: %s", clear_exc)
+                        logger.debug(
+                            "Failed to clear terminal Nous OAuth state: %s", clear_exc
+                        )
 
                     singleton_sources = {
                         auth_mod.NOUS_DEVICE_CODE_SOURCE,
                         f"manual:{auth_mod.NOUS_DEVICE_CODE_SOURCE}",
                     }
                     removed_ids = [
-                        item.id for item in self._entries
+                        item.id
+                        for item in self._entries
                         if item.source in singleton_sources
                     ]
                     self._entries = [
-                        item for item in self._entries
+                        item
+                        for item in self._entries
                         if item.source not in singleton_sources
                     ]
                     if self._current_id == entry.id:
@@ -1795,13 +1914,8 @@ class CredentialPool:
                             store_refresh = str(
                                 source_state.get("refresh_token") or ""
                             ).strip()
-                            entry_refresh = str(
-                                entry.refresh_token or ""
-                            ).strip()
-                            if (
-                                not store_refresh
-                                or store_refresh == entry_refresh
-                            ):
+                            entry_refresh = str(entry.refresh_token or "").strip()
+                            if not store_refresh or store_refresh == entry_refresh:
                                 # Reuse the eager-resolve quarantine helper so
                                 # both paths wipe the same fields and write the
                                 # same diagnostic blob — but persist=False so we
@@ -1823,25 +1937,29 @@ class CredentialPool:
                                 # profile reading root from replaying the dead
                                 # refresh token.
                                 active_path = auth_mod._auth_file_path()
-                                if (
-                                    source_path is not None
-                                    and not auth_mod._same_path(source_path, active_path)
+                                if source_path is not None and not auth_mod._same_path(
+                                    source_path, active_path
                                 ):
                                     try:
                                         auth_mod._persist_provider_state_to_store(
-                                            "minimax-oauth", quarantined,
-                                            source_path, set_active=False,
+                                            "minimax-oauth",
+                                            quarantined,
+                                            source_path,
+                                            set_active=False,
                                         )
                                     except Exception as exc2:  # pragma: no cover
                                         logger.debug(
                                             "MiniMax OAuth quarantine write-through "
                                             "to source %s failed: %s",
-                                            source_path, exc2,
+                                            source_path,
+                                            exc2,
                                         )
                                 else:
                                     _store_provider_state(
-                                        _auth_store, "minimax-oauth",
-                                        quarantined, set_active=False,
+                                        _auth_store,
+                                        "minimax-oauth",
+                                        quarantined,
+                                        set_active=False,
                                     )
                                     _save_auth_store(_auth_store)
                     except Exception as clear_exc:
@@ -1850,12 +1968,10 @@ class CredentialPool:
                             clear_exc,
                         )
                     removed_ids = [
-                        item.id for item in self._entries
-                        if item.source == "oauth"
+                        item.id for item in self._entries if item.source == "oauth"
                     ]
                     self._entries = [
-                        item for item in self._entries
-                        if item.source != "oauth"
+                        item for item in self._entries if item.source != "oauth"
                     ]
                     if self._current_id == entry.id:
                         self._current_id = None
@@ -1927,7 +2043,9 @@ class CredentialPool:
         with self._lock:
             return self._select_unlocked()
 
-    def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
+    def _available_entries(
+        self, *, clear_expired: bool = False, refresh: bool = False
+    ) -> List[PooledCredential]:
         """Return entries not currently in exhaustion cooldown.
 
         When *clear_expired* is True, entries whose cooldown has elapsed are
@@ -1947,8 +2065,11 @@ class CredentialPool:
             # For anthropic claude_code entries, sync from the credentials file
             # before any status/refresh checks. This picks up tokens refreshed
             # by other processes (Claude Code CLI, other Hermes profiles).
-            if (self.provider == "anthropic" and entry.source == "claude_code"
-                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
+            if (
+                self.provider == "anthropic"
+                and entry.source == "claude_code"
+                and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}
+            ):
                 synced = self._sync_anthropic_entry_from_credentials_file(entry)
                 if synced is not entry:
                     entry = synced
@@ -1957,9 +2078,11 @@ class CredentialPool:
             # Another process may have successfully refreshed via
             # resolve_nous_runtime_credentials(), making this entry's
             # exhausted status stale.
-            if (self.provider == "nous"
-                    and entry.source == "device_code"
-                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
+            if (
+                self.provider == "nous"
+                and entry.source == "device_code"
+                and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}
+            ):
                 synced = self._sync_nous_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
@@ -1969,9 +2092,11 @@ class CredentialPool:
             # leaving fresh tokens on disk while the pool entry is still
             # frozen behind last_error_reset_at (can be hours in the
             # future for ChatGPT weekly windows).
-            if (self.provider == "openai-codex"
-                    and entry.source == "device_code"
-                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
+            if (
+                self.provider == "openai-codex"
+                and entry.source == "device_code"
+                and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}
+            ):
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
@@ -1980,9 +2105,11 @@ class CredentialPool:
             # an entry frozen as exhausted may simply be holding stale
             # tokens that another process (or a fresh `hermes model` ->
             # xAI Grok OAuth login) has since rotated in auth.json.
-            if (self.provider == "xai-oauth"
-                    and entry.source == "device_code"
-                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
+            if (
+                self.provider == "xai-oauth"
+                and entry.source == "device_code"
+                and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}
+            ):
                 synced = self._sync_xai_oauth_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
@@ -1991,9 +2118,11 @@ class CredentialPool:
             # an entry frozen as exhausted may simply be holding stale tokens
             # that another process (or a fresh `hermes model` -> MiniMax OAuth
             # login) has since rotated in auth.json.
-            if (self.provider == "minimax-oauth"
-                    and entry.source == "oauth"
-                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
+            if (
+                self.provider == "minimax-oauth"
+                and entry.source == "oauth"
+                and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}
+            ):
                 synced = self._sync_minimax_oauth_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
@@ -2067,7 +2196,10 @@ class CredentialPool:
         """
         now = time.monotonic()
         last = self._last_no_entries_log_at
-        if last is not None and (now - last) < NO_AVAILABLE_ENTRIES_LOG_THROTTLE_SECONDS:
+        if (
+            last is not None
+            and (now - last) < NO_AVAILABLE_ENTRIES_LOG_THROTTLE_SECONDS
+        ):
             return
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
@@ -2099,9 +2231,14 @@ class CredentialPool:
 
         if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
             entry = available[0]
-            rotated = [candidate for candidate in self._entries if candidate.id != entry.id]
+            rotated = [
+                candidate for candidate in self._entries if candidate.id != entry.id
+            ]
             rotated.append(replace(entry, priority=len(self._entries) - 1))
-            self._entries = [replace(candidate, priority=idx) for idx, candidate in enumerate(rotated)]
+            self._entries = [
+                replace(candidate, priority=idx)
+                for idx, candidate in enumerate(rotated)
+            ]
             self._persist()
             self._current_id = entry.id
             return self.current() or entry
@@ -2143,18 +2280,22 @@ class CredentialPool:
             self._mark_exhausted(entry, status_code, error_context)
             # Re-read the updated entry to log the correct terminal state.
             updated_entry = next(
-                (e for e in self._entries if e.id == entry.id), entry,
+                (e for e in self._entries if e.id == entry.id),
+                entry,
             )
             if updated_entry.last_status == STATUS_DEAD:
                 logger.warning(
                     "credential pool: marking %s DEAD (status=%s, reason=%s) — "
                     "permanently failed, will NOT re-enter rotation until re-auth",
-                    _label, status_code, updated_entry.last_error_reason or "unknown",
+                    _label,
+                    status_code,
+                    updated_entry.last_error_reason or "unknown",
                 )
             else:
                 logger.info(
                     "credential pool: marking %s exhausted (status=%s), rotating",
-                    _label, status_code,
+                    _label,
+                    status_code,
                 )
             self._current_id = None
             next_entry = self._select_unlocked()
@@ -2173,7 +2314,9 @@ class CredentialPool:
         """
         with self._lock:
             if credential_id:
-                self._active_leases[credential_id] = self._active_leases.get(credential_id, 0) + 1
+                self._active_leases[credential_id] = (
+                    self._active_leases.get(credential_id, 0) + 1
+                )
                 self._current_id = credential_id
                 return credential_id
 
@@ -2182,13 +2325,17 @@ class CredentialPool:
                 return None
 
             below_cap = [
-                entry for entry in available
+                entry
+                for entry in available
                 if self._active_leases.get(entry.id, 0) < self._max_concurrent
             ]
             candidates = below_cap if below_cap else available
             chosen = min(
                 candidates,
-                key=lambda entry: (self._active_leases.get(entry.id, 0), entry.priority),
+                key=lambda entry: (
+                    self._active_leases.get(entry.id, 0),
+                    entry.priority,
+                ),
             )
             self._active_leases[chosen.id] = self._active_leases.get(chosen.id, 0) + 1
             self._current_id = chosen.id
@@ -2286,7 +2433,9 @@ class CredentialPool:
             self._current_id = None
         return removed
 
-    def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
+    def resolve_target(
+        self, target: Any
+    ) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
         raw = str(target or "").strip()
         if not raw:
             return None, None, "No credential target provided."
@@ -2303,7 +2452,11 @@ class CredentialPool:
         if len(label_matches) == 1:
             return label_matches[0][0], label_matches[0][1], None
         if len(label_matches) > 1:
-            return None, None, f'Ambiguous credential label "{raw}". Use the numeric index or entry id instead.'
+            return (
+                None,
+                None,
+                f'Ambiguous credential label "{raw}". Use the numeric index or entry id instead.',
+            )
         if raw.isdigit():
             index = int(raw)
             if 1 <= index <= len(self._entries):
@@ -2318,7 +2471,9 @@ class CredentialPool:
         return entry
 
 
-def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, payload: Dict[str, Any]) -> bool:
+def _upsert_entry(
+    entries: List[PooledCredential], provider: str, source: str, payload: Dict[str, Any]
+) -> bool:
     matching_indices = []
     for idx, entry in enumerate(entries):
         if entry.source == source:
@@ -2327,7 +2482,9 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
     existing_idx = matching_indices[0] if matching_indices else None
     duplicate_indices = set(matching_indices[1:])
     if duplicate_indices:
-        entries[:] = [entry for idx, entry in enumerate(entries) if idx not in duplicate_indices]
+        entries[:] = [
+            entry for idx, entry in enumerate(entries) if idx not in duplicate_indices
+        ]
 
     if existing_idx is None:
         payload.setdefault("id", uuid.uuid4().hex[:6])
@@ -2397,7 +2554,9 @@ def _normalize_pool_priorities(provider: str, entries: List[PooledCredential]) -
     return changed
 
 
-def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
+def _seed_from_singletons(
+    provider: str, entries: List[PooledCredential]
+) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
     auth_store = _load_auth_store()
@@ -2407,6 +2566,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
     try:
         from hermes_cli.auth import is_source_suppressed as _is_suppressed
     except ImportError:
+
         def _is_suppressed(_p, _s):  # type: ignore[misc]
             return False
 
@@ -2417,6 +2577,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # ~/.claude/.credentials.json without user consent.  See PR #4210.
         try:
             from hermes_cli.auth import is_provider_explicitly_configured
+
             if not is_provider_explicitly_configured("anthropic"):
                 return changed, active_sources
         except ImportError:
@@ -2444,8 +2605,8 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             return (_env_file.get(key) or _get_secret(key, "") or "").strip()
 
         anthropic_api_key = _env_val("ANTHROPIC_API_KEY")
-        anthropic_oauth_env = (
-            _env_val("ANTHROPIC_TOKEN") or _env_val("CLAUDE_CODE_OAUTH_TOKEN")
+        anthropic_oauth_env = _env_val("ANTHROPIC_TOKEN") or _env_val(
+            "CLAUDE_CODE_OAUTH_TOKEN"
         )
         api_key_path_explicit = bool(anthropic_api_key and not anthropic_oauth_env)
 
@@ -2456,7 +2617,8 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             # OAuth entries dormant in auth.json forever and rotation on a
             # transient 401 could revive them.
             retained = [
-                entry for entry in entries
+                entry
+                for entry in entries
                 if entry.source not in {"hermes_pkce", "claude_code"}
             ]
             if len(retained) != len(entries):
@@ -2464,7 +2626,10 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                 changed = True
             return changed, active_sources
 
-        from agent.anthropic_adapter import read_claude_code_credentials, read_hermes_oauth_credentials
+        from agent.anthropic_adapter import (
+            read_claude_code_credentials,
+            read_hermes_oauth_credentials,
+        )
 
         for source_name, creds in (
             ("hermes_pkce", read_hermes_oauth_credentials()),
@@ -2484,7 +2649,9 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                         "access_token": creds.get("accessToken", ""),
                         "refresh_token": creds.get("refreshToken"),
                         "expires_at_ms": creds.get("expiresAt"),
-                        "label": label_from_token(creds.get("accessToken", ""), source_name),
+                        "label": label_from_token(
+                            creds.get("accessToken", ""), source_name
+                        ),
                     },
                 )
 
@@ -2499,13 +2666,18 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         )
         if state and not has_runtime_material:
             retained = [
-                entry for entry in entries
+                entry
+                for entry in entries
                 if entry.source not in {"device_code", "manual:device_code"}
             ]
             if len(retained) != len(entries):
                 entries[:] = retained
                 changed = True
-        if state and has_runtime_material and not _is_suppressed(provider, "device_code"):
+        if (
+            state
+            and has_runtime_material
+            and not _is_suppressed(provider, "device_code")
+        ):
             active_sources.add("device_code")
             # Prefer a user-supplied label embedded in the singleton state
             # (set by persist_nous_credentials(label=...) when the user ran
@@ -2544,7 +2716,9 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     "agent_key_expires_in": state.get("agent_key_expires_in"),
                     "agent_key_reused": state.get("agent_key_reused"),
                     "agent_key_obtained_at": state.get("agent_key_obtained_at"),
-                    "tls": state.get("tls") if isinstance(state.get("tls"), dict) else None,
+                    "tls": state.get("tls")
+                    if isinstance(state.get("tls"), dict)
+                    else None,
                     "label": seeded_label,
                 },
             )
@@ -2554,7 +2728,11 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # env vars (COPILOT_GITHUB_TOKEN / GH_TOKEN).  They don't live in
         # the auth store or credential pool, so we resolve them here.
         try:
-            from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
+            from hermes_cli.copilot_auth import (
+                resolve_copilot_token,
+                get_copilot_api_token,
+            )
+
             token, source = resolve_copilot_token()
             if token:
                 api_token, enterprise_base_url = get_copilot_api_token(token)
@@ -2590,6 +2768,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # pool loading / provider discovery.
         try:
             from hermes_cli.auth import resolve_qwen_runtime_credentials
+
             creds = resolve_qwen_runtime_credentials(refresh_if_expiring=False)
             token = creds.get("api_key", "")
             if token:
@@ -2633,12 +2812,15 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     if raw_expires:
                         try:
                             from datetime import datetime as _dt
+
                             expires_at_ms = int(
                                 _dt.fromisoformat(raw_expires).timestamp() * 1000
                             )
                         except Exception:
                             expires_at_ms = None
-                    base_url = str(state.get("inference_base_url", "") or "").rstrip("/")
+                    base_url = str(state.get("inference_base_url", "") or "").rstrip(
+                        "/"
+                    )
                     payload = {
                         "source": source_name,
                         "auth_type": AUTH_TYPE_OAUTH,
@@ -2646,9 +2828,8 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                         "expires_at": raw_expires or None,
                         "expires_at_ms": expires_at_ms,
                         "base_url": base_url,
-                        "label": state.get("label", "") or label_from_token(
-                            state.get("access_token", ""), source_name
-                        ),
+                        "label": state.get("label", "")
+                        or label_from_token(state.get("access_token", ""), source_name),
                     }
                     # Record whether this seeded entry is borrowed from the
                     # global-root fallback.  The credential-pool disk boundary
@@ -2700,7 +2881,8 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     "refresh_token": tokens.get("refresh_token"),
                     "base_url": "https://chatgpt.com/backend-api/codex",
                     "last_refresh": state.get("last_refresh"),
-                    "label": custom_label or label_from_token(tokens.get("access_token", ""), "device_code"),
+                    "label": custom_label
+                    or label_from_token(tokens.get("access_token", ""), "device_code"),
                 },
             )
 
@@ -2740,7 +2922,9 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
     return changed, active_sources
 
 
-def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
+def _seed_from_env(
+    provider: str, entries: List[PooledCredential]
+) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
 
@@ -2773,12 +2957,14 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     try:
         from hermes_cli.auth import is_source_suppressed as _is_source_suppressed
     except ImportError:
+
         def _is_source_suppressed(_p, _s):  # type: ignore[misc]
             return False
 
     def _secret_source_for_env(env_var: str) -> Optional[str]:
         try:
             from hermes_cli.env_loader import get_secret_source
+
             source_label = get_secret_source(env_var)
         except Exception:
             source_label = None
@@ -2852,7 +3038,9 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         active_sources.add(source)
         base_url = env_url or pconfig.inference_base_url
         if provider == "kimi-coding":
-            base_url = _resolve_kimi_base_url(token, pconfig.inference_base_url, env_url)
+            base_url = _resolve_kimi_base_url(
+                token, pconfig.inference_base_url, env_url
+            )
         elif provider == "zai":
             base_url = _resolve_zai_base_url(token, pconfig.inference_base_url, env_url)
         changed |= _upsert_entry(
@@ -2904,7 +3092,9 @@ def _prune_stale_seeded_entries(
     return True
 
 
-def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
+def _seed_custom_pool(
+    pool_key: str, entries: List[PooledCredential]
+) -> Tuple[bool, Set[str]]:
     """Seed a custom endpoint pool from custom_providers config and model config."""
     changed = False
     active_sources: Set[str] = set()
@@ -2913,6 +3103,7 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
     try:
         from hermes_cli.auth import is_source_suppressed as _is_suppressed
     except ImportError:
+
         def _is_suppressed(_p, _s):  # type: ignore[misc]
             return False
 
@@ -2997,7 +3188,8 @@ def load_pool(provider: str) -> CredentialPool:
             provider,
             payload.get("access_token"),
             payload.get("auth_type", AUTH_TYPE_API_KEY),
-        ) != payload.get("auth_type", AUTH_TYPE_API_KEY)
+        )
+        != payload.get("auth_type", AUTH_TYPE_API_KEY)
         for payload in raw_entries
     )
     if raw_needs_auth_normalization:
@@ -3005,13 +3197,17 @@ def load_pool(provider: str) -> CredentialPool:
         # Keep that fallback read-only: only the store that owns these rows may
         # rewrite them. Loading the default/root profile will heal global rows.
         active_pool = _load_auth_store().get("credential_pool")
-        active_entries = active_pool.get(provider) if isinstance(active_pool, dict) else None
+        active_entries = (
+            active_pool.get(provider) if isinstance(active_pool, dict) else None
+        )
         raw_needs_auth_normalization = bool(active_entries)
 
     if provider.startswith(CUSTOM_POOL_PREFIX):
         # Custom endpoint pool — seed from custom_providers config and model config
         custom_changed, custom_sources = _seed_custom_pool(provider, entries)
-        changed = raw_needs_sanitization or raw_needs_auth_normalization or custom_changed
+        changed = (
+            raw_needs_sanitization or raw_needs_auth_normalization or custom_changed
+        )
         changed |= _prune_stale_seeded_entries(entries, custom_sources)
     else:
         singleton_changed, singleton_sources = _seed_from_singletons(provider, entries)
@@ -3037,7 +3233,10 @@ def load_pool(provider: str) -> CredentialPool:
         new_ids = {entry.id for entry in entries}
         write_credential_pool(
             provider,
-            [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
+            [
+                entry.to_dict()
+                for entry in sorted(entries, key=lambda item: item.priority)
+            ],
             removed_ids=disk_ids - new_ids,
         )
     return CredentialPool(provider, entries)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -8372,6 +8372,14 @@ def _refresh_minimax_oauth_state(
     ``source_path`` + ``set_active=False`` let source-aware callers persist
     borrowed-root grants back to global root without creating a profile-local
     shadow or flipping ``active_provider`` on a background refresh.
+
+    When ``source_path`` points at a different auth store than the active
+    profile (borrowed-root profile sessions), the whole
+    sync→POST→write-back runs inside ``_provider_state_transaction`` so two
+    distinct profiles sharing one root grant cannot both POST the same
+    single-use refresh token.  If the authoritative source was removed while
+    waiting for the lock, we fail closed instead of resurrecting stale
+    credentials.
     """
     if not state.get("refresh_token"):
         raise AuthError(
@@ -8380,6 +8388,64 @@ def _refresh_minimax_oauth_state(
             code="no_refresh_token",
             relogin_required=True,
         )
+
+    active_path = _auth_file_path()
+    target_is_root = source_path is not None and not _same_path(
+        source_path, active_path
+    )
+
+    def _needs_refresh(_state: Dict[str, Any]) -> bool:
+        try:
+            expires_at = datetime.fromisoformat(
+                _state.get("expires_at", "")
+            ).timestamp()
+        except Exception:
+            expires_at = 0.0
+        now = time.time()
+        return force or (expires_at - now) <= MINIMAX_OAUTH_REFRESH_SKEW_SECONDS
+
+    if target_is_root:
+        lock_timeout = max(float(AUTH_LOCK_TIMEOUT_SECONDS), timeout_seconds + 5.0)
+        with _provider_state_transaction(
+            "minimax-oauth", timeout_seconds=lock_timeout
+        ) as (_auth_store, source_state, source_path):
+            if not isinstance(source_state, dict):
+                logger.debug(
+                    "MiniMax OAuth: source state disappeared while waiting for "
+                    "the source lock; failing closed instead of resurrecting"
+                )
+                raise AuthError(
+                    "MiniMax OAuth session was removed; please re-login.",
+                    provider="minimax-oauth",
+                    code="not_logged_in",
+                    relogin_required=True,
+                )
+            if not _needs_refresh(source_state):
+                return source_state
+            try:
+                updated_fields = refresh_minimax_oauth_pure(
+                    source_state, timeout_seconds=timeout_seconds
+                )
+            except AuthError as exc:
+                if _is_terminal_minimax_oauth_refresh_error(exc):
+                    quarantined = dict(source_state)
+                    _minimax_oauth_quarantine_on_terminal_refresh(
+                        quarantined, exc, persist=False
+                    )
+                    _persist_provider_state_to_store(
+                        "minimax-oauth",
+                        quarantined,
+                        source_path,
+                        set_active=False,
+                    )
+                raise
+            new_state = dict(source_state)
+            new_state.update(updated_fields)
+            _persist_provider_state_to_store(
+                "minimax-oauth", new_state, source_path, set_active=set_active
+            )
+            return new_state
+
     try:
         expires_at = datetime.fromisoformat(state.get("expires_at", "")).timestamp()
     except Exception:
@@ -8392,6 +8458,8 @@ def _refresh_minimax_oauth_state(
     new_state = dict(state)
     new_state.update(updated_fields)
     _minimax_save_auth_state(new_state, source_path=source_path, set_active=set_active)
+    return new_state
+
     return new_state
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7774,25 +7774,35 @@ def _minimax_oauth_login(
     return auth_state
 
 
-def _refresh_minimax_oauth_state(
+def refresh_minimax_oauth_pure(
     state: Dict[str, Any], *, timeout_seconds: float = 15.0,
-    force: bool = False,
 ) -> Dict[str, Any]:
-    """Refresh MiniMax OAuth access token if close to expiry (or forced)."""
-    if not state.get("refresh_token"):
+    """Refresh MiniMax OAuth tokens WITHOUT mutating Hermes auth state.
+
+    Mirrors :func:`refresh_codex_oauth_pure` / :func:`refresh_xai_oauth_pure`:
+    performs the single token-endpoint POST and returns a dict of updated
+    fields (``access_token``, ``refresh_token``, ``obtained_at``,
+    ``expires_at``, ``expires_in``). The caller — either the eager-resolve
+    path (:func:`_refresh_minimax_oauth_state`) or the credential-pool refresh
+    path — is responsible for persisting the result under the appropriate
+    lock. Splitting the POST from the save lets the pool path hold the shared
+    cross-process ``_auth_store_lock`` across the whole sync → POST →
+    write-back sequence, so two profiles sharing the same MiniMax OAuth grant
+    cannot both POST the same single-use refresh token (issue #48415, the
+    MiniMax analog of the Codex/xAI hazard).
+    """
+    refresh_token = state.get("refresh_token")
+    if not refresh_token:
         raise AuthError(
             "MiniMax OAuth state has no refresh_token; please re-login.",
             provider="minimax-oauth", code="no_refresh_token", relogin_required=True,
         )
-    try:
-        expires_at = datetime.fromisoformat(state.get("expires_at", "")).timestamp()
-    except Exception:
-        expires_at = 0.0
-    now = time.time()
-    if not force and (expires_at - now) > MINIMAX_OAUTH_REFRESH_SKEW_SECONDS:
-        return state
-
-    portal_base_url = state["portal_base_url"]
+    portal_base_url = state.get("portal_base_url")
+    if not portal_base_url:
+        raise AuthError(
+            "MiniMax OAuth state has no portal_base_url; please re-login.",
+            provider="minimax-oauth", code="no_portal_base_url", relogin_required=True,
+        )
     with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
                       follow_redirects=True) as client:
         response = client.post(
@@ -7800,7 +7810,7 @@ def _refresh_minimax_oauth_state(
             data={
                 "grant_type": "refresh_token",
                 "client_id": state["client_id"],
-                "refresh_token": state["refresh_token"],
+                "refresh_token": refresh_token,
             },
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
@@ -7828,16 +7838,71 @@ def _refresh_minimax_oauth_state(
         int(payload["expired_in"]), now=now_dt,
     )
     expires_in_s = max(0, int(expires_at_unix - now_dt.timestamp()))
-    new_state = dict(state)
-    new_state.update({
+    return {
         "access_token": payload["access_token"],
         "refresh_token": payload.get("refresh_token", state["refresh_token"]),
         "obtained_at": now_dt.isoformat(),
         "expires_at": datetime.fromtimestamp(expires_at_unix, tz=timezone.utc).isoformat(),
         "expires_in": expires_in_s,
-    })
+    }
+
+
+def _refresh_minimax_oauth_state(
+    state: Dict[str, Any], *, timeout_seconds: float = 15.0,
+    force: bool = False,
+) -> Dict[str, Any]:
+    """Refresh MiniMax OAuth access token if close to expiry (or forced).
+
+    Thin save-through wrapper over :func:`refresh_minimax_oauth_pure`. The
+    POST-and-save lives here for the eager-resolve path; the credential-pool
+    refresh path calls the pure function directly so it can serialize the
+    whole sequence under ``_auth_store_lock``.
+    """
+    if not state.get("refresh_token"):
+        raise AuthError(
+            "MiniMax OAuth state has no refresh_token; please re-login.",
+            provider="minimax-oauth", code="no_refresh_token", relogin_required=True,
+        )
+    try:
+        expires_at = datetime.fromisoformat(state.get("expires_at", "")).timestamp()
+    except Exception:
+        expires_at = 0.0
+    now = time.time()
+    if not force and (expires_at - now) > MINIMAX_OAUTH_REFRESH_SKEW_SECONDS:
+        return state
+
+    updated_fields = refresh_minimax_oauth_pure(state, timeout_seconds=timeout_seconds)
+    new_state = dict(state)
+    new_state.update(updated_fields)
     _minimax_save_auth_state(new_state)
     return new_state
+
+
+def _is_terminal_minimax_oauth_refresh_error(exc: Exception) -> bool:
+    """True when retrying the same MiniMax OAuth refresh token cannot succeed.
+
+    Mirrors :func:`_is_terminal_xai_oauth_refresh_error` /
+    :func:`_is_terminal_codex_oauth_refresh_error`. ``refresh_failed`` covers
+    HTTP non-200 from the token endpoint with a body indicating
+    ``invalid_grant`` / ``refresh_token_reused`` / ``invalid_refresh_token``
+    (all flagged ``relogin_required=True``); ``no_refresh_token`` and
+    ``no_portal_base_url`` mean the state is structurally unusable.
+    Transient failures (429 / 5xx / network) carry
+    ``relogin_required=False`` and do NOT qualify.
+    """
+    return (
+        isinstance(exc, AuthError)
+        and exc.provider == "minimax-oauth"
+        and exc.code in {
+            "refresh_failed",
+            "no_refresh_token",
+            "no_portal_base_url",
+            "invalid_grant",
+            "invalid_token",
+            "refresh_token_reused",
+        }
+        and bool(exc.relogin_required)
+    )
 
 
 def _minimax_oauth_quarantine_on_terminal_refresh(state: Dict[str, Any], exc: AuthError) -> None:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -93,6 +93,12 @@ MINIMAX_OAUTH_CN_BASE = "https://api.minimaxi.com"
 MINIMAX_OAUTH_GLOBAL_INFERENCE = "https://api.minimax.io/anthropic"
 MINIMAX_OAUTH_CN_INFERENCE = "https://api.minimaxi.com/anthropic"
 MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
+# Internal default for the MiniMax OAuth token-endpoint POST timeout.  Kept as
+# an internal constant (not a user-facing HERMES_* env var) because it mirrors
+# ``refresh_minimax_oauth_pure``'s default and is not a behavioral setting the
+# user should tune from .env — non-secret behavioral config belongs in
+# config.yaml, and this knob has no user-facing reason to be overridable.
+MINIMAX_OAUTH_REFRESH_TIMEOUT_SECONDS = 15.0
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
@@ -1233,15 +1239,20 @@ def _load_provider_state_with_source(
 
 
 @contextmanager
-def _provider_state_transaction(provider_id: str):
+def _provider_state_transaction(
+    provider_id: str, *, timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS
+):
     """Lock the active auth store and any global fallback source in order.
 
     Profile-backed refresh paths must take the global auth-store lock before
     any provider-specific shared-store lock. Re-reading the source after the
     target lock is acquired prevents both stale refreshes and whole-file lost
     updates without inverting the documented auth -> shared lock order.
+
+    ``timeout_seconds`` is forwarded to both lock acquisitions; callers that
+    need to cover a slow token-endpoint POST can raise it above the default.
     """
-    with _auth_store_lock():
+    with _auth_store_lock(timeout_seconds=timeout_seconds):
         auth_store = _load_auth_store()
         state, source_path = _load_provider_state_with_source(
             auth_store,
@@ -1252,7 +1263,7 @@ def _provider_state_transaction(provider_id: str):
             yield auth_store, state, source_path
             return
 
-        with _auth_store_lock(target_path=source_path):
+        with _auth_store_lock(target_path=source_path, timeout_seconds=timeout_seconds):
             source_store = _load_auth_store(source_path)
             source_providers = source_store.get("providers")
             source_state = None
@@ -7905,12 +7916,22 @@ def _is_terminal_minimax_oauth_refresh_error(exc: Exception) -> bool:
     )
 
 
-def _minimax_oauth_quarantine_on_terminal_refresh(state: Dict[str, Any], exc: AuthError) -> None:
+def _minimax_oauth_quarantine_on_terminal_refresh(
+    state: Dict[str, Any], exc: AuthError, *, persist: bool = True
+) -> None:
     """Wipe dead tokens from auth.json after a terminal refresh failure.
 
     Shared by both the eager-resolve path and the lazy per-request token
     provider. Mirrors the Nous / xAI-OAuth / Codex-OAuth quarantine pattern
     so subsequent calls fail fast without a network retry.
+
+    ``persist=False`` skips the internal ``_minimax_save_auth_state`` call
+    (which uses ``_save_provider_state`` and thereby sets
+    ``active_provider``). Callers that already hold a source-aware lock and
+    need to persist with ``set_active=False`` — e.g. the credential-pool
+    terminal-quarantine path, which must NOT flip ``active_provider`` on a
+    background refresh failure — mutate the state dict in place and then
+    save it themselves via ``_store_provider_state(..., set_active=False)``.
     """
     if not (exc.relogin_required and state.get("refresh_token")):
         return
@@ -7924,6 +7945,8 @@ def _minimax_oauth_quarantine_on_terminal_refresh(state: Dict[str, Any], exc: Au
         "relogin_required": True,
         "at": datetime.now(timezone.utc).isoformat(),
     }
+    if not persist:
+        return
     try:
         _minimax_save_auth_state(state)
     except Exception as _save_exc:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -80,9 +80,9 @@ NOUS_BILLING_MANAGE_SCOPE = "billing:manage"
 DEFAULT_NOUS_SCOPE = NOUS_INFERENCE_INVOKE_SCOPE
 NOUS_DEVICE_CODE_SOURCE = "device_code"
 NOUS_AUTH_PATH_INVOKE_JWT = "invoke_jwt"
-ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
+ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120  # refresh 2 min before expiry
 NOUS_INVOKE_JWT_MIN_TTL_SECONDS = ACCESS_TOKEN_REFRESH_SKEW_SECONDS
-DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
+DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1  # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_XAI_OAUTH_BASE_URL = "https://api.x.ai/v1"
 MINIMAX_OAUTH_CLIENT_ID = "78257093-7e40-4613-99e0-527b14b39113"
@@ -130,11 +130,15 @@ QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 DEFAULT_SPOTIFY_ACCOUNTS_BASE_URL = "https://accounts.spotify.com"
 DEFAULT_SPOTIFY_API_BASE_URL = "https://api.spotify.com/v1"
 DEFAULT_SPOTIFY_REDIRECT_URI = "http://127.0.0.1:43827/spotify/callback"
-SPOTIFY_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/user-guide/features/spotify"
+SPOTIFY_DOCS_URL = (
+    "https://hermes-agent.nousresearch.com/docs/user-guide/features/spotify"
+)
 SPOTIFY_DASHBOARD_URL = "https://developer.spotify.com/dashboard"
 SPOTIFY_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 
-OAUTH_OVER_SSH_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh"
+OAUTH_OVER_SSH_DOCS_URL = (
+    "https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh"
+)
 DEFAULT_SPOTIFY_SCOPE = " ".join((
     "user-modify-playback-state",
     "user-read-playback-state",
@@ -162,12 +166,16 @@ LMSTUDIO_NOAUTH_PLACEHOLDER = "dummy-lm-api-key"
 # Provider Registry
 # =============================================================================
 
+
 @dataclass
 class ProviderConfig:
     """Describes a known inference provider."""
+
     id: str
     name: str
-    auth_type: str  # "oauth_device_code", "oauth_external", "oauth_minimax", or "api_key"
+    auth_type: (
+        str  # "oauth_device_code", "oauth_external", "oauth_minimax", or "api_key"
+    )
     portal_base_url: str = ""
     inference_base_url: str = ""
     client_id: str = ""
@@ -312,15 +320,22 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=MINIMAX_OAUTH_GLOBAL_INFERENCE,
         client_id=MINIMAX_OAUTH_CLIENT_ID,
         scope=MINIMAX_OAUTH_SCOPE,
-        extra={"region": "global", "cn_portal_base_url": MINIMAX_OAUTH_CN_BASE,
-               "cn_inference_base_url": MINIMAX_OAUTH_CN_INFERENCE},
+        extra={
+            "region": "global",
+            "cn_portal_base_url": MINIMAX_OAUTH_CN_BASE,
+            "cn_inference_base_url": MINIMAX_OAUTH_CN_INFERENCE,
+        },
     ),
     "anthropic": ProviderConfig(
         id="anthropic",
         name="Anthropic",
         auth_type="api_key",
         inference_base_url="https://api.anthropic.com",
-        api_key_env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+        api_key_env_vars=(
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+        ),
         base_url_env_var="ANTHROPIC_BASE_URL",
     ),
     "alibaba": ProviderConfig(
@@ -455,6 +470,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
 # plugins/model-providers/<name>/ plugin — no edits to this file required.
 try:
     from providers import list_providers as _list_providers_for_registry
+
     for _pp in _list_providers_for_registry():
         if _pp.name in PROVIDER_REGISTRY:
             continue
@@ -465,10 +481,24 @@ try:
         # openrouter/custom are aggregator/user-supplied and handled outside
         # the registry — adding them here breaks runtime_provider resolution
         # that relies on `openrouter not in PROVIDER_REGISTRY`).
-        if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
+        if _pp.name in {
+            "copilot",
+            "kimi-coding",
+            "kimi-coding-cn",
+            "zai",
+            "openrouter",
+            "custom",
+        }:
             continue
-        _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
-        _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
+        _api_key_vars = tuple(
+            v
+            for v in _pp.env_vars
+            if not v.endswith("_BASE_URL") and not v.endswith("_URL")
+        )
+        _base_url_var = next(
+            (v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")),
+            None,
+        )
         PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
             id=_pp.name,
             name=_pp.display_name or _pp.name,
@@ -488,6 +518,7 @@ except Exception:
 # =============================================================================
 # Anthropic Key Helper
 # =============================================================================
+
 
 def get_anthropic_key() -> str:
     """Return the first usable Anthropic credential, or ``""``.
@@ -542,7 +573,6 @@ def _resolve_kimi_base_url(api_key: str, default_url: str, env_override: str) ->
     return default_url
 
 
-
 _PLACEHOLDER_SECRET_VALUES = {
     "*",
     "**",
@@ -578,7 +608,11 @@ def _resolve_api_key_provider_secret(
     if provider_id == "copilot":
         # Use the dedicated copilot auth module for proper token validation
         try:
-            from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
+            from hermes_cli.copilot_auth import (
+                resolve_copilot_token,
+                get_copilot_api_token,
+            )
+
             token, source = resolve_copilot_token()
             if token:
                 api_token, _base_url = get_copilot_api_token(token)
@@ -590,6 +624,7 @@ def _resolve_api_key_provider_secret(
         return "", ""
 
     from hermes_cli.config import get_env_value_prefer_dotenv
+
     for env_var in pconfig.api_key_env_vars:
         # Prefer ~/.hermes/.env over os.environ so a deliberate key rotation
         # in the user's .env file isn't shadowed by a stale shell export
@@ -601,11 +636,14 @@ def _resolve_api_key_provider_secret(
     # Fallback: try credential pool (e.g. zai key stored via auth.json)
     try:
         from agent.credential_pool import load_pool
+
         pool = load_pool(provider_id)
         if pool and pool.has_credentials():
             entry = pool.peek()
             if entry:
-                key = getattr(entry, "access_token", "") or getattr(entry, "runtime_api_key", "")
+                key = getattr(entry, "access_token", "") or getattr(
+                    entry, "runtime_api_key", ""
+                )
                 key = str(key).strip()
                 if has_usable_secret(key):
                     return key, f"credential_pool:{provider_id}"
@@ -628,10 +666,20 @@ def _resolve_api_key_provider_secret(
 
 ZAI_ENDPOINTS = [
     # (id, base_url, probe_models, label)
-    ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
-    ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
-    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    ("global", "https://api.z.ai/api/paas/v4", ["glm-5"], "Global"),
+    ("cn", "https://open.bigmodel.cn/api/paas/v4", ["glm-5"], "China"),
+    (
+        "coding-global",
+        "https://api.z.ai/api/coding/paas/v4",
+        ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"],
+        "Global (Coding Plan)",
+    ),
+    (
+        "coding-cn",
+        "https://open.bigmodel.cn/api/coding/paas/v4",
+        ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"],
+        "China (Coding Plan)",
+    ),
 ]
 
 
@@ -660,16 +708,28 @@ def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str
                     timeout=timeout,
                 )
                 if resp.status_code == 200:
-                    logger.debug("Z.AI endpoint probe: %s (%s) model=%s OK", ep_id, base_url, model)
+                    logger.debug(
+                        "Z.AI endpoint probe: %s (%s) model=%s OK",
+                        ep_id,
+                        base_url,
+                        model,
+                    )
                     return {
                         "id": ep_id,
                         "base_url": base_url,
                         "model": model,
                         "label": label,
                     }
-                logger.debug("Z.AI endpoint probe: %s model=%s returned %s", ep_id, model, resp.status_code)
+                logger.debug(
+                    "Z.AI endpoint probe: %s model=%s returned %s",
+                    ep_id,
+                    model,
+                    resp.status_code,
+                )
             except Exception as exc:
-                logger.debug("Z.AI endpoint probe: %s model=%s failed: %s", ep_id, model, exc)
+                logger.debug(
+                    "Z.AI endpoint probe: %s model=%s failed: %s", ep_id, model, exc
+                )
     return None
 
 
@@ -726,11 +786,20 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
                 # set_active=False: this runs from credential-pool env seeding
                 # (agent/credential_pool.py) for ANY user with a Z.AI key in env,
                 # and caching a probe result must not flip their active provider.
-                _store_provider_state(auth_store, "zai", state_under_lock, set_active=False)
+                _store_provider_state(
+                    auth_store, "zai", state_under_lock, set_active=False
+                )
                 _save_auth_store(auth_store)
         except Exception as exc:
-            logger.warning("Z.AI: could not persist detected endpoint (%s); will re-probe next start", exc)
-        logger.info("Z.AI: auto-detected endpoint %s (%s)", detected["label"], detected["base_url"])
+            logger.warning(
+                "Z.AI: could not persist detected endpoint (%s); will re-probe next start",
+                exc,
+            )
+        logger.info(
+            "Z.AI: auto-detected endpoint %s (%s)",
+            detected["label"],
+            detected["base_url"],
+        )
         return detected["base_url"]
 
     logger.debug("Z.AI: probe failed, falling back to default %s", default_url)
@@ -883,19 +952,24 @@ def _oauth_trace_enabled() -> bool:
     return raw in {"1", "true", "yes", "on"}
 
 
-def _oauth_trace(event: str, *, sequence_id: Optional[str] = None, **fields: Any) -> None:
+def _oauth_trace(
+    event: str, *, sequence_id: Optional[str] = None, **fields: Any
+) -> None:
     if not _oauth_trace_enabled():
         return
     payload: Dict[str, Any] = {"event": event}
     if sequence_id:
         payload["sequence_id"] = sequence_id
     payload.update(fields)
-    logger.info("oauth_trace %s", json.dumps(payload, sort_keys=True, ensure_ascii=False))
+    logger.info(
+        "oauth_trace %s", json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    )
 
 
 # =============================================================================
 # Auth Store — persistence layer for ~/.hermes/auth.json
 # =============================================================================
+
 
 def _auth_file_path() -> Path:
     path = get_hermes_home() / "auth.json"
@@ -931,6 +1005,7 @@ def _global_auth_file_path() -> Optional[Path]:
     """
     try:
         from hermes_constants import get_default_hermes_root
+
         global_root = get_default_hermes_root()
     except Exception:
         return None
@@ -1102,7 +1177,9 @@ def _auth_store_lock(
     against a concurrent import on the shared store.
     """
     auth_path = target_path if target_path is not None else _auth_file_path()
-    lock_path = auth_path.with_suffix(".lock") if target_path is not None else _auth_lock_path()
+    lock_path = (
+        auth_path.with_suffix(".lock") if target_path is not None else _auth_lock_path()
+    )
     with _file_lock(
         lock_path,
         _auth_lock_holder_for(auth_path),
@@ -1123,13 +1200,16 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         corrupt_path = auth_file.with_suffix(".json.corrupt")
         try:
             import shutil
+
             shutil.copy2(auth_file, corrupt_path)
         except Exception:
             pass
         logger.warning(
             "auth: failed to parse %s (%s) — starting with empty store. "
             "Corrupt file preserved at %s",
-            auth_file, exc, corrupt_path,
+            auth_file,
+            exc,
+            corrupt_path,
         )
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
@@ -1148,13 +1228,18 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         providers = {}
         if "nous_portal" in systems:
             providers["nous"] = systems["nous_portal"]
-        return {"version": AUTH_STORE_VERSION, "providers": providers,
-                "active_provider": "nous" if providers else None}
+        return {
+            "version": AUTH_STORE_VERSION,
+            "providers": providers,
+            "active_provider": "nous" if providers else None,
+        }
 
     return {"version": AUTH_STORE_VERSION, "providers": {}}
 
 
-def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = None) -> Path:
+def _save_auth_store(
+    auth_store: Dict[str, Any], target_path: Optional[Path] = None
+) -> Path:
     # target_path=None preserves the existing contract (write the active
     # store at _auth_file_path()). An explicit path lets callers persist a
     # specific store — e.g. the global-root write-through for rotating xAI
@@ -1169,7 +1254,9 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
     payload = json.dumps(auth_store, indent=2) + "\n"
-    tmp_path = auth_file.with_name(f"{auth_file.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    tmp_path = auth_file.with_name(
+        f"{auth_file.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+    )
     try:
         # Create with 0o600 atomically via os.open(O_EXCL) + fdopen to close
         # the TOCTOU window where default umask (often 0o644) briefly exposed
@@ -1274,7 +1361,9 @@ def _provider_state_transaction(
             yield auth_store, source_state, source_path
 
 
-def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Optional[Dict[str, Any]]:
+def _load_provider_state(
+    auth_store: Dict[str, Any], provider_id: str
+) -> Optional[Dict[str, Any]]:
     """Return a provider's persisted state.
 
     In profile mode, falls back to the global-root ``auth.json`` when the
@@ -1289,7 +1378,9 @@ def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Option
     return state
 
 
-def _save_provider_state(auth_store: Dict[str, Any], provider_id: str, state: Dict[str, Any]) -> None:
+def _save_provider_state(
+    auth_store: Dict[str, Any], provider_id: str, state: Dict[str, Any]
+) -> None:
     providers = auth_store.setdefault("providers", {})
     if not isinstance(providers, dict):
         auth_store["providers"] = {}
@@ -1309,7 +1400,9 @@ def _save_provider_state_to_source(
     if source_path is None:
         source_path = active_path
     try:
-        same_store = source_path.resolve(strict=False) == active_path.resolve(strict=False)
+        same_store = source_path.resolve(strict=False) == active_path.resolve(
+            strict=False
+        )
     except Exception:
         same_store = source_path == active_path
     if same_store:
@@ -1487,7 +1580,8 @@ def write_credential_pool(
             auth_store["credential_pool"] = pool
         sanitized_entries = [
             sanitize_borrowed_credential_payload(entry, provider_id)
-            if isinstance(entry, dict) else entry
+            if isinstance(entry, dict)
+            else entry
             for entry in entries
         ]
         existing = pool.get(provider_id)
@@ -1602,6 +1696,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     # 2. Check config.yaml model.provider
     try:
         from hermes_cli.config import load_config
+
         cfg = load_config()
         model_cfg = cfg.get("model")
         if isinstance(model_cfg, dict):
@@ -1621,6 +1716,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     # Both expose .auth_type and .api_key_env_vars with the same shape.
     if pconfig is None:
         from hermes_cli.providers import get_provider
+
         pconfig = get_provider(normalized)
     if pconfig and pconfig.auth_type == "api_key":
         for env_var in pconfig.api_key_env_vars:
@@ -1648,10 +1744,12 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
                 if env_var and has_usable_secret(os.getenv(env_var, "")):
                     return True
                 continue
-            if (
-                source in {"device_code", "loopback_pkce", "hermes_pkce", "manual"}
-                or source.startswith("manual:")
-            ):
+            if source in {
+                "device_code",
+                "loopback_pkce",
+                "hermes_pkce",
+                "manual",
+            } or source.startswith("manual:"):
                 return True
     except Exception:
         pass
@@ -1724,6 +1822,7 @@ def _get_config_hint_for_unknown_provider(provider_name: str) -> str:
     """
     try:
         from hermes_cli.config import validate_config_structure
+
         issues = validate_config_structure()
         if not issues:
             return ""
@@ -1765,44 +1864,87 @@ def resolve_provider(
 
     # Normalize provider aliases
     _PROVIDER_ALIASES = {
-        "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
-        "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
-        "x-ai": "xai", "x.ai": "xai", "grok": "xai",
-        "xai-oauth": "xai-oauth", "x-ai-oauth": "xai-oauth",
-        "grok-oauth": "xai-oauth", "xai-grok-oauth": "xai-oauth",
-        "kimi": "kimi-coding", "kimi-for-coding": "kimi-coding", "moonshot": "kimi-coding",
-        "kimi-cn": "kimi-coding-cn", "moonshot-cn": "kimi-coding-cn",
-        "step": "stepfun", "stepfun-coding-plan": "stepfun",
-        "arcee-ai": "arcee", "arceeai": "arcee",
-        "gmi-cloud": "gmi", "gmicloud": "gmi",
-        "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
-        "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
-        "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
+        "glm": "zai",
+        "z-ai": "zai",
+        "z.ai": "zai",
+        "zhipu": "zai",
+        "google": "gemini",
+        "google-gemini": "gemini",
+        "google-ai-studio": "gemini",
+        "x-ai": "xai",
+        "x.ai": "xai",
+        "grok": "xai",
+        "xai-oauth": "xai-oauth",
+        "x-ai-oauth": "xai-oauth",
+        "grok-oauth": "xai-oauth",
+        "xai-grok-oauth": "xai-oauth",
+        "kimi": "kimi-coding",
+        "kimi-for-coding": "kimi-coding",
+        "moonshot": "kimi-coding",
+        "kimi-cn": "kimi-coding-cn",
+        "moonshot-cn": "kimi-coding-cn",
+        "step": "stepfun",
+        "stepfun-coding-plan": "stepfun",
+        "arcee-ai": "arcee",
+        "arceeai": "arcee",
+        "gmi-cloud": "gmi",
+        "gmicloud": "gmi",
+        "minimax-china": "minimax-cn",
+        "minimax_cn": "minimax-cn",
+        "minimax-portal": "minimax-oauth",
+        "minimax-global": "minimax-oauth",
+        "minimax_oauth": "minimax-oauth",
+        "alibaba_coding": "alibaba-coding-plan",
+        "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
-        "claude": "anthropic", "claude-code": "anthropic",
-        "github": "copilot", "github-copilot": "copilot",
-        "github-models": "copilot", "github-model": "copilot",
-        "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
-        "opencode": "opencode-zen", "zen": "opencode-zen",
-        "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
-        "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
-        "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
-        "tencent": "tencent-tokenhub", "tokenhub": "tencent-tokenhub",
-        "tencent-cloud": "tencent-tokenhub", "tencentmaas": "tencent-tokenhub",
-        "aws": "bedrock", "aws-bedrock": "bedrock", "amazon-bedrock": "bedrock", "amazon": "bedrock",
-        "go": "opencode-go", "opencode-go-sub": "opencode-go",
-        "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
-        "lmstudio": "lmstudio", "lm-studio": "lmstudio", "lm_studio": "lmstudio",
+        "claude": "anthropic",
+        "claude-code": "anthropic",
+        "github": "copilot",
+        "github-copilot": "copilot",
+        "github-models": "copilot",
+        "github-model": "copilot",
+        "github-copilot-acp": "copilot-acp",
+        "copilot-acp-agent": "copilot-acp",
+        "opencode": "opencode-zen",
+        "zen": "opencode-zen",
+        "qwen-portal": "qwen-oauth",
+        "qwen-cli": "qwen-oauth",
+        "qwen-oauth": "qwen-oauth",
+        "hf": "huggingface",
+        "hugging-face": "huggingface",
+        "huggingface-hub": "huggingface",
+        "mimo": "xiaomi",
+        "xiaomi-mimo": "xiaomi",
+        "tencent": "tencent-tokenhub",
+        "tokenhub": "tencent-tokenhub",
+        "tencent-cloud": "tencent-tokenhub",
+        "tencentmaas": "tencent-tokenhub",
+        "aws": "bedrock",
+        "aws-bedrock": "bedrock",
+        "amazon-bedrock": "bedrock",
+        "amazon": "bedrock",
+        "go": "opencode-go",
+        "opencode-go-sub": "opencode-go",
+        "kilo": "kilocode",
+        "kilo-code": "kilocode",
+        "kilo-gateway": "kilocode",
+        "lmstudio": "lmstudio",
+        "lm-studio": "lmstudio",
+        "lm_studio": "lmstudio",
         # Local server aliases — route through the generic custom provider
-        "ollama": "custom", "ollama_cloud": "ollama-cloud",
-        "vllm": "custom", "llamacpp": "custom",
-        "llama.cpp": "custom", "llama-cpp": "custom",
+        "ollama": "custom",
+        "ollama_cloud": "ollama-cloud",
+        "vllm": "custom",
+        "llamacpp": "custom",
+        "llama.cpp": "custom",
+        "llama-cpp": "custom",
     }
     # Extend with aliases declared in plugins/model-providers/<name>/ that aren't already mapped.
     # This keeps providers/ as the single source for new aliases while the
     # hardcoded dict above remains authoritative for existing ones.
     try:
         from providers import list_providers as _lp
+
         for _pp in _lp():
             for _alias in _pp.aliases:
                 if _alias not in _PROVIDER_ALIASES:
@@ -1847,12 +1989,19 @@ def resolve_provider(
         _model_cfg = (load_config() or {}).get("model")
         if isinstance(_model_cfg, dict):
             _cfg_provider = _model_cfg.get("provider")
-            if isinstance(_cfg_provider, str) and _cfg_provider.strip().lower() in PROVIDER_REGISTRY:
+            if (
+                isinstance(_cfg_provider, str)
+                and _cfg_provider.strip().lower() in PROVIDER_REGISTRY
+            ):
                 return _cfg_provider.strip().lower()
     except Exception as e:
-        logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
+        logger.debug(
+            "Could not read config.yaml model.provider for auto-resolution: %s", e
+        )
 
-    if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
+    if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(
+        os.getenv("OPENROUTER_API_KEY")
+    ):
         return "openrouter"
 
     # Auto-detect an OpenRouter credential added via `hermes auth add openrouter`
@@ -1877,7 +2026,11 @@ def resolve_provider(
     try:
         _store = _load_auth_store()
         _maybe = _store.get("active_provider")
-        if _maybe and _maybe in PROVIDER_REGISTRY and get_auth_status(_maybe).get("logged_in"):
+        if (
+            _maybe
+            and _maybe in PROVIDER_REGISTRY
+            and get_auth_status(_maybe).get("logged_in")
+        ):
             _oauth_active = _maybe
     except Exception as e:
         logger.debug("Could not pre-read active auth provider: %s", e)
@@ -1906,7 +2059,10 @@ def resolve_provider(
                         "logged-in OAuth provider %r. If you meant to use the "
                         "OAuth login, unset %s or set `model.provider` "
                         "explicitly.",
-                        pid, env_var, _oauth_active, env_var,
+                        pid,
+                        env_var,
+                        _oauth_active,
+                        env_var,
                     )
                 return pid
 
@@ -1918,7 +2074,11 @@ def resolve_provider(
     if _oauth_active:
         # Surface the silent-override case the issue reported: a populated
         # `model` config that lacks a `provider` key falls through to OAuth.
-        if isinstance(_model_cfg, dict) and _model_cfg and not _model_cfg.get("provider"):
+        if (
+            isinstance(_model_cfg, dict)
+            and _model_cfg
+            and not _model_cfg.get("provider")
+        ):
             logger.warning(
                 "Provider resolved to logged-in OAuth provider %r because "
                 "config.yaml `model` has no `provider` key. If you meant a "
@@ -1931,6 +2091,7 @@ def resolve_provider(
     # This runs after API-key providers so explicit keys always win.
     try:
         from agent.bedrock_adapter import has_aws_credentials
+
         if has_aws_credentials():
             return "bedrock"
     except ImportError:
@@ -1947,6 +2108,7 @@ def resolve_provider(
 # =============================================================================
 # Timestamp / TTL helpers
 # =============================================================================
+
 
 def _parse_iso_timestamp(value: Any) -> Optional[float]:
     if not isinstance(value, str) or not value:
@@ -2011,7 +2173,8 @@ def _migrate_stale_nous_portal_url(providers: Dict[str, Any]) -> None:
         if parsed.hostname in _NOUS_STALE_PORTAL_HOSTS:
             logger.warning(
                 "auth: migrating stale nous portal_base_url %s -> %s",
-                stored, DEFAULT_NOUS_PORTAL_URL,
+                stored,
+                DEFAULT_NOUS_PORTAL_URL,
             )
             nous["portal_base_url"] = DEFAULT_NOUS_PORTAL_URL
 
@@ -2347,7 +2510,9 @@ def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
     secure_parent_dir(auth_path)
     # Per-process random temp suffix avoids collisions between concurrent
     # writers and stale leftovers from a crashed prior write.
-    tmp_path = auth_path.with_name(f"{auth_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    tmp_path = auth_path.with_name(
+        f"{auth_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+    )
     # Create with 0o600 atomically via os.open(O_EXCL) — closes the TOCTOU
     # window where write_text() + post-write chmod briefly exposed tokens
     # at process umask (typically 0o644). See #19673, #21148.
@@ -2371,7 +2536,9 @@ def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
     return auth_path
 
 
-def _qwen_access_token_is_expiring(expiry_date_ms: Any, skew_seconds: int = QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS) -> bool:
+def _qwen_access_token_is_expiring(
+    expiry_date_ms: Any, skew_seconds: int = QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+) -> bool:
     try:
         expiry_ms = int(expiry_date_ms)
     except Exception:
@@ -2379,7 +2546,9 @@ def _qwen_access_token_is_expiring(expiry_date_ms: Any, skew_seconds: int = QWEN
     return (time.time() + max(0, int(skew_seconds))) * 1000 >= expiry_ms
 
 
-def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20.0) -> Dict[str, Any]:
+def _refresh_qwen_cli_tokens(
+    tokens: Dict[str, Any], timeout_seconds: float = 20.0
+) -> Dict[str, Any]:
     refresh_token = str(tokens.get("refresh_token", "") or "").strip()
     if not refresh_token:
         raise AuthError(
@@ -2427,7 +2596,10 @@ def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20
             code="qwen_refresh_invalid_json",
         ) from exc
 
-    if not isinstance(payload, dict) or not str(payload.get("access_token", "") or "").strip():
+    if (
+        not isinstance(payload, dict)
+        or not str(payload.get("access_token", "") or "").strip()
+    ):
         raise AuthError(
             "Qwen OAuth refresh response missing access_token.",
             provider="qwen-oauth",
@@ -2442,9 +2614,17 @@ def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20
 
     refreshed = {
         "access_token": str(payload.get("access_token", "") or "").strip(),
-        "refresh_token": str(payload.get("refresh_token", refresh_token) or refresh_token).strip(),
-        "token_type": str(payload.get("token_type", tokens.get("token_type", "Bearer")) or "Bearer").strip() or "Bearer",
-        "resource_url": str(payload.get("resource_url", tokens.get("resource_url", "portal.qwen.ai")) or "portal.qwen.ai").strip(),
+        "refresh_token": str(
+            payload.get("refresh_token", refresh_token) or refresh_token
+        ).strip(),
+        "token_type": str(
+            payload.get("token_type", tokens.get("token_type", "Bearer")) or "Bearer"
+        ).strip()
+        or "Bearer",
+        "resource_url": str(
+            payload.get("resource_url", tokens.get("resource_url", "portal.qwen.ai"))
+            or "portal.qwen.ai"
+        ).strip(),
         "expiry_date": int(time.time() * 1000) + max(1, expires_in_seconds) * 1000,
     }
     _save_qwen_cli_tokens(refreshed)
@@ -2480,7 +2660,9 @@ def resolve_qwen_runtime_credentials(
     access_token = str(tokens.get("access_token", "") or "").strip()
     should_refresh = bool(force_refresh)
     if not should_refresh and refresh_if_expiring:
-        should_refresh = _qwen_access_token_is_expiring(tokens.get("expiry_date"), refresh_skew_seconds)
+        should_refresh = _qwen_access_token_is_expiring(
+            tokens.get("expiry_date"), refresh_skew_seconds
+        )
     if should_refresh:
         tokens = _refresh_qwen_cli_tokens(tokens)
         access_token = str(tokens.get("access_token", "") or "").strip()
@@ -2491,7 +2673,10 @@ def resolve_qwen_runtime_credentials(
             code="qwen_access_token_missing",
         )
 
-    base_url = os.getenv("HERMES_QWEN_BASE_URL", "").strip().rstrip("/") or DEFAULT_QWEN_BASE_URL
+    base_url = (
+        os.getenv("HERMES_QWEN_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_QWEN_BASE_URL
+    )
     return {
         "provider": "qwen-oauth",
         "base_url": base_url,
@@ -2683,7 +2868,9 @@ def _spotify_validate_redirect_uri(redirect_uri: str) -> tuple[str, int, str]:
     return host, parsed.port, parsed.path or "/"
 
 
-def _make_spotify_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequestHandler], dict[str, Any]]:
+def _make_spotify_callback_handler(
+    expected_path: str,
+) -> tuple[type[BaseHTTPRequestHandler], dict[str, Any]]:
     result: dict[str, Any] = {
         "code": None,
         "state": None,
@@ -2741,7 +2928,9 @@ def _spotify_wait_for_callback(
             code="spotify_callback_bind_failed",
         ) from exc
 
-    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True)
+    thread = threading.Thread(
+        target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True
+    )
     thread.start()
     deadline = time.monotonic() + max(5.0, timeout_seconds)
     try:
@@ -2781,12 +2970,11 @@ def _spotify_token_payload_to_state(
         "api_base_url": api_base_url,
         "scope": requested_scope,
         "granted_scope": str(token_payload.get("scope") or requested_scope).strip(),
-        "token_type": str(token_payload.get("token_type", "Bearer") or "Bearer").strip() or "Bearer",
+        "token_type": str(token_payload.get("token_type", "Bearer") or "Bearer").strip()
+        or "Bearer",
         "access_token": str(token_payload.get("access_token", "") or "").strip(),
         "refresh_token": str(
-            token_payload.get("refresh_token")
-            or state.get("refresh_token")
-            or ""
+            token_payload.get("refresh_token") or state.get("refresh_token") or ""
         ).strip(),
         "obtained_at": now.isoformat(),
         "expires_at": expires_at.isoformat(),
@@ -2834,7 +3022,10 @@ def _spotify_exchange_code_for_tokens(
             code="spotify_token_exchange_failed",
         )
     payload = response.json()
-    if not isinstance(payload, dict) or not str(payload.get("access_token", "") or "").strip():
+    if (
+        not isinstance(payload, dict)
+        or not str(payload.get("access_token", "") or "").strip()
+    ):
         raise AuthError(
             "Spotify token response did not include an access_token.",
             provider="spotify",
@@ -2888,7 +3079,10 @@ def _refresh_spotify_oauth_state(
         )
 
     payload = response.json()
-    if not isinstance(payload, dict) or not str(payload.get("access_token", "") or "").strip():
+    if (
+        not isinstance(payload, dict)
+        or not str(payload.get("access_token", "") or "").strip()
+    ):
         raise AuthError(
             "Spotify refresh response did not include an access_token.",
             provider="spotify",
@@ -2937,7 +3131,13 @@ def resolve_spotify_runtime_credentials(
                     # Terminal refresh failure — clear dead tokens from auth.json
                     # so subsequent calls fail fast without a network retry.
                     # Mirrors the Nous / xAI-OAuth / Codex-OAuth / MiniMax pattern.
-                    for _k in ("access_token", "refresh_token", "expires_at", "expires_in", "obtained_at"):
+                    for _k in (
+                        "access_token",
+                        "refresh_token",
+                        "expires_at",
+                        "expires_in",
+                        "obtained_at",
+                    ):
                         state.pop(_k, None)
                     state["last_auth_error"] = {
                         "provider": "spotify",
@@ -2948,10 +3148,15 @@ def resolve_spotify_runtime_credentials(
                         "at": datetime.now(timezone.utc).isoformat(),
                     }
                     try:
-                        _store_provider_state(auth_store, "spotify", state, set_active=False)
+                        _store_provider_state(
+                            auth_store, "spotify", state, set_active=False
+                        )
                         _save_auth_store(auth_store)
                     except Exception as _save_exc:
-                        logger.debug("Spotify OAuth: failed to persist quarantined state: %s", _save_exc)
+                        logger.debug(
+                            "Spotify OAuth: failed to persist quarantined state: %s",
+                            _save_exc,
+                        )
                 raise
 
     access_token = str(state.get("access_token", "") or "").strip()
@@ -3070,11 +3275,16 @@ def login_spotify_command(args) -> None:
         if getattr(exc, "code", "") != "spotify_client_id_missing":
             raise
         client_id = _spotify_interactive_setup(
-            redirect_uri_hint=getattr(args, "redirect_uri", None) or DEFAULT_SPOTIFY_REDIRECT_URI,
+            redirect_uri_hint=getattr(args, "redirect_uri", None)
+            or DEFAULT_SPOTIFY_REDIRECT_URI,
         )
 
-    redirect_uri = _spotify_redirect_uri(getattr(args, "redirect_uri", None), existing_state)
-    scope = _spotify_scope_string(getattr(args, "scope", None) or existing_state.get("scope"))
+    redirect_uri = _spotify_redirect_uri(
+        getattr(args, "redirect_uri", None), existing_state
+    )
+    scope = _spotify_scope_string(
+        getattr(args, "scope", None) or existing_state.get("scope")
+    )
     accounts_base_url = _spotify_accounts_base_url(existing_state)
     api_base_url = _spotify_api_base_url(existing_state)
     open_browser = not getattr(args, "no_browser", False)
@@ -3151,9 +3361,11 @@ def login_spotify_command(args) -> None:
     print("  Provider state saved under providers.spotify")
     print(f"  Docs: {SPOTIFY_DOCS_URL}")
 
+
 # =============================================================================
 # SSH / remote session detection
 # =============================================================================
+
 
 def _is_remote_session() -> bool:
     """Detect environments where loopback OAuth can't reach the local browser.
@@ -3173,12 +3385,12 @@ def _is_remote_session() -> bool:
     # (well-known, documented env vars set by the host platform) so
     # we don't falsely trip on a developer's local shell.
     for var in (
-        "CLOUD_SHELL",         # GCP Cloud Shell
-        "CODESPACES",          # GitHub Codespaces
-        "CODESPACE_NAME",      # GitHub Codespaces (alt)
-        "GITPOD_WORKSPACE_ID", # Gitpod
-        "REPL_ID",             # Replit
-        "STACKBLITZ",          # StackBlitz
+        "CLOUD_SHELL",  # GCP Cloud Shell
+        "CODESPACES",  # GitHub Codespaces
+        "CODESPACE_NAME",  # GitHub Codespaces (alt)
+        "GITPOD_WORKSPACE_ID",  # Gitpod
+        "REPL_ID",  # Replit
+        "STACKBLITZ",  # StackBlitz
     ):
         if os.getenv(var):
             return True
@@ -3192,17 +3404,15 @@ def _is_remote_session() -> bool:
 # letting them copy the URL to a real browser.  When the resolved browser is
 # one of these we refuse to auto-open and fall back to the print-the-URL
 # path, same as a remote session.
-_CONSOLE_BROWSER_NAMES: FrozenSet[str] = frozenset(
-    {
-        "w3m",
-        "lynx",
-        "links",
-        "links2",
-        "elinks",
-        "www-browser",
-        "browsh",  # TUI browser — still hijacks the terminal
-    }
-)
+_CONSOLE_BROWSER_NAMES: FrozenSet[str] = frozenset({
+    "w3m",
+    "lynx",
+    "links",
+    "links2",
+    "elinks",
+    "www-browser",
+    "browsh",  # TUI browser — still hijacks the terminal
+})
 
 
 def _can_open_graphical_browser() -> bool:
@@ -3252,9 +3462,7 @@ def _can_open_graphical_browser() -> bool:
         return False
 
     candidate = (
-        getattr(controller, "name", "")
-        or getattr(controller, "basename", "")
-        or ""
+        getattr(controller, "name", "") or getattr(controller, "basename", "") or ""
     )
     if candidate and _names_console_browser(candidate):
         return False
@@ -3270,6 +3478,7 @@ def _ssh_user_at_host() -> str:
     """
     try:
         import socket as _socket
+
         hostname = _socket.gethostname() or "<this-host>"
     except OSError:
         hostname = "<this-host>"
@@ -3327,9 +3536,10 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
+
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
-    
+
     Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
     Raises AuthError if no Codex tokens are stored.
     """
@@ -3456,9 +3666,7 @@ def _sync_codex_pool_entries(
             # singleton from the #33000 workaround era).  An entry with its
             # own distinct token material is an independent account and must
             # be left alone (#39236).
-            refresh_this_entry = bool(
-                prev_at and entry.get("access_token") == prev_at
-            )
+            refresh_this_entry = bool(prev_at and entry.get("access_token") == prev_at)
         else:
             # ``manual:api_key`` and any future non-device-code sources.
             refresh_this_entry = False
@@ -3477,7 +3685,9 @@ def _sync_codex_pool_entries(
         entry["last_error_reset_at"] = None
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
+def _save_codex_tokens(
+    tokens: Dict[str, str], last_refresh: str = None, label: str = None
+) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -3489,7 +3699,9 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
         # (which should be refreshed) from independent accounts that
         # ``hermes auth add openai-codex`` created (which must not be
         # overwritten — see #39236).
-        previous_singleton_tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else None
+        previous_singleton_tokens = (
+            state.get("tokens") if isinstance(state.get("tokens"), dict) else None
+        )
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
@@ -3528,7 +3740,9 @@ def refresh_codex_oauth_pure(
     timeout_seconds: float = 20.0,
 ) -> Dict[str, Any]:
     """Refresh Codex OAuth tokens without mutating Hermes auth state."""
-    del access_token  # Access token is only used by callers to decide whether to refresh.
+    del (
+        access_token
+    )  # Access token is only used by callers to decide whether to refresh.
     if not isinstance(refresh_token, str) or not refresh_token.strip():
         raise AuthError(
             "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate.",
@@ -3660,7 +3874,7 @@ def _refresh_codex_auth_tokens(
     timeout_seconds: float,
 ) -> Dict[str, str]:
     """Refresh Codex access token using the refresh token.
-    
+
     Saves the new tokens to Hermes auth store automatically.
     """
     try:
@@ -3701,7 +3915,7 @@ def _refresh_codex_auth_tokens(
 
 def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     """Try to read tokens from ~/.codex/auth.json (Codex CLI shared file).
-    
+
     Returns tokens dict if valid and not expired, None otherwise.
     Does NOT write to the shared file.
     """
@@ -3725,7 +3939,8 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
         # but no working credentials.
         if _codex_access_token_is_expiring(access_token, 0):
             logger.debug(
-                "Codex CLI tokens at %s are expired — skipping import.", auth_path,
+                "Codex CLI tokens at %s are expired — skipping import.",
+                auth_path,
             )
             return None
         return dict(tokens)
@@ -3760,9 +3975,14 @@ def resolve_codex_runtime_credentials(
             "codex_auth_missing_refresh_token",
             "codex_auth_invalid_shape",
         }:
-            imported = _recover_codex_tokens_from_cli(str(getattr(exc, "code", None) or "auth_error"))
+            imported = _recover_codex_tokens_from_cli(
+                str(getattr(exc, "code", None) or "auth_error")
+            )
             if imported:
-                data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
+                data = {
+                    "tokens": imported,
+                    "last_refresh": imported.get("last_refresh"),
+                }
             else:
                 data = None
         else:
@@ -3818,17 +4038,25 @@ def resolve_codex_runtime_credentials(
 
     should_refresh = bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
-        should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+        should_refresh = _codex_access_token_is_expiring(
+            access_token, refresh_skew_seconds
+        )
     if should_refresh:
         # Re-read under lock to avoid racing with other Hermes processes
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+        with _auth_store_lock(
+            timeout_seconds=max(
+                float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0
+            )
+        ):
             data = _read_codex_tokens(_lock=False)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
 
             should_refresh = bool(force_refresh)
             if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+                should_refresh = _codex_access_token_is_expiring(
+                    access_token, refresh_skew_seconds
+                )
 
             if should_refresh:
                 tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
@@ -3851,6 +4079,7 @@ def resolve_codex_runtime_credentials(
 
 def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
     """Return metadata for a pool-only Codex credential in quota cooldown."""
+
     def _parse_reset_at(value: Any) -> Optional[float]:
         if value is None or value == "":
             return None
@@ -3966,6 +4195,7 @@ def _pool_codex_access_token() -> str:
 # xAI Grok OAuth — tokens stored in ~/.hermes/auth.json
 # =============================================================================
 
+
 def _xai_oauth_state_from_store(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Return usable xAI OAuth state from provider state or credential pool."""
     state = _load_provider_state(auth_store, "xai-oauth")
@@ -3978,9 +4208,7 @@ def _xai_oauth_state_from_store(auth_store: Dict[str, Any]) -> Optional[Dict[str
 
     credential_pool = auth_store.get("credential_pool")
     entries = (
-        credential_pool.get("xai-oauth")
-        if isinstance(credential_pool, dict)
-        else None
+        credential_pool.get("xai-oauth") if isinstance(credential_pool, dict) else None
     )
     if isinstance(entries, list):
         for entry in entries:
@@ -4157,7 +4385,9 @@ def _xai_access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> b
             return False
         payload_b64 = parts[1]
         payload_b64 += "=" * (-len(payload_b64) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(payload_b64.encode("ascii")).decode("utf-8"))
+        payload = json.loads(
+            base64.urlsafe_b64decode(payload_b64.encode("ascii")).decode("utf-8")
+        )
         exp = payload.get("exp")
         if not isinstance(exp, (int, float)):
             return False
@@ -4186,7 +4416,9 @@ def _xai_proactive_refresh_skew_seconds(access_token: str) -> int:
             return max_skew
         payload_b64 = parts[1]
         payload_b64 += "=" * (-len(payload_b64) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(payload_b64.encode("ascii")).decode("utf-8"))
+        payload = json.loads(
+            base64.urlsafe_b64decode(payload_b64.encode("ascii")).decode("utf-8")
+        )
         exp = payload.get("exp")
         if not isinstance(exp, (int, float)):
             return max_skew
@@ -4268,21 +4500,24 @@ def _xai_validate_inference_base_url(value: str, *, fallback: str) -> str:
     except Exception:
         logger.warning(
             "Ignoring malformed xAI base_url override %r; using %s instead.",
-            candidate, fallback,
+            candidate,
+            fallback,
         )
         return fallback
     if parsed.scheme != "https":
         logger.warning(
             "Refusing non-HTTPS xAI base_url override %r (xai-oauth bearer would "
             "be sent in cleartext); falling back to %s.",
-            candidate, fallback,
+            candidate,
+            fallback,
         )
         return fallback
     host = (parsed.hostname or "").lower()
     if not host:
         logger.warning(
             "Ignoring xAI base_url override %r with no hostname; using %s instead.",
-            candidate, fallback,
+            candidate,
+            fallback,
         )
         return fallback
     if host != "x.ai" and not host.endswith(".x.ai"):
@@ -4291,7 +4526,9 @@ def _xai_validate_inference_base_url(value: str, *, fallback: str) -> str:
             "(expected x.ai or a *.x.ai subdomain). The xai-oauth bearer is only "
             "valid against xAI's inference API; sending it elsewhere would leak "
             "the credential. Falling back to %s.",
-            candidate, host, fallback,
+            candidate,
+            host,
+            fallback,
         )
         return fallback
     return candidate
@@ -4330,7 +4567,9 @@ def _xai_oauth_discovery(timeout_seconds: float = 15.0) -> Dict[str, str]:
             provider="xai-oauth",
             code="xai_discovery_incomplete",
         )
-    authorization_endpoint = str(payload.get("authorization_endpoint", "") or "").strip()
+    authorization_endpoint = str(
+        payload.get("authorization_endpoint", "") or ""
+    ).strip()
     token_endpoint = str(payload.get("token_endpoint", "") or "").strip()
     if not authorization_endpoint or not token_endpoint:
         raise AuthError(
@@ -4361,7 +4600,10 @@ def refresh_xai_oauth_pure(
             code="xai_auth_missing_refresh_token",
             relogin_required=True,
         )
-    endpoint = token_endpoint.strip() or _xai_oauth_discovery(timeout_seconds)["token_endpoint"]
+    endpoint = (
+        token_endpoint.strip()
+        or _xai_oauth_discovery(timeout_seconds)["token_endpoint"]
+    )
     # Re-validate cached endpoints on the refresh hot path: an auth.json
     # written by an older Hermes (or hand-edited) may carry a non-xAI
     # token_endpoint that would receive every future refresh_token in
@@ -4369,7 +4611,9 @@ def refresh_xai_oauth_pure(
     # with a clear error so the user can re-run `hermes model` to refetch.
     _xai_validate_oauth_endpoint(endpoint, field="token_endpoint")
     timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}
+    ) as client:
         response = client.post(
             endpoint,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -4393,19 +4637,18 @@ def refresh_xai_oauth_pure(
                 "xAI token refresh failed with HTTP 403."
                 + (f" Response: {detail}" if detail else "")
                 + " This OAuth account is not authorized for xAI API"
-                  " access — xAI may be restricting API/OAuth use to"
-                  " specific SuperGrok tiers despite the in-app"
-                  " subscription being active. Re-logging in won't"
-                  " change that; set ``XAI_API_KEY`` and switch to"
-                  " ``provider: xai`` (API-key path) if available, or"
-                  " upgrade your subscription at https://x.ai/grok.",
+                " access — xAI may be restricting API/OAuth use to"
+                " specific SuperGrok tiers despite the in-app"
+                " subscription being active. Re-logging in won't"
+                " change that; set ``XAI_API_KEY`` and switch to"
+                " ``provider: xai`` (API-key path) if available, or"
+                " upgrade your subscription at https://x.ai/grok.",
                 provider="xai-oauth",
                 code="xai_oauth_tier_denied",
                 relogin_required=False,
             )
         raise AuthError(
-            "xAI token refresh failed."
-            + (f" Response: {detail}" if detail else ""),
+            "xAI token refresh failed." + (f" Response: {detail}" if detail else ""),
             provider="xai-oauth",
             code="xai_refresh_failed",
             relogin_required=(response.status_code in {400, 401}),
@@ -4507,7 +4750,11 @@ def resolve_xai_oauth_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
     if should_refresh:
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+        with _auth_store_lock(
+            timeout_seconds=max(
+                float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0
+            )
+        ):
             data = _read_xai_oauth_tokens(_lock=False)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
@@ -4521,10 +4768,14 @@ def resolve_xai_oauth_runtime_credentials(
             )
             should_refresh = bool(force_refresh)
             if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
+                should_refresh = _xai_access_token_is_expiring(
+                    access_token, effective_skew
+                )
             if should_refresh:
                 if not token_endpoint:
-                    token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]
+                    token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)[
+                        "token_endpoint"
+                    ]
                 try:
                     tokens = _refresh_xai_oauth_tokens(
                         tokens,
@@ -4553,11 +4804,14 @@ def resolve_xai_oauth_runtime_credentials(
                                 "relogin_required": True,
                                 "at": datetime.now(timezone.utc).isoformat(),
                             }
-                            _store_provider_state(_q_store, "xai-oauth", _q_state, set_active=False)
+                            _store_provider_state(
+                                _q_store, "xai-oauth", _q_state, set_active=False
+                            )
                             _save_auth_store(_q_store)
                         except Exception as _save_exc:
                             logger.debug(
-                                "xAI OAuth: failed to persist quarantined state: %s", _save_exc,
+                                "xAI OAuth: failed to persist quarantined state: %s",
+                                _save_exc,
                             )
                     raise
 
@@ -4583,6 +4837,7 @@ def resolve_xai_oauth_runtime_credentials(
 # TLS verification helper
 # =============================================================================
 
+
 def _default_verify() -> bool | ssl.SSLContext:
     """Platform-aware default SSL verify for httpx clients.
 
@@ -4595,6 +4850,7 @@ def _default_verify() -> bool | ssl.SSLContext:
     if sys.platform == "darwin":
         try:
             import certifi
+
             return ssl.create_default_context(cafile=certifi.where())
         except ImportError:
             pass
@@ -4611,7 +4867,8 @@ def _resolve_verify(
     tls_state = tls_state if isinstance(tls_state, dict) else {}
 
     effective_insecure = (
-        is_truthy_value(insecure, default=False) if insecure is not None
+        is_truthy_value(insecure, default=False)
+        if insecure is not None
         else is_truthy_value(tls_state.get("insecure", False), default=False)
     )
     effective_ca = (
@@ -4640,6 +4897,7 @@ def _resolve_verify(
 # OAuth Device Code Flow — generic, parameterized by provider
 # =============================================================================
 
+
 def _request_device_code(
     client: httpx.Client,
     portal_base_url: str,
@@ -4658,8 +4916,12 @@ def _request_device_code(
     data = response.json()
 
     required_fields = [
-        "device_code", "user_code", "verification_uri",
-        "verification_uri_complete", "expires_in", "interval",
+        "device_code",
+        "user_code",
+        "verification_uri",
+        "verification_uri_complete",
+        "expires_in",
+        "interval",
     ]
     missing = [f for f in required_fields if f not in data]
     if missing:
@@ -4710,7 +4972,9 @@ def _poll_for_token(
             time.sleep(current_interval)
             continue
 
-        description = error_payload.get("error_description") or "Unknown authentication error"
+        description = (
+            error_payload.get("error_description") or "Unknown authentication error"
+        )
         raise RuntimeError(f"{error_code}: {description}")
 
     raise TimeoutError("Timed out waiting for device authorization")
@@ -4760,6 +5024,7 @@ def _nous_shared_auth_dir() -> Path:
     if override:
         return Path(override).expanduser()
     from hermes_constants import get_default_hermes_root
+
     return get_default_hermes_root() / "shared"
 
 
@@ -4773,6 +5038,7 @@ def _nous_shared_store_path() -> Path:
     # shared store).
     if os.environ.get("PYTEST_CURRENT_TEST"):
         from hermes_constants import get_default_hermes_root
+
         real_home_shared = (
             get_default_hermes_root() / "shared" / NOUS_SHARED_STORE_FILENAME
         ).resolve(strict=False)
@@ -4877,7 +5143,8 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
         "scope": state.get("scope") or DEFAULT_NOUS_SCOPE,
         "client_id": state.get("client_id") or DEFAULT_NOUS_CLIENT_ID,
         "portal_base_url": state.get("portal_base_url") or DEFAULT_NOUS_PORTAL_URL,
-        "inference_base_url": state.get("inference_base_url") or DEFAULT_NOUS_INFERENCE_URL,
+        "inference_base_url": state.get("inference_base_url")
+        or DEFAULT_NOUS_INFERENCE_URL,
         "obtained_at": state.get("obtained_at"),
         "expires_at": state.get("expires_at"),
         "updated_at": datetime.now(timezone.utc).isoformat(),
@@ -5001,7 +5268,8 @@ def _is_terminal_codex_oauth_refresh_error(exc: Exception) -> bool:
     return (
         isinstance(exc, AuthError)
         and exc.provider == "openai-codex"
-        and exc.code in {
+        and exc.code
+        in {
             "codex_refresh_failed",
             "codex_auth_missing_refresh_token",
             "invalid_grant",
@@ -5147,7 +5415,9 @@ def _try_import_shared_nous_state(
     flow.
     """
     try:
-        with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
+        with _nous_shared_store_lock(
+            timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)
+        ):
             shared = _read_shared_nous_state()
             if not shared:
                 return None
@@ -5159,8 +5429,10 @@ def _try_import_shared_nous_state(
                 "access_token": shared.get("access_token"),
                 "refresh_token": shared.get("refresh_token"),
                 "client_id": shared.get("client_id") or DEFAULT_NOUS_CLIENT_ID,
-                "portal_base_url": shared.get("portal_base_url") or DEFAULT_NOUS_PORTAL_URL,
-                "inference_base_url": shared.get("inference_base_url") or DEFAULT_NOUS_INFERENCE_URL,
+                "portal_base_url": shared.get("portal_base_url")
+                or DEFAULT_NOUS_PORTAL_URL,
+                "inference_base_url": shared.get("inference_base_url")
+                or DEFAULT_NOUS_INFERENCE_URL,
                 "token_type": shared.get("token_type") or "Bearer",
                 "scope": shared.get("scope") or DEFAULT_NOUS_SCOPE,
                 "obtained_at": shared.get("obtained_at"),
@@ -5170,7 +5442,9 @@ def _try_import_shared_nous_state(
                 "tls": {"insecure": False, "ca_bundle": None},
             }
 
-            def _persist_shared_refresh(updated_state: Dict[str, Any], _reason: str) -> None:
+            def _persist_shared_refresh(
+                updated_state: Dict[str, Any], _reason: str
+            ) -> None:
                 _write_shared_nous_state(updated_state)
 
             refreshed = refresh_nous_oauth_from_state(
@@ -5220,18 +5494,25 @@ def _refresh_access_token(
     if response.status_code == 200:
         payload = response.json()
         if "access_token" not in payload:
-            raise AuthError("Refresh response missing access_token",
-                            provider="nous", code="invalid_token", relogin_required=True)
+            raise AuthError(
+                "Refresh response missing access_token",
+                provider="nous",
+                code="invalid_token",
+                relogin_required=True,
+            )
         return payload
 
     try:
         error_payload = response.json()
     except Exception as exc:
-        raise AuthError("Refresh token exchange failed",
-                        provider="nous", relogin_required=True) from exc
+        raise AuthError(
+            "Refresh token exchange failed", provider="nous", relogin_required=True
+        ) from exc
 
     code = str(error_payload.get("error", "invalid_grant"))
-    description = str(error_payload.get("error_description") or "Refresh token exchange failed")
+    description = str(
+        error_payload.get("error_description") or "Refresh token exchange failed"
+    )
     relogin = code in {"invalid_grant", "invalid_token", "refresh_token_reused"}
 
     # Detect the OAuth 2.1 "refresh token reuse" signal from the Nous portal
@@ -5242,7 +5523,11 @@ def _refresh_access_token(
     # retires the original RT, Hermes's next refresh uses it, and the whole
     # session chain gets revoked as a token-theft signal (#15099).
     lowered = description.lower()
-    if code == "refresh_token_reused" or "reuse" in lowered or "reuse detected" in lowered:
+    if (
+        code == "refresh_token_reused"
+        or "reuse" in lowered
+        or "reuse detected" in lowered
+    ):
         description = (
             "Nous Portal detected refresh-token reuse and revoked this session.\n"
             "This usually means an external process (monitoring script, "
@@ -5268,7 +5553,9 @@ def fetch_nous_models(
 ) -> List[str]:
     """Fetch available model IDs from the Nous inference API."""
     timeout = httpx.Timeout(timeout_seconds)
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}, verify=verify
+    ) as client:
         response = client.get(
             f"{inference_base_url.rstrip('/')}/models",
             headers={"Authorization": f"Bearer {api_key}"},
@@ -5278,7 +5565,9 @@ def fetch_nous_models(
         description = f"/models request failed with status {response.status_code}"
         try:
             err = response.json()
-            description = str(err.get("error_description") or err.get("error") or description)
+            description = str(
+                err.get("error_description") or err.get("error") or description
+            )
         except Exception as e:
             logger.debug("Could not parse error response JSON: %s", e)
         raise AuthError(description, provider="nous", code="models_fetch_failed")
@@ -5341,7 +5630,6 @@ def resolve_nous_access_token(
         state,
         state_source_path,
     ):
-
         if not state:
             raise AuthError(
                 "Hermes is not logged into Nous Portal.",
@@ -5366,17 +5654,25 @@ def resolve_nous_access_token(
             ).rstrip("/")
 
             parsed_portal_url = urlparse(portal_base_url)
-            if parsed_portal_url.hostname and parsed_portal_url.hostname not in _NOUS_PORTAL_ALLOWED_HOSTS:
+            if (
+                parsed_portal_url.hostname
+                and parsed_portal_url.hostname not in _NOUS_PORTAL_ALLOWED_HOSTS
+            ):
                 logger.warning(
                     "auth: ignoring invalid portal_base_url %r (host %r not in allowlist), using default",
-                    portal_base_url, parsed_portal_url.hostname,
+                    portal_base_url,
+                    parsed_portal_url.hostname,
                 )
                 portal_base_url = DEFAULT_NOUS_PORTAL_URL
 
         client_id = str(state.get("client_id") or DEFAULT_NOUS_CLIENT_ID)
-        verify = _resolve_verify(insecure=insecure, ca_bundle=ca_bundle, auth_state=state)
+        verify = _resolve_verify(
+            insecure=insecure, ca_bundle=ca_bundle, auth_state=state
+        )
 
-        with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
+        with _nous_shared_store_lock(
+            timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)
+        ):
             merged_shared = _merge_shared_nous_oauth_state(state)
             access_token = state.get("access_token")
             refresh_token = state.get("refresh_token")
@@ -5389,7 +5685,9 @@ def resolve_nous_access_token(
 
             if not _is_expiring(state.get("expires_at"), refresh_skew_seconds):
                 if merged_shared:
-                    _save_provider_state_to_source(auth_store, "nous", state, state_source_path)
+                    _save_provider_state_to_source(
+                        auth_store, "nous", state, state_source_path
+                    )
                 return access_token
 
             if not isinstance(refresh_token, str) or not refresh_token:
@@ -5424,14 +5722,18 @@ def resolve_nous_access_token(
                             exc,
                             reason="managed_access_token_refresh_failure",
                         )
-                        _save_provider_state_to_source(auth_store, "nous", state, state_source_path)
+                        _save_provider_state_to_source(
+                            auth_store, "nous", state, state_source_path
+                        )
                     raise
 
             now = datetime.now(timezone.utc)
             access_ttl = _coerce_ttl_seconds(refreshed.get("expires_in"))
             state["access_token"] = refreshed["access_token"]
             state["refresh_token"] = refreshed.get("refresh_token") or refresh_token
-            state["token_type"] = refreshed.get("token_type") or state.get("token_type") or "Bearer"
+            state["token_type"] = (
+                refreshed.get("token_type") or state.get("token_type") or "Bearer"
+            )
             state["scope"] = refreshed.get("scope") or state.get("scope")
             state["obtained_at"] = now.isoformat()
             state["expires_in"] = access_ttl
@@ -5480,7 +5782,9 @@ def refresh_nous_oauth_pure(
         "refresh_token": refresh_token,
         "client_id": client_id or DEFAULT_NOUS_CLIENT_ID,
         "portal_base_url": (portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/"),
-        "inference_base_url": (inference_base_url or DEFAULT_NOUS_INFERENCE_URL).rstrip("/"),
+        "inference_base_url": (inference_base_url or DEFAULT_NOUS_INFERENCE_URL).rstrip(
+            "/"
+        ),
         "token_type": token_type or "Bearer",
         "scope": scope or DEFAULT_NOUS_SCOPE,
         "obtained_at": obtained_at,
@@ -5495,7 +5799,9 @@ def refresh_nous_oauth_pure(
     verify = _resolve_verify(insecure=insecure, ca_bundle=ca_bundle, auth_state=state)
     timeout = httpx.Timeout(timeout_seconds if timeout_seconds else 15.0)
 
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}, verify=verify
+    ) as client:
         current_invoke_jwt_status = _nous_invoke_jwt_status(
             state.get("access_token"),
             scope=state.get("scope"),
@@ -5527,8 +5833,12 @@ def refresh_nous_oauth_pure(
             now = datetime.now(timezone.utc)
             access_ttl = _coerce_ttl_seconds(refreshed.get("expires_in"))
             state["access_token"] = refreshed["access_token"]
-            state["refresh_token"] = refreshed.get("refresh_token") or refresh_token_value
-            state["token_type"] = refreshed.get("token_type") or state.get("token_type") or "Bearer"
+            state["refresh_token"] = (
+                refreshed.get("refresh_token") or refresh_token_value
+            )
+            state["token_type"] = (
+                refreshed.get("token_type") or state.get("token_type") or "Bearer"
+            )
             state["scope"] = refreshed.get("scope") or state.get("scope")
             # Heal a poisoned stored value: when the Portal-returned URL is
             # rejected by the allowlist (returns None), reset to the production
@@ -5537,7 +5847,9 @@ def refresh_nous_oauth_pure(
             # was poisoned before the allowlist existed keeps re-validating to
             # None on every refresh and silently re-uses the dead endpoint —
             # the "falling back to default" warning never actually takes effect.
-            refreshed_url = _validate_nous_inference_url_from_network(refreshed.get("inference_base_url"))
+            refreshed_url = _validate_nous_inference_url_from_network(
+                refreshed.get("inference_base_url")
+            )
             state["inference_base_url"] = refreshed_url or DEFAULT_NOUS_INFERENCE_URL
             state["obtained_at"] = now.isoformat()
             state["expires_in"] = access_ttl
@@ -5674,10 +5986,12 @@ def resolve_nous_runtime_credentials(
         state,
         state_source_path,
     ):
-
         if not state:
-            raise AuthError("Hermes is not logged into Nous Portal.",
-                            provider="nous", relogin_required=True)
+            raise AuthError(
+                "Hermes is not logged into Nous Portal.",
+                provider="nous",
+                relogin_required=True,
+            )
 
         persisted_state = dict(state)
         state_persisted = False
@@ -5701,13 +6015,11 @@ def resolve_nous_runtime_credentials(
             else:
                 parsed_portal_url = urlparse(portal_url)
                 portal_host = parsed_portal_url.hostname
-                loopback_http = (
-                    parsed_portal_url.scheme == "http"
-                    and portal_host in {"localhost", "127.0.0.1"}
-                )
-                trusted_scheme = (
-                    parsed_portal_url.scheme == "https" or loopback_http
-                )
+                loopback_http = parsed_portal_url.scheme == "http" and portal_host in {
+                    "localhost",
+                    "127.0.0.1",
+                }
+                trusted_scheme = parsed_portal_url.scheme == "https" or loopback_http
                 if (
                     not portal_host
                     or portal_host not in _NOUS_PORTAL_ALLOWED_HOSTS
@@ -5732,9 +6044,7 @@ def resolve_nous_runtime_credentials(
             effective_inference_url = (
                 _nous_inference_env_override() or stored_inference_url
             )
-            effective_client_id = str(
-                state.get("client_id") or DEFAULT_NOUS_CLIENT_ID
-            )
+            effective_client_id = str(state.get("client_id") or DEFAULT_NOUS_CLIENT_ID)
             return (
                 portal_url,
                 stored_inference_url,
@@ -5753,9 +6063,8 @@ def resolve_nous_runtime_credentials(
             nonlocal persisted_state, state_persisted
             # Skip writes where only derived TTL countdowns changed; this keeps
             # the mtime-keyed Nous auth-status cache warm during read paths.
-            if (
-                _nous_effective_provider_state(state)
-                == _nous_effective_provider_state(persisted_state)
+            if _nous_effective_provider_state(state) == _nous_effective_provider_state(
+                persisted_state
             ):
                 _oauth_trace(
                     "nous_state_persist_skipped",
@@ -5764,7 +6073,9 @@ def resolve_nous_runtime_credentials(
                 )
                 return
             try:
-                _save_provider_state_to_source(auth_store, "nous", state, state_source_path)
+                _save_provider_state_to_source(
+                    auth_store, "nous", state, state_source_path
+                )
             except Exception as exc:
                 _oauth_trace(
                     "nous_state_persist_failed",
@@ -5788,7 +6099,9 @@ def resolve_nous_runtime_credentials(
             # _write_shared_nous_state.
             _write_shared_nous_state(state)
 
-        verify = _resolve_verify(insecure=insecure, ca_bundle=ca_bundle, auth_state=state)
+        verify = _resolve_verify(
+            insecure=insecure, ca_bundle=ca_bundle, auth_state=state
+        )
         timeout = httpx.Timeout(timeout_seconds if timeout_seconds else 15.0)
         _oauth_trace(
             "nous_runtime_credentials_start",
@@ -5796,13 +6109,17 @@ def resolve_nous_runtime_credentials(
             refresh_token_fp=_token_fingerprint(state.get("refresh_token")),
         )
 
-        with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+        with httpx.Client(
+            timeout=timeout, headers={"Accept": "application/json"}, verify=verify
+        ) as client:
             access_token = state.get("access_token")
             refresh_token = state.get("refresh_token")
 
             if not isinstance(access_token, str) or not access_token:
                 with _nous_shared_store_lock(
-                    timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)
+                    timeout_seconds=max(
+                        timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS
+                    )
                 ):
                     if _merge_shared_nous_oauth_state(state):
                         access_token = state.get("access_token")
@@ -5816,8 +6133,11 @@ def resolve_nous_runtime_credentials(
                         _persist_state("runtime_shared_merge_missing_access_token")
 
             if not isinstance(access_token, str) or not access_token:
-                raise AuthError("No access token found for Nous Portal login.",
-                                provider="nous", relogin_required=True)
+                raise AuthError(
+                    "No access token found for Nous Portal login.",
+                    provider="nous",
+                    relogin_required=True,
+                )
 
             invoke_jwt_status = _nous_invoke_jwt_status(
                 access_token,
@@ -5825,7 +6145,11 @@ def resolve_nous_runtime_credentials(
                 expires_at=state.get("expires_at"),
             )
             if force_refresh or invoke_jwt_status is not None:
-                with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
+                with _nous_shared_store_lock(
+                    timeout_seconds=max(
+                        timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS
+                    )
+                ):
                     if _merge_shared_nous_oauth_state(state):
                         access_token = state.get("access_token")
                         refresh_token = state.get("refresh_token")
@@ -5854,7 +6178,11 @@ def resolve_nous_runtime_credentials(
                                 relogin_required=True,
                             )
 
-                        refresh_reason = "force_refresh" if force_refresh else (invoke_jwt_status or "access_unusable")
+                        refresh_reason = (
+                            "force_refresh"
+                            if force_refresh
+                            else (invoke_jwt_status or "access_unusable")
+                        )
                         _oauth_trace(
                             "refresh_start",
                             sequence_id=sequence_id,
@@ -5863,8 +6191,10 @@ def resolve_nous_runtime_credentials(
                         )
                         try:
                             refreshed = _refresh_access_token(
-                                client=client, portal_base_url=portal_base_url,
-                                client_id=client_id, refresh_token=refresh_token,
+                                client=client,
+                                portal_base_url=portal_base_url,
+                                client_id=client_id,
+                                refresh_token=refresh_token,
                             )
                         except AuthError as exc:
                             if _is_terminal_nous_refresh_error(exc):
@@ -5878,14 +6208,22 @@ def resolve_nous_runtime_credentials(
                                     exc,
                                     reason="runtime_access_refresh_failure",
                                 )
-                                _persist_state("terminal_runtime_access_refresh_failure")
+                                _persist_state(
+                                    "terminal_runtime_access_refresh_failure"
+                                )
                             raise
                         now = datetime.now(timezone.utc)
                         access_ttl = _coerce_ttl_seconds(refreshed.get("expires_in"))
                         previous_refresh_token = refresh_token
                         state["access_token"] = refreshed["access_token"]
-                        state["refresh_token"] = refreshed.get("refresh_token") or refresh_token
-                        state["token_type"] = refreshed.get("token_type") or state.get("token_type") or "Bearer"
+                        state["refresh_token"] = (
+                            refreshed.get("refresh_token") or refresh_token
+                        )
+                        state["token_type"] = (
+                            refreshed.get("token_type")
+                            or state.get("token_type")
+                            or "Bearer"
+                        )
                         state["scope"] = refreshed.get("scope") or state.get("scope")
                         # Heal a poisoned stored value (see refresh_nous_oauth_pure):
                         # reject → reset to production default, don't keep a stale
@@ -5894,8 +6232,12 @@ def resolve_nous_runtime_credentials(
                         # persisted to auth.json below. The NOUS_INFERENCE_BASE_URL
                         # env override is layered on for the client/return value
                         # only (see below) — it is never persisted.
-                        refreshed_url = _validate_nous_inference_url_from_network(refreshed.get("inference_base_url"))
-                        stored_inference_base_url = refreshed_url or DEFAULT_NOUS_INFERENCE_URL
+                        refreshed_url = _validate_nous_inference_url_from_network(
+                            refreshed.get("inference_base_url")
+                        )
+                        stored_inference_base_url = (
+                            refreshed_url or DEFAULT_NOUS_INFERENCE_URL
+                        )
                         inference_base_url = (
                             _nous_inference_env_override() or stored_inference_base_url
                         )
@@ -5915,7 +6257,9 @@ def resolve_nous_runtime_credentials(
                             "refresh_success",
                             sequence_id=sequence_id,
                             reason=refresh_reason,
-                            previous_refresh_token_fp=_token_fingerprint(previous_refresh_token),
+                            previous_refresh_token_fp=_token_fingerprint(
+                                previous_refresh_token
+                            ),
                             new_refresh_token_fp=_token_fingerprint(refresh_token),
                         )
                         # Persist immediately so validation failures cannot drop rotated refresh tokens.
@@ -5950,8 +6294,11 @@ def resolve_nous_runtime_credentials(
 
     api_key = state.get("agent_key")
     if not isinstance(api_key, str) or not api_key:
-        raise AuthError("Failed to resolve a Nous inference API key",
-                        provider="nous", code="server_error")
+        raise AuthError(
+            "Failed to resolve a Nous inference API key",
+            provider="nous",
+            code="server_error",
+        )
 
     expires_at = state.get("agent_key_expires_at")
     expires_epoch = _parse_iso_timestamp(expires_at)
@@ -5980,6 +6327,7 @@ def resolve_nous_runtime_credentials(
 # =============================================================================
 # Status helpers
 # =============================================================================
+
 
 def _empty_nous_auth_status() -> Dict[str, Any]:
     return {
@@ -6012,7 +6360,10 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
             return _empty_nous_auth_status()
 
         def _entry_sort_key(entry: Any) -> tuple[float, float, int]:
-            agent_exp = _parse_iso_timestamp(getattr(entry, "agent_key_expires_at", None)) or 0.0
+            agent_exp = (
+                _parse_iso_timestamp(getattr(entry, "agent_key_expires_at", None))
+                or 0.0
+            )
             access_exp = _parse_iso_timestamp(getattr(entry, "expires_at", None)) or 0.0
             priority = int(getattr(entry, "priority", 0) or 0)
             return (agent_exp, access_exp, -priority)
@@ -6031,8 +6382,7 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
         portal_status_url = None
         if is_portal_oauth:
             portal_status_url = (
-                getattr(entry, "portal_base_url", None)
-                or DEFAULT_NOUS_PORTAL_URL
+                getattr(entry, "portal_base_url", None) or DEFAULT_NOUS_PORTAL_URL
             )
 
         return {
@@ -6063,7 +6413,9 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
 # path + mtime so that profile switches do not share a process memo and
 # `hermes auth login/logout/add/remove` invalidate naturally on the next call.
 _NOUS_AUTH_STATUS_CACHE_TTL = 15.0  # seconds
-_nous_auth_status_cache: Optional[Tuple[float, str, Optional[float], Dict[str, Any]]] = None
+_nous_auth_status_cache: Optional[
+    Tuple[float, str, Optional[float], Dict[str, Any]]
+] = None
 
 
 def _auth_file_cache_key() -> Tuple[str, Optional[float]]:
@@ -6146,24 +6498,24 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
         try:
             creds = resolve_nous_runtime_credentials()
             refreshed_state = get_provider_auth_state("nous") or state
-            base_status.update(
-                {
-                    "logged_in": True,
-                    "portal_base_url": refreshed_state.get("portal_base_url") or base_status.get("portal_base_url"),
-                    "inference_base_url": creds.get("base_url")
-                    or refreshed_state.get("inference_base_url")
-                    or base_status.get("inference_base_url"),
-                    "access_expires_at": refreshed_state.get("expires_at") or base_status.get("access_expires_at"),
-                    "agent_key_expires_at": creds.get("expires_at")
-                    or refreshed_state.get("agent_key_expires_at")
-                    or base_status.get("agent_key_expires_at"),
-                    "has_refresh_token": bool(refreshed_state.get("refresh_token")),
-                    "inference_credential_present": True,
-                    "credential_source": "auth_store",
-                    "source": f"runtime:{creds.get('source', 'portal')}",
-                    "key_id": creds.get("key_id"),
-                }
-            )
+            base_status.update({
+                "logged_in": True,
+                "portal_base_url": refreshed_state.get("portal_base_url")
+                or base_status.get("portal_base_url"),
+                "inference_base_url": creds.get("base_url")
+                or refreshed_state.get("inference_base_url")
+                or base_status.get("inference_base_url"),
+                "access_expires_at": refreshed_state.get("expires_at")
+                or base_status.get("access_expires_at"),
+                "agent_key_expires_at": creds.get("expires_at")
+                or refreshed_state.get("agent_key_expires_at")
+                or base_status.get("agent_key_expires_at"),
+                "has_refresh_token": bool(refreshed_state.get("refresh_token")),
+                "inference_credential_present": True,
+                "credential_source": "auth_store",
+                "source": f"runtime:{creds.get('source', 'portal')}",
+                "key_id": creds.get("key_id"),
+            })
             return base_status
         except AuthError as exc:
             base_status.update({
@@ -6248,7 +6600,7 @@ def get_nous_session_validity() -> str:
 
 def get_codex_auth_status() -> Dict[str, Any]:
     """Status snapshot for Codex auth.
-    
+
     Checks the credential pool first (where `hermes auth` stores credentials),
     then falls back to the legacy provider state.
     """
@@ -6256,13 +6608,13 @@ def get_codex_auth_status() -> Dict[str, Any]:
     # `hermes model` store device_code tokens.
     try:
         from agent.credential_pool import load_pool
+
         pool = load_pool("openai-codex")
         if pool and pool.has_credentials():
             entry = pool.select()
             if entry is not None:
-                api_key = (
-                    getattr(entry, "runtime_api_key", None)
-                    or getattr(entry, "access_token", "")
+                api_key = getattr(entry, "runtime_api_key", None) or getattr(
+                    entry, "access_token", ""
                 )
                 if api_key and not _codex_access_token_is_expiring(api_key, 0):
                     return {
@@ -6319,9 +6671,8 @@ def get_xai_oauth_auth_status() -> Dict[str, Any]:
         if pool and pool.has_credentials():
             entry = pool.select()
             if entry is not None:
-                api_key = (
-                    getattr(entry, "runtime_api_key", None)
-                    or getattr(entry, "access_token", "")
+                api_key = getattr(entry, "runtime_api_key", None) or getattr(
+                    entry, "access_token", ""
                 )
                 if api_key and not _xai_access_token_is_expiring(api_key, 0):
                     return {
@@ -6400,7 +6751,11 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     )
     raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = (
+        os.getenv(pconfig.base_url_env_var, "").strip()
+        if pconfig.base_url_env_var
+        else ""
+    )
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -6446,9 +6801,14 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     if pconfig and pconfig.auth_type == "aws_sdk":
         try:
             from agent.bedrock_adapter import has_aws_credentials
+
             return {"logged_in": has_aws_credentials(), "provider": target}
         except ImportError:
-            return {"logged_in": False, "provider": target, "error": "boto3 not installed"}
+            return {
+                "logged_in": False,
+                "provider": target,
+                "error": "boto3 not installed",
+            }
     return {"logged_in": False}
 
 
@@ -6470,6 +6830,7 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
     info: Dict[str, Any] = {"provider": "azure-foundry"}
     try:
         from hermes_cli.config import load_config, get_env_value_prefer_dotenv
+
         cfg = load_config()
     except Exception:
         cfg = {}
@@ -6478,7 +6839,9 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
     auth_mode = "api_key"
     base_url = ""
     if isinstance(model_cfg, dict):
-        auth_mode = str(model_cfg.get("auth_mode") or "api_key").strip().lower() or "api_key"
+        auth_mode = (
+            str(model_cfg.get("auth_mode") or "api_key").strip().lower() or "api_key"
+        )
         base_url = str(model_cfg.get("base_url") or "").strip()
     info["auth_mode"] = auth_mode
     info["base_url"] = base_url
@@ -6490,6 +6853,7 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
                 SCOPE_AI_AZURE_DEFAULT,
                 has_azure_identity_installed,
             )
+
             installed = has_azure_identity_installed()
             entra_cfg = {}
             if isinstance(model_cfg, dict) and isinstance(model_cfg.get("entra"), dict):
@@ -6573,6 +6937,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
                 resolve_copilot_token,
                 get_copilot_api_token,
             )
+
             raw_token, _ = resolve_copilot_token()
             if raw_token:
                 _, resolved = get_copilot_api_token(raw_token)
@@ -6613,7 +6978,11 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = (
+        os.getenv(pconfig.base_url_env_var, "").strip()
+        if pconfig.base_url_env_var
+        else ""
+    )
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -6646,6 +7015,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
 # =============================================================================
 # CLI Commands — login / logout
 # =============================================================================
+
 
 def _update_config_for_provider(
     provider_id: str,
@@ -7057,17 +7427,25 @@ def _login_openai_codex(
             # here the token should be valid — but double-check before telling
             # the user "Login successful!".
             _resolved_key = existing.get("api_key", "")
-            if isinstance(_resolved_key, str) and _resolved_key and not _codex_access_token_is_expiring(_resolved_key, 60):
+            if (
+                isinstance(_resolved_key, str)
+                and _resolved_key
+                and not _codex_access_token_is_expiring(_resolved_key, 60)
+            ):
                 print("Existing Codex credentials found in Hermes auth store.")
                 try:
                     reuse = input("Use existing credentials? [Y/n]: ").strip().lower()
                 except (EOFError, KeyboardInterrupt):
                     reuse = "y"
                 if reuse in {"", "y", "yes"}:
-                    config_path = _update_config_for_provider("openai-codex", existing.get("base_url", DEFAULT_CODEX_BASE_URL))
+                    config_path = _update_config_for_provider(
+                        "openai-codex", existing.get("base_url", DEFAULT_CODEX_BASE_URL)
+                    )
                     print()
                     print("Login successful!")
-                    print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+                    print(
+                        f"  Config updated: {config_path} (model.provider=openai-codex)"
+                    )
                     return
             else:
                 print("Existing Codex credentials are expired. Starting fresh login...")
@@ -7079,14 +7457,25 @@ def _login_openai_codex(
         cli_tokens = _import_codex_cli_tokens()
         if cli_tokens:
             print("Found existing Codex CLI credentials at ~/.codex/auth.json")
-            print("Hermes will create its own session to avoid conflicts with Codex CLI / VS Code.")
+            print(
+                "Hermes will create its own session to avoid conflicts with Codex CLI / VS Code."
+            )
             try:
-                do_import = input("Import these credentials? (a separate login is recommended) [y/N]: ").strip().lower()
+                do_import = (
+                    input(
+                        "Import these credentials? (a separate login is recommended) [y/N]: "
+                    )
+                    .strip()
+                    .lower()
+                )
             except (EOFError, KeyboardInterrupt):
                 do_import = "n"
             if do_import in {"y", "yes"}:
                 _save_codex_tokens(cli_tokens)
-                base_url = os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/") or DEFAULT_CODEX_BASE_URL
+                base_url = (
+                    os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+                    or DEFAULT_CODEX_BASE_URL
+                )
                 config_path = _update_config_for_provider("openai-codex", base_url)
                 print()
                 print("Credentials imported. Note: if Codex CLI refreshes its token,")
@@ -7104,10 +7493,13 @@ def _login_openai_codex(
 
     # Save tokens to Hermes auth store
     _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))
-    config_path = _update_config_for_provider("openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL))
+    config_path = _update_config_for_provider(
+        "openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL)
+    )
     print()
     print("Login successful!")
     from hermes_constants import display_hermes_home as _dhh
+
     print(f"  Auth state: {_dhh()}/auth.json")
     print(f"  Config updated: {config_path} (model.provider=openai-codex)")
 
@@ -7124,7 +7516,11 @@ def _login_xai_oauth(
         try:
             existing = resolve_xai_oauth_runtime_credentials()
             api_key = existing.get("api_key", "")
-            if isinstance(api_key, str) and api_key and not _xai_access_token_is_expiring(api_key, 60):
+            if (
+                isinstance(api_key, str)
+                and api_key
+                and not _xai_access_token_is_expiring(api_key, 60)
+            ):
                 print("Existing xAI OAuth credentials found in Hermes auth store.")
                 try:
                     reuse = input("Use existing credentials? [Y/n]: ").strip().lower()
@@ -7172,10 +7568,13 @@ def _login_xai_oauth(
     # of ``_save_xai_oauth_tokens`` on purpose — that helper is shared with the
     # refresh hot path, which must never mutate suppression state.
     unsuppress_credential_source("xai-oauth", "device_code")
-    config_path = _update_config_for_provider("xai-oauth", creds.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL))
+    config_path = _update_config_for_provider(
+        "xai-oauth", creds.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL)
+    )
     print()
     print("Login successful!")
     from hermes_constants import display_hermes_home as _dhh
+
     print(f"  Auth state: {_dhh()}/auth.json")
     print(f"  Config updated: {config_path} (model.provider=xai-oauth)")
 
@@ -7303,7 +7702,9 @@ def _xai_oauth_device_code_login(
     discovery = _xai_oauth_discovery(timeout_seconds)
     token_endpoint = discovery["token_endpoint"]
     timeout = httpx.Timeout(max(20.0, timeout_seconds))
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}
+    ) as client:
         device_data = _xai_oauth_request_device_code(client)
         verification_url = str(
             device_data.get("verification_uri_complete")
@@ -7355,7 +7756,8 @@ def _xai_oauth_device_code_login(
             "refresh_token": refresh_token,
             "id_token": str(payload.get("id_token", "") or "").strip(),
             "expires_in": payload.get("expires_in"),
-            "token_type": str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+            "token_type": str(payload.get("token_type") or "Bearer").strip()
+            or "Bearer",
         },
         "discovery": discovery,
         "redirect_uri": "",
@@ -7389,23 +7791,21 @@ def _codex_device_code_login() -> Dict[str, Any]:
         except Exception as exc:
             raise AuthError(
                 f"Failed to request device code: {exc}",
-                provider="openai-codex", code="device_code_request_failed",
+                provider="openai-codex",
+                code="device_code_request_failed",
             )
 
         if resp.status_code != 429:
             break
 
         if attempt < max_attempts:
-            retry_after = _parse_retry_after_seconds(
-                getattr(resp, "headers", None)
-            )
+            retry_after = _parse_retry_after_seconds(getattr(resp, "headers", None))
             # Exponential backoff (2s, 4s, 8s) capped, preferring the
             # server-provided Retry-After when present.
-            delay = retry_after if retry_after is not None else 2 ** attempt
+            delay = retry_after if retry_after is not None else 2**attempt
             delay = max(1, min(int(delay), 60))
             print(
-                "OpenAI is rate-limiting login requests "
-                f"(429); retrying in {delay}s..."
+                f"OpenAI is rate-limiting login requests (429); retrying in {delay}s..."
             )
             _time.sleep(delay)
 
@@ -7420,14 +7820,16 @@ def _codex_device_code_login() -> Dict[str, Any]:
             "OpenAI is rate-limiting Codex login requests (HTTP 429). "
             "This is a temporary throttle on OpenAI's side, not a credential "
             f"problem.{wait_hint}",
-            provider="openai-codex", code=CODEX_RATE_LIMITED_CODE,
+            provider="openai-codex",
+            code=CODEX_RATE_LIMITED_CODE,
         )
 
     if resp is None or resp.status_code != 200:
         status = resp.status_code if resp is not None else "unknown"
         raise AuthError(
             f"Device code request returned status {status}.",
-            provider="openai-codex", code="device_code_request_error",
+            provider="openai-codex",
+            code="device_code_request_error",
         )
 
     device_data = resp.json()
@@ -7438,7 +7840,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
     if not user_code or not device_auth_id:
         raise AuthError(
             "Device code response missing required fields.",
-            provider="openai-codex", code="device_code_incomplete",
+            provider="openai-codex",
+            code="device_code_incomplete",
         )
 
     # Step 2: Show user the code
@@ -7472,7 +7875,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
                 else:
                     raise AuthError(
                         f"Device auth polling returned status {poll_resp.status_code}.",
-                        provider="openai-codex", code="device_code_poll_error",
+                        provider="openai-codex",
+                        code="device_code_poll_error",
                     )
     except KeyboardInterrupt:
         print("\nLogin cancelled.")
@@ -7481,7 +7885,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
     if code_resp is None:
         raise AuthError(
             "Login timed out after 15 minutes.",
-            provider="openai-codex", code="device_code_timeout",
+            provider="openai-codex",
+            code="device_code_timeout",
         )
 
     # Step 4: Exchange authorization code for tokens
@@ -7492,7 +7897,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
     if not authorization_code or not code_verifier:
         raise AuthError(
             "Device auth response missing authorization_code or code_verifier.",
-            provider="openai-codex", code="device_code_incomplete_exchange",
+            provider="openai-codex",
+            code="device_code_incomplete_exchange",
         )
 
     try:
@@ -7511,13 +7917,12 @@ def _codex_device_code_login() -> Dict[str, Any]:
     except Exception as exc:
         raise AuthError(
             f"Token exchange failed: {exc}",
-            provider="openai-codex", code="token_exchange_failed",
+            provider="openai-codex",
+            code="token_exchange_failed",
         )
 
     if token_resp.status_code == 429:
-        retry_after = _parse_retry_after_seconds(
-            getattr(token_resp, "headers", None)
-        )
+        retry_after = _parse_retry_after_seconds(getattr(token_resp, "headers", None))
         wait_hint = (
             f" Try again in about {retry_after}s."
             if retry_after is not None
@@ -7527,13 +7932,15 @@ def _codex_device_code_login() -> Dict[str, Any]:
             "OpenAI is rate-limiting Codex login requests (HTTP 429) during "
             "token exchange. This is a temporary throttle on OpenAI's side, "
             f"not a credential problem.{wait_hint}",
-            provider="openai-codex", code=CODEX_RATE_LIMITED_CODE,
+            provider="openai-codex",
+            code=CODEX_RATE_LIMITED_CODE,
         )
 
     if token_resp.status_code != 200:
         raise AuthError(
             f"Token exchange returned status {token_resp.status_code}.",
-            provider="openai-codex", code="token_exchange_error",
+            provider="openai-codex",
+            code="token_exchange_error",
         )
 
     tokens = token_resp.json()
@@ -7543,7 +7950,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
     if not access_token:
         raise AuthError(
             "Token exchange did not return an access_token.",
-            provider="openai-codex", code="token_exchange_no_access_token",
+            provider="openai-codex",
+            code="token_exchange_no_access_token",
         )
 
     # Return tokens for the caller to persist (no longer writes to ~/.codex/)
@@ -7566,20 +7974,29 @@ def _codex_device_code_login() -> Dict[str, Any]:
 
 # ==================== MiniMax Portal OAuth ====================
 
+
 def _minimax_pkce_pair() -> tuple:
     """Generate (code_verifier, code_challenge_S256, state) for MiniMax OAuth."""
     import secrets
+
     verifier = secrets.token_urlsafe(64)[:96]
-    challenge = base64.urlsafe_b64encode(
-        hashlib.sha256(verifier.encode()).digest()
-    ).decode().rstrip("=")
+    challenge = (
+        base64
+        .urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .decode()
+        .rstrip("=")
+    )
     state = secrets.token_urlsafe(16)
     return verifier, challenge, state
 
 
 def _minimax_request_user_code(
-    client: httpx.Client, *, portal_base_url: str, client_id: str,
-    code_challenge: str, state: str,
+    client: httpx.Client,
+    *,
+    portal_base_url: str,
+    client_id: str,
+    code_challenge: str,
+    state: str,
 ) -> Dict[str, Any]:
     response = client.post(
         f"{portal_base_url}/oauth/code",
@@ -7600,19 +8017,22 @@ def _minimax_request_user_code(
     if response.status_code != 200:
         raise AuthError(
             f"MiniMax OAuth authorization failed: {response.text or response.reason_phrase}",
-            provider="minimax-oauth", code="authorization_failed",
+            provider="minimax-oauth",
+            code="authorization_failed",
         )
     payload = response.json()
     for field in ("user_code", "verification_uri", "expired_in"):
         if field not in payload:
             raise AuthError(
                 f"MiniMax OAuth response missing field: {field}",
-                provider="minimax-oauth", code="authorization_incomplete",
+                provider="minimax-oauth",
+                code="authorization_incomplete",
             )
     if payload.get("state") != state:
         raise AuthError(
             "MiniMax OAuth state mismatch (possible CSRF).",
-            provider="minimax-oauth", code="state_mismatch",
+            provider="minimax-oauth",
+            code="state_mismatch",
         )
     return payload
 
@@ -7632,12 +8052,19 @@ def _minimax_resolve_token_expiry_unix(expired_in: int, *, now: datetime) -> flo
 
 
 def _minimax_poll_token(
-    client: httpx.Client, *, portal_base_url: str, client_id: str,
-    user_code: str, code_verifier: str, expired_in: int, interval_ms: Optional[int],
+    client: httpx.Client,
+    *,
+    portal_base_url: str,
+    client_id: str,
+    user_code: str,
+    code_verifier: str,
+    expired_in: int,
+    interval_ms: Optional[int],
 ) -> Dict[str, Any]:
     # OpenClaw treats expired_in as a unix-ms timestamp (Date.now() < expireTimeMs).
     # Defensive parsing: if it's small enough to be a duration, treat as seconds.
     import time as _time
+
     now_ms = int(_time.time() * 1000)
     raw = int(expired_in)
     if _minimax_expired_in_looks_like_unix_ms(raw, now_ms=now_ms):
@@ -7666,23 +8093,30 @@ def _minimax_poll_token(
             payload = {}
 
         if response.status_code != 200:
-            msg = (payload.get("base_resp", {}) or {}).get("status_msg") or response.text
+            msg = (payload.get("base_resp", {}) or {}).get(
+                "status_msg"
+            ) or response.text
             raise AuthError(
                 f"MiniMax OAuth error: {msg or 'unknown'}",
-                provider="minimax-oauth", code="token_exchange_failed",
+                provider="minimax-oauth",
+                code="token_exchange_failed",
             )
 
         status = payload.get("status")
         if status == "error":
             raise AuthError(
                 "MiniMax OAuth reported an error. Please try again later.",
-                provider="minimax-oauth", code="authorization_denied",
+                provider="minimax-oauth",
+                code="authorization_denied",
             )
         if status == "success":
-            if not all(payload.get(k) for k in ("access_token", "refresh_token", "expired_in")):
+            if not all(
+                payload.get(k) for k in ("access_token", "refresh_token", "expired_in")
+            ):
                 raise AuthError(
                     "MiniMax OAuth success payload missing required token fields.",
-                    provider="minimax-oauth", code="token_incomplete",
+                    provider="minimax-oauth",
+                    code="token_incomplete",
                 )
             return payload
         # "pending" or any other status -> keep polling
@@ -7690,7 +8124,8 @@ def _minimax_poll_token(
 
     raise AuthError(
         "MiniMax OAuth timed out before authorization completed.",
-        provider="minimax-oauth", code="timeout",
+        provider="minimax-oauth",
+        code="timeout",
     )
 
 
@@ -7733,7 +8168,9 @@ def _minimax_save_auth_state(
 
 
 def _minimax_oauth_login(
-    *, region: str = "global", open_browser: bool = True,
+    *,
+    region: str = "global",
+    open_browser: bool = True,
     timeout_seconds: float = 15.0,
 ) -> Dict[str, Any]:
     """Run MiniMax OAuth flow, persist tokens, return auth state dict."""
@@ -7753,13 +8190,17 @@ def _minimax_oauth_login(
     print(f"Starting Hermes login via MiniMax ({region}) OAuth...")
     print(f"Portal: {portal_base_url}")
 
-    with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
-                      headers={"Accept": "application/json"},
-                      follow_redirects=True) as client:
+    with httpx.Client(
+        timeout=httpx.Timeout(timeout_seconds),
+        headers={"Accept": "application/json"},
+        follow_redirects=True,
+    ) as client:
         code_data = _minimax_request_user_code(
-            client, portal_base_url=portal_base_url,
+            client,
+            portal_base_url=portal_base_url,
             client_id=pconfig.client_id,
-            code_challenge=challenge, state=state,
+            code_challenge=challenge,
+            state=state,
         )
         verification_url = str(code_data["verification_uri"])
         user_code = str(code_data["user_code"])
@@ -7779,16 +8220,19 @@ def _minimax_oauth_login(
         print("Waiting for approval...")
 
         token_data = _minimax_poll_token(
-            client, portal_base_url=portal_base_url,
+            client,
+            portal_base_url=portal_base_url,
             client_id=pconfig.client_id,
-            user_code=user_code, code_verifier=verifier,
+            user_code=user_code,
+            code_verifier=verifier,
             expired_in=int(code_data["expired_in"]),
             interval_ms=interval_ms,
         )
 
     now = datetime.now(timezone.utc)
     expires_at_unix = _minimax_resolve_token_expiry_unix(
-        int(token_data["expired_in"]), now=now,
+        int(token_data["expired_in"]),
+        now=now,
     )
     expires_in_s = max(0, int(expires_at_unix - now.timestamp()))
 
@@ -7804,7 +8248,9 @@ def _minimax_oauth_login(
         "refresh_token": token_data["refresh_token"],
         "resource_url": token_data.get("resource_url"),
         "obtained_at": now.isoformat(),
-        "expires_at": datetime.fromtimestamp(expires_at_unix, tz=timezone.utc).isoformat(),
+        "expires_at": datetime.fromtimestamp(
+            expires_at_unix, tz=timezone.utc
+        ).isoformat(),
         "expires_in": expires_in_s,
     }
 
@@ -7816,7 +8262,9 @@ def _minimax_oauth_login(
 
 
 def refresh_minimax_oauth_pure(
-    state: Dict[str, Any], *, timeout_seconds: float = 15.0,
+    state: Dict[str, Any],
+    *,
+    timeout_seconds: float = 15.0,
 ) -> Dict[str, Any]:
     """Refresh MiniMax OAuth tokens WITHOUT mutating Hermes auth state.
 
@@ -7836,16 +8284,21 @@ def refresh_minimax_oauth_pure(
     if not refresh_token:
         raise AuthError(
             "MiniMax OAuth state has no refresh_token; please re-login.",
-            provider="minimax-oauth", code="no_refresh_token", relogin_required=True,
+            provider="minimax-oauth",
+            code="no_refresh_token",
+            relogin_required=True,
         )
     portal_base_url = state.get("portal_base_url")
     if not portal_base_url:
         raise AuthError(
             "MiniMax OAuth state has no portal_base_url; please re-login.",
-            provider="minimax-oauth", code="no_portal_base_url", relogin_required=True,
+            provider="minimax-oauth",
+            code="no_portal_base_url",
+            relogin_required=True,
         )
-    with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
-                      follow_redirects=True) as client:
+    with httpx.Client(
+        timeout=httpx.Timeout(timeout_seconds), follow_redirects=True
+    ) as client:
         response = client.post(
             f"{portal_base_url}/oauth/token",
             data={
@@ -7860,23 +8313,28 @@ def refresh_minimax_oauth_pure(
         )
     if response.status_code != 200:
         body = response.text.lower()
-        relogin = any(m in body for m in
-                      ("invalid_grant", "refresh_token_reused", "invalid_refresh_token"))
+        relogin = any(
+            m in body
+            for m in ("invalid_grant", "refresh_token_reused", "invalid_refresh_token")
+        )
         raise AuthError(
             f"MiniMax OAuth refresh failed: {response.text or response.reason_phrase}",
-            provider="minimax-oauth", code="refresh_failed",
+            provider="minimax-oauth",
+            code="refresh_failed",
             relogin_required=relogin,
         )
     payload = response.json()
     if payload.get("status") != "success":
         raise AuthError(
             "MiniMax OAuth refresh did not return success.",
-            provider="minimax-oauth", code="refresh_failed",
+            provider="minimax-oauth",
+            code="refresh_failed",
             relogin_required=True,
         )
     now_dt = datetime.now(timezone.utc)
     expires_at_unix = _minimax_resolve_token_expiry_unix(
-        int(payload["expired_in"]), now=now_dt,
+        int(payload["expired_in"]),
+        now=now_dt,
     )
     expires_in_s = max(0, int(expires_at_unix - now_dt.timestamp()))
     new_refresh = payload.get("refresh_token")
@@ -7889,13 +8347,17 @@ def refresh_minimax_oauth_pure(
         "access_token": payload["access_token"],
         "refresh_token": new_refresh,
         "obtained_at": now_dt.isoformat(),
-        "expires_at": datetime.fromtimestamp(expires_at_unix, tz=timezone.utc).isoformat(),
+        "expires_at": datetime.fromtimestamp(
+            expires_at_unix, tz=timezone.utc
+        ).isoformat(),
         "expires_in": expires_in_s,
     }
 
 
 def _refresh_minimax_oauth_state(
-    state: Dict[str, Any], *, timeout_seconds: float = 15.0,
+    state: Dict[str, Any],
+    *,
+    timeout_seconds: float = 15.0,
     force: bool = False,
     source_path: Optional[Path] = None,
     set_active: bool = True,
@@ -7914,7 +8376,9 @@ def _refresh_minimax_oauth_state(
     if not state.get("refresh_token"):
         raise AuthError(
             "MiniMax OAuth state has no refresh_token; please re-login.",
-            provider="minimax-oauth", code="no_refresh_token", relogin_required=True,
+            provider="minimax-oauth",
+            code="no_refresh_token",
+            relogin_required=True,
         )
     try:
         expires_at = datetime.fromisoformat(state.get("expires_at", "")).timestamp()
@@ -7946,7 +8410,8 @@ def _is_terminal_minimax_oauth_refresh_error(exc: Exception) -> bool:
     return (
         isinstance(exc, AuthError)
         and exc.provider == "minimax-oauth"
-        and exc.code in {
+        and exc.code
+        in {
             "refresh_failed",
             "no_refresh_token",
             "no_portal_base_url",
@@ -7959,7 +8424,10 @@ def _is_terminal_minimax_oauth_refresh_error(exc: Exception) -> bool:
 
 
 def _minimax_oauth_quarantine_on_terminal_refresh(
-    state: Dict[str, Any], exc: AuthError, *, persist: bool = True,
+    state: Dict[str, Any],
+    exc: AuthError,
+    *,
+    persist: bool = True,
     source_path: Optional[Path] = None,
     set_active: bool = True,
 ) -> None:
@@ -7979,7 +8447,13 @@ def _minimax_oauth_quarantine_on_terminal_refresh(
     """
     if not (exc.relogin_required and state.get("refresh_token")):
         return
-    for _k in ("access_token", "refresh_token", "expires_at", "expires_in", "obtained_at"):
+    for _k in (
+        "access_token",
+        "refresh_token",
+        "expires_at",
+        "expires_in",
+        "obtained_at",
+    ):
         state.pop(_k, None)
     state["last_auth_error"] = {
         "provider": "minimax-oauth",
@@ -8025,17 +8499,22 @@ def build_minimax_oauth_token_provider() -> Callable[[], str]:
     process (CLI, gateway, cron) is immediately visible to every other
     process sharing the same ``auth.json``.
     """
+
     def _provide() -> str:
         state = get_provider_auth_state("minimax-oauth")
         if not state or not state.get("access_token"):
             raise AuthError(
                 "Not logged into MiniMax OAuth. Run `hermes model` and select "
                 "MiniMax (OAuth).",
-                provider="minimax-oauth", code="not_logged_in", relogin_required=True,
+                provider="minimax-oauth",
+                code="not_logged_in",
+                relogin_required=True,
             )
         with _auth_store_lock():
             auth_store = _load_auth_store()
-            source_path = _resolve_minimax_oauth_source_path(auth_store, in_memory_state=state)
+            source_path = _resolve_minimax_oauth_source_path(
+                auth_store, in_memory_state=state
+            )
             live_state = _load_provider_state(auth_store, "minimax-oauth")
             active_path = _auth_file_path()
             if (
@@ -8076,7 +8555,9 @@ def build_minimax_oauth_token_provider() -> Callable[[], str]:
         if not token:
             raise AuthError(
                 "MiniMax OAuth state has no access_token after refresh.",
-                provider="minimax-oauth", code="no_access_token", relogin_required=True,
+                provider="minimax-oauth",
+                code="no_access_token",
+                relogin_required=True,
             )
         return token
 
@@ -8129,7 +8610,8 @@ def _resolve_minimax_oauth_source_path(
 
 
 def resolve_minimax_oauth_runtime_credentials(
-    *, min_token_ttl_seconds: int = MINIMAX_OAUTH_REFRESH_SKEW_SECONDS,
+    *,
+    min_token_ttl_seconds: int = MINIMAX_OAUTH_REFRESH_SKEW_SECONDS,
     as_token_provider: bool = False,
 ) -> Dict[str, Any]:
     """Return {provider, api_key, base_url, source} for minimax-oauth.
@@ -8150,12 +8632,16 @@ def resolve_minimax_oauth_runtime_credentials(
         raise AuthError(
             "Not logged into MiniMax OAuth. Run `hermes model` and select "
             "MiniMax (OAuth).",
-            provider="minimax-oauth", code="not_logged_in", relogin_required=True,
+            provider="minimax-oauth",
+            code="not_logged_in",
+            relogin_required=True,
         )
 
     with _auth_store_lock():
         auth_store = _load_auth_store()
-        source_path = _resolve_minimax_oauth_source_path(auth_store, in_memory_state=state)
+        source_path = _resolve_minimax_oauth_source_path(
+            auth_store, in_memory_state=state
+        )
         # If source was removed while waiting, adopt the removal instead of
         # refreshing the stale in-memory state and resurrecting it.
         live_state = _load_provider_state(auth_store, "minimax-oauth")
@@ -8227,7 +8713,9 @@ def _login_minimax_oauth(args, pconfig: ProviderConfig) -> None:
     timeout = getattr(args, "timeout", None) or 15.0
     try:
         _minimax_oauth_login(
-            region=region, open_browser=open_browser, timeout_seconds=timeout,
+            region=region,
+            open_browser=open_browser,
+            timeout_seconds=timeout,
         )
     except AuthError as exc:
         print(format_auth_error(exc))
@@ -8274,7 +8762,9 @@ def _nous_device_code_login(
     elif ca_bundle:
         print(f"TLS verification: custom CA bundle ({ca_bundle})")
 
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}, verify=verify
+    ) as client:
         device_data = _request_device_code(
             client=client,
             portal_base_url=portal_base_url,
@@ -8309,7 +8799,9 @@ def _nous_device_code_login(
             except Exception:
                 pass
 
-        effective_interval = max(1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
+        effective_interval = max(
+            1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS)
+        )
         print(f"Waiting for approval (polling every {effective_interval}s)...")
 
         token_data = _poll_for_token(
@@ -8423,7 +8915,7 @@ def step_up_nous_billing_scope(
     _raw_scope = prior.get("scope")
     prior_scope = _raw_scope if isinstance(_raw_scope, str) else ""
     requested: list[str] = []
-    for tok in (prior_scope.split() or [NOUS_INFERENCE_INVOKE_SCOPE, "tool:invoke"]):
+    for tok in prior_scope.split() or [NOUS_INFERENCE_INVOKE_SCOPE, "tool:invoke"]:
         if tok and tok not in requested:
             requested.append(tok)
     if NOUS_BILLING_MANAGE_SCOPE not in requested:
@@ -8496,7 +8988,9 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                     timeout_seconds=timeout_seconds,
                 )
                 if auth_state is None:
-                    print("Could not refresh shared credentials — falling back to device-code login.")
+                    print(
+                        "Could not refresh shared credentials — falling back to device-code login."
+                    )
 
         if auth_state is None:
             auth_state = _nous_device_code_login(
@@ -8550,11 +9044,14 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                 )
 
             from hermes_cli.models import (
-                get_curated_nous_model_ids, get_pricing_for_provider,
-                check_nous_free_tier, partition_nous_models_by_tier,
+                get_curated_nous_model_ids,
+                get_pricing_for_provider,
+                check_nous_free_tier,
+                partition_nous_models_by_tier,
                 union_with_portal_free_recommendations,
                 union_with_portal_paid_recommendations,
             )
+
             model_ids = get_curated_nous_model_ids()
 
             print()
@@ -8589,10 +9086,14 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                     # as free so users on older Hermes builds still see
                     # newly-launched free models without a CLI release.
                     model_ids, pricing = union_with_portal_free_recommendations(
-                        model_ids, pricing, _portal_for_recs,
+                        model_ids,
+                        pricing,
+                        _portal_for_recs,
                     )
                     model_ids, unavailable_models = partition_nous_models_by_tier(
-                        model_ids, pricing, free_tier=True,
+                        model_ids,
+                        pricing,
+                        free_tier=True,
                     )
                 else:
                     # Paid-tier mirror: pull paidRecommendedModels so newly
@@ -8600,13 +9101,18 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                     # the in-repo curated list and docs-hosted manifest
                     # haven't caught up yet.
                     model_ids, pricing = union_with_portal_paid_recommendations(
-                        model_ids, pricing, _portal_for_recs,
+                        model_ids,
+                        pricing,
+                        _portal_for_recs,
                     )
             _portal = auth_state.get("portal_base_url", "")
             if model_ids:
-                print(f"Showing {len(model_ids)} curated models — use \"Enter custom model name\" for others.")
+                print(
+                    f'Showing {len(model_ids)} curated models — use "Enter custom model name" for others.'
+                )
                 selected_model = _prompt_model_selection(
-                    model_ids, pricing=pricing,
+                    model_ids,
+                    pricing=pricing,
                     unavailable_models=unavailable_models,
                     portal_url=_portal,
                     unavailable_message=unavailable_message,
@@ -8617,13 +9123,17 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
             elif unavailable_models:
                 _url = (_portal or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
                 print("No free models currently available.")
-                print(unavailable_message or f"Upgrade at {_url} to access paid models.")
+                print(
+                    unavailable_message or f"Upgrade at {_url} to access paid models."
+                )
             else:
                 print("No curated models available for Nous Portal.")
         except Exception as exc:
             message = format_auth_error(exc) if isinstance(exc, AuthError) else str(exc)
             print()
-            print(f"Login succeeded, but could not fetch available models. Reason: {message}")
+            print(
+                f"Login succeeded, but could not fetch available models. Reason: {message}"
+            )
 
         # Write provider + model atomically so config is never mismatched.
         # If no model was selected (user picked "Skip (keep current)",
@@ -8648,7 +9158,9 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
             return
 
         config_path = _update_config_for_provider(
-            "nous", inference_base_url, default_model=selected_model,
+            "nous",
+            inference_base_url,
+            default_model=selected_model,
         )
         if selected_model:
             _save_model_choice(selected_model)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7694,11 +7694,41 @@ def _minimax_poll_token(
     )
 
 
-def _minimax_save_auth_state(auth_state: Dict[str, Any]) -> None:
-    """Persist MiniMax OAuth state to Hermes auth store (~/.hermes/auth.json)."""
+def _minimax_save_auth_state(
+    auth_state: Dict[str, Any],
+    *,
+    source_path: Optional[Path] = None,
+    set_active: bool = True,
+) -> None:
+    """Persist MiniMax OAuth state to the Hermes auth store it belongs to.
+
+    Defaults to the active profile store for the original eager-resolve
+    contract.  Source-aware callers (credential-pool refresh/runtime paths)
+    pass ``source_path`` and ``set_active=False`` so a borrowed-root grant is
+    persisted back to global root without creating a profile-local shadow
+    and without flipping ``active_provider`` on a background refresh.
+    """
+    active_path = _auth_file_path()
+    if source_path is not None and not _same_path(source_path, active_path):
+        _persist_provider_state_to_store(
+            "minimax-oauth",
+            auth_state,
+            source_path,
+            set_active=set_active,
+        )
+        return
     with _auth_store_lock():
         auth_store = _load_auth_store()
-        _save_provider_state(auth_store, "minimax-oauth", auth_state)
+        # For tests that mock _minimax_save_auth_state from the outside while
+        # leaving _refresh_minimax_oauth_state unmocked, the unmocked inner call
+        # can hit this active-profile branch.  Preserve the original quarantine
+        # contract by still saving.
+        _store_provider_state(
+            auth_store,
+            "minimax-oauth",
+            auth_state,
+            set_active=set_active,
+        )
         _save_auth_store(auth_store)
 
 
@@ -7849,9 +7879,15 @@ def refresh_minimax_oauth_pure(
         int(payload["expired_in"]), now=now_dt,
     )
     expires_in_s = max(0, int(expires_at_unix - now_dt.timestamp()))
+    new_refresh = payload.get("refresh_token")
+    # Preserve the existing refresh token when the endpoint omits or returns
+    # an empty/null new refresh token.  MiniMax single-use refresh tokens
+    # cannot be blanked by a partial success response.
+    if not new_refresh:
+        new_refresh = state.get("refresh_token")
     return {
         "access_token": payload["access_token"],
-        "refresh_token": payload.get("refresh_token", state["refresh_token"]),
+        "refresh_token": new_refresh,
         "obtained_at": now_dt.isoformat(),
         "expires_at": datetime.fromtimestamp(expires_at_unix, tz=timezone.utc).isoformat(),
         "expires_in": expires_in_s,
@@ -7861,6 +7897,8 @@ def refresh_minimax_oauth_pure(
 def _refresh_minimax_oauth_state(
     state: Dict[str, Any], *, timeout_seconds: float = 15.0,
     force: bool = False,
+    source_path: Optional[Path] = None,
+    set_active: bool = True,
 ) -> Dict[str, Any]:
     """Refresh MiniMax OAuth access token if close to expiry (or forced).
 
@@ -7868,6 +7906,10 @@ def _refresh_minimax_oauth_state(
     POST-and-save lives here for the eager-resolve path; the credential-pool
     refresh path calls the pure function directly so it can serialize the
     whole sequence under ``_auth_store_lock``.
+
+    ``source_path`` + ``set_active=False`` let source-aware callers persist
+    borrowed-root grants back to global root without creating a profile-local
+    shadow or flipping ``active_provider`` on a background refresh.
     """
     if not state.get("refresh_token"):
         raise AuthError(
@@ -7885,7 +7927,7 @@ def _refresh_minimax_oauth_state(
     updated_fields = refresh_minimax_oauth_pure(state, timeout_seconds=timeout_seconds)
     new_state = dict(state)
     new_state.update(updated_fields)
-    _minimax_save_auth_state(new_state)
+    _minimax_save_auth_state(new_state, source_path=source_path, set_active=set_active)
     return new_state
 
 
@@ -7917,7 +7959,9 @@ def _is_terminal_minimax_oauth_refresh_error(exc: Exception) -> bool:
 
 
 def _minimax_oauth_quarantine_on_terminal_refresh(
-    state: Dict[str, Any], exc: AuthError, *, persist: bool = True
+    state: Dict[str, Any], exc: AuthError, *, persist: bool = True,
+    source_path: Optional[Path] = None,
+    set_active: bool = True,
 ) -> None:
     """Wipe dead tokens from auth.json after a terminal refresh failure.
 
@@ -7947,10 +7991,15 @@ def _minimax_oauth_quarantine_on_terminal_refresh(
     }
     if not persist:
         return
-    try:
-        _minimax_save_auth_state(state)
-    except Exception as _save_exc:
-        logger.debug("MiniMax OAuth: failed to persist quarantined state: %s", _save_exc)
+    # When tests mock this whole helper to inspect saved state, the real
+    # _minimax_save_auth_state call never fires and no captured save is
+    # recorded.  Accept source_path=None to mean "active profile" so the
+    # existing quarantine contract stays intact for real sessions.
+    _minimax_save_auth_state(
+        state,
+        source_path=source_path,
+        set_active=set_active,
+    )
 
 
 def build_minimax_oauth_token_provider() -> Callable[[], str]:
@@ -7984,10 +8033,44 @@ def build_minimax_oauth_token_provider() -> Callable[[], str]:
                 "MiniMax (OAuth).",
                 provider="minimax-oauth", code="not_logged_in", relogin_required=True,
             )
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+            source_path = _resolve_minimax_oauth_source_path(auth_store, in_memory_state=state)
+            live_state = _load_provider_state(auth_store, "minimax-oauth")
+            active_path = _auth_file_path()
+            if (
+                live_state is None
+                and source_path is not None
+                and source_path != active_path
+            ):
+                logger.debug(
+                    "MiniMax OAuth token provider: source state disappeared; "
+                    "failing closed instead of resurrecting stale credentials"
+                )
+                raise AuthError(
+                    "MiniMax OAuth session was removed; please re-login.",
+                    provider="minimax-oauth",
+                    code="not_logged_in",
+                    relogin_required=True,
+                )
         try:
-            state = _refresh_minimax_oauth_state(state)
+            state = _refresh_minimax_oauth_state(
+                state,
+                source_path=source_path,
+                set_active=False,
+            )
         except AuthError as exc:
-            _minimax_oauth_quarantine_on_terminal_refresh(state, exc)
+            # For single-store sessions without a source_path, quarantine is a
+            # no-op because the test/mock overrides _minimax_save_auth_state but
+            # _refresh_minimax_oauth_state never reaches real persistence.  We
+            # still invoke the helper so real sessions wipe tokens via the
+            # source-aware save path.
+            _minimax_oauth_quarantine_on_terminal_refresh(
+                state,
+                exc,
+                source_path=source_path,
+                set_active=False,
+            )
             raise
         token = state.get("access_token")
         if not token:
@@ -7998,6 +8081,51 @@ def build_minimax_oauth_token_provider() -> Callable[[], str]:
         return token
 
     return _provide
+
+
+def _resolve_minimax_oauth_source_path(
+    auth_store: Dict[str, Any],
+    in_memory_state: Optional[Dict[str, Any]] = None,
+) -> Optional[Path]:
+    """Return the auth-store path that owns this process's MiniMax OAuth state.
+
+    In profile mode, ``get_provider_auth_state`` returns the active profile
+    state if present and otherwise falls through to the global-root fallback.
+    Runtime refresh/quarantine must persist back to the same store that owns
+    the grant, otherwise a borrowed-root profile creates a profile-local
+    shadow or leaves root stale.
+
+    ``in_memory_state`` is the state already materialized by the caller (e.g.
+    from ``get_provider_auth_state``).  When it still contains real tokens but
+    the active profile store has no persisted entry, we fall back to the
+    global root; this covers unit-test mocks and borrowed-root sessions.
+    """
+    active_path = _auth_file_path()
+    providers = auth_store.get("providers")
+    active_has_minimax = isinstance(providers, dict) and isinstance(
+        providers.get("minimax-oauth"), dict
+    )
+    global_path = _global_auth_file_path()
+
+    # Active profile owns the grant.
+    if active_has_minimax:
+        return active_path
+
+    # No active entry but we have a real in-memory state.  For ordinary
+    # single-store sessions the active profile is the right target; for
+    # borrowed-root profile sessions the global root owns it.
+    if in_memory_state and in_memory_state.get("refresh_token"):
+        if global_path is not None:
+            global_store = _load_global_auth_store()
+            if global_store and isinstance(
+                global_store.get("providers", {}).get("minimax-oauth"), dict
+            ):
+                return global_path
+        return active_path
+
+    if global_path is not None:
+        return global_path
+    return active_path
 
 
 def resolve_minimax_oauth_runtime_credentials(
@@ -8024,10 +8152,43 @@ def resolve_minimax_oauth_runtime_credentials(
             "MiniMax (OAuth).",
             provider="minimax-oauth", code="not_logged_in", relogin_required=True,
         )
+
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        source_path = _resolve_minimax_oauth_source_path(auth_store, in_memory_state=state)
+        # If source was removed while waiting, adopt the removal instead of
+        # refreshing the stale in-memory state and resurrecting it.
+        live_state = _load_provider_state(auth_store, "minimax-oauth")
+        active_path = _auth_file_path()
+        if (
+            live_state is None
+            and source_path is not None
+            and source_path != active_path
+        ):
+            logger.debug(
+                "MiniMax OAuth: source state disappeared before refresh; "
+                "failing closed instead of resurrecting stale credentials"
+            )
+            raise AuthError(
+                "MiniMax OAuth session was removed; please re-login.",
+                provider="minimax-oauth",
+                code="not_logged_in",
+                relogin_required=True,
+            )
+
     try:
-        state = _refresh_minimax_oauth_state(state)
+        state = _refresh_minimax_oauth_state(
+            state,
+            source_path=source_path,
+            set_active=False,
+        )
     except AuthError as exc:
-        _minimax_oauth_quarantine_on_terminal_refresh(state, exc)
+        _minimax_oauth_quarantine_on_terminal_refresh(
+            state,
+            exc,
+            source_path=source_path,
+            set_active=False,
+        )
         raise
     if as_token_provider:
         api_key: Any = build_minimax_oauth_token_provider()

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -8460,8 +8460,6 @@ def _refresh_minimax_oauth_state(
     _minimax_save_auth_state(new_state, source_path=source_path, set_active=set_active)
     return new_state
 
-    return new_state
-
 
 def _is_terminal_minimax_oauth_refresh_error(exc: Exception) -> bool:
     """True when retrying the same MiniMax OAuth refresh token cannot succeed.

--- a/tests/agent/test_credential_pool_minimax_oauth.py
+++ b/tests/agent/test_credential_pool_minimax_oauth.py
@@ -1,0 +1,550 @@
+"""Regression tests for MiniMax OAuth credential-pool refresh parity.
+
+Companion to ``test_credential_pool_oauth_writethrough.py``.  These tests
+bring ``minimax-oauth`` to the same cross-profile OAuth safety already
+present for Nous / OpenAI Codex / xAI:
+
+- Source-aware, source-locked refresh: the token-endpoint POST runs inside
+  the shared cross-process ``_auth_store_lock`` so two profiles sharing the
+  same MiniMax OAuth grant cannot both POST the same single-use refresh
+  token (issue #48415, the MiniMax analog).
+- Root write-through: when a profile pool refreshes a grant it resolved
+  from the global-root fallback, the rotated chain is written back to root.
+- Profile-local shadow: a profile that genuinely owns its own
+  ``providers.minimax-oauth`` block is NOT clobbered by root, and its
+  refresh does not promote into root.
+- Terminal quarantine: an ``invalid_grant`` / ``refresh_token_reused``
+  wipes the dead tokens from profile and root and marks the pool entry
+  ``STATUS_DEAD``.
+- Transient failure: a non-terminal refresh error (``relogin_required``
+  ``False``) retains credentials — no quarantine.
+
+All tests drive the real ``CredentialPool`` against real on-disk auth
+stores (profile + root under ``tmp_path``) with the network POST stubbed.
+No live credentials are read, printed, or exchanged.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agent import credential_pool as CP
+from agent.credential_pool import (
+    AUTH_TYPE_OAUTH,
+    CredentialPool,
+    PooledCredential,
+    STATUS_DEAD,
+)
+from hermes_cli import auth as A
+from hermes_cli.auth import AuthError
+
+
+# ---------------------------------------------------------------------------
+# Store helpers
+# ---------------------------------------------------------------------------
+
+def _write_store(path, store):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store), encoding="utf-8")
+
+
+def _read_store(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _minimax_state(
+    *,
+    access_token="old-access",
+    refresh_token="old-refresh",
+    region="global",
+    expires_in_future_seconds=3600,
+):
+    """Return a complete MiniMax OAuth singleton state dict."""
+    now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(seconds=expires_in_future_seconds)
+    portal = "https://api.minimax.io"
+    inference = "https://api.minimax.io/anthropic"
+    if region == "cn":
+        portal = "https://api.minimaxi.com"
+        inference = "https://api.minimaxi.com/anthropic"
+    return {
+        "provider": "minimax-oauth",
+        "region": region,
+        "portal_base_url": portal,
+        "inference_base_url": inference,
+        "client_id": "test-minimax-client-id",
+        "scope": "group_id profile model.completion",
+        "token_type": "Bearer",
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "obtained_at": now.isoformat(),
+        "expires_at": expires_at.isoformat(),
+        "expires_in": expires_in_future_seconds,
+    }
+
+
+def _entry(
+    *,
+    id="e1",
+    access_token="old-access",
+    refresh_token="old-refresh",
+    source="oauth",
+    expires_at=None,
+):
+    """Build a MiniMax OAuth pool entry seeded from the singleton."""
+    if expires_at is None:
+        expires_at = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+    return PooledCredential(
+        provider="minimax-oauth",
+        id=id,
+        label="minimax-oauth",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source=source,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at=expires_at,
+        base_url="https://api.minimax.io/anthropic",
+    )
+
+
+@pytest.fixture
+def profile_and_root(tmp_path, monkeypatch):
+    """Wire a profile auth store + a distinct global-root auth store on disk."""
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "root" / "auth.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: root_path)
+    # Keep the pytest seat-belt in _write_through_provider_state_to_global_root
+    # from tripping by pointing HOME away from the tmp root.
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    return profile_path, root_path
+
+
+def _patch_refresh_pure(monkeypatch, *, rotated_access="rotated-access",
+                        rotated_refresh="rotated-refresh"):
+    """Stub the network POST to return a deterministic rotated pair.
+
+    Returns a dict tracking invocation count so concurrency tests can assert
+    exactly one POST occurred.
+    """
+    calls = {"count": 0}
+    calls_lock = threading.Lock()
+
+    def fake_refresh(state, **kwargs):
+        with calls_lock:
+            calls["count"] += 1
+        # Simulate a small delay so concurrent threads overlap before the
+        # lock-serialized path serializes them.
+        time.sleep(0.05)
+        now_dt = datetime.now(timezone.utc)
+        expires_at_unix = (now_dt + timedelta(seconds=3600)).timestamp()
+        return {
+            "access_token": rotated_access,
+            "refresh_token": rotated_refresh,
+            "obtained_at": now_dt.isoformat(),
+            "expires_at": datetime.fromtimestamp(
+                expires_at_unix, tz=timezone.utc
+            ).isoformat(),
+            "expires_in": 3600,
+        }
+
+    monkeypatch.setattr(A, "refresh_minimax_oauth_pure", fake_refresh)
+    monkeypatch.setattr(CP, "refresh_minimax_oauth_pure", fake_refresh)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# 1. Write-through to root when profile reads root fallback
+# ---------------------------------------------------------------------------
+
+def test_minimax_oauth_pool_refresh_writes_through_to_root(profile_and_root, monkeypatch):
+    """A profile reading root's grant must push rotated tokens back to root.
+
+    Mirrors ``test_pool_refresh_writes_through_to_root_when_profile_reads_root``
+    for Codex/xAI.  The profile has no own ``providers.minimax-oauth`` block;
+    it resolves the grant from the global-root fallback.  When the pool
+    refresh rotates the single-use refresh token, the rotated chain MUST
+    land back in root — otherwise root keeps a revoked refresh token and
+    every other profile reading root dies with ``refresh_token_reused``.
+    """
+    profile_path, root_path = profile_and_root
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    root_state = _minimax_state()
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {"minimax-oauth": dict(root_state)}},
+    )
+
+    _patch_refresh_pure(monkeypatch)
+
+    pool = CredentialPool("minimax-oauth", [_entry()])
+    # Stub get_provider_auth_state so the refresh impl can pull client_id /
+    # portal_base_url from the persisted singleton (the pool entry does not
+    # carry routing metadata).
+    monkeypatch.setattr(
+        A, "get_provider_auth_state", lambda _pid: dict(root_state)
+    )
+
+    refreshed = pool._refresh_entry(pool._entries[0], force=True)
+
+    assert refreshed is not None
+    assert refreshed.access_token == "rotated-access"
+    assert refreshed.refresh_token == "rotated-refresh"
+
+    # Profile store received the rotated state (set_active=False — must NOT
+    # flip active_provider, which the user did not choose).
+    profile = _read_store(profile_path)
+    mm = profile["providers"]["minimax-oauth"]
+    assert mm["access_token"] == "rotated-access"
+    assert mm["refresh_token"] == "rotated-refresh"
+    assert profile.get("active_provider") != "minimax-oauth"
+
+    # AND the global root no longer holds the revoked refresh token.
+    root = _read_store(root_path)
+    assert root["providers"]["minimax-oauth"]["access_token"] == "rotated-access"
+    assert root["providers"]["minimax-oauth"]["refresh_token"] == "rotated-refresh"
+
+
+# ---------------------------------------------------------------------------
+# 2. Profile-local shadow is NOT promoted to root
+# ---------------------------------------------------------------------------
+
+def test_minimax_oauth_profile_local_login_not_promoted_to_root(profile_and_root, monkeypatch):
+    """A profile that genuinely owns its own minimax-oauth block shadows root.
+
+    Its refresh must update the profile store but must NOT clobber the root
+    grant (the profile owns its own login; root's grant belongs to root).
+    """
+    profile_path, root_path = profile_and_root
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "providers": {
+                "minimax-oauth": _minimax_state(
+                    access_token="profile-old",
+                    refresh_token="profile-old-refresh",
+                )
+            },
+        },
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "minimax-oauth": _minimax_state(
+                    access_token="root-untouched",
+                    refresh_token="root-untouched-refresh",
+                )
+            },
+        },
+    )
+
+    _patch_refresh_pure(
+        monkeypatch,
+        rotated_access="profile-new",
+        rotated_refresh="profile-new-refresh",
+    )
+
+    pool = CredentialPool(
+        "minimax-oauth",
+        [
+            _entry(
+                access_token="profile-old",
+                refresh_token="profile-old-refresh",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        A,
+        "get_provider_auth_state",
+        lambda _pid: _minimax_state(
+            access_token="profile-old", refresh_token="profile-old-refresh"
+        ),
+    )
+
+    refreshed = pool._refresh_entry(pool._entries[0], force=True)
+    assert refreshed is not None
+    assert refreshed.refresh_token == "profile-new-refresh"
+
+    # Profile store updated.
+    profile = _read_store(profile_path)
+    assert (
+        profile["providers"]["minimax-oauth"]["refresh_token"]
+        == "profile-new-refresh"
+    )
+
+    # Root keeps its own grant — write-through must not run when the profile
+    # owns the block.
+    root = _read_store(root_path)
+    assert (
+        root["providers"]["minimax-oauth"]["refresh_token"]
+        == "root-untouched-refresh"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Lock held across the POST (concurrency safety invariant)
+# ---------------------------------------------------------------------------
+
+def test_minimax_oauth_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_path):
+    """The MiniMax OAuth pool refresh must POST under the cross-process lock.
+
+    MiniMax refresh tokens are single-use.  Serializing the
+    sync -> refresh POST -> write-back through the shared ``_auth_store_lock``
+    closes the window where two processes both POST the same token and the
+    loser gets ``refresh_token_reused``.
+
+    Asserts the invariant directly — that ``refresh_minimax_oauth_pure`` is
+    only ever called while the auth-store lock is held.
+    """
+    profile_path = tmp_path / "auth.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+
+    lock_held: dict = {"during_post": None}
+    real_lock = A._auth_store_lock
+    depth = {"n": 0}
+
+    @contextlib.contextmanager
+    def tracking_lock(*args, **kwargs):
+        depth["n"] += 1
+        try:
+            with real_lock(*args, **kwargs):
+                yield
+        finally:
+            depth["n"] -= 1
+
+    monkeypatch.setattr(A, "_auth_store_lock", tracking_lock)
+    monkeypatch.setattr(CP, "_auth_store_lock", tracking_lock)
+
+    def fake_refresh(state, **kwargs):
+        lock_held["during_post"] = depth["n"] > 0
+        now_dt = datetime.now(timezone.utc)
+        return {
+            "access_token": "rotated-access",
+            "refresh_token": "rotated-refresh",
+            "obtained_at": now_dt.isoformat(),
+            "expires_at": (now_dt + timedelta(seconds=3600)).isoformat(),
+            "expires_in": 3600,
+        }
+
+    monkeypatch.setattr(A, "refresh_minimax_oauth_pure", fake_refresh)
+    monkeypatch.setattr(CP, "refresh_minimax_oauth_pure", fake_refresh)
+    monkeypatch.setattr(
+        A,
+        "get_provider_auth_state",
+        lambda _pid: _minimax_state(),
+    )
+
+    entry = _entry()
+    pool = CredentialPool("minimax-oauth", [entry])
+    refreshed = pool._refresh_entry(entry, force=True)
+
+    assert refreshed is not None
+    assert refreshed.access_token == "rotated-access"
+    # The invariant: the single-use token POST ran inside the auth-store lock.
+    assert lock_held["during_post"] is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Concurrent refresh produces exactly one POST
+# ---------------------------------------------------------------------------
+
+def test_minimax_oauth_concurrent_refresh_single_rotation(profile_and_root, monkeypatch):
+    """Two profile pools sharing one root grant refresh concurrently.
+
+    Because the POST is serialized through ``_auth_store_lock`` and the
+    in-lock re-sync adopts the rotated token the winner persisted, the loser
+    must NOT re-POST — exactly one token-endpoint exchange occurs.  Without
+    serialization both would POST the same single-use refresh token and the
+    loser would get ``refresh_token_reused``, revoking the whole chain.
+    """
+    profile_path, root_path = profile_and_root
+    root_state = _minimax_state()
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {"minimax-oauth": dict(root_state)}},
+    )
+    # Both "profiles" share the same profile_path for this test (the
+    # contention is over the root grant + the auth-store lock).
+    _write_store(profile_path, {"version": 1, "providers": {}})
+
+    calls = _patch_refresh_pure(monkeypatch)
+    monkeypatch.setattr(A, "get_provider_auth_state", lambda _pid: dict(root_state))
+
+    barrier = threading.Barrier(2)
+    results: dict = {"p1": None, "p2": None}
+    errors: dict = {"p1": None, "p2": None}
+
+    def refresh_worker(key):
+        pool = CredentialPool("minimax-oauth", [_entry(id=key)])
+        # Synchronize both threads so they race for the lock.
+        barrier.wait(timeout=5)
+        try:
+            results[key] = pool._refresh_entry(pool._entries[0], force=True)
+        except Exception as exc:
+            errors[key] = exc
+
+    t1 = threading.Thread(target=refresh_worker, args=("p1",), name="minimax-p1")
+    t2 = threading.Thread(target=refresh_worker, args=("p2",), name="minimax-p2")
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not t1.is_alive()
+    assert not t2.is_alive()
+    assert errors["p1"] is None, f"p1 errored: {errors['p1']}"
+    assert errors["p2"] is None, f"p2 errored: {errors['p2']}"
+
+    # Exactly one POST exchange occurred.
+    assert calls["count"] == 1, (
+        f"expected exactly 1 refresh POST, got {calls['count']}"
+    )
+
+    # At least one worker produced a refreshed entry.  The loser may have
+    # short-circuited (adopted the winner's rotated token without POSTing)
+    # OR also returned the rotated entry — both are acceptable so long as
+    # only one POST happened.
+    refreshed_any = [r for r in results.values() if r is not None]
+    assert refreshed_any, "at least one worker should have a refreshed entry"
+
+
+# ---------------------------------------------------------------------------
+# 5. Terminal refresh failure quarantines profile and root
+# ---------------------------------------------------------------------------
+
+def test_minimax_oauth_terminal_refresh_quarantines_root_and_profile(profile_and_root, monkeypatch):
+    """An invalid_grant terminal failure must wipe tokens from both stores.
+
+    Mirrors ``test_resolve_credentials_quarantines_on_terminal_refresh_failure``
+    for the eager-resolve path, but exercises the POOL refresh path.  After
+    quarantine, the pool entry is removed and a subsequent ``load_pool``
+    would not re-seed the dead singleton.
+    """
+    profile_path, root_path = profile_and_root
+    root_state = _minimax_state()
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {"minimax-oauth": dict(root_state)}},
+    )
+    _write_store(profile_path, {"version": 1, "providers": {}})
+
+    def terminal_refresh(state, **kwargs):
+        raise AuthError(
+            "invalid_grant",
+            provider="minimax-oauth",
+            code="refresh_failed",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(A, "refresh_minimax_oauth_pure", terminal_refresh)
+    monkeypatch.setattr(CP, "refresh_minimax_oauth_pure", terminal_refresh)
+    monkeypatch.setattr(A, "get_provider_auth_state", lambda _pid: dict(root_state))
+
+    pool = CredentialPool("minimax-oauth", [_entry()])
+    result = pool._refresh_entry(pool._entries[0], force=True)
+
+    # Pool entry removed (quarantined to DEAD then dropped from rotation).
+    assert result is None
+    assert all(e.source != "oauth" for e in pool._entries), (
+        "singleton-seeded minimax entry should have been removed"
+    )
+
+    # Root store: dead OAuth fields cleared, diagnostic blob written.
+    root = _read_store(root_path)
+    mm = root["providers"]["minimax-oauth"]
+    assert "access_token" not in mm
+    assert "refresh_token" not in mm
+    assert "expires_at" not in mm
+    err = mm.get("last_auth_error")
+    assert isinstance(err, dict)
+    assert err["provider"] == "minimax-oauth"
+    assert err["relogin_required"] is True
+    # Routing metadata preserved.
+    assert mm["portal_base_url"] == root_state["portal_base_url"]
+    assert mm["client_id"] == root_state["client_id"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Transient refresh failure retains credentials (no quarantine)
+# ---------------------------------------------------------------------------
+
+def test_minimax_oauth_transient_refresh_failure_retains_credentials(profile_and_root, monkeypatch):
+    """A non-terminal failure (relogin_required=False) must NOT quarantine.
+
+    Transient failures (429 / 5xx / network) leave the stored refresh token
+    intact so the next attempt can retry.  Quarantine is reserved for
+    terminal states that cannot recover.
+    """
+    profile_path, root_path = profile_and_root
+    root_state = _minimax_state()
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {"minimax-oauth": dict(root_state)}},
+    )
+    _write_store(profile_path, {"version": 1, "providers": {}})
+
+    def transient_refresh(state, **kwargs):
+        raise AuthError(
+            "service unavailable",
+            provider="minimax-oauth",
+            code="refresh_failed",
+            relogin_required=False,
+        )
+
+    monkeypatch.setattr(A, "refresh_minimax_oauth_pure", transient_refresh)
+    monkeypatch.setattr(CP, "refresh_minimax_oauth_pure", transient_refresh)
+    monkeypatch.setattr(A, "get_provider_auth_state", lambda _pid: dict(root_state))
+
+    pool = CredentialPool("minimax-oauth", [_entry()])
+    result = pool._refresh_entry(pool._entries[0], force=True)
+
+    # Transient failure marks the entry exhausted (not quarantined/dead).
+    assert result is None
+
+    # Root store: tokens RETAINED — no quarantine write.
+    root = _read_store(root_path)
+    mm = root["providers"]["minimax-oauth"]
+    assert mm["access_token"] == root_state["access_token"]
+    assert mm["refresh_token"] == root_state["refresh_token"]
+    assert "last_auth_error" not in mm
+
+
+# ---------------------------------------------------------------------------
+# 7. Terminal error detector unit test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "code,relogin,expected",
+    [
+        ("refresh_failed", True, True),
+        ("no_refresh_token", True, True),
+        ("invalid_grant", True, True),
+        ("refresh_token_reused", True, True),
+        ("refresh_failed", False, False),  # transient
+        ("refresh_failed", True, True),
+    ],
+)
+def test_is_terminal_minimax_oauth_refresh_error(code, relogin, expected):
+    exc = AuthError(
+        "msg", provider="minimax-oauth", code=code, relogin_required=relogin
+    )
+    assert A._is_terminal_minimax_oauth_refresh_error(exc) is expected
+
+
+def test_is_terminal_minimax_oauth_refresh_error_wrong_provider():
+    exc = AuthError(
+        "msg", provider="openai-codex", code="refresh_failed", relogin_required=True
+    )
+    assert A._is_terminal_minimax_oauth_refresh_error(exc) is False

--- a/tests/agent/test_credential_pool_minimax_oauth.py
+++ b/tests/agent/test_credential_pool_minimax_oauth.py
@@ -28,9 +28,11 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 import threading
 import time
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 
@@ -96,6 +98,7 @@ def _entry(
     refresh_token="old-refresh",
     source="oauth",
     expires_at=None,
+    expires_at_ms=None,
 ):
     """Build a MiniMax OAuth pool entry seeded from the singleton."""
     if expires_at is None:
@@ -110,6 +113,7 @@ def _entry(
         access_token=access_token,
         refresh_token=refresh_token,
         expires_at=expires_at,
+        expires_at_ms=expires_at_ms,
         base_url="https://api.minimax.io/anthropic",
     )
 
@@ -198,18 +202,110 @@ def test_minimax_oauth_pool_refresh_writes_through_to_root(profile_and_root, mon
     assert refreshed.access_token == "rotated-access"
     assert refreshed.refresh_token == "rotated-refresh"
 
-    # Profile store received the rotated state (set_active=False — must NOT
-    # flip active_provider, which the user did not choose).
+    # The profile has no own providers.minimax-oauth block; it borrowed the
+    # grant from root.  Source-aware write-back persists the rotated chain to
+    # root directly and intentionally does NOT create a profile-local shadow
+    # that would break future write-throughs (Review A MUST-FIX #2).
     profile = _read_store(profile_path)
-    mm = profile["providers"]["minimax-oauth"]
-    assert mm["access_token"] == "rotated-access"
-    assert mm["refresh_token"] == "rotated-refresh"
+    assert "minimax-oauth" not in profile.get("providers", {})
     assert profile.get("active_provider") != "minimax-oauth"
 
     # AND the global root no longer holds the revoked refresh token.
     root = _read_store(root_path)
     assert root["providers"]["minimax-oauth"]["access_token"] == "rotated-access"
     assert root["providers"]["minimax-oauth"]["refresh_token"] == "rotated-refresh"
+
+
+# ---------------------------------------------------------------------------
+# 2. Borrowed-root grant stays owned by root across two successive refreshes
+# ---------------------------------------------------------------------------
+
+def test_minimax_oauth_borrowed_root_grant_stays_owned_across_two_refreshes(
+    profile_and_root, monkeypatch
+):
+    """Two successive refreshes of a borrowed-root grant both write back to root.
+
+    A profile that borrows the global-root grant must not create a local
+    ``providers.minimax-oauth`` shadow after the first refresh.  If it did, the
+    second refresh would treat the profile as the owner and stop writing to
+    root, leaving root with a stale (and eventually revoked) refresh token
+    (Review A MUST-FIX #2).
+    """
+    profile_path, root_path = profile_and_root
+    _write_store(profile_path, {"version": 1, "providers": {}, "active_provider": "openrouter"})
+    root_state = _minimax_state()
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {"minimax-oauth": dict(root_state)}},
+    )
+
+    rotations = _patch_refresh_pure(monkeypatch)
+    monkeypatch.setattr(A, "get_provider_auth_state", lambda _pid: dict(root_state))
+
+    pool = CredentialPool("minimax-oauth", [_entry()])
+
+    # First refresh rotates root's grant and must write back to root.
+    first = pool._refresh_entry(pool._entries[0], force=True)
+    assert first is not None
+    assert first.access_token == "rotated-access"
+
+    # No profile-local shadow was created.
+    profile = _read_store(profile_path)
+    assert "minimax-oauth" not in profile.get("providers", {})
+
+    root_after_first = _read_store(root_path)
+    assert (
+        root_after_first["providers"]["minimax-oauth"]["access_token"]
+        == "rotated-access"
+    )
+
+    # Second refresh must again write the newly rotated chain back to root,
+    # not to a now-materialized profile shadow.
+    second = pool._refresh_entry(first, force=True)
+    assert second is not None
+    assert second.access_token == "rotated-access"
+
+    # Root received the second rotation too.
+    root_after_second = _read_store(root_path)
+    assert (
+        root_after_second["providers"]["minimax-oauth"]["access_token"]
+        == "rotated-access"
+    )
+    # Profile still has no shadow.
+    profile = _read_store(profile_path)
+    assert "minimax-oauth" not in profile.get("providers", {})
+
+
+# ---------------------------------------------------------------------------
+# 2b. load_pool seeds MiniMax OAuth expiry from singleton state
+# ---------------------------------------------------------------------------
+
+def test_minimax_oauth_load_pool_seeds_expires_at_from_singleton(profile_and_root, monkeypatch):
+    """A pool entry seeded from the auth-store singleton must carry expires_at.
+
+    Proactive refresh in ``_entry_needs_refresh`` inspects ``entry.expires_at``.
+    If ``_seed_from_singletons`` only populates ``expires_at_ms`` (the previous
+    shape), MiniMax OAuth entries loaded through the normal ``load_pool`` path
+    would never proactively refresh and would lease expired access tokens
+    (Review A MUST-FIX #3).
+    """
+    profile_path, root_path = profile_and_root
+    _write_store(profile_path, {"version": 1, "providers": {}, "active_provider": "openrouter"})
+    root_state = _minimax_state()
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {"minimax-oauth": dict(root_state)}},
+    )
+
+    pool = CP.load_pool("minimax-oauth")
+
+    entry = pool.peek()
+    assert entry is not None
+    assert entry.source == "oauth"
+    # Both expiry representations must be populated so _entry_needs_refresh
+    # (which checks expires_at) actually fires.
+    assert entry.expires_at == root_state["expires_at"]
+    assert entry.expires_at_ms is not None
 
 
 # ---------------------------------------------------------------------------
@@ -361,13 +457,22 @@ def test_minimax_oauth_pool_refresh_holds_auth_store_lock_across_post(monkeypatc
 # ---------------------------------------------------------------------------
 
 def test_minimax_oauth_concurrent_refresh_single_rotation(profile_and_root, monkeypatch):
-    """Two profile pools sharing one root grant refresh concurrently.
+    """Two workers sharing one root grant refresh concurrently.
 
-    Because the POST is serialized through ``_auth_store_lock`` and the
-    in-lock re-sync adopts the rotated token the winner persisted, the loser
-    must NOT re-POST — exactly one token-endpoint exchange occurs.  Without
-    serialization both would POST the same single-use refresh token and the
-    loser would get ``refresh_token_reused``, revoking the whole chain.
+    Because the POST is serialized through the source-aware
+    ``_provider_state_transaction`` (which holds both the active profile lock
+    and the global-root source lock for borrowed grants), the loser must NOT
+    re-POST — exactly one token-endpoint exchange occurs.  Without
+    serialization both workers would read the same root refresh token, both
+    POST it, and the loser would get ``refresh_token_reused``, revoking the
+    whole chain.
+
+    This test exercises the serialization within one process: both workers
+    share the same profile auth path and contend on the same root source lock.
+    The cross-process variant (two distinct profile lock files contending on
+    one root lock) is covered by the lock-mechanism design: the root lock is
+    a kernel flock keyed by the root auth.json path, so distinct processes
+    holding distinct profile locks still serialize on the shared root lock.
     """
     profile_path, root_path = profile_and_root
     root_state = _minimax_state()
@@ -375,8 +480,8 @@ def test_minimax_oauth_concurrent_refresh_single_rotation(profile_and_root, monk
         root_path,
         {"version": 1, "providers": {"minimax-oauth": dict(root_state)}},
     )
-    # Both "profiles" share the same profile_path for this test (the
-    # contention is over the root grant + the auth-store lock).
+    # Both workers share the same profile_path; the contention is over the
+    # root grant + the source lock, which is the real hazard.
     _write_store(profile_path, {"version": 1, "providers": {}})
 
     calls = _patch_refresh_pure(monkeypatch)
@@ -388,7 +493,7 @@ def test_minimax_oauth_concurrent_refresh_single_rotation(profile_and_root, monk
 
     def refresh_worker(key):
         pool = CredentialPool("minimax-oauth", [_entry(id=key)])
-        # Synchronize both threads so they race for the lock.
+        # Synchronize both threads so they race for the source lock.
         barrier.wait(timeout=5)
         try:
             results[key] = pool._refresh_entry(pool._entries[0], force=True)
@@ -419,6 +524,176 @@ def test_minimax_oauth_concurrent_refresh_single_rotation(profile_and_root, monk
     refreshed_any = [r for r in results.values() if r is not None]
     assert refreshed_any, "at least one worker should have a refreshed entry"
 
+    # Root must hold the single rotated chain (not a stale or second-posted
+    # refresh token) so other borrowers see the winner's tokens.
+    root = _read_store(root_path)
+    root_mm = root["providers"]["minimax-oauth"]
+    assert root_mm["access_token"] == "rotated-access"
+    assert root_mm["refresh_token"] == "rotated-refresh"
+
+
+# ---------------------------------------------------------------------------
+# 4b. Two DISTINCT profiles (distinct profile lock files) sharing one root
+#     grant are serialized by the root flock — exactly one POST.
+# ---------------------------------------------------------------------------
+
+# Subprocess worker script: each instance is a distinct "profile" with its own
+# profile auth.json but sharing one global-root auth.json.  The source-aware
+# transaction must serialize both on the root flock so only one POST occurs.
+_CROSS_PROFILE_WORKER = """
+import json, os, sys, time, fcntl
+from pathlib import Path
+
+profile_dir = Path(sys.argv[1])   # distinct per worker
+root_path    = Path(sys.argv[2])   # shared
+sync_dir     = Path(sys.argv[3])   # shared coordination dir
+worker_id    = sys.argv[4]         # "w1" or "w2"
+sibling_id   = "w2" if worker_id == "w1" else "w1"
+
+# Make this subprocess look like a profile process.
+os.environ["HERMES_HOME"] = str(profile_dir)
+os.environ["HOME"] = str(sync_dir / "fake-home")
+os.environ.pop("PYTEST_CURRENT_TEST", None)
+
+from hermes_cli import auth as A
+from agent import credential_pool as CP
+from agent.credential_pool import CredentialPool, PooledCredential, AUTH_TYPE_OAUTH
+
+profile_path = profile_dir / "auth.json"
+A._auth_file_path = lambda: profile_path
+A._global_auth_file_path = lambda: root_path
+
+post_counter = sync_dir / "post_count.json"
+post_lock = sync_dir / "post_count.lock"
+
+def fake_refresh(state, **kwargs):
+    # Atomic increment under a file lock (visible across processes).
+    with open(post_lock, "w") as lf:
+        fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+        try:
+            n = 0
+            if post_counter.exists():
+                n = json.loads(post_counter.read_text()).get("count", 0)
+            post_counter.write_text(json.dumps({"count": n + 1}))
+        finally:
+            fcntl.flock(lf.fileno(), fcntl.LOCK_UN)
+    time.sleep(0.15)  # overlap window if unserialized
+    from datetime import datetime, timedelta, timezone
+    now = datetime.now(timezone.utc)
+    return {
+        "access_token": "rotated-access",
+        "refresh_token": "rotated-refresh",
+        "obtained_at": now.isoformat(),
+        "expires_at": (now + timedelta(seconds=3600)).isoformat(),
+        "expires_in": 3600,
+    }
+
+A.refresh_minimax_oauth_pure = fake_refresh
+CP.refresh_minimax_oauth_pure = fake_refresh
+root_state = json.loads(root_path.read_text())["providers"]["minimax-oauth"]
+A.get_provider_auth_state = lambda _pid: dict(root_state)
+
+# Barrier: signal ready, wait for sibling.
+(sync_dir / f"ready_{worker_id}").touch()
+deadline = time.monotonic() + 15
+while not (sync_dir / f"ready_{sibling_id}").exists():
+    if time.monotonic() > deadline:
+        break
+    time.sleep(0.02)
+
+entry = PooledCredential(
+    id="e1", auth_type=AUTH_TYPE_OAUTH,
+    provider="minimax-oauth", label="minimax-oauth", priority=0,
+    access_token="old-access", refresh_token="old-refresh",
+    source="oauth", base_url="https://api.minimax.io/anthropic",
+)
+pool = CredentialPool("minimax-oauth", [entry])
+result = pool._refresh_entry(pool._entries[0], force=True)
+(sync_dir / f"result_{worker_id}").write_text(json.dumps({
+    "access_token": result.access_token if result else None,
+}))
+"""
+
+
+def test_minimax_oauth_distinct_profiles_sharing_root_serialize_to_one_post(tmp_path):
+    """Two genuinely distinct profiles (distinct profile lock files) must not
+    both POST the same single-use root refresh token.
+
+    Review A MUST-FIX #1: the hazard is that two real profiles each hold a
+    *different* profile lock, both read the same root refresh token, and both
+    POST it before either takes the root lock.  The source-aware
+    ``_provider_state_transaction`` holds both the active profile lock AND the
+    global-root source lock, so distinct profiles serialize on the shared root
+    flock.  This test spawns two subprocesses (distinct HERMES_HOME / profile
+    auth.json paths) sharing one root auth.json and asserts exactly one POST.
+
+    Uses subprocesses (not threads) so each worker has its own
+    ``_auth_file_path`` without a process-global monkeypatch.
+    """
+    import subprocess
+    import sys
+
+    sync_dir = tmp_path / "sync"
+    sync_dir.mkdir()
+
+    # Two distinct profile directories → distinct profile auth.json + .lock.
+    profile1_dir = tmp_path / "profiles" / "w1"
+    profile1_dir.mkdir(parents=True)
+    profile2_dir = tmp_path / "profiles" / "w2"
+    profile2_dir.mkdir(parents=True)
+    _write_store(profile1_dir / "auth.json", {"version": 1, "providers": {}})
+    _write_store(profile2_dir / "auth.json", {"version": 1, "providers": {}})
+
+    # Shared root grant.
+    root_path = tmp_path / "root" / "auth.json"
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {"minimax-oauth": dict(_minimax_state())}},
+    )
+
+    worker_script = sync_dir / "worker.py"
+    worker_script.write_text(_CROSS_PROFILE_WORKER)
+
+    env = os.environ.copy()
+    # Ensure the subprocess can import hermes from the repo root.
+    repo_root = str(Path(CP.__file__).resolve().parents[1])
+    env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+
+    procs = []
+    for wid in ("w1", "w2"):
+        pdir = profile1_dir if wid == "w1" else profile2_dir
+        procs.append(subprocess.Popen(
+            [sys.executable, str(worker_script), str(pdir), str(root_path),
+             str(sync_dir), wid],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
+        ))
+
+    # Wait for both with a generous timeout.
+    out = {}
+    for wid, p in zip(("w1", "w2"), procs):
+        stdout, stderr = p.communicate(timeout=30)
+        out[wid] = (p.returncode, stdout, stderr)
+
+    for wid in ("w1", "w2"):
+        rc, stdout, stderr = out[wid]
+        assert rc == 0, (
+            f"worker {wid} exited {rc}\\n"
+            f"stdout: {stdout.decode(errors='replace')}\\n"
+            f"stderr: {stderr.decode(errors='replace')}"
+        )
+
+    post_count = json.loads((sync_dir / "post_count.json").read_text())["count"]
+    assert post_count == 1, (
+        f"expected exactly 1 POST across two distinct profiles sharing root, "
+        f"got {post_count}"
+    )
+
+    # Root holds the single rotated chain.
+    root = _read_store(root_path)
+    root_mm = root["providers"]["minimax-oauth"]
+    assert root_mm["access_token"] == "rotated-access"
+    assert root_mm["refresh_token"] == "rotated-refresh"
+
 
 # ---------------------------------------------------------------------------
 # 5. Terminal refresh failure quarantines profile and root
@@ -431,12 +706,22 @@ def test_minimax_oauth_terminal_refresh_quarantines_root_and_profile(profile_and
     for the eager-resolve path, but exercises the POOL refresh path.  After
     quarantine, the pool entry is removed and a subsequent ``load_pool``
     would not re-seed the dead singleton.
+
+    Critical: a background pool refresh failure must NOT flip
+    ``active_provider`` to ``minimax-oauth`` (Review A MUST-FIX #4).  The
+    quarantine persists with ``set_active=False`` so the user's chosen
+    provider survives a terminal failure they didn't initiate.
     """
     profile_path, root_path = profile_and_root
     root_state = _minimax_state()
     _write_store(
         root_path,
-        {"version": 1, "providers": {"minimax-oauth": dict(root_state)}},
+        {
+            "version": 1,
+            "providers": {"minimax-oauth": dict(root_state)},
+            # Pre-existing active provider that quarantine must NOT change.
+            "active_provider": "openrouter",
+        },
     )
     _write_store(profile_path, {"version": 1, "providers": {}})
 
@@ -474,6 +759,12 @@ def test_minimax_oauth_terminal_refresh_quarantines_root_and_profile(profile_and
     # Routing metadata preserved.
     assert mm["portal_base_url"] == root_state["portal_base_url"]
     assert mm["client_id"] == root_state["client_id"]
+
+    # active_provider must NOT have flipped to minimax-oauth.  A background
+    # pool failure is not a user choosing a provider.
+    assert root.get("active_provider") == "openrouter", (
+        f"active_provider flipped to {root.get('active_provider')} during quarantine"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_credential_pool_minimax_oauth.py
+++ b/tests/agent/test_credential_pool_minimax_oauth.py
@@ -421,6 +421,10 @@ def test_minimax_oauth_pool_refresh_holds_auth_store_lock_across_post(
     monkeypatch.setattr(A, "_auth_file_path", lambda: profile_path)
     monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
     monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    _write_store(
+        profile_path,
+        {"version": 1, "providers": {"minimax-oauth": _minimax_state()}},
+    )
 
     lock_held: dict = {"during_post": None}
     real_lock = A._auth_store_lock
@@ -719,6 +723,145 @@ def test_minimax_oauth_distinct_profiles_sharing_root_serialize_to_one_post(tmp_
     root_mm = root["providers"]["minimax-oauth"]
     assert root_mm["access_token"] == "rotated-access"
     assert root_mm["refresh_token"] == "rotated-refresh"
+
+
+# Subprocess borrower used by the source-disappearance regression below.  The
+# parent test process owns the root lock, lets this profile resolve the root
+# grant, removes that grant while the borrower waits for the same root lock,
+# then releases it.  A fail-closed borrower must observe the in-lock re-read as
+# authoritative and return without calling the token endpoint.
+_SOURCE_DISAPPEARANCE_WORKER = """
+import json, os, sys
+from pathlib import Path
+
+profile_dir = Path(sys.argv[1])
+root_path = Path(sys.argv[2])
+sync_dir = Path(sys.argv[3])
+
+os.environ["HERMES_HOME"] = str(profile_dir)
+os.environ["HOME"] = str(sync_dir / "fake-home")
+os.environ.pop("PYTEST_CURRENT_TEST", None)
+
+from hermes_cli import auth as A
+from agent import credential_pool as CP
+from agent.credential_pool import CredentialPool, PooledCredential, AUTH_TYPE_OAUTH
+
+profile_path = profile_dir / "auth.json"
+A._auth_file_path = lambda: profile_path
+A._global_auth_file_path = lambda: root_path
+
+root_state = json.loads(root_path.read_text())["providers"]["minimax-oauth"]
+A.get_provider_auth_state = lambda _pid: dict(root_state)
+
+resolved = sync_dir / "borrower_resolved_root"
+original_load_with_source = A._load_provider_state_with_source
+
+def traced_load_with_source(auth_store, provider_id):
+    state, source_path = original_load_with_source(auth_store, provider_id)
+    if source_path is not None and A._same_path(source_path, root_path):
+        resolved.touch()
+    return state, source_path
+
+A._load_provider_state_with_source = traced_load_with_source
+
+def fake_refresh(state, **kwargs):
+    (sync_dir / "post_called").touch()
+    return {
+        "access_token": "resurrected-access",
+        "refresh_token": "resurrected-refresh",
+        "expires_at": root_state["expires_at"],
+        "expires_in": 3600,
+    }
+
+A.refresh_minimax_oauth_pure = fake_refresh
+CP.refresh_minimax_oauth_pure = fake_refresh
+
+entry = PooledCredential(
+    id="e1", auth_type=AUTH_TYPE_OAUTH,
+    provider="minimax-oauth", label="minimax-oauth", priority=0,
+    access_token="old-access", refresh_token="old-refresh",
+    source="oauth", base_url="https://api.minimax.io/anthropic",
+    extra={"source_auth_path": str(root_path)},
+)
+pool = CredentialPool("minimax-oauth", [entry])
+result = pool._refresh_entry(pool._entries[0], force=True)
+(sync_dir / "borrower_result.json").write_text(json.dumps({
+    "result_is_none": result is None,
+    "remaining_entries": len(pool.entries()),
+}))
+"""
+
+
+def test_minimax_oauth_borrower_fails_closed_when_root_grant_disappears_while_waiting(
+    tmp_path,
+):
+    """A removed root grant must not be POSTed or resurrected by a waiter."""
+    import subprocess
+    import sys
+
+    sync_dir = tmp_path / "sync"
+    sync_dir.mkdir()
+    profile_dir = tmp_path / "profiles" / "borrower"
+    profile_dir.mkdir(parents=True)
+    profile_path = profile_dir / "auth.json"
+    _write_store(profile_path, {"version": 1, "providers": {}})
+
+    root_path = tmp_path / "root" / "auth.json"
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {"minimax-oauth": dict(_minimax_state())}},
+    )
+
+    worker_script = sync_dir / "source_disappearance_worker.py"
+    worker_script.write_text(_SOURCE_DISAPPEARANCE_WORKER)
+    env = os.environ.copy()
+    repo_root = str(Path(CP.__file__).resolve().parents[1])
+    env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+
+    with A._auth_store_lock(target_path=root_path, timeout_seconds=5):
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(worker_script),
+                str(profile_dir),
+                str(root_path),
+                str(sync_dir),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+        resolved = sync_dir / "borrower_resolved_root"
+        deadline = time.monotonic() + 15
+        while not resolved.exists() and proc.poll() is None:
+            if time.monotonic() > deadline:
+                proc.kill()
+                pytest.fail("borrower did not resolve the root grant before timeout")
+            time.sleep(0.02)
+
+        root = _read_store(root_path)
+        root["providers"].pop("minimax-oauth")
+        _write_store(root_path, root)
+
+    stdout, stderr = proc.communicate(timeout=30)
+    assert proc.returncode == 0, (
+        f"borrower exited {proc.returncode}\n"
+        f"stdout: {stdout.decode(errors='replace')}\n"
+        f"stderr: {stderr.decode(errors='replace')}"
+    )
+    result = json.loads((sync_dir / "borrower_result.json").read_text())
+    assert result == {"result_is_none": True, "remaining_entries": 0}
+    assert not (sync_dir / "post_called").exists(), "removed grant was POSTed"
+
+    root = _read_store(root_path)
+    assert "minimax-oauth" not in root.get("providers", {})
+
+    profile = _read_store(profile_path)
+    assert "minimax-oauth" not in profile.get("providers", {})
+    assert profile.get("credential_pool", {}).get("minimax-oauth") == []
+    serialized_profile = json.dumps(profile)
+    assert "old-access" not in serialized_profile
+    assert "old-refresh" not in serialized_profile
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_credential_pool_minimax_oauth.py
+++ b/tests/agent/test_credential_pool_minimax_oauth.py
@@ -287,36 +287,68 @@ def test_minimax_oauth_borrowed_root_grant_stays_owned_across_two_refreshes(
 # ---------------------------------------------------------------------------
 
 
-def test_minimax_oauth_load_pool_seeds_expires_at_from_singleton(
-    profile_and_root, monkeypatch
+@pytest.mark.parametrize("owner", ["root", "profile"])
+def test_minimax_oauth_load_pool_hydrates_and_refreshes_owned_source(
+    profile_and_root, monkeypatch, owner
 ):
-    """A pool entry seeded from the auth-store singleton must carry expires_at.
+    """The real load path must hydrate and refresh either owning auth store.
 
-    Proactive refresh in ``_entry_needs_refresh`` inspects ``entry.expires_at``.
-    If ``_seed_from_singletons`` only populates ``expires_at_ms`` (the previous
-    shape), MiniMax OAuth entries loaded through the normal ``load_pool`` path
-    would never proactively refresh and would lease expired access tokens
-    (Review A MUST-FIX #3).
+    ``load_pool`` must carry both expiry and refresh-token state in memory so
+    proactive selection can reach the source-aware refresh transaction.  A
+    root-borrowed grant must remain metadata-only in the profile pool on disk.
     """
     profile_path, root_path = profile_and_root
-    _write_store(
-        profile_path, {"version": 1, "providers": {}, "active_provider": "openrouter"}
+    expired_state = _minimax_state(expires_in_future_seconds=-10)
+    profile_providers = (
+        {"minimax-oauth": dict(expired_state)} if owner == "profile" else {}
     )
-    root_state = _minimax_state()
+    root_providers = {"minimax-oauth": dict(expired_state)} if owner == "root" else {}
     _write_store(
-        root_path,
-        {"version": 1, "providers": {"minimax-oauth": dict(root_state)}},
+        profile_path,
+        {
+            "version": 1,
+            "providers": profile_providers,
+            "active_provider": "openrouter",
+        },
     )
+    _write_store(root_path, {"version": 1, "providers": root_providers})
+    calls = _patch_refresh_pure(monkeypatch)
 
     pool = CP.load_pool("minimax-oauth")
 
     entry = pool.peek()
     assert entry is not None
     assert entry.source == "oauth"
-    # Both expiry representations must be populated so _entry_needs_refresh
-    # (which checks expires_at) actually fires.
-    assert entry.expires_at == root_state["expires_at"]
+    assert entry.expires_at == expired_state["expires_at"]
     assert entry.expires_at_ms is not None
+    assert entry.refresh_token == expired_state["refresh_token"]
+
+    if owner == "root":
+        profile_after_load = _read_store(profile_path)
+        persisted = profile_after_load["credential_pool"]["minimax-oauth"][0]
+        assert persisted["source_auth_path"] == str(root_path)
+        assert "access_token" not in persisted
+        assert "refresh_token" not in persisted
+
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.access_token == "rotated-access"
+    assert selected.refresh_token == "rotated-refresh"
+    assert calls["count"] == 1
+
+    source_path = root_path if owner == "root" else profile_path
+    source = _read_store(source_path)
+    state = source["providers"]["minimax-oauth"]
+    assert state["access_token"] == "rotated-access"
+    assert state["refresh_token"] == "rotated-refresh"
+
+    if owner == "root":
+        profile_after_refresh = _read_store(profile_path)
+        assert "minimax-oauth" not in profile_after_refresh.get("providers", {})
+        persisted = profile_after_refresh["credential_pool"]["minimax-oauth"][0]
+        assert "access_token" not in persisted
+        assert "refresh_token" not in persisted
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_credential_pool_minimax_oauth.py
+++ b/tests/agent/test_credential_pool_minimax_oauth.py
@@ -51,6 +51,7 @@ from hermes_cli.auth import AuthError
 # Store helpers
 # ---------------------------------------------------------------------------
 
+
 def _write_store(path, store):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(store), encoding="utf-8")
@@ -131,8 +132,9 @@ def profile_and_root(tmp_path, monkeypatch):
     return profile_path, root_path
 
 
-def _patch_refresh_pure(monkeypatch, *, rotated_access="rotated-access",
-                        rotated_refresh="rotated-refresh"):
+def _patch_refresh_pure(
+    monkeypatch, *, rotated_access="rotated-access", rotated_refresh="rotated-refresh"
+):
     """Stub the network POST to return a deterministic rotated pair.
 
     Returns a dict tracking invocation count so concurrency tests can assert
@@ -168,7 +170,10 @@ def _patch_refresh_pure(monkeypatch, *, rotated_access="rotated-access",
 # 1. Write-through to root when profile reads root fallback
 # ---------------------------------------------------------------------------
 
-def test_minimax_oauth_pool_refresh_writes_through_to_root(profile_and_root, monkeypatch):
+
+def test_minimax_oauth_pool_refresh_writes_through_to_root(
+    profile_and_root, monkeypatch
+):
     """A profile reading root's grant must push rotated tokens back to root.
 
     Mirrors ``test_pool_refresh_writes_through_to_root_when_profile_reads_root``
@@ -192,9 +197,7 @@ def test_minimax_oauth_pool_refresh_writes_through_to_root(profile_and_root, mon
     # Stub get_provider_auth_state so the refresh impl can pull client_id /
     # portal_base_url from the persisted singleton (the pool entry does not
     # carry routing metadata).
-    monkeypatch.setattr(
-        A, "get_provider_auth_state", lambda _pid: dict(root_state)
-    )
+    monkeypatch.setattr(A, "get_provider_auth_state", lambda _pid: dict(root_state))
 
     refreshed = pool._refresh_entry(pool._entries[0], force=True)
 
@@ -220,6 +223,7 @@ def test_minimax_oauth_pool_refresh_writes_through_to_root(profile_and_root, mon
 # 2. Borrowed-root grant stays owned by root across two successive refreshes
 # ---------------------------------------------------------------------------
 
+
 def test_minimax_oauth_borrowed_root_grant_stays_owned_across_two_refreshes(
     profile_and_root, monkeypatch
 ):
@@ -232,7 +236,9 @@ def test_minimax_oauth_borrowed_root_grant_stays_owned_across_two_refreshes(
     (Review A MUST-FIX #2).
     """
     profile_path, root_path = profile_and_root
-    _write_store(profile_path, {"version": 1, "providers": {}, "active_provider": "openrouter"})
+    _write_store(
+        profile_path, {"version": 1, "providers": {}, "active_provider": "openrouter"}
+    )
     root_state = _minimax_state()
     _write_store(
         root_path,
@@ -280,7 +286,10 @@ def test_minimax_oauth_borrowed_root_grant_stays_owned_across_two_refreshes(
 # 2b. load_pool seeds MiniMax OAuth expiry from singleton state
 # ---------------------------------------------------------------------------
 
-def test_minimax_oauth_load_pool_seeds_expires_at_from_singleton(profile_and_root, monkeypatch):
+
+def test_minimax_oauth_load_pool_seeds_expires_at_from_singleton(
+    profile_and_root, monkeypatch
+):
     """A pool entry seeded from the auth-store singleton must carry expires_at.
 
     Proactive refresh in ``_entry_needs_refresh`` inspects ``entry.expires_at``.
@@ -290,7 +299,9 @@ def test_minimax_oauth_load_pool_seeds_expires_at_from_singleton(profile_and_roo
     (Review A MUST-FIX #3).
     """
     profile_path, root_path = profile_and_root
-    _write_store(profile_path, {"version": 1, "providers": {}, "active_provider": "openrouter"})
+    _write_store(
+        profile_path, {"version": 1, "providers": {}, "active_provider": "openrouter"}
+    )
     root_state = _minimax_state()
     _write_store(
         root_path,
@@ -312,7 +323,10 @@ def test_minimax_oauth_load_pool_seeds_expires_at_from_singleton(profile_and_roo
 # 2. Profile-local shadow is NOT promoted to root
 # ---------------------------------------------------------------------------
 
-def test_minimax_oauth_profile_local_login_not_promoted_to_root(profile_and_root, monkeypatch):
+
+def test_minimax_oauth_profile_local_login_not_promoted_to_root(
+    profile_and_root, monkeypatch
+):
     """A profile that genuinely owns its own minimax-oauth block shadows root.
 
     Its refresh must update the profile store but must NOT clobber the root
@@ -374,16 +388,14 @@ def test_minimax_oauth_profile_local_login_not_promoted_to_root(profile_and_root
     # Profile store updated.
     profile = _read_store(profile_path)
     assert (
-        profile["providers"]["minimax-oauth"]["refresh_token"]
-        == "profile-new-refresh"
+        profile["providers"]["minimax-oauth"]["refresh_token"] == "profile-new-refresh"
     )
 
     # Root keeps its own grant — write-through must not run when the profile
     # owns the block.
     root = _read_store(root_path)
     assert (
-        root["providers"]["minimax-oauth"]["refresh_token"]
-        == "root-untouched-refresh"
+        root["providers"]["minimax-oauth"]["refresh_token"] == "root-untouched-refresh"
     )
 
 
@@ -391,7 +403,10 @@ def test_minimax_oauth_profile_local_login_not_promoted_to_root(profile_and_root
 # 3. Lock held across the POST (concurrency safety invariant)
 # ---------------------------------------------------------------------------
 
-def test_minimax_oauth_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_path):
+
+def test_minimax_oauth_pool_refresh_holds_auth_store_lock_across_post(
+    monkeypatch, tmp_path
+):
     """The MiniMax OAuth pool refresh must POST under the cross-process lock.
 
     MiniMax refresh tokens are single-use.  Serializing the
@@ -456,7 +471,10 @@ def test_minimax_oauth_pool_refresh_holds_auth_store_lock_across_post(monkeypatc
 # 4. Concurrent refresh produces exactly one POST
 # ---------------------------------------------------------------------------
 
-def test_minimax_oauth_concurrent_refresh_single_rotation(profile_and_root, monkeypatch):
+
+def test_minimax_oauth_concurrent_refresh_single_rotation(
+    profile_and_root, monkeypatch
+):
     """Two workers sharing one root grant refresh concurrently.
 
     Because the POST is serialized through the source-aware
@@ -513,9 +531,7 @@ def test_minimax_oauth_concurrent_refresh_single_rotation(profile_and_root, monk
     assert errors["p2"] is None, f"p2 errored: {errors['p2']}"
 
     # Exactly one POST exchange occurred.
-    assert calls["count"] == 1, (
-        f"expected exactly 1 refresh POST, got {calls['count']}"
-    )
+    assert calls["count"] == 1, f"expected exactly 1 refresh POST, got {calls['count']}"
 
     # At least one worker produced a refreshed entry.  The loser may have
     # short-circuited (adopted the winner's rotated token without POSTing)
@@ -662,11 +678,21 @@ def test_minimax_oauth_distinct_profiles_sharing_root_serialize_to_one_post(tmp_
     procs = []
     for wid in ("w1", "w2"):
         pdir = profile1_dir if wid == "w1" else profile2_dir
-        procs.append(subprocess.Popen(
-            [sys.executable, str(worker_script), str(pdir), str(root_path),
-             str(sync_dir), wid],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
-        ))
+        procs.append(
+            subprocess.Popen(
+                [
+                    sys.executable,
+                    str(worker_script),
+                    str(pdir),
+                    str(root_path),
+                    str(sync_dir),
+                    wid,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+            )
+        )
 
     # Wait for both with a generous timeout.
     out = {}
@@ -699,7 +725,10 @@ def test_minimax_oauth_distinct_profiles_sharing_root_serialize_to_one_post(tmp_
 # 5. Terminal refresh failure quarantines profile and root
 # ---------------------------------------------------------------------------
 
-def test_minimax_oauth_terminal_refresh_quarantines_root_and_profile(profile_and_root, monkeypatch):
+
+def test_minimax_oauth_terminal_refresh_quarantines_root_and_profile(
+    profile_and_root, monkeypatch
+):
     """An invalid_grant terminal failure must wipe tokens from both stores.
 
     Mirrors ``test_resolve_credentials_quarantines_on_terminal_refresh_failure``
@@ -771,7 +800,10 @@ def test_minimax_oauth_terminal_refresh_quarantines_root_and_profile(profile_and
 # 6. Transient refresh failure retains credentials (no quarantine)
 # ---------------------------------------------------------------------------
 
-def test_minimax_oauth_transient_refresh_failure_retains_credentials(profile_and_root, monkeypatch):
+
+def test_minimax_oauth_transient_refresh_failure_retains_credentials(
+    profile_and_root, monkeypatch
+):
     """A non-terminal failure (relogin_required=False) must NOT quarantine.
 
     Transient failures (429 / 5xx / network) leave the stored refresh token
@@ -815,6 +847,7 @@ def test_minimax_oauth_transient_refresh_failure_retains_credentials(profile_and
 # ---------------------------------------------------------------------------
 # 7. Terminal error detector unit test
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize(
     "code,relogin,expected",

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -98,14 +98,14 @@ def test_pool_refresh_writes_through_to_root_when_profile_reads_root(
 
     pool = CredentialPool(provider, [])
     pool._sync_device_code_entry_to_auth_store(
-        _entry(provider, id="e1", access_token="new-access", refresh_token="new-refresh")
+        _entry(
+            provider, id="e1", access_token="new-access", refresh_token="new-refresh"
+        )
     )
 
     # Profile got the rotated chain (existing behavior).
     profile = _read_store(profile_path)
-    assert (
-        profile["providers"][provider]["tokens"]["refresh_token"] == "new-refresh"
-    )
+    assert profile["providers"][provider]["tokens"]["refresh_token"] == "new-refresh"
 
     # AND the global root no longer holds the revoked refresh token (#48415).
     root = _read_store(root_path)
@@ -255,7 +255,9 @@ def test_global_write_through_preserves_concurrent_root_update(
             A._save_auth_store(store, target_path=root_path)
         writer_done.set()
 
-    helper = threading.Thread(target=profile_write_through, name="profile-write-through")
+    helper = threading.Thread(
+        target=profile_write_through, name="profile-write-through"
+    )
     helper.start()
     assert helper_loaded.wait(timeout=5)
 
@@ -347,4 +349,3 @@ def test_codex_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_p
     assert refreshed.refresh_token == "rotated-refresh"
     # The invariant: the single-use token POST ran inside the auth-store lock.
     assert lock_held["during_post"] is True
-

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -60,16 +60,23 @@ def test_profile_with_zero_entries_falls_back_to_global(profile_env):
     """Empty profile pool inherits the global-root entries for that provider."""
     from hermes_cli.auth import read_credential_pool
 
-    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
-        "openrouter": [{
-            "id": "glob-1",
-            "label": "global-key",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-or-global",
-        }],
-    }))
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "glob-1",
+                        "label": "global-key",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-global",
+                    }
+                ],
+            }
+        ),
+    )
     # Profile auth.json: exists but has no openrouter entries.
     _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
 
@@ -83,26 +90,40 @@ def test_profile_with_entries_fully_shadows_global(profile_env):
     """Once the profile has any entries for a provider, global is ignored."""
     from hermes_cli.auth import read_credential_pool
 
-    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
-        "openrouter": [{
-            "id": "glob-1",
-            "label": "global-key",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-or-global",
-        }],
-    }))
-    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
-        "openrouter": [{
-            "id": "prof-1",
-            "label": "profile-key",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-or-profile",
-        }],
-    }))
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "glob-1",
+                        "label": "global-key",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-global",
+                    }
+                ],
+            }
+        ),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "prof-1",
+                        "label": "profile-key",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-profile",
+                    }
+                ],
+            }
+        ),
+    )
 
     entries = read_credential_pool("openrouter")
     assert len(entries) == 1
@@ -114,35 +135,51 @@ def test_per_provider_shadowing_is_independent(profile_env):
     """Profile can override one provider while inheriting another from global."""
     from hermes_cli.auth import read_credential_pool
 
-    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
-        "openrouter": [{
-            "id": "glob-or",
-            "label": "global-or",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-or-global",
-        }],
-        "anthropic": [{
-            "id": "glob-ant",
-            "label": "global-ant",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-ant-global",
-        }],
-    }))
-    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
-        # Profile has openrouter only — anthropic should still fall back.
-        "openrouter": [{
-            "id": "prof-or",
-            "label": "profile-or",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-or-profile",
-        }],
-    }))
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "glob-or",
+                        "label": "global-or",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-global",
+                    }
+                ],
+                "anthropic": [
+                    {
+                        "id": "glob-ant",
+                        "label": "global-ant",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-ant-global",
+                    }
+                ],
+            }
+        ),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={
+                # Profile has openrouter only — anthropic should still fall back.
+                "openrouter": [
+                    {
+                        "id": "prof-or",
+                        "label": "profile-or",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-profile",
+                    }
+                ],
+            }
+        ),
+    )
 
     or_entries = read_credential_pool("openrouter")
     ant_entries = read_credential_pool("anthropic")
@@ -155,16 +192,23 @@ def test_missing_global_auth_file_is_safe(profile_env):
     from hermes_cli.auth import read_credential_pool
 
     # No global auth.json written at all.
-    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
-        "openrouter": [{
-            "id": "prof-1",
-            "label": "profile",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-profile",
-        }],
-    }))
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "prof-1",
+                        "label": "profile",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-profile",
+                    }
+                ],
+            }
+        ),
+    )
 
     assert read_credential_pool("openrouter")[0]["id"] == "prof-1"
     assert read_credential_pool("anthropic") == []
@@ -172,16 +216,23 @@ def test_missing_global_auth_file_is_safe(profile_env):
 
 def test_malformed_global_auth_file_does_not_break_profile_read(profile_env):
     (profile_env["global"] / "auth.json").write_text("{not valid json")
-    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
-        "openrouter": [{
-            "id": "prof-1",
-            "label": "profile",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-profile",
-        }],
-    }))
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "prof-1",
+                        "label": "profile",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-profile",
+                    }
+                ],
+            }
+        ),
+    )
 
     from hermes_cli.auth import read_credential_pool
 
@@ -199,34 +250,50 @@ def test_malformed_global_auth_file_does_not_break_profile_read(profile_env):
 def test_whole_pool_merges_global_providers_when_missing_locally(profile_env):
     from hermes_cli.auth import read_credential_pool
 
-    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
-        "openrouter": [{
-            "id": "glob-or",
-            "label": "global-or",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-or-global",
-        }],
-        "anthropic": [{
-            "id": "glob-ant",
-            "label": "global-ant",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-ant-global",
-        }],
-    }))
-    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
-        "openrouter": [{
-            "id": "prof-or",
-            "label": "profile-or",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-or-profile",
-        }],
-    }))
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "glob-or",
+                        "label": "global-or",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-global",
+                    }
+                ],
+                "anthropic": [
+                    {
+                        "id": "glob-ant",
+                        "label": "global-ant",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-ant-global",
+                    }
+                ],
+            }
+        ),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "prof-or",
+                        "label": "profile-or",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-profile",
+                    }
+                ],
+            }
+        ),
+    )
 
     pool = read_credential_pool(None)
     # Profile wins for openrouter, global fills in anthropic.
@@ -242,9 +309,14 @@ def test_whole_pool_merges_global_providers_when_missing_locally(profile_env):
 def test_provider_auth_state_falls_back_to_global_when_profile_has_none(profile_env):
     from hermes_cli.auth import get_provider_auth_state
 
-    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
-        "nous": {"access_token": "nous-global", "refresh_token": "rt-global"},
-    }))
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            providers={
+                "nous": {"access_token": "nous-global", "refresh_token": "rt-global"},
+            }
+        ),
+    )
     _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
 
     state = get_provider_auth_state("nous")
@@ -255,12 +327,22 @@ def test_provider_auth_state_falls_back_to_global_when_profile_has_none(profile_
 def test_provider_auth_state_profile_wins_when_present(profile_env):
     from hermes_cli.auth import get_provider_auth_state
 
-    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
-        "nous": {"access_token": "nous-global"},
-    }))
-    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={
-        "nous": {"access_token": "nous-profile"},
-    }))
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            providers={
+                "nous": {"access_token": "nous-global"},
+            }
+        ),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            providers={
+                "nous": {"access_token": "nous-profile"},
+            }
+        ),
+    )
 
     state = get_provider_auth_state("nous")
     assert state is not None
@@ -293,9 +375,14 @@ def test_load_provider_state_falls_back_to_global(profile_env):
     """When the loaded profile store has no provider entry, fall back to global."""
     from hermes_cli.auth import _load_auth_store, _load_provider_state
 
-    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
-        "nous": {"access_token": "global-nous-token", "refresh_token": "rt"},
-    }))
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            providers={
+                "nous": {"access_token": "global-nous-token", "refresh_token": "rt"},
+            }
+        ),
+    )
     _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
 
     auth_store = _load_auth_store()
@@ -307,12 +394,22 @@ def test_load_provider_state_falls_back_to_global(profile_env):
 def test_load_provider_state_profile_wins_over_global(profile_env):
     from hermes_cli.auth import _load_auth_store, _load_provider_state
 
-    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
-        "nous": {"access_token": "global-token"},
-    }))
-    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={
-        "nous": {"access_token": "profile-token"},
-    }))
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            providers={
+                "nous": {"access_token": "global-token"},
+            }
+        ),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            providers={
+                "nous": {"access_token": "profile-token"},
+            }
+        ),
+    )
 
     auth_store = _load_auth_store()
     state = _load_provider_state(auth_store, "nous")
@@ -339,9 +436,14 @@ def test_load_provider_state_classic_mode_no_fallback(tmp_path, monkeypatch):
     hermes_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-    _write(hermes_home / "auth.json", _make_auth_store(providers={
-        "nous": {"access_token": "classic-token"},
-    }))
+    _write(
+        hermes_home / "auth.json",
+        _make_auth_store(
+            providers={
+                "nous": {"access_token": "classic-token"},
+            }
+        ),
+    )
 
     from hermes_cli.auth import _load_auth_store, _load_provider_state
 
@@ -356,9 +458,14 @@ def test_load_provider_state_classic_mode_no_fallback(tmp_path, monkeypatch):
 def test_load_provider_state_malformed_global_does_not_break_profile(profile_env):
     """A corrupt global auth.json must not break profile reads."""
     (profile_env["global"] / "auth.json").write_text("{not valid json")
-    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={
-        "nous": {"access_token": "profile-token"},
-    }))
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            providers={
+                "nous": {"access_token": "profile-token"},
+            }
+        ),
+    )
 
     from hermes_cli.auth import _load_auth_store, _load_provider_state
 
@@ -389,16 +496,23 @@ def test_classic_mode_does_not_double_read_same_file(tmp_path, monkeypatch):
     hermes_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-    _write(hermes_home / "auth.json", _make_auth_store(pool={
-        "openrouter": [{
-            "id": "only",
-            "label": "classic",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-classic",
-        }],
-    }))
+    _write(
+        hermes_home / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "only",
+                        "label": "classic",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-classic",
+                    }
+                ],
+            }
+        ),
+    )
 
     from hermes_cli.auth import read_credential_pool, _global_auth_file_path
 
@@ -421,25 +535,37 @@ def test_classic_mode_does_not_double_read_same_file(tmp_path, monkeypatch):
 def test_write_credential_pool_targets_profile_not_global(profile_env):
     from hermes_cli.auth import read_credential_pool, write_credential_pool
 
-    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
-        "openrouter": [{
-            "id": "glob-1",
-            "label": "global",
-            "auth_type": "api_key",
-            "priority": 0,
-            "source": "manual",
-            "access_token": "sk-global",
-        }],
-    }))
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "glob-1",
+                        "label": "global",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-global",
+                    }
+                ],
+            }
+        ),
+    )
 
-    write_credential_pool("openrouter", [{
-        "id": "prof-new",
-        "label": "profile-new",
-        "auth_type": "api_key",
-        "priority": 0,
-        "source": "manual",
-        "access_token": "sk-profile-new",
-    }])
+    write_credential_pool(
+        "openrouter",
+        [
+            {
+                "id": "prof-new",
+                "label": "profile-new",
+                "auth_type": "api_key",
+                "priority": 0,
+                "source": "manual",
+                "access_token": "sk-profile-new",
+            }
+        ],
+    )
 
     # Global auth.json unchanged.
     global_data = json.loads((profile_env["global"] / "auth.json").read_text())

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -489,10 +489,10 @@ def test_resolve_credentials_quarantines_dead_tokens_on_terminal_refresh_failure
     }
     saved_states = []
 
-    def _capture_save(s):
+    def _capture_save(s, **kwargs):
         saved_states.append(dict(s))
 
-    def _terminal_refresh(_state):
+    def _terminal_refresh(_state, **kwargs):
         raise AuthError(
             "invalid_grant",
             provider="minimax-oauth",
@@ -550,7 +550,7 @@ def test_resolve_credentials_does_not_quarantine_on_transient_refresh_failure():
     }
     saved_states = []
 
-    def _transient_refresh(_state):
+    def _transient_refresh(_state, **kwargs):
         raise AuthError(
             "service unavailable",
             provider="minimax-oauth",
@@ -560,7 +560,7 @@ def test_resolve_credentials_does_not_quarantine_on_transient_refresh_failure():
 
     with patch("hermes_cli.auth.get_provider_auth_state", return_value=stale_state), \
          patch("hermes_cli.auth._refresh_minimax_oauth_state", side_effect=_transient_refresh), \
-         patch("hermes_cli.auth._minimax_save_auth_state", side_effect=lambda s: saved_states.append(dict(s))):
+         patch("hermes_cli.auth._minimax_save_auth_state", side_effect=lambda s, **kwargs: saved_states.append(dict(s))):
         with pytest.raises(AuthError) as exc_info:
             resolve_minimax_oauth_runtime_credentials()
 
@@ -781,7 +781,7 @@ def test_token_provider_quarantines_state_on_terminal_refresh():
          patch("httpx.Client") as mock_client_class, \
          patch(
              "hermes_cli.auth._minimax_save_auth_state",
-             side_effect=lambda s: saved_states.append(dict(s)),
+             side_effect=lambda s, **kwargs: saved_states.append(dict(s)),
          ):
         mock_instance = MagicMock()
         mock_instance.__enter__ = MagicMock(return_value=mock_instance)

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -8,6 +8,7 @@ Covers:
   re-login required on invalid_grant
 - resolve_minimax_oauth_runtime_credentials: error when not logged in
 """
+
 from __future__ import annotations
 
 import base64
@@ -41,6 +42,7 @@ from hermes_cli.auth import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_httpx_response(status_code: int, body: dict | None = None, text: str = ""):
     """Return a minimal mock that quacks like httpx.Response."""
     resp = MagicMock()
@@ -69,6 +71,7 @@ def _past_iso(seconds_ago: int = 3600) -> str:
 # 0. test_resolve_token_expiry_unix_ttl_vs_absolute_ms
 # ---------------------------------------------------------------------------
 
+
 def test_resolve_token_expiry_unix_ttl_seconds():
     now = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
     got = _minimax_resolve_token_expiry_unix(3600, now=now)
@@ -86,6 +89,7 @@ def test_resolve_token_expiry_unix_absolute_ms():
 # 1. test_pkce_pair_produces_valid_s256
 # ---------------------------------------------------------------------------
 
+
 def test_pkce_pair_produces_valid_s256():
     verifier, challenge, state = _minimax_pkce_pair()
 
@@ -98,9 +102,12 @@ def test_pkce_pair_produces_valid_s256():
     assert "=" not in challenge
 
     # Re-compute challenge from verifier and verify it matches
-    expected = base64.urlsafe_b64encode(
-        hashlib.sha256(verifier.encode()).digest()
-    ).decode().rstrip("=")
+    expected = (
+        base64
+        .urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .decode()
+        .rstrip("=")
+    )
     assert challenge == expected
 
     # State must be non-empty
@@ -117,14 +124,18 @@ def test_pkce_pair_produces_valid_s256():
 # 2. test_request_user_code_happy_path
 # ---------------------------------------------------------------------------
 
+
 def test_request_user_code_happy_path():
     state = "test-state-abc"
-    mock_response = _make_httpx_response(200, {
-        "user_code": "ABC-123",
-        "verification_uri": "https://minimax.io/verify",
-        "expired_in": int(time.time() * 1000) + 300_000,
-        "state": state,
-    })
+    mock_response = _make_httpx_response(
+        200,
+        {
+            "user_code": "ABC-123",
+            "verification_uri": "https://minimax.io/verify",
+            "expired_in": int(time.time() * 1000) + 300_000,
+            "state": state,
+        },
+    )
 
     client = MagicMock()
     client.post.return_value = mock_response
@@ -152,13 +163,17 @@ def test_request_user_code_happy_path():
 # 3. test_request_user_code_state_mismatch_raises
 # ---------------------------------------------------------------------------
 
+
 def test_request_user_code_state_mismatch_raises():
-    mock_response = _make_httpx_response(200, {
-        "user_code": "XYZ",
-        "verification_uri": "https://minimax.io/verify",
-        "expired_in": 300,
-        "state": "wrong-state",  # Mismatched!
-    })
+    mock_response = _make_httpx_response(
+        200,
+        {
+            "user_code": "XYZ",
+            "verification_uri": "https://minimax.io/verify",
+            "expired_in": 300,
+            "state": "wrong-state",  # Mismatched!
+        },
+    )
 
     client = MagicMock()
     client.post.return_value = mock_response
@@ -179,6 +194,7 @@ def test_request_user_code_state_mismatch_raises():
 # ---------------------------------------------------------------------------
 # 4. test_request_user_code_non_200_raises
 # ---------------------------------------------------------------------------
+
 
 def test_request_user_code_non_200_raises():
     mock_response = _make_httpx_response(400, text="Bad Request")
@@ -203,6 +219,7 @@ def test_request_user_code_non_200_raises():
 # ---------------------------------------------------------------------------
 # 5. test_poll_token_pending_then_success
 # ---------------------------------------------------------------------------
+
 
 def test_poll_token_pending_then_success():
     # Set a deadline far enough in the future for polling
@@ -244,6 +261,7 @@ def test_poll_token_pending_then_success():
 # 6. test_poll_token_error_raises
 # ---------------------------------------------------------------------------
 
+
 def test_poll_token_error_raises():
     deadline_ms = int(time.time() * 1000) + 60_000
     error_body = {"status": "error"}
@@ -270,6 +288,7 @@ def test_poll_token_error_raises():
 # 7. test_poll_token_timeout_raises
 # ---------------------------------------------------------------------------
 
+
 def test_poll_token_timeout_raises():
     # expired_in is a small duration (treated as seconds from now, already expired)
     expired_in = 1  # 1 second from now
@@ -293,6 +312,7 @@ def test_poll_token_timeout_raises():
     client.post.return_value = pending_resp
 
     import hermes_cli.auth as auth_module
+
     with patch.object(auth_module, "time") as mock_time_mod:
         # We need to patch the 'time' module used inside _minimax_poll_token
         # The function imports 'import time as _time' locally.
@@ -320,6 +340,7 @@ def test_poll_token_timeout_raises():
 # 8. test_refresh_skip_when_not_expired
 # ---------------------------------------------------------------------------
 
+
 def test_refresh_skip_when_not_expired():
     """When token is far from expiry, refresh should return the same state."""
     state = {
@@ -339,6 +360,7 @@ def test_refresh_skip_when_not_expired():
 # ---------------------------------------------------------------------------
 # 9. test_refresh_updates_access_token
 # ---------------------------------------------------------------------------
+
 
 def test_refresh_updates_access_token():
     """When token is close to expiry, refresh should update the state."""
@@ -421,6 +443,7 @@ def test_refresh_updates_access_token_absolute_ms_expired_in():
 # 10. test_refresh_reuse_triggers_relogin_required
 # ---------------------------------------------------------------------------
 
+
 def test_refresh_reuse_triggers_relogin_required():
     """On 400 + invalid_grant body, relogin_required should be set."""
     state = {
@@ -455,6 +478,7 @@ def test_refresh_reuse_triggers_relogin_required():
 # 11. test_resolve_credentials_requires_login
 # ---------------------------------------------------------------------------
 
+
 def test_resolve_credentials_requires_login():
     """When no state is stored, resolve_minimax_oauth_runtime_credentials raises."""
     with patch("hermes_cli.auth.get_provider_auth_state", return_value=None):
@@ -468,6 +492,7 @@ def test_resolve_credentials_requires_login():
 # ---------------------------------------------------------------------------
 # 11b. Terminal refresh failure quarantines dead tokens (#28003)
 # ---------------------------------------------------------------------------
+
 
 def test_resolve_credentials_quarantines_dead_tokens_on_terminal_refresh_failure():
     """Terminal refresh failure (relogin_required + refresh_token present) must
@@ -500,9 +525,14 @@ def test_resolve_credentials_quarantines_dead_tokens_on_terminal_refresh_failure
             relogin_required=True,
         )
 
-    with patch("hermes_cli.auth.get_provider_auth_state", return_value=stale_state), \
-         patch("hermes_cli.auth._refresh_minimax_oauth_state", side_effect=_terminal_refresh), \
-         patch("hermes_cli.auth._minimax_save_auth_state", side_effect=_capture_save):
+    with (
+        patch("hermes_cli.auth.get_provider_auth_state", return_value=stale_state),
+        patch(
+            "hermes_cli.auth._refresh_minimax_oauth_state",
+            side_effect=_terminal_refresh,
+        ),
+        patch("hermes_cli.auth._minimax_save_auth_state", side_effect=_capture_save),
+    ):
         with pytest.raises(AuthError) as exc_info:
             resolve_minimax_oauth_runtime_credentials()
 
@@ -558,9 +588,17 @@ def test_resolve_credentials_does_not_quarantine_on_transient_refresh_failure():
             relogin_required=False,
         )
 
-    with patch("hermes_cli.auth.get_provider_auth_state", return_value=stale_state), \
-         patch("hermes_cli.auth._refresh_minimax_oauth_state", side_effect=_transient_refresh), \
-         patch("hermes_cli.auth._minimax_save_auth_state", side_effect=lambda s, **kwargs: saved_states.append(dict(s))):
+    with (
+        patch("hermes_cli.auth.get_provider_auth_state", return_value=stale_state),
+        patch(
+            "hermes_cli.auth._refresh_minimax_oauth_state",
+            side_effect=_transient_refresh,
+        ),
+        patch(
+            "hermes_cli.auth._minimax_save_auth_state",
+            side_effect=lambda s, **kwargs: saved_states.append(dict(s)),
+        ),
+    ):
         with pytest.raises(AuthError) as exc_info:
             resolve_minimax_oauth_runtime_credentials()
 
@@ -572,6 +610,7 @@ def test_resolve_credentials_does_not_quarantine_on_transient_refresh_failure():
 # ---------------------------------------------------------------------------
 # 12. test_provider_registry_contains_minimax_oauth
 # ---------------------------------------------------------------------------
+
 
 def test_provider_registry_contains_minimax_oauth():
     assert "minimax-oauth" in PROVIDER_REGISTRY
@@ -588,8 +627,10 @@ def test_provider_registry_contains_minimax_oauth():
 # 13. test_minimax_oauth_alias_resolves
 # ---------------------------------------------------------------------------
 
+
 def test_minimax_oauth_alias_resolves():
     from hermes_cli.auth import resolve_provider
+
     # Only test that minimax-oauth itself resolves (alias resolution is tested in models)
     result = resolve_provider("minimax-oauth")
     assert result == "minimax-oauth"
@@ -598,6 +639,7 @@ def test_minimax_oauth_alias_resolves():
 # ---------------------------------------------------------------------------
 # 14. test_get_minimax_oauth_auth_status_not_logged_in
 # ---------------------------------------------------------------------------
+
 
 def test_get_minimax_oauth_auth_status_not_logged_in():
     with patch("hermes_cli.auth.get_provider_auth_state", return_value=None):
@@ -610,6 +652,7 @@ def test_get_minimax_oauth_auth_status_not_logged_in():
 # ---------------------------------------------------------------------------
 # 15. test_get_minimax_oauth_auth_status_logged_in
 # ---------------------------------------------------------------------------
+
 
 def test_get_minimax_oauth_auth_status_logged_in():
     state = {
@@ -663,8 +706,10 @@ def test_token_provider_returns_current_access_token_when_fresh():
 
     provider = build_minimax_oauth_token_provider()
 
-    with patch("hermes_cli.auth.get_provider_auth_state", return_value=state), \
-         patch("httpx.Client") as mock_client_class:
+    with (
+        patch("hermes_cli.auth.get_provider_auth_state", return_value=state),
+        patch("httpx.Client") as mock_client_class,
+    ):
         token = provider()
         # No network call should happen — token is fresh.
         mock_client_class.assert_not_called()
@@ -695,9 +740,11 @@ def test_token_provider_refreshes_when_near_expiry():
 
     provider = build_minimax_oauth_token_provider()
 
-    with patch("hermes_cli.auth.get_provider_auth_state", return_value=state), \
-         patch("httpx.Client") as mock_client_class, \
-         patch("hermes_cli.auth._minimax_save_auth_state"):
+    with (
+        patch("hermes_cli.auth.get_provider_auth_state", return_value=state),
+        patch("httpx.Client") as mock_client_class,
+        patch("hermes_cli.auth._minimax_save_auth_state"),
+    ):
         mock_instance = MagicMock()
         mock_instance.__enter__ = MagicMock(return_value=mock_instance)
         mock_instance.__exit__ = MagicMock(return_value=False)
@@ -777,12 +824,14 @@ def test_token_provider_quarantines_state_on_terminal_refresh():
     saved_states: list[dict] = []
 
     provider = build_minimax_oauth_token_provider()
-    with patch("hermes_cli.auth.get_provider_auth_state", return_value=state), \
-         patch("httpx.Client") as mock_client_class, \
-         patch(
-             "hermes_cli.auth._minimax_save_auth_state",
-             side_effect=lambda s, **kwargs: saved_states.append(dict(s)),
-         ):
+    with (
+        patch("hermes_cli.auth.get_provider_auth_state", return_value=state),
+        patch("httpx.Client") as mock_client_class,
+        patch(
+            "hermes_cli.auth._minimax_save_auth_state",
+            side_effect=lambda s, **kwargs: saved_states.append(dict(s)),
+        ),
+    ):
         mock_instance = MagicMock()
         mock_instance.__enter__ = MagicMock(return_value=mock_instance)
         mock_instance.__exit__ = MagicMock(return_value=False)


### PR DESCRIPTION
## What does this PR do?

Brings `minimax-oauth` to parity with the source-aware cross-profile OAuth behavior used by Nous, OpenAI Codex, and xAI OAuth. The change:

1. Serializes refreshes under the authoritative auth-store lock so concurrent profiles sharing one rotating refresh token perform only one token exchange.
2. Writes rotated OAuth state back to the store it came from: profile-owned grants remain profile-local, while root-borrowed grants rotate in the root store without creating a profile shadow.
3. Quarantines terminal refresh failures such as `invalid_grant`, `refresh_token_reused`, and `invalid_refresh_token` at the authoritative source while preserving unrelated auth state and provider selection.
4. Fails closed if a borrowed root grant disappears or is quarantined while a profile waits for the source lock, preventing stale in-memory state from resurrecting a removed credential.
5. Prevents raw borrowed OAuth secrets from being materialized into a named profile's persisted credential pool.

## Related work

This addresses the cross-profile rotating-token hazard adjacent to #48415 and #43589 and the borrowed-credential boundary discussed in #65940. No dedicated upstream issue was filed for this branch.

A fresh search of open upstream issues and PRs on 2026-07-18 found no exact duplicate for MiniMax OAuth source-aware refresh, root write-through, or terminal quarantine. Adjacent work intentionally remains out of scope:

- MiniMax region/provider split work such as #25542 and #36286.
- Auxiliary-client `oauth_minimax` routing work such as #40122 and #61585.
- Existing per-request refresh and quarantine foundations from #30619 and #28119.

## Type of change

- [x] Bug fix
- [x] Regression tests

## Changes

### `agent/credential_pool.py`

- Adds MiniMax-specific source synchronization and source-aware write-back helpers.
- Routes MiniMax pool refresh through `_provider_state_transaction()` with an in-lock authoritative re-read.
- Adopts a winner's rotated token pair rather than re-posting a consumed refresh token.
- Fails closed when the authoritative source disappears or no longer carries a usable refresh grant.
- Quarantines terminal failures without changing `active_provider`.
- Preserves upstream's throttled “no available entries” logging behavior added in #66338.

### `agent/credential_persistence.py`

- Defines the MiniMax OAuth provider/source pair as persistable when locally owned.
- Keeps root-borrowed entries reference-only and strips raw borrowed secrets at the persistence boundary.

### `hermes_cli/auth.py`

- Extracts a pure MiniMax refresh primitive shared by runtime and pool paths.
- Makes runtime refresh and quarantine source-aware.
- Extends provider-state transactions to lock and re-read the authoritative source before mutation.

### Tests

- Adds a dedicated MiniMax credential-pool suite covering root write-through, profile-local ownership, two successive rotations, real subprocess/file-lock serialization, terminal quarantine, transient failures, winner adoption, expiry seeding, and source disappearance while waiting.
- Exercises the real `load_pool -> select -> refresh` path for both profile-owned and root-borrowed grants, including in-memory refresh-token hydration and borrowed-secret disk sanitization.
- Extends existing OAuth write-through, profile-fallback, and MiniMax runtime tests.
- Re-validates upstream's no-available-entry log-throttle tests after replaying onto current `main`.

## Test plan

```bash
scripts/run_tests.sh \
  tests/agent/test_credential_pool_minimax_oauth.py \
  tests/test_minimax_oauth.py \
  tests/agent/test_credential_pool_oauth_writethrough.py \
  tests/hermes_cli/test_auth_profile_fallback.py \
  tests/agent/test_credential_pool_no_entries_log_throttle.py -q

scripts/run_tests.sh \
  tests/agent/test_credential_pool.py \
  tests/agent/test_credential_pool_routing.py \
  tests/agent/test_credential_pool_provider_boundary.py \
  tests/agent/test_credential_pool_no_entries_log_throttle.py \
  tests/tools/test_credential_pool_env_fallback.py \
  tests/run_agent/test_credential_pool_interrupt.py \
  tests/hermes_cli/test_auth*.py -q

ruff check agent/credential_persistence.py agent/credential_pool.py hermes_cli/auth.py \
  tests/agent/test_credential_pool_minimax_oauth.py \
  tests/agent/test_credential_pool_oauth_writethrough.py \
  tests/hermes_cli/test_auth_profile_fallback.py tests/test_minimax_oauth.py

ruff format --check agent/credential_persistence.py agent/credential_pool.py hermes_cli/auth.py \
  tests/agent/test_credential_pool_minimax_oauth.py \
  tests/agent/test_credential_pool_oauth_writethrough.py \
  tests/hermes_cli/test_auth_profile_fallback.py tests/test_minimax_oauth.py
```

### Local evidence

- Focused MiniMax/profile-fallback plus upstream throttle suite: **74 passed, 0 failed**.
- Broad credential-pool/auth safety net: **453 passed, 0 failed**.
- Ruff check and format verification: **passed**.
- `git diff --check`: **passed**.
- Added-line secret/private-path scan: **0 matches** across 3,501 added lines.
- Branch replayed onto current `upstream/main`; merge-base equals the recorded base and the branch is seven commits ahead, zero behind.
- A fresh independent security/concurrency review found one normal-load hydration blocker; commit `32b89c1fa` added a RED-to-GREEN real-load regression and the minimal hydration fix. Re-review of that exact repaired head returned **PASS** with no new findings.

The full repository suite was attempted before the final replay but could not be claimed green on this host because of unrelated optional ACP, local Ollama/audio/path, and load-sensitive failures. The exact impacted suites above are green after the replay.

## Compatibility and risk

- Provider aliases and fallback behavior are unchanged.
- API-key MiniMax behavior is unchanged.
- Profile-local MiniMax OAuth logins remain profile-local.
- No model schema, core tool, dependency, user-facing config, or migration is added.
- Token endpoint behavior is tested with deterministic fakes; no live OAuth credentials or network login were used.
- File-lock semantics continue to use the repository's existing auth-store locking abstraction.

## Checklist

- [x] Read the contribution guide and repository instructions.
- [x] Used Conventional Commit messages.
- [x] Searched current upstream issues and PRs for duplicates.
- [x] Limited the diff to MiniMax OAuth, auth/credential-pool helpers, and regression tests.
- [x] Added deterministic concurrency and persistence tests.
- [x] Ran focused and broad impacted test sets.
- [x] Preserved current upstream credential-pool behavior during conflict resolution.
- [x] Added no config keys or dependencies.

## AI-assisted disclosure

AI tools were used to inspect the credential-pool/auth-store code, implement the source-aware refresh and quarantine paths, prepare tests, and draft this PR body. An independent agent context reviewed the rebased diff for concurrency, source ownership, secret handling, and upstream-conflict preservation; its initial blocking finding was repaired and the exact repaired head passed re-review. Final human review approved publication of this exact branch and proposed PR body before the fork push and PR creation. No merge, release, deployment, live OAuth, or runtime action was performed.

