### PR TITLE
fix: add encoding="utf-8" to dead_targets read/write

### DIFF
--- a/gateway/dead_targets.py
+++ b/gateway/dead_targets.py
@@ -67,7 +67,7 @@ class DeadTargetRegistry:
     def _load(self) -> None:
         try:
             if self._path.exists():
-                raw = json.loads(self._path.read_text())
+                raw = json.loads(self._path.read_text(encoding="utf-8"))
                 if isinstance(raw, dict):
                     # Only keep well-shaped entries.
                     self._dead = {
@@ -82,7 +82,7 @@ class DeadTargetRegistry:
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
             tmp = self._path.with_suffix(self._path.suffix + ".tmp")
-            tmp.write_text(json.dumps(self._dead, indent=2))
+            tmp.write_text(json.dumps(self._dead, indent=2), encoding="utf-8")
             tmp.replace(self._path)
         except OSError as exc:
             # Best-effort: keep the in-memory state, don't break delivery.


### PR DESCRIPTION
## Summary

`DeadTargetRegistry._load()` and `_flush_locked()` use `Path.read_text()` and `Path.write_text()` without `encoding=`, defaulting to the platform's preferred encoding (`cp1252` on Windows). Gateway target metadata containing non-ASCII characters (channel names, display names, etc.) is silently corrupted when round-tripped through the wrong codec.

## Changes

- `gateway/dead_targets.py:70` — add `encoding="utf-8"` to `_path.read_text()`
- `gateway/dead_targets.py:85` — add `encoding="utf-8"` to `tmp.write_text()`

## Test Plan

- [x] `py_compile` passes
- [ ] CI passes
