### PR TITLE
fix(cron): prefer Git Bash for Windows shell scripts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2182,8 +2182,12 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             try:
                 from tools.environments.local import _find_bash
 
-                _bash = _find_bash()
-            except (ImportError, RuntimeError):
+                _bash = _find_bash(reject_wsl=True)
+            except RuntimeError as exc:
+                return False, (
+                    f"Cannot run .sh/.bash script {path.name!r}: {exc}"
+                )
+            except ImportError:
                 _bash = None
         else:
             _bash = shutil.which("bash") or (

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2174,14 +2174,21 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     # choice explicit here keeps the allowed surface small and auditable.
     suffix = path.suffix.lower()
     if suffix in {".sh", ".bash"}:
-        # Resolve bash dynamically so Windows (Git Bash) and Linux/macOS
-        # all work.  On native Windows without Git for Windows installed
-        # shutil.which returns None — fall back to a clear error rather
-        # than a FileNotFoundError with a confusing "[WinError 2]"
-        # traceback.
-        _bash = shutil.which("bash") or (
-            "/bin/bash" if os.path.isfile("/bin/bash") else None
-        )
+        # Native Windows can expose WSL's C:\Windows\System32\bash.exe before
+        # Git for Windows on PATH. WSL bash cannot execute the Windows/MSYS
+        # script paths used by native Hermes, so reuse the terminal backend's
+        # Git-Bash-first resolver instead of relying on shutil.which().
+        if sys.platform == "win32":
+            try:
+                from tools.environments.local import _find_bash
+
+                _bash = _find_bash()
+            except (ImportError, RuntimeError):
+                _bash = None
+        else:
+            _bash = shutil.which("bash") or (
+                "/bin/bash" if os.path.isfile("/bin/bash") else None
+            )
         if _bash is None:
             return False, (
                 f"Cannot run .sh/.bash script {path.name!r}: bash not found on PATH. "

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -263,13 +263,17 @@ class TestRunJobScript:
         git_bash = r"C:\Program Files\Git\bin\bash.exe"
         captured = {}
 
+        def fake_find_bash(*, reject_wsl=False):
+            captured["reject_wsl"] = reject_wsl
+            return git_bash
+
         def fake_run(argv, **kwargs):
             captured["argv"] = argv
             return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
 
         monkeypatch.setattr(sched_mod.sys, "platform", "win32")
         monkeypatch.setattr(sched_mod.shutil, "which", lambda command: wsl_bash)
-        monkeypatch.setattr(local_env, "_find_bash", lambda: git_bash)
+        monkeypatch.setattr(local_env, "_find_bash", fake_find_bash)
         monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
         monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
 
@@ -278,6 +282,71 @@ class TestRunJobScript:
         assert success is True
         assert output == "ok"
         assert captured["argv"] == [git_bash, str(script.resolve())]
+        assert captured["reject_wsl"] is True
+
+    @pytest.mark.parametrize(
+        "resolver_error",
+        [
+            (
+                "Git Bash cannot start while Windows Mandatory ASLR is enabled. "
+                "Run Set-ProcessMitigation for the Git executables."
+            ),
+            (
+                "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"
+                "Install it from: https://git-scm.com/download/win"
+            ),
+        ],
+    )
+    def test_windows_shell_script_preserves_git_bash_resolver_error(
+        self, cron_env, monkeypatch, resolver_error
+    ):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+        from tools.environments import local as local_env
+
+        script = cron_env / "scripts" / "probe.sh"
+        script.write_text('#!/usr/bin/env bash\nprintf "ok\\n"\n')
+        def fail_resolver(*, reject_wsl=False):
+            assert reject_wsl is True
+            raise RuntimeError(resolver_error)
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "win32")
+        monkeypatch.setattr(local_env, "_find_bash", fail_resolver)
+
+        success, output = _run_job_script("probe.sh")
+
+        assert success is False
+        assert resolver_error in output
+        assert "install Git for Windows" not in output
+
+    def test_non_windows_shell_script_still_uses_path_bash(
+        self, cron_env, monkeypatch
+    ):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.sh"
+        script.write_text('#!/usr/bin/env bash\nprintf "ok\\n"\n')
+        bash = "/usr/bin/bash"
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "linux")
+        monkeypatch.setattr(
+            sched_mod.shutil,
+            "which",
+            lambda command: bash if command == "bash" else None,
+        )
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+
+        success, output = _run_job_script("probe.sh")
+
+        assert success is True
+        assert output == "ok"
+        assert captured["argv"] == [bash, str(script.resolve())]
 
     def test_non_windows_script_preserves_default_text_decoding(self, cron_env, monkeypatch):
         from cron import scheduler as sched_mod

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -249,6 +249,36 @@ class TestRunJobScript:
         assert captured["kwargs"]["encoding"] == "utf-8"
         assert captured["kwargs"]["errors"] == "replace"
 
+    def test_windows_shell_script_prefers_git_bash_when_path_finds_wsl(
+        self, cron_env, monkeypatch
+    ):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+        from tools.environments import local as local_env
+
+        script = cron_env / "scripts" / "probe.sh"
+        script.write_text('#!/usr/bin/env bash\nprintf "ok\\n"\n')
+
+        wsl_bash = r"C:\Windows\System32\bash.exe"
+        git_bash = r"C:\Program Files\Git\bin\bash.exe"
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "win32")
+        monkeypatch.setattr(sched_mod.shutil, "which", lambda command: wsl_bash)
+        monkeypatch.setattr(local_env, "_find_bash", lambda: git_bash)
+        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+
+        success, output = _run_job_script("probe.sh")
+
+        assert success is True
+        assert output == "ok"
+        assert captured["argv"] == [git_bash, str(script.resolve())]
+
     def test_non_windows_script_preserves_default_text_decoding(self, cron_env, monkeypatch):
         from cron import scheduler as sched_mod
         from cron.scheduler import _run_job_script

--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -135,7 +135,7 @@ class TestFindBashSkipsBrokenCustomPath:
         monkeypatch.setenv("HERMES_GIT_BASH_PATH", str(broken))
         monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
 
-        def fake_starts(path: str) -> bool:
+        def fake_starts(path: str, *, env=None) -> bool:
             return path == str(portable)
 
         monkeypatch.setattr(local_mod, "_bash_starts", fake_starts)
@@ -163,6 +163,185 @@ class TestGitBashExternalProgramProbe:
         assert local_mod._bash_starts(r"C:\Git\bin\bash.exe") is True
         assert calls[0][0][-1] == "/usr/bin/true; /usr/bin/cat --version >/dev/null"
 
+    def test_find_bash_prefers_git_and_sanitizes_probe_environment(
+        self, tmp_path, monkeypatch
+    ):
+        import tools.environments.local as local_mod
+
+        local_mod._bash_starts_cache.clear()
+        local_mod._bash_probe_details_cache.clear()
+        git_bash = tmp_path / "program-files" / "Git" / "bin" / "bash.exe"
+        git_bash.parent.mkdir(parents=True)
+        git_bash.write_text("", encoding="utf-8")
+        wsl_bash = r"C:\Windows\System32\bash.exe"
+        calls = []
+
+        def fake_which(name):
+            return wsl_bash if name == "bash" else None
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod.shutil, "which", fake_which)
+        monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+        monkeypatch.delenv("HERMES_GIT_BASH_PATH", raising=False)
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local-appdata"))
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "program-files"))
+        monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "program-files-x86"))
+        monkeypatch.setenv("OPENAI_API_KEY", "provider-secret")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "gateway-secret")
+        monkeypatch.setenv("SLACK_SIGNING_SECRET", "tier-one-secret")
+        monkeypatch.setenv("BUSHEL_PROBE_MARKER", "preserved")
+
+        assert local_mod._find_bash() == str(git_bash)
+        assert calls[0][0][0] == str(git_bash)
+        probe_env = calls[0][1].get("env")
+        assert probe_env is not None
+        assert "OPENAI_API_KEY" not in probe_env
+        assert "TELEGRAM_BOT_TOKEN" not in probe_env
+        assert "SLACK_SIGNING_SECRET" not in probe_env
+        assert probe_env["BUSHEL_PROBE_MARKER"] == "preserved"
+
+    def test_find_bash_never_falls_back_to_system32_wsl(
+        self, tmp_path, monkeypatch
+    ):
+        import tools.environments.local as local_mod
+
+        local_mod._bash_starts_cache.clear()
+        local_mod._bash_probe_details_cache.clear()
+        git_bash = tmp_path / "program-files" / "Git" / "bin" / "bash.exe"
+        git_bash.parent.mkdir(parents=True)
+        git_bash.write_text("", encoding="utf-8")
+        wsl_bash = r"C:\Windows\System32\bash.exe"
+        probed = []
+
+        def fake_starts(path: str, *, env=None) -> bool:
+            probed.append(path)
+            if path == str(git_bash):
+                local_mod._bash_probe_details_cache[path] = (
+                    "dofork: child -1 - forked process died unexpectedly"
+                )
+                return False
+            return path == wsl_bash
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(
+            local_mod.shutil,
+            "which",
+            lambda name: wsl_bash if name == "bash" else None,
+        )
+        monkeypatch.setattr(local_mod, "_bash_starts", fake_starts)
+        monkeypatch.setattr(
+            local_mod, "_mandatory_aslr_enabled", lambda *, env=None: False
+        )
+        monkeypatch.delenv("HERMES_GIT_BASH_PATH", raising=False)
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local-appdata"))
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "program-files"))
+        monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "program-files-x86"))
+
+        with pytest.raises(RuntimeError, match="Mandatory ASLR"):
+            local_mod._find_bash(reject_wsl=True)
+
+        assert probed == [str(git_bash)]
+
+    @pytest.mark.parametrize("directory", ["System32", "Sysnative", "SysWOW64"])
+    def test_wsl_launcher_recognizes_direct_windows_paths(
+        self, directory, monkeypatch
+    ):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+
+        assert local_mod._is_wsl_bash_launcher(
+            rf"C:\Windows\{directory}\bash.exe"
+        )
+
+    def test_strict_find_bash_rejects_canonicalized_wsl_alias(
+        self, tmp_path, monkeypatch
+    ):
+        import tools.environments.local as local_mod
+
+        local_mod._bash_starts_cache.clear()
+        alias = tmp_path / "aliases" / "bash.exe"
+        alias.parent.mkdir(parents=True)
+        alias.write_text("", encoding="utf-8")
+        wsl_bash = r"C:\Windows\System32\bash.exe"
+        original_realpath = local_mod.os.path.realpath
+
+        def fake_realpath(path):
+            if os.fspath(path) == str(alias):
+                return wsl_bash
+            return original_realpath(path)
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod.os.path, "realpath", fake_realpath)
+        monkeypatch.setattr(local_mod.shutil, "which", lambda name: None)
+        monkeypatch.setattr(
+            local_mod,
+            "_bash_starts",
+            lambda path, *, env=None: pytest.fail(f"WSL alias was probed: {path}"),
+        )
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+        monkeypatch.setenv("HERMES_GIT_BASH_PATH", str(alias))
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local-appdata"))
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "program-files"))
+        monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "program-files-x86"))
+
+        with pytest.raises(RuntimeError, match="Git Bash not found"):
+            local_mod._find_bash(reject_wsl=True)
+
+    def test_default_find_bash_preserves_documented_wsl_override(
+        self, tmp_path, monkeypatch
+    ):
+        import tools.environments.local as local_mod
+
+        local_mod._bash_starts_cache.clear()
+        alias = tmp_path / "aliases" / "bash.exe"
+        alias.parent.mkdir(parents=True)
+        alias.write_text("", encoding="utf-8")
+        wsl_bash = r"C:\Windows\System32\bash.exe"
+        original_realpath = local_mod.os.path.realpath
+
+        def fake_realpath(path):
+            if os.fspath(path) == str(alias):
+                return wsl_bash
+            return original_realpath(path)
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod.os.path, "realpath", fake_realpath)
+        monkeypatch.setattr(local_mod.shutil, "which", lambda name: None)
+        monkeypatch.setattr(local_mod, "_bash_starts", lambda path, *, env=None: True)
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+        monkeypatch.setenv("HERMES_GIT_BASH_PATH", str(alias))
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local-appdata"))
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "program-files"))
+        monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "program-files-x86"))
+
+        assert local_mod._find_bash() == str(alias)
+
+    def test_mandatory_aslr_probe_sanitizes_environment(self, monkeypatch):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_mandatory_aslr_enabled_cache", None)
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return subprocess.CompletedProcess(argv, 0, stdout="ON\n", stderr="")
+
+        monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+        monkeypatch.setenv("OPENAI_API_KEY", "provider-secret")
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "gateway-secret")
+
+        assert local_mod._mandatory_aslr_enabled() is True
+        probe_env = calls[0][1].get("env")
+        assert probe_env is not None
+        assert "OPENAI_API_KEY" not in probe_env
+        assert "DISCORD_BOT_TOKEN" not in probe_env
+
     def test_aslr_failure_surfaces_targeted_windows_command(
         self, tmp_path, monkeypatch
     ):
@@ -180,9 +359,11 @@ class TestGitBashExternalProgramProbe:
         monkeypatch.setenv("ProgramFiles", str(tmp_path / "empty-program-files"))
         monkeypatch.delenv("ProgramFiles(x86)", raising=False)
         monkeypatch.setattr(local_mod.shutil, "which", lambda _name: None)
-        monkeypatch.setattr(local_mod, "_mandatory_aslr_enabled", lambda: True)
+        monkeypatch.setattr(
+            local_mod, "_mandatory_aslr_enabled", lambda *, env=None: True
+        )
 
-        def failed_probe(path: str) -> bool:
+        def failed_probe(path: str, *, env=None) -> bool:
             local_mod._bash_probe_details_cache[path] = (
                 "dofork: child -1 - forked process died unexpectedly"
             )

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -260,6 +260,32 @@ class TestForceEnvOptIn:
 
         assert result_env["OPENAI_BASE_URL"] == "http://intended/v1"
 
+    def test_force_prefix_cannot_restore_tier_one_secrets(self):
+        """Gateway, GitHub, and infrastructure secrets are never forceable."""
+        from tools.environments.local import (
+            _ALWAYS_STRIP_KEYS,
+            _sanitize_subprocess_env,
+        )
+
+        base = {key: f"base-{key}" for key in _ALWAYS_STRIP_KEYS}
+        forced = {
+            f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}{key}": f"forced-{key}"
+            for key in _ALWAYS_STRIP_KEYS
+        }
+
+        result = _sanitize_subprocess_env(base, forced)
+
+        leaked = {key for key in _ALWAYS_STRIP_KEYS if key in result}
+        assert not leaked, f"Tier-1 keys restored by force prefix: {sorted(leaked)}"
+
+        terminal_result = _run_with_env(extra_os_env=base, self_env=forced)
+        terminal_leaks = {
+            key for key in _ALWAYS_STRIP_KEYS if key in terminal_result
+        }
+        assert not terminal_leaks, (
+            f"Tier-1 keys leaked to terminal env: {sorted(terminal_leaks)}"
+        )
+
 
 class TestActiveVenvMarkerStripping:
     """Active-virtualenv markers must not leak into terminal subprocesses (#23473).
@@ -322,6 +348,12 @@ class TestBlocklistCoverage:
             "LLM_MODEL",
         }
         assert must_block.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
+
+    def test_tier_one_keys_are_also_in_provider_blocklist(self):
+        from tools.environments.local import _ALWAYS_STRIP_KEYS
+
+        missing = _ALWAYS_STRIP_KEYS - _HERMES_PROVIDER_ENV_BLOCKLIST
+        assert not missing, f"Tier-1 keys missing from blocklist: {sorted(missing)}"
 
     def test_registry_vars_are_in_blocklist(self):
         """Every api_key_env_var and base_url_env_var from PROVIDER_REGISTRY

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -282,6 +282,7 @@ def _build_provider_env_blocklist() -> frozenset:
         "DISCORD_REQUIRE_MENTION",
         "DISCORD_FREE_RESPONSE_CHANNELS",
         "DISCORD_AUTO_THREAD",
+        "SLACK_SIGNING_SECRET",
         "SLACK_HOME_CHANNEL",
         "SLACK_HOME_CHANNEL_NAME",
         "SLACK_ALLOWED_USERS",
@@ -460,6 +461,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for key, value in (base_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             continue
+        if key in _ALWAYS_STRIP_KEYS:
+            continue
         if _is_hermes_internal_secret(key):
             continue
         if key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
@@ -468,9 +471,11 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for key, value in (extra_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = key[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
-            if _is_hermes_internal_secret(real_key):
+            if real_key in _ALWAYS_STRIP_KEYS or _is_hermes_internal_secret(real_key):
                 continue
             sanitized[real_key] = value
+        elif key in _ALWAYS_STRIP_KEYS:
+            continue
         elif _is_hermes_internal_secret(key):
             continue
         elif key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
@@ -615,8 +620,66 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     return env
 
 
-def _find_bash() -> str:
-    """Find bash for command execution."""
+def _is_wsl_bash_launcher(path: str) -> bool:
+    """True for Windows' legacy WSL ``bash.exe`` launcher.
+
+    The launcher can successfully run Linux commands when a WSL distribution
+    is installed, but it cannot consume the native Windows/MSYS paths Hermes
+    passes to a shell. It must therefore never qualify as Git Bash merely
+    because it starts successfully.
+    """
+    if not path:
+        return False
+    windows_dir = os.environ.get("SystemRoot") or os.environ.get("WINDIR")
+    windows_dir = windows_dir or r"C:\Windows"
+    launchers = {
+        ntpath.normcase(ntpath.join(windows_dir, directory, "bash.exe"))
+        for directory in ("System32", "Sysnative", "SysWOW64")
+    }
+
+    def _normalized(candidate: str) -> str:
+        normalized = ntpath.normpath(candidate)
+        if normalized.startswith("\\\\?\\UNC\\"):
+            normalized = "\\\\" + normalized[8:]
+        elif normalized.startswith("\\\\?\\"):
+            normalized = normalized[4:]
+        return ntpath.normcase(normalized)
+
+    raw = _normalized(path)
+    if raw in launchers:
+        return True
+
+    # On native Windows, realpath uses GetFinalPathNameByHandleW. This expands
+    # symlinks, junctions and 8.3 aliases so a renamed System32 launcher cannot
+    # bypass the direct-path check above. It is best-effort because candidates
+    # can disappear between discovery and inspection.
+    try:
+        resolved = _normalized(os.path.realpath(path))
+    except (OSError, ValueError):
+        resolved = raw
+    if resolved in launchers:
+        return True
+
+    # UNC aliases can retain their share prefix after final-path resolution.
+    # Match only the Windows-directory tail, not arbitrary */System32/bash.exe
+    # paths, so a normal Git/MSYS installation remains eligible.
+    windows_leaf = ntpath.basename(ntpath.normpath(windows_dir)) or "Windows"
+    return any(
+        resolved.endswith(
+            "\\" + ntpath.normcase(ntpath.join(windows_leaf, directory, "bash.exe"))
+        )
+        for directory in ("System32", "Sysnative", "SysWOW64")
+    )
+
+
+def _find_bash(*, reject_wsl: bool = False) -> str:
+    """Find bash for command execution.
+
+    ``reject_wsl`` is for native Windows callers that pass Windows script
+    paths directly to bash (notably cron). The default remains permissive so
+    the terminal's documented ``HERMES_GIT_BASH_PATH`` WSL override continues
+    to work.
+    """
     if not _IS_WINDOWS:
         return (
             shutil.which("bash")
@@ -626,6 +689,10 @@ def _find_bash() -> str:
             or "/bin/sh"
         )
 
+    # Resolver probes execute a candidate shell before the caller's command.
+    # Keep those probes under the same credential-scoping policy as terminal
+    # and cron subprocesses rather than inheriting the agent's full environment.
+    probe_env = _sanitize_subprocess_env(os.environ.copy())
     candidates: list[str] = []
 
     custom = os.environ.get("HERMES_GIT_BASH_PATH")
@@ -666,12 +733,19 @@ def _find_bash() -> str:
     if found and found not in candidates:
         candidates.append(found)
 
+    if reject_wsl:
+        candidates = [
+            candidate
+            for candidate in candidates
+            if not _is_wsl_bash_launcher(candidate)
+        ]
+
     # Prefer the first candidate that can actually start.  A stale
     # HERMES_GIT_BASH_PATH pointing at a broken Git-for-Windows install
     # (``Directory \\drivers\\etc does not exist``) must not win over a
     # healthy portable Git under %LOCALAPPDATA%\\hermes\\git.
     for candidate in candidates:
-        if _bash_starts(candidate):
+        if _bash_starts(candidate, env=probe_env):
             if candidate != custom and custom and os.path.isfile(custom):
                 logger.warning(
                     "HERMES_GIT_BASH_PATH=%s fails to start; using %s instead",
@@ -686,7 +760,7 @@ def _find_bash() -> str:
             for candidate in candidates
             if (detail := _bash_probe_details_cache.get(candidate))
         )
-        if _mandatory_aslr_enabled() is True or _looks_like_msys_spawn_failure(
+        if _mandatory_aslr_enabled(env=probe_env) is True or _looks_like_msys_spawn_failure(
             probe_details
         ):
             raise RuntimeError(_git_bash_aslr_help(candidates[0], probe_details))
@@ -724,11 +798,14 @@ def _looks_like_msys_spawn_failure(details: str) -> bool:
     )
 
 
-def _mandatory_aslr_enabled() -> "bool | None":
+def _mandatory_aslr_enabled(*, env: dict[str, str] | None = None) -> "bool | None":
     """Return Windows' system-wide ForceRelocateImages state when available."""
     global _mandatory_aslr_enabled_cache
     if _mandatory_aslr_enabled_cache is not None:
         return _mandatory_aslr_enabled_cache
+
+    if env is None:
+        env = _sanitize_subprocess_env(os.environ.copy())
 
     try:
         powershell = shutil.which("powershell.exe") or "powershell.exe"
@@ -744,6 +821,7 @@ def _mandatory_aslr_enabled() -> "bool | None":
             text=True,
             timeout=10,
             creationflags=windows_hide_flags(),
+            env=env,
         )
         if result.returncode != 0:
             return None
@@ -790,7 +868,7 @@ def _git_bash_aslr_help(bash: str, details: str = "") -> str:
     )
 
 
-def _bash_starts(bash: str) -> bool:
+def _bash_starts(bash: str, *, env: dict[str, str] | None = None) -> bool:
     """True if *bash* can launch external MSYS programs.
 
     Uses ``--noprofile --norc`` so a broken login post-install
@@ -803,6 +881,9 @@ def _bash_starts(bash: str) -> bool:
     if cached is not None:
         return cached
 
+    if env is None:
+        env = _sanitize_subprocess_env(os.environ.copy())
+
     try:
         result = subprocess.run(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
@@ -810,6 +891,7 @@ def _bash_starts(bash: str) -> bool:
             text=True,
             timeout=15,
             creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
+            env=env,
         )
         ok = result.returncode == 0
         if not ok:
@@ -1137,10 +1219,10 @@ def _make_run_env(env: dict) -> dict:
     for k, v in merged.items():
         if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = k[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
-            if _is_hermes_internal_secret(real_key):
+            if real_key in _ALWAYS_STRIP_KEYS or _is_hermes_internal_secret(real_key):
                 continue
             run_env[real_key] = v
-        elif _is_hermes_internal_secret(k):
+        elif k in _ALWAYS_STRIP_KEYS or _is_hermes_internal_secret(k):
             continue
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v


### PR DESCRIPTION
## Summary
- use Hermes' Bash resolver in strict native-Windows mode for cron `.sh` / `.bash` jobs
- reject the legacy WSL `bash.exe` launcher at `System32`, `Sysnative`, and `SysWOW64`, including canonicalized symlink, junction, 8.3, and UNC aliases
- preserve the default terminal resolver's documented support for user-configured WSL overrides
- sanitize Git-Bash and Mandatory-ASLR resolver probes before they spawn, and enforce Tier-1 secret stripping across both subprocess environment builders (including `_HERMES_FORCE_` inputs)
- preserve actionable resolver failures such as Mandatory-ASLR remediation instead of replacing them with a generic "install Git" message

## Root cause
On native Windows, the gateway PATH can resolve `bash` to `C:\Windows\System32\bash.exe` before Git for Windows. That launcher enters WSL and cannot consume the native/MSYS script path passed by cron, producing exit 127 and a mangled path such as `C:Users...`.

The first repair exposed two adjacent hardening gaps during fail-closed review: resolver probes inherited the gateway environment, and resolver `RuntimeError` details were discarded. A follow-up review also identified alias-based WSL selection and a Tier-1 blocklist drift case. This PR now closes all four paths.

## Verification
- regression tests were observed RED before each repair and GREEN afterward
- affected Windows-compatible suite: **796 passed, 13 skipped, 26 platform-assumption tests deselected**
- the actual Windows-only failures outside this change reproduce unchanged at base `c48d53413` (POSIX/macOS path-separator, HOME-expansion, and mode-bit assumptions)
- `ruff` on all five changed files: passed
- `compileall`: passed
- `git diff --check`: passed
- Bandit high-severity scan of both changed source files: passed
- direct runtime checks: strict/default resolver both select `C:\Program Files\Git\bin\bash.exe`; all three Windows WSL launcher paths classify as rejected in strict mode
- live gateway verification after the final code: `bushel-source-freshness-mwf` completed successfully through its `.sh` script
- independent fail-closed review: initial findings fixed; final review returned no security concerns or logic errors
