### PR TITLE
fix(kimi): preserve Hermes request identity

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -51,6 +51,7 @@ from hermes_cli.config import cfg_get
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
+from providers.base import hermes_user_agent
 from utils import base_url_host_matches, is_truthy_value
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
@@ -1148,7 +1149,7 @@ def init_agent(
                 client_kwargs["default_headers"] = copilot_default_headers()
             elif base_url_host_matches(effective_base, "api.kimi.com"):
                 client_kwargs["default_headers"] = {
-                    "User-Agent": "claude-code/0.1.0",
+                    "User-Agent": hermes_user_agent(),
                 }
             elif base_url_host_matches(effective_base, "portal.qwen.ai"):
                 client_kwargs["default_headers"] = _ra()._qwen_portal_headers()

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from hermes_constants import get_hermes_home
+from providers.base import hermes_user_agent
 from typing import Any, Dict, List, Optional, Tuple
 from utils import base_url_host_matches, normalize_proxy_env_vars
 
@@ -807,12 +808,12 @@ def build_anthropic_client(
     )
 
     if _is_kimi_coding_endpoint(base_url):
-        # Kimi's /coding endpoint requires User-Agent: claude-code/0.1.0
-        # to be recognized as a valid Coding Agent. Without it, returns 403.
+        # Kimi's /coding endpoint requires third-party agents to retain their
+        # real identity. See https://www.kimi.com/code/docs/en/
         # Check this BEFORE _requires_bearer_auth since both match api.kimi.com/coding.
         kwargs["api_key"] = api_key
         kwargs["default_headers"] = {
-            "User-Agent": "claude-code/0.1.0",
+            "User-Agent": hermes_user_agent(),
             **( {"anthropic-beta": ",".join(common_betas)} if common_betas else {} )
         }
     elif _requires_bearer_auth(normalized_base_url):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -108,6 +108,7 @@ from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
+from providers.base import hermes_user_agent
 from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
 
 logger = logging.getLogger(__name__)
@@ -2041,7 +2042,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                     return GeminiNativeClient(api_key=api_key, base_url=base_url), model
             extra = {}
             if base_url_host_matches(base_url, "api.kimi.com"):
-                extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+                extra["default_headers"] = {"User-Agent": hermes_user_agent()}
             elif base_url_host_matches(base_url, "githubcopilot.com"):
                 from hermes_cli.models import copilot_default_headers
 
@@ -2081,7 +2082,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 return GeminiNativeClient(api_key=api_key, base_url=base_url), model
         extra = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
-            extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+            extra["default_headers"] = {"User-Agent": hermes_user_agent()}
         elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.models import copilot_default_headers
 
@@ -4782,7 +4783,7 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
             is_agent_turn=True, is_vision=is_vision
         )
     elif base_url_host_matches(sync_base_url, "api.kimi.com"):
-        async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+        async_kwargs["default_headers"] = {"User-Agent": hermes_user_agent()}
     elif base_url_host_matches(sync_base_url, "integrate.api.nvidia.com"):
         async_kwargs["default_headers"] = build_nvidia_nim_headers(sync_base_url)
     else:
@@ -5130,7 +5131,7 @@ def resolve_provider_client(
             if _dq:
                 extra["default_query"] = _dq
             if base_url_host_matches(custom_base, "api.kimi.com"):
-                extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+                extra["default_headers"] = {"User-Agent": hermes_user_agent()}
             elif base_url_host_matches(custom_base, "githubcopilot.com"):
                 from hermes_cli.copilot_auth import copilot_request_headers
                 extra["default_headers"] = copilot_request_headers(
@@ -5387,7 +5388,7 @@ def resolve_provider_client(
         # Provider-specific headers
         headers = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
-            headers["User-Agent"] = "claude-code/0.1.0"
+            headers["User-Agent"] = hermes_user_agent()
         elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.copilot_auth import copilot_request_headers
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -31,6 +31,7 @@ load_hermes_dotenv(hermes_home=_env_path.parent, project_env=PROJECT_ROOT / ".en
 
 from hermes_cli.colors import Colors, color
 from hermes_cli.models import _HERMES_USER_AGENT
+from providers.base import hermes_user_agent
 from hermes_constants import OPENROUTER_MODELS_URL
 from utils import base_url_host_matches
 
@@ -2184,7 +2185,7 @@ def run_doctor(args):
                 "User-Agent": _HERMES_USER_AGENT,
             }
             if base_url_host_matches(base, "api.kimi.com"):
-                headers["User-Agent"] = "claude-code/0.1.0"
+                headers["User-Agent"] = hermes_user_agent()
             # Google's Generative Language API (generativelanguage.googleapis.com)
             # rejects ``Authorization: Bearer <api-key>`` with 401
             # ``ACCESS_TOKEN_TYPE_UNSUPPORTED`` — that header is reserved for

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -11,7 +11,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from providers import register_provider
-from providers.base import OMIT_TEMPERATURE, ProviderProfile
+from providers.base import OMIT_TEMPERATURE, ProviderProfile, hermes_user_agent
 
 
 def _is_confirmed_kimi_coding_url(base_url: str) -> bool:
@@ -102,7 +102,7 @@ kimi = KimiProfile(
     base_url="https://api.moonshot.ai/v1",
     fixed_temperature=OMIT_TEMPERATURE,
     default_max_tokens=32000,
-    default_headers={"User-Agent": "hermes-agent/1.0"},
+    default_headers={"User-Agent": hermes_user_agent()},
     default_aux_model="kimi-k2-turbo-preview",
 )
 
@@ -113,7 +113,7 @@ kimi_cn = KimiProfile(
     base_url="https://api.moonshot.cn/v1",
     fixed_temperature=OMIT_TEMPERATURE,
     default_max_tokens=32000,
-    default_headers={"User-Agent": "hermes-agent/1.0"},
+    default_headers={"User-Agent": hermes_user_agent()},
     default_aux_model="kimi-k2-turbo-preview",
 )
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -35,6 +35,15 @@ def _profile_user_agent() -> str:
         return "hermes-cli"
 
 
+def hermes_user_agent() -> str:
+    """Return Hermes Agent's versioned HTTP product identity."""
+    try:
+        from hermes_cli import __version__ as _ver  # lazy: avoid layer cycle at import time
+        return f"hermes-agent/{_ver}"
+    except Exception:
+        return "hermes-agent"
+
+
 @dataclass
 class ProviderProfile:
     """Base provider profile — subclass or instantiate with overrides."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -215,6 +215,7 @@ from agent.tool_dispatch_helpers import (
     _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens
+from providers.base import hermes_user_agent
 
 
 # Internal flags that mark a message as ephemeral empty-response/prefill
@@ -4962,7 +4963,7 @@ class AIAgent:
 
             self._client_kwargs["default_headers"] = copilot_default_headers()
         elif base_url_host_matches(base_url, "api.kimi.com"):
-            self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+            self._client_kwargs["default_headers"] = {"User-Agent": hermes_user_agent()}
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):

--- a/tests/agent/test_kimi_coding_anthropic_thinking.py
+++ b/tests/agent/test_kimi_coding_anthropic_thinking.py
@@ -19,7 +19,12 @@ in ``ChatCompletionsTransport`` (#13503).
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 import pytest
+
+from hermes_cli import __version__
 
 
 class TestKimiCodingAnthropicThinking:
@@ -207,3 +212,34 @@ class TestKimiFamilyGetsAdaptiveThinking:
         ]
         assert len(thinking_blocks) == 1
         assert thinking_blocks[0]["thinking"] == "planning the tool call"
+
+
+def test_kimi_anthropic_client_uses_real_hermes_identity() -> None:
+    from agent import anthropic_adapter
+
+    anthropic_ctor = MagicMock(return_value=MagicMock())
+    fake_sdk = SimpleNamespace(Anthropic=anthropic_ctor)
+
+    with patch.object(anthropic_adapter, "_get_anthropic_sdk", return_value=fake_sdk):
+        anthropic_adapter.build_anthropic_client(
+            "sk-kimi-test",
+            base_url="https://api.kimi.com/coding",
+        )
+
+    headers = anthropic_ctor.call_args.kwargs["default_headers"]
+    assert headers["User-Agent"] == f"hermes-agent/{__version__}"
+
+
+def test_kimi_auxiliary_async_client_uses_real_hermes_identity() -> None:
+    from agent.auxiliary_client import _to_async_client
+
+    sync_client = SimpleNamespace(
+        api_key="sk-kimi-test",
+        base_url="https://api.kimi.com/coding/v1",
+    )
+
+    with patch("openai.AsyncOpenAI", return_value=MagicMock()) as async_openai:
+        _to_async_client(sync_client, "kimi-for-coding")
+
+    headers = async_openai.call_args.kwargs["default_headers"]
+    assert headers["User-Agent"] == f"hermes-agent/{__version__}"

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -790,6 +790,57 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
     assert any(url == "https://api.moonshot.cn/v1/models" for url, _, _ in calls)
 
 
+def test_run_doctor_kimi_coding_probe_uses_real_hermes_identity(monkeypatch, tmp_path):
+    from hermes_cli import __version__
+
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("KIMI_API_KEY=sk-kimi-test\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("KIMI_API_KEY", "sk-kimi-test")
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200)
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    kimi_calls = [
+        (url, headers)
+        for url, headers, _ in calls
+        if url.startswith("https://api.kimi.com/coding")
+    ]
+    assert kimi_calls
+    assert kimi_calls[0][1]["User-Agent"] == f"hermes-agent/{__version__}"
+
+
 def test_run_doctor_dashscope_retries_china_endpoint_after_intl_unauthorized(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import pytest
 
+from hermes_cli import __version__
+
 
 @pytest.fixture
 def kimi_profile():
@@ -33,6 +35,11 @@ def kimi_profile():
 
 class TestKimiReasoningWireShape:
     """``build_api_kwargs_extras`` never emits thinking + reasoning_effort together."""
+
+    def test_profile_declares_real_hermes_identity(self, kimi_profile):
+        assert kimi_profile.default_headers["User-Agent"] == (
+            f"hermes-agent/{__version__}"
+        )
 
     def test_no_config_enables_thinking_without_effort(self, kimi_profile):
         """No reasoning_config → thinking on, server picks the depth.

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -2,6 +2,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from hermes_cli import __version__
 from run_agent import AIAgent
 
 
@@ -40,6 +41,43 @@ def test_routermint_base_url_applies_user_agent_header(mock_openai):
 
     headers = agent._client_kwargs["default_headers"]
     assert headers["User-Agent"].startswith("HermesAgent/")
+
+
+@patch("run_agent.OpenAI")
+def test_kimi_initial_client_uses_real_hermes_identity(mock_openai):
+    mock_openai.return_value = MagicMock()
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.kimi.com/coding/v1",
+        model="kimi-for-coding",
+        provider="kimi-coding",
+        api_mode="chat_completions",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["User-Agent"] == f"hermes-agent/{__version__}"
+
+
+@patch("run_agent.OpenAI")
+def test_kimi_header_refresh_uses_real_hermes_identity(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://api.kimi.com/coding/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["User-Agent"] == f"hermes-agent/{__version__}"
 
 
 @patch("run_agent.OpenAI")

--- a/tests/run_agent/test_switch_model_reapplies_headers.py
+++ b/tests/run_agent/test_switch_model_reapplies_headers.py
@@ -3,12 +3,12 @@ default headers when it rebuilds _client_kwargs from scratch.
 
 Without _apply_client_headers_for_base_url() in the rebuild path, a /model
 switch drops OpenRouter attribution headers (HTTP-Referer / X-Title → logs
-show "Unknown") and, worse, functional headers like Kimi's User-Agent
-sentinel (403 without it).
+show "Unknown") and Kimi's real Hermes User-Agent identity.
 """
 
 from unittest.mock import MagicMock, patch
 
+from hermes_cli import __version__
 from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
 
@@ -62,9 +62,8 @@ def test_switch_to_openrouter_reapplies_attribution_headers(mock_ctx_len):
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=131_072)
-def test_switch_to_kimi_reapplies_user_agent_sentinel(mock_ctx_len):
-    """Kimi requires a User-Agent sentinel; a switch to api.kimi.com must
-    carry it or every request 403s."""
+def test_switch_to_kimi_reapplies_hermes_user_agent(mock_ctx_len):
+    """A switch to api.kimi.com must preserve Hermes's real identity."""
     agent = _make_agent(provider="openrouter", base_url="https://openrouter.ai/api/v1")
 
     agent.switch_model(
@@ -75,7 +74,7 @@ def test_switch_to_kimi_reapplies_user_agent_sentinel(mock_ctx_len):
     )
 
     headers = agent._client_kwargs.get("default_headers") or {}
-    assert headers.get("User-Agent", "").startswith("claude-code/")
+    assert headers["User-Agent"] == f"hermes-agent/{__version__}"
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=131_072)


### PR DESCRIPTION
## Summary

- replace the hard-coded `claude-code/0.1.0` identity on Kimi endpoints with a versioned `hermes-agent/<version>` identity
- centralize Hermes's HTTP product identity and apply it consistently to primary clients, model switches, Anthropic transport, auxiliary clients, doctor probes, and Kimi provider profiles
- add regression coverage for each affected request-construction path

## Why

Hermes currently identifies Kimi requests as Claude Code. Kimi Code's current documentation says third-party agents must retain the tool's real identity identifier and explicitly lists Hermes as a supported agent framework:

https://www.kimi.com/code/docs/en/

Changing the header to another upstream product such as `KimiCLI` would still misidentify Hermes. This patch preserves Hermes's actual product identity while keeping the existing Kimi endpoint and authentication behavior unchanged.

Related to #46001 and #15209, but intentionally does not impersonate either Kimi CLI or Claude Code.

## Test plan

- `scripts/run_tests.sh tests/run_agent/test_provider_attribution_headers.py tests/run_agent/test_switch_model_reapplies_headers.py tests/agent/test_kimi_coding_anthropic_thinking.py tests/agent/test_auxiliary_client.py tests/plugins/model_providers/test_kimi_profile.py tests/hermes_cli/test_doctor.py` — 448 passed
- `uv run ruff check .` — passed
- `uv run python -m compileall -q ...` for all changed production modules — passed
- source audit confirms no remaining `claude-code/0.1.0` or `KimiCLI/` identity in Python request paths

A paid Kimi membership credential was not available in the test environment, so no live subscription request was made.

## Platform

- macOS 26.4.1
- Python 3.11.15
