### PR TITLE
feat(compression): persist decision and blocker checkpoints

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2274,10 +2274,24 @@ Be specific with file paths, commands, line numbers, and results.]
 [Work currently underway — what was being done when compaction fired]
 
 ## Blocked
-[Any blockers, errors, or issues not yet resolved. Include exact error messages.]
+[Only blockers, errors, or issues that are still unresolved. Use one bullet per
+blocker in this compact form. Every displayed field is required and non-empty;
+write "unknown" explicitly when history cannot recover a value:
+Blocker: ... | Evidence: ... | Failed attempts: ... | Artifact state: ... |
+Required input: ... | Resume: exact next action or command.
+Write "None." when no unresolved blocker remains.]
 
 ## Key Decisions
-[Important technical decisions and WHY they were made]
+[Only decisions that still apply. Use one bullet per decision in this compact
+form. Every displayed field is required and non-empty; write "unknown"
+explicitly when history cannot recover a value:
+Decision: ... | Rationale: ... | Rejected: materially relevant alternatives |
+Scope: where the decision applies.
+Remove superseded decisions instead of carrying both forward.]
+
+Across `## Blocked` and `## Key Decisions`, emit at most 8 bullets total and keep
+each bullet under 2000 characters. If more state exists, consolidate related items
+without dropping an exact `Resume:` action.
 
 ## Resolved Questions
 [Questions the user asked that were ALREADY answered — include the answer so it is not repeated]

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -240,8 +240,31 @@ def _required_checkpoint_field(
     return value if key == "resume" else value.strip()
 
 
-def build_compression_checkpoint(summary: str, *, session_id: str) -> dict[str, Any]:
-    """Build the durable decision/blocker sidecar from a generated summary."""
+def build_compression_checkpoint(
+    summary: str,
+    *,
+    session_id: str,
+    source: str = "model",
+) -> dict[str, Any]:
+    """Build the durable decision/blocker sidecar from a generated summary.
+
+    Model summaries are untrusted and must satisfy the strict structured
+    schema below. The deterministic static fallback is trusted control flow,
+    but its narrative error bullets cannot reliably supply that schema. Keep
+    its structured state explicitly opaque rather than fabricating fields or
+    weakening validation for model output.
+    """
+    if source == "static_fallback":
+        return {
+            "version": _COMPRESSION_CHECKPOINT_VERSION,
+            "session_id": str(session_id or ""),
+            "decisions": [],
+            "blockers": [],
+            "checkpoint_quality": "fallback_opaque",
+        }
+    if source != "model":
+        raise ValueError(f"unknown compression checkpoint source: {source}")
+
     decision_entries = _checkpoint_entries(_summary_section(summary, "Key Decisions"))
     blocker_entries = _checkpoint_entries(_summary_section(summary, "Blocked"))
     if len(decision_entries) + len(blocker_entries) > _MAX_CHECKPOINT_ENTRIES:
@@ -350,10 +373,16 @@ def _inject_compression_checkpoint(
     except Exception:
         return False
 
+    checkpoint_note = (
+        "Structured decision and blocker state is opaque because this checkpoint "
+        "came from the deterministic static fallback. Re-verify current state."
+        if checkpoint.get("checkpoint_quality") == "fallback_opaque"
+        else "Only current decisions and unresolved blockers are authoritative here."
+    )
     block = (
         f"{_COMPRESSION_CHECKPOINT_START}\n"
         "## Durable Compression Checkpoint\n"
-        "Only current decisions and unresolved blockers are authoritative here.\n"
+        f"{checkpoint_note}\n"
         f"```json\n{_checkpoint_json(checkpoint)}\n```\n"
         f"{_COMPRESSION_CHECKPOINT_END}"
     )
@@ -362,7 +391,8 @@ def _inject_compression_checkpoint(
         rf"{re.escape(_COMPRESSION_CHECKPOINT_END)}\n*"
     )
     stale_state_re = re.compile(
-        r"(?ims)^##\s+(?:Blocked|Key Decisions)\s*$\n?.*?(?=^##\s+|\Z)"
+        rf"(?ims)^##\s+(?:Blocked|Key Decisions)\s*$\n?.*?"
+        rf"(?=^##\s+|^{re.escape(_SUMMARY_END_MARKER)}|\Z)"
     )
 
     def _copy_content(content: Any) -> Any:
@@ -457,7 +487,11 @@ def _inject_compression_checkpoint(
         return combined
 
     def _inject_content(content: Any) -> Any:
-        copied = _remove_spans(content, remove_stale_state=False)
+        # The checkpoint is the canonical decision/blocker state for the target
+        # summary too. Remove its narrative copies before injection so an opaque
+        # fallback cannot retain unstructured blocker prose beside an empty
+        # structured list, and a model summary cannot expose two authorities.
+        copied = _remove_spans(content, remove_stale_state=True)
         if copied is None:
             return None
         combined, segments = _text_segments(copied)
@@ -1709,6 +1743,7 @@ def compress_context(
             _checkpoint = build_compression_checkpoint(
                 _summary_body_for_checkpoint(agent.context_compressor, compressed),
                 session_id=_lock_sid,
+                source=("static_fallback" if _compression_used_fallback else "model"),
             )
             if not _inject_compression_checkpoint(compressed, _checkpoint):
                 raise RuntimeError("compressed summary message was not found")

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -265,8 +265,23 @@ def build_compression_checkpoint(
     if source != "model":
         raise ValueError(f"unknown compression checkpoint source: {source}")
 
-    decision_entries = _checkpoint_entries(_summary_section(summary, "Key Decisions"))
-    blocker_entries = _checkpoint_entries(_summary_section(summary, "Blocked"))
+    decision_section = _summary_section(summary, "Key Decisions")
+    blocker_section = _summary_section(summary, "Blocked")
+    missing_sections = [
+        heading
+        for heading, section in (
+            ("Blocked", blocker_section),
+            ("Key Decisions", decision_section),
+        )
+        if not section.strip()
+    ]
+    if missing_sections:
+        raise ValueError(
+            "compression checkpoint model summary is missing required section(s): "
+            + ", ".join(missing_sections)
+        )
+    decision_entries = _checkpoint_entries(decision_section)
+    blocker_entries = _checkpoint_entries(blocker_section)
     if len(decision_entries) + len(blocker_entries) > _MAX_CHECKPOINT_ENTRIES:
         raise ValueError("compression checkpoint exceeds entry limit")
 
@@ -1845,9 +1860,14 @@ def compress_context(
                             agent.session_id,
                             compressed,
                             state_meta=_target_state_meta,
+                            system_prompt=new_system_prompt,
                         )
                     else:
-                        agent._session_db.archive_and_compact(agent.session_id, compressed)
+                        agent._session_db.archive_and_compact(
+                            agent.session_id,
+                            compressed,
+                            system_prompt=new_system_prompt,
+                        )
                     _committed_checkpoint = _target_checkpoint
                     # Reset the flush identity set so the next turn's appends are
                     # diffed against the COMPACTED transcript: the compacted dicts
@@ -1872,7 +1892,6 @@ def compress_context(
                         pass  # plugin engines retain their legacy best-effort behavior
                     # Propagate title to the new session with auto-numbering
                     old_title = agent._session_db.get_session_title(agent.session_id)
-                    agent._session_db.end_session(agent.session_id, "compression")
                     old_session_id = agent.session_id
                     agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
                     # Ordering contract: the agent thread updates the contextvar here;
@@ -1906,14 +1925,16 @@ def compress_context(
                         _create_kwargs = {
                             "model": agent.model,
                             "model_config": agent._session_init_model_config,
-                            "parent_session_id": old_session_id,
+                            "system_prompt": new_system_prompt,
                         }
                         if _target_state_meta:
                             _create_kwargs["state_meta"] = _target_state_meta
-                        agent._session_db.create_session(
-                            session_id=agent.session_id,
+                        agent._session_db.rotate_session_with_messages(
+                            parent_session_id=old_session_id,
+                            child_session_id=agent.session_id,
                             source=agent.platform
                             or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            messages=compressed,
                             **_create_kwargs,
                         )
                         _committed_checkpoint = _target_checkpoint
@@ -1943,12 +1964,8 @@ def compress_context(
                             set_session_context(agent.session_id)
                         except Exception:
                             pass
-                        # Re-open the parent: it was ended above, but we're
-                        # continuing on it, so it must not stay closed.
-                        try:
-                            agent._session_db.reopen_session(old_session_id)
-                        except Exception:
-                            pass
+                        # Parent end + child/checkpoint/transcript are one DB
+                        # transaction, so a failure leaves the parent live.
                         old_session_id = None  # no rotation happened
                         # The parent row already exists in state.db, so mark the
                         # session as created — _ensure_db_session would otherwise
@@ -1975,16 +1992,13 @@ def compress_context(
 
                 # Shared post-write steps (both modes target agent.session_id, which
                 # in-place keeps and rotation has already reassigned to the new id):
-                # refresh the stored system prompt and reset the flush cursor so the
-                # next turn re-bases its append diff.
-                agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+                # The DB boundary already committed the system prompt with the
+                # checkpoint and transcript. Reset only the in-memory flush cursor.
                 if in_place:
                     agent._last_flushed_db_idx = 0
                 else:
-                    # A headless turn can be killed before its finalizer. Persist
-                    # the rotated child's compacted handoff at the boundary so
-                    # the new session is immediately resumable.
-                    agent._session_db.replace_messages(agent.session_id, compressed)
+                    # The atomic rotation already persisted the compacted handoff,
+                    # so a headless process is immediately resumable.
                     agent._last_flushed_db_idx = len(compressed)
                     agent._flushed_db_message_session_id = agent.session_id
                     agent._flushed_db_message_ids = {

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -28,15 +28,18 @@ these paths see no behavioural change.
 
 from __future__ import annotations
 
+import copy
 import inspect
+import json
 import logging
 import os
+import re
 import tempfile
 import uuid
 import threading
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, cast
 
 from agent.model_metadata import estimate_request_tokens_rough
 
@@ -51,6 +54,514 @@ COMPACTION_STATUS_MARKER = "Compacting context"
 COMPACTION_STATUS = (
     f"🗜️ {COMPACTION_STATUS_MARKER} — summarizing earlier conversation so I can continue..."
 )
+
+_COMPRESSION_CHECKPOINT_VERSION = 1
+_COMPRESSION_CHECKPOINT_META_PREFIX = "compression_checkpoint:"
+_COMPRESSION_CHECKPOINT_START = "<!-- hermes:compression-checkpoint:v1 -->"
+_COMPRESSION_CHECKPOINT_END = "<!-- /hermes:compression-checkpoint -->"
+_MAX_CHECKPOINT_ENTRIES = 8
+_MAX_CHECKPOINT_ENTRY_CHARS = 2000
+_MAX_CHECKPOINT_JSON_CHARS = 24 * 1024
+_RESOLVED_BLOCKER_STATUSES = {"resolved", "closed", "fixed", "done", "unblocked", "cleared"}
+
+
+def _summary_section(summary: str, heading: str) -> str:
+    """Return one level-2 Markdown section from a compaction summary."""
+    if not isinstance(summary, str) or not summary.strip():
+        return ""
+    match = re.search(
+        rf"(?ms)^##\s+{re.escape(heading)}\s*$\n?(.*?)(?=^##\s+|\Z)",
+        summary,
+    )
+    # Remove only the Markdown section-boundary newlines. Spaces can be part of
+    # an exact multiline Resume value and must survive checkpoint extraction.
+    return match.group(1).strip("\r\n") if match else ""
+
+
+def _checkpoint_entries(section: str) -> list[str]:
+    """Normalize a summary section into bounded, non-placeholder entries."""
+    if not section:
+        return []
+    entries: list[str] = []
+    current: list[str] = []
+    for raw_line in section.splitlines():
+        line = raw_line
+        stripped = line.strip()
+        if not stripped:
+            if current:
+                current.append(line)
+            continue
+        structural = line.lstrip()
+        if re.match(r"^(?:[-*]|\d+[.)])\s+", structural):
+            if current:
+                entries.append("\n".join(current).rstrip("\r\n"))
+            current = [
+                re.sub(r"^(?:[-*]|\d+[.)])\s+", "", structural)
+            ]
+        elif current:
+            current.append(line)
+        else:
+            current = [structural]
+    if current:
+        entries.append("\n".join(current).rstrip("\r\n"))
+
+    placeholders = {
+        "none",
+        "none.",
+        "n/a",
+        "unknown",
+        "no blockers",
+        "no blockers.",
+        "none recoverable from deterministic fallback.",
+    }
+    out: list[str] = []
+    for entry in entries:
+        placeholder_text = entry.strip()
+        placeholder_key = re.sub(r"\s+", " ", placeholder_text).casefold()
+        if placeholder_text and placeholder_key not in placeholders:
+            if len(entry) > _MAX_CHECKPOINT_ENTRY_CHARS:
+                raise ValueError("compression checkpoint entry exceeds size limit")
+            out.append(entry)
+    return out
+
+
+def _checkpoint_value_before_delimiter(text: str, match: re.Match[str]) -> str:
+    """Return value text before a field pipe, removing one framing separator."""
+    pipe_index = text.find("|", match.start(), match.end())
+    if pipe_index < 0:
+        return text[:match.start()]
+    value_end = pipe_index
+    if text[:value_end].endswith("\r\n"):
+        value_end -= 2
+    elif value_end and text[value_end - 1] in " \t\r\n":
+        value_end -= 1
+    return text[:value_end]
+
+
+def _split_checkpoint_fields(entry: str) -> dict[str, str]:
+    """Parse ordered checkpoint fields without splitting label-like value text."""
+    decision_labels = (
+        ("decision", "Decision"),
+        ("rationale", "Rationale"),
+        ("rejected", "Rejected"),
+        ("scope", "Scope"),
+    )
+    blocker_labels = (
+        ("blocker", "Blocker"),
+        ("evidence", "Evidence"),
+        ("failed_attempts", "Failed attempts"),
+        ("artifact_state", "Artifact state"),
+        ("required_input", "Required input"),
+        ("resume", "Resume"),
+    )
+    stripped = entry.lstrip()
+    if re.match(r"^Decision\s*:", stripped, flags=re.IGNORECASE):
+        labels = decision_labels
+    elif re.match(r"^Blocker\s*:", stripped, flags=re.IGNORECASE):
+        labels = blocker_labels
+    else:
+        return {"text": entry}
+
+    remainder = stripped
+    fields: dict[str, str] = {}
+
+    # Status is not part of the required summary schema, but older summaries
+    # may append it. Accept it only when the entire suffix is a recognized
+    # status; quoted shell text such as ``'x | Status: unresolved | wc -c'``
+    # must remain byte-for-byte inside the Resume value.
+    if labels is blocker_labels:
+        status_matches = list(
+            re.finditer(r"\s+\|\s+Status\s*:\s*", remainder, flags=re.IGNORECASE)
+        )
+        if status_matches:
+            match = status_matches[-1]
+            status_value = remainder[match.end():].strip()
+            normalized_status = re.sub(r"[^a-z]+", " ", status_value.casefold()).strip()
+            known_statuses = _RESOLVED_BLOCKER_STATUSES | {"unresolved", "blocked", "open"}
+            if normalized_status in known_statuses:
+                fields["status"] = status_value
+                remainder = _checkpoint_value_before_delimiter(remainder, match)
+
+    # Split right-to-left in schema order. Once Resume has been removed,
+    # label-like pipeline text inside it cannot be mistaken for earlier fields.
+    for key, label in reversed(labels[1:]):
+        # The schema uses one conventional horizontal separator after each
+        # colon. Consume at most that one byte for Resume; any additional
+        # leading whitespace belongs to the exact command value.
+        value_whitespace = r"[ \t]?" if key == "resume" else r"\s*"
+        matches = list(
+            re.finditer(
+                rf"\s+\|\s+{re.escape(label)}\s*:{value_whitespace}",
+                remainder,
+                flags=re.IGNORECASE,
+            )
+        )
+        if not matches:
+            continue
+        match = matches[-1]
+        value = remainder[match.end():]
+        fields[key] = value if key == "resume" else value.strip()
+        remainder = remainder[:match.start()]
+
+    if labels is blocker_labels and "status" not in fields:
+        status_matches = list(
+            re.finditer(r"\s+\|\s+Status\s*:\s*", remainder, flags=re.IGNORECASE)
+        )
+        if status_matches:
+            match = status_matches[-1]
+            status_value = remainder[match.end():].strip()
+            normalized_status = re.sub(r"[^a-z]+", " ", status_value.casefold()).strip()
+            known_statuses = _RESOLVED_BLOCKER_STATUSES | {"unresolved", "blocked", "open"}
+            if normalized_status in known_statuses:
+                fields["status"] = status_value
+                remainder = _checkpoint_value_before_delimiter(remainder, match)
+
+    first_key, first_label = labels[0]
+    first_match = re.match(
+        rf"^{re.escape(first_label)}\s*:\s*",
+        remainder,
+        flags=re.IGNORECASE,
+    )
+    if first_match is None:
+        return {"text": entry}
+    fields[first_key] = remainder[first_match.end():].strip()
+    return fields
+
+
+def _required_checkpoint_field(
+    fields: dict[str, str],
+    key: str,
+    *,
+    entry_kind: str,
+) -> str:
+    value = fields.pop(key, "")
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"compression checkpoint {entry_kind} is missing required {key}")
+    return value if key == "resume" else value.strip()
+
+
+def build_compression_checkpoint(summary: str, *, session_id: str) -> dict[str, Any]:
+    """Build the durable decision/blocker sidecar from a generated summary."""
+    decision_entries = _checkpoint_entries(_summary_section(summary, "Key Decisions"))
+    blocker_entries = _checkpoint_entries(_summary_section(summary, "Blocked"))
+    if len(decision_entries) + len(blocker_entries) > _MAX_CHECKPOINT_ENTRIES:
+        raise ValueError("compression checkpoint exceeds entry limit")
+
+    decisions = []
+    for entry in decision_entries:
+        fields = _split_checkpoint_fields(entry)
+        if "text" in fields:
+            raise ValueError("compression checkpoint decision is not structured")
+        decisions.append(
+            {
+                "decision": _required_checkpoint_field(
+                    fields, "decision", entry_kind="decision"
+                ),
+                "rationale": _required_checkpoint_field(
+                    fields, "rationale", entry_kind="decision"
+                ),
+                "rejected_alternatives": _required_checkpoint_field(
+                    fields, "rejected", entry_kind="decision"
+                ),
+                "scope": _required_checkpoint_field(
+                    fields, "scope", entry_kind="decision"
+                ),
+                **fields,
+            }
+        )
+
+    blockers = []
+    for entry in blocker_entries:
+        fields = _split_checkpoint_fields(entry)
+        declared_status = re.sub(
+            r"[^a-z]+",
+            " ",
+            fields.pop("status", "").casefold(),
+        ).strip()
+        entry_prefix = entry.lstrip().casefold()
+        if (
+            any(
+                declared_status == status or declared_status.startswith(status + " ")
+                for status in _RESOLVED_BLOCKER_STATUSES
+            )
+            or re.match(
+                r"^(?:\[(?:resolved|closed|fixed|done|unblocked|cleared)\]|"
+                r"(?:resolved|closed|fixed|done|unblocked|cleared)\s*[:—-])",
+                entry_prefix,
+            )
+        ):
+            continue
+        if "text" in fields:
+            raise ValueError("compression checkpoint blocker is not structured")
+        blockers.append(
+            {
+                "blocker": _required_checkpoint_field(
+                    fields, "blocker", entry_kind="blocker"
+                ),
+                "evidence": _required_checkpoint_field(
+                    fields, "evidence", entry_kind="blocker"
+                ),
+                "failed_attempts": _required_checkpoint_field(
+                    fields, "failed_attempts", entry_kind="blocker"
+                ),
+                "artifact_state": _required_checkpoint_field(
+                    fields, "artifact_state", entry_kind="blocker"
+                ),
+                "required_input": _required_checkpoint_field(
+                    fields, "required_input", entry_kind="blocker"
+                ),
+                "resume_action": _required_checkpoint_field(
+                    fields, "resume", entry_kind="blocker"
+                ),
+                "status": "unresolved",
+                **fields,
+            }
+        )
+
+    return {
+        "version": _COMPRESSION_CHECKPOINT_VERSION,
+        "session_id": str(session_id or ""),
+        "decisions": decisions,
+        "blockers": blockers,
+    }
+
+
+def _checkpoint_json(checkpoint: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        checkpoint,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    if len(encoded.encode("utf-8")) > _MAX_CHECKPOINT_JSON_CHARS:
+        raise ValueError("compression checkpoint exceeds JSON size limit")
+    return encoded
+
+
+def _inject_compression_checkpoint(
+    compressed: list[dict[str, Any]], checkpoint: dict[str, Any]
+) -> bool:
+    """Append the canonical checkpoint inside the existing summary boundary."""
+    try:
+        from agent.context_compressor import (
+            COMPRESSED_SUMMARY_METADATA_KEY,
+            _SUMMARY_END_MARKER,
+        )
+    except Exception:
+        return False
+
+    block = (
+        f"{_COMPRESSION_CHECKPOINT_START}\n"
+        "## Durable Compression Checkpoint\n"
+        "Only current decisions and unresolved blockers are authoritative here.\n"
+        f"```json\n{_checkpoint_json(checkpoint)}\n```\n"
+        f"{_COMPRESSION_CHECKPOINT_END}"
+    )
+    marker_re = re.compile(
+        rf"(?ms)\n*{re.escape(_COMPRESSION_CHECKPOINT_START)}.*?"
+        rf"{re.escape(_COMPRESSION_CHECKPOINT_END)}\n*"
+    )
+    stale_state_re = re.compile(
+        r"(?ims)^##\s+(?:Blocked|Key Decisions)\s*$\n?.*?(?=^##\s+|\Z)"
+    )
+
+    def _copy_content(content: Any) -> Any:
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            return None
+        return [
+            dict(item)
+            if isinstance(item, dict) and isinstance(item.get("text"), str)
+            else item
+            for item in content
+        ]
+
+    def _text_segments(content: Any) -> tuple[str, list[tuple[int, int, int]]]:
+        if isinstance(content, str):
+            return content, [(-1, 0, len(content))]
+        if not isinstance(content, list):
+            return "", []
+        combined: list[str] = []
+        segments: list[tuple[int, int, int]] = []
+        cursor = 0
+        for index, item in enumerate(content):
+            text = item if isinstance(item, str) else (
+                item.get("text") if isinstance(item, dict) else None
+            )
+            if not isinstance(text, str):
+                continue
+            start = cursor
+            cursor += len(text)
+            combined.append(text)
+            segments.append((index, start, cursor))
+        return "".join(combined), segments
+
+    def _set_segment_text(content: Any, index: int, text: str) -> Any:
+        if index < 0:
+            return text
+        item = content[index]
+        if isinstance(item, str):
+            content[index] = text
+        else:
+            item["text"] = text
+        return content
+
+    def _remove_spans(content: Any, *, remove_stale_state: bool) -> Any:
+        copied = _copy_content(content)
+        if copied is None:
+            return None
+        combined, segments = _text_segments(copied)
+        marker_matches = list(marker_re.finditer(combined))
+        marker_remainder = marker_re.sub("", combined)
+        if (
+            _COMPRESSION_CHECKPOINT_START in marker_remainder
+            or _COMPRESSION_CHECKPOINT_END in marker_remainder
+        ):
+            return None
+        spans = [match.span() for match in marker_matches]
+        if remove_stale_state:
+            spans.extend(match.span() for match in stale_state_re.finditer(combined))
+        merged: list[tuple[int, int]] = []
+        for start, end in sorted(spans):
+            if merged and start <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(end, merged[-1][1]))
+            else:
+                merged.append((start, end))
+
+        def _kept_text(start: int, end: int) -> str:
+            chunks: list[str] = []
+            cursor = start
+            for removed_start, removed_end in merged:
+                if removed_end <= cursor:
+                    continue
+                if removed_start >= end:
+                    break
+                if removed_start > cursor:
+                    chunks.append(combined[cursor:min(removed_start, end)])
+                cursor = max(cursor, removed_end)
+                if cursor >= end:
+                    break
+            if cursor < end:
+                chunks.append(combined[cursor:end])
+            return "".join(chunks)
+
+        if isinstance(copied, str):
+            return _kept_text(0, len(combined)).rstrip()
+        for index, start, end in segments:
+            _set_segment_text(copied, index, _kept_text(start, end))
+        return copied
+
+    def _logical_text(content: Any) -> str:
+        combined, _ = _text_segments(content)
+        return combined
+
+    def _inject_content(content: Any) -> Any:
+        copied = _remove_spans(content, remove_stale_state=False)
+        if copied is None:
+            return None
+        combined, segments = _text_segments(copied)
+        if not segments:
+            if isinstance(copied, list):
+                copied.append({"type": "text", "text": block})
+                return copied
+            return None
+
+        boundary = combined.rfind(_SUMMARY_END_MARKER)
+        insertion_at = boundary if boundary >= 0 else len(combined)
+        target_index, target_start, _ = segments[-1]
+        for segment in segments:
+            index, start, end = segment
+            if start <= insertion_at < end or (insertion_at == start == end):
+                target_index, target_start, _ = segment
+                break
+        target_text = (
+            copied
+            if target_index < 0
+            else copied[target_index]
+            if isinstance(copied[target_index], str)
+            else copied[target_index]["text"]
+        )
+        offset = max(0, min(len(target_text), insertion_at - target_start))
+        before = target_text[:offset].rstrip()
+        after = target_text[offset:].lstrip("\r\n")
+        injected_text = (
+            f"{before}\n\n{block}\n\n{after}"
+            if before
+            else f"{block}\n\n{after}"
+        ).rstrip()
+        copied = _set_segment_text(copied, target_index, injected_text)
+        rendered = _logical_text(copied)
+        rendered_boundary = rendered.rfind(_SUMMARY_END_MARKER)
+        rendered_checkpoint_end = rendered.rfind(_COMPRESSION_CHECKPOINT_END)
+        if rendered_boundary >= 0 and rendered_checkpoint_end >= rendered_boundary:
+            return None
+        return copied
+
+    summaries: list[tuple[int, dict[str, Any]]] = []
+    marked: list[tuple[int, dict[str, Any]]] = []
+    for index, message in enumerate(compressed):
+        text = _logical_text(message.get("content"))
+        is_marked = bool(message.get(COMPRESSED_SUMMARY_METADATA_KEY))
+        if is_marked or (
+            _SUMMARY_END_MARKER in text
+            or "[CONTEXT COMPACTION" in text
+            or "## Historical Task Snapshot" in text
+        ):
+            item = (index, message)
+            summaries.append(item)
+            if is_marked:
+                marked.append(item)
+    if not summaries:
+        return False
+
+    target_index, target_message = marked[-1] if marked else summaries[-1]
+    for index, message in summaries:
+        if index >= target_index:
+            continue
+        sanitized = _remove_spans(message.get("content"), remove_stale_state=True)
+        if sanitized is None:
+            return False
+        message["content"] = sanitized
+
+    injected = _inject_content(target_message.get("content"))
+    if injected is None:
+        return False
+    target_message[COMPRESSED_SUMMARY_METADATA_KEY] = True
+    target_message["content"] = injected
+    return True
+
+
+def _summary_body_for_checkpoint(compressor: Any, compressed: list[dict[str, Any]]) -> str:
+    """Prefer the unprefixed generated body; fall back to the summary message."""
+    strip_prefix = getattr(compressor, "_strip_summary_prefix", None)
+
+    def _normalized(text: str) -> str:
+        if callable(strip_prefix):
+            try:
+                return str(strip_prefix(text) or "").strip()
+            except Exception:
+                pass
+        return text.strip()
+
+    previous = getattr(compressor, "_previous_summary", None)
+    if (
+        not getattr(compressor, "_last_summary_fallback_used", False)
+        and isinstance(previous, str)
+        and previous.strip()
+    ):
+        return _normalized(previous)
+    try:
+        from agent.context_compressor import (
+            COMPRESSED_SUMMARY_METADATA_KEY,
+            _content_text_for_contains,
+        )
+    except Exception:
+        return ""
+    for message in reversed(compressed):
+        if message.get(COMPRESSED_SUMMARY_METADATA_KEY):
+            return _normalized(_content_text_for_contains(message.get("content")))
+    return ""
 
 
 def _lock_api_is_absent_on_session_db(lock_db: Any) -> bool:
@@ -834,8 +1345,14 @@ def compress_context(
                 _lock_refresh_interval,
             ).start()
 
+    _lock_released = False
+
     def _release_lock() -> None:
         """Release the lock keyed on the OLD session_id (before rotation)."""
+        nonlocal _lock_released
+        if _lock_released:
+            return
+        _lock_released = True
         if _lock_refresher is not None:
             _lock_refresher.stop()
         if _lock_db is not None and _lock_sid and _lock_holder:
@@ -896,6 +1413,57 @@ def compress_context(
                 existing_prompt = agent._build_system_prompt(system_message)
             return messages, existing_prompt
 
+    # Acquiring the lock proves that no other path is compressing this parent
+    # *now*. It does not prove that this AIAgent still points at the live tip: a
+    # competing path can finish its rotation and release the parent lock while
+    # this path is delayed in preflight provider checks. Revalidate lineage only
+    # after acquisition, when the winner's end-parent/create-child writes are
+    # stable. Otherwise the delayed path can acquire the old id and create a
+    # second continuation sibling despite the lock never being held concurrently.
+    try:
+        from hermes_state import SessionDB as _ConcreteSessionDB
+
+        _can_revalidate_lineage = isinstance(_lock_db, _ConcreteSessionDB)
+    except Exception:
+        _can_revalidate_lineage = False
+    _get_compression_tip = None
+    if _can_revalidate_lineage and _lock_db is not None:
+        _get_compression_tip = getattr(_lock_db, "get_compression_tip", None)
+    if callable(_get_compression_tip) and _lock_sid:
+        try:
+            _compression_tip = _get_compression_tip(_lock_sid)
+        except Exception as _lineage_err:
+            logger.warning(
+                "compression lineage revalidation failed for session=%s "
+                "(%s: %s) — skipping compression this cycle",
+                _lock_sid,
+                type(_lineage_err).__name__,
+                _lineage_err,
+            )
+            _existing_sp = getattr(agent, "_cached_system_prompt", None)
+            if not _existing_sp:
+                _existing_sp = agent._build_system_prompt(system_message)
+            _release_lock()
+            return messages, _existing_sp
+        if _compression_tip and _compression_tip != _lock_sid:
+            logger.warning(
+                "compression skipped: stale session=%s already continued as %s",
+                _lock_sid,
+                _compression_tip,
+            )
+            _existing_sp = getattr(agent, "_cached_system_prompt", None)
+            if not _existing_sp:
+                _existing_sp = agent._build_system_prompt(system_message)
+            _release_lock()
+            return messages, _existing_sp
+
+    try:
+        from agent.context_compressor import ContextCompressor as _BuiltInContextCompressor
+
+        _is_builtin_compressor = type(agent.context_compressor) is _BuiltInContextCompressor
+    except Exception:
+        _is_builtin_compressor = False
+
     # Notify external memory provider before compression discards context
     if agent._memory_manager:
         try:
@@ -903,6 +1471,76 @@ def compress_context(
         except Exception:
             pass
 
+    # A successful built-in compression mutates iterative, anti-thrash, and
+    # diagnostic state before the SessionDB boundary is rewritten. Snapshot the
+    # complete instance state so a checkpoint failure cannot consume an attempt
+    # or leave a cooldown/savings verdict for a boundary that never committed.
+    _compressor_state_before: Optional[dict[str, Any]] = None
+    _compressor_dict_before = (
+        getattr(agent.context_compressor, "__dict__", None)
+        if _is_builtin_compressor
+        else None
+    )
+    _compressor_durable_state_before: dict[str, Any] = {}
+    _compressor_state_snapshot_error: Optional[Exception] = None
+    if isinstance(_compressor_dict_before, dict):
+        try:
+            _compressor_state_before = {
+                key: value if key == "_session_db" else copy.deepcopy(value)
+                for key, value in _compressor_dict_before.items()
+            }
+            _compressor_db = _compressor_dict_before.get("_session_db") or _lock_db
+            _compressor_sid = str(
+                _compressor_dict_before.get("_session_id") or _lock_sid or ""
+            )
+            if _compressor_db is not None and _compressor_sid:
+                _cooldown_getter = getattr(
+                    _compressor_db, "get_compression_failure_cooldown", None
+                )
+                _cooldown_recorder = getattr(
+                    _compressor_db, "record_compression_failure_cooldown", None
+                )
+                _cooldown_clearer = getattr(
+                    _compressor_db, "clear_compression_failure_cooldown", None
+                )
+                if (
+                    callable(_cooldown_getter)
+                    and callable(_cooldown_recorder)
+                    and callable(_cooldown_clearer)
+                ):
+                    _compressor_durable_state_before["cooldown"] = copy.deepcopy(
+                        _cooldown_getter(_compressor_sid)
+                    )
+                _streak_getter = getattr(
+                    _compressor_db, "get_compression_fallback_streak", None
+                )
+                _streak_setter = getattr(
+                    _compressor_db, "set_compression_fallback_streak", None
+                )
+                if callable(_streak_getter) and callable(_streak_setter):
+                    _compressor_durable_state_before["fallback_streak"] = copy.deepcopy(
+                        _streak_getter(_compressor_sid)
+                    )
+                _compressor_durable_state_before["db"] = _compressor_db
+                _compressor_durable_state_before["session_id"] = _compressor_sid
+        except (OSError, TypeError, ValueError, RuntimeError) as _snapshot_err:
+            _compressor_state_before = None
+            _compressor_durable_state_before = {}
+            _compressor_state_snapshot_error = _snapshot_err
+
+    if _compressor_state_snapshot_error is not None:
+        try:
+            agent._emit_warning(
+                "⚠ Compression aborted: built-in compressor state could not be "
+                f"snapshotted ({_compressor_state_snapshot_error}). No messages were dropped."
+            )
+        except Exception:
+            pass
+        _existing_sp = getattr(agent, "_cached_system_prompt", None)
+        if not _existing_sp:
+            _existing_sp = agent._build_system_prompt(system_message)
+        _release_lock()
+        return messages, _existing_sp
     try:
         compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
     except TypeError:
@@ -985,6 +1623,118 @@ def compress_context(
         _release_lock()
         return messages, _existing_sp
 
+    _system_prompt_before_boundary = getattr(agent, "_cached_system_prompt", None)
+
+    def _abort_builtin_checkpoint_boundary(
+        error: Exception,
+        *,
+        stage: str,
+    ) -> Tuple[list[dict[str, Any]], str]:
+        _compressor_dict = getattr(agent.context_compressor, "__dict__", None)
+        if isinstance(_compressor_dict, dict) and _compressor_state_before is not None:
+            _compressor_dict.clear()
+            _compressor_dict.update(_compressor_state_before)
+        _durable_restore_error: Optional[Exception] = None
+        if _compressor_durable_state_before:
+            try:
+                _state_db = _compressor_durable_state_before["db"]
+                _state_sid = _compressor_durable_state_before["session_id"]
+                if "cooldown" in _compressor_durable_state_before:
+                    _cooldown_state = cast(
+                        Optional[dict[str, Any]],
+                        _compressor_durable_state_before["cooldown"],
+                    )
+                    if _cooldown_state:
+                        _state_db.record_compression_failure_cooldown(
+                            _state_sid,
+                            float(_cooldown_state["cooldown_until"]),
+                            _cooldown_state.get("error"),
+                        )
+                    else:
+                        _state_db.clear_compression_failure_cooldown(_state_sid)
+                if "fallback_streak" in _compressor_durable_state_before:
+                    _streak_state = cast(
+                        Optional[int],
+                        _compressor_durable_state_before["fallback_streak"],
+                    )
+                    _state_db.set_compression_fallback_streak(
+                        _state_sid,
+                        int(_streak_state or 0),
+                    )
+            except (OSError, TypeError, ValueError, RuntimeError) as restore_error:
+                _durable_restore_error = restore_error
+        agent.context_compressor._last_compress_aborted = True
+        agent.context_compressor._last_compression_made_progress = False
+        agent.context_compressor._last_summary_error = (
+            f"compression checkpoint {stage} failed: {error}"
+        )
+        logger.warning(
+            "Compression checkpoint %s failed for session=%s (%s: %s) — "
+            "returning the unchanged transcript",
+            stage,
+            _lock_sid or "none",
+            type(error).__name__,
+            error,
+        )
+        if _durable_restore_error is not None:
+            logger.error(
+                "Compressor durable-state rollback also failed for session=%s (%s: %s)",
+                _lock_sid or "none",
+                type(_durable_restore_error).__name__,
+                _durable_restore_error,
+            )
+        try:
+            agent._emit_warning(
+                "⚠ Compression aborted because its durable checkpoint/transcript "
+                "boundary could not be committed. No messages were dropped."
+            )
+        except Exception:
+            pass
+        agent._cached_system_prompt = _system_prompt_before_boundary
+        _existing_system_prompt = _system_prompt_before_boundary
+        if not _existing_system_prompt:
+            _existing_system_prompt = agent._build_system_prompt(system_message)
+        _release_lock()
+        return messages, _existing_system_prompt
+
+    # The built-in compressor's narrative already contains ``## Key Decisions``
+    # and ``## Blocked``. Convert those sections into a compact, versioned
+    # sidecar in memory. Persistence is deferred to the same SessionDB transaction
+    # that archives the in-place transcript or creates the continuation child.
+    # Plugin context engines keep their existing behavior because they own their
+    # persistence contract.
+    _checkpoint: Optional[dict[str, Any]] = None
+    if _is_builtin_compressor:
+        try:
+            _checkpoint = build_compression_checkpoint(
+                _summary_body_for_checkpoint(agent.context_compressor, compressed),
+                session_id=_lock_sid,
+            )
+            if not _inject_compression_checkpoint(compressed, _checkpoint):
+                raise RuntimeError("compressed summary message was not found")
+            _checkpoint_json(_checkpoint)
+        except Exception as _checkpoint_err:
+            return _abort_builtin_checkpoint_boundary(
+                _checkpoint_err,
+                stage="preparation",
+            )
+
+    def _checkpoint_state_for_session(
+        session_id: str,
+    ) -> Tuple[Optional[dict[str, Any]], Optional[dict[str, str]]]:
+        if not _is_builtin_compressor or _checkpoint is None:
+            return None, None
+        targeted = copy.deepcopy(_checkpoint)
+        targeted["session_id"] = session_id
+        if not _inject_compression_checkpoint(compressed, targeted):
+            raise RuntimeError("compressed summary message was not found during retarget")
+        payload = _checkpoint_json(targeted)
+        return targeted, {
+            _COMPRESSION_CHECKPOINT_META_PREFIX + session_id: payload,
+        }
+
+    _committed_checkpoint: Optional[dict[str, Any]] = None
+
     try:
         summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
         if summary_error:
@@ -1052,7 +1802,18 @@ def compress_context(
                     # for search/recovery (Teknium review — keep one durable id
                     # WITHOUT destroying history, unlike a hard replace_messages).
                     # See #38763.
-                    agent._session_db.archive_and_compact(agent.session_id, compressed)
+                    _target_checkpoint, _target_state_meta = _checkpoint_state_for_session(
+                        agent.session_id
+                    )
+                    if _target_state_meta:
+                        agent._session_db.archive_and_compact(
+                            agent.session_id,
+                            compressed,
+                            state_meta=_target_state_meta,
+                        )
+                    else:
+                        agent._session_db.archive_and_compact(agent.session_id, compressed)
+                    _committed_checkpoint = _target_checkpoint
                     # Reset the flush identity set so the next turn's appends are
                     # diffed against the COMPACTED transcript: the compacted dicts
                     # are passed as conversation_history next turn and skipped by
@@ -1071,7 +1832,9 @@ def compress_context(
                     try:
                         agent._flush_messages_to_session_db(messages)
                     except Exception:
-                        pass  # best-effort — don't block compression on a flush error
+                        if _is_builtin_compressor:
+                            raise
+                        pass  # plugin engines retain their legacy best-effort behavior
                     # Propagate title to the new session with auto-numbering
                     old_title = agent._session_db.get_session_title(agent.session_id)
                     agent._session_db.end_session(agent.session_id, "compression")
@@ -1102,13 +1865,23 @@ def compress_context(
                         pass
                     agent._session_db_created = False
                     try:
+                        _target_checkpoint, _target_state_meta = (
+                            _checkpoint_state_for_session(agent.session_id)
+                        )
+                        _create_kwargs = {
+                            "model": agent.model,
+                            "model_config": agent._session_init_model_config,
+                            "parent_session_id": old_session_id,
+                        }
+                        if _target_state_meta:
+                            _create_kwargs["state_meta"] = _target_state_meta
                         agent._session_db.create_session(
                             session_id=agent.session_id,
-                            source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
-                            model=agent.model,
-                            model_config=agent._session_init_model_config,
-                            parent_session_id=old_session_id,
+                            source=agent.platform
+                            or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            **_create_kwargs,
                         )
+                        _committed_checkpoint = _target_checkpoint
                     except Exception as _cs_err:
                         # The child row could not be created (e.g. FK constraint,
                         # contended write). Previously the outer handler simply
@@ -1185,6 +1958,11 @@ def compress_context(
                         if isinstance(message, dict)
                     }
             except Exception as e:
+                if _is_builtin_compressor:
+                    return _abort_builtin_checkpoint_boundary(
+                        e,
+                        stage="session persistence",
+                    )
                 # If the rotation rolled back to the parent (orphan-avoidance
                 # above), agent.session_id is the still-indexed parent and
                 # old_session_id was cleared — so this is recovery, not an
@@ -1197,6 +1975,13 @@ def compress_context(
                     )
                 else:
                     logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
+
+        if _is_builtin_compressor:
+            if _committed_checkpoint is None:
+                _committed_checkpoint, _ = _checkpoint_state_for_session(
+                    agent.session_id or _lock_sid
+                )
+            agent._last_compression_checkpoint = _committed_checkpoint
 
         # Compaction-boundary bookkeeping, computed once. `old_session_id` is only
         # bound in the rotation branch; in-place leaves it unset. `_boundary_parent`

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1953,6 +1953,9 @@ class SessionDB:
         cwd: str = None,
         profile_name: str = None,
         state_meta: Optional[Dict[str, str]] = None,
+        _initial_messages: Optional[List[Dict[str, Any]]] = None,
+        _end_parent_session_id: Optional[str] = None,
+        _end_parent_reason: str = "compression",
     ) -> None:
         """Insert a session row, enriching NULL metadata on conflict.
 
@@ -1971,8 +1974,24 @@ class SessionDB:
         a persisted, now-inactive row belongs to the caller's chat/thread before
         switching to it (IDOR scoping — without them the ``sessions`` table has
         no chat/thread to compare).
+
+        Private ``_initial_messages`` / ``_end_parent_session_id`` are used by
+        :meth:`rotate_session_with_messages` so parent end, child row, state
+        metadata, transcript, and counters share one transaction.
         """
         def _do(conn):
+            if _initial_messages is not None:
+                if conn.execute(
+                    "SELECT 1 FROM sessions WHERE id = ? LIMIT 1",
+                    (session_id,),
+                ).fetchone() is not None:
+                    raise ValueError(f"rotation child session already exists: {session_id}")
+            if _end_parent_session_id:
+                conn.execute(
+                    "UPDATE sessions SET ended_at = ?, end_reason = ? "
+                    "WHERE id = ? AND ended_at IS NULL",
+                    (time.time(), _end_parent_reason, _end_parent_session_id),
+                )
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
@@ -2013,12 +2032,54 @@ class SessionDB:
                     "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                     tuple(state_meta.items()),
                 )
+            if _initial_messages is not None:
+                inserted, tool_calls_total = self._insert_message_rows(
+                    conn, session_id, _initial_messages
+                )
+                conn.execute(
+                    "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+                    (inserted, tool_calls_total, session_id),
+                )
         self._execute_write(_do)
 
     def create_session(self, session_id: str, source: str, **kwargs) -> str:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
+    def rotate_session_with_messages(
+        self,
+        *,
+        parent_session_id: str,
+        child_session_id: str,
+        source: str,
+        messages: List[Dict[str, Any]],
+        end_reason: str = "compression",
+        **kwargs,
+    ) -> str:
+        """Atomically end a parent and create its populated continuation.
+
+        The child session row, state metadata (including compression checkpoint),
+        system prompt, compacted transcript, and counters commit together. Any
+        failure rolls the entire rotation back, leaving the parent live and no
+        partial child behind.
+        """
+        if not parent_session_id or not child_session_id:
+            raise ValueError("rotation requires parent and child session ids")
+        if parent_session_id == child_session_id:
+            raise ValueError("rotation child session id must differ from parent")
+        if not messages:
+            raise ValueError("rotation requires a non-empty compacted transcript")
+        self._insert_session_row(
+            child_session_id,
+            source,
+            parent_session_id=parent_session_id,
+            _initial_messages=messages,
+            _end_parent_session_id=parent_session_id,
+            _end_parent_reason=end_reason,
+            **kwargs,
+        )
+        return child_session_id
 
     def record_gateway_session_peer(
         self,
@@ -4431,6 +4492,7 @@ class SessionDB:
         compacted_messages: List[Dict[str, Any]],
         *,
         state_meta: Optional[Dict[str, str]] = None,
+        system_prompt: Optional[str] = None,
     ) -> int:
         """Non-destructive in-place compaction for a single durable session id.
 
@@ -4486,6 +4548,11 @@ class SessionDB:
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
                 (inserted, tool_calls_total, session_id),
             )
+            if system_prompt is not None:
+                conn.execute(
+                    "UPDATE sessions SET system_prompt = ? WHERE id = ?",
+                    (system_prompt, session_id),
+                )
             return inserted
 
         return self._execute_write(_do)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1952,6 +1952,7 @@ class SessionDB:
         parent_session_id: str = None,
         cwd: str = None,
         profile_name: str = None,
+        state_meta: Optional[Dict[str, str]] = None,
     ) -> None:
         """Insert a session row, enriching NULL metadata on conflict.
 
@@ -2006,6 +2007,12 @@ class SessionDB:
                     time.time(),
                 ),
             )
+            if state_meta:
+                conn.executemany(
+                    "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    tuple(state_meta.items()),
+                )
         self._execute_write(_do)
 
     def create_session(self, session_id: str, source: str, **kwargs) -> str:
@@ -4419,7 +4426,11 @@ class SessionDB:
             return cursor.fetchone() is not None
 
     def archive_and_compact(
-        self, session_id: str, compacted_messages: List[Dict[str, Any]]
+        self,
+        session_id: str,
+        compacted_messages: List[Dict[str, Any]],
+        *,
+        state_meta: Optional[Dict[str, str]] = None,
     ) -> int:
         """Non-destructive in-place compaction for a single durable session id.
 
@@ -4446,6 +4457,15 @@ class SessionDB:
         """
 
         def _do(conn):
+            # Commit the durable compression sidecar in the SAME transaction,
+            # before any active transcript row is archived. A later insert or
+            # count failure rolls both changes back together.
+            if state_meta:
+                conn.executemany(
+                    "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    tuple(state_meta.items()),
+                )
             # Soft-archive the live turns: active=0 hides them from the live
             # context load, compacted=1 marks them as "summarized away" (vs
             # rewind/undo's active=0+compacted=0, which means "user took it

--- a/tests/agent/test_compression_checkpoint.py
+++ b/tests/agent/test_compression_checkpoint.py
@@ -80,6 +80,32 @@ None recoverable from deterministic fallback.
     assert checkpoint["blockers"] == []
 
 
+def test_static_fallback_checkpoint_is_explicitly_opaque():
+    checkpoint = build_compression_checkpoint(
+        """## Blocked
+- fatal: tool output could not be parsed | Blocker: spoofed schema
+
+## Key Decisions
+- free-form fallback prose
+""",
+        session_id="s-fallback",
+        source="static_fallback",
+    )
+
+    assert checkpoint == {
+        "version": 1,
+        "session_id": "s-fallback",
+        "decisions": [],
+        "blockers": [],
+        "checkpoint_quality": "fallback_opaque",
+    }
+
+
+def test_unknown_checkpoint_source_fails_closed():
+    with pytest.raises(ValueError, match="unknown compression checkpoint source"):
+        build_compression_checkpoint(SUMMARY, session_id="s-unknown", source="summary-text")
+
+
 def test_blocker_pipeline_is_preserved_and_resolved_entries_are_dropped():
     checkpoint = build_compression_checkpoint(
         """## Blocked
@@ -261,6 +287,8 @@ def test_reinjection_removes_persisted_stale_checkpoint_and_state_sections():
     assert "old blocker" not in rendered
     assert "keep this history" in rendered
     assert "current choice" in rendered
+    assert "## Blocked" not in rendered
+    assert "## Key Decisions" not in rendered
     assert _COMPRESSION_CHECKPOINT_START not in old_summary["content"]
     assert _COMPRESSION_CHECKPOINT_START in new_summary["content"]
 
@@ -412,6 +440,10 @@ class _BuiltinLikeCompressor:
     _last_compression_made_progress = False
     _last_summary_fallback_used = False
     _last_summary_error = None
+
+    @staticmethod
+    def _is_context_summary_content(text: str) -> bool:
+        return _SUMMARY_END_MARKER in text or "[CONTEXT COMPACTION" in text
 
     def __init__(self):
         self._anti_thrash = {"attempts": [1]}

--- a/tests/agent/test_compression_checkpoint.py
+++ b/tests/agent/test_compression_checkpoint.py
@@ -106,6 +106,21 @@ def test_unknown_checkpoint_source_fails_closed():
         build_compression_checkpoint(SUMMARY, session_id="s-unknown", source="summary-text")
 
 
+@pytest.mark.parametrize(
+    "summary, missing",
+    [
+        ("## Goal\nShip it.", "Blocked, Key Decisions"),
+        ("## Blocked\nNone.", "Key Decisions"),
+        ("## Key Decisions\nNone.", "Blocked"),
+        ("## Blocked\n\n## Key Decisions\nNone.", "Blocked"),
+    ],
+)
+def test_model_checkpoint_requires_both_nonempty_state_sections(summary, missing):
+    with pytest.raises(ValueError, match=r"missing required section") as exc_info:
+        build_compression_checkpoint(summary, session_id="s-missing-sections")
+    assert missing in str(exc_info.value)
+
+
 def test_blocker_pipeline_is_preserved_and_resolved_entries_are_dropped():
     checkpoint = build_compression_checkpoint(
         """## Blocked
@@ -138,7 +153,7 @@ def test_resume_action_preserves_internal_whitespace_exactly():
         "## Blocked\n- Blocker: verify whitespace | Evidence: pending | "
         "Failed attempts: none | Artifact state: unchanged | Required input: none | Resume: "
         + command
-        + " | Status: unresolved",
+        + " | Status: unresolved\n\n## Key Decisions\nNone.",
         session_id="s-exact-whitespace",
     )
 
@@ -176,7 +191,8 @@ def test_resume_action_preserves_quoted_label_like_pipeline_text():
     checkpoint = build_compression_checkpoint(
         "## Blocked\n- Blocker: verify quoted pipeline | Evidence: pending | "
         "Failed attempts: none | Artifact state: unchanged | Required input: none | Resume: "
-        + command,
+        + command
+        + "\n\n## Key Decisions\nNone.",
         session_id="s-exact-label",
     )
 
@@ -193,7 +209,9 @@ def test_checkpoint_bounds_fail_closed_without_truncating_state():
 
     with pytest.raises(ValueError, match="size limit"):
         build_compression_checkpoint(
-            "## Key Decisions\n- Decision: " + ("x" * 2001),
+            "## Key Decisions\n- Decision: "
+            + ("x" * 2001)
+            + "\n\n## Blocked\nNone.",
             session_id="bounded",
         )
 
@@ -216,12 +234,13 @@ def test_free_form_colons_fail_closed_instead_of_creating_partial_schema():
     [
         (
             "## Key Decisions\n- Decision: ship | Rationale:  | "
-            "Rejected: later | Scope: parser",
+            "Rejected: later | Scope: parser\n\n## Blocked\nNone.",
             "rationale",
         ),
         (
             "## Blocked\n- Blocker: CI | Evidence:  | Failed attempts: none | "
-            "Artifact state: clean | Required input: token | Resume: pytest -q",
+            "Artifact state: clean | Required input: token | Resume: pytest -q\n\n"
+            "## Key Decisions\nNone.",
             "evidence",
         ),
     ],
@@ -276,7 +295,7 @@ def test_reinjection_removes_persisted_stale_checkpoint_and_state_sections():
     }
     current = build_compression_checkpoint(
         "## Key Decisions\n- Decision: current choice | Rationale: current | "
-        "Rejected: old choice | Scope: current scope",
+        "Rejected: old choice | Scope: current scope\n\n## Blocked\nNone.",
         session_id="current",
     )
 
@@ -341,7 +360,7 @@ def test_reinjection_sanitizes_stale_state_across_multimodal_text_blocks():
     }
     current = build_compression_checkpoint(
         "## Key Decisions\n- Decision: current choice | Rationale: current | "
-        "Rejected: superseded option | Scope: multimodal",
+        "Rejected: superseded option | Scope: multimodal\n\n## Blocked\nNone.",
         session_id="current-multimodal",
     )
 
@@ -427,9 +446,12 @@ class _FailingCheckpointDB:
     def get_compression_lock_holder(self, session_id):
         return None
 
-    def archive_and_compact(self, _session_id, _messages, *, state_meta):
+    def archive_and_compact(
+        self, _session_id, _messages, *, state_meta, system_prompt=None
+    ):
         self.calls.append("archive")
         assert set(state_meta) == {_COMPRESSION_CHECKPOINT_META_PREFIX + "s-fail"}
+        assert system_prompt == "rebuilt system"
         raise OSError("disk full")
 
 

--- a/tests/agent/test_compression_checkpoint.py
+++ b/tests/agent/test_compression_checkpoint.py
@@ -1,0 +1,520 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    _SUMMARY_END_MARKER,
+)
+from agent.conversation_compression import (
+    _COMPRESSION_CHECKPOINT_END,
+    _COMPRESSION_CHECKPOINT_META_PREFIX,
+    _COMPRESSION_CHECKPOINT_START,
+    _inject_compression_checkpoint,
+    build_compression_checkpoint,
+    compress_context,
+)
+
+
+SUMMARY = """## Goal
+Ship the feature.
+
+## Blocked
+- Blocker: CI cannot authenticate | Evidence: HTTP 401 | Failed attempts: retried twice | Artifact state: commit abc123 | Required input: refreshed token | Resume: pytest -q
+
+## Key Decisions
+- Decision: use SessionDB state_meta | Rationale: reuse the existing transactional store | Rejected: standalone YAML files | Scope: context compression
+
+## Resolved Questions
+None.
+"""
+
+
+def test_build_checkpoint_extracts_structured_current_state():
+    checkpoint = build_compression_checkpoint(SUMMARY, session_id="s-1")
+
+    assert checkpoint == {
+        "version": 1,
+        "session_id": "s-1",
+        "decisions": [
+            {
+                "decision": "use SessionDB state_meta",
+                "rationale": "reuse the existing transactional store",
+                "rejected_alternatives": "standalone YAML files",
+                "scope": "context compression",
+            }
+        ],
+        "blockers": [
+            {
+                "blocker": "CI cannot authenticate",
+                "evidence": "HTTP 401",
+                "failed_attempts": "retried twice",
+                "artifact_state": "commit abc123",
+                "required_input": "refreshed token",
+                "resume_action": "pytest -q",
+                "status": "unresolved",
+            }
+        ],
+    }
+
+
+def test_build_checkpoint_drops_placeholders_and_superseded_sections():
+    checkpoint = build_compression_checkpoint(
+        """## Blocked
+None.
+
+## Key Decisions
+None recoverable from deterministic fallback.
+
+## Historical Remaining Work
+- stale work
+""",
+        session_id="s-2",
+    )
+
+    assert checkpoint["decisions"] == []
+    assert checkpoint["blockers"] == []
+
+
+def test_blocker_pipeline_is_preserved_and_resolved_entries_are_dropped():
+    checkpoint = build_compression_checkpoint(
+        """## Blocked
+- Blocker: CI count is unknown | Evidence: command not run | Failed attempts: none yet | Artifact state: worktree unchanged | Required input: none | Resume: git status --porcelain | wc -l | Status: unresolved
+- Blocker: old token failure | Status: resolved | Resume: refresh-token
+- [closed] superseded network outage
+
+## Key Decisions
+None.
+""",
+        session_id="s-pipeline",
+    )
+
+    assert checkpoint["blockers"] == [
+        {
+            "blocker": "CI count is unknown",
+            "evidence": "command not run",
+            "failed_attempts": "none yet",
+            "artifact_state": "worktree unchanged",
+            "required_input": "none",
+            "resume_action": "git status --porcelain | wc -l",
+            "status": "unresolved",
+        }
+    ]
+
+
+def test_resume_action_preserves_internal_whitespace_exactly():
+    command = "printf 'a  b' | sed 's/  / /' | wc -c"
+    checkpoint = build_compression_checkpoint(
+        "## Blocked\n- Blocker: verify whitespace | Evidence: pending | "
+        "Failed attempts: none | Artifact state: unchanged | Required input: none | Resume: "
+        + command
+        + " | Status: unresolved",
+        session_id="s-exact-whitespace",
+    )
+
+    assert checkpoint["blockers"][0]["resume_action"] == command
+
+
+def test_resume_action_preserves_boundary_and_multiline_whitespace_exactly():
+    command = "  printf %s value  \n  continuation-arg  "
+    checkpoint = build_compression_checkpoint(
+        "## Blocked\n- Blocker: verify whitespace | Evidence: pending | "
+        "Failed attempts: none | Artifact state: unchanged | Required input: none | Resume: "
+        + command
+        + "\n\n## Key Decisions\nNone.",
+        session_id="s-exact-boundary-whitespace",
+    )
+
+    assert checkpoint["blockers"][0]["resume_action"] == command
+
+
+def test_resume_action_preserves_trailing_whitespace_before_status():
+    command = "printf %s value  "
+    checkpoint = build_compression_checkpoint(
+        "## Blocked\n- Blocker: verify whitespace | Evidence: pending | "
+        "Failed attempts: none | Artifact state: unchanged | Required input: none | Resume: "
+        + command
+        + " | Status: unresolved\n\n## Key Decisions\nNone.",
+        session_id="s-exact-status-boundary-whitespace",
+    )
+
+    assert checkpoint["blockers"][0]["resume_action"] == command
+
+
+def test_resume_action_preserves_quoted_label_like_pipeline_text():
+    command = "printf '%s\\n' 'x | Status: unresolved | wc -c'"
+    checkpoint = build_compression_checkpoint(
+        "## Blocked\n- Blocker: verify quoted pipeline | Evidence: pending | "
+        "Failed attempts: none | Artifact state: unchanged | Required input: none | Resume: "
+        + command,
+        session_id="s-exact-label",
+    )
+
+    assert checkpoint["blockers"][0]["resume_action"] == command
+
+
+def test_checkpoint_bounds_fail_closed_without_truncating_state():
+    too_many = "\n".join(f"- Decision: current {index}" for index in range(9))
+    with pytest.raises(ValueError, match="entry limit"):
+        build_compression_checkpoint(
+            f"## Key Decisions\n{too_many}\n\n## Blocked\nNone.",
+            session_id="bounded",
+        )
+
+    with pytest.raises(ValueError, match="size limit"):
+        build_compression_checkpoint(
+            "## Key Decisions\n- Decision: " + ("x" * 2001),
+            session_id="bounded",
+        )
+
+
+def test_free_form_colons_fail_closed_instead_of_creating_partial_schema():
+    with pytest.raises(ValueError, match="is not structured"):
+        build_compression_checkpoint(
+            """## Blocked
+- CI remains blocked: token refresh is pending
+
+## Key Decisions
+- Keep the API shape: callers already depend on it
+""",
+            session_id="s-free-form",
+        )
+
+
+@pytest.mark.parametrize(
+    "summary, missing",
+    [
+        (
+            "## Key Decisions\n- Decision: ship | Rationale:  | "
+            "Rejected: later | Scope: parser",
+            "rationale",
+        ),
+        (
+            "## Blocked\n- Blocker: CI | Evidence:  | Failed attempts: none | "
+            "Artifact state: clean | Required input: token | Resume: pytest -q",
+            "evidence",
+        ),
+    ],
+)
+def test_required_semantic_fields_cannot_be_empty(summary, missing):
+    with pytest.raises(ValueError, match=rf"missing required {missing}"):
+        build_compression_checkpoint(summary, session_id="s-required")
+
+
+def test_injection_is_inside_boundary_and_replaces_older_checkpoint():
+    old = {
+        "role": "user",
+        "content": (
+            f"summary\n\n{_COMPRESSION_CHECKPOINT_START}\nold\n"
+            f"{_COMPRESSION_CHECKPOINT_END}\n\n{_SUMMARY_END_MARKER}"
+        ),
+        COMPRESSED_SUMMARY_METADATA_KEY: True,
+    }
+    checkpoint = build_compression_checkpoint(SUMMARY, session_id="s-3")
+
+    assert _inject_compression_checkpoint([old], checkpoint) is True
+    content = old["content"]
+    assert content.count(_COMPRESSION_CHECKPOINT_START) == 1
+    assert content.count(_COMPRESSION_CHECKPOINT_END) == 1
+    assert content.index(_COMPRESSION_CHECKPOINT_END) < content.index(_SUMMARY_END_MARKER)
+    assert json.dumps(checkpoint, ensure_ascii=False, sort_keys=True, separators=(",", ":")) in content
+    assert "\nold\n" not in content
+
+
+def test_reinjection_removes_persisted_stale_checkpoint_and_state_sections():
+    old_checkpoint = build_compression_checkpoint(
+        "## Key Decisions\n- Decision: obsolete choice | Rationale: old | "
+        "Rejected: none | Scope: old scope\n\n## Blocked\nNone.",
+        session_id="old",
+    )
+    old_summary = {
+        "role": "user",
+        "content": (
+            "[CONTEXT COMPACTION — REFERENCE ONLY]\n"
+            "## Historical Task Snapshot\nkeep this history\n\n"
+            "## Blocked\n- Blocker: old blocker\n\n"
+            "## Key Decisions\n- Decision: obsolete choice\n\n"
+            f"{_COMPRESSION_CHECKPOINT_START}\n```json\n"
+            f"{json.dumps(old_checkpoint)}\n```\n{_COMPRESSION_CHECKPOINT_END}\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        ),
+    }
+    new_summary = {
+        "role": "assistant",
+        "content": "## Key Decisions\n- Decision: current choice\n\n" + _SUMMARY_END_MARKER,
+        COMPRESSED_SUMMARY_METADATA_KEY: True,
+    }
+    current = build_compression_checkpoint(
+        "## Key Decisions\n- Decision: current choice | Rationale: current | "
+        "Rejected: old choice | Scope: current scope",
+        session_id="current",
+    )
+
+    assert _inject_compression_checkpoint([old_summary, new_summary], current) is True
+    rendered = "\n".join(str(message["content"]) for message in (old_summary, new_summary))
+    assert rendered.count(_COMPRESSION_CHECKPOINT_START) == 1
+    assert "obsolete choice" not in rendered
+    assert "old blocker" not in rendered
+    assert "keep this history" in rendered
+    assert "current choice" in rendered
+    assert _COMPRESSION_CHECKPOINT_START not in old_summary["content"]
+    assert _COMPRESSION_CHECKPOINT_START in new_summary["content"]
+
+
+def test_reinjection_sanitizes_stale_state_across_multimodal_text_blocks():
+    image = {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
+    checkpoint_start_cut = len(_COMPRESSION_CHECKPOINT_START) // 2
+    checkpoint_end_cut = len(_COMPRESSION_CHECKPOINT_END) // 2
+    boundary_cut = len(_SUMMARY_END_MARKER) // 2
+    old_summary = {
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": "[CONTEXT COMPACTION — REFERENCE ONLY]\nkeep history\n## Key Deci",
+            },
+            {"type": "text", "text": "sions\n"},
+            {"type": "text", "text": "- Decision: obsolete choice\n"},
+            image,
+            {
+                "type": "text",
+                "text": "## Other History\nkeep other\n"
+                + _COMPRESSION_CHECKPOINT_START[:checkpoint_start_cut],
+            },
+            {
+                "type": "text",
+                "text": _COMPRESSION_CHECKPOINT_START[checkpoint_start_cut:]
+                + "stale checkpoint payload"
+                + _COMPRESSION_CHECKPOINT_END[:checkpoint_end_cut],
+            },
+            {
+                "type": "text",
+                "text": _COMPRESSION_CHECKPOINT_END[checkpoint_end_cut:]
+                + "\n"
+                + _SUMMARY_END_MARKER,
+            },
+        ],
+    }
+    new_summary = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "text",
+                "text": "## Key Decisions\n- Decision: current choice\n\n"
+                + _SUMMARY_END_MARKER[:boundary_cut],
+            },
+            {"type": "text", "text": _SUMMARY_END_MARKER[boundary_cut:]},
+        ],
+        COMPRESSED_SUMMARY_METADATA_KEY: True,
+    }
+    current = build_compression_checkpoint(
+        "## Key Decisions\n- Decision: current choice | Rationale: current | "
+        "Rejected: superseded option | Scope: multimodal",
+        session_id="current-multimodal",
+    )
+
+    assert _inject_compression_checkpoint([old_summary, new_summary], current) is True
+
+    def _render(message):
+        content = message["content"]
+        blocks = content if isinstance(content, list) else [content]
+        return "".join(
+            block if isinstance(block, str) else str(block.get("text") or "")
+            for block in blocks
+        )
+
+    old_rendered = _render(old_summary)
+    new_rendered = _render(new_summary)
+    rendered = old_rendered + "\n" + new_rendered
+    assert rendered.count(_COMPRESSION_CHECKPOINT_START) == 1
+    assert "obsolete choice" not in rendered
+    assert "stale checkpoint payload" not in rendered
+    assert "keep history" in rendered
+    assert "keep other" in rendered
+    assert "current choice" in rendered
+    assert old_summary["content"][3] is image
+    assert new_rendered.index(_COMPRESSION_CHECKPOINT_END) < new_rendered.index(
+        _SUMMARY_END_MARKER
+    )
+
+
+def test_injection_preserves_multimodal_blocks_and_stays_inside_boundary():
+    original_text_block = {"type": "text", "text": "preserved tail"}
+    image_block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
+    summary_block = {
+        "type": "text",
+        "text": (
+            "summary body\n\n"
+            f"{_COMPRESSION_CHECKPOINT_START}\nold\n"
+            f"{_COMPRESSION_CHECKPOINT_END}\n\n{_SUMMARY_END_MARKER}"
+        ),
+    }
+    message = {
+        "role": "user",
+        "content": [original_text_block, image_block, summary_block],
+        COMPRESSED_SUMMARY_METADATA_KEY: True,
+    }
+    checkpoint = build_compression_checkpoint(SUMMARY, session_id="s-multimodal")
+
+    assert _inject_compression_checkpoint([message], checkpoint) is True
+    assert isinstance(message["content"], list)
+    assert message["content"][0] == original_text_block
+    assert message["content"][1] is image_block
+    assert message["content"][2] is not summary_block
+    rendered = "\n".join(
+        block if isinstance(block, str) else str(block.get("text") or "")
+        for block in message["content"]
+    )
+    assert rendered.count(_COMPRESSION_CHECKPOINT_START) == 1
+    assert rendered.count(_COMPRESSION_CHECKPOINT_END) == 1
+    assert rendered.index(_COMPRESSION_CHECKPOINT_END) < rendered.index(_SUMMARY_END_MARKER)
+    assert "\nold\n" not in rendered
+
+    assert _inject_compression_checkpoint([message], checkpoint) is True
+    rendered_again = "\n".join(
+        block if isinstance(block, str) else str(block.get("text") or "")
+        for block in message["content"]
+    )
+    assert rendered_again.count(_COMPRESSION_CHECKPOINT_START) == 1
+
+
+class _FailingCheckpointDB:
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def try_acquire_compression_lock(self, session_id, holder, *, ttl_seconds):
+        self.calls.append("lock")
+        return True
+
+    def refresh_compression_lock(self, session_id, holder, *, ttl_seconds):
+        return True
+
+    def release_compression_lock(self, session_id, holder):
+        self.calls.append("release")
+
+    def get_compression_lock_holder(self, session_id):
+        return None
+
+    def archive_and_compact(self, _session_id, _messages, *, state_meta):
+        self.calls.append("archive")
+        assert set(state_meta) == {_COMPRESSION_CHECKPOINT_META_PREFIX + "s-fail"}
+        raise OSError("disk full")
+
+
+class _BuiltinLikeCompressor:
+    compression_count = 4
+    _previous_summary = "older summary"
+    _last_compress_aborted = False
+    _last_compression_made_progress = False
+    _last_summary_fallback_used = False
+    _last_summary_error = None
+
+    def __init__(self):
+        self._anti_thrash = {"attempts": [1]}
+        self._nested_tuple = (["before"],)
+        self._last_compression_savings_pct = 10.0
+
+    def compress(self, messages, **kwargs):
+        self.compression_count += 1
+        self._previous_summary = SUMMARY
+        self._last_compression_made_progress = True
+        self._anti_thrash["attempts"].append(2)
+        self._nested_tuple[0].append("mutated")
+        self._last_compression_savings_pct = 99.0
+        return [
+            {
+                "role": "user",
+                "content": SUMMARY + "\n\n" + _SUMMARY_END_MARKER,
+                COMPRESSED_SUMMARY_METADATA_KEY: True,
+            }
+        ]
+
+
+def test_checkpoint_write_failure_aborts_before_boundary_and_rolls_back_compressor():
+    db = _FailingCheckpointDB()
+    compressor = _BuiltinLikeCompressor()
+    warnings: list[str] = []
+    messages = [
+        {"role": "user", "content": "original one"},
+        {"role": "assistant", "content": "original two"},
+    ]
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        context_compressor=compressor,
+        _compression_feasibility_checked=True,
+        compression_in_place=True,
+        session_id="s-fail",
+        _session_db=db,
+        _memory_manager=None,
+        model="test-model",
+        platform="cli",
+        _cached_system_prompt="existing system",
+        _todo_store=SimpleNamespace(format_for_injection=lambda: ""),
+        _emit_status=lambda _message: None,
+        _emit_warning=warnings.append,
+        _invalidate_system_prompt=lambda: None,
+        _build_system_prompt=lambda _message: "rebuilt system",
+        commit_memory_session=lambda _messages: None,
+        _compression_lock_refresh_interval=999.0,
+    )
+
+    with patch("agent.context_compressor.ContextCompressor", _BuiltinLikeCompressor):
+        returned, system_prompt = compress_context(agent, messages, "system")
+
+    assert returned is messages
+    assert system_prompt == "existing system"
+    assert compressor.compression_count == 4
+    assert compressor._previous_summary == "older summary"
+    assert compressor._anti_thrash == {"attempts": [1]}
+    assert compressor._nested_tuple == (["before"],)
+    assert compressor._last_compression_savings_pct == 10.0
+    assert compressor._last_compress_aborted is True
+    assert compressor._last_compression_made_progress is False
+    assert compressor._last_summary_error is not None
+    assert "disk full" in compressor._last_summary_error
+    assert db.calls == ["lock", "archive", "release"]
+    assert warnings and "No messages were dropped" in warnings[-1]
+
+
+def test_plugin_compressor_state_is_not_snapshotted_or_deepcopied():
+    class ExplosiveState(dict):
+        def __deepcopy__(self, memo):
+            raise OSError("plugin state must not be copied")
+
+    class PluginCompressor:
+        def __init__(self):
+            self.state = ExplosiveState(value=1)
+            self.called = False
+
+        def compress(self, messages, *, current_tokens):
+            self.called = True
+            return messages
+
+    compressor = PluginCompressor()
+    messages = [{"role": "user", "content": "unchanged"}]
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        context_compressor=compressor,
+        _compression_feasibility_checked=True,
+        compression_in_place=True,
+        session_id="s-plugin",
+        _session_db=None,
+        _memory_manager=None,
+        model="test-model",
+        platform="cli",
+        _cached_system_prompt="existing system",
+        _emit_status=lambda _message: None,
+        _emit_warning=lambda _message: None,
+        _build_system_prompt=lambda _message: "rebuilt system",
+    )
+
+    returned, system_prompt = compress_context(agent, messages, "system")
+
+    assert compressor.called is True
+    assert returned is messages
+    assert system_prompt == "existing system"
+    assert compressor.state == {"value": 1}

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -174,6 +174,46 @@ def test_concurrent_compression_does_not_fork_session(tmp_path: Path) -> None:
     )
 
 
+def test_delayed_stale_agent_cannot_rotate_completed_parent_again(
+    tmp_path: Path,
+) -> None:
+    """A path delayed before lock acquisition must not fork an ended parent.
+
+    The SQLite lock serializes overlapping holders, but serialization alone is
+    insufficient when a second AIAgent still carries the old parent id after
+    the winner has completed and released that lock. The delayed path can then
+    acquire the now-free parent lock unless it revalidates the compression tip.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "STALE_PARENT_TEST_SESSION"
+    db.create_session(parent_sid, source="discord")
+
+    winner = _build_agent_with_db(db, parent_sid)
+    delayed = _build_agent_with_db(db, parent_sid)
+    setattr(winner, "_compression_feasibility_checked", True)
+    setattr(delayed, "_compression_feasibility_checked", True)
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    winner._compress_context(messages, "sys", approx_tokens=120_000)
+
+    winner_session_id = getattr(winner, "session_id")
+    assert winner_session_id != parent_sid
+    assert db.get_compression_tip(parent_sid) == winner_session_id
+    assert _count_children(db, parent_sid) == 1
+
+    returned, _ = delayed._compress_context(
+        messages,
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    assert returned is messages or returned == messages
+    assert getattr(delayed, "session_id") == parent_sid
+    getattr(delayed, "context_compressor").compress.assert_not_called()
+    assert _count_children(db, parent_sid) == 1
+    assert db.get_compression_lock_holder(parent_sid) is None
+
+
 def test_skipped_compression_returns_messages_unchanged(tmp_path: Path) -> None:
     """The loser of the lock race must return its input messages verbatim.
 

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -126,21 +126,24 @@ class TestOrphanRollbackOnCreateFailure:
         db.create_session(parent, source="cli")
         agent = _build_agent_with_db(db, parent)
 
-        # Make the CHILD create_session raise, but let the initial parent
-        # end_session/reopen work. We patch create_session to blow up.
-        real_create = db.create_session
-
+        # Make the atomic parent-end + child/checkpoint/transcript transaction fail.
         def _boom(*a, **k):
             raise RuntimeError("FOREIGN KEY constraint failed")
 
-        with patch.object(db, "create_session", side_effect=_boom):
+        with patch.object(db, "rotate_session_with_messages", side_effect=_boom):
             agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
 
         # The live id must roll back to the still-indexed parent — NOT a
         # phantom child id that has no row in state.db.
         assert agent.session_id == parent
-        assert db.get_session(parent) is not None
-        _ = real_create  # silence unused
+        parent_row = db.get_session(parent)
+        assert parent_row is not None
+        assert parent_row["ended_at"] is None
+        conn = db._conn
+        assert conn is not None
+        assert conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?", (parent,)
+        ).fetchone()[0] == 0
 
 
 class TestPlatformForwardedAtBoundary:

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -570,7 +570,16 @@ class TestPreflightCompression:
 
         def _fake_compress(messages, current_tokens=None, focus_topic=None):
             events.append(("compress", "started"))
-            return [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+            return [
+                {
+                    "role": "user",
+                    "content": (
+                        f"{SUMMARY_PREFIX}\nPrevious conversation\n\n"
+                        "## Blocked\nNone.\n\n## Key Decisions\nNone."
+                    ),
+                    "_compressed_summary": True,
+                }
+            ]
 
         with (
             patch.object(agent.context_compressor, "compress", side_effect=_fake_compress),

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -587,10 +587,12 @@ class TestPreflightCompression:
         # message no longer satisfies the human-anchor check, so the real
         # user turn is restored after it (repair merges the pair
         # summary-first before the next API call).
-        assert compressed == [
-            {"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"},
-            {"role": "user", "content": "hello"},
-        ]
+        assert len(compressed) == 2
+        assert compressed[0]["role"] == "user"
+        assert compressed[0]["content"].startswith(f"{SUMMARY_PREFIX}\nPrevious conversation")
+        assert "<!-- hermes:compression-checkpoint:v1 -->" in compressed[0]["content"]
+        assert compressed[0]["_compressed_summary"] is True
+        assert compressed[1] == {"role": "user", "content": "hello"}
         assert new_system_prompt == "new system prompt"
         assert events[0][0] == "lifecycle"
         assert "Compacting context" in events[0][1]

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -38,7 +38,14 @@ def _make_agent(session_db, session_id, *, in_place):
     # test exercises the DB-mutation path, not summarization quality.
     def _fake_compress(messages, current_tokens=None, focus_topic=None, force=False):
         return [
-            {"role": "user", "content": "[CONTEXT COMPACTION] summary of prior turns"},
+            {
+                "role": "user",
+                "content": (
+                    "[CONTEXT COMPACTION] summary of prior turns\n\n"
+                    "## Blocked\nNone.\n\n## Key Decisions\nNone."
+                ),
+                "_compressed_summary": True,
+            },
             {"role": "assistant", "content": "recent reply"},
         ]
 
@@ -98,7 +105,7 @@ class TestInPlaceCompaction:
                 "- Decision: retain multimodal content | Rationale: preserve provider input | "
                 "Rejected: flattening blocks | Scope: compressed transcript"
             )):
-                compressed, _ = compress_context(
+                compressed, new_system_prompt = compress_context(
                     agent,
                     messages,
                     approx_tokens=100_000,
@@ -123,6 +130,9 @@ class TestInPlaceCompaction:
                 db.get_meta(_COMPRESSION_CHECKPOINT_META_PREFIX + sid) or "{}"
             )
             assert checkpoint["decisions"][0]["decision"] == "retain multimodal content"
+            session_row = db.get_session(sid)
+            assert session_row is not None
+            assert session_row["system_prompt"] == new_system_prompt
 
     def test_static_fallback_with_tool_error_commits_opaque_checkpoint(self):
         from agent.conversation_compression import (
@@ -538,9 +548,15 @@ class TestRotationFallbackWhenFlagOff:
             agent._last_flushed_db_idx = 5
 
             messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
-            compressed, _ = compress_context(
-                agent, messages, approx_tokens=100_000, system_message="sys"
-            )
+            with patch.object(
+                db,
+                "replace_messages",
+                side_effect=AssertionError("rotation must persist in one transaction"),
+            ) as replace_probe:
+                compressed, new_system_prompt = compress_context(
+                    agent, messages, approx_tokens=100_000, system_message="sys"
+                )
+            replace_probe.assert_not_called()
 
             # Identity rotated to a fresh id.
             assert agent.session_id != sid
@@ -556,6 +572,9 @@ class TestRotationFallbackWhenFlagOff:
             # still resume it without duplicating the two handoff messages.
             assert agent._last_flushed_db_idx == 2
             child_id = child[0]["id"]
+            child_row = db.get_session(child_id)
+            assert child_row is not None
+            assert child_row["system_prompt"] == new_system_prompt
             assert db.get_meta(_COMPRESSION_CHECKPOINT_META_PREFIX + sid) is None
             child_checkpoint = json.loads(
                 db.get_meta(_COMPRESSION_CHECKPOINT_META_PREFIX + child_id) or "{}"
@@ -576,6 +595,43 @@ class TestRotationFallbackWhenFlagOff:
             assert persisted[1].get("content") == "recent reply"
             # Rotation mode does NOT set the in-place signal.
             assert getattr(agent, "_last_compaction_in_place", False) is False
+
+    def test_atomic_rotation_rolls_back_parent_child_and_checkpoint_on_insert_failure(self):
+        from agent.conversation_compression import _COMPRESSION_CHECKPOINT_META_PREFIX
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            parent = "rotation-parent"
+            child = "rotation-child"
+            _seed(db, parent, "atomic-rotation", n=4)
+            checkpoint_key = _COMPRESSION_CHECKPOINT_META_PREFIX + child
+
+            with (
+                patch.object(
+                    db,
+                    "_insert_message_rows",
+                    side_effect=OSError("injected transcript failure"),
+                ),
+                pytest.raises(OSError, match="injected transcript failure"),
+            ):
+                db.rotate_session_with_messages(
+                    parent_session_id=parent,
+                    child_session_id=child,
+                    source="cli",
+                    messages=[{"role": "user", "content": "compacted handoff"}],
+                    model="test/model",
+                    system_prompt="new system prompt",
+                    state_meta={checkpoint_key: '{"version":1}'},
+                )
+
+            parent_row = db.get_session(parent)
+            assert parent_row is not None
+            assert parent_row["ended_at"] is None
+            assert parent_row["end_reason"] is None
+            assert db.get_session(child) is None
+            assert db.get_messages_as_conversation(child) == []
+            assert db.get_meta(checkpoint_key) is None
 
 
 class TestInPlaceSignalForGateway:

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -9,8 +9,10 @@ gaps, #42228 null cwd). When the flag is False (default), rotation behaves
 exactly as before.
 """
 
+import json
 import os
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -59,6 +61,252 @@ def _seed(db, sid, title, n=8):
 
 
 class TestInPlaceCompaction:
+    def test_multimodal_merged_summary_persists_checkpoint(self):
+        """A summary merged into list content remains compactable and durable."""
+        from agent.conversation_compression import (
+            _COMPRESSION_CHECKPOINT_META_PREFIX,
+            compress_context,
+        )
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260619_115500_multimodal"
+            _seed(db, sid, "multimodal", n=9)
+            agent = _make_agent(db, sid, in_place=True)
+            compressor = getattr(agent, "context_compressor")
+            del compressor.__dict__["compress"]
+            compressor.protect_first_n = 2
+            compressor.protect_last_n = 3
+            compressor._previous_summary = None
+            compressor.compression_count = 0
+            messages = [
+                {"role": "system", "content": "system prompt"},
+                {"role": "user", "content": "msg 1"},
+                {"role": "assistant", "content": "msg 2"},
+                {"role": "user", "content": "msg 3"},
+                {"role": "assistant", "content": "msg 4"},
+                {"role": "user", "content": "msg 5"},
+                {"role": "user", "content": [{"type": "text", "text": "msg 6"}]},
+                {"role": "assistant", "content": "msg 7"},
+                {"role": "user", "content": "msg 8"},
+            ]
+
+            with patch.object(compressor, "_generate_summary", return_value=(
+                "## Blocked\nNone.\n\n"
+                "## Key Decisions\n"
+                "- Decision: retain multimodal content | Rationale: preserve provider input | "
+                "Rejected: flattening blocks | Scope: compressed transcript"
+            )):
+                compressed, _ = compress_context(
+                    agent,
+                    messages,
+                    approx_tokens=100_000,
+                    system_message="sys",
+                )
+
+            assert compressed is not messages
+            merged = next(
+                message for message in compressed
+                if message.get("_compressed_summary")
+            )
+            assert isinstance(merged["content"], list)
+            rendered = "\n".join(
+                block if isinstance(block, str) else str(block.get("text") or "")
+                for block in merged["content"]
+            )
+            assert "<!-- hermes:compression-checkpoint:v1 -->" in rendered
+            assert rendered.index("<!-- /hermes:compression-checkpoint -->") < rendered.index(
+                "--- END OF CONTEXT SUMMARY"
+            )
+            checkpoint = json.loads(
+                db.get_meta(_COMPRESSION_CHECKPOINT_META_PREFIX + sid) or "{}"
+            )
+            assert checkpoint["decisions"][0]["decision"] == "retain multimodal content"
+
+    def test_checkpoint_failure_restores_real_compressor_durable_state(self):
+        from agent.conversation_compression import (
+            _COMPRESSION_CHECKPOINT_META_PREFIX,
+            compress_context,
+        )
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260619_115600_rollback"
+            _seed(db, sid, "rollback", n=9)
+            agent = _make_agent(db, sid, in_place=True)
+            compressor = getattr(agent, "context_compressor")
+            del compressor.__dict__["compress"]
+            compressor.protect_first_n = 2
+            compressor.protect_last_n = 3
+            compressor._previous_summary = None
+            compressor.compression_count = 0
+            cooldown_until = time.time() + 600
+            db.record_compression_failure_cooldown(sid, cooldown_until, "before")
+            compressor.get_active_compression_failure_cooldown()
+            before = db.get_compression_failure_cooldown(sid)
+            assert before is not None
+            active_before = db.get_messages_as_conversation(sid)
+            messages = [
+                {"role": "system", "content": "system prompt"},
+                *[
+                    {
+                        "role": "user" if index % 2 else "assistant",
+                        "content": f"msg {index}",
+                    }
+                    for index in range(1, 9)
+                ],
+            ]
+            summary = (
+                "## Blocked\nNone.\n\n## Key Decisions\n"
+                "- Decision: preserve rollback | Rationale: atomic boundary | "
+                "Rejected: partial commit | Scope: checkpoint failure"
+            )
+
+            def _generate_and_clear(*_args, **_kwargs):
+                compressor._previous_summary = summary
+                compressor._clear_compression_failure_cooldown()
+                return summary
+
+            def _fail_message_insert(*_args, **_kwargs):
+                raise OSError("disk full")
+
+            with (
+                patch.object(compressor, "_generate_summary", _generate_and_clear),
+                patch.object(db, "_insert_message_rows", _fail_message_insert),
+            ):
+                returned, _ = compress_context(
+                    agent,
+                    messages,
+                    approx_tokens=100_000,
+                    system_message="sys",
+                )
+
+            after = db.get_compression_failure_cooldown(sid)
+            assert returned is messages
+            assert after is not None
+            assert after["error"] == before["error"] == "before"
+            assert after["cooldown_until"] == pytest.approx(
+                before["cooldown_until"], abs=0.01
+            )
+            assert db.get_meta(_COMPRESSION_CHECKPOINT_META_PREFIX + sid) is None
+            assert db.get_messages_as_conversation(sid) == active_before
+
+    def test_persisted_checkpoint_is_replaced_after_reload_and_recompression(self):
+        from agent.context_compressor import _SUMMARY_END_MARKER
+        from agent.conversation_compression import (
+            _COMPRESSION_CHECKPOINT_END,
+            _COMPRESSION_CHECKPOINT_META_PREFIX,
+            _COMPRESSION_CHECKPOINT_START,
+            compress_context,
+        )
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260619_115700_recompress"
+            db.create_session(sid, "cli", model="test/model")
+            old_checkpoint = json.dumps(
+                {
+                    "version": 1,
+                    "session_id": sid,
+                    "decisions": [{"decision": "obsolete choice"}],
+                    "blockers": [{"blocker": "old blocker", "status": "unresolved"}],
+                }
+            )
+            checkpoint_start_cut = len(_COMPRESSION_CHECKPOINT_START) // 2
+            checkpoint_end_cut = len(_COMPRESSION_CHECKPOINT_END) // 2
+            old_summary = [
+                {
+                    "type": "text",
+                    "text": (
+                        "[CONTEXT COMPACTION — REFERENCE ONLY]\n"
+                        "## Historical Task Snapshot\nkeep historical fact\n\n"
+                        "## Blo"
+                    ),
+                },
+                {"type": "text", "text": "cked\n- Blocker: old blocker\n\n"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,old"}},
+                {"type": "text", "text": "## Key Deci"},
+                {"type": "text", "text": "sions\n- Decision: obsolete choice\n\n"},
+                {
+                    "type": "text",
+                    "text": _COMPRESSION_CHECKPOINT_START[:checkpoint_start_cut],
+                },
+                {
+                    "type": "text",
+                    "text": _COMPRESSION_CHECKPOINT_START[checkpoint_start_cut:]
+                    + "\n```json\n"
+                    + old_checkpoint
+                    + "\n```\n"
+                    + _COMPRESSION_CHECKPOINT_END[:checkpoint_end_cut],
+                },
+                {
+                    "type": "text",
+                    "text": _COMPRESSION_CHECKPOINT_END[checkpoint_end_cut:]
+                    + "\n\n"
+                    + _SUMMARY_END_MARKER,
+                },
+            ]
+            persisted = [
+                {"role": "system", "content": "system prompt"},
+                {"role": "user", "content": old_summary, "_compressed_summary": True},
+                {"role": "assistant", "content": "msg 2"},
+                {"role": "user", "content": "msg 3"},
+                {"role": "assistant", "content": "msg 4"},
+                {"role": "user", "content": "msg 5"},
+                {"role": "user", "content": "msg 6"},
+                {"role": "assistant", "content": "msg 7"},
+                {"role": "user", "content": "msg 8"},
+            ]
+            db.replace_messages(sid, persisted)
+            reloaded = db.get_messages_as_conversation(sid)
+            assert all("_compressed_summary" not in message for message in reloaded)
+
+            agent = _make_agent(db, sid, in_place=True)
+            compressor = getattr(agent, "context_compressor")
+            del compressor.__dict__["compress"]
+            compressor.protect_first_n = 2
+            compressor.protect_last_n = 3
+            compressor.tail_token_budget = 1
+            compressor._previous_summary = None
+            compressor.compression_count = 0
+            with patch.object(
+                compressor,
+                "_generate_summary",
+                return_value=(
+                    "## Blocked\nNone.\n\n"
+                    "## Key Decisions\n- Decision: current choice | Rationale: current | "
+                    "Rejected: prior approach | Scope: recompression"
+                ),
+            ):
+                compressed, _ = compress_context(
+                    agent,
+                    reloaded,
+                    approx_tokens=100_000,
+                    system_message="sys",
+                )
+
+            rendered = "\n".join(str(message.get("content") or "") for message in compressed)
+            assert rendered.count(_COMPRESSION_CHECKPOINT_START) == 1
+            assert "obsolete choice" not in rendered
+            assert "old blocker" not in rendered
+            assert "keep historical fact" in rendered
+            assert "data:image/png;base64,old" in rendered
+            assert "current choice" in rendered
+            checkpoint = json.loads(
+                db.get_meta(_COMPRESSION_CHECKPOINT_META_PREFIX + sid) or "{}"
+            )
+            assert checkpoint["decisions"][0]["decision"] == "current choice"
+
+            persisted_again = "\n".join(
+                str(message.get("content") or "")
+                for message in db.get_messages_as_conversation(sid)
+            )
+            assert persisted_again.count(_COMPRESSION_CHECKPOINT_START) == 1
+            assert "obsolete choice" not in persisted_again
+
     def test_in_place_keeps_same_session_id(self):
         """In-place mode: id unchanged, no child row, no rename, history kept."""
         from hermes_state import SessionDB
@@ -95,10 +343,12 @@ class TestInPlaceCompaction:
             # doesn't immediately re-compact (#38763).
             reloaded = db.get_messages_as_conversation(sid)
             assert len(reloaded) == 2
-            assert [m.get("content") for m in reloaded] == [
-                "[CONTEXT COMPACTION] summary of prior turns",
-                "recent reply",
-            ]
+            summary = reloaded[0].get("content") or ""
+            assert summary.startswith("[CONTEXT COMPACTION] summary of prior turns")
+            assert "<!-- hermes:compression-checkpoint:v1 -->" in summary
+            assert '"blockers":[]' in summary
+            assert '"decisions":[]' in summary
+            assert reloaded[1].get("content") == "recent reply"
             assert row["message_count"] == 2  # live (active) count
             # NON-DESTRUCTIVE: the 8 seeded originals survive at active=0
             # alongside the 2 compacted rows — nothing was DELETEd.
@@ -190,7 +440,10 @@ class TestRotationFallbackWhenFlagOff:
         #38763). With in_place=False explicitly set, legacy rotation is
         unchanged — forks a renamed continuation session."""
         from hermes_state import SessionDB
-        from agent.conversation_compression import compress_context
+        from agent.conversation_compression import (
+            _COMPRESSION_CHECKPOINT_META_PREFIX,
+            compress_context,
+        )
 
         with tempfile.TemporaryDirectory() as tmp:
             db = SessionDB(db_path=Path(tmp) / "t.db")
@@ -200,7 +453,7 @@ class TestRotationFallbackWhenFlagOff:
             agent._last_flushed_db_idx = 5
 
             messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
-            compress_context(
+            compressed, _ = compress_context(
                 agent, messages, approx_tokens=100_000, system_message="sys"
             )
 
@@ -217,10 +470,25 @@ class TestRotationFallbackWhenFlagOff:
             # boundary, so a headless process killed before finalization can
             # still resume it without duplicating the two handoff messages.
             assert agent._last_flushed_db_idx == 2
-            assert [m.get("content") for m in db.get_messages_as_conversation(agent.session_id)] == [
-                "[CONTEXT COMPACTION] summary of prior turns",
-                "recent reply",
-            ]
+            child_id = child[0]["id"]
+            assert db.get_meta(_COMPRESSION_CHECKPOINT_META_PREFIX + sid) is None
+            child_checkpoint = json.loads(
+                db.get_meta(_COMPRESSION_CHECKPOINT_META_PREFIX + child_id) or "{}"
+            )
+            assert child_checkpoint["session_id"] == child_id
+            assert getattr(agent, "_last_compression_checkpoint")["session_id"] == child_id
+            assert child_id in "\n".join(
+                str(message.get("content") or "") for message in compressed
+            )
+            persisted = db.get_messages_as_conversation(child_id)
+            assert len(persisted) == 2
+            persisted_summary = str(persisted[0].get("content") or "")
+            assert persisted_summary.startswith(
+                "[CONTEXT COMPACTION] summary of prior turns"
+            )
+            assert "<!-- hermes:compression-checkpoint:v1 -->" in persisted_summary
+            assert child_id in persisted_summary
+            assert persisted[1].get("content") == "recent reply"
             # Rotation mode does NOT set the in-place signal.
             assert getattr(agent, "_last_compaction_in_place", False) is False
 

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -124,6 +124,91 @@ class TestInPlaceCompaction:
             )
             assert checkpoint["decisions"][0]["decision"] == "retain multimodal content"
 
+    def test_static_fallback_with_tool_error_commits_opaque_checkpoint(self):
+        from agent.conversation_compression import (
+            _COMPRESSION_CHECKPOINT_META_PREFIX,
+            _COMPRESSION_CHECKPOINT_START,
+            compress_context,
+        )
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260719_opaque_fallback"
+            _seed(db, sid, "opaque-fallback", n=11)
+            agent = _make_agent(db, sid, in_place=True)
+            compressor = getattr(agent, "context_compressor")
+            del compressor.__dict__["compress"]
+            compressor.protect_first_n = 2
+            compressor.protect_last_n = 3
+            compressor._previous_summary = None
+            compressor.compression_count = 0
+            compressor._last_summary_auth_failure = False
+            compressor._last_summary_network_failure = False
+            compressor.abort_on_summary_failure = False
+            messages = [
+                {"role": "system", "content": "system prompt"},
+                {"role": "user", "content": "inspect the project"},
+                {"role": "assistant", "content": "I will inspect it."},
+                {"role": "user", "content": "run the failing command"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-error",
+                            "type": "function",
+                            "function": {
+                                "name": "terminal",
+                                "arguments": json.dumps({"command": "false"}),
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-error",
+                    "name": "terminal",
+                    "content": "fatal error: command failed with exit code 1",
+                },
+                {"role": "assistant", "content": "The command failed."},
+                {"role": "user", "content": "record that and continue"},
+                {"role": "assistant", "content": "Recorded."},
+                {"role": "user", "content": "what is the current state?"},
+                {"role": "assistant", "content": "Checking now."},
+            ]
+
+            with patch.object(compressor, "_generate_summary", return_value=None):
+                compressed, _ = compress_context(
+                    agent,
+                    messages,
+                    approx_tokens=100_000,
+                    system_message="sys",
+                )
+
+            assert compressed is not messages
+            assert len(compressed) < len(messages)
+            checkpoint = json.loads(
+                db.get_meta(_COMPRESSION_CHECKPOINT_META_PREFIX + sid) or "{}"
+            )
+            assert checkpoint == {
+                "version": 1,
+                "session_id": sid,
+                "decisions": [],
+                "blockers": [],
+                "checkpoint_quality": "fallback_opaque",
+            }
+            rendered = "\n".join(
+                str(message.get("content") or "") for message in compressed
+            )
+            assert _COMPRESSION_CHECKPOINT_START in rendered
+            assert "structured decision and blocker state is opaque" in rendered.casefold()
+            assert "## Blocked" not in rendered
+            assert "## Key Decisions" not in rendered
+            assert "fatal error: command failed with exit code 1" in rendered
+            assert getattr(agent, "_last_compression_checkpoint") == checkpoint
+            assert db.get_compression_fallback_streak(sid) == 1
+
     def test_checkpoint_failure_restores_real_compressor_durable_state(self):
         from agent.conversation_compression import (
             _COMPRESSION_CHECKPOINT_META_PREFIX,


### PR DESCRIPTION
## Description

Context compression currently relies on prose summaries to carry execution state across compaction. Active decisions and blockers can be flattened or dropped, and a persistence failure at the destructive boundary can leave the summary, transcript, and compressor state inconsistent.

This change adds a bounded v1 compression checkpoint for current decisions and unresolved blockers. The built-in compressor now:

- parses canonical decision and blocker records, including pipeline state and an exact resume action;
- preserves command-significant leading, multiline, and trailing whitespace after the schema's single framing separator;
- preserves multimodal/non-text content while injecting the checkpoint into the compressed summary;
- stores checkpoint metadata transactionally with in-place transcript compaction or continuation-session creation;
- keys rotated checkpoints to the child session and keeps the embedded session identity consistent;
- restores the original transcript, prompt cache, and Hermes-owned built-in compressor state when persistence fails;
- leaves arbitrary plugin compressor state untouched;
- revalidates the compression lineage after lock acquisition so a delayed stale agent cannot create a second continuation child.

The implementation uses the existing `SessionDB.state_meta` store and compression paths. It does not add a new persistence subsystem or model tool.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings in the exercised test surface
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally in the exercised compression surface
- [ ] Any dependent changes have been merged and published in downstream modules

## How has this been tested?

- focused checkpoint, concurrency, 413, and in-place matrix: **79 passed**
- broader compression/context/gateway/run-agent wildcard matrix: **626 passed**
- repository-wide `ruff check .`: passed
- `python scripts/check-windows-footguns.py --all`: **772 files scanned, no findings**
- `git diff --check`: passed
- fresh-context adversarial review of exact commit `cf3b9e9dc393e988547042003f25dd5dcf6b80b9`: **PASS**
- independent reviewer probes:
  - exact resume whitespace, including leading spaces, spaces before newline, multiline indentation, Unicode/label-like text, trailing spaces, and legacy `Status` suffix: passed
  - injected SQLite failure after metadata/archive mutation: transaction rolled back metadata and preserved the original active transcript

The complete repository suite is left to CI; this PR does not claim a local full-suite pass.

## Reviewer focus

Please scrutinize:

- the ordered checkpoint parser and exact resume-action framing;
- in-place and child-session transaction boundaries;
- rollback of built-in mutable compressor and prompt-cache state;
- multimodal summary mutation;
- stale-parent lineage revalidation after compression-lock acquisition.
