### PR TITLE
feat(agent): summarize and continue at iteration limits

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1537,6 +1537,12 @@ def init_agent(
     # conversation loop's intent-ack block.
     agent._intent_ack_continuation = _agent_section.get("intent_ack_continuation", "auto")
 
+    # Optional iteration-budget rollover. When enabled, max_turns becomes a
+    # forced context-summary checkpoint rather than a terminal condition.
+    agent._summarize_and_continue_on_limit = bool(
+        _agent_section.get("summarize_and_continue_on_limit", False)
+    )
+
     # Universal task-completion guidance toggle.  Default True.  Surfaced
     # as a separate flag from tool_use_enforcement because the guidance
     # applies to ALL models, not just the model families enforcement

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -650,6 +650,8 @@ def run_conversation(
 
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
+    iteration_window_count = 0
+    iteration_summary_rollovers = 0
     final_response = None
     interrupted = False
     failed = False
@@ -686,7 +688,80 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
-    while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+    while True:
+        _iteration_window_open = (
+            iteration_window_count < agent.max_iterations
+            and agent.iteration_budget.remaining > 0
+        )
+        if not (_iteration_window_open or agent._budget_grace_call):
+            if (
+                not getattr(agent, "_summarize_and_continue_on_limit", False)
+                or agent.max_iterations <= 0
+            ):
+                break
+
+            # max_turns is a summary checkpoint, not a stop signal. Reuse the
+            # context-compression path so the checkpoint stays internal,
+            # cache-safe, and cannot masquerade as the final answer.
+            iteration_summary_rollovers += 1
+            agent._touch_activity(
+                f"summarizing iteration window #{iteration_summary_rollovers}"
+            )
+            agent._emit_status(
+                f"📦 Iteration checkpoint {iteration_summary_rollovers}: "
+                f"summarizing after {iteration_window_count} calls, then continuing"
+            )
+            _pre_rollover_messages = messages
+            try:
+                messages, active_system_prompt = agent._compress_context(
+                    messages,
+                    system_message,
+                    approx_tokens=estimate_request_tokens_rough(
+                        messages, tools=agent.tools or None
+                    ),
+                    task_id=effective_task_id,
+                    force=True,
+                )
+            except Exception as _rollover_error:
+                logger.warning(
+                    "Iteration checkpoint summary failed; continuing with the "
+                    "existing context (window=%d, calls=%d): %s",
+                    iteration_summary_rollovers,
+                    api_call_count,
+                    _rollover_error,
+                    exc_info=True,
+                )
+                messages = _pre_rollover_messages
+            else:
+                if messages is _pre_rollover_messages:
+                    logger.warning(
+                        "Iteration checkpoint summary made no progress; continuing "
+                        "with the existing context (window=%d, calls=%d)",
+                        iteration_summary_rollovers,
+                        api_call_count,
+                    )
+                conversation_history = conversation_history_after_compression(
+                    agent, messages
+                )
+
+            # Compression may rewrite the transcript. Rebase API-only context
+            # injection onto the newest preserved user row before continuing.
+            for _summary_user_idx in range(len(messages) - 1, -1, -1):
+                if messages[_summary_user_idx].get("role") == "user":
+                    current_turn_user_idx = _summary_user_idx
+                    break
+
+            agent.iteration_budget = IterationBudget(agent.max_iterations)
+            iteration_window_count = 0
+            agent._budget_exhausted_injected = False
+            agent._budget_grace_call = False
+            agent._empty_content_retries = 0
+            agent._thinking_prefill_retries = 0
+            agent._last_content_with_tools = None
+            agent._last_content_tools_all_housekeeping = False
+            agent._mute_post_response = False
+            continue
+
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 
@@ -699,6 +774,7 @@ def run_conversation(
             break
         
         api_call_count += 1
+        iteration_window_count += 1
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")
 
@@ -1041,6 +1117,7 @@ def run_conversation(
             messages.append({"role": "assistant", "content": final_response})
             agent._emit_status("❌ Ollama runtime context is too small for Hermes tool use")
             api_call_count -= 1
+            iteration_window_count -= 1
             agent._api_call_count = api_call_count
             try:
                 agent.iteration_budget.refund()
@@ -1121,6 +1198,7 @@ def run_conversation(
                 agent, messages
             )
             api_call_count -= 1
+            iteration_window_count -= 1
             agent._api_call_count = api_call_count
             agent.iteration_budget.refund()
             continue
@@ -5644,8 +5722,10 @@ def run_conversation(
             # message pollutes history, burns tokens, and risks violating
             # role-alternation invariants.
 
-            # If we're near the limit, break to avoid infinite loops
-            if api_call_count >= agent.max_iterations - 1:
+            # Repeated non-tool errors are a hard blocker within the current
+            # summary window; a prior rollover must not make every later error
+            # look permanently near the limit.
+            if iteration_window_count >= agent.max_iterations - 1:
                 _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
                 final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
                 # Append as assistant so the history stays valid for
@@ -5672,6 +5752,7 @@ def run_conversation(
         _should_review_memory=_should_review_memory,
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
+        iteration_summary_rollovers=iteration_summary_rollovers,
     )
 
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -43,6 +43,7 @@ def finalize_turn(
     _should_review_memory,
     _turn_exit_reason,
     _pending_verification_response=None,
+    iteration_summary_rollovers=0,
 ):
     """Run the post-loop finalization and return the turn ``result`` dict.
 
@@ -436,6 +437,7 @@ def finalize_turn(
         "last_reasoning": last_reasoning,
         "messages": messages,
         "api_calls": api_call_count,
+        "iteration_summary_rollovers": iteration_summary_rollovers,
         "completed": completed,
         "turn_exit_reason": _turn_exit_reason,
         "failed": failed,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1011,6 +1011,10 @@ DEFAULT_CONFIG = {
     "max_live_sessions": 16,
     "agent": {
         "max_turns": 90,
+        # Treat max_turns as a forced context-summary checkpoint instead of a
+        # terminal budget. The agent compacts the transcript, resets the
+        # per-window budget, and continues the same user turn.
+        "summarize_and_continue_on_limit": False,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/tests/agent/test_iteration_summary_rollover_config.py
+++ b/tests/agent/test_iteration_summary_rollover_config.py
@@ -1,0 +1,35 @@
+"""Config wiring for iteration-summary rollover."""
+
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _agent_with_config(agent_config):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch(
+            "hermes_cli.config.load_config",
+            return_value={"agent": agent_config},
+        ),
+    ):
+        return AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            enabled_toolsets=[],
+        )
+
+
+def test_iteration_summary_rollover_is_opt_in_by_default():
+    agent = _agent_with_config({})
+    assert getattr(agent, "_summarize_and_continue_on_limit") is False
+
+
+def test_iteration_summary_rollover_loads_enabled_config():
+    agent = _agent_with_config({"summarize_and_continue_on_limit": True})
+    assert getattr(agent, "_summarize_and_continue_on_limit") is True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4305,6 +4305,71 @@ class TestRunConversation:
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
 
+    def test_iteration_limit_summary_rollover_continues_same_turn(self, agent):
+        """The configured limit is a summary checkpoint, not a stop signal."""
+        self._setup_agent(agent)
+        agent.max_iterations = 1
+        agent._summarize_and_continue_on_limit = True
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        resp2 = _mock_response(content="Done after checkpoint", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+        compacted = [
+            {
+                "role": "user",
+                "content": "[Conversation summary]\nSearch started; continue the unfinished task.",
+            }
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(
+                agent,
+                "_compress_context",
+                return_value=(compacted, "You are helpful."),
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Done after checkpoint"
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert result["iteration_summary_rollovers"] == 1
+        mock_compress.assert_called_once()
+        assert mock_compress.call_args.kwargs["force"] is True
+
+    def test_iteration_summary_failure_does_not_stop_unfinished_work(self, agent):
+        """A broken summarizer is not a hard blocker for the underlying task."""
+        self._setup_agent(agent)
+        agent.max_iterations = 1
+        agent._summarize_and_continue_on_limit = True
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc]),
+            _mock_response(content="Done despite summary outage", finish_reason="stop"),
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(
+                agent,
+                "_compress_context",
+                side_effect=RuntimeError("summarizer unavailable"),
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Done despite summary outage"
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert result["iteration_summary_rollovers"] == 1
+
     def test_tool_call_none_args_verbose_logging_does_not_crash(self, agent):
         self._setup_agent(agent)
         agent.verbose_logging = True

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -838,10 +838,17 @@ Instead, when the budget is actually exhausted (90/90), Hermes injects one messa
 ```yaml
 agent:
   max_turns: 90                # Max iterations per conversation turn (default: 90)
+  summarize_and_continue_on_limit: false  # Summarize, reset, and continue
   api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
 ```
 
 When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (90/90) — response may be incomplete`.
+
+Set `agent.summarize_and_continue_on_limit: true` when long-running tasks must
+not stop at that boundary. Hermes then forces an internal context summary,
+renews the `max_turns` window, and continues the same user turn. The checkpoint
+summary is not delivered as the final answer. Interrupts, guardrail halts,
+provider failures, and other hard errors still stop normally.
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 


### PR DESCRIPTION
## Summary
- add opt-in `agent.summarize_and_continue_on_limit`
- force an internal context compaction at each `max_turns` boundary
- reset the per-window iteration budget and continue the same user turn
- keep hard failures, interrupts, and guardrail halts terminal

## Verification
- observed RED before implementation
- 20 targeted config/finalizer/cache tests passed
- 3 targeted conversation-loop tests passed
- `git diff --check` and Python byte-compilation passed
- `hermes doctor`: all checks passed