### PR TITLE
fix(memory): clear error when both 'action' and 'operations' are missing (#64291)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -559,6 +559,20 @@ class TestMemoryToolDispatcher:
         result = json.loads(memory_tool(action="unknown", store=store))
         assert result["success"] is False
 
+    def test_missing_action_and_operations_returns_clear_error(self, store):
+        """#64291: a tool call that supplies target but omits both ``action``
+        and ``operations`` used to fall through to the ``else`` branch and
+        surface as ``Unknown action 'None'``, which gave the model no signal
+        about *which* parameter was missing. The runtime guard must catch this
+        before dispatch and return an explicit, named error."""
+        result = json.loads(memory_tool(target="memory", store=store))
+        assert result["success"] is False
+        # The error must name the two valid shapes, not just say
+        # ``Unknown action 'None'``.
+        assert "action" in result["error"]
+        assert "operations" in result["error"]
+        assert "Unknown action" not in result["error"]
+
     def test_add_via_tool(self, store):
         result = json.loads(memory_tool(action="add", target="memory", content="via tool", store=store))
         assert result["success"] is True

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -986,6 +986,19 @@ def memory_tool(
     if target not in {"memory", "user"}:
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)
 
+    # --- Guard: neither action nor operations provided ---------------------
+    # The schema marks both as optional (because each belongs to a different
+    # call shape — single-op vs batch), but at least one MUST be present.
+    # Catching this here produces a clear error message instead of the
+    # confusing ``Unknown action 'None'`` that follows if we let action=None
+    # fall through to the else-branch below (#64291).
+    if action is None and not operations:
+        return tool_error(
+            "Either 'action' (single-op: add/replace/remove) or 'operations' "
+            "(batch list) is required.",
+            success=False,
+        )
+
     # --- Batch path -------------------------------------------------------
     if operations:
         if not isinstance(operations, list):


### PR DESCRIPTION
## Summary

Fixes #64291.

The `memory` tool's runtime handler (`memory_tool()`) received a tool call where `action` was `None` and `operations` was also omitted. Without a dedicated guard, this falls through to the `else` branch at line 1032 and produces `Unknown action 'None'. Use: add, replace, remove`, which gives the model no signal about *which* parameter was actually missing.

The schema (`MEMORY_SCHEMA`) marks both `action` and `operations` as optional because they belong to different call shapes (single-op vs batch). Adding `action` to `parameters.required` would break the batch path that legitimately omits `action`. So the fix belongs in the runtime entry point, not the schema.

## Fix

Add a guard at the top of `memory_tool()` that checks `if action is None and not operations` and returns a clear error message naming both valid shapes:

> Either 'action' (single-op: add/replace/remove) or 'operations' (batch list) is required.

The schema-level test in `tests/tools/test_memory_tool_schema.py` remains unchanged (still asserts `required: ["target"]`).

## Commit

```
commit f5fc2155c
Author: xxiaoxiong
Date:   Sat Jul 18 2026

    fix(memory): clear error when both 'action' and 'operations' are missing (#64291)

    The runtime guard prevents the confusing 'Unknown action \'None\''
    error that surfaces when a tool call supplies target but omits both
    action and operations. Schema-level required would break the batch
    path (which legitimately omits action), so the check belongs in the
    runtime entry, not MEMORY_SCHEMA.
```

## Tests

Existing: `tests/tools/test_memory_tool.py` — 86 tests pass.
New: `test_missing_action_and_operations_returns_clear_error` — verifies that:
- Result is `success: False`
- Error contains both "action" and "operations"
- Error does NOT contain "Unknown action"