### PR TITLE
fix: add encoding="utf-8" to read_text() calls in auth/config readers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1703,7 +1703,7 @@ def _read_nous_auth() -> Optional[dict]:
     try:
         if not _AUTH_JSON_PATH.is_file():
             return None
-        data = json.loads(_AUTH_JSON_PATH.read_text())
+        data = json.loads(_AUTH_JSON_PATH.read_text(encoding="utf-8"))
         if data.get("active_provider") != "nous":
             return None
         provider = data.get("providers", {}).get("nous", {})

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -37,7 +37,7 @@ def _read_nous_provider_state() -> Optional[dict]:
         path = auth_json_path()
         if not path.is_file():
             return None
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         providers = data.get("providers", {})
         if not isinstance(providers, dict):
             return None

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -44,7 +44,7 @@ def has_xai_credentials() -> bool:
         auth_path = get_hermes_home() / "auth.json"
         if not auth_path.exists():
             return False
-        store = json.loads(auth_path.read_text())
+        store = json.loads(auth_path.read_text(encoding="utf-8"))
         providers = store.get("providers") if isinstance(store, dict) else None
         xai_state = providers.get("xai-oauth") if isinstance(providers, dict) else None
         tokens = xai_state.get("tokens") if isinstance(xai_state, dict) else None


### PR DESCRIPTION
## Summary

`Path.read_text()` without `encoding=` defaults to the platform's preferred encoding — `cp1252` on Windows. JSON auth and config files containing non-ASCII characters (provider names, OAuth tokens, locale-specific data) are read through the wrong codec and silently corrupted, potentially causing auth failures or data loss.

## Changes

Add `encoding="utf-8"` to `read_text()` calls in 3 auth/config reader functions:

- `agent/auxiliary_client.py:1706` — `_get_nous_auth_from_json()` reads `auth.json`
- `tools/managed_tool_gateway.py:40` — provider config reader
- `tools/xai_http.py:47` — xai-oauth token store reader

All three files parse JSON that may contain non-ASCII content. On Windows, the default `cp1252` codec silently corrupts multi-byte UTF-8 sequences.

## Test Plan

- [x] `py_compile` passes for all 3 files
- [ ] CI passes
