### PR TITLE
fix(desktop): prevent passive pane reveal from hijacking active tab in Focus layout

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -126,9 +126,10 @@ export function setTreePaneHidden(paneId: string, hidden: boolean) {
 
   $hiddenTreePanes.set(next)
 
-  // Unhiding is an intent to SEE the pane — front it in its group.
+  // Unhiding makes the pane VISIBLE but does NOT steal the active tab
+  // (relevant when workspace and files share a group in Focus layout).
   if (!hidden) {
-    revealTreePane(paneId)
+    revealTreePane(paneId, false)
   }
 }
 
@@ -580,7 +581,7 @@ export function treeSideOfPane(paneId: string): TreeSide | null {
  * App intent "show pane X" (a preview target landed, ⌘G opened review, …):
  * open its side, unhide it, and bring it to the front of its group.
  */
-export function revealTreePane(paneId: string) {
+export function revealTreePane(paneId: string, activate: boolean = true) {
   // Reveal beats a Close: un-dismiss and let adoption put the pane back.
   if ($dismissedPanes.get().has(paneId)) {
     setDismissed(paneId, false)
@@ -605,7 +606,10 @@ export function revealTreePane(paneId: string) {
   if (hiddenNow.has(paneId)) {
     setTreePaneHidden(paneId, false)
 
-    return
+    // Don't return — fall through so the outer `activate` flag still takes
+    // effect for explicit callers (preview reveal, review toggle, etc.).
+    // The inner setTreePaneHidden → revealTreePane(…, false) already handled
+    // un-minimizing and side restore; we only need activation from here.
   }
 
   const tree = $layoutTree.get()
@@ -624,7 +628,7 @@ export function revealTreePane(paneId: string) {
       next = setGroupMinimized(next, group.id, false)
     }
 
-    if (group.active !== paneId) {
+    if (activate && group.active !== paneId) {
       next = setActivePaneOp(next, group.id, paneId)
     }
 


### PR DESCRIPTION
## Bug

When the "Focus" layout is active in Hermes Desktop, creating a new session automatically switches the active tab from "NEW SESSION" to "FILES", forcing the user to manually click back to the new session.

## Root Cause

The Focus layout places `workspace` and `files` into the same GroupNode (tab strip):

```typescript
// controller.tsx:346-350
const FOCUS_TREE = split('row', [
  group(['sessions']),
  group(['workspace', 'files', 'preview', 'review', 'terminal'])
], [1, 4.6])
```

Creating a new session triggers an async cwd sync: `$currentCwd` updates → `$hasWorkspace` becomes `true` → `bindPaneVisibility('files', $hasWorkspace)` → `setTreePaneHidden('files', false)` → `revealTreePane('files')` → `setActivePaneOp` steals the active tab from workspace. The ~1s delay visible in the screen recording matches the cwd async update timing.

The **Default** layout is unaffected because `files` lives in its own independent `GroupNode`.

## Fix

Add an `activate` parameter (default `true`, backward-compatible) to `revealTreePane`, distinguishing "user-initiated reveals" from "passive visibility syncs" triggered by workspace/binding changes.

### Changes — `apps/desktop/src/components/pane-shell/tree/store.ts`

| Patch | Location (approx.) | Effect |
|-------|-------------------|--------|
| `revealTreePane(id, activate=true)` | L584 | New optional parameter, default preserves all 10 external callers |
| `if (activate && group.active !== paneId)` | L631 | Passive reveals skip `setActivePaneOp` |
| `revealTreePane(id, false)` + remove early return | L132+L609 | Unhiding doesn't steal the active tab; explicit reveals still work via fall-through |

### Safety analysis

- `tsc --noEmit` ✅ zero errors
- All 10 external call sites use the default `activate=true` — zero behavior change for: preview reveal, review toggle (⌘G), session tile clicks, terminal toggle, sidebar session focus, etc.
- Only `setTreePaneHidden` passes `activate=false`

### Re-entrancy note

When a pane is hidden and an explicit caller calls `revealTreePane(id, true)`, the path is: `revealTreePane(true)` → `setTreePaneHidden(false)` → `revealTreePane(false)` (no activation, commit) → fall through → outer `revealTreePane(true)` executes `setActivePaneOp` (second commit). Both commits serialize through the same nanostore atom and coalesce into one React render cycle — no flickering or intermediate state.

## Verification

- Screen recording analysis (via Gemini API, `analyze_user_video.py` script at `E:/VideoEditingProject/tools/`) confirmed reproduction: new session → NEW SESSION briefly visible (~1s) → FILES auto-activates
- `tsc --noEmit` ✅
- No existing tests cover `revealTreePane` directly (confirmed by grep)

## Before vs After

| Scenario | Before (buggy) | After (fixed) |
|----------|---------------|---------------|
| Focus layout + new session | workspace → 1s later → files ❌ | workspace stays active ✅ |
| Focus layout + manual files click | files activates ✅ | files activates ✅ (unchanged) |
| Default layout + new session | workspace stays active ✅ | workspace stays active ✅ |
| Preview reveal ($previewTarget) | preview activates ✅ | preview activates ✅ |
| Review toggle (⌘G) | review activates ✅ | review activates ✅ |
| Sidebar session click | tile activates ✅ | tile activates ✅ |
| Terminal toggle | terminal activates ✅ | terminal activates ✅ |
