### PR TITLE
fix(desktop): preserve closed workspace sidebar state

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -434,10 +434,11 @@ function bindPaneVisibility(
   paneId: string,
   $open: { get(): boolean; listen(fn: (open: boolean) => void): void },
   close?: () => void,
-  open?: () => void
+  open?: () => void,
+  revealOnShow = true
 ) {
-  setTreePaneHidden(paneId, !$open.get())
-  $open.listen(isOpen => setTreePaneHidden(paneId, !isOpen))
+  setTreePaneHidden(paneId, !$open.get(), { revealOnShow })
+  $open.listen(isOpen => setTreePaneHidden(paneId, !isOpen, { revealOnShow }))
 
   // The tab menu's Close routes through the owning store (never dismissal),
   // so the pane's toggle buttons stay truthful.
@@ -517,13 +518,24 @@ bindTreeSideVisibility('right', $fileBrowserOpen, setFileBrowserOpen)
 // rode the rail's row and vanished with it), its zone stands on its own.
 const $hasWorkspace = computed($currentCwd, cwd => Boolean(cwd.trim()))
 
-bindPaneVisibility('files', $hasWorkspace)
+// Workspace discovery is structural availability, not user intent to reveal
+// the pane. Unhide Files without reopening a side the user explicitly closed;
+// an actual file/browser action still goes through revealTreePane.
+bindPaneVisibility('files', $hasWorkspace, undefined, undefined, false)
 // ⌘G — the review sidebar appears/disappears (and comes to the front).
 bindPaneVisibility(
   'review',
   computed([$reviewOpen, $hasWorkspace], (open, workspace) => open && workspace),
-  closeReview
+  closeReview,
+  undefined,
+  false
 )
+// Unlike a cwd change, toggling Review on is explicit reveal intent.
+$reviewOpen.listen(open => {
+  if (open && $hasWorkspace.get()) {
+    revealTreePane(REVIEW_PANE_ID)
+  }
+})
 // ⌃` / statusbar toggle — the terminal COLLAPSES to a rail (tab stays), not
 // hides; PTYs stay alive while collapsed (see PersistentTerminal).
 bindPaneCollapse(

--- a/apps/desktop/src/components/pane-shell/tree/store-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store-visibility.test.ts
@@ -1,0 +1,45 @@
+import { atom } from 'nanostores'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { group, split } from './model'
+import {
+  $collapsedTreeSides,
+  $hiddenTreePanes,
+  bindTreeSideVisibility,
+  declareDefaultTree,
+  setTreePaneHidden
+} from './store'
+
+describe('tree pane visibility intent', () => {
+  const disposers: Array<() => void> = []
+
+  afterEach(() => {
+    disposers.splice(0).forEach(dispose => dispose())
+  })
+
+  it('does not reopen a collapsed side for a structural unhide', () => {
+    disposers.push(
+      registry.register({ id: 'files', area: 'panes', title: 'files', data: { placement: 'right' } }),
+      registry.register({ id: 'workspace', area: 'panes', title: 'workspace', data: { placement: 'main' } })
+    )
+    declareDefaultTree(split('row', [group(['workspace']), group(['files'])], [3, 1]))
+
+    const sideOpen = atom(false)
+    const setSideOpen = vi.fn()
+    bindTreeSideVisibility('right', sideOpen, setSideOpen)
+    expect($collapsedTreeSides.get().has('right')).toBe(true)
+
+    setTreePaneHidden('files', true)
+    setTreePaneHidden('files', false, { revealOnShow: false })
+
+    expect($hiddenTreePanes.get().has('files')).toBe(false)
+    expect($collapsedTreeSides.get().has('right')).toBe(true)
+    expect(setSideOpen).not.toHaveBeenCalled()
+
+    setTreePaneHidden('files', true)
+    setTreePaneHidden('files', false)
+    expect(setSideOpen).toHaveBeenCalledWith(true)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -117,7 +117,7 @@ function toggledSet<T>(set: ReadonlySet<T>, item: T, present: boolean): Set<T> |
   return next
 }
 
-export function setTreePaneHidden(paneId: string, hidden: boolean) {
+export function setTreePaneHidden(paneId: string, hidden: boolean, options: { revealOnShow?: boolean } = {}) {
   const next = toggledSet($hiddenTreePanes.get(), paneId, hidden)
 
   if (!next) {
@@ -126,8 +126,10 @@ export function setTreePaneHidden(paneId: string, hidden: boolean) {
 
   $hiddenTreePanes.set(next)
 
-  // Unhiding is an intent to SEE the pane — front it in its group.
-  if (!hidden) {
+  // Most unhide calls are explicit intent to SEE the pane, so front it in its
+  // group and open its side. Structural availability changes (for example a
+  // workspace cwd appearing) opt out so they cannot override persisted chrome.
+  if (!hidden && options.revealOnShow !== false) {
     revealTreePane(paneId)
   }
 }


### PR DESCRIPTION
## Summary

- distinguish structural pane availability from explicit user reveal intent
- restore workspace-gated Files and Review panes without reopening a side the user explicitly closed
- preserve normal reveal behavior for manual file/browser actions and explicit Review toggles
- keep rearranged Files panes independent from the right-sidebar toggle
- add regression coverage for non-revealing structural unhides and explicit reveals

## Problem

Files and Review are workspace-gated. When a session or new-chat cwd became available, the existing visibility bindings called `setTreePaneHidden(..., false)`. That API treated every unhide as explicit reveal intent, called `revealTreePane`, and reopened the collapsed right side even though the user had manually hidden it.

## Fix

`setTreePaneHidden` now accepts an opt-out for structural availability changes. Workspace-driven Files and Review transitions use that path, so cwd/session changes remove structural hiding without opening or fronting a pane.

Explicit actions retain reveal behavior:

- file/browser actions still use the default reveal path
- changing `$reviewOpen` to true explicitly calls `revealTreePane`

This deliberately does **not** bind the Files pane's global visibility to `$fileBrowserOpen`: doing so would incorrectly hide Files after the user rearranges it into a main or sessions group.

## Test plan

- `npm run test:ui -- src/components/pane-shell/tree/store-visibility.test.ts`
- `npm run test:ui` — 176 files, 1423 tests passed
- `npm run typecheck`
- ESLint and Prettier on all changed files
- `npm run build`
- Built Electron canaries on macOS:
  1. manually opened and closed Projects
  2. entered a real workspace-backed session, then created a new session
  3. verified the right-sidebar control remained `Show right sidebar` and the Projects track stayed `0×0`
  4. manually reopened the right sidebar and verified Projects became visible
  5. persisted Review as open while the right side was closed, entered a workspace, and verified the side stayed closed
  6. toggled Review off/on with `⌘G` and verified the explicit open still revealed the side

Addresses #65173.
