### PR TITLE
fix(desktop): open setup for missing provider rows

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -21,6 +21,7 @@ const saveMoaModels = vi.fn()
 const setEnvVar = vi.fn()
 const getHermesConfigRecord = vi.fn()
 const saveHermesConfig = vi.fn()
+const startManualLocalEndpoint = vi.fn()
 const startManualProviderOAuth = vi.fn()
 
 vi.mock('@/hermes', () => ({
@@ -38,6 +39,7 @@ vi.mock('@/hermes', () => ({
 }))
 
 vi.mock('@/store/onboarding', () => ({
+  startManualLocalEndpoint: () => startManualLocalEndpoint(),
   startManualProviderOAuth: (slug: string) => startManualProviderOAuth(slug)
 }))
 
@@ -96,6 +98,17 @@ describe('ModelSettings', () => {
     // "Nous" shows in both the trigger and the open list.
     expect((await screen.findAllByText('Nous')).length).toBeGreaterThan(0)
     expect(screen.queryByText(/DeepSeek/)).toBeNull()
+  })
+
+  it('opens custom endpoint setup when the selected provider has no inventory row', async () => {
+    getGlobalModelInfo.mockResolvedValueOnce({ provider: 'custom', model: '' })
+    getGlobalModelOptions.mockResolvedValueOnce({ providers: [] })
+
+    await renderModelSettings()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Set up provider' }))
+
+    expect(startManualLocalEndpoint).toHaveBeenCalledOnce()
   })
 
   it('writes the profile default speed (service_tier) when the fast switch is toggled', async () => {

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Radix Select calls scrollIntoView on its items when the content opens; jsdom
@@ -22,7 +22,9 @@ const setEnvVar = vi.fn()
 const getHermesConfigRecord = vi.fn()
 const saveHermesConfig = vi.fn()
 const startManualLocalEndpoint = vi.fn()
+const startManualOnboarding = vi.fn()
 const startManualProviderOAuth = vi.fn()
+let profileSwitchHandler: (() => void) | null = null
 
 vi.mock('@/hermes', () => ({
   getGlobalModelInfo: () => getGlobalModelInfo(),
@@ -40,7 +42,14 @@ vi.mock('@/hermes', () => ({
 
 vi.mock('@/store/onboarding', () => ({
   startManualLocalEndpoint: () => startManualLocalEndpoint(),
+  startManualOnboarding: () => startManualOnboarding(),
   startManualProviderOAuth: (slug: string) => startManualProviderOAuth(slug)
+}))
+
+vi.mock('../hooks/use-on-profile-switch', () => ({
+  useOnProfileSwitch: (handler: () => void) => {
+    profileSwitchHandler = handler
+  }
 }))
 
 beforeEach(() => {
@@ -71,6 +80,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  profileSwitchHandler = null
 })
 
 async function renderModelSettings() {
@@ -100,15 +110,101 @@ describe('ModelSettings', () => {
     expect(screen.queryByText(/DeepSeek/)).toBeNull()
   })
 
-  it('opens custom endpoint setup when the selected provider has no inventory row', async () => {
-    getGlobalModelInfo.mockResolvedValueOnce({ provider: 'custom', model: '' })
+  it.each(['custom', 'local', 'custom:lab'])(
+    'opens local endpoint setup when %s has no inventory row',
+    async provider => {
+      getGlobalModelInfo.mockResolvedValueOnce({ provider, model: '' })
+      getGlobalModelOptions.mockResolvedValueOnce({ providers: [] })
+
+      await renderModelSettings()
+
+      const providerSelect = (await screen.findAllByRole('combobox'))[0]
+
+      expect(providerSelect.textContent).toContain(provider)
+      expect(screen.queryByText(/undefined/)).toBeNull()
+      expect(screen.queryByText(/signs in through your browser/)).toBeNull()
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Set up provider' }))
+
+      expect(startManualLocalEndpoint).toHaveBeenCalledOnce()
+      expect(startManualOnboarding).not.toHaveBeenCalled()
+      expect(startManualProviderOAuth).not.toHaveBeenCalled()
+    }
+  )
+
+  it('opens the generic provider picker for an unknown provider with no inventory row', async () => {
+    getGlobalModelInfo.mockResolvedValueOnce({ provider: 'retired-provider', model: '' })
     getGlobalModelOptions.mockResolvedValueOnce({ providers: [] })
 
     await renderModelSettings()
 
     fireEvent.click(await screen.findByRole('button', { name: 'Set up provider' }))
 
-    expect(startManualLocalEndpoint).toHaveBeenCalledOnce()
+    expect(startManualOnboarding).toHaveBeenCalledOnce()
+    expect(startManualLocalEndpoint).not.toHaveBeenCalled()
+    expect(startManualProviderOAuth).not.toHaveBeenCalled()
+  })
+
+  it('deep-links a known OAuth provider row into its setup flow', async () => {
+    getGlobalModelInfo.mockResolvedValueOnce({ provider: 'anthropic', model: '' })
+    getGlobalModelOptions.mockResolvedValueOnce({
+      providers: [
+        {
+          name: 'Anthropic',
+          slug: 'anthropic',
+          models: [],
+          authenticated: false,
+          auth_type: 'oauth'
+        }
+      ]
+    })
+
+    await renderModelSettings()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Set up Anthropic' }))
+
+    expect(startManualProviderOAuth).toHaveBeenCalledWith('anthropic')
+    expect(startManualLocalEndpoint).not.toHaveBeenCalled()
+    expect(startManualOnboarding).not.toHaveBeenCalled()
+  })
+
+  it('replaces the selected provider and model when the active profile changes', async () => {
+    getGlobalModelInfo
+      .mockResolvedValueOnce({ provider: 'custom', model: 'local-a' })
+      .mockResolvedValueOnce({ provider: 'nous', model: 'hermes-4' })
+    getGlobalModelOptions
+      .mockResolvedValueOnce({
+        providers: [
+          {
+            name: 'Custom A',
+            slug: 'custom',
+            models: ['local-a'],
+            authenticated: true
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        providers: [
+          {
+            name: 'Nous',
+            slug: 'nous',
+            models: ['hermes-4'],
+            authenticated: true,
+            capabilities: { 'hermes-4': { reasoning: true, fast: true } }
+          }
+        ]
+      })
+
+    await renderModelSettings()
+    expect((await screen.findAllByRole('combobox'))[0].textContent).toContain('Custom A')
+
+    await act(async () => {
+      profileSwitchHandler?.()
+    })
+
+    await waitFor(() => expect(getGlobalModelInfo).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(screen.getAllByRole('combobox')[0].textContent).toContain('Nous'))
+    expect(screen.queryByRole('button', { name: 'Set up provider' })).toBeNull()
   })
 
   it('writes the profile default speed (service_tier) when the fast switch is toggled', async () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -561,7 +561,10 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   // local-endpoint form (URL + optional API key) instead of being dead-ended
   // on the OAuth picker (the original "booted back to the first screen" loop).
   const startProviderSetup = useCallback(() => {
-    const slug = selectedProviderRow?.slug
+    // The saved provider can be present even when the options inventory has no
+    // matching row. That state renders the generic "Set up provider" action;
+    // fall back to the selected slug so the action does not become a no-op.
+    const slug = selectedProviderRow?.slug || selectedProvider
 
     if (!slug) {
       return
@@ -574,7 +577,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     } else {
       startManualProviderOAuth(slug)
     }
-  }, [selectedProviderRow])
+  }, [selectedProvider, selectedProviderRow])
 
   const applyMainModel = useCallback(async () => {
     if (!selectedProvider || !selectedModel) {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -27,7 +27,7 @@ import { useI18n } from '@/i18n'
 import { AlertTriangle, Cpu, Loader2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notifyError } from '@/store/notifications'
-import { startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
+import { startManualLocalEndpoint, startManualOnboarding, startManualProviderOAuth } from '@/store/onboarding'
 
 import { invalidateHermesConfig, setHermesConfigCache, useHermesConfigRecord } from '../hooks/use-config-record'
 import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
@@ -220,7 +220,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   // A's models/providers into profile B (or fire onMainModelChanged for A).
   const profileEpoch = useRef(0)
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async ({ replaceSelection = false }: { replaceSelection?: boolean } = {}) => {
     const epoch = profileEpoch.current
     setLoading(true)
     setError('')
@@ -239,8 +239,15 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
 
       setMainModel({ model: modelInfo.model, provider: modelInfo.provider })
       setProviders(modelOptions.providers || [])
-      setSelectedProvider(prev => prev || modelInfo.provider)
-      setSelectedModel(prev => prev || modelInfo.model)
+
+      if (replaceSelection) {
+        setSelectedProvider(modelInfo.provider)
+        setSelectedModel(modelInfo.model)
+      } else {
+        setSelectedProvider(prev => prev || modelInfo.provider)
+        setSelectedModel(prev => prev || modelInfo.model)
+      }
+
       setAuxiliary(auxiliaryModels)
       setMoa(moaModels)
 
@@ -270,10 +277,27 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   // new profile (bumping the epoch first so any in-flight A request is discarded).
   useOnProfileSwitch(() => {
     profileEpoch.current += 1
-    void refresh()
+    // The panel stays mounted across profile switches, so clear the previous
+    // profile's draft selection before loading the new profile's source of
+    // truth. Ordinary same-profile refreshes still preserve in-progress edits.
+    setSelectedProvider('')
+    setSelectedModel('')
+    setApiKeyDraft('')
+    void refresh({ replaceSelection: true })
   })
 
   const providerOptions = providers.length ? providers : NO_PROVIDERS
+
+  // Radix renders a blank trigger when the controlled value has no matching
+  // item. Keep a missing saved provider visible in the main selector while
+  // leaving it out of the real inventory used for readiness/setup metadata.
+  const mainProviderOptions = useMemo(
+    () =>
+      selectedProvider && !providers.some(provider => provider.slug === selectedProvider)
+        ? [{ name: selectedProvider, slug: selectedProvider, models: [] }, ...providers]
+        : providerOptions,
+    [providerOptions, providers, selectedProvider]
+  )
 
   // MoA reference/aggregator slots must never be the moa virtual provider —
   // that would create a recursive MoA tree (the backend rejects it on save).
@@ -561,10 +585,8 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   // local-endpoint form (URL + optional API key) instead of being dead-ended
   // on the OAuth picker (the original "booted back to the first screen" loop).
   const startProviderSetup = useCallback(() => {
-    // The saved provider can be present even when the options inventory has no
-    // matching row. That state renders the generic "Set up provider" action;
-    // fall back to the selected slug so the action does not become a no-op.
-    const slug = selectedProviderRow?.slug || selectedProvider
+    const rowSlug = selectedProviderRow?.slug.trim() ?? ''
+    const slug = rowSlug || selectedProvider.trim()
 
     if (!slug) {
       return
@@ -574,8 +596,12 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
 
     if (lower === 'custom' || lower === 'local' || lower.startsWith('custom:')) {
       startManualLocalEndpoint()
+    } else if (rowSlug) {
+      startManualProviderOAuth(rowSlug)
     } else {
-      startManualProviderOAuth(slug)
+      // An absent row has no trustworthy auth metadata. Open the generic
+      // provider picker instead of deep-linking an unknown or stale slug.
+      startManualOnboarding()
     }
   }, [selectedProvider, selectedProviderRow])
 
@@ -703,7 +729,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
               <SelectValue placeholder={m.provider} />
             </SelectTrigger>
             <SelectContent>
-              {providerOptions.map(provider => (
+              {mainProviderOptions.map(provider => (
                 <SelectItem key={provider.slug || 'none'} value={provider.slug || 'none'}>
                   {provider.name}
                 </SelectItem>
@@ -765,7 +791,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
             </>
           )}
         </div>
-        {needsSetup && !setupIsApiKey && (
+        {needsSetup && !setupIsApiKey && selectedProviderRow && (
           <p className="mt-2 text-xs text-muted-foreground">
             {selectedProviderRow?.auth_type === 'api_key'
               ? `${selectedProviderRow?.name} needs an API key — set it up to choose a model.`

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -528,7 +528,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         notifyError(err, m.defaultsFailed)
       }
     },
-    [config, m.defaultsFailed]
+    [config, m.defaultsFailed, setConfig]
   )
 
   // Paste an API key for the selected `api_key` provider, persist it, then


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop model settings action that rendered as `Set up provider` but did nothing when the saved provider was not present in the current provider-options inventory.

The settings state can retain a saved provider slug such as `custom` while `getGlobalModelOptions()` returns no matching row. In that state, the setup handler previously read only `selectedProviderRow?.slug`, got `undefined`, and returned.

Missing custom/local providers now open the existing manual endpoint setup flow. Other missing or obsolete provider slugs open the generic provider picker rather than being treated as trustworthy OAuth IDs. Known provider rows retain their provider-specific setup flow. The missing saved value also remains visible in the provider selector without being treated as real inventory metadata.

Profile changes now clear the previous profile's provider/model selection and replace it with the new profile's authoritative model info, preventing a stale provider slug from launching setup against the wrong profile.

## Related Issue

Discord support thread: <https://discord.com/channels/1053877538025386074/1527911076648194069>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/src/app/settings/model-settings.tsx` to route missing custom/local providers to endpoint setup and unknown missing providers to the generic provider picker.
- Kept a missing saved provider visible in the main provider selector without using the synthetic display row as readiness/auth metadata.
- Suppressed row-dependent explanatory copy when no provider row exists, avoiding `undefined` and incorrect browser-sign-in text.
- Replaced stale provider/model selections when the active profile changes while preserving in-progress selections during ordinary same-profile refreshes.
- Expanded `apps/desktop/src/app/settings/model-settings.test.tsx` with missing-row routing, visible-state, known OAuth, and profile-switch regressions.

## How to Test

1. Return `{ provider: 'custom', model: '' }` from the global model-info request and an empty provider list from the model-options request.
2. Verify `custom` remains visible, no `undefined`/browser-sign-in copy renders, and `Set up provider` opens the manual endpoint flow.
3. Repeat with an unknown provider slug and verify the generic provider picker opens instead of a provider-specific OAuth deep-link.
4. Switch from a profile using `custom` to one using `nous` and verify the provider and model selection are replaced with the new profile's values.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `npm run test:ui -- src/app/settings/model-settings.test.tsx`: 16 tests passed.
- Prettier check for both changed files: passed.
- ESLint for both changed files: 0 errors and 0 warnings.
- GitHub CI `JS & TS checks / Typecheck & Test (apps/desktop)`: passed, including the full Desktop typecheck, test suite, and formatting check.


