### PR TITLE
fix(gateway): route inbound-image decision off the event loop (salvage #66688)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10840,7 +10840,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if image_paths:
                 # Decide routing: native (attach pixels) vs text (vision_analyze
                 # pre-run + prepend description).  See agent/image_routing.py.
-                _img_mode = self._decide_image_input_mode(
+                # Offload to a worker thread: the decision does blocking network
+                # I/O — a models.dev fetch on cache miss, and the Ollama
+                # ``/api/show`` capability probe for local servers — whose
+                # request timeout would otherwise stall the whole gateway event
+                # loop (every session) while a single image is routed.
+                _img_mode = await asyncio.to_thread(
+                    self._decide_image_input_mode,
                     source=source,
                     session_key=session_key,
                 )

--- a/tests/gateway/test_image_input_routing_runtime.py
+++ b/tests/gateway/test_image_input_routing_runtime.py
@@ -143,3 +143,48 @@ async def test_prepare_image_routing_falls_back_to_text_for_text_only_session_ov
     session_key = runner._session_key_for_source(source)
     assert result == "[vision summary]\n\nlook"
     assert runner._pending_native_image_paths_by_session.get(session_key) is None
+
+
+@pytest.mark.asyncio
+async def test_prepare_image_routing_runs_off_the_event_loop(monkeypatch):
+    """The image-routing decision does blocking network I/O — a models.dev fetch
+    on cache miss, and the Ollama ``/api/show`` capability probe for local
+    servers — so it must run on a worker thread. Run inline on the gateway
+    event loop it would freeze *every* session for up to the request timeout
+    while a single image is routed.
+    """
+    import threading
+
+    runner = _make_runner()
+    source = _source()
+    event = _image_event()
+    cfg = _auto_config()
+
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("agent.auxiliary_client._read_main_provider", lambda: "xiaomi")
+    monkeypatch.setattr("agent.auxiliary_client._read_main_model", lambda: "mimo-v2.5-pro")
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **_: ("gpt-5.5", {"provider": "openai-codex"}),
+    )
+
+    main_thread = threading.current_thread()
+    seen: dict = {}
+
+    def recording_supports(provider, model, config):
+        # Stands in for the real, blocking capability lookup and records the
+        # thread it executes on.
+        seen["thread"] = threading.current_thread()
+        return True  # vision-capable → native routing (skips _enrich_message_with_vision)
+
+    monkeypatch.setattr("agent.image_routing._lookup_supports_vision", recording_supports)
+
+    await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+
+    assert seen.get("thread") is not None, "capability lookup was never reached"
+    assert seen["thread"] is not main_thread, (
+        "the blocking image-routing decision must be offloaded off the gateway "
+        "event loop, not run inline on it"
+    )


### PR DESCRIPTION
## Summary

Salvage of #66688 by @Frowtek — the gateway's inbound-image routing decision now runs on a worker thread instead of inline on the event loop, so one user attaching an image can no longer stall every session on the gateway.

`_prepare_inbound_message_text` called `_decide_image_input_mode` inline. That decision does blocking network I/O — a models.dev HTTP GET (15s timeout) on cold cache and an Ollama `/api/show` capability probe for local servers — which froze the entire gateway event loop (all sessions, heartbeats included) until the request returned or timed out.

## Changes

- `gateway/run.py`: wrap the `_decide_image_input_mode` call in `await asyncio.to_thread(...)`. Decision result and routing unchanged.
- `tests/gateway/test_image_input_routing_runtime.py`: new `test_prepare_image_routing_runs_off_the_event_loop` asserting the capability lookup executes off the main thread.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/gateway/test_image_input_routing_runtime.py` | 3/3 passed |
| E2E (real runner, real loop, 1.5s blocked lookup) | heartbeat max gap 0.100s — loop stayed responsive; lookup ran on `asyncio_0` worker thread |
| Sibling sites | CLI is synchronous (no loop); TUI decision already runs inside the `_run_prompt_submit` worker thread — gateway was the only inline-on-loop site |

Contributor commit cherry-picked with authorship preserved (rebase-merge this PR).

## Infographic

![Image routing off the event loop](https://v3b.fal.media/files/b/0aa2b890/iDrtZrBNG0ahHZHdcMdFk_Xu3qCtYX.png)
