### PR TITLE
fix(doctor): probe Azure Foundry Anthropic endpoints correctly

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2223,15 +2223,23 @@ def run_doctor(args):
                 anth_base = base.rstrip("/")
                 if anth_base.endswith("/v1"):
                     anth_base = anth_base[:-3].rstrip("/")
+                # Match the runtime Anthropic adapter contract for Azure
+                # Foundry: Authorization: Bearer <api-key> (see
+                # agent/anthropic_adapter.py _requires_bearer_auth ->
+                # auth_token, lines ~532-553/801-810), NOT x-api-key. Azure
+                # also requires an api-version query param, which the runtime
+                # supplies via the SDK's default_query (api-version=2025-04-15,
+                # per docs/guides/azure-foundry.md:247-248).
                 headers = {
-                    "x-api-key": key,
+                    "Authorization": f"Bearer {key}",
                     "anthropic-version": "2023-06-01",
                     "content-type": "application/json",
                     "User-Agent": _HERMES_USER_AGENT,
                 }
+                anth_params = {"api-version": "2025-04-15"}
                 # Prefer a cheap GET /v1/models when the gateway implements it
                 models_url = anth_base + "/v1/models"
-                r = httpx.get(models_url, headers=headers, timeout=10)
+                r = httpx.get(models_url, headers=headers, params=anth_params, timeout=10)
                 if r.status_code == 200:
                     return _ConnectivityResult(
                         pname,
@@ -2256,6 +2264,7 @@ def run_doctor(args):
                     mr = httpx.post(
                         anth_base + "/v1/messages",
                         headers=headers,
+                        params=anth_params,
                         json=payload,
                         timeout=15,
                     )

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -440,7 +440,7 @@ def _build_apikey_providers_list() -> list:
     # API-key loop (with custom headers/auth). Skip their pluggable profiles
     # here so the generic Bearer-auth loop doesn't run a duplicate, broken
     # check (e.g. Anthropic native API requires x-api-key, not Bearer).
-    _dedicated_canonical = {"anthropic", "openrouter", "bedrock"}
+    _dedicated_canonical = {"anthropic", "openrouter", "bedrock", "azure-foundry"}
     _known_canonical.update(_dedicated_canonical)
     try:
         from providers import list_providers
@@ -2129,6 +2129,213 @@ def run_doctor(args):
                                        b=_base_env, s=_supports:
                                 _probe_apikey_provider(p, e, u, b, s)))
 
+
+    def _probe_azure_foundry_apikey() -> _ConnectivityResult:
+        """Probe Azure Foundry when configured with a static API key.
+
+        Azure AI Foundry commonly exposes either:
+
+        * OpenAI-compatible ``…/openai/v1`` (or similar) URLs, or
+        * Anthropic Messages under a ``…/anthropic`` suffix.
+
+        The generic API-key loop always hit ``{base}/models`` with
+        ``Authorization: Bearer …``. Anthropic-style Foundry deployments
+        answer that with HTTP 404 even when chat works (issue #66756), and
+        Bearer auth is the wrong header family for Anthropic traffic
+        (``x-api-key``). Probe with the same transport heuristics the
+        runtime uses, then fall back to a soft "key configured" pass when
+        the endpoint simply has no listable ``/models``.
+        """
+        pname = "Azure Foundry"
+        label = pname.ljust(20)
+        try:
+            from hermes_cli.config import load_config, get_env_value_prefer_dotenv
+        except Exception:
+            get_env_value_prefer_dotenv = None  # type: ignore
+            load_config = None  # type: ignore
+
+        key = ""
+        if get_env_value_prefer_dotenv is not None:
+            try:
+                key = get_env_value_prefer_dotenv("AZURE_FOUNDRY_API_KEY") or ""
+            except Exception:
+                key = ""
+        if not key:
+            key = os.getenv("AZURE_FOUNDRY_API_KEY", "") or ""
+        if not key:
+            return _ConnectivityResult(pname, [], [])
+
+        base = ""
+        api_mode = ""
+        model_name = ""
+        auth_mode = "api_key"
+        try:
+            if load_config is not None:
+                cfg = load_config()
+                model_cfg = cfg.get("model") if isinstance(cfg, dict) else {}
+                if isinstance(model_cfg, dict):
+                    cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+                    auth_mode = str(model_cfg.get("auth_mode") or "api_key").strip().lower() or "api_key"
+                    if cfg_provider in {"azure-foundry", "azure", "azure-ai-foundry", "azure-ai"}:
+                        base = str(model_cfg.get("base_url") or "").strip()
+                        api_mode = str(model_cfg.get("api_mode") or "").strip().lower()
+                        model_name = str(model_cfg.get("default") or model_cfg.get("model") or "").strip()
+        except Exception:
+            pass
+        if not base:
+            base = os.getenv("AZURE_FOUNDRY_BASE_URL", "") or ""
+        # Entra deployments are covered by _probe_azure_entra; don't double-report.
+        if auth_mode == "entra_id":
+            return _ConnectivityResult(pname, [], [])
+        if not base:
+            return _ConnectivityResult(
+                pname,
+                [(color("✓", Colors.GREEN), label,
+                  color("(key configured)", Colors.DIM))],
+                [],
+            )
+
+        try:
+            import httpx
+            from hermes_cli.runtime_provider import _detect_api_mode_for_url
+            from agent.auxiliary_client import _to_openai_base_url
+        except Exception as e:
+            return _ConnectivityResult(
+                pname,
+                [(color("⚠", Colors.YELLOW), label,
+                  color(f"({e})", Colors.DIM))],
+                [],
+            )
+
+        detected = api_mode or (_detect_api_mode_for_url(base) or "")
+        if not detected and model_name:
+            try:
+                from hermes_cli.models import azure_foundry_model_api_mode
+                detected = azure_foundry_model_api_mode(model_name) or ""
+            except Exception:
+                detected = ""
+
+        try:
+            if detected == "anthropic_messages" or base.rstrip("/").endswith("/anthropic"):
+                # Match runtime: strip trailing /v1 if present, probe Messages
+                # with Anthropic headers. A 200/4xx on /v1/models invent or a
+                # short messages call both prove auth+route are live.
+                anth_base = base.rstrip("/")
+                if anth_base.endswith("/v1"):
+                    anth_base = anth_base[:-3].rstrip("/")
+                headers = {
+                    "x-api-key": key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                    "User-Agent": _HERMES_USER_AGENT,
+                }
+                # Prefer a cheap GET /v1/models when the gateway implements it
+                models_url = anth_base + "/v1/models"
+                r = httpx.get(models_url, headers=headers, timeout=10)
+                if r.status_code == 200:
+                    return _ConnectivityResult(
+                        pname,
+                        [(color("✓", Colors.GREEN), label, "")],
+                        [],
+                    )
+                if r.status_code == 401:
+                    return _ConnectivityResult(
+                        pname,
+                        [(color("✗", Colors.RED), label,
+                          color("(invalid API key)", Colors.DIM))],
+                        ["Check AZURE_FOUNDRY_API_KEY in .env"],
+                    )
+                # Many Foundry Anthropic deployments have no models listing
+                # (404). Fall through to a minimal messages POST.
+                if r.status_code in {404, 405, 501}:
+                    payload = {
+                        "model": model_name or "claude-sonnet-4-5",
+                        "max_tokens": 1,
+                        "messages": [{"role": "user", "content": "ping"}],
+                    }
+                    mr = httpx.post(
+                        anth_base + "/v1/messages",
+                        headers=headers,
+                        json=payload,
+                        timeout=15,
+                    )
+                    # 200 = healthy. 400 with a model/param complaint still
+                    # proves the route+auth worked (same bar as curl in #66756).
+                    if mr.status_code in {200, 400}:
+                        return _ConnectivityResult(
+                            pname,
+                            [(color("✓", Colors.GREEN), label,
+                              color("(anthropic endpoint)", Colors.DIM))],
+                            [],
+                        )
+                    if mr.status_code == 401:
+                        return _ConnectivityResult(
+                            pname,
+                            [(color("✗", Colors.RED), label,
+                              color("(invalid API key)", Colors.DIM))],
+                            ["Check AZURE_FOUNDRY_API_KEY in .env"],
+                        )
+                    return _ConnectivityResult(
+                        pname,
+                        [(color("⚠", Colors.YELLOW), label,
+                          color(f"(HTTP {mr.status_code})", Colors.DIM))],
+                        [],
+                    )
+                return _ConnectivityResult(
+                    pname,
+                    [(color("⚠", Colors.YELLOW), label,
+                      color(f"(HTTP {r.status_code})", Colors.DIM))],
+                    [],
+                )
+
+            # OpenAI-compatible Foundry: /models via Bearer (and api-key).
+            oai_base = base
+            if oai_base.rstrip("/").endswith("/anthropic"):
+                oai_base = _to_openai_base_url(oai_base)
+            url = oai_base.rstrip("/") + "/models"
+            headers = {
+                "Authorization": f"Bearer {key}",
+                "api-key": key,
+                "User-Agent": _HERMES_USER_AGENT,
+            }
+            r = httpx.get(url, headers=headers, timeout=10)
+            if r.status_code == 200:
+                return _ConnectivityResult(
+                    pname,
+                    [(color("✓", Colors.GREEN), label, "")],
+                    [],
+                )
+            if r.status_code == 401:
+                return _ConnectivityResult(
+                    pname,
+                    [(color("✗", Colors.RED), label,
+                      color("(invalid API key)", Colors.DIM))],
+                    ["Check AZURE_FOUNDRY_API_KEY in .env"],
+                )
+            # No list endpoint: key is present and URL is configured — don't
+            # scare the user when runtime chat already works.
+            if r.status_code in {404, 405, 501}:
+                return _ConnectivityResult(
+                    pname,
+                    [(color("✓", Colors.GREEN), label,
+                      color("(key configured)", Colors.DIM))],
+                    [],
+                )
+            return _ConnectivityResult(
+                pname,
+                [(color("⚠", Colors.YELLOW), label,
+                  color(f"(HTTP {r.status_code})", Colors.DIM))],
+                [],
+            )
+        except Exception as e:
+            return _ConnectivityResult(
+                pname,
+                [(color("⚠", Colors.YELLOW), label,
+                  color(f"({e})", Colors.DIM))],
+                [],
+            )
+
+    _probes.append(("Azure Foundry", _probe_azure_foundry_apikey))
     _probes.append(("AWS Bedrock", _probe_bedrock))
     _probes.append(("Azure Foundry (Entra ID)", _probe_azure_entra))
 

--- a/tests/hermes_cli/test_doctor_azure_foundry_probe.py
+++ b/tests/hermes_cli/test_doctor_azure_foundry_probe.py
@@ -67,13 +67,13 @@ def test_run_doctor_azure_foundry_anthropic_endpoint_reports_healthy(
 
     calls: list[tuple] = []
 
-    def fake_get(url, headers=None, timeout=None):
-        calls.append(("GET", url, headers))
+    def fake_get(url, headers=None, params=None, timeout=None):
+        calls.append(("GET", url, headers, params))
         # Anthropic-style Foundry: /models is often missing
         return types.SimpleNamespace(status_code=404, text="not found")
 
-    def fake_post(url, headers=None, json=None, timeout=None):
-        calls.append(("POST", url, headers, json))
+    def fake_post(url, headers=None, params=None, json=None, timeout=None):
+        calls.append(("POST", url, headers, params, json))
         return types.SimpleNamespace(status_code=200, text="{}")
 
     import httpx
@@ -93,11 +93,14 @@ def test_run_doctor_azure_foundry_anthropic_endpoint_reports_healthy(
 
     assert "Azure Foundry" in out
     assert "HTTP 404" not in out
-    # Must have used x-api-key on the anthropic probe path
+    # Must use the runtime Anthropic adapter contract on the anthropic probe
+    # path: Authorization: Bearer <key> (not x-api-key) and the Azure-required
+    # api-version query param (agent/anthropic_adapter.py:532-553,801-810;
+    # docs/guides/azure-foundry.md:247-248).
     anth_calls = [c for c in calls if isinstance(c[1], str) and "/anthropic" in c[1]]
     assert anth_calls, f"expected anthropic endpoint probe, got {calls}"
     headers = anth_calls[0][2] or {}
-    assert headers.get("x-api-key") == "sk-foundry-test"
-    assert "Authorization" not in headers or not str(headers.get("Authorization", "")).startswith(
-        "Bearer sk-foundry"
-    )
+    params = anth_calls[0][3] or {}
+    assert headers.get("Authorization") == "Bearer sk-foundry-test"
+    assert "x-api-key" not in headers
+    assert params.get("api-version") == "2025-04-15"

--- a/tests/hermes_cli/test_doctor_azure_foundry_probe.py
+++ b/tests/hermes_cli/test_doctor_azure_foundry_probe.py
@@ -1,0 +1,103 @@
+"""Azure Foundry doctor connectivity probe (issue #66756).
+
+Anthropic-style Foundry bases (`…/anthropic`) return HTTP 404 for the
+generic Bearer `/models` health check even when chat works. Doctor must
+use Anthropic headers / a messages probe instead.
+"""
+
+from __future__ import annotations
+
+import types
+from argparse import Namespace
+
+import pytest
+
+
+def test_azure_foundry_skipped_by_generic_apikey_loop():
+    from hermes_cli import doctor
+
+    doctor._APIKEY_PROVIDERS_CACHE = None
+    entries = doctor._build_apikey_providers_list()
+    names = {entry[0].lower() for entry in entries}
+    assert not any("azure foundry" in name or "azure-foundry" in name for name in names), (
+        f"Azure Foundry must use the dedicated probe, not the generic Bearer "
+        f"loop. Got: {sorted(names)}"
+    )
+
+
+def test_run_doctor_azure_foundry_anthropic_endpoint_reports_healthy(
+    monkeypatch, tmp_path
+):
+    from hermes_cli import doctor as doctor_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    base = "https://myresource.services.ai.azure.com/anthropic"
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: azure-foundry\n"
+        "  default: claude-sonnet-5\n"
+        f"  base_url: {base}\n",
+        encoding="utf-8",
+    )
+    (home / ".env").write_text("AZURE_FOUNDRY_API_KEY=sk-foundry-test\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "sk-foundry-test")
+    monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", base)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(__import__("sys").modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    calls: list[tuple] = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append(("GET", url, headers))
+        # Anthropic-style Foundry: /models is often missing
+        return types.SimpleNamespace(status_code=404, text="not found")
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls.append(("POST", url, headers, json))
+        return types.SimpleNamespace(status_code=200, text="{}")
+
+    import httpx
+    import io
+    import contextlib
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    # Clear cached provider list so azure-foundry skip is re-evaluated.
+    doctor_mod._APIKEY_PROVIDERS_CACHE = None
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "Azure Foundry" in out
+    assert "HTTP 404" not in out
+    # Must have used x-api-key on the anthropic probe path
+    anth_calls = [c for c in calls if isinstance(c[1], str) and "/anthropic" in c[1]]
+    assert anth_calls, f"expected anthropic endpoint probe, got {calls}"
+    headers = anth_calls[0][2] or {}
+    assert headers.get("x-api-key") == "sk-foundry-test"
+    assert "Authorization" not in headers or not str(headers.get("Authorization", "")).startswith(
+        "Bearer sk-foundry"
+    )


### PR DESCRIPTION
## Summary

- Stops false Azure Foundry HTTP 404 from doctor on Anthropic-style Foundry bases
- Dedicated probe uses x-api-key and a minimal /v1/messages fallback when /models is missing

## Motivation

Closes #66756.

`hermes doctor` reported Azure Foundry (HTTP 404) for working Anthropic-style Foundry deployments. Runtime chat was fine; the generic health check hit {base}/models with Bearer auth.

## Verification

- pytest tests/hermes_cli/test_doctor_azure_foundry_probe.py tests/hermes_cli/test_doctor_dedicated_provider_skip.py — 4 passed
- Did NOT change Entra ID probe path