### PR TITLE
fix(agent): tolerate lone UTF-16 surrogates in tool-guardrail hashing (salvage #66650)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -472,4 +472,8 @@ def _positive_int(value: Any, default: int) -> int:
 
 
 def _sha256(value: str) -> str:
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+    # surrogatepass: tool results scraped from the web can carry unpaired
+    # UTF-16 surrogates (e.g. half of a mathematical-bold pair); a strict
+    # encode raises and takes down the whole conversation loop. The hash only
+    # needs deterministic bytes, not valid UTF-8.
+    return hashlib.sha256(value.encode("utf-8", "surrogatepass")).hexdigest()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -375,6 +375,7 @@ LEGACY_AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "juniperbevensee@users.noreply.github.com": "juniperbevensee",
     "krowd3v@users.noreply.github.com": "krowd3v",
     "dfein38347g@users.noreply.github.com": "dfein38347g",
     "nicktaylor@TheWorldofNick-Lappy.local": "thegoodguysla",

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -256,3 +256,24 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+def test_after_call_survives_lone_surrogates_in_result_and_args():
+    # Scraped web/social text can contain unpaired UTF-16 surrogates (e.g. the
+    # first half of a mathematical-bold pair, '\ud835'). str.encode('utf-8')
+    # rejects them, and the result hasher crashed the whole conversation loop
+    # (live outage: "Outer loop error in API call #34 ... surrogates not
+    # allowed"). Weird text must never take down the loop.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, exact_failure_block_after=2, no_progress_block_after=2)
+    )
+    dirty = "price \ud835 update"
+
+    decision = controller.after_call("web_search", {"query": dirty}, dirty, failed=False)
+    assert decision.action in {"allow", "warn"}
+
+    # hashing stays deterministic: the same dirty failure twice still trips
+    # the exact-failure guard, proving the hash is stable across calls
+    controller.after_call("web_search", {"query": dirty}, '{"error":"\ud835 boom"}', failed=True)
+    controller.after_call("web_search", {"query": dirty}, '{"error":"\ud835 boom"}', failed=True)
+    assert controller.before_call("web_search", {"query": dirty}).action == "block"


### PR DESCRIPTION
## Summary
Tool results containing lone UTF-16 surrogates (common in scraped web text) no longer crash the conversation loop: the tool-guardrail hasher now encodes with `surrogatepass` instead of strict UTF-8.

Salvage of #66650 by @juniperbevensee (NimbleCoAI) — authorship preserved via cherry-pick.

Root cause: `_sha256()` in `agent/tool_guardrails.py` did a strict `value.encode("utf-8")` on every tool call's args and result. An unpaired surrogate (e.g. `\ud835`, half a mathematical-bold pair) raises `UnicodeEncodeError`, which escaped as "Outer loop error ... surrogates not allowed" and took down the whole turn. The message sanitizers run later, on API messages — nothing upstream protects this site.

## Changes
- `agent/tool_guardrails.py`: `_sha256` uses `encode("utf-8", "surrogatepass")` — the single hasher behind both `ToolCallSignature.from_call` (args) and `_result_hash` (results), so this covers the whole class in the module
- `tests/agent/test_tool_guardrails.py`: regression test — dirty result survives `after_call`, and the same dirty failure twice still trips the exact-failure block (hash determinism preserved)
- `scripts/release.py`: AUTHOR_MAP entry for contributor

## Validation
| | Before | After |
|---|---|---|
| Dirty tool result through `after_call` | `UnicodeEncodeError`, loop down | `allow` |
| Dirty args through `before_call` | `UnicodeEncodeError` | `allow` |
| Exact-failure dedup on dirty payloads | n/a (crashed) | `block` after 2, hash stable |
| Clean-string hashes | — | byte-identical to strict encode |

E2E: real imports from the worktree reproduced the crash on strict encode and verified all four paths above. Targeted suite `tests/agent/test_tool_guardrails.py` green.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa2b8c6/5-lN8ESwaj2N-gHbgL5qz_nxGOvGH2.png)
