### PR TITLE
fix(cron): add per-job memory_enabled override for memory provider access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1075,8 +1075,10 @@ Hardening invariants:
 - Grace window: 120s for one-shot jobs whose fire time was missed.
 - File lock at `~/.hermes/cron/.tick.lock` prevents duplicate ticks
   across processes.
-- Cron sessions pass `skip_memory=True` by default; memory providers
-  intentionally do not run during cron.
+- Cron sessions pass `skip_memory=True` by default; cron jobs can opt
+  in to memory access per-job with `memory_enabled=true`. The default prevents
+  cron system prompts from polluting user memory, while maintenance jobs (e.g.
+  memory dump/filing) can request memory access explicitly.
 
 Cron deliveries are **not** mirrored into the target gateway session —
 they land in their own cron session with a header/footer frame so the

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1084,6 +1084,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    memory_enabled: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1255,6 +1256,12 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+
+    # Only persist memory_enabled when explicitly set, so existing jobs and
+    # the common case stay byte-identical (absent key => cron default of
+    # skip_memory=True).
+    if isinstance(memory_enabled, bool):
+        job["memory_enabled"] = memory_enabled
 
     with _jobs_lock():
         jobs = load_jobs()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3345,7 +3345,7 @@ def run_job(
             # Without a workdir, keep cwd context discovery disabled.
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
-            skip_memory=True,  # Cron system prompts would corrupt user representations
+            skip_memory=not bool(job.get("memory_enabled")),  # Per-job override; default True prevents cron prompts from polluting user memory
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,

--- a/tests/cron/test_cron_memory_enabled.py
+++ b/tests/cron/test_cron_memory_enabled.py
@@ -1,0 +1,271 @@
+"""Tests for per-job memory_enabled override in cron jobs.
+
+Covers:
+  - jobs.create_job: param plumbing for memory_enabled, default-None preservation
+  - scheduler.run_job: skip_memory wiring (memory_enabled=true -> skip_memory=False,
+    unset/false -> skip_memory=True, unchanged from pre-PR behavior)
+  - tools.cronjob_tools: create + update JSON round-trip for memory_enabled,
+    schema includes memory_enabled, _format_job exposes it when set
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Isolate cron job storage into a temp dir so tests don't stomp on real jobs."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# jobs.create_job: memory_enabled param plumbing
+# ---------------------------------------------------------------------------
+
+class TestCreateJobMemoryEnabled:
+    def test_memory_enabled_true_stored(self, tmp_cron_dir):
+        """When memory_enabled=True is passed, it is persisted in the job."""
+        from cron.jobs import create_job, get_job
+
+        job = create_job(
+            prompt="hello",
+            schedule="every 1h",
+            memory_enabled=True,
+        )
+        stored = get_job(job["id"])
+        assert stored["memory_enabled"] is True
+
+    def test_memory_enabled_false_stored(self, tmp_cron_dir):
+        """When memory_enabled=False is passed explicitly, it is persisted."""
+        from cron.jobs import create_job, get_job
+
+        job = create_job(
+            prompt="hello",
+            schedule="every 1h",
+            memory_enabled=False,
+        )
+        stored = get_job(job["id"])
+        assert stored["memory_enabled"] is False
+
+    def test_memory_enabled_none_not_stored(self, tmp_cron_dir):
+        """When memory_enabled is left at its default (None), no key is written
+        to jobs.json -- the absent key means 'use the cron default of
+        skip_memory=True' so existing jobs stay byte-identical."""
+        from cron.jobs import create_job, get_job
+
+        job = create_job(prompt="hello", schedule="every 1h")
+        stored = get_job(job["id"])
+        # The key should not be present at all (not even None), because
+        # create_job only writes it when isinstance(memory_enabled, bool).
+        assert "memory_enabled" not in stored
+
+
+# ---------------------------------------------------------------------------
+# scheduler.run_job: skip_memory wiring
+# ---------------------------------------------------------------------------
+
+class TestRunJobSkipMemory:
+    """run_job must wire skip_memory based on the per-job memory_enabled field:
+    - memory_enabled=True -> skip_memory=False (memory IS active)
+    - memory_enabled=False/unset -> skip_memory=True (memory stays off)
+
+    We stub AIAgent so no real API call happens, capturing the
+    skip_memory kwarg passed to its __init__.
+    """
+
+    @staticmethod
+    def _install_stubs(monkeypatch, observed: dict):
+        """Patch enough of run_job's deps that it executes without real creds."""
+        import sys
+        import cron.scheduler as sched
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                observed["skip_memory"] = kwargs.get("skip_memory")
+                observed["skip_context_files"] = kwargs.get("skip_context_files")
+
+            def run_conversation(self, *_a, **_kw):
+                return {"final_response": "done", "messages": []}
+
+            def get_activity_summary(self):
+                return {"seconds_since_activity": 0.0}
+
+        fake_mod = type(sys)("run_agent")
+        fake_mod.AIAgent = FakeAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_mod)
+
+        # Bypass the real provider resolver.
+        from hermes_cli import runtime_provider as _rtp
+        monkeypatch.setattr(
+            _rtp,
+            "resolve_runtime_provider",
+            lambda **_kw: {
+                "provider": "test",
+                "api_key": "k",
+                "base_url": "http://test.local",
+                "api_mode": "chat_completions",
+            },
+        )
+
+        monkeypatch.setattr(sched, "_build_job_prompt", lambda job, prerun_script=None: "hi")
+        monkeypatch.setattr(sched, "_resolve_origin", lambda job: None)
+        monkeypatch.setattr(sched, "_resolve_delivery_target", lambda job: None)
+        monkeypatch.setattr(sched, "_resolve_cron_enabled_toolsets", lambda job, cfg: None)
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+
+        import dotenv
+        monkeypatch.setattr(dotenv, "load_dotenv", lambda *_a, **_kw: True)
+
+    def test_memory_enabled_true_disables_skip_memory(self, tmp_path, monkeypatch):
+        """memory_enabled=True -> skip_memory=False (memory provider is loaded)."""
+        import cron.scheduler as sched
+
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+
+        job = {
+            "id": "mem-yes",
+            "name": "mem-enabled-job",
+            "memory_enabled": True,
+            "schedule_display": "manual",
+        }
+
+        success, _output, response, error = sched.run_job(job)
+        assert success is True, f"run_job failed: error={error!r}"
+        assert observed["skip_memory"] is False
+
+    def test_memory_enabled_false_keeps_skip_memory_true(self, tmp_path, monkeypatch):
+        """memory_enabled=False explicitly -> skip_memory=True (unchanged default)."""
+        import cron.scheduler as sched
+
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+
+        job = {
+            "id": "mem-no",
+            "name": "mem-disabled-job",
+            "memory_enabled": False,
+            "schedule_display": "manual",
+        }
+
+        success, *_ = sched.run_job(job)
+        assert success is True
+        assert observed["skip_memory"] is True
+
+    def test_memory_enabled_unset_keeps_skip_memory_true(self, tmp_path, monkeypatch):
+        """When memory_enabled is absent from the job dict (default-None case),
+        skip_memory must stay True -- backward-compatible pre-PR behavior."""
+        import cron.scheduler as sched
+
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+
+        job = {
+            "id": "mem-unset",
+            "name": "mem-unset-job",
+            # memory_enabled key intentionally absent
+            "schedule_display": "manual",
+        }
+
+        success, *_ = sched.run_job(job)
+        assert success is True
+        assert observed["skip_memory"] is True
+
+
+# ---------------------------------------------------------------------------
+# tools.cronjob_tools: end-to-end JSON round-trip
+# ---------------------------------------------------------------------------
+
+class TestCronjobToolMemoryEnabled:
+    def test_create_with_memory_enabled_true_json_roundtrip(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="hi",
+                schedule="every 1h",
+                memory_enabled=True,
+            )
+        )
+        assert result["success"] is True
+        assert result["job"]["memory_enabled"] is True
+
+    def test_create_without_memory_enabled_hides_field_in_format(self, tmp_cron_dir):
+        """When memory_enabled is not set, _format_job should omit it."""
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="hi",
+                schedule="every 1h",
+            )
+        )
+        assert result["success"] is True
+        assert "memory_enabled" not in result["job"]
+
+    def test_update_sets_memory_enabled(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(
+            cronjob(action="create", prompt="hi", schedule="every 1h")
+        )
+        job_id = created["job_id"]
+
+        updated = json.loads(
+            cronjob(action="update", job_id=job_id, memory_enabled=True)
+        )
+        assert updated["success"] is True
+        assert updated["job"]["memory_enabled"] is True
+
+    def test_update_sets_memory_enabled_false(self, tmp_cron_dir):
+        """Update with memory_enabled=False persists to storage, but
+        _format_job omits falsy fields (same pattern as workdir, no_agent, etc.).
+        We verify the storage directly via load_jobs."""
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import load_jobs
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="hi",
+                schedule="every 1h",
+                memory_enabled=True,
+            )
+        )
+        job_id = created["job_id"]
+
+        updated = json.loads(
+            cronjob(action="update", job_id=job_id, memory_enabled=False)
+        )
+        assert updated["success"] is True
+        # _format_job omits falsy fields, so we check the raw stored job.
+        stored = [j for j in load_jobs() if j["id"] == job_id][0]
+        assert stored.get("memory_enabled") is False
+
+    def test_schema_advertises_memory_enabled(self):
+        from tools.cronjob_tools import CRONJOB_SCHEMA
+
+        props = CRONJOB_SCHEMA["parameters"]["properties"]
+        assert "memory_enabled" in props, "memory_enabled must be in CRONJOB_SCHEMA"
+        desc = props["memory_enabled"]["description"]
+        assert "memory" in desc.lower()
+
+    def test_registry_handler_plumbs_memory_enabled(self):
+        """The registry handler lambda must pass memory_enabled through to
+        cronjob() so that the tool works when called via the tool schema."""
+        import inspect
+        from tools.cronjob_tools import registry
+
+        tool = registry.get_entry("cronjob")
+        source = inspect.getsource(tool.handler)
+        assert "memory_enabled" in source, (
+            "registry handler must forward memory_enabled to cronjob()"
+        )

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -596,6 +596,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["no_agent"] = True
     if job.get("enabled_toolsets"):
         result["enabled_toolsets"] = job["enabled_toolsets"]
+    if job.get("memory_enabled"):
+        result["memory_enabled"] = True
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
     return result
@@ -1089,6 +1091,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "memory_enabled": {
+                "type": "boolean",
+                "description": "When True, this job's session will have access to the persistent memory tool (default: False for cron to avoid polluting user memory). Use when a cron job needs to read or write durable facts across runs."
+            },
         },
         "required": ["action"]
     }
@@ -1144,6 +1150,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        memory_enabled=args.get("memory_enabled"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -677,6 +677,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    memory_enabled: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -750,6 +751,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                memory_enabled=memory_enabled,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -923,6 +925,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if memory_enabled is not None:
+                updates["memory_enabled"] = bool(memory_enabled)
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.


### PR DESCRIPTION
## Problem

Cron sessions pass `skip_memory=True` to `AIAgent`, which prevents **all** cron jobs from using the memory tool or the external memory provider (e.g., hindsight). This is correct for most jobs (daily briefings, reports) but blocks cron jobs whose entire purpose is memory maintenance — like `bepop-hindsight-memory-dump`.

## Root Cause

`cron/scheduler.py` hardcoded `skip_memory=True` at the `AIAgent` construction site (~line 3073). The memory provider plugin and `MemoryStore` are never initialized when `skip_memory=True` (`agent/agent_init.py`, lines 1335-1419), so the `memory` tool always returns `\"Memory is not available.\"` in cron sessions.

## Fix

Add a per-job `memory_enabled` override following the same pattern as `attach_to_session` (already used in the codebase to opt cron jobs into session delivery):

| File | Change |
|------|--------|
| `cron/scheduler.py` | `skip_memory=not bool(job.get(\"memory_enabled\"))` — defaults `True` (backward compatible) |
| `cron/jobs.py` | Add `memory_enabled: Optional[bool] = None` to `create_job()`; persist only when explicitly set as `bool` |
| `tools/cronjob_tools.py` | Surface `memory_enabled` in both create and update paths of the `cronjob` tool |
| `AGENTS.md` | Document the opt-in override mechanism |

## Backward Compatibility

- **Zero impact on existing jobs** — the key is absent, so `job.get("memory_enabled")` returns `None` → `skip_memory=True` (existing behavior).
- **Storage format unchanged** — `memory_enabled` is only persisted when explicitly `True` or `False`, keeping existing `jobs.json` entries byte-identical.
- **No merge or gateway restart required** — this is a pure code change; the next cron tick picks it up.