### PR TITLE
fix: escape bare $ in Telegram rich messages to prevent LaTeX garbling

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1627,7 +1627,15 @@ class TelegramAdapter(BasePlatformAdapter):
         multi-line content (slash-command lists, etc.) renders correctly
         in the rich-message path.  See ``_rich_normalize_linebreaks``.
         """
-        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(content)}
+        # Escape bare ``$`` so Telegram's client-side LaTeX parser does not
+        # swallow dollar-amount prose (e.g. ``$395k``) into math spans.
+        # ``\$`` renders as a literal ``$`` in rich-message markdown.
+        # Double-dollar display-math ``$$`` is left untouched — it is
+        # intentional LaTeX authored by the LLM.
+        escaped = content.replace("$$", "\x00DBL$\x00")
+        escaped = escaped.replace("$", r"\$")
+        escaped = escaped.replace("\x00DBL$\x00", "$$")
+        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(escaped)}
         if skip_entity_detection:
             payload["skip_entity_detection"] = True
         return payload


### PR DESCRIPTION
## Summary

Telegram's rich markdown parser treats bare `$...$` as inline LaTeX math delimiters ([docs](https://core.telegram.org/bots/api#rich-markdown-style)). When the LLM produces financial figures like `$395k` or `$483k`, Telegram's client pairs the first two `$` characters and swallows everything between them into a garbled math span (e.g. `395kvsUI483k` rendered in italic serif math font).

## Changes

- Escape single `$` to `\$` in `_rich_message_payload()` before building the rich-message payload
- Double-dollar `$$` display math is preserved by round-tripping through a sentinel placeholder

## Repro

With `telegram.extra.rich_messages: true`, send a query that produces:
```
- **Red collateral**: API shows $395k vs UI $483k **88k gap**
| A | B |
|---|---|
| 1 | 2 |
```
Before: `$395k vs UI $483k` renders as garbled math. After: renders as plain text dollar amounts.

## Test Plan

- [x] `py_compile` passes
- [ ] Manual test with Telegram rich messages enabled

Fixes #66746
