### PR TITLE
fix(moonshot): ensure required array is always present in tool schemas

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -170,15 +170,29 @@ def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
 def sanitize_moonshot_tool_parameters(parameters: Any) -> Dict[str, Any]:
     """Normalize tool parameters to a Moonshot-compatible object schema.
 
-    Returns a deep-copied schema with the two flavored-JSON-Schema repairs
+    Returns a deep-copied schema with the flavored-JSON-Schema repairs
     applied.  Input is not mutated.
+
+    Repairs applied:
+
+    1. Every property schema carries a ``type`` (Moonshot rejects nodes
+       without one).  See ``_repair_schema`` / ``_fill_missing_type``.
+    2. ``type`` at the parent of ``anyOf`` is stripped; null-type branches
+       are collapsed so nullable fields round-trip cleanly.
+    3. Top-level object schema always carries an explicit ``required`` array
+       (Moonshot's validator 400s on its absence, ``details: <At path
+       'required': required must be an array>``).  Entries that don't
+       exist in ``properties`` are pruned to defend against dangling refs.
+
+       Standard JSON Schema makes ``required`` optional; Moonshot does not.
+       See #66835.
     """
     if not isinstance(parameters, dict):
-        return {"type": "object", "properties": {}}
+        return {"type": "object", "properties": {}, "required": []}
 
     repaired = _repair_schema(copy.deepcopy(parameters), is_schema=True)
     if not isinstance(repaired, dict):
-        return {"type": "object", "properties": {}}
+        return {"type": "object", "properties": {}, "required": []}
 
     # Top-level must be an object schema
     if repaired.get("type") != "object":
@@ -186,7 +200,39 @@ def sanitize_moonshot_tool_parameters(parameters: Any) -> Dict[str, Any]:
     if "properties" not in repaired:
         repaired["properties"] = {}
 
+    _ensure_required_list(repaired)
+
     return repaired
+
+
+def _ensure_required_list(schema: Dict[str, Any]) -> None:
+    """Force ``required`` to a list of valid property names (in place).
+
+    Moonshot's tool-parameter validator rejects schemas that omit the
+    ``required`` key, and also rejects dangling entries that don't exist
+    in ``properties``.  Treat both cases:
+
+    - Missing or non-list ``required`` -> ``[]``
+    - List -> filtered to entries that are present in ``properties``
+
+    Only mutates the dict if ``required`` is absent, mistyped, or has
+    dangling entries.
+    """
+    props = schema.get("properties")
+    if not isinstance(props, dict):
+        # Should not happen (caller ensures properties is a dict), but
+        # still be defensive about the type.
+        schema["required"] = []
+        return
+
+    raw = schema.get("required")
+    if not isinstance(raw, list):
+        schema["required"] = []
+        return
+
+    pruned = [name for name in raw if isinstance(name, str) and name in props]
+    if len(pruned) != len(raw):
+        schema["required"] = pruned
 
 
 def sanitize_moonshot_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -184,9 +184,9 @@ class TestTopLevelGuarantees:
     """The returned top-level schema is always a well-formed object."""
 
     def test_non_dict_input_returns_empty_object(self):
-        assert sanitize_moonshot_tool_parameters(None) == {"type": "object", "properties": {}}
-        assert sanitize_moonshot_tool_parameters("garbage") == {"type": "object", "properties": {}}
-        assert sanitize_moonshot_tool_parameters([]) == {"type": "object", "properties": {}}
+        assert sanitize_moonshot_tool_parameters(None) == {"type": "object", "properties": {}, "required": []}
+        assert sanitize_moonshot_tool_parameters("garbage") == {"type": "object", "properties": {}, "required": []}
+        assert sanitize_moonshot_tool_parameters([]) == {"type": "object", "properties": {}, "required": []}
 
     def test_non_object_top_level_coerced(self):
         params = {"type": "string"}
@@ -236,7 +236,7 @@ class TestToolListSanitizer:
         out = sanitize_moonshot_tools(tools)
         assert out[0]["function"]["parameters"]["properties"]["q"]["type"] == "string"
         # Second tool already clean — should be structurally equivalent
-        assert out[1]["function"]["parameters"] == {"type": "object", "properties": {}}
+        assert out[1]["function"]["parameters"] == {"type": "object", "properties": {}, "required": []}
 
     def test_empty_list_is_passthrough(self):
         assert sanitize_moonshot_tools([]) == []


### PR DESCRIPTION
## Problem

When using a Moonshot/Kimi model (e.g. `kimi-k2.6`, `kimi-k3`) via any OpenAI-compatible endpoint, requests that include certain Hermes tool schemas fail with HTTP 400 before any token is emitted:

```
Invalid request: tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'required': required must be an array>
```

## Root cause

Moonshot's tool-parameter validator is stricter than standard JSON Schema — it requires **every object schema to carry an explicit `required` array**, even when empty.

Standard JSON Schema allows omitting `required` when there are no required fields. Moonshot 400s on that.

### Affected tools (examples)

- `browser_back`, `browser_console`, `browser_get_images`, `browser_snapshot`
- `delegate_task`
- Several MCP tools with zero required parameters

## Fix

1. Add `_ensure_required_list()` helper that:
   - Sets `required` to `[]` when missing or not a list
   - Prunes dangling entries not present in `properties` (defense against dangling refs)
2. Apply it inside `sanitize_moonshot_tool_parameters()` after all other repairs
3. Updated docstring

## Verification

- 37/37 `tests/agent/test_moonshot_schema.py` pass (2 test assertions adjusted for new return shape)

Fixes #66835