### PR TITLE
fix(mcp): add disable_watchdog config option for uvx servers (#66423)

### DIFF
--- a/test_issue_66423.py
+++ b/test_issue_66423.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Test for issue #66423: disable_watchdog config option"""
+import sys
+sys.path.insert(0, '.')
+
+from tools.mcp_tool import _wrap_command_with_watchdog
+
+# Test 1: Default behavior wraps command
+cmd, args = _wrap_command_with_watchdog('uvx', ['foo'])
+assert 'mcp_stdio_watchdog.py' in ' '.join(args), 'Default should wrap'
+print('✓ Test 1: Default wraps command')
+
+# Test 2: disable_watchdog=True skips wrap
+config = {'command': 'uvx', 'args': ['foo'], 'disable_watchdog': True}
+cmd, args = config['command'], config['args']
+if not config.get('disable_watchdog', False):
+    cmd, args = _wrap_command_with_watchdog(cmd, args)
+assert cmd == 'uvx' and args == ['foo'], 'disable_watchdog=True should skip wrap'
+print('✓ Test 2: disable_watchdog=True skips wrap')
+
+# Test 3: disable_watchdog=False (explicit) wraps
+config = {'command': 'uvx', 'args': ['foo'], 'disable_watchdog': False}
+cmd, args = config['command'], config['args']
+if not config.get('disable_watchdog', False):
+    cmd, args = _wrap_command_with_watchdog(cmd, args)
+assert 'mcp_stdio_watchdog.py' in ' '.join(args), 'disable_watchdog=False should wrap'
+print('✓ Test 3: disable_watchdog=False wraps')
+
+print('\nAll tests passed')

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2275,7 +2275,10 @@ class MCPServerTask:
         # elsewhere, matching existing killpg-based cleanup's platform scope.
         # Applied AFTER the OSV preflight so the check inspects the real
         # package, not the watchdog wrapper.
-        command, args = _wrap_command_with_watchdog(command, args)
+        # Some commands (e.g. uvx) break under the watchdog wrapper (#66423);
+        # allow per-server opt-out via `disable_watchdog: true` in config.
+        if not config.get("disable_watchdog", False):
+            command, args = _wrap_command_with_watchdog(command, args)
 
         server_params = StdioServerParameters(
             command=command,


### PR DESCRIPTION
## Problem
Stdio MCP servers launched via `uvx` fail to connect when run through the gateway. The connection fails with "Connection closed" after 3 retry attempts.

Root cause: the `mcp_stdio_watchdog.py` wrapper that intercepts the subprocess spawn breaks the stdio relay for `uvx`-spawned servers.

## Solution
Add per-server `disable_watchdog: true` config option to skip the watchdog wrapper for commands that break under it (e.g. uvx).

Default behavior unchanged — watchdog remains enabled for all other servers.

## Usage
```yaml
mcp_servers:
  aws:
    command: "uvx"
    args: ["awslabs.aws-api-mcp-server@latest"]
    disable_watchdog: true  # Skip watchdog wrapper
    enabled: true
```

Fixes #66423