### PR TITLE
fix(acp): persist namespaced provider (custom:xxx) instead of normalized 'custom'

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -422,7 +422,15 @@ class SessionManager:
         # Ensure model is a plain string (not a MagicMock or other proxy).
         model_str = str(state.model) if state.model else None
         session_meta = {"cwd": state.cwd}
-        provider = getattr(state.agent, "provider", None)
+        # Prefer the namespaced requested provider (e.g. ``custom:anthropic``)
+        # over the normalized ``agent.provider`` (which collapses to bare
+        # ``"custom"`` for any custom_providers entry). Without the namespace,
+        # session restore cannot re-resolve the named custom provider and
+        # auth fails (#63681).
+        provider = (
+            getattr(state.agent, "requested_provider", None)
+            or getattr(state.agent, "provider", None)
+        )
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
         if isinstance(provider, str) and provider.strip():
@@ -644,11 +652,27 @@ class SessionManager:
                     "args": list(runtime.get("args") or []),
                 }
             )
+            # Preserve the *namespaced* requested provider (e.g. ``custom:anthropic``)
+            # alongside the normalized one. ``resolve_runtime_provider`` returns
+            # ``runtime["provider"]`` normalized to a bare ``"custom"`` for custom
+            # providers, which loses the namespace required to re-resolve the
+            # entry on session restore. Stash the original requested string on
+            # the agent so ``_persist`` can write it to the DB instead of the
+            # normalized value (issue #63681).
+            runtime_requested = runtime.get("requested_provider")
+            if isinstance(runtime_requested, str) and runtime_requested.strip():
+                resolved_namespace = runtime_requested
+            else:
+                resolved_namespace = requested_provider or config_provider
         except Exception:
             logger.debug("ACP session falling back to default provider resolution", exc_info=True)
+            resolved_namespace = requested_provider or config_provider
 
         _register_task_cwd(session_id, cwd)
         agent = AIAgent(**kwargs)
+        # Stash the namespaced provider so _persist writes it to the DB
+        # instead of the normalized bare "custom" (issue #63681).
+        agent.requested_provider = resolved_namespace
         # Codex app-server sessions are spawned lazily on the first turn. Stamp
         # the ACP workspace onto the agent so the Codex runtime starts from the
         # editor/session cwd instead of the Hermes daemon's process cwd.

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -727,6 +727,81 @@ class TestPersistence:
         assert restored.agent.provider == "anthropic"
         assert restored.agent.base_url == "https://anthropic.example/v1"
 
+    def test_restore_preserves_custom_anthropic_namespace(self, tmp_path, monkeypatch):
+        """Namespaced custom provider (``custom:anthropic``) must survive persist → restore.
+
+        Regression for #63681: ``resolve_runtime_provider`` returns
+        ``provider="custom"`` (normalized), but the DB needs the original
+        ``"custom:anthropic"`` so ``_restore`` can re-resolve the named custom
+        provider entry.
+        """
+        # Simulate what ``_resolve_named_custom_runtime`` returns: provider
+        # normalized to ``"custom"`` but ``requested_provider`` retains the
+        # full namespace.
+        runtime_return = {
+            "provider": "custom",
+            "requested_provider": "custom:anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://anthropic-custom.example/v1",
+            "api_key": "test-key",
+            "command": None,
+            "args": [],
+        }
+
+        resolve_calls = []
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            resolve_calls.append(requested)
+            return dict(runtime_return)
+
+        captured_kwargs = {}
+
+        def fake_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "custom:anthropic", "default": "test-model"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db)
+            state = manager.create_session(cwd="/work")
+
+        # The agent must have ``requested_provider`` stamped by _make_agent.
+        assert getattr(state.agent, "requested_provider", None) == "custom:anthropic"
+        manager.save_session(state.session_id)
+
+        # Verify the DB stored the namespaced provider (not bare "custom").
+        row = db.get_session(state.session_id)
+        mc = json.loads(row["model_config"])
+        assert mc.get("provider") == "custom:anthropic", (
+            f"Expected 'custom:anthropic', got {mc.get('provider')!r}"
+        )
+
+        # Drop from memory and restore — the namespaced provider must survive.
+        sid = state.session_id
+        resolve_calls.clear()
+        with manager._lock:
+            del manager._sessions[sid]
+
+        restored = manager.get_session(sid)
+        assert restored is not None
+        assert (
+            getattr(restored.agent, "requested_provider", None) == "custom:anthropic"
+        ), "Restored agent lost the namespaced provider"
+        assert restored.agent.base_url == "https://anthropic-custom.example/v1"
+
     def test_acp_agents_route_human_output_to_stderr(self, tmp_path, monkeypatch):
         """ACP agents must keep stdout clean for JSON-RPC stdio transport."""
 


### PR DESCRIPTION
## Summary

When a `custom_providers` entry is used (e.g. `custom:anthropic`), `resolve_runtime_provider` normalizes `provider` to bare `"custom"` in the returned dict. The ACP session `_make_agent` stashed only the normalized value onto the agent, and `_persist` wrote it into the DB.

On session restore, `_restore` passed `"custom"` to `resolve_runtime_provider`, which could not re-resolve the named custom provider — silently falling back to a different provider (OpenRouter, env-var key, etc.) and potentially leaking credentials or auth-failing entirely.

## Fix

1. **`_make_agent`** preserves the namespaced `requested_provider` from the runtime resolution result on `agent.requested_provider`.
2. **`_persist`** reads `agent.requested_provider` first, falling back to `agent.provider` only when the namespaced version is absent.
3. **`_restore`** already reads `provider` from `model_config` metadata — it now sees the full namespace it needs.

## Test

`test_restore_preserves_custom_anthropic_namespace` (new) verifies the full persist→restore round-trip with a `custom:anthropic` provider, asserting DB storage contains the namespaced string and the restored agent carries `requested_provider`.

Fixes #63681