### PR TITLE
fix(ui): increase visibility of stale auxiliary model warning banner

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -169,9 +169,9 @@ function StaleAuxWarning({ applying, onReset, slots, taskLabel }: StaleAuxWarnin
   const names = slots.map(slot => taskLabel(slot.task)).join(', ')
 
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
-      <AlertTriangle className="size-3.5 shrink-0" />
-      <span className="grow">
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-400/60 bg-amber-500/15 px-3 py-2.5 text-sm text-amber-50">
+      <AlertTriangle className="size-4 shrink-0" />
+      <span className="grow font-medium">
         {slots.length} auxiliary task{slots.length === 1 ? '' : 's'} ({names}) still run on{' '}
         <span className="font-mono">{allSameProvider ? provider : 'other providers'}</span>, not your main model.
       </span>


### PR DESCRIPTION
## Problem

Issue #66740: The yellow warning banner for stale auxiliary model assignments was too subtle - small text (text-xs), low contrast amber colors, and small icon made it easy to overlook, especially for new users.

## Fix

Enhanced the `StaleAuxWarning` component in model-settings.tsx:
- **Bigger text**: `text-xs` → `text-sm`
- **Higher contrast**: `text-amber-200` → `text-amber-50` (lighter text on amber background)
- **Stronger border**: `border-amber-500/40` → `border-amber-400/60`
- **Slightly more padding**: `py-2` → `py-2.5`
- **Medium-weight font**: added `font-medium` to the message text
- **Larger icon**: `size-3.5` → `size-4`
- **Slightly stronger background**: `bg-amber-500/10` → `bg-amber-500/15`

Closes #66740