### PR TITLE
fix(backup): report silently skipped symlinks in backup summary

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -239,7 +239,9 @@ def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> 
         return True
 
     # zipfile.write() follows file symlinks, so skip links before any archive
-    # write can copy data from outside HERMES_HOME.
+    # write can copy data from outside HERMES_HOME. run_backup separately
+    # records the skipped links and reports them in its summary so the omission
+    # is never silent.
     if abs_path.is_symlink():
         return True
 
@@ -326,6 +328,7 @@ def run_backup(args) -> None:
     print(f"Scanning {display_hermes_home()} ...")
     files_to_add: list[tuple[Path, Path]] = []  # (absolute, relative)
     skipped_dirs = set()
+    skipped_symlinks: list[str] = []
 
     for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
         dp = Path(dirpath)
@@ -343,9 +346,23 @@ def run_backup(args) -> None:
         for removed in set(orig_dirnames) - set(dirnames):
             skipped_dirs.add(str(rel_dir / removed))
 
+        # Symlinked directories are listed in ``dirnames`` but os.walk (with
+        # followlinks=False) never descends into them, so the whole subtree is
+        # silently dropped from the archive. Record them — highest-impact case
+        # for a lost content tree — so the summary can surface the omission.
+        for d in dirnames:
+            if (dp / d).is_symlink():
+                skipped_symlinks.append(str(rel_dir / d))
+
         for fname in filenames:
             fpath = dp / fname
             rel = fpath.relative_to(hermes_root)
+
+            # Symlinked files are dropped for security (see
+            # _should_skip_backup_file). Record ones that would otherwise have
+            # been archived so the skip is reported, not silent.
+            if fpath.is_symlink() and not _should_exclude(rel):
+                skipped_symlinks.append(str(rel))
 
             if _should_skip_backup_file(fpath, rel, out_path):
                 continue
@@ -463,6 +480,17 @@ def run_backup(args) -> None:
         print("\n  Excluded directories:")
         for d in sorted(skipped_dirs):
             print(f"    {d}/")
+
+    # Symlinks are deliberately not followed into the archive (security), so
+    # this is not an error and does not flip "Backup complete" — but the
+    # dropped content must be visible, especially a whole symlinked subtree an
+    # operator only discovers is missing at restore time.
+    if skipped_symlinks:
+        print(f"\n  Symlinks skipped (not archived): {len(skipped_symlinks)}")
+        for p in sorted(skipped_symlinks)[:10]:
+            print(f"    {p}")
+        if len(skipped_symlinks) > 10:
+            print(f"    ... and {len(skipped_symlinks) - 10} more")
 
     if errors:
         print(f"\n  Warnings ({len(errors)} files skipped):")

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -239,9 +239,10 @@ def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> 
         return True
 
     # zipfile.write() follows file symlinks, so skip links before any archive
-    # write can copy data from outside HERMES_HOME. run_backup separately
-    # records the skipped links and reports them in its summary so the omission
-    # is never silent.
+    # write can copy data from outside HERMES_HOME. Callers use
+    # _find_skipped_symlinks to record and report the skipped links (summary
+    # for run_backup, logger for _write_full_zip_backup) so the omission is
+    # never silent.
     if abs_path.is_symlink():
         return True
 
@@ -249,6 +250,34 @@ def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> 
         return abs_path.resolve() == out_path.resolve()
     except (OSError, ValueError):
         return False
+
+
+def _find_skipped_symlinks(
+    dirpath: Path, dirnames: List[str], filenames: List[str], hermes_root: Path
+) -> List[str]:
+    """Return relative paths of symlinks under *dirpath* that a backup walk
+    drops but never archives.
+
+    Two cases, both deliberate skips (see ``_should_skip_backup_file``) that
+    would otherwise be silent: symlinked directories — ``os.walk`` with
+    ``followlinks=False`` lists them in *dirnames* but never descends, so the
+    whole subtree is omitted (the highest-impact case for a lost content tree)
+    — and symlinked files that aren't already excluded. Call this AFTER excluded
+    dirs have been pruned from *dirnames* so excluded links aren't reported.
+    Shared by every full-zip producer so the accounting can't drift between
+    ``run_backup`` and ``_write_full_zip_backup``.
+    """
+    rel_dir = dirpath.relative_to(hermes_root)
+    found: List[str] = []
+    for d in dirnames:
+        if (dirpath / d).is_symlink():
+            found.append(str(rel_dir / d))
+    for fname in filenames:
+        fpath = dirpath / fname
+        rel = fpath.relative_to(hermes_root)
+        if fpath.is_symlink() and not _should_exclude(rel):
+            found.append(str(rel))
+    return found
 
 
 # ---------------------------------------------------------------------------
@@ -346,23 +375,15 @@ def run_backup(args) -> None:
         for removed in set(orig_dirnames) - set(dirnames):
             skipped_dirs.add(str(rel_dir / removed))
 
-        # Symlinked directories are listed in ``dirnames`` but os.walk (with
-        # followlinks=False) never descends into them, so the whole subtree is
-        # silently dropped from the archive. Record them — highest-impact case
-        # for a lost content tree — so the summary can surface the omission.
-        for d in dirnames:
-            if (dp / d).is_symlink():
-                skipped_symlinks.append(str(rel_dir / d))
+        # Record symlinks the walk drops (dir subtrees + files) so they're
+        # reported below rather than silently omitted.
+        skipped_symlinks.extend(
+            _find_skipped_symlinks(dp, dirnames, filenames, hermes_root)
+        )
 
         for fname in filenames:
             fpath = dp / fname
             rel = fpath.relative_to(hermes_root)
-
-            # Symlinked files are dropped for security (see
-            # _should_skip_backup_file). Record ones that would otherwise have
-            # been archived so the skip is reported, not silent.
-            if fpath.is_symlink() and not _should_exclude(rel):
-                skipped_symlinks.append(str(rel))
 
             if _should_skip_backup_file(fpath, rel, out_path):
                 continue
@@ -1235,11 +1256,18 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
     or write error — caller should surface the outcome but not raise).
     """
     files_to_add: list[tuple[Path, Path]] = []
+    skipped_symlinks: list[str] = []
     try:
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
             # Prune excluded directories in-place so os.walk doesn't descend
             dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+
+            # Record symlinks the walk drops (dir subtrees + files); this path
+            # has no interactive summary, so they're logged after the write.
+            skipped_symlinks.extend(
+                _find_skipped_symlinks(dp, dirnames, filenames, hermes_root)
+            )
 
             for fname in filenames:
                 fpath = dp / fname
@@ -1304,6 +1332,20 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
         except OSError:
             pass
         return None
+
+    # Surface deliberately-skipped symlinks through this path's only output
+    # surface (it logs rather than prints), so a whole symlinked subtree
+    # dropped from a pre-update/pre-migration backup isn't silent either.
+    if skipped_symlinks:
+        preview = ", ".join(sorted(skipped_symlinks)[:10])
+        more = len(skipped_symlinks) - 10
+        if more > 0:
+            preview += f", ... and {more} more"
+        logger.warning(
+            "Full-zip backup: %d symlink(s) skipped (not archived): %s",
+            len(skipped_symlinks),
+            preview,
+        )
 
     return out_path
 

--- a/tests/hermes_cli/test_backup_symlink_visibility.py
+++ b/tests/hermes_cli/test_backup_symlink_visibility.py
@@ -9,6 +9,7 @@ vanished from the backup while the run still printed "Backup complete", so the
 loss only surfaced at restore time. The backup must now name what it dropped.
 """
 
+import logging
 import zipfile
 from argparse import Namespace
 from pathlib import Path
@@ -108,3 +109,37 @@ def test_no_symlinks_prints_no_symlink_block(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Symlinks skipped" not in out
     assert "Backup complete" in out
+
+
+def test_pre_update_backup_reports_skipped_subtree_via_log(tmp_path, caplog):
+    """The pre-update/pre-migration full-zip path (_write_full_zip_backup) has
+    no interactive summary, so it must surface the same dropped subtree through
+    its logger instead of dropping it silently."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    _make_minimal_home(hermes_home)
+
+    outside_tree = tmp_path / "shared-skills"
+    outside_tree.mkdir()
+    (outside_tree / "shared.md").write_text("shared skill body\n")
+    (hermes_home / "profiles").mkdir()
+    (hermes_home / "profiles" / "coder").mkdir()
+    _symlink_or_skip(hermes_home / "profiles" / "coder" / "skills", outside_tree)
+
+    from hermes_cli.backup import create_pre_update_backup
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.backup"):
+        out = create_pre_update_backup(hermes_home=hermes_home)
+
+    assert out is not None and out.exists()
+
+    messages = "\n".join(r.getMessage() for r in caplog.records)
+    assert "symlink(s) skipped (not archived)" in messages
+    assert "profiles/coder/skills" in messages
+
+    with zipfile.ZipFile(out) as zf:
+        names = zf.namelist()
+        assert not any(n.startswith("profiles/coder/skills") for n in names)
+        assert "shared skill body\n" not in [
+            zf.read(n).decode("utf-8", "ignore") for n in names
+        ]

--- a/tests/hermes_cli/test_backup_symlink_visibility.py
+++ b/tests/hermes_cli/test_backup_symlink_visibility.py
@@ -1,0 +1,110 @@
+"""`hermes backup` must report symlinks it deliberately drops.
+
+Symlinks are skipped for security — zipfile.write() follows a file symlink and
+os.walk won't descend a symlinked directory, so a link could otherwise pull
+data from outside HERMES_HOME into the archive (or silently omit a whole
+content tree). That skip is correct and stays. The bug these tests pin is that
+the skip used to be *silent*: a symlinked ``profiles/<name>/skills`` tree
+vanished from the backup while the run still printed "Backup complete", so the
+loss only surfaced at restore time. The backup must now name what it dropped.
+"""
+
+import zipfile
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+
+def _make_minimal_home(root: Path) -> None:
+    """A backup-valid HERMES_HOME with no symlinks of its own."""
+    (root / "config.yaml").write_text("model:\n  provider: openrouter\n")
+    (root / ".env").write_text("OPENROUTER_API_KEY=sk-test\n")
+    (root / "skills").mkdir()
+    (root / "skills" / "my-skill").mkdir()
+    (root / "skills" / "my-skill" / "SKILL.md").write_text("# My Skill\n")
+
+
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except OSError as exc:  # pragma: no cover - platform-dependent
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+
+def _run_backup(hermes_home: Path, tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    out_zip = tmp_path / "backup.zip"
+    from hermes_cli.backup import run_backup
+    run_backup(Namespace(output=str(out_zip)))
+    return out_zip
+
+
+def test_symlinked_file_is_skipped_and_reported(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    _make_minimal_home(hermes_home)
+
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("outside secret\n")
+    _symlink_or_skip(hermes_home / "skills" / "outside-link.txt", outside)
+
+    out_zip = _run_backup(hermes_home, tmp_path, monkeypatch)
+
+    out = capsys.readouterr().out
+    assert "Symlinks skipped (not archived): 1" in out
+    assert "skills/outside-link.txt" in out
+    # Reporting the skip must not turn a policy skip into a failure.
+    assert "Backup complete" in out
+    assert "Backup incomplete" not in out
+
+    with zipfile.ZipFile(out_zip) as zf:
+        names = zf.namelist()
+        assert "skills/outside-link.txt" not in names
+        assert all(zf.read(n) != b"outside secret\n" for n in names)
+
+
+def test_symlinked_directory_subtree_is_skipped_and_reported(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    _make_minimal_home(hermes_home)
+
+    # A real content tree that lives outside HERMES_HOME, linked in as a whole
+    # subtree — the exact "symlinked profile skills tree" failure case.
+    outside_tree = tmp_path / "shared-skills"
+    outside_tree.mkdir()
+    (outside_tree / "shared.md").write_text("shared skill body\n")
+    (outside_tree / "nested").mkdir()
+    (outside_tree / "nested" / "deep.md").write_text("deep body\n")
+
+    (hermes_home / "profiles").mkdir()
+    (hermes_home / "profiles" / "coder").mkdir()
+    _symlink_or_skip(hermes_home / "profiles" / "coder" / "skills", outside_tree)
+
+    out_zip = _run_backup(hermes_home, tmp_path, monkeypatch)
+
+    out = capsys.readouterr().out
+    assert "Symlinks skipped (not archived): 1" in out
+    assert "profiles/coder/skills" in out
+    assert "Backup complete" in out
+
+    with zipfile.ZipFile(out_zip) as zf:
+        names = zf.namelist()
+        # The subtree and its contents are genuinely absent from the archive.
+        assert not any(n.startswith("profiles/coder/skills") for n in names)
+        assert "shared skill body\n" not in [
+            zf.read(n).decode("utf-8", "ignore") for n in names
+        ]
+
+
+def test_no_symlinks_prints_no_symlink_block(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    _make_minimal_home(hermes_home)
+
+    _run_backup(hermes_home, tmp_path, monkeypatch)
+
+    out = capsys.readouterr().out
+    assert "Symlinks skipped" not in out
+    assert "Backup complete" in out


### PR DESCRIPTION
## What does this PR do?

`hermes backup` deliberately skips symlinks for security — `zipfile.write()`
follows a file symlink (which could copy data from outside `HERMES_HOME` into
the archive) and `os.walk(followlinks=False)` never descends into a symlinked
directory. That skip is correct and this PR does **not** change it.

The problem is that the skip is **completely silent**. If a whole content tree
is a symlink — e.g. `profiles/<name>/skills` pointing at a shared directory —
the backup drops the entire subtree yet still prints `Backup complete`. With
short retention windows the operator only discovers the loss at restore time,
after the archive that "should" have contained it has already been pruned. This
bit a real deployment: a profile's skills tree was suspected missing from a
rotated-out backup and could not be verified because the zip was already gone.

This PR makes the omission **visible** in every full-zip producer: the backup
tracks the symlinks it skips (both symlinked files and, more importantly,
symlinked directory subtrees `os.walk` won't enter) and reports them through
each path's own output surface — `run_backup` in its end-of-run printed
summary, and `_write_full_zip_backup` (pre-update / pre-migration
auto-backups, which log rather than print) via a `logger.warning` with the
same count-plus-paths content. Detection is factored into a shared
`_find_skipped_symlinks` helper so the two paths can't drift. Behavior of
what gets archived is unchanged — this is visibility only. Because the skip is
deliberate policy and not an error, it does **not** flip `Backup complete` to
`incomplete`, matching how the existing `errors`/warnings path works.

## Related Issue

No existing issue — this was found during an operational backup-integrity
audit and reproduced directly against `main`. No issue number to link.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py` (`run_backup`): collect skipped symlinks during the
  `os.walk` collection pass — symlinked directories detected via `dirnames`
  (the silently-dropped-subtree case) and symlinked files that would otherwise
  have been archived — into a new `skipped_symlinks` list.
- `hermes_cli/backup.py` (summary): print a `Symlinks skipped (not archived):
  N` block listing up to 10 relative paths, styled like the existing
  `Excluded directories` / `Warnings (N files skipped)` blocks. It does not
  change the `Backup complete` line.
- `hermes_cli/backup.py` (`_should_skip_backup_file`): extended the existing
  security comment to note the skip is now recorded and reported; the skip
  logic itself is untouched.
- `hermes_cli/backup.py` (`_find_skipped_symlinks`, new): shared helper for
  the symlink accounting, used by both `run_backup` and
  `_write_full_zip_backup` (per review feedback — the pre-update and
  pre-migration full backups had the same silent omission).
- `hermes_cli/backup.py` (`_write_full_zip_backup`): on successful write,
  emit a `logger.warning` with the skipped-symlink count and up to 10 paths;
  this path has no interactive summary, so it logs instead of printing.
- `tests/hermes_cli/test_backup_symlink_visibility.py` (new): behavior tests
  driving `run_backup` against a temp `HERMES_HOME` and asserting on the real
  archive contents and printed summary, plus a `create_pre_update_backup`
  test asserting the logged warning (`caplog`) and the archive contents.

## How to Test

Reproduce against a scratch `HERMES_HOME` (no need to touch a real one):

1. Create a minimal home and both a symlinked file and a symlinked subtree:
   ```bash
   sb=$(mktemp -d); mkdir -p "$sb/.hermes/profiles/coder"
   printf 'model: test\n' > "$sb/.hermes/config.yaml"
   printf 'K=v\n'         > "$sb/.hermes/.env"
   mkdir -p "$sb/shared-skills/nested"
   printf 'body\n'  > "$sb/shared-skills/nested/deep.md"
   ln -s "$sb/shared-skills" "$sb/.hermes/profiles/coder/skills"   # subtree link
   printf 'secret\n' > "$sb/secret.txt"
   ln -s "$sb/secret.txt" "$sb/.hermes/link.txt"                   # file link
   ```
2. Run the backup against it:
   ```bash
   HERMES_HOME="$sb/.hermes" hermes backup -o "$sb/backup.zip"
   ```
3. Observe the new report in the summary (previously nothing was printed):
   ```
   Backup complete: .../backup.zip
     ...
     Symlinks skipped (not archived): 2
       link.txt
       profiles/coder/skills
   ```
   The `Backup complete` line is unchanged (symlink skips are policy, not
   errors), and `unzip -l "$sb/backup.zip"` confirms neither `link.txt` nor
   anything under `profiles/coder/skills` is in the archive.

Automated coverage (all pass):

```bash
scripts/run_tests.sh tests/hermes_cli/test_backup_symlink_visibility.py tests/hermes_cli/test_backup.py
```

The new file covers: a symlinked file is skipped AND reported; a symlinked
directory subtree is skipped AND reported (asserting the archive genuinely
lacks the content via `zipfile.namelist()`); and a symlink-free backup prints
no symlink block.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the backup test files and all tests pass (159 passed; full `pytest tests/ -q` not run in this environment)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior of what's archived is unchanged; only an added summary line)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — symlink detection uses `Path.is_symlink()`; on platforms without symlinks there is simply nothing to report
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEEzX1MjrpvBp9FcRPEEQu
