### PR TITLE
fix(update): protect tailored local commits

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -41,6 +41,18 @@ use crate::events::{BootstrapEvent, LogStream, StageInfo, StageState};
 /// hermes_cli/main.py (sys.exit(2)). We surface a targeted message for this.
 const UPDATE_EXIT_CONCURRENT: i32 = 2;
 
+/// `hermes update` exit code meaning a configured safety policy rejected the
+/// update before any destructive checkout/reset. Retrying the same request
+/// cannot make it safe and can produce misleading lock errors.
+const UPDATE_EXIT_PROTECTED: i32 = 3;
+
+fn update_needs_retry(exit_code: Option<i32>) -> bool {
+    !matches!(
+        exit_code,
+        Some(0) | Some(UPDATE_EXIT_CONCURRENT) | Some(UPDATE_EXIT_PROTECTED)
+    )
+}
+
 /// How long to wait for the old desktop process to release files under the
 /// install tree before giving up and letting `hermes update`'s own guard decide.
 const DESKTOP_EXIT_WAIT: Duration = Duration::from_secs(20);
@@ -267,7 +279,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
     // stare at a scary crash first), retry once automatically. Skip the retry
     // for the concurrent-instance guard (exit 2) — that's a "close Hermes" state
     // a retry can't fix.
-    if !matches!(update.exit_code, Some(0) | Some(UPDATE_EXIT_CONCURRENT)) {
+    if update_needs_retry(update.exit_code) {
         emit_log(
             &app,
             Some("update"),
@@ -294,6 +306,26 @@ async fn run_update(app: AppHandle) -> Result<()> {
         Some(code) if code == UPDATE_EXIT_CONCURRENT => {
             let msg = "Hermes is still running. Close all Hermes windows and try \
                        the update again."
+                .to_string();
+            emit_stage(
+                &app,
+                "update",
+                StageState::Failed,
+                Some(update_ms),
+                Some(msg.clone()),
+            );
+            emit(
+                &app,
+                BootstrapEvent::Failed {
+                    stage: Some("update".into()),
+                    error: msg.clone(),
+                },
+            );
+            return Err(anyhow!(msg));
+        }
+        Some(code) if code == UPDATE_EXIT_PROTECTED => {
+            let msg = "Update blocked to preserve reviewed local deployment commits. \
+                       Publish or manually integrate those commits before updating."
                 .to_string();
             emit_stage(
                 &app,
@@ -1173,6 +1205,21 @@ mod tests {
             with_install.len(),
             base.len() + 1,
             "include_install adds exactly one stage"
+        );
+    }
+
+    #[test]
+    fn update_retries_only_for_transient_failures() {
+        assert!(!update_needs_retry(Some(0)), "success must not retry");
+        assert!(update_needs_retry(Some(1)), "ordinary failure retries once");
+        assert!(update_needs_retry(None), "a killed update retries once");
+        assert!(
+            !update_needs_retry(Some(UPDATE_EXIT_CONCURRENT)),
+            "concurrent-process rejection is terminal"
+        );
+        assert!(
+            !update_needs_retry(Some(UPDATE_EXIT_PROTECTED)),
+            "local-commit protection rejection is terminal"
         );
     }
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3191,6 +3191,13 @@ DEFAULT_CONFIG = {
         #               ignored paths — node_modules, venv, build outputs —
         #               are never touched.
         "non_interactive_local_changes": "stash",
+        # Refuse git-based updates when the current checkout contains commits
+        # that are not reachable from the selected origin branch. This is off
+        # by default for backward compatibility with managed installs that
+        # intentionally mirror origin after divergence. Enable it on tailored
+        # deployments where resetting local integration commits would remove
+        # reviewed runtime behavior.
+        "protect_local_commits": False,
         # Refresh an already-installed cua-driver during `hermes update`.
         # The refresh is best-effort and macOS-only. Turn this off if the
         # upstream installer is not appropriate for the machine, for example

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10124,12 +10124,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
 
         def _restore_protected_checkout(
-            *, restore_stash: bool = True, prompt_user: bool = False
+            *,
+            restore_stash: bool = True,
+            prompt_user: bool = False,
+            allow_updated_target: bool = False,
         ) -> bool:
             """Restore the exact caller checkout before a protected-mode abort."""
             nonlocal auto_stash_ref
 
-            if current_branch == "HEAD":
+            if allow_updated_target and current_branch == branch:
+                # A successful pull/upstream sync is the expected movement of
+                # the update target. Keep that branch attached at its new tip.
+                checkout_args = ["checkout", current_branch]
+            elif current_branch == "HEAD":
                 checkout_args = ["checkout", "--detach", original_head_sha]
             else:
                 original_branch_ref = subprocess.run(
@@ -10253,7 +10260,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     _discard_stashed_changes(git_cmd, PROJECT_ROOT, auto_stash_ref)
                     auto_stash_ref = None
                 else:
-                    _restore_protected_checkout(prompt_user=prompt_for_restore)
+                    _restore_protected_checkout(
+                        prompt_user=prompt_for_restore,
+                        allow_updated_target=True,
+                    )
             else:
                 if current_branch == "HEAD":
                     subprocess.run(
@@ -10484,30 +10494,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
             update_succeeded = True
         finally:
-            if update_succeeded and protect_local_commits:
-                # Successful protected updates must return to the exact caller
-                # checkout before applying staged/unstaged changes. Otherwise a
-                # custom-branch stash is consumed on the update target branch.
-                if discard_local_changes and auto_stash_ref is not None:
-                    _restore_protected_checkout(restore_stash=False)
-                    _discard_stashed_changes(git_cmd, PROJECT_ROOT, auto_stash_ref)
-                    auto_stash_ref = None
-                else:
-                    restored = _restore_protected_checkout(
-                        prompt_user=prompt_for_restore
-                    )
-                    if not restored and auto_stash_ref is not None:
-                        print(
-                            f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
-                        )
-            elif auto_stash_ref is not None:
+            if auto_stash_ref is not None:
                 # Don't attempt stash restore if the code update itself failed —
                 # working tree is in an unknown state.
                 if not update_succeeded:
                     print(
                         f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
                     )
-                    print("  Restore manually with: git stash apply")
+                    print("  Restore manually with: git stash apply --index")
+                elif protect_local_commits:
+                    # Defer protected success restoration until all dependency,
+                    # build, and gateway-restart work finishes on the updated tree.
+                    pass
                 elif discard_local_changes:
                     # Non-interactive update + user opted into discarding local
                     # source edits (updates.non_interactive_local_changes:
@@ -11715,6 +11713,28 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("    Node.js dependency refresh did not complete.")
         else:
             _kill_stale_dashboard_processes()
+
+        if protect_local_commits:
+            # Keep the updated target checked out through dependency install,
+            # builds, and gateway restarts. Only now return to a custom caller
+            # branch/detached SHA and replay its exact index/worktree state.
+            if discard_local_changes and auto_stash_ref is not None:
+                restored = _restore_protected_checkout(
+                    restore_stash=False,
+                    allow_updated_target=True,
+                )
+                if restored:
+                    _discard_stashed_changes(git_cmd, PROJECT_ROOT, auto_stash_ref)
+                    auto_stash_ref = None
+            else:
+                restored = _restore_protected_checkout(
+                    prompt_user=prompt_for_restore,
+                    allow_updated_target=True,
+                )
+            if not restored and auto_stash_ref is not None:
+                print(
+                    f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
+                )
 
         print()
         print("Tip: You can now select a provider and model:")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10123,7 +10123,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
         else:
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
 
-        def _restore_protected_checkout(*, restore_stash: bool = True) -> bool:
+        def _restore_protected_checkout(
+            *, restore_stash: bool = True, prompt_user: bool = False
+        ) -> bool:
             """Restore the exact caller checkout before a protected-mode abort."""
             nonlocal auto_stash_ref
 
@@ -10171,7 +10173,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     git_cmd,
                     PROJECT_ROOT,
                     auto_stash_ref,
-                    prompt_user=False,
+                    prompt_user=prompt_user,
                     input_fn=gw_input_fn,
                 ):
                     return False
@@ -10243,23 +10245,44 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if is_fork and branch == "main":
                 _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
 
-            # Restore stash and switch back to original branch if we moved
-            if auto_stash_ref is not None:
-                _restore_stashed_changes(
-                    git_cmd,
-                    PROJECT_ROOT,
-                    auto_stash_ref,
-                    prompt_user=prompt_for_restore,
-                    input_fn=gw_input_fn,
-                )
-            if current_branch not in {branch, "HEAD"}:
-                subprocess.run(
-                    git_cmd + ["checkout", current_branch],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
+            # Restore the exact original checkout before applying its stash.
+            # Applying first can strand custom-branch edits on the update target.
+            if protect_local_commits:
+                if discard_local_changes and auto_stash_ref is not None:
+                    _restore_protected_checkout(restore_stash=False)
+                    _discard_stashed_changes(git_cmd, PROJECT_ROOT, auto_stash_ref)
+                    auto_stash_ref = None
+                else:
+                    _restore_protected_checkout(prompt_user=prompt_for_restore)
+            else:
+                if current_branch == "HEAD":
+                    subprocess.run(
+                        git_cmd + ["checkout", "--detach", original_head_sha],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                elif current_branch != branch:
+                    subprocess.run(
+                        git_cmd + ["checkout", current_branch],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                if auto_stash_ref is not None:
+                    if discard_local_changes:
+                        _discard_stashed_changes(git_cmd, PROJECT_ROOT, auto_stash_ref)
+                    else:
+                        _restore_stashed_changes(
+                            git_cmd,
+                            PROJECT_ROOT,
+                            auto_stash_ref,
+                            prompt_user=prompt_for_restore,
+                            input_fn=gw_input_fn,
+                        )
+                    auto_stash_ref = None
 
             # A current checkout does NOT imply a healthy install: a previous
             # dependency sync may have failed partway (classic on Windows,
@@ -10461,7 +10484,23 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
             update_succeeded = True
         finally:
-            if auto_stash_ref is not None:
+            if update_succeeded and protect_local_commits:
+                # Successful protected updates must return to the exact caller
+                # checkout before applying staged/unstaged changes. Otherwise a
+                # custom-branch stash is consumed on the update target branch.
+                if discard_local_changes and auto_stash_ref is not None:
+                    _restore_protected_checkout(restore_stash=False)
+                    _discard_stashed_changes(git_cmd, PROJECT_ROOT, auto_stash_ref)
+                    auto_stash_ref = None
+                else:
+                    restored = _restore_protected_checkout(
+                        prompt_user=prompt_for_restore
+                    )
+                    if not restored and auto_stash_ref is not None:
+                        print(
+                            f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
+                        )
+            elif auto_stash_ref is not None:
                 # Don't attempt stash restore if the code update itself failed —
                 # working tree is in an unknown state.
                 if not update_succeeded:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9790,18 +9790,23 @@ def _cmd_update_impl(args, gateway_mode: bool):
         or not (sys.stdin.isatty() and sys.stdout.isatty())
     )
     discard_local_changes = False
-    if _non_interactive_update:
-        try:
-            from hermes_cli.config import load_config
+    protect_local_commits = False
+    try:
+        from hermes_cli.config import load_config
 
-            _update_cfg = (load_config() or {}).get("updates", {})
-            if isinstance(_update_cfg, dict):
-                _mode = str(_update_cfg.get("non_interactive_local_changes", "stash")).lower()
+        _update_cfg = (load_config() or {}).get("updates", {})
+        if isinstance(_update_cfg, dict):
+            protect_local_commits = _update_cfg.get("protect_local_commits") is True
+            if _non_interactive_update:
+                _mode = str(
+                    _update_cfg.get("non_interactive_local_changes", "stash")
+                ).lower()
                 discard_local_changes = _mode == "discard"
-        except Exception as exc:
-            # Never let a config read failure change the safe default.
-            logger.debug("Could not read updates.non_interactive_local_changes: %s", exc)
-            discard_local_changes = False
+    except Exception as exc:
+        # Never let a config read failure opt into destructive behavior.
+        logger.debug("Could not read update safety configuration: %s", exc)
+        discard_local_changes = False
+        protect_local_commits = False
 
     print("⚕ Updating Hermes Agent...")
     print()
@@ -9961,6 +9966,42 @@ def _cmd_update_impl(args, gateway_mode: bool):
             check=True,
         )
         current_branch = result.stdout.strip()
+
+        if protect_local_commits:
+            local_commit_result = subprocess.run(
+                git_cmd + ["rev-list", "--count", f"origin/{branch}..HEAD"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            try:
+                local_commit_count = (
+                    int(local_commit_result.stdout.strip())
+                    if local_commit_result.returncode == 0
+                    else None
+                )
+            except ValueError:
+                local_commit_count = None
+
+            if local_commit_count is None or local_commit_count > 0:
+                print()
+                print("✗ Update blocked: this checkout contains protected local commits.")
+                if local_commit_count is not None:
+                    print(
+                        f"  {local_commit_count} commit(s) from HEAD are not contained in "
+                        f"origin/{branch}."
+                    )
+                else:
+                    print(
+                        f"  Hermes could not prove that HEAD is contained in origin/{branch}."
+                    )
+                print("  Updating could reset reviewed local deployment changes.")
+                print(
+                    "  Review and publish/integrate those commits first, or explicitly set "
+                    "updates.protect_local_commits to false."
+                )
+                _resume_windows_gateways_after_update(_windows_gateway_resume)
+                sys.exit(1)
 
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9950,6 +9950,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         return
 
     # Fetch and pull
+    protected_checkout_finalized = False
     try:
 
         # Resolve the target branch up front so the fetch can be scoped to it.
@@ -10245,12 +10246,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
         )
         commit_count = int(result.stdout.strip())
 
+        # A fork can be current against origin yet behind upstream. Detect a
+        # successful upstream fast-forward by SHA movement and route it through
+        # the full dependency/build/restart lifecycle rather than the no-op exit.
+        if commit_count == 0 and is_fork and branch == "main":
+            before_upstream_sync = _capture_head_sha(git_cmd, PROJECT_ROOT)
+            _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
+            after_upstream_sync = _capture_head_sha(git_cmd, PROJECT_ROOT)
+            if (
+                before_upstream_sync
+                and after_upstream_sync
+                and after_upstream_sync != before_upstream_sync
+            ):
+                commit_count = 1
+
         if commit_count == 0:
             _invalidate_update_cache()
-
-            # Even if origin is up to date, the fork may be behind upstream
-            if is_fork and branch == "main":
-                _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
 
             # Restore the exact original checkout before applying its stash.
             # Applying first can strand custom-branch edits on the update target.
@@ -10293,6 +10304,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             input_fn=gw_input_fn,
                         )
                     auto_stash_ref = None
+
+            if protect_local_commits:
+                protected_checkout_finalized = True
 
             # A current checkout does NOT imply a healthy install: a previous
             # dependency sync may have failed partway (classic on Windows,
@@ -10454,6 +10468,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     restored = _restore_protected_checkout(
                         restore_stash=rollback_tree_ok
                     )
+                    # This rollback path has made its one safe restoration
+                    # attempt. Never let the outer failure cleanup replay a
+                    # stash when the rollback tree could not be verified.
+                    protected_checkout_finalized = True
                     print()
                     if (
                         rollback_ref.returncode == 0
@@ -11735,6 +11753,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print(
                     f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
                 )
+            protected_checkout_finalized = True
 
         print()
         print("Tip: You can now select a provider and model:")
@@ -11754,6 +11773,34 @@ def _cmd_update_impl(args, gateway_mode: bool):
             else:
                 print(f"✗ Update failed: {e}")
             sys.exit(3 if protect_local_commits else 1)
+    finally:
+        if (
+            protect_local_commits
+            and not protected_checkout_finalized
+            and "_restore_protected_checkout" in locals()
+        ):
+            # Any failure after a successful pull (dependency install, build,
+            # migration, restart, etc.) must still return a custom/detached
+            # caller to its checkout and preserve/replay its local changes.
+            try:
+                restored = _restore_protected_checkout(
+                    prompt_user=False,
+                    allow_updated_target=True,
+                )
+                if not restored and auto_stash_ref is not None:
+                    print(
+                        f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
+                    )
+            except Exception as restore_exc:
+                logger.debug(
+                    "Protected checkout restoration after update failure failed: %s",
+                    restore_exc,
+                )
+                if auto_stash_ref is not None:
+                    print(
+                        f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
+                    )
+            protected_checkout_finalized = True
 
 
 def _coalesce_session_name_args(argv: list) -> list:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10402,9 +10402,27 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         text=True,
                         check=False,
                     )
+                    rollback_tree = None
+                    if rollback_ref.returncode == 0:
+                        # The CAS above proves the target ref still points at the
+                        # commit installed by this pull. Local changes were
+                        # stashed before checkout, so it is now safe and necessary
+                        # to restore the index/worktree as well as the branch ref.
+                        rollback_tree = subprocess.run(
+                            git_cmd + ["reset", "--hard", pre_pull_sha],
+                            cwd=PROJECT_ROOT,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                        )
                     restored = _restore_protected_checkout()
                     print()
-                    if rollback_ref.returncode == 0 and restored:
+                    if (
+                        rollback_ref.returncode == 0
+                        and rollback_tree is not None
+                        and rollback_tree.returncode == 0
+                        and restored
+                    ):
                         print(
                             "  Protected rollback restored the target ref and original checkout."
                         )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9822,7 +9822,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
         if _config_path.exists():
             try:
                 with open(_config_path, encoding="utf-8") as _config_file:
-                    _raw_config = fast_safe_load(_config_file) or {}
+                    _raw_config = fast_safe_load(_config_file)
+                if _raw_config is None:
+                    _raw_config = {}
                 if not isinstance(_raw_config, dict):
                     raise ValueError("config root must be a mapping")
                 _raw_updates = _raw_config.get("updates", {})
@@ -9904,6 +9906,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
     git_dir = PROJECT_ROOT / ".git"
 
     if not git_dir.exists():
+        if protect_local_commits:
+            print("✗ Update blocked: git metadata is unavailable.")
+            print(
+                "  Hermes cannot prove that reviewed local deployment commits are preserved."
+            )
+            _resume_windows_gateways_after_update(_windows_gateway_resume)
+            sys.exit(3)
         if sys.platform == "win32":
             use_zip_update = True
         else:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9927,23 +9927,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             sys.exit(1)
 
-    # On Windows, git can fail with "unable to write loose object file: Invalid argument"
-    # due to filesystem atomicity issues. Set the recommended workaround.
-    if sys.platform == "win32" and git_dir.exists():
-        subprocess.run(
-            [
-                "git",
-                "-c",
-                "windows.appendAtomically=false",
-                "config",
-                "windows.appendAtomically",
-                "false",
-            ],
-            cwd=PROJECT_ROOT,
-            check=False,
-            capture_output=True,
-        )
-
     # Build git command once — reused for fork detection and the update itself.
     git_cmd = ["git"]
     if sys.platform == "win32":
@@ -9998,7 +9981,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print("✗ Failed to fetch updates from origin.")
                 if stderr:
                     print(f"  {stderr.splitlines()[0]}")
-            sys.exit(1)
+            # Under protected mode, any inability to refresh/prove git refs is
+            # a terminal policy rejection, not a retryable generic failure.
+            sys.exit(3 if protect_local_commits else 1)
 
         # Get current branch (returns literal "HEAD" when detached)
         result = subprocess.run(
@@ -10078,6 +10063,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _resume_windows_gateways_after_update(_windows_gateway_resume)
                 # Exit 3 is the staged Desktop updater's terminal policy-rejection code.
                 sys.exit(3)
+
+        # Persist the Windows atomic-append workaround only after the protected
+        # commit proof. The inline ``-c`` on git_cmd is sufficient for fetch and
+        # proof, so a policy rejection need not mutate repository configuration.
+        if sys.platform == "win32":
+            subprocess.run(
+                git_cmd + ["config", "windows.appendAtomically", "false"],
+                cwd=PROJECT_ROOT,
+                check=False,
+                capture_output=True,
+            )
 
         # Discard npm lockfile churn only after the protected-commit proof.
         # npm rewrites tracked package-lock.json files non-deterministically at

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9995,8 +9995,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         )
         current_branch = result.stdout.strip()
         original_head_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
-        if protect_local_commits and current_branch == "HEAD" and not original_head_sha:
-            print("✗ Update blocked: detached HEAD could not be captured for restoration.")
+        if protect_local_commits and not original_head_sha:
+            print("✗ Update blocked: original HEAD could not be captured for restoration.")
             _resume_windows_gateways_after_update(_windows_gateway_resume)
             sys.exit(3)
 
@@ -10130,7 +10130,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if current_branch == "HEAD":
                 checkout_args = ["checkout", "--detach", original_head_sha]
             else:
-                checkout_args = ["checkout", current_branch]
+                original_branch_ref = subprocess.run(
+                    git_cmd + ["rev-parse", f"refs/heads/{current_branch}"],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                branch_still_exact = (
+                    original_branch_ref.returncode == 0
+                    and original_branch_ref.stdout.strip() == original_head_sha
+                )
+                checkout_args = (
+                    ["checkout", current_branch]
+                    if branch_still_exact
+                    else ["checkout", "--detach", original_head_sha]
+                )
             restore_checkout = subprocess.run(
                 git_cmd + checkout_args,
                 cwd=PROJECT_ROOT,
@@ -10372,7 +10387,34 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     # ~6 lines so the user sees the actual SyntaxError text.
                     for line in str(syntax_error).splitlines()[:6]:
                         print(f"    {line}")
-                if pre_pull_sha and not protect_local_commits:
+                if pre_pull_sha and protect_local_commits:
+                    post_pull_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
+                    rollback_ref = subprocess.run(
+                        git_cmd
+                        + [
+                            "update-ref",
+                            f"refs/heads/{branch}",
+                            pre_pull_sha,
+                            post_pull_sha or "",
+                        ],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    restored = _restore_protected_checkout()
+                    print()
+                    if rollback_ref.returncode == 0 and restored:
+                        print(
+                            "  Protected rollback restored the target ref and original checkout."
+                        )
+                    else:
+                        print(
+                            "  Protected rollback could not restore all state automatically; "
+                            "the stash was preserved."
+                        )
+                    sys.exit(3)
+                if pre_pull_sha:
                     print()
                     print(f"→ Rolling back to {pre_pull_sha[:10]}...")
                     rollback_result = subprocess.run(
@@ -10393,10 +10435,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print()
                     print("  Could not capture pre-pull SHA — recover manually with:")
                     print(f"    cd {PROJECT_ROOT} && git reflog && git reset --hard <prev-sha>")
-                else:
-                    print()
-                    print("  Automatic rollback is disabled while local commits are protected.")
-                    print(f"  Review the update and recover manually from {pre_pull_sha} if needed.")
                 sys.exit(3 if protect_local_commits else 1)
 
             update_succeeded = True

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10064,23 +10064,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # Exit 3 is the staged Desktop updater's terminal policy-rejection code.
                 sys.exit(3)
 
-        # Persist the Windows atomic-append workaround only after the protected
-        # commit proof. The inline ``-c`` on git_cmd is sufficient for fetch and
-        # proof, so a policy rejection need not mutate repository configuration.
-        if sys.platform == "win32":
-            subprocess.run(
-                git_cmd + ["config", "windows.appendAtomically", "false"],
-                cwd=PROJECT_ROOT,
-                check=False,
-                capture_output=True,
-            )
-
-        # Discard npm lockfile churn only after the protected-commit proof.
-        # npm rewrites tracked package-lock.json files non-deterministically at
-        # install/build time, but a blocked tailored deployment must not mutate
-        # even this generated file before reporting the policy rejection.
-        _discard_lockfile_churn(git_cmd, PROJECT_ROOT)
-
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical
         # "always update against main" behavior; for any other target it's
@@ -10134,6 +10117,61 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     sys.exit(1)
         else:
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
+
+        if protect_local_commits:
+            # Re-prove the checked-out target immediately after branch
+            # transition. A different process may have advanced the target ref
+            # after the initial preflight; protected mode must detect that before
+            # generated-file cleanup, pull, or any reset-capable path. Restore the
+            # caller's branch/stash before returning the terminal policy result.
+            target_recheck = subprocess.run(
+                git_cmd + ["rev-list", "--count", f"origin/{branch}..HEAD"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            try:
+                target_local_count = (
+                    int(target_recheck.stdout.strip())
+                    if target_recheck.returncode == 0
+                    else None
+                )
+            except ValueError:
+                target_local_count = None
+            if target_local_count is None or target_local_count > 0:
+                if current_branch not in {branch, "HEAD"}:
+                    subprocess.run(
+                        git_cmd + ["checkout", current_branch],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                if auto_stash_ref is not None:
+                    _restore_stashed_changes(
+                        git_cmd,
+                        PROJECT_ROOT,
+                        auto_stash_ref,
+                        prompt_user=False,
+                        input_fn=gw_input_fn,
+                    )
+                print("✗ Update blocked: target branch changed during protected preflight.")
+                print(f"  Refusing to update or reset branch '{branch}'.")
+                _resume_windows_gateways_after_update(_windows_gateway_resume)
+                sys.exit(3)
+
+        # Persist the Windows atomic-append workaround only after both protected
+        # proofs. The inline ``-c`` on git_cmd is sufficient for those reads.
+        if sys.platform == "win32":
+            subprocess.run(
+                git_cmd + ["config", "windows.appendAtomically", "false"],
+                cwd=PROJECT_ROOT,
+                check=False,
+                capture_output=True,
+            )
+
+        # Discard npm lockfile churn only after both protected-commit proofs.
+        _discard_lockfile_churn(git_cmd, PROJECT_ROOT)
 
         prompt_for_restore = (
             auto_stash_ref is not None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9848,7 +9848,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print("✗ Update blocked: update safety configuration is invalid or unreadable.")
         print(f"  {update_safety_config_error}")
         print("  Fix config.yaml before retrying the update.")
-        sys.exit(1)
+        # Exit 3 is the staged Desktop updater's terminal policy-rejection code.
+        sys.exit(3)
 
     print("⚕ Updating Hermes Agent...")
     print()
@@ -10075,7 +10076,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     "updates.protect_local_commits to false."
                 )
                 _resume_windows_gateways_after_update(_windows_gateway_resume)
-                sys.exit(1)
+                # Exit 3 is the staged Desktop updater's terminal policy-rejection code.
+                sys.exit(3)
 
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical
@@ -10102,8 +10104,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # it up as a tracking branch of origin/<branch>. This is
                 # the common case when the requested branch exists upstream
                 # but was never checked out locally.
+                checkout_args = (
+                    ["checkout", "--track", "-b", branch, f"origin/{branch}"]
+                    if protect_local_commits
+                    else ["checkout", "-B", branch, f"origin/{branch}"]
+                )
                 track_result = subprocess.run(
-                    git_cmd + ["checkout", "-B", branch, f"origin/{branch}"],
+                    git_cmd + checkout_args,
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True,
@@ -10238,6 +10245,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True,
             )
             if pull_result.returncode != 0:
+                if protect_local_commits:
+                    print(
+                        "✗ Fast-forward update is not possible while local commits are protected."
+                    )
+                    print(
+                        f"  Refusing to reset branch '{branch}' to origin/{branch}. "
+                        "Review and integrate the divergence manually."
+                    )
+                    _resume_windows_gateways_after_update(_windows_gateway_resume)
+                    # Exit 3 prevents Desktop from retrying a policy rejection.
+                    sys.exit(3)
                 # ff-only failed — local and remote have diverged (e.g. upstream
                 # force-pushed or rebase).  Since local changes are already
                 # stashed, reset to match the remote exactly.
@@ -10277,7 +10295,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     # ~6 lines so the user sees the actual SyntaxError text.
                     for line in str(syntax_error).splitlines()[:6]:
                         print(f"    {line}")
-                if pre_pull_sha:
+                if pre_pull_sha and not protect_local_commits:
                     print()
                     print(f"→ Rolling back to {pre_pull_sha[:10]}...")
                     rollback_result = subprocess.run(
@@ -10294,11 +10312,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         print(f"    cd {PROJECT_ROOT} && git reset --hard {pre_pull_sha}")
                         if rollback_result.stderr.strip():
                             print(f"    ({rollback_result.stderr.strip().splitlines()[0]})")
-                else:
+                elif not pre_pull_sha:
                     print()
                     print("  Could not capture pre-pull SHA — recover manually with:")
                     print(f"    cd {PROJECT_ROOT} && git reflog && git reset --hard <prev-sha>")
-                sys.exit(1)
+                else:
+                    print()
+                    print("  Automatic rollback is disabled while local commits are protected.")
+                    print(f"  Review the update and recover manually from {pre_pull_sha} if needed.")
+                sys.exit(3 if protect_local_commits else 1)
 
             update_succeeded = True
         finally:
@@ -11535,7 +11557,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _resume_windows_gateways_after_update(_windows_gateway_resume)
             else:
                 print(f"✗ Update failed: {e}")
-            sys.exit(1)
+            sys.exit(3 if protect_local_commits else 1)
 
 
 def _coalesce_session_name_args(argv: list) -> list:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9791,22 +9791,64 @@ def _cmd_update_impl(args, gateway_mode: bool):
     )
     discard_local_changes = False
     protect_local_commits = False
+    update_safety_config_error = None
     try:
-        from hermes_cli.config import load_config
+        from hermes_cli.config import fast_safe_load, get_config_path, load_config
 
         _update_cfg = (load_config() or {}).get("updates", {})
         if isinstance(_update_cfg, dict):
-            protect_local_commits = _update_cfg.get("protect_local_commits") is True
+            _protect_value = _update_cfg.get("protect_local_commits", False)
+            if not isinstance(_protect_value, bool):
+                update_safety_config_error = (
+                    "updates.protect_local_commits must be true or false, not "
+                    f"{type(_protect_value).__name__}"
+                )
+            else:
+                protect_local_commits = _protect_value
             if _non_interactive_update:
                 _mode = str(
                     _update_cfg.get("non_interactive_local_changes", "stash")
                 ).lower()
                 discard_local_changes = _mode == "discard"
+        else:
+            update_safety_config_error = "the updates section must be a mapping"
+
+        # ``load_config`` deliberately falls back to defaults in a fresh process
+        # when YAML is malformed. That is appropriate for ordinary settings but
+        # not for a guard whose job is to prevent destructive resets. Parse the
+        # user file strictly enough to distinguish "unset" from "unreadable" and
+        # reject a mistyped raw value even if a merged/default value looks safe.
+        _config_path = get_config_path()
+        if _config_path.exists():
+            try:
+                with open(_config_path, encoding="utf-8") as _config_file:
+                    _raw_config = fast_safe_load(_config_file) or {}
+                if not isinstance(_raw_config, dict):
+                    raise ValueError("config root must be a mapping")
+                _raw_updates = _raw_config.get("updates", {})
+                if not isinstance(_raw_updates, dict):
+                    raise ValueError("updates section must be a mapping")
+                if "protect_local_commits" in _raw_updates and not isinstance(
+                    _raw_updates["protect_local_commits"], bool
+                ):
+                    raise ValueError(
+                        "updates.protect_local_commits must be true or false"
+                    )
+            except Exception as exc:
+                update_safety_config_error = str(exc)
     except Exception as exc:
-        # Never let a config read failure opt into destructive behavior.
+        # A safety-policy read failure must not silently enable destructive
+        # checkout/reset behavior.
         logger.debug("Could not read update safety configuration: %s", exc)
         discard_local_changes = False
         protect_local_commits = False
+        update_safety_config_error = str(exc)
+
+    if update_safety_config_error:
+        print("✗ Update blocked: update safety configuration is invalid or unreadable.")
+        print(f"  {update_safety_config_error}")
+        print("  Fix config.yaml before retrying the update.")
+        sys.exit(1)
 
     print("⚕ Updating Hermes Agent...")
     print()
@@ -9968,20 +10010,52 @@ def _cmd_update_impl(args, gateway_mode: bool):
         current_branch = result.stdout.strip()
 
         if protect_local_commits:
-            local_commit_result = subprocess.run(
-                git_cmd + ["rev-list", "--count", f"origin/{branch}..HEAD"],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True,
-            )
-            try:
-                local_commit_count = (
-                    int(local_commit_result.stdout.strip())
-                    if local_commit_result.returncode == 0
-                    else None
+            protected_revisions = [("HEAD", "HEAD")]
+            local_commit_count = 0
+
+            # Starting from a different branch/detached HEAD can otherwise hide
+            # local commits on the target branch: HEAD may be contained in the
+            # remote while checkout + reset would still discard the target ref.
+            if current_branch != branch:
+                target_ref_result = subprocess.run(
+                    git_cmd
+                    + ["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
                 )
-            except ValueError:
-                local_commit_count = None
+                if target_ref_result.returncode == 0:
+                    protected_revisions.append(
+                        (f"local branch {branch}", f"refs/heads/{branch}")
+                    )
+                elif target_ref_result.returncode != 1:
+                    local_commit_count = None
+
+            if local_commit_count is not None:
+                for _label, _revision in protected_revisions:
+                    local_commit_result = subprocess.run(
+                        git_cmd
+                        + [
+                            "rev-list",
+                            "--count",
+                            f"origin/{branch}..{_revision}",
+                        ],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    try:
+                        _count = (
+                            int(local_commit_result.stdout.strip())
+                            if local_commit_result.returncode == 0
+                            else None
+                        )
+                    except ValueError:
+                        _count = None
+                    if _count is None:
+                        local_commit_count = None
+                        break
+                    local_commit_count += _count
 
             if local_commit_count is None or local_commit_count > 0:
                 print()
@@ -11449,13 +11523,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print("  hermes model              # Select provider and model")
 
     except subprocess.CalledProcessError as e:
-        if sys.platform == "win32":
+        if sys.platform == "win32" and not protect_local_commits:
             print(f"⚠ Git update failed: {e}")
             print("→ Falling back to ZIP download...")
             print()
             _update_via_zip(args)
         else:
-            print(f"✗ Update failed: {e}")
+            if sys.platform == "win32" and protect_local_commits:
+                print("✗ Protected update failed before local commits could be preserved.")
+                print("  ZIP fallback is disabled while updates.protect_local_commits is true.")
+                _resume_windows_gateways_after_update(_windows_gateway_resume)
+            else:
+                print(f"✗ Update failed: {e}")
             sys.exit(1)
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6629,12 +6629,12 @@ def _restore_stashed_changes(
         if response not in {"", "y", "yes"}:
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")
-            print(f"Restore manually with: git stash apply {stash_ref}")
+            print(f"Restore manually with: git stash apply --index {stash_ref}")
             return False
 
     print("→ Restoring local changes...")
     restore = subprocess.run(
-        git_cmd + ["stash", "apply", stash_ref],
+        git_cmd + ["stash", "apply", "--index", stash_ref],
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -6675,7 +6675,7 @@ def _restore_stashed_changes(
             capture_output=True,
         )
         print("Working tree reset to clean state.")
-        print(f"Restore your changes later with: git stash apply {stash_ref}")
+        print(f"Restore your changes later with: git stash apply --index {stash_ref}")
         # Don't sys.exit — the code update itself succeeded, only the stash
         # restore had conflicts.  Let cmd_update continue with pip install,
         # skill sync, and gateway restart.
@@ -10123,7 +10123,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         else:
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
 
-        def _restore_protected_checkout() -> bool:
+        def _restore_protected_checkout(*, restore_stash: bool = True) -> bool:
             """Restore the exact caller checkout before a protected-mode abort."""
             nonlocal auto_stash_ref
 
@@ -10166,7 +10166,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 )
             if restore_checkout.returncode != 0:
                 return False
-            if auto_stash_ref is not None:
+            if restore_stash and auto_stash_ref is not None:
                 if not _restore_stashed_changes(
                     git_cmd,
                     PROJECT_ROOT,
@@ -10415,12 +10415,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             text=True,
                             check=False,
                         )
-                    restored = _restore_protected_checkout()
+                    rollback_tree_ok = (
+                        rollback_tree is not None and rollback_tree.returncode == 0
+                    )
+                    restored = _restore_protected_checkout(
+                        restore_stash=rollback_tree_ok
+                    )
                     print()
                     if (
                         rollback_ref.returncode == 0
-                        and rollback_tree is not None
-                        and rollback_tree.returncode == 0
+                        and rollback_tree_ok
                         and restored
                     ):
                         print(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9949,15 +9949,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
     if sys.platform == "win32":
         git_cmd = ["git", "-c", "windows.appendAtomically=false"]
 
-    # Discard npm lockfile churn before any stash/branch logic. npm rewrites
-    # tracked package-lock.json files non-deterministically at install/build
-    # time (platform-specific optional deps, ideallyInert annotations, etc.),
-    # which is never an intentional edit on a managed install but leaves the
-    # tree dirty — forcing an autostash on every update and making branch
-    # switches fragile. Restoring them first lets the common case (only
-    # lockfile churn) update with a clean tree.
-    _discard_lockfile_churn(git_cmd, PROJECT_ROOT)
-
     # Detect if we're updating from a fork (before any branch logic)
     origin_url = _get_origin_url(git_cmd, PROJECT_ROOT)
     is_fork = _is_fork(origin_url)
@@ -10087,6 +10078,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _resume_windows_gateways_after_update(_windows_gateway_resume)
                 # Exit 3 is the staged Desktop updater's terminal policy-rejection code.
                 sys.exit(3)
+
+        # Discard npm lockfile churn only after the protected-commit proof.
+        # npm rewrites tracked package-lock.json files non-deterministically at
+        # install/build time, but a blocked tailored deployment must not mutate
+        # even this generated file before reporting the policy rejection.
+        _discard_lockfile_churn(git_cmd, PROJECT_ROOT)
 
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9994,6 +9994,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             check=True,
         )
         current_branch = result.stdout.strip()
+        original_head_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
+        if protect_local_commits and current_branch == "HEAD" and not original_head_sha:
+            print("✗ Update blocked: detached HEAD could not be captured for restoration.")
+            _resume_windows_gateways_after_update(_windows_gateway_resume)
+            sys.exit(3)
 
         if protect_local_commits:
             protected_revisions = [("HEAD", "HEAD")]
@@ -10118,6 +10123,46 @@ def _cmd_update_impl(args, gateway_mode: bool):
         else:
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
 
+        def _restore_protected_checkout() -> bool:
+            """Restore the exact caller checkout before a protected-mode abort."""
+            nonlocal auto_stash_ref
+
+            if current_branch == "HEAD":
+                checkout_args = ["checkout", "--detach", original_head_sha]
+            else:
+                checkout_args = ["checkout", current_branch]
+            restore_checkout = subprocess.run(
+                git_cmd + checkout_args,
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if restore_checkout.returncode != 0 and original_head_sha:
+                # The original branch may have moved or been deleted during the
+                # race. Detaching at its captured SHA still preserves the exact
+                # caller tree and avoids applying a stash on the wrong branch.
+                restore_checkout = subprocess.run(
+                    git_cmd + ["checkout", "--detach", original_head_sha],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            if restore_checkout.returncode != 0:
+                return False
+            if auto_stash_ref is not None:
+                if not _restore_stashed_changes(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    auto_stash_ref,
+                    prompt_user=False,
+                    input_fn=gw_input_fn,
+                ):
+                    return False
+                auto_stash_ref = None
+            return True
+
         if protect_local_commits:
             # Re-prove the checked-out target immediately after branch
             # transition. A different process may have advanced the target ref
@@ -10139,24 +10184,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             except ValueError:
                 target_local_count = None
             if target_local_count is None or target_local_count > 0:
-                if current_branch not in {branch, "HEAD"}:
-                    subprocess.run(
-                        git_cmd + ["checkout", current_branch],
-                        cwd=PROJECT_ROOT,
-                        capture_output=True,
-                        text=True,
-                        check=False,
-                    )
-                if auto_stash_ref is not None:
-                    _restore_stashed_changes(
-                        git_cmd,
-                        PROJECT_ROOT,
-                        auto_stash_ref,
-                        prompt_user=False,
-                        input_fn=gw_input_fn,
-                    )
+                restored = _restore_protected_checkout()
                 print("✗ Update blocked: target branch changed during protected preflight.")
                 print(f"  Refusing to update or reset branch '{branch}'.")
+                if not restored:
+                    print("  Original checkout could not be restored automatically; stash was preserved.")
                 _resume_windows_gateways_after_update(_windows_gateway_resume)
                 sys.exit(3)
 
@@ -10286,6 +10318,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if pull_result.returncode != 0:
                 if protect_local_commits:
+                    restored = _restore_protected_checkout()
                     print(
                         "✗ Fast-forward update is not possible while local commits are protected."
                     )
@@ -10293,6 +10326,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         f"  Refusing to reset branch '{branch}' to origin/{branch}. "
                         "Review and integrate the divergence manually."
                     )
+                    if not restored:
+                        print(
+                            "  Original checkout could not be restored automatically; stash was preserved."
+                        )
                     _resume_windows_gateways_after_update(_windows_gateway_resume)
                     # Exit 3 prevents Desktop from retrying a policy rejection.
                     sys.exit(3)

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -424,7 +424,7 @@ def test_cmd_update_protects_local_commits_before_checkout_or_pull(
     with pytest.raises(SystemExit) as exc:
         hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
 
-    assert exc.value.code == 1
+    assert exc.value.code == 3
     assert "protected local commits" in capsys.readouterr().out
     assert not any(" checkout " in f" {' '.join(cmd)} " for cmd in calls)
     assert not any(" pull " in f" {' '.join(cmd)} " for cmd in calls)
@@ -460,7 +460,7 @@ def test_cmd_update_local_commit_guard_fails_closed_when_proof_is_unavailable(
     with pytest.raises(SystemExit) as exc:
         hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
 
-    assert exc.value.code == 1
+    assert exc.value.code == 3
     assert "could not prove" in capsys.readouterr().out
 
 
@@ -496,7 +496,7 @@ def test_cmd_update_protects_local_commits_on_target_branch_before_switch(
     with pytest.raises(SystemExit) as exc:
         hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
 
-    assert exc.value.code == 1
+    assert exc.value.code == 3
     assert "2 commit(s)" in capsys.readouterr().out
     assert not any(" checkout " in f" {' '.join(cmd)} " for cmd in calls)
     assert not any(" reset " in f" {' '.join(cmd)} " for cmd in calls)
@@ -516,7 +516,7 @@ def test_cmd_update_rejects_invalid_local_commit_protection_value(
     with pytest.raises(SystemExit) as exc:
         hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
 
-    assert exc.value.code == 1
+    assert exc.value.code == 3
     assert "safety configuration is invalid" in capsys.readouterr().out
 
 
@@ -546,9 +546,89 @@ def test_cmd_update_protection_disables_windows_zip_fallback(
     with pytest.raises(SystemExit) as exc:
         hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
 
-    assert exc.value.code == 1
+    assert exc.value.code == 3
     assert zip_calls == []
     assert "ZIP fallback is disabled" in capsys.readouterr().out
+
+
+def test_cmd_update_protection_never_resets_after_failed_fast_forward(
+    monkeypatch, tmp_path, capsys
+):
+    """A ref moving after preflight must turn divergence into a terminal block."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        joined = " ".join(str(part) for part in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+        if "rev-list --count origin/main..HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
+        if "rev-list HEAD..origin/main --count" in joined:
+            return SimpleNamespace(returncode=0, stdout="1\n", stderr="")
+        if "pull --ff-only origin main" in joined:
+            return SimpleNamespace(returncode=128, stdout="", stderr="diverged")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 3
+    assert "Refusing to reset branch" in capsys.readouterr().out
+    assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
+
+
+def test_cmd_update_protection_disables_syntax_rollback_reset(
+    monkeypatch, tmp_path, capsys
+):
+    """Protected mode must not hard-reset even after a bad incoming commit."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        joined = " ".join(str(part) for part in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+        if "rev-list --count origin/main..HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
+        if "rev-list HEAD..origin/main --count" in joined:
+            return SimpleNamespace(returncode=0, stdout="1\n", stderr="")
+        if "pull --ff-only origin main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(hermes_main, "_capture_head_sha", lambda *args: "abc123")
+    monkeypatch.setattr(
+        hermes_main,
+        "_validate_critical_files_syntax",
+        lambda root: (False, "hermes_cli/main.py", "SyntaxError"),
+    )
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 3
+    assert "Automatic rollback is disabled" in capsys.readouterr().out
+    assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
 
 
 def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -539,6 +539,57 @@ def test_cmd_update_protects_local_commits_on_target_branch_before_switch(
     assert not any(" reset " in f" {' '.join(cmd)} " for cmd in calls)
 
 
+def test_cmd_update_rechecks_target_after_branch_switch_race(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    calls = []
+    head_proofs = 0
+    discarded = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_discard_lockfile_churn",
+        lambda *args: discarded.append(args),
+    )
+
+    def fake_run(cmd, **kwargs):
+        nonlocal head_proofs
+        calls.append(cmd)
+        joined = " ".join(str(part) for part in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="deploy/custom\n", stderr="")
+        if "show-ref --verify --quiet refs/heads/main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-list --count origin/main..refs/heads/main" in joined:
+            return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
+        if "rev-list --count origin/main..HEAD" in joined:
+            head_proofs += 1
+            value = "0\n" if head_proofs == 1 else "2\n"
+            return SimpleNamespace(returncode=0, stdout=value, stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 3
+    assert "target branch changed" in capsys.readouterr().out
+    assert head_proofs == 2
+    assert ["git", "checkout", "main"] in calls
+    assert ["git", "checkout", "deploy/custom"] in calls
+    assert discarded == []
+    assert not any(" pull " in f" {' '.join(cmd)} " for cmd in calls)
+    assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
+
+
 @pytest.mark.parametrize("value", ["true", 1, [], {}])
 def test_cmd_update_rejects_invalid_local_commit_protection_value(
     monkeypatch, tmp_path, capsys, value

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -520,6 +520,49 @@ def test_cmd_update_rejects_invalid_local_commit_protection_value(
     assert "safety configuration is invalid" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize("raw_config", ["[]\n", "false\n"])
+def test_cmd_update_rejects_falsy_non_mapping_config_root(
+    monkeypatch, tmp_path, capsys, raw_config
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(raw_config)
+    monkeypatch.setattr(hermes_config, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": False}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 3
+    assert "config root must be a mapping" in capsys.readouterr().out
+
+
+def test_cmd_update_protection_blocks_windows_zip_path_without_git_metadata(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    (tmp_path / ".git").rmdir()
+    zip_calls = []
+    monkeypatch.setattr(hermes_main.sys, "platform", "win32")
+    monkeypatch.setattr(hermes_main, "_update_via_zip", lambda args: zip_calls.append(args))
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 3
+    assert zip_calls == []
+    assert "git metadata is unavailable" in capsys.readouterr().out
+
+
 def test_cmd_update_protection_disables_windows_zip_fallback(
     monkeypatch, tmp_path, capsys
 ):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -116,7 +116,7 @@ def test_restore_stashed_changes_prompts_before_applying(monkeypatch, tmp_path, 
     restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
 
     assert restored is True
-    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
+    assert calls[0][0] == ["git", "stash", "apply", "--index", "abc123"]
     assert calls[1][0] == ["git", "diff", "--name-only", "--diff-filter=U"]
     assert calls[2][0] == ["git", "stash", "list", "--format=%gd %H"]
     assert calls[3][0] == ["git", "stash", "drop", "stash@{1}"]
@@ -144,7 +144,7 @@ def test_restore_stashed_changes_can_skip_restore_and_keep_stash(monkeypatch, tm
     out = capsys.readouterr().out
     assert "Restore local changes now? [Y/n]" in out
     assert "Your changes are still preserved in git stash." in out
-    assert "git stash apply abc123" in out
+    assert "git stash apply --index abc123" in out
 
 
 def test_restore_stashed_changes_applies_without_prompt_when_disabled(monkeypatch, tmp_path, capsys):
@@ -167,7 +167,7 @@ def test_restore_stashed_changes_applies_without_prompt_when_disabled(monkeypatc
     restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=False)
 
     assert restored is True
-    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
+    assert calls[0][0] == ["git", "stash", "apply", "--index", "abc123"]
     assert calls[1][0] == ["git", "diff", "--name-only", "--diff-filter=U"]
     assert calls[2][0] == ["git", "stash", "list", "--format=%gd %H"]
     assert calls[3][0] == ["git", "stash", "drop", "stash@{0}"]
@@ -203,7 +203,10 @@ def test_restore_stashed_changes_keeps_going_when_stash_entry_cannot_be_resolved
     restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=False)
 
     assert restored is True
-    assert calls[0] == (["git", "stash", "apply", "abc123"], {"cwd": tmp_path, "capture_output": True, "text": True})
+    assert calls[0] == (
+        ["git", "stash", "apply", "--index", "abc123"],
+        {"cwd": tmp_path, "capture_output": True, "text": True},
+    )
     assert calls[1] == (["git", "diff", "--name-only", "--diff-filter=U"], {"cwd": tmp_path, "capture_output": True, "text": True})
     assert calls[2] == (["git", "stash", "list", "--format=%gd %H"], {"cwd": tmp_path, "capture_output": True, "text": True, "check": True})
     out = capsys.readouterr().out
@@ -273,7 +276,7 @@ def test_restore_stashed_changes_always_resets_on_conflict(monkeypatch, tmp_path
     assert "hermes_cli/main.py" in out
     assert "stashed changes are preserved" in out
     assert "Working tree reset to clean state" in out
-    assert "git stash apply abc123" in out
+    assert "git stash apply --index abc123" in out
     reset_calls = [c for c, _ in calls if c[1:3] == ["reset", "--hard"]]
     assert len(reset_calls) == 1
 
@@ -841,12 +844,35 @@ def test_cmd_update_protected_pull_abort_restores_branch_and_stash(
     assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
 
 
+@pytest.mark.parametrize(
+    ("reset_returncode", "expected_restores", "expected_message"),
+    [
+        (0, ["stash-sha"], "Protected rollback restored"),
+        (1, [], "stash was preserved"),
+    ],
+)
 def test_cmd_update_protection_uses_cas_before_syntax_rollback_reset(
-    monkeypatch, tmp_path, capsys
+    monkeypatch,
+    tmp_path,
+    capsys,
+    reset_returncode,
+    expected_restores,
+    expected_message,
 ):
     """A bad incoming commit is reset only after an exact compare-and-swap."""
     _setup_update_mocks(monkeypatch, tmp_path)
     calls = []
+    restored_stashes = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_stash_local_changes_if_needed",
+        lambda *args, **kwargs: "stash-sha",
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_restore_stashed_changes",
+        lambda *args, **kwargs: restored_stashes.append(args[2]) or True,
+    )
 
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
@@ -861,6 +887,12 @@ def test_cmd_update_protection_uses_cas_before_syntax_rollback_reset(
             return SimpleNamespace(returncode=0, stdout="1\n", stderr="")
         if "pull --ff-only origin main" in joined:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "reset --hard abc123" in joined:
+            return SimpleNamespace(
+                returncode=reset_returncode,
+                stdout="",
+                stderr="rollback failed" if reset_returncode else "",
+            )
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
@@ -880,7 +912,8 @@ def test_cmd_update_protection_uses_cas_before_syntax_rollback_reset(
         hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
 
     assert exc.value.code == 3
-    assert "Protected rollback restored" in capsys.readouterr().out
+    assert expected_message in capsys.readouterr().out
+    assert restored_stashes == expected_restores
     assert [
         "git",
         "update-ref",

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -590,6 +590,52 @@ def test_cmd_update_rechecks_target_after_branch_switch_race(
     assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
 
 
+def test_cmd_update_restores_detached_head_after_target_recheck_failure(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    calls = []
+    head_proofs = 0
+    monkeypatch.setattr(
+        hermes_main,
+        "_capture_head_sha",
+        lambda *args: "detached-original-sha",
+    )
+
+    def fake_run(cmd, **kwargs):
+        nonlocal head_proofs
+        calls.append(cmd)
+        joined = " ".join(str(part) for part in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="HEAD\n", stderr="")
+        if "show-ref --verify --quiet refs/heads/main" in joined:
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+        if "rev-list --count origin/main..HEAD" in joined:
+            head_proofs += 1
+            value = "0\n" if head_proofs == 1 else "1\n"
+            return SimpleNamespace(returncode=0, stdout=value, stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 3
+    assert ["git", "checkout", "main"] in calls
+    assert ["git", "checkout", "--detach", "detached-original-sha"] in calls
+    assert "target branch changed" in capsys.readouterr().out
+    assert not any(" pull " in f" {' '.join(cmd)} " for cmd in calls)
+    assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
+
+
 @pytest.mark.parametrize("value", ["true", 1, [], {}])
 def test_cmd_update_rejects_invalid_local_commit_protection_value(
     monkeypatch, tmp_path, capsys, value
@@ -716,6 +762,68 @@ def test_cmd_update_protection_never_resets_after_failed_fast_forward(
 
     assert exc.value.code == 3
     assert "Refusing to reset branch" in capsys.readouterr().out
+    assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
+
+
+def test_cmd_update_protected_pull_abort_restores_branch_and_stash(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    calls = []
+    restored_stashes = []
+    head_proofs = 0
+    monkeypatch.setattr(
+        hermes_main,
+        "_capture_head_sha",
+        lambda *args: "original-sha",
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_stash_local_changes_if_needed",
+        lambda *args, **kwargs: "stash-sha",
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_restore_stashed_changes",
+        lambda *args, **kwargs: restored_stashes.append(args[2]) or True,
+    )
+
+    def fake_run(cmd, **kwargs):
+        nonlocal head_proofs
+        calls.append(cmd)
+        joined = " ".join(str(part) for part in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="deploy/custom\n", stderr="")
+        if "show-ref --verify --quiet refs/heads/main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-list --count origin/main..refs/heads/main" in joined:
+            return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
+        if "rev-list --count origin/main..HEAD" in joined:
+            head_proofs += 1
+            return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
+        if "rev-list HEAD..origin/main --count" in joined:
+            return SimpleNamespace(returncode=0, stdout="1\n", stderr="")
+        if "pull --ff-only origin main" in joined:
+            return SimpleNamespace(returncode=128, stdout="", stderr="diverged")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 3
+    assert ["git", "checkout", "main"] in calls
+    assert ["git", "checkout", "deploy/custom"] in calls
+    assert restored_stashes == ["stash-sha"]
+    assert "Local changes preserved in stash" not in capsys.readouterr().out
     assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
 
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -396,6 +396,74 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda: None)
 
 
+def test_cmd_update_protects_local_commits_before_checkout_or_pull(
+    monkeypatch, tmp_path, capsys
+):
+    """A tailored deployment must fail closed before update can reset its HEAD."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        joined = " ".join(str(part) for part in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="deploy/custom\n", stderr="")
+        if "rev-list --count origin/main..HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="3\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 1
+    assert "protected local commits" in capsys.readouterr().out
+    assert not any(" checkout " in f" {' '.join(cmd)} " for cmd in calls)
+    assert not any(" pull " in f" {' '.join(cmd)} " for cmd in calls)
+    assert not any(" reset " in f" {' '.join(cmd)} " for cmd in calls)
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout"),
+    [(1, ""), (0, "not-a-count\n")],
+)
+def test_cmd_update_local_commit_guard_fails_closed_when_proof_is_unavailable(
+    monkeypatch, tmp_path, capsys, returncode, stdout
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        joined = " ".join(str(part) for part in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+        if "rev-list --count origin/main..HEAD" in joined:
+            return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="proof failed")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 1
+    assert "could not prove" in capsys.readouterr().out
+
+
 def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypatch, tmp_path, capsys):
     """When .[all] fails, update should keep base deps and retry extras individually."""
     _setup_update_mocks(monkeypatch, tmp_path)

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -387,6 +387,11 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     """Common setup for cmd_update tests."""
     (tmp_path / ".git").mkdir()
     monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        hermes_main,
+        "_capture_head_sha",
+        lambda *args: "original-sha",
+    )
     monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
     monkeypatch.setattr(hermes_main, "_restore_stashed_changes", lambda *a, **kw: True)
     monkeypatch.setattr(hermes_config, "get_missing_env_vars", lambda required_only=True: [])
@@ -551,6 +556,11 @@ def test_cmd_update_rechecks_target_after_branch_switch_race(
         "_discard_lockfile_churn",
         lambda *args: discarded.append(args),
     )
+    monkeypatch.setattr(
+        hermes_main,
+        "_capture_head_sha",
+        lambda *args: "original-sha",
+    )
 
     def fake_run(cmd, **kwargs):
         nonlocal head_proofs
@@ -564,6 +574,8 @@ def test_cmd_update_rechecks_target_after_branch_switch_race(
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if "rev-list --count origin/main..refs/heads/main" in joined:
             return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
+        if "rev-parse refs/heads/deploy/custom" in joined:
+            return SimpleNamespace(returncode=0, stdout="original-sha\n", stderr="")
         if "rev-list --count origin/main..HEAD" in joined:
             head_proofs += 1
             value = "0\n" if head_proofs == 1 else "2\n"
@@ -800,6 +812,8 @@ def test_cmd_update_protected_pull_abort_restores_branch_and_stash(
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if "rev-list --count origin/main..refs/heads/main" in joined:
             return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
+        if "rev-parse refs/heads/deploy/custom" in joined:
+            return SimpleNamespace(returncode=0, stdout="original-sha\n", stderr="")
         if "rev-list --count origin/main..HEAD" in joined:
             head_proofs += 1
             return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
@@ -866,7 +880,7 @@ def test_cmd_update_protection_disables_syntax_rollback_reset(
         hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
 
     assert exc.value.code == 3
-    assert "Automatic rollback is disabled" in capsys.readouterr().out
+    assert "Protected rollback restored" in capsys.readouterr().out
     assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
 
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -464,6 +464,93 @@ def test_cmd_update_local_commit_guard_fails_closed_when_proof_is_unavailable(
     assert "could not prove" in capsys.readouterr().out
 
 
+def test_cmd_update_protects_local_commits_on_target_branch_before_switch(
+    monkeypatch, tmp_path, capsys
+):
+    """A clean current HEAD must not hide divergent commits on the target ref."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        joined = " ".join(str(part) for part in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="deploy/custom\n", stderr="")
+        if "show-ref --verify --quiet refs/heads/main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-list --count origin/main..HEAD" in joined:
+            return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
+        if "rev-list --count origin/main..refs/heads/main" in joined:
+            return SimpleNamespace(returncode=0, stdout="2\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 1
+    assert "2 commit(s)" in capsys.readouterr().out
+    assert not any(" checkout " in f" {' '.join(cmd)} " for cmd in calls)
+    assert not any(" reset " in f" {' '.join(cmd)} " for cmd in calls)
+
+
+@pytest.mark.parametrize("value", ["true", 1, [], {}])
+def test_cmd_update_rejects_invalid_local_commit_protection_value(
+    monkeypatch, tmp_path, capsys, value
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": value}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 1
+    assert "safety configuration is invalid" in capsys.readouterr().out
+
+
+def test_cmd_update_protection_disables_windows_zip_fallback(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    zip_calls = []
+
+    def fake_run(cmd, **kwargs):
+        joined = " ".join(str(part) for part in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            raise CalledProcessError(1, cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(hermes_main.sys, "platform", "win32")
+    monkeypatch.setattr(hermes_main, "_update_via_zip", lambda args: zip_calls.append(args))
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 1
+    assert zip_calls == []
+    assert "ZIP fallback is disabled" in capsys.readouterr().out
+
+
 def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypatch, tmp_path, capsys):
     """When .[all] fails, update should keep base deps and retry extras individually."""
     _setup_update_mocks(monkeypatch, tmp_path)

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -841,10 +841,10 @@ def test_cmd_update_protected_pull_abort_restores_branch_and_stash(
     assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
 
 
-def test_cmd_update_protection_disables_syntax_rollback_reset(
+def test_cmd_update_protection_uses_cas_before_syntax_rollback_reset(
     monkeypatch, tmp_path, capsys
 ):
-    """Protected mode must not hard-reset even after a bad incoming commit."""
+    """A bad incoming commit is reset only after an exact compare-and-swap."""
     _setup_update_mocks(monkeypatch, tmp_path)
     calls = []
 
@@ -881,7 +881,14 @@ def test_cmd_update_protection_disables_syntax_rollback_reset(
 
     assert exc.value.code == 3
     assert "Protected rollback restored" in capsys.readouterr().out
-    assert not any(" reset --hard " in f" {' '.join(cmd)} " for cmd in calls)
+    assert [
+        "git",
+        "update-ref",
+        "refs/heads/main",
+        "abc123",
+        "abc123",
+    ] in calls
+    assert ["git", "reset", "--hard", "abc123"] in calls
 
 
 def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -402,6 +402,12 @@ def test_cmd_update_protects_local_commits_before_checkout_or_pull(
     """A tailored deployment must fail closed before update can reset its HEAD."""
     _setup_update_mocks(monkeypatch, tmp_path)
     calls = []
+    discarded_lockfiles = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_discard_lockfile_churn",
+        lambda *args: discarded_lockfiles.append(args),
+    )
 
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
@@ -429,6 +435,7 @@ def test_cmd_update_protects_local_commits_before_checkout_or_pull(
     assert not any(" checkout " in f" {' '.join(cmd)} " for cmd in calls)
     assert not any(" pull " in f" {' '.join(cmd)} " for cmd in calls)
     assert not any(" reset " in f" {' '.join(cmd)} " for cmd in calls)
+    assert discarded_lockfiles == []
 
 
 @pytest.mark.parametrize(

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -471,6 +471,36 @@ def test_cmd_update_local_commit_guard_fails_closed_when_proof_is_unavailable(
     assert "could not prove" in capsys.readouterr().out
 
 
+def test_cmd_update_protected_fetch_failure_is_terminal(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    mutations = []
+
+    def fake_run(cmd, **kwargs):
+        joined = " ".join(str(part) for part in cmd)
+        if "fetch origin main" in joined:
+            return SimpleNamespace(returncode=128, stdout="", stderr="fatal: bad repository")
+        if " config " in f" {joined} ":
+            mutations.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(hermes_main.sys, "platform", "win32")
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"updates": {"protect_local_commits": True}},
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        hermes_main._cmd_update_impl(SimpleNamespace(yes=True), gateway_mode=False)
+
+    assert exc.value.code == 3
+    assert "Failed to fetch" in capsys.readouterr().out
+    assert mutations == []
+
+
 def test_cmd_update_protects_local_commits_on_target_branch_before_switch(
     monkeypatch, tmp_path, capsys
 ):


### PR DESCRIPTION
## Summary

- add an opt-in `updates.protect_local_commits` safety policy for tailored git deployments
- refuse checkout/pull/reset when either current HEAD or the local target branch contains commits absent from the selected origin branch
- fail closed when ancestry proof or safety config parsing fails
- disable the Windows ZIP fallback while local-commit protection is enabled

This prevents Desktop/gateway-driven updates from silently replacing reviewed local integration commits with `origin/main`.

## Test plan

- `python -m pytest tests/hermes_cli/test_update_*.py tests/hermes_cli/test_cmd_update.py tests/test_install_diverged_update.py -o 'addopts=' -q` — 230 passed
- `python -m ruff check hermes_cli/config.py hermes_cli/main.py tests/hermes_cli/test_update_autostash.py`
- `git diff --check`
- two independent read-only exact-HEAD reviews approved `6bf1695316e09e14a3cd67252add7ff827cbd5a1`

## Operational proof

On a tailored checkout with 30 local integration commits, `hermes update --yes --gateway --no-backup` exits 1 before checkout/reset and reports that the update is blocked.
