### PR TITLE
fix(agent): inject empty required array on Moonshot object schemas (#66835)

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -15,6 +15,9 @@ and MoonshotAI/kimi-cli#1595:
 2. When ``anyOf`` is used, ``type`` must be on the ``anyOf`` children, not
    the parent.  Presence of both causes "type should be defined in anyOf
    items instead of the parent schema".
+3. Every object schema must carry a ``required`` array, even an empty one.
+   Standard JSON Schema allows omitting it; Moonshot 400s with
+   "required must be an array".
 
 The ``#/definitions/...`` → ``#/$defs/...`` rewrite for draft-07 refs is
 handled separately in ``tools/mcp_tool._normalize_mcp_input_schema`` so it
@@ -130,7 +133,30 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
             else:
                 repaired.pop("enum")
 
+    # Rule 4: object schemas must carry a `required` array, even when empty.
+    if repaired.get("type") == "object":
+        repaired = _ensure_required_array(repaired)
+
     return repaired
+
+
+def _ensure_required_array(node: Dict[str, Any]) -> Dict[str, Any]:
+    """Guarantee an object schema carries a ``required`` array (Moonshot rule).
+
+    Standard JSON Schema lets you omit ``required`` when nothing is required;
+    Moonshot 400s on that ("required must be an array").  Ensure the key is a
+    list.  When ``properties`` is known, prune ``required`` entries that don't
+    name a real property — defensive against dangling names, which Moonshot
+    also rejects.  Mutates and returns ``node``.
+    """
+    props = node.get("properties")
+    req = node.get("required")
+    if isinstance(req, list):
+        if isinstance(props, dict):
+            node["required"] = [r for r in req if r in props]
+    else:
+        node["required"] = []
+    return node
 
 
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
@@ -174,17 +200,18 @@ def sanitize_moonshot_tool_parameters(parameters: Any) -> Dict[str, Any]:
     applied.  Input is not mutated.
     """
     if not isinstance(parameters, dict):
-        return {"type": "object", "properties": {}}
+        return {"type": "object", "properties": {}, "required": []}
 
     repaired = _repair_schema(copy.deepcopy(parameters), is_schema=True)
     if not isinstance(repaired, dict):
-        return {"type": "object", "properties": {}}
+        return {"type": "object", "properties": {}, "required": []}
 
     # Top-level must be an object schema
     if repaired.get("type") != "object":
         repaired["type"] = "object"
     if "properties" not in repaired:
         repaired["properties"] = {}
+    _ensure_required_array(repaired)
 
     return repaired
 

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -184,9 +184,10 @@ class TestTopLevelGuarantees:
     """The returned top-level schema is always a well-formed object."""
 
     def test_non_dict_input_returns_empty_object(self):
-        assert sanitize_moonshot_tool_parameters(None) == {"type": "object", "properties": {}}
-        assert sanitize_moonshot_tool_parameters("garbage") == {"type": "object", "properties": {}}
-        assert sanitize_moonshot_tool_parameters([]) == {"type": "object", "properties": {}}
+        empty = {"type": "object", "properties": {}, "required": []}
+        assert sanitize_moonshot_tool_parameters(None) == empty
+        assert sanitize_moonshot_tool_parameters("garbage") == empty
+        assert sanitize_moonshot_tool_parameters([]) == empty
 
     def test_non_object_top_level_coerced(self):
         params = {"type": "string"}
@@ -206,6 +207,66 @@ class TestTopLevelGuarantees:
         sanitize_moonshot_tool_parameters(params)
         assert params["type"] == snapshot["type"]
         assert "type" not in params["properties"]["q"]
+
+
+class TestRequiredArray:
+    """Rule 4: every object schema must carry a ``required`` array (#66835)."""
+
+    def test_empty_object_gets_empty_required(self):
+        out = sanitize_moonshot_tool_parameters({"type": "object", "properties": {}})
+        assert out["required"] == []
+
+    def test_object_with_only_optional_props_gets_empty_required(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == []
+
+    def test_existing_required_preserved(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == ["q"]
+
+    def test_dangling_required_pruned(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q", "ghost"],
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == ["q"]
+
+    def test_non_list_required_replaced(self):
+        params = {
+            "type": "object",
+            "properties": {},
+            "required": "q",  # invalid: string, not array
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == []
+
+    def test_nested_object_property_gets_required(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "filter": {"type": "object", "properties": {}},
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["filter"]["required"] == []
+        assert out["required"] == []
+
+    def test_coerced_top_level_gets_required(self):
+        # A non-object top level is forced to object and must gain required.
+        out = sanitize_moonshot_tool_parameters({"type": "string"})
+        assert out["type"] == "object"
+        assert out["required"] == []
 
 
 class TestToolListSanitizer:
@@ -235,8 +296,10 @@ class TestToolListSanitizer:
         ]
         out = sanitize_moonshot_tools(tools)
         assert out[0]["function"]["parameters"]["properties"]["q"]["type"] == "string"
-        # Second tool already clean — should be structurally equivalent
-        assert out[1]["function"]["parameters"] == {"type": "object", "properties": {}}
+        # Second tool: empty object gains the required-array Moonshot demands
+        assert out[1]["function"]["parameters"] == {
+            "type": "object", "properties": {}, "required": []
+        }
 
     def test_empty_list_is_passthrough(self):
         assert sanitize_moonshot_tools([]) == []


### PR DESCRIPTION
## What does this PR do?

Moonshot/Kimi's tool-parameter validator is stricter than standard JSON Schema:
it requires **every object schema to carry a `required` array**, even an empty
one. Requests that include a Hermes tool whose parameters omit `required` fail
with HTTP 400 before any token is emitted:

```
Invalid request: tools.function.parameters is not a valid moonshot flavored
json schema, details: <At path 'required': required must be an array>
```

Standard JSON Schema allows omitting `required` when nothing is required, so any
Hermes tool with zero required parameters (`browser_back`, `browser_snapshot`,
`delegate_task`, `project_list`, `read_terminal`, `session_search`, several MCP
`list_*` tools, …) trips this whenever it's routed to a Moonshot endpoint.

`agent/moonshot_schema.py` already sanitizes several Moonshot-specific quirks
(missing `type`, `anyOf` parent type, nullable/enum cleanup) but did not inject
`required`. This adds that as a fourth rule.

## Related Issue

Fixes #66835

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moonshot_schema.py`:
  - New `_ensure_required_array()` helper — guarantees a `required` list on an
    object schema; when `properties` is known, prunes `required` entries that
    don't name a real property (dangling names are also rejected upstream).
  - `_repair_schema()`: apply it to every node whose resolved `type` is
    `object` (so nested object schemas are covered too).
  - `sanitize_moonshot_tool_parameters()`: apply it after the top-level
    object coercion, and include `"required": []` in the empty-object
    fallbacks.
  - Docstring: document the new rule.
- `tests/agent/test_moonshot_schema.py`:
  - New `TestRequiredArray` (empty object, only-optional props, preserved
    existing `required`, dangling-name pruning, non-list replacement, nested
    object, coerced top level).
  - Updated the two existing assertions that encoded the pre-fix empty-object
    output to include `"required": []`.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_moonshot_schema.py` — 44 passed.
2. Minimal shape check: `{"type": "object", "properties": {}}` now sanitizes to
   `{"type": "object", "properties": {}, "required": []}` (the shape Moonshot
   accepts).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — updated the sanitizer module docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — N/A (pure schema transform)
