### PR TITLE
fix: add CREATE_NO_WINDOW to subprocess calls in tts_tool and vision_tools

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -734,6 +734,7 @@ def _terminate_command_tts_process_tree(proc: subprocess.Popen) -> None:
                 stderr=subprocess.DEVNULL,
                 timeout=5,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
         except Exception:
             proc.kill()

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -292,6 +292,7 @@ def _rasterize_svg_to_png(svg_path: Path, out_path: Path) -> bool:
                 _subprocess.run(
                     cmd, check=True, capture_output=True, timeout=30,
                     stdin=_subprocess.DEVNULL,
+                    **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
                 )
                 if out_path.exists() and out_path.stat().st_size > 0:
                     return True


### PR DESCRIPTION
## Summary

On Windows, `subprocess.run()`/`Popen()` without `CREATE_NO_WINDOW` (0x08000000) spawns a visible console window (cmd.exe / conhost.exe) that flashes briefly. The main terminal path in `tools/environments/local.py` already has creationflags, and prior PRs (#64081, #65635, #65660) covered most side paths. Two additional sites were missed:

## Changes

- `tools/tts_tool.py:731` — `taskkill` subprocess for TTS process cleanup. Already imports `windows_hide_flags` at module level (line 55), just needed the kwarg.
- `tools/vision_tools.py:292` — `rsvg-convert`/`inkscape` subprocess for SVG-to-PNG rasterization. Uses local `subprocess` import, applied inline `0x08000000` constant.

## Test Plan

- [x] `py_compile` passes for both files
- [ ] CI passes
