### PR TITLE
fix(auth): scope credential pool env seeds to profiles

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -16,8 +16,8 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
-from agent.secret_scope import current_secret_scope as _current_secret_scope
 from agent.secret_scope import get_secret as _get_secret
+from agent.secret_scope import is_multiplex_active as _is_multiplex_active
 from agent.credential_persistence import (
     is_borrowed_credential_source,
     sanitize_borrowed_credential_payload,
@@ -2321,14 +2321,11 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         # config block.  For every non-op:// value the original
         # .env-takes-precedence behaviour is preserved unchanged.
         if raw.startswith("op://"):
-            # A multiplexed profile scope is authoritative. Its unresolved
-            # 1Password reference must not be "resolved" from another
-            # profile's process-global environment value.
-            if _current_secret_scope() is not None:
-                scoped = _get_secret(key, "")
+            if _is_multiplex_active():
+                scoped = _get_secret(key, "") or ""
                 return "" if scoped.startswith("op://") else scoped
             return env_val or raw
-        return raw or _get_secret(key, "")
+        return raw or _get_secret(key, "") or ""
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
+from agent.secret_scope import current_secret_scope as _current_secret_scope
 from agent.secret_scope import get_secret as _get_secret
 from agent.credential_persistence import (
     is_borrowed_credential_source,
@@ -2319,9 +2320,15 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         # references straight into .env rather than the secrets.onepassword
         # config block.  For every non-op:// value the original
         # .env-takes-precedence behaviour is preserved unchanged.
-        if raw.startswith("op://") and env_val:
-            return env_val
-        return raw or _get_secret(key, "") or env_val
+        if raw.startswith("op://"):
+            # A multiplexed profile scope is authoritative. Its unresolved
+            # 1Password reference must not be "resolved" from another
+            # profile's process-global environment value.
+            if _current_secret_scope() is not None:
+                scoped = _get_secret(key, "")
+                return "" if scoped.startswith("op://") else scoped
+            return env_val or raw
+        return raw or _get_secret(key, "")
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -98,6 +98,50 @@ def test_pool_keeps_single_profile_resolved_op_reference(tmp_path, monkeypatch):
     assert entries[0].access_token == "sk-single-profile"
 
 
+def test_pool_fails_closed_for_unscoped_op_reference_when_multiplex_active(tmp_path, monkeypatch):
+    """A raw profile reference must not borrow a global key outside its scope."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("OPENROUTER_API_KEY=op://profile-a/key\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-other-profile")
+
+    scope_token = ss.set_secret_scope(None)
+    ss.set_multiplex_active(True)
+    try:
+        from agent.credential_pool import _seed_from_env
+
+        with pytest.raises(ss.UnscopedSecretError):
+            _seed_from_env("openrouter", [])
+    finally:
+        ss.set_multiplex_active(False)
+        ss.reset_secret_scope(scope_token)
+
+
+def test_pool_uses_scoped_resolution_for_op_reference_when_multiplex_active(tmp_path, monkeypatch):
+    """A scoped profile resolves its own 1Password value, never the global one."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("OPENROUTER_API_KEY=op://profile-a/key\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-other-profile")
+
+    scope_token = ss.set_secret_scope({"OPENROUTER_API_KEY": "sk-profile-a"})
+    ss.set_multiplex_active(True)
+    try:
+        from agent.credential_pool import _seed_from_env
+
+        entries = []
+        changed, active_sources = _seed_from_env("openrouter", entries)
+    finally:
+        ss.set_multiplex_active(False)
+        ss.reset_secret_scope(scope_token)
+
+    assert changed is True
+    assert active_sources == {"env:OPENROUTER_API_KEY"}
+    assert [entry.access_token for entry in entries] == ["sk-profile-a"]
+
+
 def test_fill_first_selection_skips_recently_exhausted_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 
 import pytest
 
+from agent import secret_scope as ss
+
 
 def _write_auth_store(tmp_path, payload: dict) -> None:
     hermes_home = tmp_path / "hermes"
@@ -22,6 +24,78 @@ def _jwt_with_claims(claims: dict) -> str:
         return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
 
     return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
+
+
+@pytest.fixture(autouse=True)
+def _reset_secret_scope():
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+def _load_openrouter_pool_in_scope(profile_home, secrets):
+    from agent.credential_pool import load_pool
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    home_token = set_hermes_home_override(profile_home)
+    secret_token = ss.set_secret_scope(secrets)
+    try:
+        return load_pool("openrouter").entries()
+    finally:
+        ss.reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+
+
+def test_pool_does_not_seed_another_profiles_process_env_key(tmp_path, monkeypatch):
+    """A scoped profile with no key must not re-import a global profile's key."""
+    profile_home = tmp_path / "profiles" / "profile-a"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-other-profile")
+    ss.set_multiplex_active(True)
+
+    assert _load_openrouter_pool_in_scope(profile_home, {}) == []
+
+
+def test_pool_does_not_resolve_profile_op_reference_from_another_profiles_env(tmp_path, monkeypatch):
+    """An unresolved profile reference must not borrow a process-global key."""
+    profile_home = tmp_path / "profiles" / "profile-a"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text("OPENROUTER_API_KEY=op://profile-a/key\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-other-profile")
+    ss.set_multiplex_active(True)
+
+    assert _load_openrouter_pool_in_scope(profile_home, {"OPENROUTER_API_KEY": "op://profile-a/key"}) == []
+
+
+def test_pool_keeps_process_env_key_without_profile_scope(tmp_path, monkeypatch):
+    """Single-profile deployments retain the legacy environment fallback."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-single-profile")
+
+    from agent.credential_pool import load_pool
+
+    entries = load_pool("openrouter").entries()
+
+    assert len(entries) == 1
+    assert entries[0].access_token == "sk-single-profile"
+
+
+def test_pool_keeps_single_profile_resolved_op_reference(tmp_path, monkeypatch):
+    """The legacy one-password resolution path still works outside multiplexing."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("OPENROUTER_API_KEY=op://single-profile/key\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-single-profile")
+
+    from agent.credential_pool import load_pool
+
+    entries = load_pool("openrouter").entries()
+
+    assert len(entries) == 1
+    assert entries[0].access_token == "sk-single-profile"
 
 
 def test_fill_first_selection_skips_recently_exhausted_entry(tmp_path, monkeypatch):


### PR DESCRIPTION
## Current change

Current head: `53e52ed` — rebased on `NousResearch/main` `e598cef`.

Credential-pool environment seeding is profile-scoped in multiplex mode. A profile with no key, or with an unresolved raw `op://` reference, cannot borrow another profile’s process-global provider key.

## Security invariant

During a multiplexed profile turn, credential-pool seeding may use only that profile’s secret scope. An unscoped raw `op://` resolution fails closed through the profile-aware accessor; it raises rather than falling back to process-global environment state. Single-profile environment and resolved `op://` behavior remain available.

## Review disposition

The follow-up specifically covers multiplex-active with no installed scope, the path called out in review. It also proves that a scoped profile receives only its own credential.

## Validation

Isolated locked Python 3.12 dev environment:

- credential-pool / secret-scope / multiplex gateway focused suite: 10 files, 157 passed;
- Ruff, import contract, and whitespace checks passed.

## Review focus

Please review the fail-closed boundary between multiplex scope resolution and process-global environment fallback, especially the raw `op://` path.
