### PR TITLE
fix(agent): close _codex_session in AIAgent.close() to prevent Codex subprocess leak (#66671)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3609,6 +3609,27 @@ class AIAgent:
         except Exception:
             pass
 
+        # 5b. Close the Codex app-server session if this agent owns one.
+        # The lazy `_codex_session` is spawned on first codex-app-server turn
+        # (agent/codex_runtime.py) and reused across turns, but the only
+        # `_codex_session.close()` calls in the codebase were the crash/retire
+        # paths. Without this step, every session.close on the Codex route
+        # leaks one `codex app-server` subprocess plus its MCP children forever
+        # (#66671). Idempotent + guarded so a non-codex agent (no attribute)
+        # and a double-close both no-op.
+        try:
+            codex_session = getattr(self, "_codex_session", None)
+            if codex_session is not None:
+                codex_session.close()
+                self._codex_session = None
+        except Exception:
+            # Best-effort: still drop the reference so we don't retry on a
+            # half-closed session, and don't suppress the rest of close().
+            try:
+                self._codex_session = None
+            except Exception:
+                pass
+
         # 6. Free conversation history.  Mirrors _release_evicted_agent_soft's
         # soft-eviction clear — close() is the hard teardown for true session
         # boundaries (/new, /reset, session expiry), so the message list won't

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -787,3 +787,44 @@ class TestCodexToolProgressBridge:
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
 
+
+class TestCodexAgentClose:
+    """#66671: AIAgent.close() must close the _codex_session subprocess
+    so long-running hermes serve doesn't orphan codex app-server trees."""
+
+    def test_close_closes_codex_session(self):
+        """agent.close() must call close() on _codex_session and null it."""
+        agent = _make_codex_agent()
+        from unittest.mock import MagicMock
+        fake_session = MagicMock()
+        agent._codex_session = fake_session
+
+        agent.close()
+
+        fake_session.close.assert_called_once()
+        assert getattr(agent, "_codex_session", None) is None
+
+    def test_close_handles_missing_codex_session(self):
+        """agent.close() must not crash when _codex_session was never set
+        (non-codex agent paths)."""
+        agent = _make_codex_agent()
+        # Ensure no _codex_session attribute exists
+        if hasattr(agent, "_codex_session"):
+            del agent._codex_session
+
+        # Must not raise
+        agent.close()
+
+    def test_close_idempotent_on_codex_session(self):
+        """Calling agent.close() twice must not double-close the session
+        (the first call nulls _codex_session, the second skips)."""
+        agent = _make_codex_agent()
+        from unittest.mock import MagicMock
+        fake_session = MagicMock()
+        agent._codex_session = fake_session
+
+        agent.close()
+        agent.close()
+
+        fake_session.close.assert_called_once()
+        assert agent._codex_session is None


### PR DESCRIPTION
## Summary

Fixes #66671.

`AIAgent.close()` releases all resources held by an agent instance — background processes, terminal sandboxes, browser daemon sessions, child agents, the OpenAI/httpx client, conversation history, and the SQLite session row — but never closes `self._codex_session`. The only `_codex_session.close()` calls in the codebase are the crash/retire paths in `agent/codex_runtime.py`. Result: every `session.close` on the Codex app-server route permanently leaks one `codex app-server` subprocess plus its MCP children. Long-running `hermes serve` deployments accumulate one leaked process tree per closed session.

Reported on v0.18.2 (`c7e09f25`); I verified the close path is unchanged on current `main`.

## Fix

Add step 5b in `AIAgent.close()` that guards `_codex_session` with `getattr` (so non-codex agents that never set the attribute are unaffected), calls `.close()` on it, and sets it to `None`. Mirrors the existing crash/retire pattern in `agent/codex_runtime.py:700-704` and `727-731`. Idempotent and individually guarded so a failure here does not suppress the rest of `close()`.

## Regression tests

`tests/run_agent/test_codex_app_server_integration.py::TestCodexAgentClose`:

- `test_close_closes_codex_session` — `close()` calls `.close()` on the codex session and nulls the attribute
- `test_close_handles_missing_codex_session` — agent with no `_codex_session` does not crash (non-codex routes)
- `test_close_idempotent_on_codex_session` — double `close()` only calls `.close()` once

All 3 tests pass on `main` with this patch.

```
tests/run_agent/test_codex_app_server_integration.py::TestCodexAgentClose ...   [100%]
3 passed in 3.78s
```

## Checklist

- [x] Branch is focused on a single fix
- [x] Tests added that verify the bug (without the patch, `test_close_closes_codex_session` and `test_close_idempotent_on_codex_session` would fail)
- [x] Idempotent — safe to call multiple times
- [x] Guarded — non-codex agent paths unaffected
- [x] No new dependencies