### PR TITLE
fix(agent): flatten structured assistant content before interim scrub

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4750,7 +4750,35 @@ class AIAgent:
             return ""
         return re.sub(r"\s+", " ", text).strip()
 
+    @staticmethod
+    def _assistant_content_parts_as_text(content: Any) -> str:
+        """Flatten assistant content that may be plain text or content parts.
+
+        Codex/OpenAI-format responses can preserve assistant ``content`` as a
+        list of typed parts.  Interim-visible comparison runs over previous
+        assistant messages too, so it must tolerate that stored structured
+        shape instead of passing a list into the think-block regex scrubber.
+        """
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: List[str] = []
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                part_type = part.get("type")
+                if part_type not in {"text", "output_text", "input_text"}:
+                    continue
+                text = part.get("text")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+            return "\n".join(parts)
+        return str(content)
+
     def _interim_content_was_streamed(self, content: str) -> bool:
+        content = self._assistant_content_parts_as_text(content)
         visible_content = self._normalize_interim_visible_text(
             self._strip_think_blocks(content or "")
         )
@@ -4827,7 +4855,7 @@ class AIAgent:
         visible = self._extract_codex_interim_visible_text(assistant_msg)
         if visible:
             return visible
-        content = assistant_msg.get("content")
+        content = self._assistant_content_parts_as_text(assistant_msg.get("content"))
         return self._strip_think_blocks(content or "").strip()
 
     def _interim_text_was_delivered(self, text: str) -> bool:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -901,6 +901,34 @@ def test_run_codex_stream_multiple_commentary_items_are_not_reemitted(monkeypatc
     assert delivered == ["First update.", "Second update."]
 
 
+def test_interim_visible_text_flattens_structured_assistant_content(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    msg = {
+        "role": "assistant",
+        "content": [
+            {"type": "output_text", "text": "Visible update. "},
+            {"type": "text", "text": "More text."},
+            {"type": "image_url", "image_url": {"url": "ignored"}},
+        ],
+    }
+
+    assert agent._interim_assistant_visible_text(msg) == "Visible update. \nMore text."
+
+
+def test_interim_visible_text_strips_think_blocks_from_structured_content(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    msg = {
+        "role": "assistant",
+        "content": [
+            {"type": "output_text", "text": "<think>private</think>Public update."},
+        ],
+    }
+
+    assert agent._interim_assistant_visible_text(msg) == "Public update."
+
+
 def test_run_codex_stream_retry_deduplicates_multiple_commentary_items(monkeypatch):
     import httpx
 


### PR DESCRIPTION
## Summary
- fix interim assistant visible-text handling when assistant content is stored as OpenAI/Codex structured content parts
- flatten text/output_text/input_text parts before think-block regex scrubbing
- add regression coverage for structured content flattening and think-block stripping

## Bug evidence
Local Hermes logs showed repeated crashes like:

```text
Error during OpenAI-compatible API call #95: expected string or bytes-like object, got 'list'
```

The stack trace points to `_interim_assistant_visible_text(previous_msg)` passing list-shaped assistant `content` into `_strip_think_blocks()`, which eventually calls `re.sub(...)`.

## Tests
```text
uv run --with pytest --with pyyaml --with openai --with rich --with platformdirs --with prompt-toolkit --with pydantic -- python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='
107 passed in 30.64s
```