### PR TITLE
fix(desktop): skip local plugin scans for remote gateways

### DIFF
--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getStatus: vi.fn()
+}))
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal()),
+  getStatus: mocks.getStatus
+}))
+
+import { $connection } from '@/store/session'
+
+import { discoverRuntimePlugins } from './runtime-loader'
+
+describe('runtime disk-plugin discovery', () => {
+  const readDir = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { readDir }
+    $connection.set(null)
+  })
+
+  afterEach(() => {
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    $connection.set(null)
+  })
+
+  it('does not probe a remote gateway home through the local Electron filesystem', async () => {
+    mocks.getStatus.mockResolvedValue({ hermes_home: '/remote/hermes' })
+    $connection.set({ mode: 'remote' } as never)
+
+    await discoverRuntimePlugins()
+
+    expect(mocks.getStatus).not.toHaveBeenCalled()
+    expect(readDir).not.toHaveBeenCalled()
+  })
+
+  it('keeps scanning the local Hermes home for local gateways', async () => {
+    mocks.getStatus.mockResolvedValue({ hermes_home: '/local/hermes' })
+    readDir.mockResolvedValue({ entries: [] })
+    $connection.set({ mode: 'local' } as never)
+
+    await discoverRuntimePlugins()
+
+    expect(readDir).toHaveBeenCalledWith('/local/hermes/desktop-plugins')
+  })
+})

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  getStatus: vi.fn()
+  getStatus: vi.fn(),
+  installPluginSdk: vi.fn(),
+  sdkImportMap: vi.fn(() => ({}))
 }))
 
 vi.mock('@/hermes', async importOriginal => ({
@@ -9,16 +11,38 @@ vi.mock('@/hermes', async importOriginal => ({
   getStatus: mocks.getStatus
 }))
 
+vi.mock('@/sdk/runtime', () => ({
+  installPluginSdk: mocks.installPluginSdk,
+  sdkImportMap: mocks.sdkImportMap
+}))
+
 import { $connection } from '@/store/session'
 
-import { discoverRuntimePlugins } from './runtime-loader'
+import { discoverRuntimePlugins, watchRuntimePlugins } from './runtime-loader'
 
 describe('runtime disk-plugin discovery', () => {
   const readDir = vi.fn()
+  const readFileText = vi.fn()
+  const watchPreviewFile = vi.fn()
+  const stopPreviewFileWatch = vi.fn()
+  const listeners: ((payload: { id: string }) => void)[] = []
+
+  const onPreviewFileChanged = vi.fn(listener => {
+    listeners.push(listener)
+
+    return vi.fn()
+  })
 
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { readDir }
+    listeners.length = 0
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      onPreviewFileChanged,
+      readDir,
+      readFileText,
+      stopPreviewFileWatch,
+      watchPreviewFile
+    }
     $connection.set(null)
   })
 
@@ -45,5 +69,38 @@ describe('runtime disk-plugin discovery', () => {
     await discoverRuntimePlugins()
 
     expect(readDir).toHaveBeenCalledWith('/local/hermes/desktop-plugins')
+  })
+
+  it('does not scan a local home when the connection becomes remote during the status request', async () => {
+    let resolveStatus!: (value: { hermes_home: string }) => void
+    mocks.getStatus.mockReturnValue(new Promise(resolve => (resolveStatus = resolve)))
+    $connection.set({ mode: 'local' } as never)
+
+    const scan = discoverRuntimePlugins()
+    $connection.set({ mode: 'remote' } as never)
+    resolveStatus({ hermes_home: '/local/hermes' })
+    await scan
+
+    expect(readDir).not.toHaveBeenCalled()
+  })
+
+  it('disposes local disk watches before a remote watched-file change can reload them', async () => {
+    mocks.getStatus.mockResolvedValue({ hermes_home: '/local/hermes' })
+    readDir.mockResolvedValue({ entries: [{ isDirectory: true, name: 'example', path: '/local/hermes/desktop-plugins/example' }] })
+    readFileText.mockResolvedValue({ text: 'export default { id: "example", register() {} }' })
+    watchPreviewFile.mockResolvedValue({ id: 'watch-example' })
+    $connection.set({ mode: 'local' } as never)
+
+    watchRuntimePlugins()
+    await vi.waitFor(() => expect(watchPreviewFile).toHaveBeenCalledWith('/local/hermes/desktop-plugins/example/plugin.js'))
+
+    $connection.set({ mode: 'remote' } as never)
+    expect(stopPreviewFileWatch).toHaveBeenCalledWith('watch-example')
+
+    readFileText.mockClear()
+    listeners[0]?.({ id: 'watch-example' })
+    await Promise.resolve()
+
+    expect(readFileText).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -28,6 +28,7 @@
  */
 
 import { getStatus } from '@/hermes'
+import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { notifyError } from '@/store/notifications'
 
@@ -240,6 +241,13 @@ async function scanDiskPlugins(): Promise<void> {
   // Re-entrancy guard: the 5s poll must not overlap a slow in-flight scan
   // (reads/loads can exceed the interval).
   if (!desktop || scanning) {
+    return
+  }
+
+  // Disk plugins execute with full desktop authority, so they are a local-only
+  // feature. More importantly, a remote gateway's POSIX HERMES_HOME is not a
+  // host path: probing it through Electron can trigger the Windows WSL bridge.
+  if (isDesktopFsRemoteMode()) {
     return
   }
 

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -31,6 +31,7 @@ import { getStatus } from '@/hermes'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { notifyError } from '@/store/notifications'
+import { $connection } from '@/store/session'
 
 import { createPluginContext, type HermesPlugin } from './plugin'
 import { dropPlugin, pluginActive, type PluginKind, publishPlugin } from './plugins-store'
@@ -204,14 +205,57 @@ const disk = new Map<string, DiskPlugin>()
 let watching = false
 let scanning = false
 
+function clearDiskPlugins(): void {
+  const desktop = window.hermesDesktop
+
+  for (const [name, record] of disk) {
+    if (record.id) {
+      unloadRuntimePlugin(record.id)
+      dropPlugin(record.id)
+    }
+
+    dropPlugin(name)
+
+    if (record.watchId) {
+      void desktop?.stopPreviewFileWatch(record.watchId)
+    }
+
+    disk.delete(name)
+  }
+}
+
 async function loadDiskPlugin(name: string, file: string): Promise<void> {
   const desktop = window.hermesDesktop!
   const entry = disk.get(name)
   const prevId = entry?.id
 
+  if (isDesktopFsRemoteMode()) {
+    clearDiskPlugins()
+
+    return
+  }
+
   try {
     const { text } = await desktop.readFileText(file)
+
+    if (isDesktopFsRemoteMode()) {
+      clearDiskPlugins()
+
+      return
+    }
+
     const id = await loadRuntimePlugin(text, name, { file })
+
+    if (isDesktopFsRemoteMode()) {
+      if (id) {
+        unloadRuntimePlugin(id)
+        dropPlugin(id)
+      }
+
+      dropPlugin(name)
+
+      return
+    }
 
     // A hot-edit that changes `plugin.id`: loadRuntimePlugin only disposes the
     // NEW id, so unload the previous incarnation here or its contributions +
@@ -248,6 +292,8 @@ async function scanDiskPlugins(): Promise<void> {
   // feature. More importantly, a remote gateway's POSIX HERMES_HOME is not a
   // host path: probing it through Electron can trigger the Windows WSL bridge.
   if (isDesktopFsRemoteMode()) {
+    clearDiskPlugins()
+
     return
   }
 
@@ -255,10 +301,33 @@ async function scanDiskPlugins(): Promise<void> {
 
   try {
     const { hermes_home } = await getStatus()
+
+    // A connection switch can occur while the status request is in flight.
+    // Re-check before touching Electron's local filesystem so a remote home
+    // never crosses this boundary after the initial guard above.
+    if (isDesktopFsRemoteMode()) {
+      clearDiskPlugins()
+
+      return
+    }
+
     const { entries } = await desktop.readDir(`${hermes_home}/desktop-plugins`)
+
+    if (isDesktopFsRemoteMode()) {
+      clearDiskPlugins()
+
+      return
+    }
+
     const seen = new Set<string>()
 
     for (const dir of entries.filter(e => e.isDirectory)) {
+      if (isDesktopFsRemoteMode()) {
+        clearDiskPlugins()
+
+        return
+      }
+
       seen.add(dir.name)
 
       if (disk.has(dir.name)) {
@@ -273,12 +342,30 @@ async function scanDiskPlugins(): Promise<void> {
         continue // No plugin.js (yet) — not a plugin folder.
       }
 
+      if (isDesktopFsRemoteMode()) {
+        clearDiskPlugins()
+
+        return
+      }
+
       const record: DiskPlugin = { file, id: null, watchId: null }
       disk.set(dir.name, record)
       await loadDiskPlugin(dir.name, file)
 
+      if (isDesktopFsRemoteMode()) {
+        clearDiskPlugins()
+
+        return
+      }
+
       try {
         record.watchId = (await desktop.watchPreviewFile(file)).id
+
+        if (isDesktopFsRemoteMode()) {
+          clearDiskPlugins()
+
+          return
+        }
       } catch {
         // Unwatchable — the poll still reconciles new folders; edits need a
         // manual "Reload desktop plugins".
@@ -326,12 +413,24 @@ export function watchRuntimePlugins(): void {
   watching = true
 
   desktop.onPreviewFileChanged(({ id }) => {
+    if (isDesktopFsRemoteMode()) {
+      clearDiskPlugins()
+
+      return
+    }
+
     for (const [name, record] of disk) {
       if (record.watchId === id) {
         void loadDiskPlugin(name, record.file)
 
         return
       }
+    }
+  })
+
+  $connection.subscribe(connection => {
+    if (connection?.mode === 'remote') {
+      clearDiskPlugins()
     }
   })
 

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -193,14 +193,16 @@ describe('desktop filesystem facade', () => {
     expect(selectPaths).not.toHaveBeenCalled()
   })
 
-  it('uses the local Electron picker for remote file selection', async () => {
+  it('does not pass a remote POSIX default path to the local file picker', async () => {
     const remoteSelect = vi.fn(async () => ['/remote/project'])
     $connection.set({ mode: 'remote' } as never)
     setDesktopFsRemotePicker({ selectPaths: remoteSelect })
 
-    await expect(selectDesktopPaths({ directories: false, multiple: false })).resolves.toEqual(['/local'])
+    await expect(
+      selectDesktopPaths({ defaultPath: '/remote/project', directories: false, multiple: false })
+    ).resolves.toEqual(['/local'])
 
-    expect(selectPaths).toHaveBeenCalledWith({ directories: false, multiple: false })
+    expect(selectPaths).toHaveBeenCalledWith({ defaultPath: undefined, directories: false, multiple: false })
     expect(remoteSelect).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -184,7 +184,12 @@ export async function selectDesktopPaths(options?: HermesSelectPathsOptions): Pr
   }
 
   if (!options?.directories) {
-    return desktop.selectPaths(options)
+    // In remote mode this default path comes from the backend filesystem. Do
+    // not hand a remote POSIX path to the native picker on Windows: Electron
+    // would treat it as a local WSL path and probe wsl.exe.
+    const { defaultPath: _remoteDefaultPath, ...localOptions } = options || {}
+
+    return desktop.selectPaths(localOptions)
   }
 
   return remotePicker ? remotePicker.selectPaths({ ...options, multiple: false }) : []


### PR DESCRIPTION
## Current change

Current head: `d0257c7` — rebased on `NousResearch/main` `e598cef`.

When Desktop is connected to a remote gateway, it no longer scans or reloads local disk plugins and no longer sends a remote backend path into Electron’s local native file picker. Local-gateway discovery and local file selection remain available.

## Root cause

Remote gateway state could cross Electron-local filesystem boundaries: an async scan could continue after a local-to-remote switch, and an already-installed disk watcher could later reload a local plugin after that switch.

## Review disposition

The watcher lifecycle feedback is addressed: a remote switch disposes existing local plugin registrations and watches; watcher callbacks re-check remote mode; and status/read/watch async boundaries re-check mode before touching a local path.

## Validation

Node 22:

- focused UI suite: 28 files, 214 passed, 1 skipped;
- full UI suite: 194 files, 1559 passed, 1 skipped;
- typecheck, lint (existing warnings only), Prettier, and build.

## Review focus

Please review the local → remote transition invariant: no queued scan, watcher callback, or picker default can reach an Electron-local filesystem path once remote mode is active.
