### PR TITLE
fix(update): make pre-update snapshot size cap configurable

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3639,6 +3639,12 @@ DEFAULT_CONFIG = {
         # Values below 1 are floored to 1 — the backup just created is
         # always preserved. The quick snapshot always keeps exactly 1.
         "backup_keep": 5,
+        # Per-file size ceiling (MiB) for the *quick* pre-update snapshot.
+        # Default 1024 (1 GiB). Raise when state.db is only a few GiB but
+        # still needs a clean make-before-break path (#66726). Set to 0
+        # for no per-file cap (create_quick_snapshot gets max_file_size=None).
+        # Full zip backups are unaffected.
+        "pre_update_snapshot_max_mb": 1024,
         # What `hermes update` does with uncommitted local changes to the
         # source tree when it runs NON-interactively — i.e. triggered from
         # the desktop/chat app or the gateway, where there's no TTY to answer

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2768,6 +2768,12 @@ DEFAULT_CONFIG = {
         # Values below 1 are floored to 1 — the backup just created is
         # always preserved. The quick snapshot always keeps exactly 1.
         "backup_keep": 5,
+        # Per-file size ceiling (MiB) for the *quick* pre-update snapshot.
+        # Default 1024 (1 GiB). Raise when state.db is only a few GiB but
+        # still needs a clean make-before-break path (#66726). Set to 0
+        # for no per-file cap (create_quick_snapshot gets max_file_size=None).
+        # Full zip backups are unaffected.
+        "pre_update_snapshot_max_mb": 1024,
         # What `hermes update` does with uncommitted local changes to the
         # source tree when it runs NON-interactively — i.e. triggered from
         # the desktop/chat app or the gateway, where there's no TTY to answer

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5078,6 +5078,7 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _refresh_windows_gateway_launchers,
     _reload_updated_runtime_modules,
     _resolve_pre_update_backup_mode,
+    _resolve_pre_update_snapshot_max_file_size,
     _resolve_stash_selector,
     _restore_stashed_changes,
     _resume_windows_gateways_after_update,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5218,6 +5218,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_recover_gateway_restart_after_abort",
         "_reload_updated_runtime_modules",
         "_resolve_pre_update_backup_mode",
+        "_resolve_pre_update_snapshot_max_file_size",
         "_resolve_stash_selector",
         "_restart_phase_failure_is_incomplete",
         "_restore_active_tool_dependencies",
@@ -6097,6 +6098,7 @@ def _clear_bytecode_cache(root: Path) -> int:
 # __getattr__ above (see _LAZY_COMMAND_EXPORTS) so argparse wiring and test
 # monkeypatches on hermes_cli.main.<name> keep resolving unchanged without
 # paying the update_cmd import cost on every CLI invocation.
+
 
 # Stamp file recording the checkout fingerprint the bytecode cache was last
 # validated against. Lives next to the checkout (NOT in HERMES_HOME) because

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4897,6 +4897,62 @@ _LAST_SIBLING_SNAPSHOTS: dict = {}
 # of wall time and silently ate 24 GB of disk per update).
 _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE = 1 << 30  # 1 GiB
 
+
+def _resolve_pre_update_snapshot_max_file_size():
+    """Resolve per-file size cap (bytes) for the *quick* pre-update snapshot.
+
+    Config key: ``updates.pre_update_snapshot_max_mb`` (MiB).
+
+    - missing / invalid → default 1 GiB
+    - positive int → that many MiB in bytes
+    - ``0`` → sentinel ``0`` meaning "no cap" (caller maps to ``None`` for
+      ``create_quick_snapshot``; integrity checks keep an independent bound)
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception as exc:
+        logging.getLogger(__name__).debug(
+            "Could not load config for pre-update snapshot cap: %s", exc
+        )
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+
+    updates_cfg = cfg.get("updates", {}) if isinstance(cfg, dict) else {}
+    raw = updates_cfg.get("pre_update_snapshot_max_mb", None)
+    if raw is None:
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logging.getLogger(__name__).warning(
+            "Ignoring invalid updates.pre_update_snapshot_max_mb %r "
+            "— using default 1 GiB cap",
+            raw,
+        )
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+    if value < 0:
+        logging.getLogger(__name__).warning(
+            "Ignoring negative updates.pre_update_snapshot_max_mb %d "
+            "— using default 1 GiB cap",
+            value,
+        )
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+    if value == 0:
+        return 0
+    return value << 20
+
+
+def _quick_snapshot_max_file_size_arg(resolved):
+    """Map resolver output to ``create_quick_snapshot(max_file_size=...)``.
+
+    ``0`` means uncapped → ``None``. Positive byte counts pass through.
+    """
+    if resolved == 0:
+        return None
+    return resolved
+
+
 def _resolve_pre_update_backup_mode(args) -> str:
     """Resolve the pre-update backup mode: ``"off"``, ``"quick"``, or ``"full"``.
 
@@ -4986,10 +5042,11 @@ def _run_pre_update_backup(args) -> Optional[str]:
         # module-level import is shadowed and unbound here. Alias explicitly.
         from hermes_cli.config import get_hermes_home as _get_home
 
+        _snap_cap = _resolve_pre_update_snapshot_max_file_size()
         snapshot_id = create_quick_snapshot(
             label="pre-update",
             keep=_PRE_UPDATE_SNAPSHOT_KEEP,
-            max_file_size=_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+            max_file_size=_quick_snapshot_max_file_size_arg(_snap_cap),
         )
 
         # After the snapshot, verify the source state.db is still intact.
@@ -5001,11 +5058,19 @@ def _run_pre_update_backup(args) -> Optional[str]:
         if snapshot_id:
             _src_path = _get_home() / "state.db"
             if _src_path.exists():
+                # Integrity scan bound is independent of the copy cap:
+                # uncapped snapshots (config 0 → max_file_size=None) must not
+                # disable or unbounded-run PRAGMA integrity_check on huge DBs.
+                _integrity_max = (
+                    _snap_cap
+                    if isinstance(_snap_cap, int) and _snap_cap > 0
+                    else _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+                )
                 _integrity = verify_sqlite_integrity(
                     _src_path,
                     check_header=True,
                     run_pragma=True,
-                    max_bytes=_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+                    max_bytes=_integrity_max,
                 )
                 if not _integrity.get("valid"):
                     _msg = _integrity.get("message", "unknown error")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2503,6 +2503,62 @@ _PRE_UPDATE_SNAPSHOT_KEEP = 1
 # of wall time and silently ate 24 GB of disk per update).
 _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE = 1 << 30  # 1 GiB
 
+
+def _resolve_pre_update_snapshot_max_file_size():
+    """Resolve per-file size cap (bytes) for the *quick* pre-update snapshot.
+
+    Config key: ``updates.pre_update_snapshot_max_mb`` (MiB).
+
+    - missing / invalid → default 1 GiB
+    - positive int → that many MiB in bytes
+    - ``0`` → sentinel ``0`` meaning "no cap" (caller maps to ``None`` for
+      ``create_quick_snapshot``; integrity checks keep an independent bound)
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception as exc:
+        logging.getLogger(__name__).debug(
+            "Could not load config for pre-update snapshot cap: %s", exc
+        )
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+
+    updates_cfg = cfg.get("updates", {}) if isinstance(cfg, dict) else {}
+    raw = updates_cfg.get("pre_update_snapshot_max_mb", None)
+    if raw is None:
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logging.getLogger(__name__).warning(
+            "Ignoring invalid updates.pre_update_snapshot_max_mb %r "
+            "— using default 1 GiB cap",
+            raw,
+        )
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+    if value < 0:
+        logging.getLogger(__name__).warning(
+            "Ignoring negative updates.pre_update_snapshot_max_mb %d "
+            "— using default 1 GiB cap",
+            value,
+        )
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+    if value == 0:
+        return 0
+    return value << 20
+
+
+def _quick_snapshot_max_file_size_arg(resolved):
+    """Map resolver output to ``create_quick_snapshot(max_file_size=...)``.
+
+    ``0`` means uncapped → ``None``. Positive byte counts pass through.
+    """
+    if resolved == 0:
+        return None
+    return resolved
+
+
 def _resolve_pre_update_backup_mode(args) -> str:
     """Resolve the pre-update backup mode: ``"off"``, ``"quick"``, or ``"full"``.
 
@@ -2592,10 +2648,11 @@ def _run_pre_update_backup(args) -> Optional[str]:
         # module-level import is shadowed and unbound here. Alias explicitly.
         from hermes_cli.config import get_hermes_home as _get_home
 
+        _snap_cap = _resolve_pre_update_snapshot_max_file_size()
         snapshot_id = create_quick_snapshot(
             label="pre-update",
             keep=_PRE_UPDATE_SNAPSHOT_KEEP,
-            max_file_size=_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+            max_file_size=_quick_snapshot_max_file_size_arg(_snap_cap),
         )
 
         # After the snapshot, verify the source state.db is still intact.
@@ -2607,11 +2664,19 @@ def _run_pre_update_backup(args) -> Optional[str]:
         if snapshot_id:
             _src_path = _get_home() / "state.db"
             if _src_path.exists():
+                # Integrity scan bound is independent of the copy cap:
+                # uncapped snapshots (config 0 → max_file_size=None) must not
+                # disable or unbounded-run PRAGMA integrity_check on huge DBs.
+                _integrity_max = (
+                    _snap_cap
+                    if isinstance(_snap_cap, int) and _snap_cap > 0
+                    else _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+                )
                 _integrity = verify_sqlite_integrity(
                     _src_path,
                     check_header=True,
                     run_pragma=True,
-                    max_bytes=_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+                    max_bytes=_integrity_max,
                 )
                 if not _integrity.get("valid"):
                     _msg = _integrity.get("message", "unknown error")

--- a/tests/hermes_cli/test_pre_update_snapshot_cap.py
+++ b/tests/hermes_cli/test_pre_update_snapshot_cap.py
@@ -1,0 +1,119 @@
+"""Configurable pre-update snapshot size cap (issue #66726)."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+import sys
+import types
+
+
+def _install_backup_stub(monkeypatch, seen, snap_id="snap-test"):
+    """Stub hermes_cli.backup import site used by _run_pre_update_backup."""
+
+    def create_quick_snapshot(**kwargs):
+        seen.update(kwargs)
+        return snap_id
+
+    def verify_sqlite_integrity(*_a, **_k):
+        return {"valid": True}
+
+    stub = types.ModuleType("hermes_cli.backup")
+    stub.create_quick_snapshot = create_quick_snapshot
+    stub.verify_sqlite_integrity = verify_sqlite_integrity
+    stub._quick_snapshot_root = lambda: None
+    monkeypatch.setitem(sys.modules, "hermes_cli.backup", stub)
+
+
+def test_default_max_is_1gib(monkeypatch, tmp_path):
+    from hermes_cli import main as cli_main
+    from hermes_cli import config as cfg_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("updates: {}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(cfg_mod, "get_hermes_home", lambda: home)
+
+    assert cli_main._resolve_pre_update_snapshot_max_file_size() == 1 << 30
+
+
+def test_config_raises_cap_to_4gib(monkeypatch, tmp_path):
+    from hermes_cli import main as cli_main
+    from hermes_cli import config as cfg_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "updates:\n  pre_update_snapshot_max_mb: 4096\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(cfg_mod, "get_hermes_home", lambda: home)
+
+    assert cli_main._resolve_pre_update_snapshot_max_file_size() == 4096 << 20
+
+
+def test_zero_disables_cap(monkeypatch, tmp_path):
+    from hermes_cli import main as cli_main
+    from hermes_cli import config as cfg_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "updates:\n  pre_update_snapshot_max_mb: 0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(cfg_mod, "get_hermes_home", lambda: home)
+
+    assert cli_main._resolve_pre_update_snapshot_max_file_size() == 0
+
+
+def test_run_pre_update_backup_passes_raised_cap(monkeypatch, tmp_path):
+    from hermes_cli import main as cli_main
+    from hermes_cli import config as cfg_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "updates:\n  pre_update_backup: quick\n  pre_update_snapshot_max_mb: 2048\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(cfg_mod, "get_hermes_home", lambda: home)
+
+    seen = {}
+    _install_backup_stub(monkeypatch, seen, snap_id="snap-test")
+
+    out = cli_main._run_pre_update_backup(Namespace(no_backup=False, backup=False))
+    assert out == "snap-test"
+    assert seen.get("max_file_size") == 2048 << 20
+    assert seen.get("label") == "pre-update"
+
+
+def test_run_pre_update_backup_zero_passes_none_cap(monkeypatch, tmp_path):
+    """End-to-end: config `0` must reach the backup wrapper as max_file_size=None.
+
+    The resolver returns 0 for "no cap", but the advertised behavior is that the
+    quick-snapshot wrapper copies state.db in full — i.e. it receives None, not 0.
+    """
+    from hermes_cli import main as cli_main
+    from hermes_cli import config as cfg_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "updates:\n  pre_update_backup: quick\n  pre_update_snapshot_max_mb: 0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(cfg_mod, "get_hermes_home", lambda: home)
+
+    seen = {}
+    _install_backup_stub(monkeypatch, seen, snap_id="snap-none")
+
+    out = cli_main._run_pre_update_backup(Namespace(no_backup=False, backup=False))
+    assert out == "snap-none"
+    assert "max_file_size" in seen
+    assert seen["max_file_size"] is None
+    assert seen.get("label") == "pre-update"

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -82,6 +82,23 @@ updates:
 
 `updates.pre_update_backup` is a single knob with three modes: `quick` (default — the lightweight state snapshot described above), `full` (the quick snapshot plus a complete `HERMES_HOME` zip; can add minutes on large homes), and `off` (no pre-update backup at all — `--no-backup` does the same for a single run). Legacy boolean values still work: `true` means `full`, `false` means `off`.
 
+The quick snapshot skips individual files larger than **1 GiB** by default so a multi-tens-of-GB `state.db` cannot stall `hermes update`. Override that ceiling with:
+
+```yaml
+# ~/.hermes/config.yaml
+updates:
+  pre_update_snapshot_max_mb: 4096   # allow up to 4 GiB per file (e.g. large state.db)
+  # pre_update_snapshot_max_mb: 0    # no per-file cap — copy everything in the quick set
+```
+
+- **Default:** `1024` (1 GiB), same as the historical hard-coded skip.
+- **Positive integer:** max file size in mebibytes before a path is skipped.
+- **`0` (or any ≤ 0):** disables the per-file cap so large DBs are included in the quick snapshot.
+- Unset / invalid values fall back to the 1 GiB default.
+
+This only affects the **quick** state snapshot’s per-file size filter. It does not replace other safety paths: full zip backups (`updates.pre_update_backup: full` / `hermes update --backup`) and post-pull syntax auto-rollback remain available independently.
+
+
 :::tip Moving to a new machine instead?
 Update backups protect an in-place update. If you're migrating your whole setup to different hardware, use `hermes backup` + `hermes import` instead — see [Exporting Hermes to another machine](/reference/faq#exporting-hermes-to-another-machine) and [`hermes backup` vs `hermes profile export`](/reference/faq#hermes-backup-vs-hermes-profile-export).
 :::

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -114,6 +114,23 @@ updates:
 
 `updates.pre_update_backup` is a single knob with three modes: `quick` (default — the lightweight state snapshot described above), `full` (the quick snapshot plus a complete `HERMES_HOME` zip; can add minutes on large homes), and `off` (no pre-update backup at all — `--no-backup` does the same for a single run). Legacy boolean values still work: `true` means `full`, `false` means `off`.
 
+The quick snapshot skips individual files larger than **1 GiB** by default so a multi-tens-of-GB `state.db` cannot stall `hermes update`. Override that ceiling with:
+
+```yaml
+# ~/.hermes/config.yaml
+updates:
+  pre_update_snapshot_max_mb: 4096   # allow up to 4 GiB per file (e.g. large state.db)
+  # pre_update_snapshot_max_mb: 0    # no per-file cap — copy everything in the quick set
+```
+
+- **Default:** `1024` (1 GiB), same as the historical hard-coded skip.
+- **Positive integer:** max file size in mebibytes before a path is skipped.
+- **`0` (or any ≤ 0):** disables the per-file cap so large DBs are included in the quick snapshot.
+- Unset / invalid values fall back to the 1 GiB default.
+
+This only affects the **quick** state snapshot’s per-file size filter. It does not replace other safety paths: full zip backups (`updates.pre_update_backup: full` / `hermes update --backup`) and post-pull syntax auto-rollback remain available independently.
+
+
 :::tip Moving to a new machine instead?
 Update backups protect an in-place update. If you're migrating your whole setup to different hardware, use `hermes backup` + `hermes import` instead — see [Exporting Hermes to another machine](/reference/faq#exporting-hermes-to-another-machine) and [`hermes backup` vs `hermes profile export`](/reference/faq#hermes-backup-vs-hermes-profile-export).
 :::

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -104,11 +104,14 @@ Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERM
 ```yaml
 updates:
   pre_update_backup: quick       # quick (state snapshot, default) | full (snapshot + HERMES_HOME zip) | off
+  pre_update_snapshot_max_mb: 1024  # quick snapshot per-file cap (MiB); 0 = no cap
   backup_keep: 5                 # Keep this many full pre-update backup zips
   non_interactive_local_changes: stash  # stash | discard
 ```
 
-`pre_update_backup` is the single pre-update safety knob: `quick` (default) snapshots critical state files (pairing data, cron jobs, config, auth; files over 1 GiB are skipped) into `state-snapshots/`; `full` additionally zips all of `HERMES_HOME` into `backups/` and can add minutes on large homes; `off` disables both. Legacy booleans are honored (`true` → `full`, `false` → `off`).
+`pre_update_backup` is the single pre-update safety knob: `quick` (default) snapshots critical state files (pairing data, cron jobs, config, auth; files over the per-file cap are skipped) into `state-snapshots/`; `full` additionally zips all of `HERMES_HOME` into `backups/` and can add minutes on large homes; `off` disables both. Legacy booleans are honored (`true` → `full`, `false` → `off`).
+
+`pre_update_snapshot_max_mb` controls that quick-snapshot per-file size filter only (default `1024` MiB / 1 GiB). Set a higher value (e.g. `4096`) if you want large but still useful databases like a ~2 GiB `state.db` included in the pre-update snapshot. Set `0` to disable the cap entirely. Invalid values fall back to `1024`. Full zip backups and post-pull auto-rollback are separate mechanisms and are not replaced by this setting.
 
 For git installs, Hermes auto-stashes dirty tracked files and untracked files before checking out the update branch or pulling. Interactive terminal updates prompt before restoring that stash. Non-interactive updates (desktop/chat app, gateway, or `--yes`) use `updates.non_interactive_local_changes`: `stash` restores local source edits after a successful pull, while `discard` drops the update-created stash after a successful pull. Use `discard` only on managed installs where local source edits are never meant to persist.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -157,12 +157,15 @@ Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERM
 ```yaml
 updates:
   pre_update_backup: quick       # quick (state snapshot, default) | full (snapshot + HERMES_HOME zip) | off
+  pre_update_snapshot_max_mb: 1024  # quick snapshot per-file cap (MiB); 0 = no cap
   backup_keep: 5                 # Keep this many full pre-update backup zips
   non_interactive_local_changes: stash  # stash | discard
   auto_switch_parked_branch: true       # auto-switch a clean, fully merged parked branch back to main
 ```
 
-`pre_update_backup` is the single pre-update safety knob: `quick` (default) snapshots critical state files (pairing data, cron jobs, config, auth; files over 1 GiB are skipped) into `state-snapshots/`; `full` additionally zips all of `HERMES_HOME` into `backups/` and can add minutes on large homes; `off` disables both. Legacy booleans are honored (`true` → `full`, `false` → `off`).
+`pre_update_backup` is the single pre-update safety knob: `quick` (default) snapshots critical state files (pairing data, cron jobs, config, auth; files over the per-file cap are skipped) into `state-snapshots/`; `full` additionally zips all of `HERMES_HOME` into `backups/` and can add minutes on large homes; `off` disables both. Legacy booleans are honored (`true` → `full`, `false` → `off`).
+
+`pre_update_snapshot_max_mb` controls that quick-snapshot per-file size filter only (default `1024` MiB / 1 GiB). Set a higher value (e.g. `4096`) if you want large but still useful databases like a ~2 GiB `state.db` included in the pre-update snapshot. Set `0` to disable the cap entirely. Invalid values fall back to `1024`. Full zip backups and post-pull auto-rollback are separate mechanisms and are not replaced by this setting.
 
 For git installs, Hermes auto-stashes dirty tracked files and untracked files before checking out the update branch or pulling. Interactive terminal updates prompt before restoring that stash. Non-interactive updates (desktop/chat app, gateway, or `--yes`) use `updates.non_interactive_local_changes`: `stash` restores local source edits after a successful pull, while `discard` drops the update-created stash after a successful pull. Use `discard` only on managed installs where local source edits are never meant to persist.
 


### PR DESCRIPTION
## Summary

- Keeps the 1 GiB default skip so huge `state.db` cannot stall updates
- Adds `updates.pre_update_snapshot_max_mb` so multi-GiB DBs can still be included in the **quick** pre-update state snapshot when desired
- Documents the setting (default `1024`, positive MiB override, `0` = no per-file cap) in getting-started and configuration docs
- E2E wrapper test: config `0` → `create_quick_snapshot(..., max_file_size=None)`

## Motivation

Closes #66726.

After the gated pre-update snapshot, files over 1 GiB are skipped with a warning. That protects multi-tens-of-GB DBs but leaves no clean **quick-snapshot** path for merely large DBs (observed ~1.7 GiB). This change keeps the safe default and lets operators raise or disable the per-file cap.

This is **not** the only rollback / safety path: `hermes update --backup` / `updates.pre_update_backup: full` (full `HERMES_HOME` zip) and post-pull syntax auto-rollback still exist independently. `pre_update_snapshot_max_mb` only tunes the quick snapshot’s per-file size filter.

## Verification

- `pytest tests/hermes_cli/test_pre_update_snapshot_cap.py` — 5 passed
- Default remains 1024 MiB; `0` disables the per-file cap (`max_file_size=None`)
