### PR TITLE
fix(mcp): recognize 'Invalid request parameters' as a session-expired signal

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -17,6 +17,14 @@ from unittest.mock import MagicMock
 import pytest
 
 
+def _mcp_error(code, message="boom"):
+    """Build a real McpError carrying a JSON-RPC error code (structural
+    shape, not a plain string exception)."""
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+    return McpError(ErrorData(code=code, message=message))
+
+
 # ---------------------------------------------------------------------------
 # _is_session_expired_error — unit coverage
 # ---------------------------------------------------------------------------
@@ -90,10 +98,41 @@ def test_is_session_expired_detects_invalid_request_parameters():
     this exact generic message -- not one of the more specific phrases
     above. Studio North MCP incident, 2026-07-18: this was the literal
     error text hit after every deploy, and it fell through unrecognized
-    before this marker was added, requiring a manual gateway restart."""
+    before this marker was added, requiring a manual gateway restart.
+
+    Plain-exception form (no structural .error.code) still matches on
+    the exact-text fallback -- some transports re-wrap the original
+    McpError before it reaches this classifier."""
     from tools.mcp_tool import _is_session_expired_error
     assert _is_session_expired_error(RuntimeError("Invalid request parameters")) is True
     assert _is_session_expired_error(RuntimeError("INVALID REQUEST PARAMETERS")) is True
+
+
+def test_is_session_expired_detects_structural_mcperror_invalid_params():
+    """The real call-site shape: an ``McpError`` carrying
+    ``ErrorData(code=INVALID_PARAMS, message="Invalid request parameters")``
+    exactly as raised by mcp/shared/session.py's incoming-request handler
+    on a stale/dropped server-side session. Structural code + exact
+    generic message -> session-expired reconnect path."""
+    from tools.mcp_tool import _is_session_expired_error
+    assert _is_session_expired_error(_mcp_error(-32602, "Invalid request parameters")) is True
+
+
+def test_is_session_expired_rejects_real_bad_argument_invalid_params():
+    """PR #66841 review fix (teknium1): a genuine bad-arguments tool call
+    also raises McpError(-32602, ...), but from a *different* code path
+    (the tool/server's own argument validation) that virtually always
+    names the offending tool/parameter -- it does not reproduce the SDK's
+    bare generic string verbatim. This must NOT be treated as a stale
+    session and must NOT trigger a silent reconnect-and-retry that would
+    mask a real error from the caller."""
+    from tools.mcp_tool import _is_session_expired_error
+    assert _is_session_expired_error(
+        _mcp_error(-32602, "Invalid arguments for tool 'search': missing required field 'query'")
+    ) is False
+    assert _is_session_expired_error(
+        _mcp_error(-32602, "Invalid params: 'limit' must be a positive integer")
+    ) is False
 
 
 def test_is_session_expired_rejects_interrupted_error():

--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -82,6 +82,20 @@ def test_is_session_expired_rejects_unrelated_errors():
     assert _is_session_expired_error(RuntimeError("401 Unauthorized")) is False
 
 
+def test_is_session_expired_detects_invalid_request_parameters():
+    """A server that restarted mid-session (redeploy, pod rotation) drops
+    its server-side session state; the client's *next* request fails
+    JSON-RPC INVALID_PARAMS validation server-side (see
+    mcp/shared/session.py's incoming-request handler) and comes back as
+    this exact generic message -- not one of the more specific phrases
+    above. Studio North MCP incident, 2026-07-18: this was the literal
+    error text hit after every deploy, and it fell through unrecognized
+    before this marker was added, requiring a manual gateway restart."""
+    from tools.mcp_tool import _is_session_expired_error
+    assert _is_session_expired_error(RuntimeError("Invalid request parameters")) is True
+    assert _is_session_expired_error(RuntimeError("INVALID REQUEST PARAMETERS")) is True
+
+
 def test_is_session_expired_rejects_interrupted_error():
     """InterruptedError is the user-cancel signal — must never route
     through the session-reconnect path."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3479,6 +3479,18 @@ _SESSION_EXPIRED_MARKERS: tuple = (
     "connection closed",
     "broken pipe",
     "end of file",
+    # Generic JSON-RPC INVALID_PARAMS validation failure (see
+    # mcp/shared/session.py's incoming-request handler). A server that
+    # restarted mid-session (e.g. a redeploy) drops its server-side
+    # session state; the *next* request from a client still holding the
+    # old session fails request validation and comes back as this
+    # exact message, not one of the more specific "session expired"
+    # phrases above. Narrow substring match is intentional — this is
+    # only reached when _is_session_expired_error is asked to classify
+    # an actual raised exception, which is inherently already the
+    # unhappy path, so a broader net here is a acceptable tradeoff for
+    # not requiring a manual gateway restart after every server deploy.
+    "invalid request parameters",
 )
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3479,19 +3479,34 @@ _SESSION_EXPIRED_MARKERS: tuple = (
     "connection closed",
     "broken pipe",
     "end of file",
-    # Generic JSON-RPC INVALID_PARAMS validation failure (see
-    # mcp/shared/session.py's incoming-request handler). A server that
-    # restarted mid-session (e.g. a redeploy) drops its server-side
-    # session state; the *next* request from a client still holding the
-    # old session fails request validation and comes back as this
-    # exact message, not one of the more specific "session expired"
-    # phrases above. Narrow substring match is intentional — this is
-    # only reached when _is_session_expired_error is asked to classify
-    # an actual raised exception, which is inherently already the
-    # unhappy path, so a broader net here is a acceptable tradeoff for
-    # not requiring a manual gateway restart after every server deploy.
-    "invalid request parameters",
 )
+
+# The MCP SDK's *exact*, hardcoded fallback message for a JSON-RPC
+# INVALID_PARAMS (-32602) request-validation failure — see
+# mcp/shared/session.py's incoming-request handler
+# (``ErrorData(code=INVALID_PARAMS, message="Invalid request parameters")``).
+# A server that restarted mid-session (e.g. a redeploy) drops its
+# server-side session state; the *next* request from a client still
+# holding the old session fails request validation and comes back as
+# exactly this message verbatim, with no further detail appended —
+# functionally identical to the other session-expiry symptoms above.
+#
+# This is intentionally NOT folded into ``_SESSION_EXPIRED_MARKERS`` as a
+# loose substring: a real tool call with genuinely bad arguments can also
+# raise ``McpError(-32602, ...)``, and those come from a *different* code
+# path (a tool/server's own argument validation) that virtually always
+# names the offending tool/parameter rather than reproducing the SDK's
+# bare generic string. Matching on that generic text as a substring would
+# risk swallowing a real bad-arguments bug as "just reconnect and retry"
+# instead of surfacing it. Structural code check + exact (not substring)
+# message match narrows this to the one code path that actually produces
+# it. See PR #66841 review discussion.
+try:
+    from mcp.types import INVALID_PARAMS as _JSONRPC_INVALID_PARAMS
+except Exception:  # pragma: no cover — older/newer SDK without the constant
+    _JSONRPC_INVALID_PARAMS = -32602
+
+_SDK_GENERIC_INVALID_PARAMS_MESSAGE = "invalid request parameters"
 
 
 def _is_session_expired_error(exc: BaseException) -> bool:
@@ -3517,7 +3532,27 @@ def _is_session_expired_error(exc: BaseException) -> bool:
     msg = str(exc).lower()
     if not msg:
         return False
-    return any(marker in msg for marker in _SESSION_EXPIRED_MARKERS)
+    if any(marker in msg for marker in _SESSION_EXPIRED_MARKERS):
+        return True
+
+    # Stale-session INVALID_PARAMS: require the structural JSON-RPC code
+    # (when available — an McpError with .error.code) AND an *exact*
+    # match against the SDK's bare generic message, not a substring
+    # match against arbitrary tool-call error text. A genuine bad-argument
+    # error (e.g. "Invalid arguments for tool 'search': missing 'query'")
+    # contains extra detail and will not exactly equal the generic
+    # fallback string, so it correctly falls through as a real error.
+    if msg.strip() == _SDK_GENERIC_INVALID_PARAMS_MESSAGE:
+        err = getattr(exc, "error", None)
+        code = getattr(err, "code", None)
+        # If the exception exposes a structural code, it must match
+        # INVALID_PARAMS. If it doesn't expose one (e.g. a plain
+        # RuntimeError wrapping the message, as some transports do),
+        # fall back to the exact-text match alone — still far narrower
+        # than the old blanket substring match.
+        if code is None or code == _JSONRPC_INVALID_PARAMS:
+            return True
+    return False
 
 
 def _handle_session_expired_and_retry(


### PR DESCRIPTION
When a Streamable HTTP/SSE MCP server restarts mid-session (a redeploy, pod rotation, etc.), it drops server-side session state. The client's next request fails JSON-RPC INVALID_PARAMS validation server-side (`mcp/shared/session.py`'s incoming-request handler catches the `model_validate` failure and returns this exact generic message) — functionally identical to the other session-expiry symptoms already recognized by `_is_session_expired_error`, but the literal string "Invalid request parameters" wasn't in `_SESSION_EXPIRED_MARKERS`, so it fell through unrecognized and required a manual gateway/client restart to clear.

## Repro
Hit this directly running a Railway-hosted MCP server (3 redeploys in one day): every tool call — including trivial no-arg ones — returned exactly this message, across both a long-lived Hermes gateway process and a separate Claude Desktop `mcp-remote` client. Neither self-healed; both needed a manual restart.

## Fix
Adds the marker to the existing `_SESSION_EXPIRED_MARKERS` allow-list. All 5 tool/resource/prompt handlers already route through `_handle_session_expired_and_retry`, so this one addition covers every call site's existing reconnect-and-retry path — no new plumbing.

## Verification
- New unit test `test_is_session_expired_detects_invalid_request_parameters` covers the exact string plus a case-insensitivity variant.
- Full `test_mcp_tool_session_expired.py` suite (20 tests) passes clean, no regressions to the 401 / interrupted-error / unrelated-error negative cases.
- Ran the broader `-k mcp` sweep across `tests/` (1044 tests). The only 5 failures are a pre-existing `test_mcp_structured_content.py` isolation issue (module-global circuit-breaker state leaking across test files in the same process) that reproduces identically on unmodified `main` — confirmed by stashing this change and rerunning, same failure, same assertion. Unrelated to and pre-dating this fix.