### PR TITLE
fix: config.set fail-closed on malformed YAML, preserving comments (#66752)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2742,15 +2742,41 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
 
 
 def _write_config_key(key_path: str, value):
-    cfg = _load_cfg()
-    current = cfg
-    keys = key_path.split(".")
-    for key in keys[:-1]:
-        if key not in current or not isinstance(current.get(key), dict):
-            current[key] = {}
-        current = current[key]
-    current[keys[-1]] = value
-    _save_cfg(cfg)
+    # Fail-closed: validate that the existing YAML parses before writing.
+    # Without this guard, a malformed config.yaml causes _load_cfg() to return
+    # {}, and the subsequent _save_cfg() overwrites the file with a document
+    # containing only the requested key — silently destroying all other config.
+    # See https://github.com/NousResearch/hermes-agent/issues/66752
+    path = _hermes_home / "config.yaml"
+    if path.exists():
+        import yaml as _yaml
+
+        with open(path, encoding="utf-8") as f:
+            raw = f.read()
+        try:
+            _yaml.safe_load(raw)
+        except _yaml.YAMLError as exc:
+            raise RuntimeError(
+                f"config.yaml contains invalid YAML and cannot be safely "
+                f"updated. Fix the syntax error first, then retry. ({exc})"
+            ) from exc
+
+    # Use round-trip YAML update to preserve comments, ordering, and quoting.
+    try:
+        from utils import atomic_roundtrip_yaml_update
+
+        atomic_roundtrip_yaml_update(path, key_path, value)
+    except ImportError:
+        # Fallback: full-document rewrite (loses comments/formatting).
+        cfg = _load_cfg()
+        current = cfg
+        keys = key_path.split(".")
+        for key in keys[:-1]:
+            if key not in current or not isinstance(current.get(key), dict):
+                current[key] = {}
+            current = current[key]
+        current[keys[-1]] = value
+        _save_cfg(cfg)
 
 
 _STATUSBAR_MODES = frozenset({"off", "top", "bottom"})


### PR DESCRIPTION
## Summary

`_write_config_key()` calls `_load_cfg()`, which silently returns `{}` when `config.yaml` contains a YAML syntax error. The subsequent `_save_cfg()` then writes a document containing **only the requested key**, destroying all other configuration.

This PR makes `_write_config_key()` **fail-closed**: it validates that the existing YAML file parses correctly before writing. If parsing fails, a `RuntimeError` is raised with the specific YAML error, leaving the original file untouched.

Additionally, the single-key update now uses `atomic_roundtrip_yaml_update()` (from `utils.py`) to **preserve comments, ordering, quoting style, and formatting** — addressing the related formatting-loss concern from #63039.

## Changes

- Validate YAML parse before writing; raise `RuntimeError` on malformed `config.yaml`
- Use `atomic_roundtrip_yaml_update()` for round-trip-preserving single-key updates
- Fallback to full-document rewrite only if `ruamel.yaml` is unavailable

## Test Plan

1. Create a malformed `config.yaml` (e.g. unterminated `[` in a list)
2. Invoke `_write_config_key("approvals.mode", "smart")`
3. **Before fix**: file is overwritten with only `approvals: {mode: smart}` — all other settings lost
4. **After fix**: `RuntimeError` raised, original file untouched
5. On valid config with comments, verify comments survive the update

Fixes #66752