### PR TITLE
fix: add usedforsecurity=False to hashlib.md5 in weixin adapter (FIPS crash)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1417,7 +1417,7 @@ class WeixinAdapter(BasePlatformAdapter):
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
         if text:
-            content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
+            content_key = f"content:{sender_id}:{hashlib.md5(text.encode(), usedforsecurity=False).hexdigest()}"
             if self._dedup.is_duplicate(content_key):
                 logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
                 return
@@ -2116,7 +2116,7 @@ class WeixinAdapter(BasePlatformAdapter):
         filekey = secrets.token_hex(16)
         aes_key = secrets.token_bytes(16)
         rawsize = len(plaintext)
-        rawfilemd5 = hashlib.md5(plaintext).hexdigest()
+        rawfilemd5 = hashlib.md5(plaintext, usedforsecurity=False).hexdigest()
         upload_response = await _get_upload_url(
             self._send_session,
             base_url=self._base_url,


### PR DESCRIPTION
## Summary

`gateway/platforms/weixin.py` has two `hashlib.md5()` calls without `usedforsecurity=False`. On FIPS-enabled systems (RHEL 8/9, Ubuntu FIPS), these crash with `ValueError: EVP_DigestInit_ex disabled for FIPS`.

Both calls are non-security uses:
- **Line 1420**: content deduplication key hash
- **Line 2119**: file upload integrity check

## Changes

- `hashlib.md5(text.encode())` → `hashlib.md5(text.encode(), usedforsecurity=False)`
- `hashlib.md5(plaintext)` → `hashlib.md5(plaintext, usedforsecurity=False)`

## Prior art

PRs #56715, #56716, #56719, #62654, #64062, #64808 covered hashlib FIPS fixes in other files. `gateway/platforms/weixin.py` was in the `gateway/platforms/` blind spot.

Fixes FIPS crash on weixin adapter.