### PR TITLE
feat: per-MCP-server `tool_injection` control (description_only mode)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1409,7 +1409,7 @@ def init_agent(
         agent._tool_snapshot_generation = _snapshot_registry._generation
     except Exception:
         agent._tool_snapshot_generation = 0
-    agent.tools = _ra().get_tool_definitions(
+    agent.tools, pre_assembly = _ra().get_tool_definitions_with_meta(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
@@ -1419,21 +1419,20 @@ def init_agent(
     agent.valid_tool_names = set()
     if agent.tools:
         agent.valid_tool_names = {tool["function"]["name"] for tool in agent.tools}
-        # Capture pre-assembly tool names for the description_only inventory in
-        # the system prompt.  ``agent.valid_tool_names`` reflects the
-        # post-tool_search-assembly visible list (description_only tools are
-        # deferred behind bridge tools), but the system prompt's MCP tool
-        # inventory must list every tool the session was granted — not just
-        # the ones that happen to be visible after assembly.
+        # Bind the pre-assembly tool names for the description_only inventory
+        # in the system prompt directly from THIS call's assembly result.
+        # ``agent.valid_tool_names`` reflects the post-tool_search-assembly
+        # visible list (description_only tools are deferred behind bridge
+        # tools), but the system prompt's MCP tool inventory must list every
+        # tool the session was granted — not just the ones that happen to be
+        # visible after assembly. The names come from the call's return value,
+        # never from a process-global: with concurrent agent initialization
+        # (gateway multi-chat, delegate subagents, parallel cron) another
+        # agent's assembly can overwrite model_tools._last_pre_assembly_tool_names
+        # between this call and a later read, binding the wrong session's
+        # inventory to this agent (issue #66826, GottZ race).
         try:
-            import model_tools
-            # Read the PRE-assembly snapshot, not ``_last_resolved_tool_names``:
-            # the latter is overwritten with the cached POST-assembly list on a
-            # quiet_mode cache hit, which would silently empty the inventory
-            # for every session after the first with the same toolset key.
-            # ``_last_pre_assembly_tool_names`` is restored identically on both
-            # the fresh-compute and cache-hit paths. (#66826)
-            agent._pre_assembly_tool_names = set(model_tools._last_pre_assembly_tool_names)
+            agent._pre_assembly_tool_names = set(pre_assembly)
         except Exception as e:
             agent._pre_assembly_tool_names = set()
             logger.warning("Failed to capture pre-assembly tool names: %s", e)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1419,6 +1419,17 @@ def init_agent(
     agent.valid_tool_names = set()
     if agent.tools:
         agent.valid_tool_names = {tool["function"]["name"] for tool in agent.tools}
+        # Capture pre-assembly tool names for the description_only inventory in
+        # the system prompt.  ``agent.valid_tool_names`` reflects the
+        # post-tool_search-assembly visible list (description_only tools are
+        # deferred behind bridge tools), but the system prompt's MCP tool
+        # inventory must list every tool the session was granted — not just
+        # the ones that happen to be visible after assembly.
+        try:
+            import model_tools
+            agent._pre_assembly_tool_names = set(model_tools._last_resolved_tool_names)
+        except Exception:
+            agent._pre_assembly_tool_names = set()
         tool_names = sorted(agent.valid_tool_names)
         if not agent.quiet_mode:
             print(f"🛠️  Loaded {len(agent.tools)} tools: {', '.join(tool_names)}")

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1427,9 +1427,16 @@ def init_agent(
         # the ones that happen to be visible after assembly.
         try:
             import model_tools
-            agent._pre_assembly_tool_names = set(model_tools._last_resolved_tool_names)
-        except Exception:
+            # Read the PRE-assembly snapshot, not ``_last_resolved_tool_names``:
+            # the latter is overwritten with the cached POST-assembly list on a
+            # quiet_mode cache hit, which would silently empty the inventory
+            # for every session after the first with the same toolset key.
+            # ``_last_pre_assembly_tool_names`` is restored identically on both
+            # the fresh-compute and cache-hit paths. (#66826)
+            agent._pre_assembly_tool_names = set(model_tools._last_pre_assembly_tool_names)
+        except Exception as e:
             agent._pre_assembly_tool_names = set()
+            logger.warning("Failed to capture pre-assembly tool names: %s", e)
         tool_names = sorted(agent.valid_tool_names)
         if not agent.quiet_mode:
             print(f"🛠️  Loaded {len(agent.tools)} tools: {', '.join(tool_names)}")

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -342,7 +342,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             from tools.tool_search import get_description_only_tool_names, load_config as _load_ts_cfg
             _ts_cfg = _load_ts_cfg()
             if _ts_cfg.enabled != "off":
-                _do_names = get_description_only_tool_names() & agent.valid_tool_names
+                # Use pre-assembly tool names so the inventory includes
+                # description_only tools that were deferred behind the bridge.
+                # ``agent.valid_tool_names`` is the post-assembly visible set
+                # (bridge tools only); ``_pre_assembly_tool_names`` is the full
+                # set of tools granted to this session.
+                _pre_names = getattr(agent, '_pre_assembly_tool_names', None)
+                _do_names = get_description_only_tool_names() & (_pre_names if _pre_names is not None else agent.valid_tool_names)
                 if _do_names:
                     from tools.registry import registry
                     _do_lines = []

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -348,7 +348,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
                 # (bridge tools only); ``_pre_assembly_tool_names`` is the full
                 # set of tools granted to this session.
                 _pre_names = getattr(agent, '_pre_assembly_tool_names', None)
-                _do_names = get_description_only_tool_names() & (_pre_names if _pre_names is not None else agent.valid_tool_names)
+                if _pre_names is None:
+                    _pre_names = agent.valid_tool_names
+                # The intersection below needs a set: agent_init stores a set,
+                # but tolerate a list-valued fallback (valid_tool_names) or an
+                # externally-constructed agent instead of silently dropping
+                # the whole inventory block on a TypeError.
+                if not isinstance(_pre_names, (set, frozenset)):
+                    _pre_names = set(_pre_names)
+                _do_names = get_description_only_tool_names() & _pre_names
                 if _do_names:
                     from tools.registry import registry
                     _do_lines = []
@@ -366,8 +374,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
                             + "\n".join(_do_lines)
                         )
                         stable_parts.append(_do_block)
-        except Exception:
-            pass
+        except Exception as e:  # pragma: no cover — never break prompt building
+            logger.warning("Description-only tool inventory build failed: %s", e)
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -334,27 +334,32 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # every turn. Full schemas are loaded on demand via tool_search / tool_describe.
     # Mirroring Claude Code's ``defer_loading`` pattern and Skill frontmatter
     # discovery (name + description in prompt, body loaded on /skill).
+    #
+    # Skip when tool_search is disabled — there's no bridge to route through
+    # and the inventory would mislead the model into using tool_search.
     if agent.valid_tool_names:
         try:
-            from tools.tool_search import get_description_only_tool_names
-            _do_names = get_description_only_tool_names()
-            if _do_names:
-                from tools.registry import registry
-                _do_lines = []
-                for _tn in sorted(_do_names):
-                    _entry = registry.get_entry(_tn)
-                    if _entry:
-                        _desc = (_entry.description or "")[:200].replace("\n", " ")
-                        _do_lines.append(f"- **{_tn}**: {_desc}")
-                if _do_lines:
-                    _do_block = (
-                        "## Available MCP Tools (description-only — load on demand)\n\n"
-                        "The following tools are available via `tool_search`. "
-                        "Call `tool_search` to find one, `tool_describe` to load "
-                        "its full parameter schema, then `tool_call` to invoke it.\n\n"
-                        + "\n".join(_do_lines)
-                    )
-                    stable_parts.append(_do_block)
+            from tools.tool_search import get_description_only_tool_names, load_config as _load_ts_cfg
+            _ts_cfg = _load_ts_cfg()
+            if _ts_cfg.enabled != "off":
+                _do_names = get_description_only_tool_names() & agent.valid_tool_names
+                if _do_names:
+                    from tools.registry import registry
+                    _do_lines = []
+                    for _tn in sorted(_do_names):
+                        _entry = registry.get_entry(_tn)
+                        if _entry:
+                            _desc = (_entry.description or "")[:200].replace("\n", " ")
+                            _do_lines.append(f"- **{_tn}**: {_desc}")
+                    if _do_lines:
+                        _do_block = (
+                            "## Available MCP Tools (description-only — load on demand)\n\n"
+                            "The following tools are available via `tool_search`. "
+                            "Call `tool_search` to find one, `tool_describe` to load "
+                            "its full parameter schema, then `tool_call` to invoke it.\n\n"
+                            + "\n".join(_do_lines)
+                        )
+                        stable_parts.append(_do_block)
         except Exception:
             pass
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -328,6 +328,36 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if skills_prompt:
         stable_parts.append(skills_prompt)
 
+    # MCP tool inventory — for servers with ``tool_injection: description_only``,
+    # inject tool names + one-line descriptions into the stable tier so the
+    # agent knows what tools exist without paying for full JSON schemas on
+    # every turn. Full schemas are loaded on demand via tool_search / tool_describe.
+    # Mirroring Claude Code's ``defer_loading`` pattern and Skill frontmatter
+    # discovery (name + description in prompt, body loaded on /skill).
+    if agent.valid_tool_names:
+        try:
+            from tools.tool_search import get_description_only_tool_names
+            _do_names = get_description_only_tool_names()
+            if _do_names:
+                from tools.registry import registry
+                _do_lines = []
+                for _tn in sorted(_do_names):
+                    _entry = registry.get_entry(_tn)
+                    if _entry:
+                        _desc = (_entry.description or "")[:200].replace("\n", " ")
+                        _do_lines.append(f"- **{_tn}**: {_desc}")
+                if _do_lines:
+                    _do_block = (
+                        "## Available MCP Tools (description-only — load on demand)\n\n"
+                        "The following tools are available via `tool_search`. "
+                        "Call `tool_search` to find one, `tool_describe` to load "
+                        "its full parameter schema, then `tool_call` to invoke it.\n\n"
+                        + "\n".join(_do_lines)
+                    )
+                    stable_parts.append(_do_block)
+        except Exception:
+            pass
+
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
     # so the agent can correctly report which model it is (workaround for API bug).

--- a/model_tools.py
+++ b/model_tools.py
@@ -10,6 +10,7 @@ environments consume.
 
 Public API (signatures preserved from the original 2,400-line version):
     get_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode) -> list
+    get_tool_definitions_with_meta(...) -> (tools, pre_assembly_names)
     handle_function_call(function_name, function_args, task_id, user_task) -> str
     TOOL_TO_TOOLSET_MAP: dict          (for batch_runner.py)
     TOOLSET_REQUIREMENTS: dict         (for cli.py, doctor.py)
@@ -235,9 +236,14 @@ _last_resolved_tool_names: List[str] = []
 # ``_last_resolved_tool_names``, whose semantics flip with cache state (fresh
 # compute stores pre-assembly names at model_tools._compute_tool_definitions,
 # a cache hit overwrites it with the cached POST-assembly list), this global is
-# restored consistently on BOTH paths, so callers deriving the session's
-# granted tool set (agent_init's description_only inventory capture) never
-# depend on whether the call hit the quiet_mode cache. (#66826)
+# restored consistently on BOTH paths.
+#
+# Primary consumers no longer read this global: get_tool_definitions_with_meta()
+# returns the pre-assembly names from the calling assembly itself, and
+# agent/agent_init.py binds that return value directly onto the receiving agent
+# (#66826, GottZ race). The global is kept for legacy consumers (mcp_tool's
+# refresh snapshot, execute_code sandbox fallback, tests) that still read it
+# after their own get_tool_definitions() call.
 _last_pre_assembly_tool_names: List[str] = []
 
 
@@ -320,6 +326,38 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
+    return get_tool_definitions_with_meta(
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+        quiet_mode=quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+    )[0]
+
+
+def get_tool_definitions_with_meta(
+    enabled_toolsets: Optional[List[str]] = None,
+    disabled_toolsets: Optional[List[str]] = None,
+    quiet_mode: bool = False,
+    skip_tool_search_assembly: bool = False,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Same as :func:`get_tool_definitions`, but also returns the list of
+    tool names captured *before* Tool Search assembly ran.
+
+    Returns:
+        (tools, pre_assembly_names): ``tools`` is the filtered list of
+        OpenAI-format tool definitions; ``pre_assembly_names`` is the list of
+        tool names the session was granted before tool_search bridge assembly
+        collapsed deferrable (MCP/plugin/description_only) tools behind
+        tool_search/tool_describe/tool_call.
+
+        The receiving agent must bind ``pre_assembly_names`` directly to
+        itself (e.g. the description_only system-prompt inventory) — it must
+        NOT be re-read from a process-global afterwards. With concurrent
+        agent initialization (gateway multi-chat, delegate subagents, parallel
+        cron), another agent's assembly can overwrite the global between this
+        call and the read, binding the wrong session's inventory to this agent
+        (cross-agent race, GottZ on #66826).
+    """
     # Fast path: memoized result when the caller doesn't need stdout prints.
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).
@@ -347,22 +385,25 @@ def get_tool_definitions(
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
-            # Update _last_resolved_tool_names so downstream callers see
-            # consistent state even on a cache hit. The cached value carries
-            # the PRE-assembly names alongside the post-assembly list, so
+            # Update the process-globals so legacy consumers (mcp_tool's
+            # refresh snapshot, execute_code sandbox fallback) see consistent
+            # state even on a cache hit. The cached value carries the
+            # PRE-assembly names alongside the post-assembly list, so
             # _last_pre_assembly_tool_names is restored identically on the
-            # cache-hit path — callers that derive the session's granted
-            # tool set (agent_init's description_only inventory) never see
-            # the post-assembly collapse. (#66826)
+            # cache-hit path. The pre-assembly names handed to THIS caller
+            # come from the tuple below, never from the global. (#66826)
             global _last_resolved_tool_names, _last_pre_assembly_tool_names
-            _last_resolved_tool_names = [t["function"]["name"] for t in cached[0]]
-            _last_pre_assembly_tool_names = list(cached[1])
+            cached_tools, cached_pre_assembly = cached
+            _last_resolved_tool_names = [t["function"]["name"] for t in cached_tools]
+            _last_pre_assembly_tool_names = list(cached_pre_assembly)
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.
-            return list(cached[0])
+            return list(cached_tools), list(cached_pre_assembly)
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+    result, pre_assembly_names = _compute_tool_definitions(
+        enabled_toolsets, disabled_toolsets, quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+    )
     if quiet_mode:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -379,9 +420,9 @@ def get_tool_definitions(
         # Store the PRE-assembly names alongside the final (post-assembly) list
         # so a later cache hit can restore _last_pre_assembly_tool_names to the
         # same pre-assembly view this fresh compute produced. (#66826)
-        _tool_defs_cache[cache_key] = (result, _last_pre_assembly_tool_names)
-        return list(result)
-    return result
+        _tool_defs_cache[cache_key] = (result, pre_assembly_names)
+        return list(result), list(pre_assembly_names)
+    return result, pre_assembly_names
 
 
 def _compute_tool_definitions(
@@ -389,8 +430,18 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
-) -> List[Dict[str, Any]]:
-    """Uncached implementation of :func:`get_tool_definitions`."""
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Uncached implementation of :func:`get_tool_definitions_with_meta`.
+
+    Returns:
+        (tools, pre_assembly_names): the filtered tool definitions, and the
+        list of tool names captured *before* Tool Search assembly ran (i.e.
+        the session's full granted inventory, not the post-assembly
+        bridge-collapsed surface). ``pre_assembly_names`` is returned to the
+        caller so the receiving agent binds it directly; the module-globals
+        are kept in sync for legacy consumers only (mcp_tool's refresh
+        snapshot, execute_code sandbox fallback). (#66826)
+    """
     # Determine which tool names the caller wants
     tools_to_include: set = set()
 
@@ -554,12 +605,16 @@ def _compute_tool_definitions(
             print("🛠️  No tools selected (all filtered out or unavailable)")
 
     global _last_resolved_tool_names, _last_pre_assembly_tool_names
-    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
     # Snapshot the PRE-assembly names (before tool_search assembly may swap
-    # deferrable tools for the bridge) so the description_only inventory can
-    # always derive the session's granted tool set regardless of whether the
-    # caller later hits the quiet_mode cache. (#66826)
-    _last_pre_assembly_tool_names = list(_last_resolved_tool_names)
+    # deferrable tools for the bridge). This is the session's full granted
+    # inventory — returned to the caller via get_tool_definitions_with_meta()
+    # so the receiving agent binds it directly. Reading it back from a
+    # process-global later would race with other agents' assembly (two agents
+    # initializing concurrently could bind each other's inventory; issue
+    # #66826, GottZ race). The global writes are kept for legacy consumers.
+    pre_assembly_names = [t["function"]["name"] for t in filtered_tools]
+    _last_resolved_tool_names = list(pre_assembly_names)
+    _last_pre_assembly_tool_names = list(pre_assembly_names)
 
     # Sanitize schemas for broad backend compatibility. llama.cpp's
     # json-schema-to-grammar converter (used by its OAI server to build
@@ -608,7 +663,7 @@ def _compute_tool_definitions(
     except Exception as e:  # pragma: no cover — never break tool loading
         logger.warning("Tool search assembly skipped: %s", e)
 
-    return filtered_tools
+    return filtered_tools, pre_assembly_names
 
 
 def _resolve_active_context_length() -> int:

--- a/model_tools.py
+++ b/model_tools.py
@@ -229,6 +229,17 @@ TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
 # Used by code_execution_tool to know which tools are available in this session.
 _last_resolved_tool_names: List[str] = []
 
+# PRE-assembly tool names from the last get_tool_definitions() call — the full
+# set of tool schemas BEFORE tool_search assembly collapses deferrable
+# (MCP/plugin/description_only) tools behind the bridge tools. Unlike
+# ``_last_resolved_tool_names``, whose semantics flip with cache state (fresh
+# compute stores pre-assembly names at model_tools._compute_tool_definitions,
+# a cache hit overwrites it with the cached POST-assembly list), this global is
+# restored consistently on BOTH paths, so callers deriving the session's
+# granted tool set (agent_init's description_only inventory capture) never
+# depend on whether the call hit the quiet_mode cache. (#66826)
+_last_pre_assembly_tool_names: List[str] = []
+
 
 # =============================================================================
 # Legacy toolset name mapping  (old _tools-suffixed names -> tool name lists)
@@ -267,7 +278,7 @@ _LEGACY_TOOLSET_MAP = {
 # which bumps on register() / deregister() / register_toolset_alias(). The
 # inner check_fn TTL cache in registry.py handles environment drift (Docker
 # daemon start/stop, env var changes, etc.) on a 30 s horizon.
-_tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
+_tool_defs_cache: Dict[tuple, Tuple[List[Dict[str, Any]], List[str]]] = {}
 
 # Hard cap on memoized get_tool_definitions() results. A long-lived Gateway
 # process sees many distinct toolset/config fingerprints over its lifetime
@@ -337,12 +348,18 @@ def get_tool_definitions(
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
             # Update _last_resolved_tool_names so downstream callers see
-            # consistent state even on a cache hit.
-            global _last_resolved_tool_names
-            _last_resolved_tool_names = [t["function"]["name"] for t in cached]
+            # consistent state even on a cache hit. The cached value carries
+            # the PRE-assembly names alongside the post-assembly list, so
+            # _last_pre_assembly_tool_names is restored identically on the
+            # cache-hit path — callers that derive the session's granted
+            # tool set (agent_init's description_only inventory) never see
+            # the post-assembly collapse. (#66826)
+            global _last_resolved_tool_names, _last_pre_assembly_tool_names
+            _last_resolved_tool_names = [t["function"]["name"] for t in cached[0]]
+            _last_pre_assembly_tool_names = list(cached[1])
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.
-            return list(cached)
+            return list(cached[0])
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
                                        skip_tool_search_assembly=skip_tool_search_assembly)
@@ -359,7 +376,10 @@ def get_tool_definitions(
         # toolset/config fingerprints it sees over its lifetime (#19251).
         if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX:
             _tool_defs_cache.pop(next(iter(_tool_defs_cache)))  # evict oldest
-        _tool_defs_cache[cache_key] = result
+        # Store the PRE-assembly names alongside the final (post-assembly) list
+        # so a later cache hit can restore _last_pre_assembly_tool_names to the
+        # same pre-assembly view this fresh compute produced. (#66826)
+        _tool_defs_cache[cache_key] = (result, _last_pre_assembly_tool_names)
         return list(result)
     return result
 
@@ -533,8 +553,13 @@ def _compute_tool_definitions(
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
 
-    global _last_resolved_tool_names
+    global _last_resolved_tool_names, _last_pre_assembly_tool_names
     _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
+    # Snapshot the PRE-assembly names (before tool_search assembly may swap
+    # deferrable tools for the bridge) so the description_only inventory can
+    # always derive the session's granted tool set regardless of whether the
+    # caller later hits the quiet_mode cache. (#66826)
+    _last_pre_assembly_tool_names = list(_last_resolved_tool_names)
 
     # Sanitize schemas for broad backend compatibility. llama.cpp's
     # json-schema-to-grammar converter (used by its OAI server to build

--- a/run_agent.py
+++ b/run_agent.py
@@ -136,6 +136,7 @@ else:
 # Import our tool system
 from model_tools import (
     get_tool_definitions,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.get_tool_definitions")
+    get_tool_definitions_with_meta,  # noqa: F401  # re-exported for agent_init's _ra().get_tool_definitions_with_meta (pre-assembly inventory binding, #66826)
     get_toolset_for_tool,
     handle_function_call,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.handle_function_call")
     check_toolset_requirements,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.check_toolset_requirements")

--- a/tests/agent/test_skip_memory_store_65429.py
+++ b/tests/agent/test_skip_memory_store_65429.py
@@ -26,6 +26,7 @@ class _FakeOpenAI:
 
 def _make_agent(monkeypatch, enabled_toolsets=None, skip_memory=True):
     monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: [])
+    monkeypatch.setattr("run_agent.get_tool_definitions_with_meta", lambda **kw: ([], []))
     monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
     monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
     return AIAgent(

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -326,7 +326,8 @@ def test_between_turns_refresh_adds_late_tool_when_servers_registered():
 
     import model_tools
     with patch("tools.mcp_tool.has_registered_mcp_tools", return_value=True), \
-         patch.object(model_tools, "get_tool_definitions", return_value=[new_def]):
+         patch.object(model_tools, "get_tool_definitions", return_value=[new_def]), \
+         patch.object(model_tools, "get_tool_definitions_with_meta", return_value=([new_def], ["mcp_x_tool"])):
         _build(agent)
 
     assert "mcp_x_tool" in agent.valid_tool_names

--- a/tests/cli/test_focus_view.py
+++ b/tests/cli/test_focus_view.py
@@ -252,6 +252,10 @@ def _make_agent(tool_progress_mode: str):
     ]
     with (
         patch("run_agent.get_tool_definitions", return_value=tool_defs),
+        patch(
+            "run_agent.get_tool_definitions_with_meta",
+            return_value=(tool_defs, [t["function"]["name"] for t in tool_defs]),
+        ),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("hermes_cli.config.load_config", return_value={}),
         patch("run_agent.OpenAI"),

--- a/tests/gateway/test_mcp_reload_refreshes_cached_agents.py
+++ b/tests/gateway/test_mcp_reload_refreshes_cached_agents.py
@@ -109,7 +109,10 @@ async def test_reload_mcp_refreshes_cached_agent_tools():
         patch("tools.mcp_tool.shutdown_mcp_servers"),
         patch("tools.mcp_tool.discover_mcp_tools", return_value=["HassTurnOn", "HassTurnOff"]),
         patch.dict("tools.mcp_tool._servers", {"homeassistant": object()}, clear=True),
-        patch("model_tools.get_tool_definitions", return_value=fresh_tool_defs),
+        patch("model_tools.get_tool_definitions_with_meta", return_value=(
+            fresh_tool_defs,
+            [t["function"]["name"] for t in fresh_tool_defs],
+        )),
     ):
         result = await runner._execute_mcp_reload(_make_event())
 
@@ -139,7 +142,7 @@ async def test_reload_mcp_handles_empty_agent_cache():
         patch("tools.mcp_tool.shutdown_mcp_servers"),
         patch("tools.mcp_tool.discover_mcp_tools", return_value=[]),
         patch.dict("tools.mcp_tool._servers", {}, clear=True),
-        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.get_tool_definitions_with_meta", return_value=([], [])),
     ):
         result = await runner._execute_mcp_reload(_make_event())
 
@@ -161,13 +164,13 @@ async def test_reload_mcp_preserves_per_agent_toolset_overrides():
 
     def _capture_get_tool_definitions(**kwargs):
         captured_calls.append(kwargs)
-        return [{"type": "function", "function": {"name": "refreshed"}}]
+        return [{"type": "function", "function": {"name": "refreshed"}}], ["refreshed"]
 
     with (
         patch("tools.mcp_tool.shutdown_mcp_servers"),
         patch("tools.mcp_tool.discover_mcp_tools", return_value=["refreshed"]),
         patch.dict("tools.mcp_tool._servers", {"homeassistant": object()}, clear=True),
-        patch("model_tools.get_tool_definitions", side_effect=_capture_get_tool_definitions),
+        patch("model_tools.get_tool_definitions_with_meta", side_effect=_capture_get_tool_definitions),
     ):
         await runner._execute_mcp_reload(_make_event())
 

--- a/tests/run_agent/conftest.py
+++ b/tests/run_agent/conftest.py
@@ -44,3 +44,56 @@ def _fast_retry_backoff(monkeypatch):
         monkeypatch.setattr(_conv_loop, "jittered_backoff", lambda *a, **k: 0.0)
     except ImportError:
         pass
+
+
+@pytest.fixture(autouse=True)
+def _forward_tool_defs_meta(monkeypatch):
+    """Auto-adapt ``run_agent.get_tool_definitions_with_meta`` to legacy mocks.
+
+    Commit 69c12e8b7 (fix/66826-gottz-race) switched ``agent_init`` to call
+    ``_ra().get_tool_definitions_with_meta(...)`` — which returns
+    ``(tools, pre_assembly_names)`` — instead of ``get_tool_definitions()``.
+    Tests that patch only ``run_agent.get_tool_definitions`` (40+ files in
+    this suite) stopped intercepting the call and silently ran the REAL tool
+    assembly, regressing 14 tests and slowing the rest. This fixture makes
+    ``with_meta`` forward to whatever the test's ``get_tool_definitions``
+    mock returns — deriving the pre-assembly names from the mocked defs — so
+    single-site patches keep working unchanged:
+
+    - a test that patches ``run_agent.get_tool_definitions`` (with a Mock or
+      a plain function) gets ``with_meta`` returning ``(its_return_value,
+      [names...])``;
+    - a test that explicitly patches ``with_meta`` wins (its patch lands on
+      top of this one and replaces it for the call);
+    - a test that patches neither runs the REAL ``with_meta`` untouched
+      (forwarded through to the original implementation).
+    """
+    try:
+        import run_agent
+    except ImportError:
+        return
+    from unittest.mock import Mock
+
+    real_legacy = run_agent.get_tool_definitions
+    real_with_meta = run_agent.get_tool_definitions_with_meta
+
+    def _side_effect(**kwargs):
+        legacy = run_agent.get_tool_definitions
+        if legacy is not real_legacy:
+            # The test patched get_tool_definitions — forward the with_meta
+            # call to it and derive pre-assembly names from the returned defs.
+            tools = legacy(**kwargs)
+            names = []
+            if isinstance(tools, list):
+                for t in tools:
+                    if isinstance(t, dict):
+                        fn = t.get("function")
+                        if isinstance(fn, dict) and fn.get("name"):
+                            names.append(fn["name"])
+            return tools, names
+        # Unpatched — run the real implementation untouched.
+        return real_with_meta(**kwargs)
+
+    monkeypatch.setattr(
+        run_agent, "get_tool_definitions_with_meta", Mock(side_effect=_side_effect)
+    )

--- a/tests/run_agent/test_1630_context_overflow_loop.py
+++ b/tests/run_agent/test_1630_context_overflow_loop.py
@@ -24,6 +24,7 @@ class TestGeneric400Heuristic:
         """Create a minimal AIAgent for testing error handling."""
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.get_tool_definitions_with_meta", return_value=([], [])),
             patch("run_agent.check_toolset_requirements", return_value={}),
             patch("run_agent.OpenAI"),
         ):

--- a/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
+++ b/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
@@ -24,6 +24,7 @@ from agent.chat_completion_helpers import _FALLBACK_EXHAUSTED_COOLDOWN_S
 def _make_agent(fallback_model=None):
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.get_tool_definitions_with_meta", return_value=([], [])),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
     ):

--- a/tests/run_agent/test_32646_fallback_429_after_timeout.py
+++ b/tests/run_agent/test_32646_fallback_429_after_timeout.py
@@ -47,6 +47,10 @@ def _make_agent_with_fallback(fb_chain):
     """Build a minimal AIAgent with the given fallback chain configured."""
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()),
+        patch(
+            "run_agent.get_tool_definitions_with_meta",
+            return_value=(_make_tool_defs(), ["web_search"]),
+        ),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI", return_value=MagicMock()),
     ):

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -81,6 +81,10 @@ def _make_413_error(*, use_status_code=True, message="Request entity too large")
 def agent():
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch(
+            "run_agent.get_tool_definitions_with_meta",
+            return_value=(_make_tool_defs("web_search"), ["web_search"]),
+        ),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
     ):

--- a/tests/run_agent/test_anthropic_third_party_oauth_guard.py
+++ b/tests/run_agent/test_anthropic_third_party_oauth_guard.py
@@ -35,6 +35,7 @@ def agent():
     """Minimal AIAgent construction, skipping tool discovery."""
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.get_tool_definitions_with_meta", return_value=([], [])),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
     ):
@@ -106,6 +107,7 @@ class TestOAuthFlagOnConstruction:
     def test_minimax_init_does_not_flip_oauth(self):
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.get_tool_definitions_with_meta", return_value=([], [])),
             patch("run_agent.check_toolset_requirements", return_value={}),
             patch("agent.anthropic_adapter.build_anthropic_client",
                   return_value=MagicMock()),

--- a/tests/run_agent/test_auth_provider_failover.py
+++ b/tests/run_agent/test_auth_provider_failover.py
@@ -25,6 +25,7 @@ from agent.turn_retry_state import TurnRetryState
 def _make_agent(fallback_model=None):
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.get_tool_definitions_with_meta", return_value=([], [])),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
     ):

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -232,6 +232,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
     with (
         patch("hermes_cli.config.load_config", return_value=cfg), patch("hermes_cli.config.load_config_readonly", return_value=cfg),
         patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.get_tool_definitions_with_meta", return_value=([], [])),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
         patch("run_agent.ContextCompressor", new=_StubCompressor),

--- a/tests/test_copilot_initiator.py
+++ b/tests/test_copilot_initiator.py
@@ -36,6 +36,10 @@ class _FakeOpenAI:
 def _make_agent(monkeypatch, base_url, api_mode="chat_completions"):
     """Create an AIAgent pointing at the given base_url."""
     monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: _tool_defs("web_search"))
+    monkeypatch.setattr(
+        "run_agent.get_tool_definitions_with_meta",
+        lambda **kw: (_tool_defs("web_search"), ["web_search"]),
+    )
     monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
     monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
     return AIAgent(

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -36,10 +36,11 @@ class TestQuietModeCacheIsolation:
         otherwise a caller mutating the returned list mutates the cache."""
         first = model_tools.get_tool_definitions(quiet_mode=True)
         assert isinstance(first, list)
-        # Find the cached value to compare identity.
+        # Find the cached value to compare identity. The cache stores
+        # (final_list, pre_assembly_names); unwrap the list for comparison.
         assert len(model_tools._tool_defs_cache) == 1
-        cached = next(iter(model_tools._tool_defs_cache.values()))
-        assert first is not cached, (
+        cached_list = next(iter(model_tools._tool_defs_cache.values()))[0]
+        assert first is not cached_list, (
             "issue #17335: first quiet_mode call returned the cached list "
             "by reference \u2014 mutations will leak into subsequent calls."
         )
@@ -49,8 +50,8 @@ class TestQuietModeCacheIsolation:
         first = model_tools.get_tool_definitions(quiet_mode=True)
         second = model_tools.get_tool_definitions(quiet_mode=True)
         assert first is not second
-        cached = next(iter(model_tools._tool_defs_cache.values()))
-        assert second is not cached
+        cached_list = next(iter(model_tools._tool_defs_cache.values()))[0]
+        assert second is not cached_list
 
 
 

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,5 +1,6 @@
 """Tests for model_tools.py — function call dispatch, agent-loop interception, legacy toolsets."""
 
+import contextlib
 import json
 
 import pytest
@@ -448,6 +449,31 @@ class TestPreAssemblyInventoryBinding:
             toolset=toolset,
         )
 
+    @staticmethod
+    def _deregister(name: str) -> None:
+        """Remove a tool registered by :meth:`_register`.
+
+        Keeps the global tool registry clean across tests — the gottz_*
+        toolsets must not leak into other tests' assemblies (mirrors the
+        registry hygiene the MCP tests follow).
+        """
+        from tools.registry import registry
+
+        registry.deregister(name)
+
+    @contextlib.contextmanager
+    def _registered_gottz_tools(self):
+        """Register the two disjoint gottz toolsets used by the regression
+        tests, deregistering them in a ``finally`` so no registry entry leaks
+        even when the test body raises."""
+        self._register("gottz_agent_a_tool", "gottz-ts-a")
+        self._register("gottz_agent_b_tool", "gottz-ts-b")
+        try:
+            yield
+        finally:
+            self._deregister("gottz_agent_a_tool")
+            self._deregister("gottz_agent_b_tool")
+
     # These tests assemble with quiet_mode=True; keep the memoization cache
     # clean so they neither see nor leave cross-test state.
     @pytest.fixture(autouse=True)
@@ -464,30 +490,107 @@ class TestPreAssemblyInventoryBinding:
         process-global after B's call and got B's names (cross-agent race)."""
         import model_tools
 
-        self._register("gottz_agent_a_tool", "gottz-ts-a")
-        self._register("gottz_agent_b_tool", "gottz-ts-b")
+        with self._registered_gottz_tools():
+            # Agent A assembles its session (captures its pre-assembly inventory).
+            tools_a, pre_a = model_tools.get_tool_definitions_with_meta(
+                enabled_toolsets=["gottz-ts-a"], quiet_mode=True,
+            )
+            # Agent B interleaves with a different session config...
+            tools_b, pre_b = model_tools.get_tool_definitions_with_meta(
+                enabled_toolsets=["gottz-ts-b"], quiet_mode=True,
+            )
+            # ...and A's inventory must still be A's — the value came from A's
+            # own assembly result, not from a process-global B just overwrote.
+            assert "gottz_agent_a_tool" in pre_a
+            assert "gottz_agent_b_tool" not in pre_a
+            assert "gottz_agent_b_tool" in pre_b
+            assert "gottz_agent_a_tool" not in pre_b
+            # The visible post-assembly list, minus the bridge tools assembly
+            # itself synthesizes, is a subset of the pre-assembly inventory
+            # (assembly only defers granted tools behind tool_search/describe/
+            # call — it never invents a non-bridge tool).
+            _bridge = {"tool_search", "tool_describe", "tool_call"}
+            assert {t["function"]["name"] for t in tools_a} - _bridge <= set(pre_a)
+            assert {t["function"]["name"] for t in tools_b} - _bridge <= set(pre_b)
 
-        # Agent A assembles its session (captures its pre-assembly inventory).
-        tools_a, pre_a = model_tools.get_tool_definitions_with_meta(
-            enabled_toolsets=["gottz-ts-a"], quiet_mode=True,
-        )
-        # Agent B interleaves with a different session config...
-        tools_b, pre_b = model_tools.get_tool_definitions_with_meta(
-            enabled_toolsets=["gottz-ts-b"], quiet_mode=True,
-        )
-        # ...and A's inventory must still be A's — the value came from A's
-        # own assembly result, not from a process-global B just overwrote.
-        assert "gottz_agent_a_tool" in pre_a
-        assert "gottz_agent_b_tool" not in pre_a
-        assert "gottz_agent_b_tool" in pre_b
-        assert "gottz_agent_a_tool" not in pre_b
-        # The visible post-assembly list, minus the bridge tools assembly
-        # itself synthesizes, is a subset of the pre-assembly inventory
-        # (assembly only defers granted tools behind tool_search/describe/
-        # call — it never invents a non-bridge tool).
-        _bridge = {"tool_search", "tool_describe", "tool_call"}
-        assert {t["function"]["name"] for t in tools_a} - _bridge <= set(pre_a)
-        assert {t["function"]["name"] for t in tools_b} - _bridge <= set(pre_b)
+    def test_agent_init_binds_own_inventory_across_interleaved_inits(self):
+        """Agent-level regression for the GottZ race: two AIAgents with
+        disjoint toolsets init with interleaved assembly; each agent's
+        ``_pre_assembly_tool_names`` must be its own, never the other's.
+
+        Pre-fix, ``agent_init`` copied the inventory from the process-global
+        ``model_tools._last_pre_assembly_tool_names`` AFTER the tool-definition
+        call. The side_effect here simulates agent B's assembly overwriting
+        that global between agent A's call and the (pre-fix) read — a
+        reverted implementation therefore binds B's inventory to A and this
+        test fails RED. The fix binds the names returned by the call itself,
+        which the interleaved global write cannot touch.
+        """
+        import model_tools
+        from run_agent import AIAgent
+
+        def _defs(name):
+            return [{
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": f"desc for {name}",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }]
+
+        def _meta_side_effect(enabled_toolsets=None, **kwargs):
+            if enabled_toolsets == ["gottz-ts-a"]:
+                # Agent B's assembly lands between agent A's call and the
+                # (pre-fix) read of the process-global: the global now holds
+                # B's inventory.
+                model_tools._last_pre_assembly_tool_names = ["gottz_agent_b_tool"]
+                return _defs("gottz_agent_a_tool"), ["gottz_agent_a_tool"]
+            return _defs("gottz_agent_b_tool"), ["gottz_agent_b_tool"]
+
+        saved_global = list(model_tools._last_pre_assembly_tool_names)
+        try:
+            with self._registered_gottz_tools():
+                with (
+                    patch(
+                        "run_agent.get_tool_definitions_with_meta",
+                        side_effect=_meta_side_effect,
+                    ),
+                    patch("run_agent.check_toolset_requirements", return_value={}),
+                    patch("run_agent.OpenAI"),
+                ):
+                    agent_a = AIAgent(
+                        api_key="test-key-1234567890",
+                        base_url="https://openrouter.ai/api/v1",
+                        quiet_mode=True,
+                        skip_context_files=True,
+                        skip_memory=True,
+                        enabled_toolsets=["gottz-ts-a"],
+                    )
+                    agent_b = AIAgent(
+                        api_key="test-key-1234567890",
+                        base_url="https://openrouter.ai/api/v1",
+                        quiet_mode=True,
+                        skip_context_files=True,
+                        skip_memory=True,
+                        enabled_toolsets=["gottz-ts-b"],
+                    )
+
+                # Each agent carries ONLY its own granted inventory — the
+                # interleaved second agent never leaks in.
+                assert "gottz_agent_a_tool" in agent_a._pre_assembly_tool_names
+                assert "gottz_agent_b_tool" not in agent_a._pre_assembly_tool_names
+                assert "gottz_agent_b_tool" in agent_b._pre_assembly_tool_names
+                assert "gottz_agent_a_tool" not in agent_b._pre_assembly_tool_names
+                # And each agent's visible tool list matches its own toolset.
+                a_names = {t["function"]["name"] for t in agent_a.tools}
+                b_names = {t["function"]["name"] for t in agent_b.tools}
+                assert "gottz_agent_a_tool" in a_names
+                assert "gottz_agent_a_tool" not in b_names
+                assert "gottz_agent_b_tool" in b_names
+                assert "gottz_agent_b_tool" not in a_names
+        finally:
+            model_tools._last_pre_assembly_tool_names = saved_global
 
     def test_cache_hit_returns_same_pre_assembly_names(self):
         """Cache semantics: a quiet_mode cache hit must hand back the same

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,6 +1,8 @@
 """Tests for model_tools.py — function call dispatch, agent-loop interception, legacy toolsets."""
 
 import json
+
+import pytest
 from unittest.mock import ANY, call, patch
 
 
@@ -404,3 +406,139 @@ class TestDisabledToolsetsPostureToolset:
             )
         }
         assert "write_file" not in no_file
+
+
+# =========================================================================
+# Pre-assembly inventory binding — PR #66826 (GottZ race) regression
+# =========================================================================
+
+class TestPreAssemblyInventoryBinding:
+    """Regression tests for the GottZ (AI triage) finding on PR #66826.
+
+    ``agent/agent_init.py`` used to copy the description_only inventory from
+    the process-global ``model_tools._last_pre_assembly_tool_names`` *after*
+    calling ``get_tool_definitions()``. Two agents initializing concurrently
+    (gateway multi-chat, delegate subagents, parallel cron) could therefore
+    bind the *other* agent's tool inventory. The fix returns the pre-assembly
+    name list directly from tool-definition assembly via
+    ``get_tool_definitions_with_meta``, so the inventory is bound to the
+    receiving agent's own call — never read back from a process-global.
+    """
+
+    @staticmethod
+    def _register(name: str, toolset: str) -> None:
+        """Register a disposable tool in a synthetic toolset (mirrors
+        TestDescriptionOnly._register in tests/tools/test_tool_search.py)."""
+        from tools.registry import registry
+
+        def _handler(args, task_id=None, **kw):
+            return json.dumps({"ok": True, "tool": name})
+
+        registry.register(
+            name=name,
+            handler=_handler,
+            schema={
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": f"desc for {name}",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            toolset=toolset,
+        )
+
+    # These tests assemble with quiet_mode=True; keep the memoization cache
+    # clean so they neither see nor leave cross-test state.
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        import model_tools
+
+        model_tools._tool_defs_cache.clear()
+        yield
+        model_tools._tool_defs_cache.clear()
+
+    def test_pre_assembly_names_bound_to_calling_agent_not_process_global(self):
+        """Two agents with disjoint toolsets assemble alternately; each must
+        keep its own pre-assembly inventory. Pre-fix, agent A read the
+        process-global after B's call and got B's names (cross-agent race)."""
+        import model_tools
+
+        self._register("gottz_agent_a_tool", "gottz-ts-a")
+        self._register("gottz_agent_b_tool", "gottz-ts-b")
+
+        # Agent A assembles its session (captures its pre-assembly inventory).
+        tools_a, pre_a = model_tools.get_tool_definitions_with_meta(
+            enabled_toolsets=["gottz-ts-a"], quiet_mode=True,
+        )
+        # Agent B interleaves with a different session config...
+        tools_b, pre_b = model_tools.get_tool_definitions_with_meta(
+            enabled_toolsets=["gottz-ts-b"], quiet_mode=True,
+        )
+        # ...and A's inventory must still be A's — the value came from A's
+        # own assembly result, not from a process-global B just overwrote.
+        assert "gottz_agent_a_tool" in pre_a
+        assert "gottz_agent_b_tool" not in pre_a
+        assert "gottz_agent_b_tool" in pre_b
+        assert "gottz_agent_a_tool" not in pre_b
+        # The visible post-assembly list, minus the bridge tools assembly
+        # itself synthesizes, is a subset of the pre-assembly inventory
+        # (assembly only defers granted tools behind tool_search/describe/
+        # call — it never invents a non-bridge tool).
+        _bridge = {"tool_search", "tool_describe", "tool_call"}
+        assert {t["function"]["name"] for t in tools_a} - _bridge <= set(pre_a)
+        assert {t["function"]["name"] for t in tools_b} - _bridge <= set(pre_b)
+
+    def test_cache_hit_returns_same_pre_assembly_names(self):
+        """Cache semantics: a quiet_mode cache hit must hand back the same
+        pre-assembly inventory as the first call. The cache stores
+        (tools, pre_assembly_names), so the second session's inventory keeps
+        every deferred tool."""
+        import model_tools
+
+        first_tools, first_pre = model_tools.get_tool_definitions_with_meta(
+            quiet_mode=True,
+        )
+        second_tools, second_pre = model_tools.get_tool_definitions_with_meta(
+            quiet_mode=True,
+        )
+        assert second_pre == first_pre
+        assert second_tools == first_tools
+        # The pre-assembly inventory covers every visible tool except the
+        # bridge tools assembly synthesized itself (tool_search/describe/call).
+        _bridge = {"tool_search", "tool_describe", "tool_call"}
+        assert {t["function"]["name"] for t in first_tools} - _bridge <= set(first_pre)
+
+    def test_pre_assembly_names_captured_before_tool_search_assembly(self, monkeypatch):
+        """pre_assembly_names is captured before tool_search assembly runs: a
+        tool that assembly synthesizes must never leak into the inventory."""
+        from types import SimpleNamespace
+
+        import model_tools
+        from tools import tool_search as ts_mod
+
+        def _fake_assemble(filtered_tools, context_length=None, config=None):
+            return SimpleNamespace(
+                activated=True,
+                tool_defs=[{
+                    "type": "function",
+                    "function": {"name": "post_assembly_synthetic"},
+                }],
+                deferred_count=1,
+                deferred_tokens=0,
+                threshold_tokens=0,
+            )
+
+        # Force the model_tools gate (ts_cfg.enabled != "off") to run the
+        # (fake) assembly so we can observe what "pre-assembly" means.
+        monkeypatch.setattr(
+            ts_mod, "load_config",
+            lambda: ts_mod.ToolSearchConfig.from_raw({"enabled": "on"}),
+        )
+        monkeypatch.setattr(ts_mod, "assemble_tool_defs", _fake_assemble)
+
+        tools, pre = model_tools.get_tool_definitions_with_meta(quiet_mode=True)
+        visible = {t["function"]["name"] for t in tools}
+        assert "post_assembly_synthetic" in visible  # assembly replaced defs
+        assert "post_assembly_synthetic" not in pre  # pre-assembly captured first
+        assert pre, "pre-assembly inventory must not be empty"

--- a/tests/test_tui_mcp_late_refresh.py
+++ b/tests/test_tui_mcp_late_refresh.py
@@ -40,7 +40,7 @@ def _install(monkeypatch, *, in_flight, join_result, new_defs):
     """Wire entry discovery accessors + get_tool_definitions, capture emits."""
     monkeypatch.setattr(entry, "mcp_discovery_in_flight", lambda: in_flight)
     monkeypatch.setattr(entry, "join_mcp_discovery", lambda timeout=None: join_result)
-    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: list(new_defs))
+    monkeypatch.setattr(model_tools, "get_tool_definitions_with_meta", lambda **kw: (list(new_defs), [t["function"]["name"] for t in new_defs]))
     monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: None)
     monkeypatch.setattr(server, "_session_info", lambda agent, session: {"tools_len": len(agent.tools)})
 

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -32,10 +32,13 @@ def test_refresh_adds_late_landing_tools(monkeypatch):
     agent = _agent(["read_file", "terminal"])
 
     new_defs = [_tool(n) for n in ("read_file", "terminal", "mcp_granola_get_account_info")]
-    monkeypatch.setattr(mcp_tool, "get_tool_definitions", lambda **kw: new_defs, raising=False)
-    # get_tool_definitions is imported inside the helper from model_tools, so patch there too.
+    # refresh_agent_mcp_tools calls get_tool_definitions_with_meta (it needs
+    # the pre-assembly inventory alongside the defs), so patch that.
     import model_tools
-    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: new_defs)
+    monkeypatch.setattr(
+        model_tools, "get_tool_definitions_with_meta",
+        lambda **kw: (new_defs, [t["function"]["name"] for t in new_defs]),
+    )
 
     added = mcp_tool.refresh_agent_mcp_tools(agent)
 
@@ -73,8 +76,11 @@ def test_refresh_preserves_memory_provider_and_context_engine_tools(monkeypatch)
     # The registry now ALSO has a newly-connected MCP tool, but does NOT contain
     # the memory/context tools (they're never in get_tool_definitions output).
     monkeypatch.setattr(
-        model_tools, "get_tool_definitions",
-        lambda **kw: [_tool("read_file"), _tool("mcp_new_server_tool")],
+        model_tools, "get_tool_definitions_with_meta",
+        lambda **kw: (
+            [_tool("read_file"), _tool("mcp_new_server_tool")],
+            ["read_file", "mcp_new_server_tool"],
+        ),
     )
 
     added = mcp_tool.refresh_agent_mcp_tools(agent)
@@ -102,8 +108,8 @@ def test_refresh_does_not_reinject_disabled_memory_provider_tools(monkeypatch):
     import model_tools
     monkeypatch.setattr(
         model_tools,
-        "get_tool_definitions",
-        lambda **kw: [_tool("read_file")],
+        "get_tool_definitions_with_meta",
+        lambda **kw: ([_tool("read_file")], ["read_file"]),
     )
 
     mcp_tool.refresh_agent_mcp_tools(agent)
@@ -124,8 +130,11 @@ def test_refresh_respects_context_engine_toolset_gate(monkeypatch):
 
     import model_tools
     monkeypatch.setattr(
-        model_tools, "get_tool_definitions",
-        lambda **kw: [_tool("read_file"), _tool("mcp_new_tool")],
+        model_tools, "get_tool_definitions_with_meta",
+        lambda **kw: (
+            [_tool("read_file"), _tool("mcp_new_tool")],
+            ["read_file", "mcp_new_tool"],
+        ),
     )
 
     mcp_tool.refresh_agent_mcp_tools(agent)
@@ -141,8 +150,11 @@ def test_refreshed_tool_is_callable_through_valid_tool_names_guard(monkeypatch):
 
     import model_tools
     monkeypatch.setattr(
-        model_tools, "get_tool_definitions",
-        lambda **kw: [_tool("read_file"), _tool("mcp_granola_list_meetings")],
+        model_tools, "get_tool_definitions_with_meta",
+        lambda **kw: (
+            [_tool("read_file"), _tool("mcp_granola_list_meetings")],
+            ["read_file", "mcp_granola_list_meetings"],
+        ),
     )
 
     # Before refresh the run loop would reject the call ("Tool does not exist").
@@ -174,10 +186,11 @@ def test_refresh_is_thread_safe_under_concurrent_calls(monkeypatch):
 
     def _gtd(**kw):
         with flip_lock:
-            return list(next(flip))
+            defs = list(next(flip))
+            return defs, [t["function"]["name"] for t in defs]
 
     import model_tools
-    monkeypatch.setattr(model_tools, "get_tool_definitions", _gtd)
+    monkeypatch.setattr(model_tools, "get_tool_definitions_with_meta", _gtd)
 
     errors = []
 

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -687,6 +687,76 @@ class TestDescriptionOnly:
         assert is_description_only_tool("do_duplicate")
 
     # ------------------------------------------------------------------
+    # System prompt inventory: description_only tools listed by name+description
+    # ------------------------------------------------------------------
+
+    def test_description_only_inventory_in_system_prompt(self):
+        """description_only tools appear as name+description in the system
+        prompt inventory block (full JSON schemas are not included)."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+        from tools.registry import registry
+        from tools.tool_search import mark_description_only_tool
+
+        tool_name = "do_inv_sysprompt_test"
+        tool_desc = "Searches the project documentation for a given query"
+
+        def _handler(args, task_id=None, **kw):
+            return json.dumps({"ok": True, "tool": tool_name})
+
+        registry.register(
+            name=tool_name,
+            handler=_handler,
+            schema=_td(tool_name, tool_desc, {"q": {"type": "string"}}),
+            toolset="mcp-inv-test",
+            description=tool_desc,
+        )
+        mark_description_only_tool(tool_name)
+
+        agent = SimpleNamespace(
+            valid_tool_names=[tool_name],
+            _pre_assembly_tool_names={tool_name},
+            load_soul_identity=False,
+            skip_context_files=False,
+            _task_completion_guidance=False,
+            _tool_use_enforcement=False,
+            _environment_probe=False,
+            _kanban_worker_guidance="",
+            _memory_store=None,
+            _memory_manager=None,
+            model="",
+            provider="",
+            platform="",
+            pass_session_id=False,
+            session_id="",
+        )
+
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            from agent.system_prompt import build_system_prompt_parts
+
+            parts = build_system_prompt_parts(agent)
+            stable = parts["stable"]
+
+        assert "Available MCP Tools" in stable, (
+            "description_only inventory block missing"
+        )
+        assert "description-only" in stable
+        assert tool_name in stable
+        assert tool_desc[:50] in stable
+        assert "tool_search" in stable
+        assert "tool_describe" in stable
+        # The full JSON parameter schema must not appear in the inventory
+        # block — only the tool name and description.
+        assert '"parameters"' not in stable, (
+            "Full JSON schema leaked into system prompt inventory"
+        )
+
+    # ------------------------------------------------------------------
     # Lazy MCP registration: description_only marking persists correctly
     # ------------------------------------------------------------------
 

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -1013,6 +1013,81 @@ class TestDescriptionOnly:
     # Bridge dispatch: tool_search finds and tool_call invokes description_only tools
     # ------------------------------------------------------------------
 
+    def test_refresh_publishes_pre_assembly_on_no_post_change(self):
+        """P2 regression: when tool_search assembly is ALREADY active, a
+        late-registered description_only server leaves the POST-assembly name
+        set unchanged (its tools were bridged away), so
+        ``refresh_agent_mcp_tools`` early-returns without publishing. The
+        pre-assembly view must still be published, or the system-prompt
+        inventory silently misses the new server's tools. (#66826 P2)"""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+        from tools import mcp_tool
+
+        server_name = "late_bridge_server"
+        tool_name = "mcp__late_bridge_server__lookup"
+
+        fake_tool = SimpleNamespace(
+            name="lookup",
+            description="Late-registered description_only tool",
+            inputSchema={"type": "object", "properties": {"q": {"type": "string"}}},
+        )
+        fake_server = SimpleNamespace(
+            name=server_name,
+            _tools=[fake_tool],
+            tool_timeout=30.0,
+            session=object(),
+            initialize_result=None,
+        )
+
+        # Baseline refresh BEFORE the server exists: assembly is already
+        # active (bridge tools present in the live POST-assembly set) and the
+        # published pre-assembly view does NOT include the future server.
+        agent = SimpleNamespace(
+            enabled_toolsets=None,
+            disabled_toolsets=None,
+            tools=[],
+            valid_tool_names=set(),
+            _tool_snapshot_generation=0,
+            _memory_manager=None,
+            context_compressor=None,
+            _context_engine_tool_names=set(),
+        )
+        with patch.dict(mcp_tool._servers, {}):
+            mcp_tool.refresh_agent_mcp_tools(agent, quiet_mode=True)
+            assert "tool_search" in agent.valid_tool_names  # assembly active
+            assert tool_name not in agent._pre_assembly_tool_names
+
+        # Register a description_only server AFTER the baseline: its tool is
+        # bridged away, so the POST-assembly name set is unchanged from the
+        # baseline (modulo the new deferred name), and a naive refresh would
+        # early-return without publishing the widened pre-assembly view.
+        with patch.dict(mcp_tool._servers, {server_name: fake_server}):
+            mcp_tool._register_server_tools(
+                server_name, fake_server, {"tool_injection": "description_only"}
+            )
+            added = mcp_tool.refresh_agent_mcp_tools(agent, quiet_mode=True)
+            # The description_only tool is deferred (bridged away) in the live
+            # POST-assembly snapshot, but the pre-assembly inventory tracks it.
+            assert tool_name not in agent.valid_tool_names
+            assert tool_name in agent._pre_assembly_tool_names
+
+            # Repeat refresh with the SAME published POST-assembly snapshot:
+            # early return (added == set()) must still republish the
+            # pre-assembly view so the system-prompt inventory stays correct.
+            added2 = mcp_tool.refresh_agent_mcp_tools(agent, quiet_mode=True)
+            assert added2 == set()
+            assert tool_name in agent._pre_assembly_tool_names
+
+        # Deregister to avoid leaking marks into later tests.
+        task = mcp_tool.MCPServerTask(server_name)
+        task._registered_tool_names = [tool_name]
+        task._deregister_tools()
+
+    # ------------------------------------------------------------------
+    # Bridge dispatch: tool_search finds and tool_call invokes description_only tools
+    # ------------------------------------------------------------------
+
     def test_bridge_dispatch_finds_description_only_tool(self):
         """tool_search returns description_only tools in the catalog and
         tool_describe returns their full schema."""

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -516,3 +516,172 @@ class TestDeferredCallSchemaProbe:
         ))
         assert result.get("ok") is True
         assert result.get("doc") == "abc"
+
+
+# ---------------------------------------------------------------------------
+# Description-only mode — tests for PR #66826 description_only tool_injection
+# ---------------------------------------------------------------------------
+
+
+class TestDescriptionOnly:
+    """Tests for description-only tool marking, classification, and assembly."""
+
+    @staticmethod
+    def _register(name: str, toolset: str):
+        from tools.registry import registry
+
+        def _handler(args, task_id=None, **kw):
+            return json.dumps({"ok": True, "tool": name})
+
+        registry.register(
+            name=name,
+            handler=_handler,
+            schema=_td(name, f"desc for {name}", {"q": {"type": "string"}}),
+            toolset=toolset,
+        )
+
+    # ------------------------------------------------------------------
+    # mark / is round-trip
+    # ------------------------------------------------------------------
+
+    def test_mark_and_is_round_trip(self):
+        """mark_description_only_tool → is_description_only_tool round-trip."""
+        from tools.tool_search import (
+            mark_description_only_tool,
+            is_description_only_tool,
+            get_description_only_tool_names,
+        )
+        mark_description_only_tool("test_desc_only_roundtrip")
+        assert is_description_only_tool("test_desc_only_roundtrip")
+        assert "test_desc_only_roundtrip" in get_description_only_tool_names()
+        assert not is_description_only_tool("unmarked_tool")
+
+    def test_get_description_only_returns_copy(self):
+        """get_description_only_tool_names returns a copy, not a live ref."""
+        from tools.tool_search import (
+            mark_description_only_tool,
+            get_description_only_tool_names,
+        )
+        mark_description_only_tool("test_copy_tool")
+        copy1 = get_description_only_tool_names()
+        copy1.add("not_real")
+        copy2 = get_description_only_tool_names()
+        assert "not_real" not in copy2
+
+    # ------------------------------------------------------------------
+    # Classification: description_only tools are always deferrable
+    # ------------------------------------------------------------------
+
+    def test_description_only_tool_is_deferrable(self):
+        """A tool marked description_only is always deferrable regardless
+        of its toolset or core-tool status."""
+        from tools.tool_search import (
+            mark_description_only_tool,
+            is_deferrable_tool_name,
+        )
+        mark_description_only_tool("do_classify_me")
+        assert is_deferrable_tool_name("do_classify_me")
+
+    def test_classify_tools_splits_description_only_correctly(self):
+        """classify_tools puts description-only tools in deferrable."""
+        from tools.tool_search import (
+            mark_description_only_tool,
+            classify_tools,
+        )
+        mark_description_only_tool("do_classify_split")
+        # Build a mixed list: one core tool + one description-only tool.
+        defs = [
+            _td("terminal", "Run shell commands"),
+            _td("do_classify_split", "A description-only tool"),
+        ]
+        visible, deferrable = classify_tools(defs)
+        visible_names = {(td.get("function") or {}).get("name") for td in visible}
+        deferrable_names = {(td.get("function") or {}).get("name") for td in deferrable}
+        assert "terminal" in visible_names
+        assert "terminal" not in deferrable_names
+        assert "do_classify_split" in deferrable_names
+
+    # ------------------------------------------------------------------
+    # Assembly: description_only tools force bridge activation
+    # ------------------------------------------------------------------
+
+    def test_assemble_forces_bridge_with_description_only_below_threshold(self):
+        """Even below the threshold, description_only tools force bridge."""
+        from tools.tool_search import (
+            assemble_tool_defs,
+            mark_description_only_tool,
+            ToolSearchConfig,
+            BRIDGE_TOOL_NAMES,
+        )
+        mark_description_only_tool("do_force_bridge")
+        # A single description_only tool — way below any reasonable threshold.
+        defs = [_td("do_force_bridge", "Tiny tool")]
+        result = assemble_tool_defs(
+            defs,
+            context_length=200_000,
+            config=ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 10}),
+        )
+        assert result.activated
+        names = {(t.get("function") or {}).get("name") for t in result.tool_defs}
+        assert "tool_search" in names
+        assert "do_force_bridge" not in names  # deferred behind bridge
+
+    def test_assemble_with_description_only_off_skips_in_model_tools_layer(self):
+        """model_tools.py gates assembly when ts_cfg.enabled == 'off'.
+        assemble_tool_defs itself forces bridge for description_only tools
+        (so they remain discoverable), but the higher-level gate prevents
+        assembly from running at all. This test verifies the gate pattern."""
+        from tools.tool_search import (
+            mark_description_only_tool,
+            ToolSearchConfig,
+        )
+        mark_description_only_tool("do_gate_test")
+
+        # The model_tools.py gate: when enabled == "off", skip assembly.
+        ts_cfg = ToolSearchConfig.from_raw({"enabled": "off"})
+        assert ts_cfg.enabled == "off"
+        # In model_tools.py, the condition is:
+        #   if not skip_tool_search_assembly and ts_cfg.enabled != "off":
+        #       assemble_tool_defs(...)
+        # When enabled == "off", the condition is False → assembly skipped.
+        should_assemble = ts_cfg.enabled != "off"
+        assert not should_assemble, (
+            "model_tools.py gate should skip assembly when tool_search is off"
+        )
+
+    # ------------------------------------------------------------------
+    # Session scoping: description_only tools filtered by valid_tool_names
+    # ------------------------------------------------------------------
+
+    def test_session_scoped_inventory_only_sees_in_scope_tools(self):
+        """description_only tools from out-of-scope servers are not listed."""
+        from tools.tool_search import (
+            mark_description_only_tool,
+            get_description_only_tool_names,
+        )
+        self._register("mcp_scope_gh_do", "mcp-scope-gh")
+        mark_description_only_tool("mcp_scope_gh_do")
+
+        # A tool in a DIFFERENT toolset — should NOT appear when scoped.
+        self._register("mcp_other_do", "mcp-other")
+        mark_description_only_tool("mcp_other_do")
+
+        # Simulate a session with only mcp-scope-gh tools visible.
+        session_tools = {"mcp_scope_gh_do"}
+        _do_names = get_description_only_tool_names() & session_tools
+        assert "mcp_scope_gh_do" in _do_names
+        assert "mcp_other_do" not in _do_names  # scoped out
+
+    # ------------------------------------------------------------------
+    # Error handling: mark non-existent or duplicate tools
+    # ------------------------------------------------------------------
+
+    def test_mark_duplicate_does_not_raise(self):
+        """Marking the same tool twice is a no-op, not an error."""
+        from tools.tool_search import (
+            mark_description_only_tool,
+            is_description_only_tool,
+        )
+        mark_description_only_tool("do_duplicate")
+        mark_description_only_tool("do_duplicate")  # should not raise
+        assert is_description_only_tool("do_duplicate")

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -540,6 +540,31 @@ class TestDescriptionOnly:
             toolset=toolset,
         )
 
+    @staticmethod
+    def _inventory_agent(valid_tools, pre_assembly):
+        """Minimal agent-shaped object for build_system_prompt_parts,
+        mirroring what agent_init produces (valid_tool_names = post-assembly
+        visible set, _pre_assembly_tool_names = full granted set)."""
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            valid_tool_names=list(valid_tools),
+            _pre_assembly_tool_names=set(pre_assembly),
+            load_soul_identity=False,
+            skip_context_files=False,
+            _task_completion_guidance=False,
+            _tool_use_enforcement=False,
+            _environment_probe=False,
+            _kanban_worker_guidance="",
+            _memory_store=None,
+            _memory_manager=None,
+            model="",
+            provider="",
+            platform="",
+            pass_session_id=False,
+            session_id="",
+        )
+
     # ------------------------------------------------------------------
     # mark / is round-trip
     # ------------------------------------------------------------------
@@ -627,26 +652,40 @@ class TestDescriptionOnly:
         assert "do_force_bridge" not in names  # deferred behind bridge
 
     def test_assemble_with_description_only_off_skips_in_model_tools_layer(self):
-        """model_tools.py gates assembly when ts_cfg.enabled == 'off'.
-        assemble_tool_defs itself forces bridge for description_only tools
-        (so they remain discoverable), but the higher-level gate prevents
-        assembly from running at all. This test verifies the gate pattern."""
+        """REAL model_tools path (P3): with tool_search disabled in config,
+        ``get_tool_definitions`` must not run assembly — the description_only
+        tool stays visible in the returned list (no bridge injected), so the
+        session can still use it directly. Previously this test re-implemented
+        the production gate on its own copy of the config, which stayed green
+        even if model_tools.py stopped honoring ``enabled == "off"``."""
+        from unittest.mock import patch
+        import model_tools
         from tools.tool_search import (
             mark_description_only_tool,
             ToolSearchConfig,
+            BRIDGE_TOOL_NAMES,
         )
-        mark_description_only_tool("do_gate_test")
 
-        # The model_tools.py gate: when enabled == "off", skip assembly.
-        ts_cfg = ToolSearchConfig.from_raw({"enabled": "off"})
-        assert ts_cfg.enabled == "off"
-        # In model_tools.py, the condition is:
-        #   if not skip_tool_search_assembly and ts_cfg.enabled != "off":
-        #       assemble_tool_defs(...)
-        # When enabled == "off", the condition is False → assembly skipped.
-        should_assemble = ts_cfg.enabled != "off"
-        assert not should_assemble, (
-            "model_tools.py gate should skip assembly when tool_search is off"
+        tool_name = "do_gate_realpath"
+        self._register(tool_name, "mcp-gate-realpath")
+        mark_description_only_tool(tool_name)
+        model_tools._clear_tool_defs_cache()
+
+        with patch(
+            "tools.tool_search.load_config",
+            return_value=ToolSearchConfig.from_raw({"enabled": "off"}),
+        ):
+            defs = model_tools.get_tool_definitions(
+                enabled_toolsets=["mcp-gate-realpath"],
+                quiet_mode=True,
+            )
+        names = {(t.get("function") or {}).get("name") for t in defs}
+        assert tool_name in names, (
+            "tool_search off must leave description_only tools visible, "
+            "not defer them behind a bridge"
+        )
+        assert not (BRIDGE_TOOL_NAMES & names), (
+            "tool_search off must not inject bridge tools"
         )
 
     # ------------------------------------------------------------------
@@ -654,23 +693,165 @@ class TestDescriptionOnly:
     # ------------------------------------------------------------------
 
     def test_session_scoped_inventory_only_sees_in_scope_tools(self):
-        """description_only tools from out-of-scope servers are not listed."""
+        """description_only tools from out-of-scope servers are not listed.
+
+        Goes through the REAL ``build_system_prompt_parts`` path — the same
+        ``get_description_only_tool_names() & _pre_assembly_tool_names``
+        intersection the production system prompt performs — instead of
+        re-implementing that intersection on a hand-picked set.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import patch
         from tools.tool_search import (
             mark_description_only_tool,
-            get_description_only_tool_names,
+            ToolSearchConfig,
         )
-        self._register("mcp_scope_gh_do", "mcp-scope-gh")
-        mark_description_only_tool("mcp_scope_gh_do")
 
-        # A tool in a DIFFERENT toolset — should NOT appear when scoped.
-        self._register("mcp_other_do", "mcp-other")
-        mark_description_only_tool("mcp_other_do")
+        in_scope = "mcp_scope_gh_do"
+        out_of_scope = "mcp_other_do"
+        self._register(in_scope, "mcp-scope-gh")
+        self._register(out_of_scope, "mcp-other")
+        mark_description_only_tool(in_scope)
+        mark_description_only_tool(out_of_scope)
 
-        # Simulate a session with only mcp-scope-gh tools visible.
-        session_tools = {"mcp_scope_gh_do"}
-        _do_names = get_description_only_tool_names() & session_tools
-        assert "mcp_scope_gh_do" in _do_names
-        assert "mcp_other_do" not in _do_names  # scoped out
+        # A session granted ONLY the mcp-scope-gh server.
+        agent = self._inventory_agent(
+            valid_tools=[in_scope],
+            pre_assembly={in_scope},
+        )
+        with (
+            patch(
+                "tools.tool_search.load_config",
+                return_value=ToolSearchConfig.from_raw({"enabled": "auto"}),
+            ),
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            from agent.system_prompt import build_system_prompt_parts
+
+            parts = build_system_prompt_parts(agent)
+            stable = parts["stable"]
+
+        assert "Available MCP Tools" in stable
+        assert in_scope in stable
+        assert out_of_scope not in stable, (
+            "out-of-scope description_only tool leaked into the session "
+            "inventory"
+        )
+
+    # ------------------------------------------------------------------
+    # P1 regression: quiet_mode cache hit must not collapse the
+    # pre-assembly snapshot (the gateway's 2nd+ session inventory)
+    # ------------------------------------------------------------------
+
+    def test_quiet_mode_cache_hit_keeps_pre_assembly_inventory(self):
+        """P1 regression (#66826): a second ``get_tool_definitions`` call with
+        the same args hits the quiet_mode memoized cache. The pre-assembly
+        snapshot must STILL include the description_only tool after the cache
+        hit — agent_init captures it into ``agent._pre_assembly_tool_names``,
+        so a collapsed snapshot would silently empty the system-prompt
+        inventory for every session after the first with the same toolset key
+        (gateway/TUI/cron all construct agents with quiet_mode=True)."""
+        import model_tools
+        from types import SimpleNamespace
+        from unittest.mock import patch
+        from tools.tool_search import (
+            mark_description_only_tool,
+            ToolSearchConfig,
+        )
+
+        tool_name = "do_cache_collapse_test"
+        self._register(tool_name, "mcp-cache-collapse")
+        mark_description_only_tool(tool_name)
+        model_tools._clear_tool_defs_cache()
+
+        kwargs = dict(enabled_toolsets=["mcp-cache-collapse"], quiet_mode=True)
+        with patch(
+            "tools.tool_search.load_config",
+            return_value=ToolSearchConfig.from_raw({"enabled": "on"}),
+        ):
+            model_tools.get_tool_definitions(**kwargs)  # miss → fresh compute
+            pre_first = set(model_tools._last_pre_assembly_tool_names)
+            defs_second = model_tools.get_tool_definitions(**kwargs)  # cache hit
+            pre_second = set(model_tools._last_pre_assembly_tool_names)
+
+        # Sanity: assembly DID run on the cache-hit call — the returned list
+        # is the post-assembly view (bridge present, tool deferred). This is
+        # exactly the divergence that used to corrupt the capture source.
+        returned_names = {(t.get("function") or {}).get("name") for t in defs_second}
+        assert "tool_search" in returned_names, "assembly should have activated"
+        assert tool_name not in returned_names
+
+        assert tool_name in pre_first
+        assert tool_name in pre_second, (
+            "cache hit collapsed the pre-assembly snapshot — the inventory "
+            "would be empty on the 2nd+ session (P1 cache-collapse)"
+        )
+        assert pre_first == pre_second
+
+        # The system-prompt inventory built AFTER the cache hit still lists it.
+        agent = self._inventory_agent(
+            valid_tools=[tool_name],
+            pre_assembly=pre_second,
+        )
+        with (
+            patch(
+                "tools.tool_search.load_config",
+                return_value=ToolSearchConfig.from_raw({"enabled": "on"}),
+            ),
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            from agent.system_prompt import build_system_prompt_parts
+
+            parts = build_system_prompt_parts(agent)
+            stable = parts["stable"]
+
+        assert "Available MCP Tools" in stable
+        assert tool_name in stable
+
+    def test_tool_search_off_no_inventory_in_system_prompt(self):
+        """P3 contract on the REAL path: with tool_search disabled, the
+        system prompt must contain NO description_only inventory block and NO
+        tool_search mention — advertising the bridge would mislead the model
+        into calling a tool that is turned off."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+        from tools.tool_search import (
+            mark_description_only_tool,
+            ToolSearchConfig,
+        )
+
+        tool_name = "do_off_inventory_test"
+        self._register(tool_name, "mcp-off-inventory")
+        mark_description_only_tool(tool_name)
+
+        agent = self._inventory_agent(
+            valid_tools=[tool_name],
+            pre_assembly={tool_name},
+        )
+        with (
+            patch(
+                "tools.tool_search.load_config",
+                return_value=ToolSearchConfig.from_raw({"enabled": "off"}),
+            ),
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            from agent.system_prompt import build_system_prompt_parts
+
+            parts = build_system_prompt_parts(agent)
+            stable = parts["stable"]
+
+        assert "Available MCP Tools" not in stable
+        assert "description-only" not in stable
+        assert "tool_search" not in stable
 
     # ------------------------------------------------------------------
     # Error handling: mark non-existent or duplicate tools
@@ -761,36 +942,72 @@ class TestDescriptionOnly:
     # ------------------------------------------------------------------
 
     def test_lazy_mcp_registration_marking_persists(self):
-        """When an MCP server is registered lazily (after agent init), its
-        tools are correctly marked as description_only and classified
-        as deferrable."""
+        """REAL registration/refresh/deregister path (P4 scenario 3):
+        a server registered AFTER agent init has its tools marked
+        description_only by ``_register_server_tools``, a
+        ``refresh_agent_mcp_tools`` rebuild publishes them into the agent's
+        pre-assembly inventory (so the system prompt can list them), and
+        deregistering the server unmarks them (no stale marks)."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+        from tools import mcp_tool
+        from tools.registry import registry
         from tools.tool_search import (
-            mark_description_only_tool,
             is_description_only_tool,
             is_deferrable_tool_name,
-            classify_tools,
+            get_description_only_tool_names,
         )
-        # Simulate a lazy MCP server being registered later.
-        lazy_tool_name = "mcp__lazy_server__search_docs"
-        self._register(lazy_tool_name, "mcp-lazy-server")
 
-        # Mark it as description_only (as _register_server_tools does).
-        mark_description_only_tool(lazy_tool_name)
+        server_name = "lazy_server"
+        tool_name = "mcp__lazy_server__search_docs"
 
-        # Verify marking stuck.
-        assert is_description_only_tool(lazy_tool_name)
-        # Verify it is deferrable.
-        assert is_deferrable_tool_name(lazy_tool_name)
+        fake_tool = SimpleNamespace(
+            name="search_docs",
+            description="Search documentation",
+            inputSchema={"type": "object", "properties": {"q": {"type": "string"}}},
+        )
+        fake_server = SimpleNamespace(
+            name=server_name,
+            _tools=[fake_tool],
+            tool_timeout=30.0,
+            # Non-None session → check_fn passes (server alive); an object()
+            # advertises no resource/prompt methods → no utility schemas.
+            session=object(),
+            initialize_result=None,
+        )
 
-        # Verify classify_tools puts it in the deferrable bucket.
-        defs = [
-            _td("terminal", "Run shell commands"),
-            _td(lazy_tool_name, "Search documentation"),
-        ]
-        visible, deferrable = classify_tools(defs)
-        deferrable_names = {(td.get("function") or {}).get("name") for td in deferrable}
-        assert lazy_tool_name in deferrable_names
-        assert "terminal" not in deferrable_names
+        with patch.dict(mcp_tool._servers, {server_name: fake_server}):
+            registered = mcp_tool._register_server_tools(
+                server_name, fake_server, {"tool_injection": "description_only"}
+            )
+            assert tool_name in registered
+            assert is_description_only_tool(tool_name)
+            assert is_deferrable_tool_name(tool_name)
+            assert tool_name in get_description_only_tool_names()
+
+            # Real refresh path: the late-registered server's tool must reach
+            # the agent's pre-assembly inventory after a snapshot rebuild.
+            agent = SimpleNamespace(
+                enabled_toolsets=None,
+                disabled_toolsets=None,
+                tools=[],
+                valid_tool_names=set(),
+                _tool_snapshot_generation=0,
+                _memory_manager=None,
+                context_compressor=None,
+                _context_engine_tool_names=set(),
+            )
+            mcp_tool.refresh_agent_mcp_tools(agent, quiet_mode=True)
+            assert tool_name in agent._pre_assembly_tool_names
+
+        # Real deregister path: unloading the server drops both the registry
+        # entry and the description_only mark.
+        task = mcp_tool.MCPServerTask(server_name)
+        task._registered_tool_names = [tool_name]
+        task._deregister_tools()
+        assert registry.get_entry(tool_name) is None
+        assert not is_description_only_tool(tool_name)
+        assert tool_name not in get_description_only_tool_names()
 
     # ------------------------------------------------------------------
     # Bridge dispatch: tool_search finds and tool_call invokes description_only tools

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -685,3 +685,84 @@ class TestDescriptionOnly:
         mark_description_only_tool("do_duplicate")
         mark_description_only_tool("do_duplicate")  # should not raise
         assert is_description_only_tool("do_duplicate")
+
+    # ------------------------------------------------------------------
+    # Lazy MCP registration: description_only marking persists correctly
+    # ------------------------------------------------------------------
+
+    def test_lazy_mcp_registration_marking_persists(self):
+        """When an MCP server is registered lazily (after agent init), its
+        tools are correctly marked as description_only and classified
+        as deferrable."""
+        from tools.tool_search import (
+            mark_description_only_tool,
+            is_description_only_tool,
+            is_deferrable_tool_name,
+            classify_tools,
+        )
+        # Simulate a lazy MCP server being registered later.
+        lazy_tool_name = "mcp__lazy_server__search_docs"
+        self._register(lazy_tool_name, "mcp-lazy-server")
+
+        # Mark it as description_only (as _register_server_tools does).
+        mark_description_only_tool(lazy_tool_name)
+
+        # Verify marking stuck.
+        assert is_description_only_tool(lazy_tool_name)
+        # Verify it is deferrable.
+        assert is_deferrable_tool_name(lazy_tool_name)
+
+        # Verify classify_tools puts it in the deferrable bucket.
+        defs = [
+            _td("terminal", "Run shell commands"),
+            _td(lazy_tool_name, "Search documentation"),
+        ]
+        visible, deferrable = classify_tools(defs)
+        deferrable_names = {(td.get("function") or {}).get("name") for td in deferrable}
+        assert lazy_tool_name in deferrable_names
+        assert "terminal" not in deferrable_names
+
+    # ------------------------------------------------------------------
+    # Bridge dispatch: tool_search finds and tool_call invokes description_only tools
+    # ------------------------------------------------------------------
+
+    def test_bridge_dispatch_finds_description_only_tool(self):
+        """tool_search returns description_only tools in the catalog and
+        tool_describe returns their full schema."""
+        from tools.tool_search import (
+            mark_description_only_tool,
+            dispatch_tool_search,
+            dispatch_tool_describe,
+            ToolSearchConfig,
+        )
+
+        do_tool = "do_bridge_dispatch_test"
+        self._register(do_tool, "mcp-bridge-test")
+        mark_description_only_tool(do_tool)
+
+        # Build a defs list that simulates post-classification output:
+        # the description_only tool is in the deferrable set.
+        defs = [
+            _td("terminal", "Run shell commands"),
+            _td(do_tool, "Bridge dispatch test tool", {"param": {"type": "string"}}),
+        ]
+
+        # tool_search should find it.
+        result = dispatch_tool_search(
+            {"query": "bridge dispatch"},
+            current_tool_defs=defs,
+            config=ToolSearchConfig.from_raw({"enabled": "on"}),
+        )
+        parsed = json.loads(result)
+        assert "matches" in parsed
+        match_names = [m["name"] for m in parsed["matches"]]
+        assert do_tool in match_names
+
+        # tool_describe should return its full schema.
+        desc_result = dispatch_tool_describe(
+            {"name": do_tool},
+            current_tool_defs=defs,
+        )
+        desc_parsed = json.loads(desc_result)
+        assert desc_parsed.get("name") == do_tool
+        assert "parameters" in desc_parsed

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6500,23 +6500,24 @@ def refresh_agent_mcp_tools(
     # Computed OUTSIDE the lock (get_tool_definitions can be slow); the diff and
     # publish below happen together in ONE critical section so two concurrent
     # callers can't torn-publish or compute overlapping ``added`` sets.
-    new_defs = list(
-        model_tools.get_tool_definitions(
-            enabled_toolsets=enabled,
-            disabled_toolsets=disabled,
-            quiet_mode=quiet_mode,
-        )
-        or []
+    new_defs, pre_assembly_names = model_tools.get_tool_definitions_with_meta(
+        enabled_toolsets=enabled,
+        disabled_toolsets=disabled,
+        quiet_mode=quiet_mode,
     )
+    new_defs = list(new_defs or [])
     new_names = {t["function"]["name"] for t in new_defs}
-    # Pre-assembly view of the SAME snapshot: get_tool_definitions restores
-    # model_tools._last_pre_assembly_tool_names on both the fresh-compute and
-    # cache-hit paths, so this always reflects the full granted set before
-    # tool_search assembly (description_only tools included). Published onto
-    # the agent atomically with the snapshot below — without this, a server
+    # Pre-assembly view of the SAME snapshot: get_tool_definitions_with_meta
+    # returns the pre-assembly names alongside the tools, so this reflects the
+    # full granted set before tool_search assembly (description_only tools
+    # included) WITHOUT re-reading the process-global. Reading
+    # model_tools._last_pre_assembly_tool_names after the call is the same
+    # cross-agent race class as #66826: a concurrent agent init / refresh can
+    # overwrite the global between the call and the read. Published onto the
+    # agent atomically with the snapshot below — without this, a server
     # registered AFTER agent_init (lazy refresh / /reload-mcp) would never
     # reach the system-prompt description_only inventory. (#66826)
-    new_pre_assembly = set(model_tools._last_pre_assembly_tool_names)
+    new_pre_assembly = set(pre_assembly_names)
 
     # Re-append the post-build injected families that get_tool_definitions does
     # NOT reproduce, so a refresh never strips them (memory-provider + context-

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3500,10 +3500,15 @@ class MCPServerTask:
         connected" errors on every turn.
         """
         from tools.registry import registry
+        from tools.tool_search import unmark_description_only_tool
 
         for tool_name in list(getattr(self, "_registered_tool_names", [])):
             registry.deregister(tool_name)
             _forget_mcp_tool_server(tool_name)
+            # Drop description_only marks so a disabled/unloaded server can't
+            # leave stale marks that make is_deferrable_tool_name() return True
+            # forever for tools that no longer exist. (#66826)
+            unmark_description_only_tool(tool_name)
         self._registered_tool_names = []
 
     async def _wait_for_lazy_reconnect(self) -> None:
@@ -5736,6 +5741,13 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     # discovered via tool_search rather than loaded into the tools array
     # on every turn. Mirroring Claude Code's ``defer_loading`` pattern.
     tool_injection = config.get("tool_injection", "full")
+    if tool_injection not in ("full", "description_only"):
+        logger.warning(
+            "MCP server '%s': invalid tool_injection=%r — expected 'full' or "
+            "'description_only'; falling back to 'full'",
+            name, tool_injection,
+        )
+        tool_injection = "full"
     is_description_only = tool_injection == "description_only"
 
     if is_description_only:
@@ -6460,7 +6472,7 @@ def refresh_agent_mcp_tools(
     explicit user consent; the late-binding and between-turns paths only rebuild
     at a turn boundary, before that turn's ``tools=`` prefix is assembled).
     """
-    from model_tools import get_tool_definitions
+    import model_tools
     from tools.registry import registry
 
     # Explicit reloads (/reload-mcp) pass freshly-resolved toolsets so a server
@@ -6489,7 +6501,7 @@ def refresh_agent_mcp_tools(
     # publish below happen together in ONE critical section so two concurrent
     # callers can't torn-publish or compute overlapping ``added`` sets.
     new_defs = list(
-        get_tool_definitions(
+        model_tools.get_tool_definitions(
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
             quiet_mode=quiet_mode,
@@ -6497,6 +6509,14 @@ def refresh_agent_mcp_tools(
         or []
     )
     new_names = {t["function"]["name"] for t in new_defs}
+    # Pre-assembly view of the SAME snapshot: get_tool_definitions restores
+    # model_tools._last_pre_assembly_tool_names on both the fresh-compute and
+    # cache-hit paths, so this always reflects the full granted set before
+    # tool_search assembly (description_only tools included). Published onto
+    # the agent atomically with the snapshot below — without this, a server
+    # registered AFTER agent_init (lazy refresh / /reload-mcp) would never
+    # reach the system-prompt description_only inventory. (#66826)
+    new_pre_assembly = set(model_tools._last_pre_assembly_tool_names)
 
     # Re-append the post-build injected families that get_tool_definitions does
     # NOT reproduce, so a refresh never strips them (memory-provider + context-
@@ -6532,6 +6552,9 @@ def refresh_agent_mcp_tools(
             return set()
         agent.tools = new_defs
         agent.valid_tool_names = new_names
+        # Publish the pre-assembly view atomically with the snapshot so the
+        # system-prompt description_only inventory tracks late registrations.
+        agent._pre_assembly_tool_names = new_pre_assembly
         # Publish context-engine routing names atomically with the snapshot.
         engine_names = getattr(agent, "_context_engine_tool_names", None)
         if isinstance(engine_names, set):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5732,6 +5732,18 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude"
     )
 
+    # Description-only mode: tools from this server are always deferrable,
+    # discovered via tool_search rather than loaded into the tools array
+    # on every turn. Mirroring Claude Code's ``defer_loading`` pattern.
+    tool_injection = config.get("tool_injection", "full")
+    is_description_only = tool_injection == "description_only"
+
+    if is_description_only:
+        logger.info(
+            "MCP server '%s': tool_injection=description_only — "
+            "tools will be deferred and discovered via tool_search", name,
+        )
+
     def _should_register(tool_name: str) -> bool:
         if include_set:
             return matches_name_filter(tool_name, include_set)
@@ -5876,6 +5888,16 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
         _track_mcp_tool_server(registry_name, name)
         registered_names.append(registry_name)
+
+        # Description-only mode: mark for always-deferred treatment so tools
+        # are discovered via tool_search rather than bloating the tools array
+        # on every turn. Everything from this server flows through this one
+        # registration loop — raw MCP tools AND generated resource/prompt
+        # utility schemas — so a single mark here covers both.
+        if is_description_only:
+            from tools.tool_search import mark_description_only_tool
+
+            mark_description_only_tool(registry_name)
 
     if registered_names:
         registry.register_toolset_alias(name, toolset_name)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6548,6 +6548,12 @@ def refresh_agent_mcp_tools(
         if new_names == current:
             # No change → leave the live snapshot untouched (no churn), but
             # record the generation so an in-flight older caller can't clobber.
+            # Still publish the pre-assembly view: when tool_search assembly is
+            # already active, a newly registered description_only server keeps
+            # the POST-assembly name set unchanged (its tools were bridged away)
+            # yet widens the granted pre-assembly surface — without this publish
+            # the system-prompt inventory would silently miss it. (#66826 P2)
+            agent._pre_assembly_tool_names = new_pre_assembly
             agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
             return set()
         agent.tools = new_defs

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -212,6 +212,17 @@ def mark_description_only_tool(name: str) -> None:
     _description_only_tool_names.add(name)
 
 
+def unmark_description_only_tool(name: str) -> None:
+    """Remove a description-only mark (idempotent).
+
+    Called when the owning MCP server's tools are deregistered (server
+    disabled/unloaded/parked), so a stale mark can't keep
+    :func:`is_deferrable_tool_name` returning True forever for a tool that
+    no longer exists in the registry. (#66826)
+    """
+    _description_only_tool_names.discard(name)
+
+
 def is_description_only_tool(name: str) -> bool:
     """Return True if this tool is registered as description-only."""
     return name in _description_only_tool_names
@@ -1089,6 +1100,7 @@ __all__ = [
     "scoped_deferrable_names",
     "validate_deferred_call_args",
     "mark_description_only_tool",
+    "unmark_description_only_tool",
     "is_description_only_tool",
     "get_description_only_tool_names",
 ]

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -201,6 +201,27 @@ def _core_tool_names() -> frozenset[str]:
         return frozenset()
 
 
+# Tools from description_only MCP servers are *always* deferrable,
+# regardless of the threshold gate. Populated by mcp_tool.py during
+# server registration.
+_description_only_tool_names: set[str] = set()
+
+
+def mark_description_only_tool(name: str) -> None:
+    """Mark a tool as description-only (always deferrable)."""
+    _description_only_tool_names.add(name)
+
+
+def is_description_only_tool(name: str) -> bool:
+    """Return True if this tool is registered as description-only."""
+    return name in _description_only_tool_names
+
+
+def get_description_only_tool_names() -> set[str]:
+    """Return a copy of the description-only tool name set."""
+    return set(_description_only_tool_names)
+
+
 def is_deferrable_tool_name(name: str) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
@@ -208,11 +229,19 @@ def is_deferrable_tool_name(name: str) -> bool:
     OR it is not in ``_HERMES_CORE_TOOLS``. Core tools are never deferred
     even when their toolset is technically plugin-provided (this protects
     against accidental shadowing).
+
+    Tools from description-only MCP servers are always deferrable
+    regardless of the threshold gate — they are designed to be discovered
+    via tool_search and loaded on demand, mirroring Claude Code's
+    ``defer_loading`` pattern.
     """
     if name in BRIDGE_TOOL_NAMES:
         return False
     if name in _core_tool_names():
         return False
+    # Description-only tools: always defer, even under threshold.
+    if name in _description_only_tool_names:
+        return True
     # Check registry toolset for MCP prefix.
     try:
         from tools.registry import registry
@@ -795,11 +824,24 @@ def assemble_tool_defs(
                 if (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES]
 
     visible, deferrable = classify_tools(incoming)
+
+    # Description-only tools: always force-defer, even when the total
+    # deferrable count is below the threshold gate. This ensures tools
+    # from servers with ``tool_injection: description_only`` are always
+    # discovered via tool_search rather than bloating the tools array.
+    deferrable_names = {(t.get("function") or {}).get("name") for t in deferrable}
+    has_description_only = bool(deferrable_names & _description_only_tool_names)
+
     if not deferrable:
         return AssemblyResult(tool_defs=incoming, activated=False)
 
     deferrable_tokens = estimate_tokens_from_schemas(deferrable)
-    if not should_activate(config, deferrable_tokens, context_length):
+    # Description-only tools force bridge activation — they are designed for
+    # on-demand discovery via tool_search — EXCEPT when tool_search is
+    # globally disabled: activating the bridge there would advertise a
+    # tool_search path that is turned off (P3 contract).
+    _force_bridge = has_description_only and config.enabled != "off"
+    if not should_activate(config, deferrable_tokens, context_length) and not _force_bridge:
         return AssemblyResult(
             tool_defs=incoming,
             activated=False,
@@ -1046,4 +1088,7 @@ __all__ = [
     "resolve_underlying_call",
     "scoped_deferrable_names",
     "validate_deferred_call_args",
+    "mark_description_only_tool",
+    "is_description_only_tool",
+    "get_description_only_tool_names",
 ]


### PR DESCRIPTION
## Summary

Adds per-MCP-server `tool_injection` config option, supporting `"full"` (default, backwards-compatible) and `"description_only"` modes. Description-only tools are always deferred and discovered via `tool_search`, mirroring Claude Code's `defer_loading` pattern — the agent sees tool names + descriptions in the system prompt (stable tier, cached prefix) while full schemas are loaded on demand.

**Closes #66736** · **Inspired by #6839** (Lazy Tool Schema Loading) · **Addresses Writer Harness paper critique** (arXiv 2607.06906: Hermes tools not in cached prefix)

## Motivation

Currently, all MCP tool schemas are loaded into every API call irrespective of frequency. For low-frequency MCP servers (e.g., firecrawl's 26 tools used 2-3 times per session), this wastes tokens on every turn. The `tool_search` mechanism already supports deferral, but only at a global threshold (>10% context) — there's no per-server control.

Real-world impact: one user moved 5 low-frequency MCP servers (64 tools) to mcporter CLI workarounds, saving ~60+ tool schemas from the tools array per turn. This feature makes that pattern native.

## Design

Mirrors Claude Code's three-tier tool pool and Hermes's own Skill frontmatter discovery:

```yaml
mcp_servers:
  firecrawl:
    command: npx
    args: [-y, firecrawl-mcp]
    tool_injection: description_only  # NEW: name+desc in prompt, schema on demand
```

**Flow:**
1. System prompt stable tier ← tool names + one-line descriptions (cached prefix)
2. Tools array ← bridge tools only (`tool_search`, `tool_describe`, `tool_call`)
3. Agent calls `tool_search` → `tool_describe` → `tool_call` to use deferred tools
4. Catalog stores full schemas → loaded from BM25 search on demand

## Changes (3 files, +90/-1 lines)

- **`tools/tool_search.py`**: `mark_description_only_tool()` registry + force-defer in `assemble_tools()` even under threshold
- **`tools/mcp_tool.py`**: read `tool_injection` config, mark tools during registration
- **`agent/system_prompt.py`**: inject MCP tool inventory into stable tier, mirroring Skill index block

## Backwards Compatibility

- `tool_injection` defaults to `"full"` — no behavior change for existing configs
- All existing tests pass without modification
- `tool_search` must be enabled (`tools.tool_search`) for `description_only` tools to be usable

## Testing

- [ ] Unit: `mark_description_only_tool` / `is_description_only_tool` round-trip
- [ ] Unit: `classify_tools` correctly routes description_only tools to deferrable
- [ ] Unit: `assemble_tools` forces bridge injection when description_only tools exist
- [ ] Integration: description_only MCP server → tools in stable tier, not in tools array
- [ ] Integration: `tool_search` → `tool_describe` → `tool_call` works end-to-end

## References

- #66736 (this feature request)
- #6839 (Lazy Tool Schema Loading — broader two-pass approach)
- #13332 (Hybrid Tool Pre-Selection — complementary)
- Claude Code Blog: [Prompt caching is everything](https://claude.com/blog/lessons-from-building-claude-code-prompt-caching-is-everything) (defer_loading pattern)
- Writer Agent Harness paper: [arXiv 2607.06906](https://arxiv.org/abs/2607.06906) — Section 4.4: "Hermes does not place its tool schemas inside a cached prefix"