### PR TITLE
fix(qwen): update auth guidance for Qwen CLI 0.19.x removal of `qwen auth`

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2158,10 +2158,11 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
 
     elif provider == "qwen-oauth":
         # Qwen OAuth tokens live in ~/.qwen/oauth_creds.json, written by
-        # the Qwen CLI (`qwen auth qwen-oauth`).  They aren't in the
-        # Hermes auth store or env vars, so resolve them here.
-        # Use refresh_if_expiring=False to avoid network calls during
-        # pool loading / provider discovery.
+        # the Qwen CLI when the user authenticates via `qwen` + `/auth`
+        # (the `qwen auth` CLI subcommand was removed in Qwen CLI 0.19.x).
+        # They aren't in the Hermes auth store or env vars, so resolve
+        # them here. Use refresh_if_expiring=False to avoid network calls
+        # during pool loading / provider discovery.
         try:
             from hermes_cli.auth import resolve_qwen_runtime_credentials
             creds = resolve_qwen_runtime_credentials(refresh_if_expiring=False)

--- a/agent/credential_sources.py
+++ b/agent/credential_sources.py
@@ -328,7 +328,9 @@ def _remove_qwen_cli(provider: str, removed) -> RemovalResult:
     return RemovalResult(hints=[
         "Suppressed qwen-cli credential — it will not be re-seeded.",
         "Note: Qwen CLI credentials still live in ~/.qwen/oauth_creds.json",
-        "Run `hermes auth add qwen-oauth` to re-enable if needed.",
+        # The `qwen auth` CLI subcommand was removed in Qwen CLI 0.19.x.
+        "Run `qwen` interactively and use `/auth` to re-enable, or edit",
+        "~/.qwen/oauth_creds.json / ~/.qwen/settings.json manually.",
     ])
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2308,7 +2308,9 @@ def _read_qwen_cli_tokens() -> Dict[str, Any]:
     auth_path = _qwen_cli_auth_path()
     if not auth_path.exists():
         raise AuthError(
-            "Qwen CLI credentials not found. Run 'qwen auth qwen-oauth' first.",
+            "Qwen CLI credentials not found. The Qwen CLI's `qwen auth` subcommand "
+            "was removed in 0.19.x — run `qwen` interactively and use `/auth`, "
+            "or write ~/.qwen/oauth_creds.json / ~/.qwen/settings.json manually.",
             provider="qwen-oauth",
             code="qwen_auth_missing",
         )
@@ -2372,7 +2374,9 @@ def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20
     refresh_token = str(tokens.get("refresh_token", "") or "").strip()
     if not refresh_token:
         raise AuthError(
-            "Qwen OAuth refresh token missing. Re-run 'qwen auth qwen-oauth'.",
+            "Qwen OAuth refresh token missing. Run `qwen` interactively and use "
+            "`/auth` to re-authenticate (the `qwen auth` CLI subcommand was "
+            "removed in Qwen CLI 0.19.x).",
             provider="qwen-oauth",
             code="qwen_refresh_token_missing",
         )
@@ -2401,7 +2405,9 @@ def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20
     if response.status_code >= 400:
         body = response.text.strip()
         raise AuthError(
-            "Qwen OAuth refresh failed. Re-run 'qwen auth qwen-oauth'."
+            "Qwen OAuth refresh failed. The `qwen auth` CLI subcommand was "
+            "removed in Qwen CLI 0.19.x — run `qwen` interactively and use "
+            "`/auth` to re-authenticate, or update ~/.qwen/oauth_creds.json."
             + (f" Response: {body}" if body else ""),
             provider="qwen-oauth",
             code="qwen_refresh_failed",
@@ -2475,7 +2481,9 @@ def resolve_qwen_runtime_credentials(
         access_token = str(tokens.get("access_token", "") or "").strip()
     if not access_token:
         raise AuthError(
-            "Qwen OAuth access token missing. Re-run 'qwen auth qwen-oauth'.",
+            "Qwen OAuth access token missing. Run `qwen` interactively and use "
+            "`/auth` to re-authenticate (the `qwen auth` CLI subcommand was "
+            "removed in Qwen CLI 0.19.x).",
             provider="qwen-oauth",
             code="qwen_access_token_missing",
         )

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -739,7 +739,11 @@ def _model_flow_qwen_oauth(_config, current_model=""):
     status = get_qwen_auth_status()
     if not status.get("logged_in"):
         print("Not logged into Qwen CLI OAuth.")
-        print("Run: qwen auth qwen-oauth")
+        # The `qwen auth` CLI subcommand was removed in Qwen CLI 0.19.x;
+        # users now re-authenticate interactively with `qwen` + `/auth`,
+        # or by editing ~/.qwen/oauth_creds.json / settings.json.
+        print("Run: qwen    (then use /auth to re-authenticate)")
+        print("Or set up Qwen OAuth via ~/.qwen/oauth_creds.json / ~/.qwen/settings.json.")
         auth_file = status.get("auth_file")
         if auth_file:
             print(f"Expected credentials file: {auth_file}")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -279,7 +279,7 @@ def show_status(args):
     qwen_logged_in = bool(qwen_status.get("logged_in"))
     print(
         f"  {'Qwen OAuth':<12}  {check_mark(qwen_logged_in)} "
-        f"{'logged in' if qwen_logged_in else 'not logged in (run: qwen auth qwen-oauth)'}"
+        f"{'logged in' if qwen_logged_in else 'not logged in (run: qwen, then /auth — `qwen auth` was removed in 0.19.x)'}"
     )
     qwen_auth_file = qwen_status.get("auth_file")
     if qwen_auth_file:

--- a/tests/hermes_cli/test_auth_qwen_provider.py
+++ b/tests/hermes_cli/test_auth_qwen_provider.py
@@ -416,7 +416,9 @@ def test_get_qwen_auth_status_expired_unrefreshable_token_is_not_logged_in(qwen_
     with patch(
         "hermes_cli.auth._refresh_qwen_cli_tokens",
         side_effect=AuthError(
-            "Qwen refresh rejected. Re-run 'qwen auth qwen-oauth'.",
+            "Qwen OAuth refresh failed. The `qwen auth` CLI subcommand was "
+            "removed in Qwen CLI 0.19.x — run `qwen` interactively and use "
+            "`/auth` to re-authenticate, or update ~/.qwen/oauth_creds.json.",
             provider="qwen-oauth",
             code="qwen_refresh_failed",
         ),
@@ -425,7 +427,10 @@ def test_get_qwen_auth_status_expired_unrefreshable_token_is_not_logged_in(qwen_
 
     mock_refresh.assert_called_once()
     assert status["logged_in"] is False
-    assert "qwen auth qwen-oauth" in status["error"]
+    assert "0.19.x" in status["error"]
+    assert "/auth" in status["error"]
+    # Old, removed subcommand must NOT appear in fresh guidance:
+    assert "qwen auth qwen-oauth" not in status["error"]
 
 
 def test_get_qwen_auth_status_not_logged_in(qwen_env):
@@ -446,7 +451,9 @@ def test_model_flow_qwen_oauth_stale_token_shows_reauth_guidance(qwen_env, monke
         "hermes_cli.auth._refresh_qwen_cli_tokens",
         lambda *args, **kwargs: (_ for _ in ()).throw(
             AuthError(
-                "Qwen refresh rejected. Re-run 'qwen auth qwen-oauth'.",
+                "Qwen OAuth refresh failed. The `qwen auth` CLI subcommand "
+                "was removed in Qwen CLI 0.19.x — run `qwen` interactively "
+                "and use `/auth` to re-authenticate.",
                 provider="qwen-oauth",
                 code="qwen_refresh_failed",
             )
@@ -468,7 +475,175 @@ def test_model_flow_qwen_oauth_stale_token_shows_reauth_guidance(qwen_env, monke
     _model_flow_qwen_oauth({}, current_model="qwen3-coder-plus")
 
     out = capsys.readouterr().out
-    assert "Run: qwen auth qwen-oauth" in out
-    assert "Qwen refresh rejected" in out
+    # Must point users at the supported replacement path:
+    assert "Run: qwen" in out
+    assert "/auth" in out
+    # Must NOT advertise the removed `qwen auth` subcommand:
+    assert "qwen auth qwen-oauth" not in out
+    # Underlying refresh error should be surfaced too:
+    assert "Qwen OAuth refresh failed" in out
     assert prompt_called["value"] is False
     assert update_called["value"] is False
+
+
+# ---------------------------------------------------------------------------
+# Guidance strings — Qwen CLI 0.19.x removed `qwen auth`
+# ---------------------------------------------------------------------------
+#
+# These tests pin the user-facing guidance produced by the Qwen OAuth code
+# paths against the current installed Qwen CLI (0.19.x). The
+# `qwen auth qwen-oauth` subcommand was removed upstream, so every error
+# and prompt must point at `qwen` + `/auth` (or manual settings.json
+# editing) instead. See:
+#   https://qwenlm.github.io/qwen-code-docs/en/users/configuration/auth/
+
+
+def test_missing_credentials_message_points_at_qwen_and_slash_auth(qwen_env):
+    """_read_qwen_cli_tokens() must advertise the supported login path."""
+    with pytest.raises(AuthError) as exc:
+        _read_qwen_cli_tokens()
+    assert exc.value.code == "qwen_auth_missing"
+    msg = str(exc.value)
+    # The interactive replacement the Qwen CLI docs prescribe:
+    assert "0.19.x" in msg
+    assert "/auth" in msg
+    assert "qwen" in msg
+    # The removed subcommand must NOT appear:
+    assert "qwen auth qwen-oauth" not in msg
+    # The credentials file path must still be mentioned so users can fix it manually:
+    assert "oauth_creds.json" in msg or "settings.json" in msg
+
+
+def test_refresh_token_missing_message_points_at_qwen_and_slash_auth(qwen_env):
+    """Missing refresh token in oauth_creds.json must steer users to /auth."""
+    # Write a token file with NO refresh_token field.
+    tokens = _make_qwen_tokens(access_token="at", refresh_token="")
+    _write_qwen_creds(qwen_env, tokens)
+
+    with pytest.raises(AuthError) as exc:
+        _refresh_qwen_cli_tokens(tokens)
+    assert exc.value.code == "qwen_refresh_token_missing"
+    msg = str(exc.value)
+    assert "0.19.x" in msg
+    assert "/auth" in msg
+    assert "qwen auth qwen-oauth" not in msg
+
+
+def test_refresh_failed_message_mentions_removed_subcommand_and_replacement(qwen_env):
+    """A refresh 4xx response must explain the replacement, not the removed cmd."""
+    expired_ms = int((time.time() - 3600) * 1000)
+    tokens = _make_qwen_tokens(
+        access_token="dead-at",
+        refresh_token="rt",
+        expiry_date=expired_ms,
+    )
+    _write_qwen_creds(qwen_env, tokens)
+
+    fake_response = MagicMock()
+    fake_response.status_code = 400
+    fake_response.text = "invalid_grant"
+
+    with patch("hermes_cli.auth.httpx.post", return_value=fake_response):
+        with pytest.raises(AuthError) as exc:
+            _refresh_qwen_cli_tokens(tokens)
+    assert exc.value.code == "qwen_refresh_failed"
+    msg = str(exc.value)
+    assert "0.19.x" in msg
+    assert "/auth" in msg
+    assert "oauth_creds.json" in msg
+    assert "qwen auth qwen-oauth" not in msg
+    # The upstream response body should still be surfaced for debuggability:
+    assert "invalid_grant" in msg
+
+
+def test_access_token_missing_message_points_at_qwen_and_slash_auth(qwen_env, monkeypatch):
+    """resolve_qwen_runtime_credentials must explain /auth when access is empty."""
+    tokens = _make_qwen_tokens(access_token="", refresh_token="rt")
+    _write_qwen_creds(qwen_env, tokens)
+
+    with pytest.raises(AuthError) as exc:
+        resolve_qwen_runtime_credentials(refresh_if_expiring=False)
+    assert exc.value.code == "qwen_access_token_missing"
+    msg = str(exc.value)
+    assert "0.19.x" in msg
+    assert "/auth" in msg
+    assert "qwen auth qwen-oauth" not in msg
+
+
+def test_model_flow_qwen_oauth_not_logged_in_guidance(qwen_env, monkeypatch, capsys):
+    """`hermes model` → qwen-oauth when not logged in must show /auth guidance."""
+    from hermes_cli.main import _model_flow_qwen_oauth
+
+    # No credentials file at all → get_qwen_auth_status() returns logged_in=False.
+    qwen_status = get_qwen_auth_status()
+    assert qwen_status.get("logged_in") is False
+    assert "error" in qwen_status
+
+    prompt_called = {"value": False}
+    update_called = {"value": False}
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda *a, **kw: prompt_called.__setitem__("value", True),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._update_config_for_provider",
+        lambda *a, **kw: update_called.__setitem__("value", True),
+    )
+
+    _model_flow_qwen_oauth({}, current_model="qwen3-coder-plus")
+    out = capsys.readouterr().out
+    assert "Not logged into Qwen CLI OAuth" in out
+    assert "Run: qwen" in out
+    assert "/auth" in out
+    # Still tells the user where to write tokens manually:
+    assert "oauth_creds.json" in out or "settings.json" in out
+    # Never the removed subcommand:
+    assert "qwen auth qwen-oauth" not in out
+    # And we must NOT have proceeded to model selection / config update:
+    assert prompt_called["value"] is False
+    assert update_called["value"] is False
+
+
+def test_status_command_qwen_row_uses_slash_auth_guidance(qwen_env, capsys):
+    """`hermes status` Qwen OAuth row must point users at /auth, not `qwen auth`.
+
+    The Qwen status row is a literal f-string in hermes_cli/status.py —
+    assert against the new message directly so the regression cannot sneak
+    back in via a refactor.
+    """
+    # No credentials file → not logged in. get_qwen_auth_status is what the
+    # status code uses, and it now must report an error so the row reads
+    # "not logged in (run: qwen, then /auth — `qwen auth` was removed in 0.19.x)".
+    qwen_status = get_qwen_auth_status()
+    assert qwen_status.get("logged_in") is False
+
+    # Reproduce the literal format used in hermes_cli/status.py:282 so a
+    # future refactor that breaks the wording fails this test.
+    expected = (
+        "not logged in (run: qwen, then /auth — `qwen auth` was removed in 0.19.x)"
+    )
+    rendered = (
+        f"  {'Qwen OAuth':<12}  {'not logged in (run: qwen, then /auth — `qwen auth` was removed in 0.19.x)'}"
+    )
+    # The actual format used by the row:
+    assert expected in rendered
+    # Make sure the OLD guidance is gone from the source file (no regression):
+    src = Path("hermes_cli/status.py").read_text(encoding="utf-8")
+    assert "run: qwen auth qwen-oauth" not in src
+    # And the NEW guidance is present:
+    assert "run: qwen, then /auth" in src
+
+
+def test_qwen_cli_remove_hints_use_supported_replacement(qwen_env):
+    """The qwen-cli suppression hint must NOT advertise the removed subcommand."""
+    from agent.credential_sources import _remove_qwen_cli
+
+    result = _remove_qwen_cli("qwen-oauth", removed=None)
+    joined = "\n".join(result.hints)
+    assert "Suppressed qwen-cli credential" in joined
+    assert "oauth_creds.json" in joined
+    # New guidance:
+    assert "/auth" in joined
+    assert "settings.json" in joined
+    # Removed guidance must be gone:
+    assert "hermes auth add qwen-oauth" not in joined


### PR DESCRIPTION
## Summary

The `qwen auth` CLI subcommand was removed in Qwen CLI 0.19.x. Installed
`qwen --help` now reports `qwen auth  Configure authentication (removed)`.
Hermes was still telling users to run `qwen auth qwen-oauth` in five
places — every one of those messages now points users at the supported
replacement (`qwen` interactively + `/auth`, or manual editing of
`~/.qwen/oauth_creds.json` / `~/.qwen/settings.json`).

The OAuth token protocol is **unchanged**: cached tokens at
`~/.qwen/oauth_creds.json` still work for existing sessions. Only the
*setup* surface moved.

## Why

`qwen --help` (installed 0.19.11) shows:

```
qwen auth                  Configure authentication (removed)
```

…and the upstream docs confirm:

```
Removed `qwen auth` CLI command
The standalone `qwen auth` CLI command has been removed. Use these
replacements instead:
- Interactive authentication setup → Run `qwen`, then use `/auth`
- Coding Plan setup → Use `/auth`, or set BAILIAN_CODING_PLAN_API_KEY …
```

Source: https://qwenlm.github.io/qwen-code-docs/en/users/configuration/auth/

Hermes still reads `~/.qwen/oauth_creds.json` for the `qwen-oauth`
provider, so users who already logged in keep working. The fix is only
about not breaking their next re-auth attempt.

## Changes

| File | Change |
| --- | --- |
| `hermes_cli/auth.py` | Four `AuthError` messages: `qwen_auth_missing`, `qwen_refresh_token_missing`, `qwen_refresh_failed`, `qwen_access_token_missing` now mention `0.19.x` and point at `qwen` + `/auth` (and manual `oauth_creds.json` editing). |
| `hermes_cli/model_setup_flows.py` | `_model_flow_qwen_oauth()` not-logged-in prompt now prints `Run: qwen (then use /auth to re-authenticate)` + manual-file hint. |
| `hermes_cli/status.py` | `hermes status` Qwen OAuth row now reads `not logged in (run: qwen, then /auth — `qwen auth` was removed in 0.19.x)`. |
| `agent/credential_sources.py` | `_remove_qwen_cli()` suppression hints replaced `Run `hermes auth add qwen-oauth`` with `Run `qwen` interactively and use `/auth`, or edit `~/.qwen/oauth_creds.json` / `~/.qwen/settings.json``. |
| `agent/credential_pool.py` | Comment updated to reflect the new setup path. |
| `tests/hermes_cli/test_auth_qwen_provider.py` | Two existing tests updated + seven new focused tests pinning the new wording. |

## Tests

```
$ python -m pytest tests/hermes_cli/test_auth_qwen_provider.py -v
============================= 39 passed in 1.16s ==============================
```

New tests (one per affected surface):

- `test_missing_credentials_message_points_at_qwen_and_slash_auth` — `qwen_auth_missing` AuthError
- `test_refresh_token_missing_message_points_at_qwen_and_slash_auth` — `qwen_refresh_token_missing` AuthError
- `test_refresh_failed_message_mentions_removed_subcommand_and_replacement` — `qwen_refresh_failed` AuthError + 4xx body propagation
- `test_access_token_missing_message_points_at_qwen_and_slash_auth` — `qwen_access_token_missing` AuthError
- `test_model_flow_qwen_oauth_not_logged_in_guidance` — `_model_flow_qwen_oauth` not-logged-in stdout
- `test_status_command_qwen_row_uses_slash_auth_guidance` — `hermes status` row literal + source-grep regression guard
- `test_qwen_cli_remove_hints_use_supported_replacement` — `_remove_qwen_cli` hints

Each test explicitly asserts both that the **new** guidance is present
(`0.19.x`, `/auth`, `Run: qwen`) and that the **removed** guidance
(`qwen auth qwen-oauth`) is **not** present — so a future regression
that re-introduces the removed subcommand fails immediately.

Broader sanity (unchanged areas, must stay green):

```
$ python -m pytest tests/hermes_cli/test_status.py tests/tools/test_credential_files.py tests/agent/test_credential_pool*.py
84 passed in 1.99s
```

## Unrelated PRs left untouched

Per task instructions, I noted these existing open PRs but did **not**
close or merge them — they're orthogonal to Qwen OAuth guidance:

- #63101 — `fix(gateway): clear stale status for disabled platforms on startup` (mergeable)
- #64203 — `fix(doctor): recognize configured MoA orchestration` (duplicate of local MoA work, can be closed separately if desired)

## Checklist

- [x] No OAuth token protocol changes — only user-facing strings/comments.
- [x] No secrets touched.
- [x] Branch is non-force; pushed to `mudrii:fix/qwen-oauth-guidance`.
- [x] All new guidance strings also assert absence of the removed `qwen auth qwen-oauth` literal.
- [x] Local test suite for the touched modules is green.