### PR TITLE
fix(ci): null-safe files iteration in detect-changes' paginated compare

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -72,12 +72,19 @@ runs:
           # Retried: a rate-limit blip or eventual-consistency 404 on a
           # freshly-pushed HEAD would otherwise silently fall open (all lanes
           # run — safe, but wasteful and it masks the API failure).
+          #
+          # `.files[]?` (null-safe): with --paginate, a PR more than 100
+          # commits ahead of its merge-base paginates the compare, and pages
+          # after the first carry `files: null` — bare `.files[]` makes jq
+          # die with "cannot iterate over: null", which fails every retry
+          # and forces the fail-open path (seen on stacked PRs). The full
+          # file list (up to the API's 300-file cap) is on page one.
           CHANGED=""
           for i in 1 2 3; do
             if CHANGED="$(gh api \
               --paginate \
               "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
-              --jq '.files[].filename')"; then
+              --jq '.files[]?.filename')"; then
               break
             fi
             if [ "$i" = 3 ]; then


### PR DESCRIPTION
The classify step runs `gh api --paginate .../compare/BASE...HEAD --jq '.files[].filename'`. When a PR sits more than 100 commits ahead of its merge-base (stacked branches do this routinely), the compare paginates — and compare pages after the first carry `files: null`. Bare `.files[]` makes jq die with `cannot iterate over: null`, which fails all three retry attempts and forces the fail-open path: every lane on, and the CI-sensitive gate demanding a `ci-reviewed` label on PRs whose diffs contain zero CI-sensitive files.

Seen live on #61054 (112 commits ahead, 25-file diff, no `.github/` changes): the same call with `.files[]?` returns the 25 filenames from page one and ignores the null tail. The API's full file list (up to its 300-file cap) is always on page one, so nothing is lost.

One expression changed, plus a comment documenting the pagination gotcha.

