### PR TITLE
fix(cron): resolve custom-provider env key for aliased providers without main_runtime (#66868)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1618,6 +1618,36 @@ def resolve_runtime_provider(
         custom_runtime["requested_provider"] = requested_provider
         return custom_runtime
 
+    # Custom-provider aliases (ollama, vllm, llamacpp, …) collapse to the
+    # generic ``"custom"`` label via resolve_provider() but carry NO
+    # custom_providers entry and NO explicit key/base_url. Their credential
+    # lives in a provider-named env var (OLLAMA_API_KEY, VLLM_API_KEY, …)
+    # that _host_derived_api_key deliberately skips (it assumes those are
+    # handled by an explicit host-gated path — but the generic ``custom``
+    # route never checks them). Without this, a cron/background run with no
+    # main_runtime context resolves ``custom`` with an empty api_key and
+    # 401s, even though the same config works for an interactive session that
+    # threads the key through its runtime. Derive <PROVIDER>_API_KEY from the
+    # ORIGINAL requested name and retry. (#66868)
+    _orig = (requested_provider or "").strip().lower()
+    if not explicit_api_key and _orig and _orig != "custom":
+        from hermes_cli.auth import resolve_provider as _rp
+        try:
+            _collapsed = _rp(_orig)
+        except Exception:
+            _collapsed = "custom"
+        if _collapsed == "custom":
+            _env_key = _getenv(f"{_orig.replace('-', '_').upper()}_API_KEY", "").strip()
+            if _env_key:
+                custom_runtime = _resolve_named_custom_runtime(
+                    requested_provider=requested_provider,
+                    explicit_api_key=_env_key,
+                    explicit_base_url=explicit_base_url,
+                )
+                if custom_runtime:
+                    custom_runtime["requested_provider"] = requested_provider
+                    return custom_runtime
+
     # If provider is "auto" (or unset) but config.yaml has an explicit base_url
     # pointing at a custom/local endpoint (e.g. Ollama at localhost:11434),
     # route through the OpenAI-compatible resolver instead of letting

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3416,3 +3416,61 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
+
+
+def test_ollama_alias_resolves_env_key_without_main_runtime(monkeypatch):
+    """A cron/background run (no main_runtime) with provider: ollama and
+    OLLAMA_API_KEY set must resolve the key from the provider-named env var,
+    not collapse to an empty api_key and 401. Regression for #66868.
+
+    ollama collapses to the generic 'custom' label via resolve_provider(), and
+    _host_derived_api_key deliberately skips OLLAMA_API_KEY — so the named-env
+    fallback in resolve_runtime_provider() must pick it up.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+    monkeypatch.setenv("OLLAMA_API_KEY", "ollama-env-key")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "ollama",
+            "default": "glm-5.2",
+            "base_url": "https://ollama.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False))
+
+    resolved = rp.resolve_runtime_provider(requested="ollama")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://ollama.com/v1"
+    assert resolved["api_key"] == "ollama-env-key"
+    assert resolved["requested_provider"] == "ollama"
+
+
+def test_custom_provider_alias_env_key_vllm(monkeypatch):
+    """Same named-env fallback for other custom aliases (vllm)."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    monkeypatch.setenv("VLLM_API_KEY", "vllm-env-key")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "vllm",
+            "default": "meta/llama-3.1-8b",
+            "base_url": "https://vllm.local/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False))
+
+    resolved = rp.resolve_runtime_provider(requested="vllm")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://vllm.local/v1"
+    assert resolved["api_key"] == "vllm-env-key"
+    assert resolved["requested_provider"] == "vllm"


### PR DESCRIPTION
## Summary
Cron jobs with an aliased custom provider (`ollama`, `vllm`, `llamacpp`, …) and only a provider-named env key (`OLLAMA_API_KEY`) failed with **HTTP 401** on the primary model call, even though the identical config worked for interactive gateway sessions.

Root cause: `resolve_provider("ollama")` collapses to the generic `"custom"` label (auth.py alias table). The generic `custom` route never checks `OLLAMA_API_KEY` — and `_host_derived_api_key` *deliberately* skips `OLLAMA` (it assumes that env var is covered by an explicit host-gated path, which `custom` does not use). Interactive sessions thread the key through their `main_runtime` context, so they survived; cron/background runs have **no** `main_runtime` and resolved `custom` with an empty `api_key` → 401.

## Changes
- `hermes_cli/runtime_provider.py`: in `resolve_runtime_provider()`, after the named-custom lookup misses, if the requested provider is a known custom alias (collapses to `"custom"`) and no explicit key is in play, derive `<PROVIDER>_API_KEY` from the **original** requested name (`ollama` → `OLLAMA_API_KEY`) and retry `_resolve_named_custom_runtime` with it. Mirrors the existing behavior for interactive sessions (which already pass the key through `main_runtime`).
- `tests/hermes_cli/test_runtime_provider_resolution.py`: 2 new regression tests — `ollama` and `vllm` aliases resolve the provider-named env key with no `main_runtime` and no `custom_providers` entry.

## How to Test
pytest tests/hermes_cli/test_runtime_provider_resolution.py -q
# ✅ 153/153 passed (2 new: test_ollama_alias_resolves_env_key_without_main_runtime, test_custom_provider_alias_env_key_vllm)

pytest tests/cron/test_cron_provider_pin.py -q
# ✅ 14/14 passed

## Checklist
- [x] Tests pass — 153/153 (runtime_provider) + 14/14 (cron provider pin)
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux) — none (pure env-var + provider resolution)
- [x] profile-safe paths used
- [x] .env not used for non-credential settings

Risk & Impact: Low. Only affects the unauthenticated `custom` fallback path for aliased providers with a provider-named env key and no `custom_providers` entry — a previously-broken combination. No change for interactive sessions or providers with a `custom_providers` block.

Type: Bug fix
Closes: #66868