### PR TITLE
fix(feishu): allow paired users to resolve approval cards

### DIFF
--- a/contributors/emails/849916464@qq.com
+++ b/contributors/emails/849916464@qq.com
@@ -1,0 +1,2 @@
+ThereWasAYang
+# PR #66807 contributor identity

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2720,15 +2720,86 @@ class FeishuAdapter(BasePlatformAdapter):
         future.add_done_callback(self._log_background_failure)
         return True
 
-    def _is_interactive_operator_authorized(self, open_id: str) -> bool:
+    @staticmethod
+    def _approval_state_chat_type(state: Dict[str, str]) -> str:
+        """Extract a trusted chat type from a gateway-generated session key."""
+        parts = str(state.get("session_key", "") or "").split(":", 4)
+        if len(parts) >= 4 and parts[0] == "agent" and parts[2] == "feishu":
+            return parts[3]
+        return ""
+
+    def _is_interactive_operator_authorized(
+        self,
+        open_id: str,
+        *,
+        user_id: str = "",
+        chat_id: str = "",
+        chat_type: str = "group",
+    ) -> bool:
         """Return whether this card-action operator may answer gated prompts."""
-        normalized = str(open_id or "").strip()
-        if not normalized:
+        identities = []
+        for raw_id in (user_id, open_id):
+            normalized = str(raw_id or "").strip()
+            if normalized and normalized not in identities:
+                identities.append(normalized)
+        if not identities:
             return False
+
+        # Reuse the gateway's full authorization union (allowlists, pairing,
+        # allow-all flags) instead of reimplementing it in the adapter. The
+        # injected callback is profile-bound in multiplex gateways, so paired
+        # users resolve against that profile's PairingStore. Feishu message
+        # identity prefers tenant-scoped user_id but older pairings may contain
+        # app-scoped open_id, so accept either alias only when independently
+        # authorized by the same gateway callback.
+        if self._authorization_check is not None:
+            for identity in identities:
+                gateway_authorized = self._is_sender_authorized(
+                    identity,
+                    chat_type=chat_type,
+                    chat_id=chat_id or None,
+                )
+                if gateway_authorized is True:
+                    return True
+            # False and callback failures (reported as None) are both denied.
+            return False
+
+        # Unit tests and standalone adapter use may not install the gateway
+        # callback. Preserve the legacy static-list/open-policy fallback there.
         allowed_ids = set(self._admins) | set(self._allowed_group_users)
         if not allowed_ids:
             return True
-        return "*" in allowed_ids or normalized in allowed_ids
+        return "*" in allowed_ids or any(identity in allowed_ids for identity in identities)
+
+    def _is_approval_operator_authorized(
+        self,
+        open_id: str,
+        *,
+        user_id: str = "",
+        state: Dict[str, str],
+    ) -> bool:
+        """Apply the correct DM or group authorization gate for a card."""
+        chat_id = str(state.get("chat_id", "") or "")
+        chat_type = self._approval_state_chat_type(state)
+        if chat_type in {"group", "forum", "channel"}:
+            sender_id = SimpleNamespace(open_id=open_id, user_id=user_id)
+            return self._allow_group_message(sender_id, chat_id, is_bot=False)
+        if chat_type == "dm":
+            return self._is_interactive_operator_authorized(
+                open_id,
+                user_id=user_id,
+                chat_id=chat_id,
+                chat_type=chat_type,
+            )
+        if not chat_type and self._authorization_check is None:
+            # Preserve legacy standalone-adapter behavior only when no gateway
+            # callback or gateway-generated session key is available.
+            return self._is_interactive_operator_authorized(
+                open_id,
+                user_id=user_id,
+                chat_id=chat_id,
+            )
+        return False
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
@@ -2744,8 +2815,12 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        user_id = str(getattr(operator, "user_id", "") or "")
+        if not self._is_approval_operator_authorized(
+            open_id,
+            user_id=user_id,
+            state=state,
+        ):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2771,6 +2846,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 choice=choice,
                 user_name=user_name,
                 open_id=open_id,
+                user_id=user_id,
                 chat_id=chat_id,
             ),
         ):
@@ -2850,6 +2926,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Pop approval state and unblock the waiting agent thread."""
@@ -2857,7 +2934,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
             return
-        if not self._is_interactive_operator_authorized(open_id):
+        if not self._is_approval_operator_authorized(
+            open_id,
+            user_id=user_id,
+            state=state,
+        ):
             logger.warning("[Feishu] Unauthorized approval click by %s for approval %s", open_id or "<unknown>", approval_id)
             return
         expected_chat_id = str(state.get("chat_id", "") or "")

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -1,5 +1,6 @@
 """Tests for Feishu interactive card approval buttons."""
 
+import asyncio
 import importlib.util
 import json
 import sys
@@ -58,6 +59,7 @@ def _make_card_action_data(
     action_value: dict,
     chat_id: str = "oc_12345",
     open_id: str = "ou_user1",
+    user_id: str = "",
     token: str = "tok_abc",
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
@@ -65,7 +67,7 @@ def _make_card_action_data(
         event=SimpleNamespace(
             token=token,
             context=SimpleNamespace(open_chat_id=chat_id),
-            operator=SimpleNamespace(open_id=open_id),
+            operator=SimpleNamespace(open_id=open_id, user_id=user_id),
             action=SimpleNamespace(
                 tag="button",
                 value=action_value,
@@ -207,6 +209,7 @@ class TestResolveApproval:
     @pytest.mark.asyncio
     async def test_resolves_once(self):
         adapter = _make_adapter()
+        adapter._allowed_group_users = {"ou_user1"}
         adapter._approval_state[1] = {
             "session_key": "agent:main:feishu:group:oc_12345",
             "message_id": "msg_001",
@@ -378,6 +381,230 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
+
+    @pytest.mark.parametrize(
+        ("open_id", "user_id", "paired_id"),
+        [
+            ("ou_paired", "", "ou_paired"),
+            ("ou_app_scoped", "tenant_paired", "tenant_paired"),
+        ],
+    )
+    def test_accepts_approval_click_from_paired_user_without_static_allowlist(
+        self,
+        _patch_callback_card_types,
+        tmp_path,
+        monkeypatch,
+        open_id,
+        user_id,
+        paired_id,
+    ):
+        from gateway.pairing import PairingStore
+        from gateway.run import GatewayRunner
+        from gateway.session import Platform
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        for name in (
+            "FEISHU_ALLOWED_USERS",
+            "FEISHU_ALLOW_ALL_USERS",
+            "GATEWAY_ALLOWED_USERS",
+            "GATEWAY_ALLOW_ALL_USERS",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        default_store = PairingStore(profile="default")
+        paired_store = PairingStore(profile="work")
+        paired_store._approve_user("feishu", paired_id, "Paired User")
+
+        runner = object.__new__(GatewayRunner)
+        runner.pairing_store = default_store
+        runner.pairing_stores = {"work": paired_store}
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._approval_state[7] = {
+            "session_key": "agent:work:feishu:dm:oc_12345",
+            "message_id": "msg-7",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 7},
+            open_id=open_id,
+            user_id=user_id,
+        )
+        adapter.set_authorization_check(
+            runner._make_adapter_auth_check(Platform.FEISHU, profile_name="work")
+        )
+        submitted = []
+
+        def _capture(coro, _loop):
+            submitted.append(coro)
+            return SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
+
+        with (
+            patch("asyncio.run_coroutine_threadsafe", side_effect=_capture),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve,
+        ):
+            response = adapter._on_card_action_trigger(data)
+            asyncio.run(submitted.pop())
+
+        assert default_store.is_approved("feishu", paired_id) is False
+        assert paired_store.is_approved("feishu", paired_id) is True
+        assert response is not None
+        assert response.card is not None
+        assert response.card.data["header"]["template"] == "green"
+        assert 7 not in adapter._approval_state
+        mock_resolve.assert_called_once_with(
+            "agent:work:feishu:dm:oc_12345", "once"
+        )
+
+    def test_rejects_approval_click_when_gateway_denies_empty_static_allowlist(
+        self, _patch_callback_card_types
+    ):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._approval_state[8] = {
+            "session_key": "agent:main:feishu:dm:oc_12345",
+            "message_id": "msg-8",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 8},
+            open_id="ou_unpaired",
+        )
+        authorization_check = MagicMock(return_value=False)
+        adapter.set_authorization_check(authorization_check)
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        authorization_check.assert_called_once_with(
+            "ou_unpaired", "dm", "oc_12345"
+        )
+
+    def test_rejects_approval_click_when_gateway_auth_check_raises(
+        self, _patch_callback_card_types
+    ):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._approval_state[9] = {
+            "session_key": "agent:main:feishu:dm:oc_12345",
+            "message_id": "msg-9",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 9},
+            open_id="ou_unknown",
+        )
+        adapter.set_authorization_check(MagicMock(side_effect=RuntimeError("boom")))
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+
+    def test_gateway_auth_rejects_non_gateway_approval_session_key(self):
+        adapter = _make_adapter()
+        authorization_check = MagicMock(return_value=True)
+        adapter.set_authorization_check(authorization_check)
+
+        assert (
+            adapter._is_approval_operator_authorized(
+                "ou_paired",
+                state={"session_key": "malformed", "chat_id": "oc_12345"},
+            )
+            is False
+        )
+        authorization_check.assert_not_called()
+
+    def test_gateway_auth_rejects_unknown_approval_chat_type(self):
+        adapter = _make_adapter()
+        authorization_check = MagicMock(return_value=True)
+        adapter.set_authorization_check(authorization_check)
+
+        assert (
+            adapter._is_approval_operator_authorized(
+                "ou_paired",
+                state={
+                    "session_key": "agent:main:feishu:p2p:oc_12345",
+                    "chat_id": "oc_12345",
+                },
+            )
+            is False
+        )
+        authorization_check.assert_not_called()
+
+    def test_paired_user_does_not_bypass_disabled_group_policy(
+        self, _patch_callback_card_types
+    ):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._group_policy = "disabled"
+        adapter._default_group_policy = "disabled"
+        adapter._approval_state[10] = {
+            "session_key": "agent:main:feishu:group:oc_group:ou_paired",
+            "message_id": "msg-10",
+            "chat_id": "oc_group",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 10},
+            chat_id="oc_group",
+            open_id="ou_paired",
+        )
+        authorization_check = MagicMock(return_value=True)
+        adapter.set_authorization_check(authorization_check)
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        authorization_check.assert_not_called()
+
+    def test_group_approval_preserves_operator_user_id_allowlist(
+        self, _patch_callback_card_types
+    ):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"on_allowed"}
+        adapter._approval_state[11] = {
+            "session_key": "agent:main:feishu:group:oc_group:on_allowed",
+            "message_id": "msg-11",
+            "chat_id": "oc_group",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 11},
+            chat_id="oc_group",
+            open_id="ou_other",
+            user_id="on_allowed",
+        )
+        submitted = []
+
+        def _capture(coro, _loop):
+            submitted.append(coro)
+            return SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
+
+        with (
+            patch("asyncio.run_coroutine_threadsafe", side_effect=_capture),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve,
+        ):
+            response = adapter._on_card_action_trigger(data)
+            asyncio.run(submitted.pop())
+
+        assert response is not None
+        assert response.card is not None
+        mock_resolve.assert_called_once_with(
+            "agent:main:feishu:group:oc_group:on_allowed", "once"
+        )
 
     def test_update_prompt_unauthorized_operator_returns_no_card(self, _patch_callback_card_types):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

- allow paired Feishu users to resolve dangerous-command approval cards in DMs
- reuse the gateway's profile-aware authorization callback instead of duplicating PairingStore access in the adapter
- preserve Feishu group-policy enforcement and fail closed when the gateway authorization check fails

## Problem

A Feishu user approved through `hermes pairing approve` can pass normal inbound gateway authorization, but clicking **Allow Once**, **Session**, **Always**, or **Deny** on a command approval card can still be rejected with:

```text
[Feishu] Unauthorized approval click by <open_id>
```

The command then remains blocked until the approval request times out. This occurs when DM pairing is the authorization grant and no static `FEISHU_ALLOWED_USERS` entry is configured.

The card-action path was applying Feishu's group-only policy gate to both group and DM approval cards, so it never consulted the gateway authorization union that already recognizes pairing.

## Fix

- extract the trusted chat type from the internally stored gateway session key (`agent:<profile>:feishu:<chat_type>:...`)
- for DM approval cards, call `BasePlatformAdapter._is_sender_authorized()`, which is backed by GatewayRunner's full authorization union and bound to the correct multiplex profile
- authorize Feishu DM card operators through both tenant-scoped `user_id` and app-scoped `open_id`, matching normal Feishu inbound identity handling and legacy pairings
- for group/forum/channel cards, continue using `_allow_group_message()` so pairing cannot bypass `group_policy`
- reject malformed, foreign-platform, and unknown chat types instead of treating them as DMs
- treat an installed authorization callback that raises as denied (fail closed)
- preserve the approval-id, same-chat, and asynchronous second-pass authorization checks
- retain the legacy fallback only for standalone adapter use where no gateway authorization callback is installed

## Security boundaries

This does **not** make card clicks globally trusted:

- unpaired DM users remain denied
- authorization lookup failures remain denied
- paired users do not bypass `group_policy=disabled` or group allowlists
- unknown or malformed approval chat types remain denied
- callback chat ID must still match the chat that received the approval card
- unknown or already-resolved approval IDs remain ignored

This complements the fail-closed approval-button hardening in #41226; it does not revert it. It is also distinct from #10256, which addresses Feishu callback-card JSON serialization (`200340`).

This PR consumes GatewayRunner's existing profile-bound authorization callback. It does not change the separate pairing-code generation or approval-storage workflow.

## Tests

```bash
pytest \
  tests/gateway/test_feishu_approval_buttons.py \
  tests/gateway/test_feishu.py \
  tests/gateway/test_pairing.py \
  tests/gateway/test_pairing_allowlist_bypass.py \
  tests/gateway/test_multiplex_pairing_stores.py \
  tests/gateway/test_feishu_bot_auth_bypass.py -q
```

Result: **327 passed**.

Additional checks:

```text
ruff check: passed
py_compile: passed
Windows footgun scan: passed (772 files)
git diff --check: passed
```

The regression coverage includes:

- real `GatewayRunner → _is_user_authorized → PairingStore` authorization against an isolated temporary `HERMES_HOME`
- paired DM operators accepted through both `open_id` and tenant-scoped `user_id` from the selected profile store without a static allowlist
- paired DM success executes the asynchronous second-pass check and calls `resolve_gateway_approval()`
- unpaired DM operator denied with an empty static allowlist
- gateway authorization exception denied
- malformed internal approval session key denied when a gateway callback is installed
- unknown normalized chat type denied before the gateway callback is consulted
- paired operator unable to bypass disabled group policy
- group approval preserves Feishu `operator.user_id` allowlist matching through the async second-pass check
