### PR TITLE
fix(runtime): don't let a local config base_url hijack an explicit --provider

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1623,7 +1623,17 @@ def resolve_runtime_provider(
     # route through the OpenAI-compatible resolver instead of letting
     # resolve_provider() pick up an ANTHROPIC_API_KEY or OPENAI_API_KEY from
     # the environment and send the request to a cloud API. Fixes #3846.
-    if not explicit_base_url and not explicit_api_key:
+    #
+    # Only when the caller did NOT explicitly name a provider. Without this
+    # guard, `--provider gemini` (requested_provider="gemini") is hijacked by a
+    # leftover local base_url in config: the block below sees a non-cloud host
+    # and routes to _resolve_openrouter_runtime, sending the request to the
+    # wrong endpoint with the wrong key.
+    if (
+        not explicit_base_url
+        and not explicit_api_key
+        and requested_provider in ("auto", "")
+    ):
         model_cfg = _get_model_config()
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3416,3 +3416,52 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
+
+
+def test_explicit_provider_not_hijacked_by_local_config_base_url(monkeypatch):
+    """Regression: `hermes --provider gemini` must reach the named provider
+    even when config.yaml still carries a leftover local base_url.
+
+    The auto/unset path deliberately routes a local config base_url (e.g.
+    Ollama at localhost:11434) through the OpenAI-compatible resolver so env
+    cloud creds don't hijack it (#3846). But that block keyed only off the
+    CONFIG provider, not the CALLER's explicit request — so an explicit
+    `--provider gemini` was silently rerouted to the local endpoint (and on to
+    _resolve_openrouter_runtime), sending the request to the wrong place with
+    the wrong key. The explicit request must win.
+    """
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "", "base_url": "http://localhost:11434/v1"},
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+    # Give the named provider a credential so resolution reaches a runtime
+    # result rather than raising for missing creds; the point under test is
+    # WHERE it routes, not auth.
+    monkeypatch.setenv("GEMINI_API_KEY", "AIza-test-key")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="gemini", target_model="gemini-2.5-flash")
+
+    # Must reach the gemini endpoint, NOT the leftover local base_url and NOT
+    # the openrouter hijack the unguarded block used to produce.
+    assert resolved["base_url"] != "http://localhost:11434/v1"
+    assert "openrouter.ai" not in (resolved.get("base_url") or "")
+    assert "generativelanguage.googleapis.com" in resolved["base_url"]
+    assert resolved["requested_provider"] == "gemini"
+
+
+def test_unset_provider_still_honors_local_config_base_url(monkeypatch):
+    """Guard the #3846 behavior the fix must NOT break: with no explicit
+    provider (requested resolves to 'auto'), a local config base_url is still
+    honored so the local model keeps working."""
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "", "base_url": "http://localhost:11434/v1"},
+    )
+
+    resolved = rp.resolve_runtime_provider(requested=None)
+
+    assert resolved["base_url"] == "http://localhost:11434/v1"


### PR DESCRIPTION
## Problem

`resolve_runtime_provider()` in `hermes_cli/runtime_provider.py` has a block (introduced in #3846) that routes a local config `base_url` (e.g. Ollama at `localhost:11434`) through the OpenAI-compatible resolver, so environment cloud credentials don't shadow a user's local endpoint. Its comment says *"If provider is 'auto' (or unset)..."* — but the guard only checks the **config's** provider, never the caller's explicit request:

```python
if not explicit_base_url and not explicit_api_key:
    ...
    if cfg_base_url and cfg_provider in ("auto", ""):
        # -> _resolve_openrouter_runtime(...)
```

So when a user explicitly picks a provider **and** their `config.yaml` still carries a local `base_url` (a very common state — you set up a local model, then try a cloud one via `--provider`), the explicit request is silently hijacked.

### Reproduce (on `main`)

```python
# config.yaml: model.provider: "", model.base_url: http://localhost:11434/v1
resolve_runtime_provider(requested="gemini", target_model="gemini-2.5-flash")
# -> {'provider': 'openrouter', 'base_url': 'https://openrouter.ai/api/v1', ...}
```

`requested="gemini"` resolves to **openrouter**, with the OpenRouter key and endpoint. In practice `hermes --provider gemini` fails with `HTTP 404: No endpoints available matching your guardrail restrictions` — an OpenRouter error, for a request the user explicitly aimed at Gemini.

## Fix

Add `requested_provider in ("auto", "")` to the block's guard so the local-endpoint bypass fires **only when the caller did not explicitly name a provider**. The auto/unset path (local Ollama, the #3846 scenario) is unchanged; an explicit `--provider` now wins and reaches its real endpoint.

## Tests

Two regression tests lock both directions of the contract:

- `test_explicit_provider_not_hijacked_by_local_config_base_url` — explicit `--provider gemini` with a leftover local `base_url` resolves to the Gemini endpoint, not localhost and not openrouter.
- `test_unset_provider_still_honors_local_config_base_url` — with no explicit provider, a local config `base_url` is still honored (guards the #3846 behavior against regression).

Full suite for the touched module passes (153 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
