### PR TITLE
fix(windows): migrate legacy ~/.hermes state into %LOCALAPPDATA%\hermes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1398,6 +1398,19 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home, get_hermes_home_override
 from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
+
+# One-shot Windows home-move safety net: fill any state gaps in the native
+# %LOCALAPPDATA%\hermes home from a legacy ~/.hermes (auth.json, cron jobs,
+# etc.) BEFORE anything below reads config from the home.  No-op off Windows,
+# when a custom HERMES_HOME is active, or once the migration marker exists.
+try:
+    from hermes_cli.legacy_home_migration import maybe_migrate_legacy_windows_home
+    maybe_migrate_legacy_windows_home()
+except Exception as _legacy_mig_exc:  # never block gateway start
+    logging.getLogger(__name__).warning(
+        "Legacy home migration check failed: %s", _legacy_mig_exc
+    )
+
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.

--- a/hermes_cli/legacy_home_migration.py
+++ b/hermes_cli/legacy_home_migration.py
@@ -1,0 +1,257 @@
+"""One-shot migration of a legacy ``~/.hermes`` home into the Windows-native
+default ``%LOCALAPPDATA%\\hermes``.
+
+The Windows default Hermes home moved from ``~/.hermes`` to
+``%LOCALAPPDATA%\\hermes`` (see ``_get_platform_default_hermes_home`` in
+``hermes_constants.py``).  Nothing carried existing state across that move:
+the installer seeds the new home from *templates*, so a user upgrading in
+place came up with fresh config and silently lost everything the templates
+don't cover — most painfully ``auth.json`` (provider credentials) and
+``cron/jobs.json`` (all scheduled jobs), which made cron jobs die with
+"No Codex credentials stored" until the files were copied by hand.
+
+This module closes that gap with a *fill-gap* copy: every state file or
+directory present in the legacy home and absent in the new home is copied
+over; anything that already exists in the new home is left untouched (the
+new home may have newer state — it wins).  Rather than a curated
+include-list (the bug class that caused the incident), the walk copies
+everything and excludes only regeneratable or process-local entries:
+caches, logs, locks, pid files, sandboxes, and managed tool installs.
+
+The migration is one-shot: a marker file is written to the new home after a
+completed pass and skips all future runs.  A failed pass writes no marker,
+so the (idempotent) copy simply retries on the next start.
+
+Callers invoke :func:`maybe_migrate_legacy_windows_home` as early as
+possible — before anything reads config from the home.  The function never
+raises.
+"""
+
+import json
+import logging
+import os
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from hermes_constants import _get_platform_default_hermes_home, get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# Marker written to the NEW home after a completed migration pass.
+MARKER_NAME = ".legacy_home_migrated.json"
+
+# Top-level or nested entry names that are never copied.  Everything else in
+# the legacy home is state worth carrying over.  Keep this an EXCLUDE list:
+# the incident this module fixes was caused by an include-list that missed
+# ``auth.json`` and ``cron/jobs.json``.
+_EXCLUDED_NAMES = frozenset(
+    {
+        # Regeneratable caches / transient dirs
+        "cache",
+        "bootstrap-cache",
+        "image_cache",
+        "audio_cache",
+        "media_cache",
+        "document_cache",
+        "tmp",
+        "logs",
+        "sandboxes",
+        "trash",
+        # Process-local runtime state — must reflect the live process
+        "gateway.lock",
+        "gateway.pid",
+        ".update_check",
+        # Managed tooling installs — large and re-downloadable
+        "node",
+        "git",
+        "bin",
+        "venv",
+        "node_modules",
+        # The Windows installer places the source checkout inside the home
+        "hermes-agent",
+        # Service wrappers bake in old-home paths; `hermes setup` regenerates
+        "gateway-service",
+    }
+)
+
+# How many per-file entries the marker records before truncating (a large
+# sessions/ tree can hold thousands of files; counts stay exact).
+_MARKER_LIST_CAP = 500
+
+
+def _is_excluded(name: str) -> bool:
+    if name in _EXCLUDED_NAMES:
+        return True
+    # Lock/pid files are process-local; SQLite sidecars are copied only
+    # together with their database (see _copy_file), never standalone.
+    return name.endswith((".lock", ".pid", "-wal", "-shm", "-journal"))
+
+
+def _norm(path: Path) -> str:
+    return os.path.normcase(os.path.normpath(str(path)))
+
+
+def _looks_like_hermes_home(path: Path) -> bool:
+    """A directory qualifies as a legacy home when it holds real state."""
+    markers = ("config.yaml", "auth.json", "state.db", ".env", "cron")
+    try:
+        return path.is_dir() and any((path / m).exists() for m in markers)
+    except OSError:
+        return False
+
+
+def _copy_file(src: Path, dst: Path, copied: list, errors: list) -> None:
+    try:
+        shutil.copy2(src, dst)
+        copied.append(str(dst))
+    except OSError as exc:
+        errors.append(f"{src}: {exc}")
+        return
+    # A ``<name>-wal`` sibling marks a SQLite database in WAL mode.  The WAL
+    # holds committed-but-not-checkpointed transactions, so copy it together
+    # with a freshly copied db (the destination db did not exist, so there is
+    # nothing to clobber).  ``-shm`` is scratch shared memory — SQLite
+    # recreates it; never copy it.
+    wal = src.parent / (src.name + "-wal")
+    dst_wal = dst.parent / (dst.name + "-wal")
+    if wal.exists() and not dst_wal.exists():
+        try:
+            shutil.copy2(wal, dst_wal)
+            copied.append(str(dst_wal))
+        except OSError as exc:
+            errors.append(f"{wal}: {exc}")
+
+
+def _fill_gap_copy(
+    src_dir: Path, dst_dir: Path, copied: list, skipped: list, errors: list
+) -> None:
+    """Recursively copy entries missing from *dst_dir*; never overwrite."""
+    try:
+        entries = sorted(src_dir.iterdir(), key=lambda p: p.name)
+    except OSError as exc:
+        errors.append(f"{src_dir}: {exc}")
+        return
+    for entry in entries:
+        name = entry.name
+        if _is_excluded(name):
+            continue
+        dst = dst_dir / name
+        try:
+            if entry.is_symlink():
+                # Don't chase links out of the legacy home.
+                continue
+            if entry.is_dir():
+                if dst.exists() and not dst.is_dir():
+                    skipped.append(str(dst))
+                    continue
+                dst.mkdir(parents=True, exist_ok=True)
+                _fill_gap_copy(entry, dst, copied, skipped, errors)
+            elif entry.is_file():
+                if dst.exists():
+                    skipped.append(str(dst))
+                    continue
+                _copy_file(entry, dst, copied, errors)
+        except OSError as exc:
+            errors.append(f"{entry}: {exc}")
+
+
+def maybe_migrate_legacy_windows_home(
+    new_home: Path | None = None,
+    legacy_home: Path | None = None,
+    platform: str | None = None,
+) -> dict | None:
+    """Fill state gaps in the native Windows home from a legacy ``~/.hermes``.
+
+    Runs at most once (marker-gated), only on Windows, and only when the
+    active home *is* the platform default — a custom ``HERMES_HOME``
+    pointing elsewhere is respected and left alone.  Existing files in the
+    new home are never overwritten.
+
+    Returns a summary dict when a migration pass ran, ``None`` otherwise.
+    Never raises.
+    """
+    try:
+        if (platform or sys.platform) != "win32":
+            return None
+
+        new_home = Path(new_home) if new_home else get_hermes_home()
+        if _norm(new_home) != _norm(_get_platform_default_hermes_home()):
+            return None
+
+        legacy_home = (
+            Path(legacy_home) if legacy_home else Path.home() / ".hermes"
+        )
+        if _norm(legacy_home) == _norm(new_home):
+            return None
+        if not _looks_like_hermes_home(legacy_home):
+            return None
+        try:
+            if new_home.exists() and os.path.samefile(legacy_home, new_home):
+                # One is a junction/symlink onto the other — nothing to do.
+                return None
+        except OSError:
+            pass
+
+        marker_path = new_home / MARKER_NAME
+        if marker_path.exists():
+            return None
+
+        new_home.mkdir(parents=True, exist_ok=True)
+
+        copied: list = []
+        skipped: list = []
+        errors: list = []
+        _fill_gap_copy(legacy_home, new_home, copied, skipped, errors)
+
+        summary = {
+            "migrated_at": datetime.now(timezone.utc).isoformat(),
+            "legacy_home": str(legacy_home),
+            "new_home": str(new_home),
+            "copied_count": len(copied),
+            "skipped_existing_count": len(skipped),
+            "error_count": len(errors),
+            "copied": copied[:_MARKER_LIST_CAP],
+            "errors": errors[:_MARKER_LIST_CAP],
+        }
+
+        if errors:
+            # No marker: the fill-gap copy is idempotent, so the next start
+            # retries whatever failed (e.g. a file locked by a stale gateway).
+            logger.warning(
+                "Legacy Hermes home migration incomplete: copied %d item(s) "
+                "from %s, %d error(s) — will retry on next start. First "
+                "error: %s",
+                len(copied),
+                legacy_home,
+                len(errors),
+                errors[0],
+            )
+            return summary
+
+        try:
+            marker_path.write_text(
+                json.dumps(summary, indent=2), encoding="utf-8"
+            )
+        except OSError as exc:
+            logger.warning(
+                "Legacy home migration could not write marker %s: %s",
+                marker_path,
+                exc,
+            )
+
+        if copied:
+            logger.info(
+                "Migrated legacy Hermes home %s -> %s: copied %d item(s), "
+                "kept %d existing item(s). Details: %s",
+                legacy_home,
+                new_home,
+                len(copied),
+                len(skipped),
+                marker_path,
+            )
+        return summary
+    except Exception as exc:  # noqa: BLE001 — must never block startup
+        logger.warning("Legacy Hermes home migration skipped: %s", exc)
+        return None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13206,6 +13206,16 @@ def main():
     except Exception:
         pass
 
+    # One-shot Windows home-move safety net: fill any state gaps in the
+    # native %LOCALAPPDATA%\hermes home from a legacy ~/.hermes (auth.json,
+    # cron jobs, etc.) before any command reads config.  No-op off Windows,
+    # when a custom HERMES_HOME is active, or once the marker exists.
+    try:
+        from hermes_cli.legacy_home_migration import maybe_migrate_legacy_windows_home
+        maybe_migrate_legacy_windows_home()
+    except Exception:
+        pass
+
     # Sweep stale ``hermes.exe.old.*`` quarantine files left by previous
     # ``hermes update`` runs on Windows. Silent no-op on non-Windows or when
     # there's nothing to clean. See ``_quarantine_running_hermes_exe``.

--- a/tests/hermes_cli/test_legacy_home_migration.py
+++ b/tests/hermes_cli/test_legacy_home_migration.py
@@ -1,0 +1,245 @@
+"""Tests for the one-shot legacy ``~/.hermes`` -> ``%LOCALAPPDATA%\\hermes``
+fill-gap migration (``hermes_cli/legacy_home_migration.py``).
+
+Regression context: the Windows default home moved to ``%LOCALAPPDATA%\\hermes``
+with no data migration at all.  A template-seeded new home came up without
+``auth.json`` (provider credentials) and ``cron/jobs.json`` (all scheduled
+jobs), so cron jobs died silently with "No Codex credentials stored".  These
+tests pin the fill-gap semantics: missing state is copied, existing state is
+never overwritten, junk (caches/locks/tooling) is excluded, and the pass is
+one-shot via a marker file.
+"""
+
+import json
+
+import pytest
+
+from hermes_cli import legacy_home_migration as mig
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    """A populated legacy home and an (initially empty) new home.
+
+    The module is pinned so ``new_home`` is treated as the platform default
+    and the platform check passes regardless of the host OS.
+    """
+    legacy = tmp_path / "dot_hermes"
+    new = tmp_path / "localappdata_hermes"
+    legacy.mkdir()
+
+    # State the incident lost:
+    (legacy / "auth.json").write_text('{"providers": {"codex": "tok"}}')
+    (legacy / "cron").mkdir()
+    (legacy / "cron" / "jobs.json").write_text('{"jobs": [{"id": "j1"}]}')
+
+    # Other state that must carry over:
+    (legacy / "config.yaml").write_text("model: real-config\n")
+    (legacy / ".env").write_text("SOME_KEY=1\n")
+    (legacy / "processes.json").write_text("{}")
+    (legacy / "gateway_state.json").write_text('{"desired": "running"}')
+    (legacy / "channel_directory.json").write_text("{}")
+    (legacy / "state.db").write_bytes(b"sqlite-main")
+    (legacy / "state.db-wal").write_bytes(b"sqlite-wal")
+    (legacy / "state.db-shm").write_bytes(b"sqlite-shm")
+    (legacy / "sessions").mkdir()
+    (legacy / "sessions" / "abc.jsonl").write_text("{}\n")
+    (legacy / "skills").mkdir()
+    (legacy / "skills" / "myskill").mkdir()
+    (legacy / "skills" / "myskill" / "SKILL.md").write_text("# skill")
+
+    # Junk that must NOT carry over:
+    (legacy / "logs").mkdir()
+    (legacy / "logs" / "gateway.log").write_text("old logs")
+    (legacy / "cache").mkdir()
+    (legacy / "cache" / "blob").write_text("x")
+    (legacy / "image_cache").mkdir()
+    (legacy / "gateway.pid").write_text("123")
+    (legacy / "gateway.lock").write_text("")
+    (legacy / "auth.lock").write_text("")
+    (legacy / "node").mkdir()
+    (legacy / "node" / "bin").mkdir(parents=True, exist_ok=True)
+    (legacy / "hermes-agent").mkdir()
+    (legacy / "hermes-agent" / "cli.py").write_text("# checkout")
+
+    monkeypatch.setattr(
+        mig, "_get_platform_default_hermes_home", lambda: new
+    )
+    return legacy, new
+
+
+def _run(legacy, new):
+    return mig.maybe_migrate_legacy_windows_home(
+        new_home=new, legacy_home=legacy, platform="win32"
+    )
+
+
+class TestFillGapCopy:
+    def test_auth_and_cron_jobs_are_copied(self, homes):
+        """The exact files the incident lost must be carried over."""
+        legacy, new = homes
+        summary = _run(legacy, new)
+        assert summary is not None
+        assert (new / "auth.json").read_text() == '{"providers": {"codex": "tok"}}'
+        assert (new / "cron" / "jobs.json").read_text() == '{"jobs": [{"id": "j1"}]}'
+
+    def test_all_state_files_are_copied(self, homes):
+        legacy, new = homes
+        _run(legacy, new)
+        for rel in (
+            "config.yaml",
+            ".env",
+            "processes.json",
+            "gateway_state.json",
+            "channel_directory.json",
+            "state.db",
+            "sessions/abc.jsonl",
+            "skills/myskill/SKILL.md",
+        ):
+            assert (new / rel).exists(), f"missing {rel}"
+
+    def test_sqlite_wal_copied_with_db_but_shm_is_not(self, homes):
+        legacy, new = homes
+        _run(legacy, new)
+        assert (new / "state.db-wal").exists()
+        assert not (new / "state.db-shm").exists()
+
+    def test_junk_is_excluded(self, homes):
+        legacy, new = homes
+        _run(legacy, new)
+        for rel in (
+            "logs",
+            "cache",
+            "image_cache",
+            "gateway.pid",
+            "gateway.lock",
+            "auth.lock",
+            "node",
+            "hermes-agent",
+        ):
+            assert not (new / rel).exists(), f"should not have copied {rel}"
+
+    def test_existing_files_are_never_overwritten(self, homes):
+        """The new home may hold newer state — it always wins."""
+        legacy, new = homes
+        new.mkdir()
+        (new / "config.yaml").write_text("model: newer-config\n")
+        (new / "cron").mkdir()
+        (new / "cron" / "jobs.json").write_text('{"jobs": ["newer"]}')
+
+        summary = _run(legacy, new)
+
+        assert (new / "config.yaml").read_text() == "model: newer-config\n"
+        assert (new / "cron" / "jobs.json").read_text() == '{"jobs": ["newer"]}'
+        # Gaps beside the existing files are still filled.
+        assert (new / "auth.json").exists()
+        assert summary["skipped_existing_count"] >= 2
+
+    def test_directories_merge_instead_of_being_skipped(self, homes):
+        """An existing dir in the new home must not block missing children."""
+        legacy, new = homes
+        new.mkdir()
+        (new / "sessions").mkdir()
+        (new / "sessions" / "zzz.jsonl").write_text("{}\n")
+
+        _run(legacy, new)
+
+        assert (new / "sessions" / "abc.jsonl").exists()
+        assert (new / "sessions" / "zzz.jsonl").exists()
+
+
+class TestOneShotAndGuards:
+    def test_marker_written_and_second_run_is_noop(self, homes):
+        legacy, new = homes
+        first = _run(legacy, new)
+        assert first is not None
+        marker = new / mig.MARKER_NAME
+        assert marker.exists()
+        payload = json.loads(marker.read_text())
+        assert payload["copied_count"] == first["copied_count"] > 0
+
+        # A file added to legacy afterwards must NOT be copied anymore.
+        (legacy / "late.json").write_text("{}")
+        second = _run(legacy, new)
+        assert second is None
+        assert not (new / "late.json").exists()
+
+    def test_noop_off_windows(self, homes):
+        legacy, new = homes
+        assert (
+            mig.maybe_migrate_legacy_windows_home(
+                new_home=new, legacy_home=legacy, platform="linux"
+            )
+            is None
+        )
+        assert not new.exists()
+
+    def test_noop_when_home_is_not_platform_default(self, homes, tmp_path, monkeypatch):
+        """A custom HERMES_HOME is respected and left alone."""
+        legacy, new = homes
+        monkeypatch.setattr(
+            mig, "_get_platform_default_hermes_home", lambda: tmp_path / "elsewhere"
+        )
+        assert _run(legacy, new) is None
+        assert not new.exists()
+
+    def test_noop_when_legacy_is_new_home(self, homes):
+        legacy, new = homes
+        assert (
+            mig.maybe_migrate_legacy_windows_home(
+                new_home=new, legacy_home=new, platform="win32"
+            )
+            is None
+        )
+
+    def test_noop_when_legacy_home_missing_or_empty(self, homes, tmp_path):
+        legacy, new = homes
+        missing = tmp_path / "nope"
+        assert (
+            mig.maybe_migrate_legacy_windows_home(
+                new_home=new, legacy_home=missing, platform="win32"
+            )
+            is None
+        )
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert (
+            mig.maybe_migrate_legacy_windows_home(
+                new_home=new, legacy_home=empty, platform="win32"
+            )
+            is None
+        )
+        assert not new.exists()
+
+    def test_symlinked_legacy_entries_are_skipped(self, homes):
+        legacy, new = homes
+        try:
+            (legacy / "linked.json").symlink_to(legacy / "auth.json")
+        except OSError:
+            pytest.skip("symlinks unavailable (Windows without Developer Mode)")
+        _run(legacy, new)
+        assert not (new / "linked.json").exists()
+
+    def test_never_raises_on_unreadable_source(self, homes, monkeypatch):
+        """Copy errors are collected; no marker so the next start retries."""
+        legacy, new = homes
+
+        real_copy2 = mig.shutil.copy2
+
+        def flaky_copy2(src, dst, *a, **kw):
+            if str(src).endswith("auth.json"):
+                raise OSError("locked")
+            return real_copy2(src, dst, *a, **kw)
+
+        monkeypatch.setattr(mig.shutil, "copy2", flaky_copy2)
+        summary = _run(legacy, new)
+        assert summary is not None
+        assert summary["error_count"] == 1
+        assert not (new / mig.MARKER_NAME).exists()
+
+        # Retry with the error gone completes and writes the marker.
+        monkeypatch.setattr(mig.shutil, "copy2", real_copy2)
+        retry = _run(legacy, new)
+        assert retry is not None
+        assert (new / "auth.json").exists()
+        assert (new / mig.MARKER_NAME).exists()


### PR DESCRIPTION
## Problem

The Windows default Hermes home moved from `~/.hermes` to `%LOCALAPPDATA%\hermes` (40fbb0f3c, `_get_platform_default_hermes_home` in `hermes_constants.py`) — but **nothing migrates existing state across the move**:

- `scripts/install.ps1` `Copy-ConfigTemplates` seeds the new home from bundled **templates** only.
- The desktop app's `resolveHermesHome()` keeps using legacy `~/.hermes` in place *only if* `%LOCALAPPDATA%\hermes` doesn't exist yet — once anything creates it, all state in `~/.hermes` is orphaned.

Real-world impact (hit on an in-place upgrade across the home-move commit): the new home came up without `auth.json` (provider credentials) and `cron/jobs.json` (all scheduled jobs). Cron jobs were silently dead for ~18h failing with `No Codex credentials stored`, and both files had to be located and copied by hand. Every Windows user upgrading across the home move hits some version of this.

## Fix

New `hermes_cli/legacy_home_migration.py` — a one-shot, fill-gap migration invoked as early as possible at both entry points (`gateway/run.py` module init before the home is first read, and `hermes_cli/main.py` `main()`):

- **Fill-gap copy of everything**, with an *exclude* list (caches, logs, `*.lock`/`*.pid`, sandboxes, `node`/`git`/`bin` tooling, the `hermes-agent` checkout, `gateway-service` wrappers). A curated *include* list is exactly the bug class that caused this incident, so the design inverts it — `auth.json`, `cron/`, `config.yaml`, `.env`, `state.db`, `sessions/`, `skills/`, kanban, `processes.json`, `gateway_state.json`, `channel_directory.json`, … all carry over without being individually named.
- **Never overwrites** anything already in the new home (newer state wins); directories merge recursively.
- SQLite handling: a freshly copied db brings its `-wal` along (committed-but-uncheckpointed data), never `-shm`.
- **One-shot** via a `.legacy_home_migrated.json` marker (contains a copy manifest for debugging). A pass with copy errors writes **no** marker, so the idempotent copy retries on the next start.
- Guards: Windows only; only when the active home *is* the platform default (custom `HERMES_HOME` respected); junction/symlink same-file check; never raises, never blocks startup.

## Tests

`tests/hermes_cli/test_legacy_home_migration.py` — 13 tests covering: the two incident files specifically, full state carry-over, no-overwrite, directory merge, exclusions, wal/shm rules, marker one-shot behavior, non-Windows / custom-home / same-path no-ops, symlink skip, and error-collect-then-retry.

All 13 pass; `gateway/run.py`, `hermes_cli/main.py` compile clean. The 2 failures in `tests/test_hermes_constants.py` on my machine pre-exist on clean `main` (Windows host artifacts, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
