### PR TITLE
fix(terminal): preserve completion wakeups across restart

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -212,6 +212,36 @@ class TestCompletionQueue:
 # =========================================================================
 
 class TestCheckpointNotify:
+    def test_terminal_rewrites_checkpoint_after_notify_metadata(self, tmp_path):
+        """The persisted entry must reflect the final notify flag, not spawn defaults."""
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.process_registry import process_registry
+        from tools.terminal_tool import terminal_tool
+
+        checkpoint = tmp_path / "procs.json"
+        tokens = set_session_vars(
+            platform="webui",
+            session_key="webui-session",
+            async_delivery=True,
+        )
+        result = None
+        try:
+            with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint), \
+                 patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+                result = json.loads(terminal_tool(
+                    "python -c \"import time; time.sleep(30)\"",
+                    background=True,
+                    notify_on_complete=True,
+                    task_id="checkpoint-notify-test",
+                ))
+                assert result["notify_on_complete"] is True
+                data = json.loads(checkpoint.read_text(encoding="utf-8"))
+                row = next(x for x in data if x["session_id"] == result["session_id"])
+                assert row["notify_on_complete"] is True
+                process_registry.kill_process(result["session_id"])
+        finally:
+            clear_session_vars(tokens)
+
     def test_checkpoint_includes_notify(self, registry, tmp_path):
         with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "procs.json"):
             s = _make_session(notify_on_complete=True)
@@ -245,6 +275,35 @@ class TestCheckpointNotify:
             assert recovered == 1
             s = registry.get("proc_live")
             assert s.notify_on_complete is True
+
+    def test_recovered_detached_process_notifies_without_polling(self, registry, tmp_path):
+        """A restarted idle host must autonomously notice recovered process exit."""
+        import subprocess
+        import sys
+
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(0.5)"])
+        checkpoint = tmp_path / "procs.json"
+        start = registry._safe_host_start_time(proc.pid)
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_recovered_notify",
+            "command": "short recovered process",
+            "pid": proc.pid,
+            "pid_scope": "host",
+            "host_start_time": start,
+            "task_id": "t1",
+            "session_key": "webui-session",
+            "notify_on_complete": True,
+        }]))
+        try:
+            with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+                assert registry.recover_from_checkpoint() == 1
+                evt = registry.completion_queue.get(timeout=4.0)
+            assert evt["type"] == "completion"
+            assert evt["session_id"] == "proc_recovered_notify"
+            assert evt["session_key"] == "webui-session"
+        finally:
+            if proc.poll() is None:
+                proc.kill()
 
     def test_recover_requeues_notify_watchers(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1769,7 +1769,6 @@ class ProcessRegistry:
                 "uptime_seconds": int(time.time() - s.started_at),
                 "status": "exited" if s.exited else "running",
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
-                "session_key": s.session_key,
             }
             # Flag processes surfaced only because they share the gateway
             # session (not the current task) — these are the long-lived

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -511,6 +511,40 @@ class ProcessRegistry:
         self._move_to_finished(session)
         return session
 
+    def _start_detached_exit_monitor(self, session: ProcessSession) -> None:
+        """Monitor a checkpoint-recovered host process until it exits.
+
+        A recovered session has no ``Popen`` handle or stdout reader. Before
+        this monitor existed, its state changed only when some caller happened
+        to poll/list it; an idle WebUI therefore never received the promised
+        notify_on_complete wakeup after a server restart.
+        """
+        if session.exited or not session.detached or session.pid_scope != "host":
+            return
+        if session._reader_thread is not None and session._reader_thread.is_alive():
+            return
+
+        def _monitor() -> None:
+            while not session.exited:
+                if session._completion_event.wait(1.0):
+                    break
+                try:
+                    self._refresh_detached_session(session)
+                except Exception:
+                    logger.debug(
+                        "Detached process exit monitor failed for %s",
+                        session.id,
+                        exc_info=True,
+                    )
+
+        thread = threading.Thread(
+            target=_monitor,
+            daemon=True,
+            name=f"proc-detached-monitor-{session.id}",
+        )
+        session._reader_thread = thread
+        thread.start()
+
     @staticmethod
     def _proc_alive(proc) -> bool:
         """True if a psutil.Process is running and not a zombie.
@@ -1735,6 +1769,7 @@ class ProcessRegistry:
                 "uptime_seconds": int(time.time() - s.started_at),
                 "status": "exited" if s.exited else "running",
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
+                "session_key": s.session_key,
             }
             # Flag processes surfaced only because they share the gateway
             # session (not the current task) — these are the long-lived
@@ -1991,6 +2026,7 @@ class ProcessRegistry:
                 self._running[session.id] = session
             recovered += 1
             logger.info("Recovered detached process: %s (pid=%d)", session.command[:60], pid)
+            self._start_detached_exit_monitor(session)
 
             # Re-enqueue watcher so gateway can resume notifications
             if session.watcher_interval > 0:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2694,6 +2694,14 @@ def terminal_tool(
                     proc_session.watch_patterns = list(watch_patterns)
                     result_data["watch_patterns"] = proc_session.watch_patterns
 
+                # ``spawn_local`` / ``spawn_via_env`` checkpoint the process
+                # before terminal_tool attaches notification/routing metadata.
+                # Persist once more after those fields are final so a host
+                # restart cannot silently recover the process as
+                # notify_on_complete=False.
+                if background and (notify_on_complete or watch_patterns):
+                    process_registry._write_checkpoint()
+
                 return json.dumps(result_data, ensure_ascii=False)
             except Exception as e:
                 return json.dumps({


### PR DESCRIPTION
## Summary

I found that a `terminal(background=True, notify_on_complete=True)` process could finish successfully but never notify its owning session if the host restarted while it was running.

This fixes two core restart gaps:

- persist the final notification/routing metadata after `terminal_tool` attaches it to the spawned process;
- actively monitor checkpoint-recovered host processes so an idle host notices their exit and enqueues the completion without requiring a later `poll` or `list` call.

`ProcessRegistry.list_sessions()` now also exposes `session_key`, allowing hosts that recover processes to rebuild their own session-routing indexes.

## Root cause

`spawn_local()` wrote `processes.json` before `terminal_tool` set `notify_on_complete=True`. The live in-memory process had notifications enabled, but the checkpoint still said `false`.

After restart, recovered processes are detached and have no `Popen`/stdout reader. Their exit state was refreshed only when a caller happened to inspect them, so an idle host could never autonomously emit the promised completion.

## Validation

- `tests/tools/test_notify_on_complete.py`: **37 passed**
- targeted restart tests: **4 passed**
- mutation checks:
  - remove the post-metadata checkpoint rewrite -> regression test fails;
  - remove the detached exit monitor -> regression test fails.
- broader Windows run: **134 passed, 12 skipped, 4 failed**. I reproduced the same four failures unchanged on a clean `origin/main` worktree (`stdin` EOF timing, two POSIX `os.getpgid` mocks, and the existing detached-PID Windows mock).
- `py_compile` passed for all changed Python files.

## End-to-end restart test

I launched a real 300-second background process with `notify_on_complete=True`, confirmed the checkpoint stored `notify_on_complete: true`, restarted the WebUI host while the child remained alive, and made no polling calls afterward.

The child finished at `15:04:50`; the recovered monitor enqueued the completion and the original session started its autonomous wakeup turn at `15:04:51`.

## Companion WebUI change

nesquena/hermes-webui#6287 invokes core process recovery during WebUI startup and rebuilds its session routing map. #6225 was closed as superseded by async-delegation PR #6283; #6287 is the clean current-master replacement for the separate ordinary terminal-process path.

