### PR TITLE
feat(cli): --no-session ephemeral mode for one-shot invocations (fixes #66319)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -346,6 +346,7 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    persist_disabled: bool = False,
 ):
     """
     Initialize the AI Agent.
@@ -1355,8 +1356,13 @@ def init_agent(
     # When True, this agent NEVER persists to the canonical session store
     # (state.db) or the JSON snapshot, regardless of session_id. Set on the
     # background skill/memory review fork so its harness turn can't leak into
-    # the user's real session and hijack the next live turn. Default False.
-    agent._persist_disabled = False
+    # the user's real session and hijack the next live turn, and by the CLI's
+    # --no-session one-shot mode (#66319). Default False.
+    agent._persist_disabled = persist_disabled
+    if persist_disabled:
+        # An ephemeral agent must not leave a JSON snapshot either, even when
+        # config enables write_json_snapshots (set earlier in this function).
+        agent._session_json_enabled = False
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,

--- a/cli.py
+++ b/cli.py
@@ -3722,6 +3722,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         checkpoints: bool = False,
         pass_session_id: bool = False,
         ignore_rules: bool = False,
+        no_session: bool = False,
     ):
         """
         Initialize the Hermes CLI.
@@ -3929,6 +3930,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # pass skip_context_files=True and skip_memory=True to AIAgent so
         # AGENTS.md/SOUL.md/.cursorrules and persistent memory are not loaded.
         self.ignore_rules = ignore_rules or os.environ.get("HERMES_IGNORE_RULES") == "1"
+        # --no-session: ephemeral one-shot — the agent is constructed with
+        # persist_disabled=True so no session row, message flush, JSON
+        # snapshot, or memory extraction ever happens (#66319).
+        # CLI flag only, deliberately no env-var form: AGENTS.md:102-107 bans
+        # new user-facing non-secret HERMES_* env vars, and flag-only keeps
+        # main()'s one-shot validation the single unbypassable gate.
+        # MUST stay assigned before the SessionDB block below, which reads it.
+        self.no_session = no_session
         
         # Ephemeral system prompt: env var takes precedence, then config
         self.system_prompt = (
@@ -4002,35 +4011,44 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Initialize SQLite session store early so /title works before first message
         self._session_db = None
         self._session_db_unavailable = False
-        try:
-            from hermes_state import SessionDB
-            self._session_db = SessionDB()
-        except Exception as e:
-            # #41386: a failed session store means the transcript is NOT
-            # persisted to state.db — the live chat looks healthy but resume
-            # later shows a truncated/empty session. A buried log line is not
-            # enough; surface it prominently so the user knows persistence is
-            # off for this run and can fix the store before relying on resume.
-            self._session_db_unavailable = True
-            logger.warning("Failed to initialize SessionDB — session will NOT be indexed for search: %s", e)
+        # ORDERING REQUIREMENT: self.no_session is assigned above (see the
+        # --no-session comment near self.ignore_rules) and is read here. Do not
+        # move this block above that assignment or ephemeral runs will open the
+        # session store anyway.
+        # Ephemeral one-shot never touches state.db. Note we deliberately leave
+        # _session_db_unavailable False: that flag drives the #41386 "persistence
+        # off / resume broken" warning, which would be wrong noise when the user
+        # explicitly asked for no session.
+        if not self.no_session:
             try:
-                # Console is imported at module scope; do NOT re-import it here.
-                # A function-local `import` would make `Console` a local name for
-                # the whole __init__ body and break the earlier `self.console =
-                # Console()` with UnboundLocalError.
-                Console(stderr=True).print(
-                    "[bold yellow]⚠ Session store unavailable[/bold yellow] — "
-                    "this conversation will [bold]NOT be saved[/bold] to disk and "
-                    "cannot be resumed later. Searching past sessions is also disabled.\n"
-                    f"  Reason: {e}\n"
-                    "  Fix the state.db store (e.g. `hermes update` to rebuild the venv) to restore persistence."
-                )
-            except Exception:
-                # Never let the warning path itself break startup.
-                print(
-                    "WARNING: Session store unavailable — this conversation will NOT be "
-                    f"saved to disk and cannot be resumed later. Reason: {e}"
-                )
+                from hermes_state import SessionDB
+                self._session_db = SessionDB()
+            except Exception as e:
+                # #41386: a failed session store means the transcript is NOT
+                # persisted to state.db — the live chat looks healthy but resume
+                # later shows a truncated/empty session. A buried log line is not
+                # enough; surface it prominently so the user knows persistence is
+                # off for this run and can fix the store before relying on resume.
+                self._session_db_unavailable = True
+                logger.warning("Failed to initialize SessionDB — session will NOT be indexed for search: %s", e)
+                try:
+                    # Console is imported at module scope; do NOT re-import it here.
+                    # A function-local `import` would make `Console` a local name for
+                    # the whole __init__ body and break the earlier `self.console =
+                    # Console()` with UnboundLocalError.
+                    Console(stderr=True).print(
+                        "[bold yellow]⚠ Session store unavailable[/bold yellow] — "
+                        "this conversation will [bold]NOT be saved[/bold] to disk and "
+                        "cannot be resumed later. Searching past sessions is also disabled.\n"
+                        f"  Reason: {e}\n"
+                        "  Fix the state.db store (e.g. `hermes update` to rebuild the venv) to restore persistence."
+                    )
+                except Exception:
+                    # Never let the warning path itself break startup.
+                    print(
+                        "WARNING: Session store unavailable — this conversation will NOT be "
+                        f"saved to disk and cannot be resumed later. Reason: {e}"
+                    )
 
         # Opportunistic state.db maintenance — runs at most once per
         # min_interval_hours, tracked via state_meta in state.db itself so
@@ -15401,10 +15419,11 @@ def main(
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
     ignore_rules: bool = False,
+    no_session: bool = False,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
-    
+
     Args:
         query: Single query to execute (then exit). Alias: -q
         q: Shorthand for --query
@@ -15488,7 +15507,25 @@ def main(
     
     # Handle query shorthand
     query = query or q
-    
+
+    # --no-session is one-shot-only: interactive mode has slash commands
+    # (/new -> cli.py:7136 create_session, /branch) that create session rows
+    # directly, bypassing the agent-level _persist_disabled guard, and resuming
+    # a persisted session into an ephemeral run makes no sense. Reject both up
+    # front (#66319).
+    # --no-session is a CLI flag only, by policy: AGENTS.md:102-107 bans new
+    # user-facing non-secret HERMES_* env vars, so there is no env form that
+    # could reach HermesCLI without passing through this check. That is what
+    # makes this the single unbypassable gate keeping /new and /branch
+    # unreachable in ephemeral mode.
+    if no_session:
+        if resume:
+            raise ValueError("--no-session cannot be combined with --resume")
+        if not (query or image):
+            raise ValueError(
+                "--no-session requires a one-shot invocation (-q/--query or --image)"
+            )
+
     # Parse toolsets - handle both string and tuple/list inputs
     # Default to hermes-cli toolset which includes cronjob management tools
     toolsets_list = None
@@ -15536,6 +15573,7 @@ def main(
         checkpoints=checkpoints,
         pass_session_id=pass_session_id,
         ignore_rules=ignore_rules,
+        no_session=no_session,
     )
 
     if parsed_skills:

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -233,6 +233,13 @@ def build_top_level_parser():
     )
     _inherited_flag(
         parser,
+        "--no-session",
+        action="store_true",
+        default=False,
+        help="Ephemeral one-shot: don't persist a session (no sessions DB row, no JSON snapshot, no memory extraction). Only valid with a one-shot invocation (-q/--query, --image, or -z)",
+    )
+    _inherited_flag(
+        parser,
         "--safe-mode",
         action="store_true",
         default=False,
@@ -411,6 +418,13 @@ def build_top_level_parser():
         action="store_true",
         default=argparse.SUPPRESS,
         help="Skip auto-injection of AGENTS.md, SOUL.md, .cursorrules, memory, and preloaded skills. Combine with --ignore-user-config for a fully isolated run.",
+    )
+    _inherited_flag(
+        chat_parser,
+        "--no-session",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Ephemeral one-shot: don't persist a session (no sessions DB row, no JSON snapshot, no memory extraction). Only valid with a one-shot invocation (-q/--query, --image, or -z). Useful for batch-testing model presets without flooding the session list.",
     )
     _inherited_flag(
         chat_parser,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -247,7 +247,9 @@ class CLIAgentSetupMixin:
         wait_for_mcp_discovery()
 
         # Initialize SQLite session store for CLI sessions (if not already done in __init__)
-        if self._session_db is None:
+        # --no-session (#66319) leaves _session_db None on purpose; without the
+        # guard this lazy re-open would silently undo the ephemeral contract.
+        if self._session_db is None and not getattr(self, "no_session", False):
             try:
                 from hermes_state import SessionDB
                 self._session_db = SessionDB()
@@ -381,6 +383,7 @@ class CLIAgentSetupMixin:
                 session_id=self.session_id,
                 platform="cli",
                 session_db=self._session_db,
+                persist_disabled=getattr(self, "no_session", False),
                 clarify_callback=self._clarify_callback,
                 reasoning_callback=self._current_reasoning_callback(),
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2492,6 +2492,7 @@ def cmd_chat(args):
         "ignore_rules": getattr(args, "ignore_rules", False) or getattr(args, "safe_mode", False),
         "ignore_user_config": getattr(args, "ignore_user_config", False) or getattr(args, "safe_mode", False),
         "compact": getattr(args, "compact", False),
+        "no_session": getattr(args, "no_session", False),
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -12982,6 +12983,7 @@ def _try_termux_fast_cli_launch() -> bool:
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
                 usage_file=getattr(args, "usage_file", None),
+                no_session=getattr(args, "no_session", False),
             )
         )
 
@@ -15139,6 +15141,7 @@ def main():
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
                 usage_file=getattr(args, "usage_file", None),
+                no_session=getattr(args, "no_session", False),
             )
         )
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -173,6 +173,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    no_session: bool = False,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +188,9 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        no_session: When True, run ephemerally — no sessions DB row, no JSON
+            snapshot, no end-of-session memory extraction (#66319). The
+            session_search/recall tool degrades gracefully to unavailable.
 
     Returns the exit code.  Caller should sys.exit() with the return.
     """
@@ -248,6 +252,7 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    no_session=no_session,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -316,6 +321,7 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    no_session: bool = False,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -395,7 +401,10 @@ def _run_agent(
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
-    session_db = _create_session_db_for_oneshot()
+    # Ephemeral runs never open the canonical store — _persist_disabled would
+    # hard-stop writes anyway, but not opening it at all keeps recall from
+    # even advertising other sessions' history to a throwaway invocation.
+    session_db = None if no_session else _create_session_db_for_oneshot()
     # Read the effective fallback chain from profile config so oneshot workers
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
@@ -410,6 +419,7 @@ def _run_agent(
         quiet_mode=True,
         platform="cli",
         session_db=session_db,
+        persist_disabled=no_session,
         credential_pool=runtime.get("credential_pool"),
         fallback_model=_fb or None,
         # Interactive callbacks are intentionally NOT wired beyond this

--- a/run_agent.py
+++ b/run_agent.py
@@ -492,6 +492,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        persist_disabled: bool = False,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -568,6 +569,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            persist_disabled=persist_disabled,
         )
 
     def _get_session_db_for_recall(self):
@@ -3456,17 +3458,23 @@ class AIAgent:
         NOT called per-turn — only at CLI exit, /reset, gateway
         session expiry, etc.
         """
+        # Persistence-isolated agents (background review, --no-session one-shots)
+        # must not run end-of-session memory extraction: an ephemeral test turn
+        # is not signal worth committing to long-term memory (#66319). Provider
+        # teardown still runs so threads/DB handles are released.
+        persist_disabled = getattr(self, "_persist_disabled", False)
         if self._memory_manager:
-            try:
-                self._memory_manager.on_session_end(messages or [])
-            except Exception as e:
-                logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
+            if not persist_disabled:
+                try:
+                    self._memory_manager.on_session_end(messages or [])
+                except Exception as e:
+                    logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
             try:
                 self._memory_manager.shutdown_all()
             except Exception:
                 pass
         # Notify context engine of session end (flush DAG, close DBs, etc.)
-        if hasattr(self, "context_compressor") and self.context_compressor:
+        if not persist_disabled and hasattr(self, "context_compressor") and self.context_compressor:
             try:
                 self.context_compressor.on_session_end(
                     self.session_id or "",
@@ -3480,6 +3488,10 @@ class AIAgent:
         Called when session_id rotates (e.g. /new, context compression);
         providers keep their state and continue running under the old
         session_id — they just flush pending extraction now."""
+        if getattr(self, "_persist_disabled", False):
+            # Ephemeral agents never commit memory (#66319) — mirror the
+            # extraction skip in shutdown_memory_provider().
+            return
         if self._memory_manager:
             try:
                 self._memory_manager.on_session_end(messages or [])

--- a/tests/test_no_session_ephemeral.py
+++ b/tests/test_no_session_ephemeral.py
@@ -1,0 +1,464 @@
+"""Tests for --no-session ephemeral one-shot mode (#66319).
+
+One-shot invocations like ``hermes chat -q "test" --no-session`` or
+``hermes -z "test" --no-session`` must leave no trace: no sessions DB row,
+no JSON snapshot, and no end-of-session memory extraction. The mechanism is
+the existing ``_persist_disabled`` isolation (born in background review),
+now reachable as an ``AIAgent(persist_disabled=True)`` constructor kwarg and
+wired through the CLI. Provider teardown still runs so threads and DB
+handles are released.
+
+``--no-session`` is a CLI flag with no environment-variable form: AGENTS.md
+lines 102-107 reject new user-facing non-secret ``HERMES_*`` env vars, and
+flag-only keeps ``cli.main()``'s one-shot validation the single unbypassable
+gate (nothing can reach ``HermesCLI`` in ephemeral mode without passing it).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_agent(db, session_id: str, **kwargs):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+            **kwargs,
+        )
+
+
+class TestPersistDisabledConstructorKwarg:
+    """persist_disabled=True at construction must behave exactly like the
+    attribute-set idiom used by background review: no row, no flush, and
+    the JSON snapshot forced off regardless of config."""
+
+    def test_no_session_row_is_created(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                agent = _make_agent(db, "s-ephemeral", persist_disabled=True)
+                agent._ensure_db_session()
+                assert db.get_session("s-ephemeral") is None
+
+                agent._flush_messages_to_session_db(
+                    [{"role": "user", "content": "throwaway test turn"}],
+                    [],
+                )
+                assert db.get_messages("s-ephemeral") == []
+            finally:
+                db.close()
+
+    def test_json_snapshot_forced_off(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                agent = _make_agent(db, "s-ephemeral", persist_disabled=True)
+                assert agent._persist_disabled is True
+                assert agent._session_json_enabled is False
+            finally:
+                db.close()
+
+    def test_default_construction_still_persists(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                agent = _make_agent(db, "s-live")
+                assert agent._persist_disabled is False
+                agent._ensure_db_session()
+                assert db.get_session("s-live") is not None
+            finally:
+                db.close()
+
+
+class TestEphemeralMemoryLifecycle:
+    """Ephemeral agents skip end-of-session extraction but still tear
+    providers down; persistent agents keep the extract-then-teardown order."""
+
+    def _agent_with_mocks(self, db, session_id: str, **kwargs):
+        agent = _make_agent(db, session_id, **kwargs)
+        agent._memory_manager = MagicMock()
+        agent.context_compressor = MagicMock()
+        return agent
+
+    def test_shutdown_skips_extraction_but_tears_down(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                agent = self._agent_with_mocks(db, "s-eph", persist_disabled=True)
+                agent.shutdown_memory_provider([{"role": "user", "content": "x"}])
+                agent._memory_manager.on_session_end.assert_not_called()
+                agent._memory_manager.shutdown_all.assert_called_once()
+                agent.context_compressor.on_session_end.assert_not_called()
+            finally:
+                db.close()
+
+    def test_shutdown_default_still_extracts(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                agent = self._agent_with_mocks(db, "s-live")
+                messages = [{"role": "user", "content": "x"}]
+                agent.shutdown_memory_provider(messages)
+                agent._memory_manager.on_session_end.assert_called_once_with(messages)
+                agent._memory_manager.shutdown_all.assert_called_once()
+                agent.context_compressor.on_session_end.assert_called_once()
+            finally:
+                db.close()
+
+    def test_commit_memory_session_is_noop_when_ephemeral(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                agent = self._agent_with_mocks(db, "s-eph", persist_disabled=True)
+                agent.commit_memory_session([{"role": "user", "content": "x"}])
+                agent._memory_manager.on_session_end.assert_not_called()
+                agent.context_compressor.on_session_end.assert_not_called()
+            finally:
+                db.close()
+
+    def test_commit_memory_session_default_extracts(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                agent = self._agent_with_mocks(db, "s-live")
+                messages = [{"role": "user", "content": "x"}]
+                agent.commit_memory_session(messages)
+                agent._memory_manager.on_session_end.assert_called_once_with(messages)
+            finally:
+                db.close()
+
+
+class TestNoSessionFlagParsing:
+    """--no-session is exposed on both the chat subcommand and the top level
+    (for -z); it defaults falsy so getattr(args, "no_session", False) is safe
+    everywhere it is consumed."""
+
+    def test_chat_subcommand_flag(self):
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _subparsers, _chat = build_top_level_parser()
+        args = parser.parse_args(["chat", "-q", "hi", "--no-session"])
+        assert getattr(args, "no_session", False) is True
+
+    def test_chat_subcommand_default_is_falsy(self):
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _subparsers, _chat = build_top_level_parser()
+        args = parser.parse_args(["chat", "-q", "hi"])
+        assert not getattr(args, "no_session", False)
+
+    def test_top_level_flag_for_oneshot(self):
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _subparsers, _chat = build_top_level_parser()
+        args = parser.parse_args(["-z", "hi", "--no-session"])
+        assert getattr(args, "no_session", False) is True
+
+
+class TestRunOneshotThreading:
+    """run_oneshot must hand no_session through to the agent builder."""
+
+    def test_no_session_reaches_run_agent(self, monkeypatch, capsys):
+        from hermes_cli import oneshot
+
+        captured = {}
+
+        def _fake_run_agent(prompt, **kwargs):
+            captured.update(kwargs, prompt=prompt)
+            return "ok", {"final_response": "ok"}
+
+        monkeypatch.setattr(oneshot, "_run_agent", _fake_run_agent)
+        try:
+            rc = oneshot.run_oneshot("hello", no_session=True)
+        finally:
+            logging.disable(logging.NOTSET)  # run_oneshot silences logging globally
+        assert rc == 0
+        assert captured["no_session"] is True
+
+
+# ---------------------------------------------------------------------------
+# CLI-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cli(**kwargs):
+    """Build a real HermesCLI with ``hermes_state.SessionDB`` patched.
+
+    ``cli.HermesCLI.__init__`` imports SessionDB lazily (``from hermes_state
+    import SessionDB``), so the patch target is the module attribute. Returns
+    ``(cli_instance, session_db_mock)``.
+    """
+    import cli as cli_mod
+    import hermes_state
+
+    with patch.object(hermes_state, "SessionDB") as session_db_cls, patch.object(
+        cli_mod, "get_tool_definitions", return_value=[]
+    ):
+        instance = cli_mod.HermesCLI(**kwargs)
+    return instance, session_db_cls
+
+
+class TestNoEnvironmentForm:
+    """``--no-session`` is CLI-flag-only (AGENTS.md:102-107). No env var may
+    turn a normal run ephemeral behind the one-shot validation in main()."""
+
+    def test_env_var_does_not_enable_ephemeral_mode(self, monkeypatch):
+        monkeypatch.setenv("HERMES_NO_SESSION", "1")
+        cli_instance, session_db_cls = _make_cli(no_session=False)
+        assert cli_instance.no_session is False
+        assert cli_instance._session_db is not None
+        assert session_db_cls.call_count == 1
+
+    def test_source_declares_no_env_var(self):
+        """Policy invariant, not a change detector: if someone reintroduces an
+        env-var form, ``cli.main()`` stops being the single gate and ``/new`` /
+        ``/branch`` become reachable inside an ephemeral run."""
+        import cli as cli_mod
+        import hermes_cli._parser as parser_mod
+
+        for module in (cli_mod, parser_mod):
+            source = Path(module.__file__).read_text(encoding="utf-8")
+            assert "HERMES_NO_SESSION" not in source, (
+                f"{Path(module.__file__).name} references HERMES_NO_SESSION; "
+                "--no-session must stay CLI-flag-only per AGENTS.md:102-107"
+            )
+
+
+class TestEphemeralCliNeverOpensSessionDb:
+    """An ephemeral CLI must never construct a SessionDB — not eagerly in
+    __init__, not lazily in _init_agent."""
+
+    def test_init_does_not_open_the_store(self):
+        cli_instance, session_db_cls = _make_cli(no_session=True)
+        assert session_db_cls.call_count == 0
+        assert cli_instance._session_db is None
+        # NOT a failure: _session_db_unavailable drives the #41386 "persistence
+        # off / resume broken" warning, which would be wrong noise here.
+        assert cli_instance._session_db_unavailable is False
+
+    def _run_init_agent(self, cli_instance):
+        """Drive the real ``_init_agent`` with only its heavy prerequisites
+        stubbed, so the lazy session-store block actually executes."""
+        import cli as cli_mod
+        import hermes_cli.mcp_startup as mcp_startup
+        import hermes_state
+
+        cli_type = type(cli_instance)
+        with patch.object(hermes_state, "SessionDB") as session_db_cls, patch.object(
+            cli_mod, "AIAgent", MagicMock()
+        ) as agent_cls, patch.object(
+            cli_mod, "_prepare_deferred_agent_startup", lambda *a, **k: None
+        ), patch.object(
+            mcp_startup, "wait_for_mcp_discovery", lambda *a, **k: None
+        ), patch.object(
+            cli_type, "_install_tool_callbacks", lambda self: None
+        ), patch.object(
+            cli_type, "_ensure_tirith_security", lambda self: None
+        ), patch.object(
+            cli_type, "_ensure_runtime_credentials", lambda self: True
+        ):
+            assert cli_instance._init_agent() is True
+        return session_db_cls, agent_cls
+
+    def test_lazy_reopen_is_suppressed(self):
+        cli_instance, _ = _make_cli(no_session=True)
+        assert cli_instance._session_db is None
+        session_db_cls, agent_cls = self._run_init_agent(cli_instance)
+        assert session_db_cls.call_count == 0
+        assert cli_instance._session_db is None
+        # Defense in depth: the agent is also told not to persist.
+        assert agent_cls.call_args.kwargs["persist_disabled"] is True
+        assert agent_cls.call_args.kwargs["session_db"] is None
+
+    def test_lazy_reopen_still_happens_for_a_normal_run(self):
+        cli_instance, _ = _make_cli(no_session=False)
+        # Force the lazy path: __init__ already opened a store for a normal run.
+        cli_instance._session_db = None
+        session_db_cls, agent_cls = self._run_init_agent(cli_instance)
+        assert session_db_cls.call_count == 1
+        assert cli_instance._session_db is not None
+        assert agent_cls.call_args.kwargs["persist_disabled"] is False
+
+    def test_normal_run_opens_the_store_exactly_once(self):
+        cli_instance, session_db_cls = _make_cli(no_session=False)
+        assert session_db_cls.call_count == 1
+        assert cli_instance._session_db is not None
+        assert cli_instance._session_db_unavailable is False
+
+
+# ---------------------------------------------------------------------------
+# Compression boundary
+# ---------------------------------------------------------------------------
+
+
+def _compressing_agent(session_db, session_id: str, *, persist_disabled: bool,
+                       in_place: bool):
+    """Modelled on tests/agent/test_compression_rotation_state.py
+    ``_build_agent_with_db``: a real AIAgent with a stub summarizer so
+    ``_compress_context`` drives the real boundary code."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            platform="cli",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+            persist_disabled=persist_disabled,
+        )
+
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "tail"},
+    ]
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_summary_auth_failure = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    agent.context_compressor = compressor
+    agent.compression_in_place = in_place
+    return agent
+
+
+def _compression_messages(n: int = 20):
+    return [{"role": "user", "content": f"m{i}"} for i in range(n)]
+
+
+def _session_rows(db_path: Path):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute(
+            "SELECT id, parent_session_id FROM sessions"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+class TestEphemeralCompressionRotation:
+    """Auto-compression is the one path that writes to state.db *during* a
+    turn, via ``create_session`` / ``archive_and_compact`` / ``replace_messages``
+    (agent/conversation_compression.py:1028). ``session_db=None`` makes that
+    whole block unreachable, so an ephemeral run that compacts still leaves
+    nothing behind."""
+
+    def test_rotation_writes_nothing_when_ephemeral(self, tmp_path: Path):
+        # Rotation (compression_in_place=False) is the fork path that creates a
+        # child session row.
+        agent = _compressing_agent(
+            None, "EPHEMERAL_ROT", persist_disabled=True, in_place=False
+        )
+        agent._compress_context(
+            _compression_messages(), "sys", approx_tokens=120_000
+        )
+        # Nothing raised, and the id did not rotate to an un-indexed child.
+        assert agent.session_id == "EPHEMERAL_ROT"
+
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            assert _session_rows(tmp_path / "state.db") == []
+        finally:
+            db.close()
+
+    def test_negative_control_rotation_does_write_when_persistent(
+        self, tmp_path: Path
+    ):
+        """Proves the assertion above tests something real: with a live store
+        and persistence on, the same call DOES create a child row."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session("PARENT_ROT_CONTROL", source="cli")
+            agent = _compressing_agent(
+                db, "PARENT_ROT_CONTROL", persist_disabled=False, in_place=False
+            )
+            agent._compress_context(
+                _compression_messages(), "sys", approx_tokens=120_000
+            )
+            child = agent.session_id
+            assert child != "PARENT_ROT_CONTROL", "rotation did not happen"
+
+            rows = dict(_session_rows(tmp_path / "state.db"))
+            assert rows.get(child) == "PARENT_ROT_CONTROL"
+        finally:
+            db.close()
+
+    def test_in_place_compaction_writes_nothing_when_ephemeral(
+        self, tmp_path: Path
+    ):
+        agent = _compressing_agent(
+            None, "EPHEMERAL_INPLACE", persist_disabled=True, in_place=True
+        )
+        agent._compress_context(
+            _compression_messages(), "sys", approx_tokens=120_000
+        )
+        assert agent.session_id == "EPHEMERAL_INPLACE"
+
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            assert _session_rows(tmp_path / "state.db") == []
+        finally:
+            db.close()
+
+
+class TestInteractiveGuard:
+    """cli.main() rejects --no-session outside a one-shot invocation. With no
+    env-var form this is the single unbypassable gate, and it is what keeps
+    /new (cli.py:7136 create_session) and /branch unreachable in ephemeral
+    mode."""
+
+    def test_interactive_is_rejected(self):
+        import cli as cli_mod
+
+        with pytest.raises(ValueError, match="one-shot"):
+            cli_mod.main(no_session=True)
+
+    def test_resume_is_rejected(self):
+        import cli as cli_mod
+
+        with pytest.raises(ValueError, match="--resume"):
+            cli_mod.main(no_session=True, query="hi", resume="20260101_000000_abc")


### PR DESCRIPTION
## What does this PR do?

Adds `--no-session`: an ephemeral mode for one-shot CLI invocations that leaves no trace — no sessions DB row, no message flush, no JSON snapshot, and no end-of-session memory extraction. Batch-testing MoA presets no longer floods the session list:

```bash
hermes chat -m 质量-高峰 -q "Reply exactly OK" --no-session
hermes -z "Reply exactly OK" --no-session
```

**Root-cause note** (from code reading, detailed in the issue thread): `hermes model` itself never creates sessions — `cmd_model` → `select_provider_and_model()` is config persistence plus HTTP `GET /models` probes only. The throwaway sessions all come from the one-shot chat turns: both `hermes chat -q` and `hermes -z` reach `AIAgent._ensure_db_session()` → `SessionDB.create_session()` on the first turn (`agent/turn_context.py` early persistence), and the CLI atexit cleanup then runs memory extraction unconditionally.

**Mechanism**: rather than inventing a parallel code path, this promotes the existing `_persist_disabled` isolation (introduced for the background skill/memory review fork in `agent/background_review.py`, which already hard-stops row creation, message flush, JSON snapshot, and recall lazy-open at three choke points in `run_agent.py`) to a public `AIAgent(persist_disabled=True)` constructor kwarg, and closes its one gap: `shutdown_memory_provider()` / `commit_memory_session()` now skip extraction for ephemeral agents while still running provider teardown (`shutdown_all()`), so threads and DB handles are released.

**Scope decisions**:

- **One-shot only.** Interactive slash commands (`/new` → `cli.py` `create_session`, `/branch`) call `SessionDB.create_session` directly, bypassing the agent-level guard — an "incognito interactive mode" would silently leak rows through those paths. So `--no-session` without `-q`/`--image` and `--no-session --resume` are both rejected up front with a clear `ValueError` (surfaced by the existing `cmd_chat` error handling).
- **CLI flag only — no environment-variable form.** An earlier revision of this PR also honoured `HERMES_NO_SESSION=1`. That has been dropped: `AGENTS.md` lines 102-107 reject new user-facing non-secret `HERMES_*` env vars (behavioral settings belong in `config.yaml`), and flag-only also keeps the `cli.main()` validation above the *single* unbypassable gate — there is no path that can reach `HermesCLI` in ephemeral mode without passing it, so `/new` and `/branch` stay unreachable.
- **Plugin `on_session_end`/`on_session_finalize` hooks are unchanged.** They fire per-turn/at-exit for observability and are cheap in-process calls; gating them behind persistence would change plugin-visible behavior beyond this issue's scope. Happy to follow up if maintainers want ephemeral runs invisible to plugins too.
- Ephemeral runs never *open* the canonical store at all (`__init__` eager open skipped, `_init_agent` lazy re-open skipped, `oneshot.py` passes `session_db=None`), so `session_search`/recall degrades to unavailable rather than exposing history to a throwaway invocation — consistent with the existing `_get_session_db_for_recall` contract. It also makes the compaction-boundary write block in `agent/conversation_compression.py` (`if agent._session_db:` → `create_session` / `archive_and_compact` / `replace_messages`) unreachable, so an ephemeral run that auto-compacts still creates no child session row.

## Related Issue

Fixes #66319

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `run_agent.py` — `AIAgent.__init__` gains `persist_disabled: bool = False` (forwarded to `init_agent`); `shutdown_memory_provider()` skips `on_session_end` extraction and the context-compressor notification for ephemeral agents but still calls `shutdown_all()`; `commit_memory_session()` early-returns.
- `agent/agent_init.py` — `init_agent(persist_disabled=...)` sets `agent._persist_disabled` from the kwarg (previously hard-coded `False`) and forces `_session_json_enabled = False` for ephemeral agents even when config enables `write_json_snapshots`.
- `hermes_cli/_parser.py` — `--no-session` on the chat subparser (`argparse.SUPPRESS` default, matching sibling flags) and top level (for `-z`).
- `hermes_cli/main.py` — `cmd_chat` threads `no_session` into `cli_main(**kwargs)`; both `run_oneshot(...)` call sites pass `no_session`.
- `cli.py` — `main(no_session=...)` with one-shot-only validation (the single gate; see scope decisions); `HermesCLI(no_session=...)` stores the flag and skips the eager `SessionDB()` open. It deliberately leaves `_session_db_unavailable` **False** for the ephemeral case: that flag drives the #41386 "persistence off / resume broken" warning, which would be wrong noise when the user explicitly asked for no session.
- `hermes_cli/cli_agent_setup_mixin.py` — `_init_agent()` skips the lazy session-store re-open when ephemeral (it would otherwise silently undo the above) and constructs `AIAgent(..., persist_disabled=self.no_session)` as defense in depth.
- `hermes_cli/oneshot.py` — `run_oneshot`/`_run_agent` accept `no_session`; skip `_create_session_db_for_oneshot()` and construct the agent with `persist_disabled=no_session`.
- `tests/test_no_session_ephemeral.py` — 22 tests:
  - constructor kwarg blocks row creation and message flush against a live DB; JSON snapshot forced off; default construction still persists;
  - ephemeral shutdown skips extraction but tears down (plus the persistent-path mirror); `commit_memory_session` no-op (plus mirror);
  - flag parsing on both parsers incl. falsy default; `run_oneshot` → `_run_agent` threading;
  - **no-env-var policy invariant** — `HERMES_NO_SESSION=1` does not make a normal run ephemeral, and neither `cli.py` nor `hermes_cli/_parser.py` references the name;
  - **CLI never opens the store** — eager (`__init__`) and lazy (`_init_agent`) paths, each with a persistent positive control asserting the store *is* opened exactly once for a normal run;
  - **compaction boundary is silent** — a real `_compress_context` in rotation mode (the default fork path) against `session_db=None` leaves zero rows in a separately-opened `state.db`, with a persistent **negative control** proving the same call otherwise writes a child row carrying `parent_session_id`; same for in-place compaction;
  - the one-shot guard rejects interactive and `--resume`.

## How to Test

1. `python -m pytest tests/test_no_session_ephemeral.py -q` — **22 passed**.
2. `python -m pytest tests/test_background_review_session_isolation.py tests/test_lazy_session_regressions.py tests/test_empty_session_hygiene.py tests/hermes_cli/test_oneshot_usage_file.py tests/test_hermes_state.py tests/cli/test_cli_shutdown_memory_messages.py tests/cli/test_cli_active_agent_ref_wiring.py tests/cli/test_cli_new_session.py tests/agent/test_memory_provider.py tests/test_tui_gateway_server.py tests/agent/test_compression_rotation_state.py tests/agent/test_compression_concurrent_fork.py tests/cli/test_cli_init.py tests/cli/test_cli_resume_command.py tests/cli/test_chat_q_exit_clear.py -q` — **1062 passed** (every suite touching the persistence choke points, memory shutdown, CLI init, and the compaction boundary).
3. `python -m ruff check cli.py hermes_cli/ tests/test_no_session_ephemeral.py` — clean.
4. Guard behavior: `hermes chat --no-session` (no `-q`) and `hermes chat --no-session --resume <id> -q hi` both exit with a clear error instead of silently persisting.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites (see How to Test: 1084 tests across the persistence/memory/compaction paths, all passing on Python 3.11.14)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5), Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — flag help text + `run_oneshot` docstring; no new config keys
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (CLI flag only, no config key, no env var)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python control flow, no shell/subprocess/paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (recall degradation reuses the existing `_get_session_db_for_recall` contract)

## Screenshots / Logs

```
$ python -m pytest tests/test_no_session_ephemeral.py -q
......................                                                   [100%]
22 passed in 7.23s

$ python -m pytest <persistence / memory / cli-init / compaction suites> -q
1062 passed in 63.38s

$ python -m ruff check cli.py hermes_cli/ tests/test_no_session_ephemeral.py
All checks passed!

$ python -c "import cli; cli.main(no_session=True)"
ValueError: --no-session requires a one-shot invocation (-q/--query or --image)
$ python -c "import cli; cli.main(no_session=True, query='hi', resume='...')"
ValueError: --no-session cannot be combined with --resume
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
