### PR TITLE
fix(cli): skip unreachable support files instead of aborting URL skill install (#66760)

### DIFF
--- a/tests/tools/test_skill_bundle_provenance.py
+++ b/tests/tools/test_skill_bundle_provenance.py
@@ -248,6 +248,80 @@ def test_real_temp_repo_and_home_install_e2e(served_repo, monkeypatch, tmp_path)
     assert "Scan provenance: fresh" in sink.getvalue()
 
 
+SKILL_MD_MISSING_REF = """---
+name: partial-bundle
+description: References a support file that is unreachable.
+---
+# Partial
+Read [the guide](references/present.md#usage) and the appendix at
+`references/absent.md`, then run `scripts/run.py`.
+"""
+
+
+@pytest.fixture
+def served_repo_missing_support(tmp_path, monkeypatch):
+    """Serve a skill whose SKILL.md references a support file that is not
+    present on the server, so fetching it returns 404."""
+    # Serve over loopback while opting this test server into private-address
+    # access, so the SSRF-safe HTTP client is exercised for real (see
+    # ``served_repo``).
+    monkeypatch.setattr("tools.url_safety._global_allow_private_urls", lambda: True)
+
+    repo = tmp_path / "upstream-missing"
+    repo.mkdir()
+    (repo / "SKILL.md").write_text(SKILL_MD_MISSING_REF)
+    # references/absent.md is deliberately NOT created, so the server 404s it.
+    for rel, content in {
+        "references/present.md": "present guide\n",
+        "scripts/run.py": "print('ok')\n",
+    }.items():
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", 0), partial(_QuietHandler, directory=str(repo))
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield repo, f"http://127.0.0.1:{server.server_port}/SKILL.md"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_install_skips_unreachable_support_file_e2e(served_repo_missing_support, monkeypatch, tmp_path):
+    """A referenced support file that 404s is skipped rather than aborting the
+    whole URL install: the bundle still installs end-to-end through quarantine,
+    scan, install, and lock provenance, with only the reachable files landing
+    on disk and recorded in the lock file (#66760)."""
+    from hermes_cli.skills_hub import do_install
+    import tools.skills_hub as hub
+
+    _repo, url = served_repo_missing_support
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("tools.skills_hub.is_safe_url", lambda _url: True)
+    monkeypatch.setattr("tools.skills_hub.check_website_access", lambda _url: None)
+    monkeypatch.setattr(hub, "create_source_router", lambda auth=None: [UrlSource()])
+
+    sink = StringIO()
+    do_install(url, console=Console(file=sink, force_terminal=False), skip_confirm=True)
+
+    installed = home / "skills" / "partial-bundle"
+    assert (installed / "SKILL.md").is_file()
+    assert (installed / "references" / "present.md").read_text() == "present guide\n"
+    assert (installed / "scripts" / "run.py").is_file()
+    # The unreachable reference neither blocked the install nor was written.
+    assert not (installed / "references" / "absent.md").exists()
+
+    entry = json.loads((home / "skills" / ".hub" / "lock.json").read_text())["installed"]["partial-bundle"]
+    assert entry["scan_provenance"]["source_url"] == url
+    assert "references/present.md" in entry["files"]
+    assert "references/absent.md" not in entry["files"]
+
+
 def test_bundled_optional_source_still_includes_support_files(tmp_path, monkeypatch):
     from tools.skills_hub import OptionalSkillSource
 

--- a/tests/tools/test_skill_bundle_provenance.py
+++ b/tests/tools/test_skill_bundle_provenance.py
@@ -229,6 +229,85 @@ def test_install_with_junctioned_skills_dir(served_repo, monkeypatch, tmp_path):
     assert "Installed:" in sink.getvalue()
 
 
+
+SKILL_MD_MISSING_REF = """---
+name: partial-bundle
+description: References a support file that is unreachable.
+---
+# Partial
+Read [the guide](references/present.md#usage) and the appendix at
+`references/absent.md`, then run `scripts/run.py`.
+"""
+
+
+@pytest.fixture
+def served_repo_missing_support(tmp_path, monkeypatch):
+    """Serve a skill whose SKILL.md references a support file that is not
+    present on the server, so fetching it returns 404."""
+    # Serve over loopback while opting this test server into private-address
+    # access, so the SSRF-safe HTTP client is exercised for real (see
+    # ``served_repo``).
+    monkeypatch.setattr("tools.url_safety._global_allow_private_urls", lambda: True)
+
+    repo = tmp_path / "upstream-missing"
+    repo.mkdir()
+    (repo / "SKILL.md").write_text(SKILL_MD_MISSING_REF)
+    # references/absent.md is deliberately NOT created, so the server 404s it.
+    for rel, content in {
+        "references/present.md": "present guide\n",
+        "scripts/run.py": "print('ok')\n",
+    }.items():
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", 0), partial(_QuietHandler, directory=str(repo))
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield repo, f"http://127.0.0.1:{server.server_port}/SKILL.md"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_install_skips_unreachable_support_file_e2e(served_repo_missing_support, monkeypatch, tmp_path):
+    """A referenced support file that 404s is skipped rather than aborting the
+    whole URL install: the bundle still installs end-to-end through quarantine,
+    scan, install, and lock provenance, with only the reachable files landing
+    on disk and recorded in the lock file (#66760)."""
+    from hermes_cli.skills_hub import do_install
+    import tools.skills_hub as hub
+
+    _repo, url = served_repo_missing_support
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("tools.skills_hub.is_safe_url", lambda _url: True)
+    monkeypatch.setattr("tools.skills_hub.check_website_access", lambda _url: None)
+    monkeypatch.setattr(hub, "create_source_router", lambda auth=None: [UrlSource()])
+
+    sink = StringIO()
+    do_install(url, console=Console(file=sink, force_terminal=False), skip_confirm=True)
+
+    installed = home / "skills" / "partial-bundle"
+    assert (installed / "SKILL.md").is_file()
+    assert (installed / "references" / "present.md").read_text() == "present guide\n"
+    assert (installed / "scripts" / "run.py").is_file()
+    # The unreachable reference neither blocked the install nor was written.
+    assert not (installed / "references" / "absent.md").exists()
+
+    entry = json.loads((home / "skills" / ".hub" / "lock.json").read_text())["installed"]["partial-bundle"]
+    assert entry["scan_provenance"]["source_url"] == url
+    assert "references/present.md" in entry["files"]
+    assert "references/absent.md" not in entry["files"]
+
+
+
+
+
+
 def test_bundled_optional_source_still_includes_support_files(tmp_path, monkeypatch):
     from tools.skills_hub import OptionalSkillSource
 

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -380,6 +380,38 @@ class TestUrlSource:
 
 
     @patch("tools.skills_hub._ssrf_safe_http_get")
+    def test_fetch_skips_missing_support_file_instead_of_aborting(self, mock_get):
+        # One referenced support file 404s; the other is reachable. The
+        # install should still succeed with the file that could be fetched,
+        # rather than aborting the whole fetch (regression for a bug where
+        # any single missing companion file failed the entire URL install).
+        skill_md = (
+            "---\n"
+            "name: my-skill\n"
+            "description: Has support files.\n"
+            "---\n\n"
+            "See `references/good.md` and `references/missing.md`.\n"
+        )
+
+        def _side_effect(url, **kwargs):
+            if url.endswith("SKILL.md"):
+                return MagicMock(status_code=200, text=skill_md)
+            if url.endswith("references/good.md"):
+                return MagicMock(status_code=200, content=b"good content")
+            if url.endswith("references/missing.md"):
+                return MagicMock(status_code=404)
+            raise AssertionError(f"unexpected URL: {url}")
+
+        mock_get.side_effect = _side_effect
+
+        bundle = self._source().fetch("https://example.com/my-skill/SKILL.md")
+        assert bundle is not None
+        assert bundle.name == "my-skill"
+        assert bundle.files["SKILL.md"] == skill_md
+        assert bundle.files["references/good.md"] == b"good content"
+        assert "references/missing.md" not in bundle.files
+
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch("tools.skills_hub.check_website_access", return_value=None)
     @patch("tools.skills_hub.is_safe_url", side_effect=[True, False])
     def test_fetch_blocks_redirect_to_private_url(self, _mock_safe, _mock_policy, mock_get):

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1105,6 +1105,38 @@ class TestUrlSource:
         assert self._source().fetch("https://example.com/SKILL.md") is None
 
     @patch("tools.skills_hub._ssrf_safe_http_get")
+    def test_fetch_skips_missing_support_file_instead_of_aborting(self, mock_get):
+        # One referenced support file 404s; the other is reachable. The
+        # install should still succeed with the file that could be fetched,
+        # rather than aborting the whole fetch (regression for a bug where
+        # any single missing companion file failed the entire URL install).
+        skill_md = (
+            "---\n"
+            "name: my-skill\n"
+            "description: Has support files.\n"
+            "---\n\n"
+            "See `references/good.md` and `references/missing.md`.\n"
+        )
+
+        def _side_effect(url, **kwargs):
+            if url.endswith("SKILL.md"):
+                return MagicMock(status_code=200, text=skill_md)
+            if url.endswith("references/good.md"):
+                return MagicMock(status_code=200, content=b"good content")
+            if url.endswith("references/missing.md"):
+                return MagicMock(status_code=404)
+            raise AssertionError(f"unexpected URL: {url}")
+
+        mock_get.side_effect = _side_effect
+
+        bundle = self._source().fetch("https://example.com/my-skill/SKILL.md")
+        assert bundle is not None
+        assert bundle.name == "my-skill"
+        assert bundle.files["SKILL.md"] == skill_md
+        assert bundle.files["references/good.md"] == b"good content"
+        assert "references/missing.md" not in bundle.files
+
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch("tools.skills_hub.check_website_access", return_value=None)
     @patch("tools.skills_hub.is_safe_url", side_effect=[True, False])
     def test_fetch_blocks_redirect_to_private_url(self, _mock_safe, _mock_policy, mock_get):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1516,7 +1516,15 @@ class UrlSource(SkillSource):
                 return None
             content = self._fetch_bytes(support_url)
             if content is None:
-                return None
+                # A referenced support file that 404s (or is otherwise
+                # unreachable) shouldn't sink the whole install — skip it
+                # and let the bundle install without it.
+                logger.warning(
+                    "URL skill %s: referenced support file %r could not be "
+                    "fetched from %s; skipping it",
+                    url, rel_path, support_url,
+                )
+                continue
             files[rel_path] = content
 
         # When auto-resolution fails, return a bundle with an empty name and

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1524,7 +1524,15 @@ class UrlSource(SkillSource):
                 return None
             content = self._fetch_bytes(support_url)
             if content is None:
-                return None
+                # A referenced support file that 404s (or is otherwise
+                # unreachable) shouldn't sink the whole install — skip it
+                # and let the bundle install without it.
+                logger.warning(
+                    "URL skill %s: referenced support file %r could not be "
+                    "fetched from %s; skipping it",
+                    url, rel_path, support_url,
+                )
+                continue
             files[rel_path] = content
 
         # When auto-resolution fails, return a bundle with an empty name and


### PR DESCRIPTION
## What does this PR do?

Fixes `UrlSource.fetch()` (raw-URL skill install, e.g. `hermes skills install https://.../SKILL.md`) so that a single unreachable referenced support file (under `references/`, `templates/`, `scripts/`, or `assets/`) no longer aborts the entire install. Previously, if `SKILL.md` referenced N support files and any one of them 404'd (or otherwise failed to fetch), `fetch()` returned `None` for the whole bundle — even when `SKILL.md` and the other N-1 files were fine. Now the missing file is skipped with a logged warning and the rest of the bundle installs normally.

Cross-origin support-file references (a security boundary, not a "missing file" case) are left unchanged — those still abort the fetch.

## Related Issue

Fixes #66760

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub.py`: in `UrlSource.fetch()`, when a referenced support file's `_fetch_bytes()` call returns `None`, log a warning naming the URL and skip it via `continue` instead of returning `None` for the whole bundle.
- `tests/tools/test_skills_hub.py`: add `test_fetch_skips_missing_support_file_instead_of_aborting` covering a `SKILL.md` that references one reachable and one 404'ing support file — asserts the bundle is still returned with the reachable file included and the missing one absent.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_skills_hub.py -q` → 159 passed, 0 failed.
2. Manual repro (per the issue): `hermes skills install https://raw.githubusercontent.com/NousResearch/hermes-agent/main/skills/creative/p5js/SKILL.md --yes` previously failed with `Error: Could not fetch '...' from any source.` whenever a referenced companion path 404'd; with this fix the install proceeds using the support files that are actually reachable.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.5.0 arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no docs reference this internal fallback behavior)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) — this touches only HTTP-fetch control flow, no OS-specific code paths
- [x] I've updated tool descriptions/schemas — N/A (no tool schema change)

## Screenshots / Logs

N/A — behavioral fix covered by the added unit test.
