### PR TITLE
fix(desktop): switch to chat when resuming the open session from a full-page tab (#66875)

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -74,7 +74,7 @@ import { RemoteFolderPicker } from '../right-sidebar/files/remote-picker'
 import { resetProjectTreeState } from '../right-sidebar/files/use-project-tree'
 import { PersistentTerminal } from '../right-sidebar/terminal/persistent'
 import { closeAllTerminals } from '../right-sidebar/terminal/terminals'
-import { CRON_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE, syncWorkspaceIsPage } from '../routes'
+import { CRON_ROUTE, resumeSessionNavTarget, routeSessionId, sessionRoute, SETTINGS_ROUTE, syncWorkspaceIsPage } from '../routes'
 import { SessionPickerOverlay } from '../session-picker-overlay'
 import { SessionSwitcher } from '../session-switcher'
 import { useBackgroundQueueDrain } from '../session/hooks/use-background-queue-drain'
@@ -762,10 +762,22 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onRemoveAttachment: id => void composer.removeAttachment(id),
     onRestoreToMessage: restoreToMessage,
     // Already on screen (open tile, or the main session)? Jump to its tab;
-    // otherwise load it into main.
+    // otherwise load it into main. When a full-page route (Plugins/Artifacts/…)
+    // is covering the chat layout, fronting an already-open pane is invisible, so
+    // resumeSessionNavTarget also routes back to chat — otherwise clicking the
+    // most recent (main) session from a non-chat tab looked like a no-op
+    // (#66875). Navigating to the main session's own route is a view-only switch:
+    // useRouteResume treats it as alreadyActive and does not re-resume.
     onResumeSession: sessionId => {
-      if (!focusOpenSession(sessionId)) {
-        navigate(sessionRoute(sessionId))
+      const target = resumeSessionNavTarget(
+        sessionId,
+        focusOpenSession(sessionId),
+        location.pathname,
+        selectedStoredSessionIdRef.current
+      )
+
+      if (target !== null) {
+        navigate(target)
       }
     },
     onRetryResume: sessionId => void resumeSession(sessionId, true),

--- a/apps/desktop/src/app/routes.resume-nav.test.ts
+++ b/apps/desktop/src/app/routes.resume-nav.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { resumeSessionNavTarget, sessionRoute } from './routes'
+
+// Regression coverage for #66875: clicking the most recent (main) session from a
+// non-chat full-page route (Plugins/Artifacts/Messaging/Skills) did nothing,
+// because focusOpenSession fronts a pane inside the hidden chat layout and the
+// old handler skipped navigation whenever the session was already open.
+describe('resumeSessionNavTarget', () => {
+  const MAIN = 'session-main'
+  const OTHER = 'session-other'
+  const ARTIFACTS = '/artifacts'
+  const CHAT = sessionRoute(MAIN)
+
+  it('routes a not-yet-open session into main via its own route', () => {
+    expect(resumeSessionNavTarget(OTHER, false, ARTIFACTS, MAIN)).toBe(sessionRoute(OTHER))
+    expect(resumeSessionNavTarget(OTHER, false, CHAT, MAIN)).toBe(sessionRoute(OTHER))
+  })
+
+  it('does nothing when the open session is clicked while already on the chat view', () => {
+    expect(resumeSessionNavTarget(MAIN, true, CHAT, MAIN)).toBeNull()
+    expect(resumeSessionNavTarget(OTHER, true, CHAT, MAIN)).toBeNull()
+  })
+
+  it('routes back to chat when the open MAIN session is clicked from a full page (#66875)', () => {
+    for (const page of ['/artifacts', '/skills', '/messaging', '/cron']) {
+      expect(resumeSessionNavTarget(MAIN, true, page, MAIN)).toBe(sessionRoute(MAIN))
+    }
+  })
+
+  it('keeps an open tile a tile — routes to MAIN, not the clicked tile, from a full page', () => {
+    // OTHER is an already-open tile; focusOpenSession fronted it. We must reveal
+    // the chat view without promoting the tile to the main session.
+    expect(resumeSessionNavTarget(OTHER, true, ARTIFACTS, MAIN)).toBe(sessionRoute(MAIN))
+  })
+
+  it('falls back to the clicked id when there is no main session', () => {
+    expect(resumeSessionNavTarget(OTHER, true, ARTIFACTS, null)).toBe(sessionRoute(OTHER))
+  })
+})

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -158,6 +158,38 @@ export function appViewForPath(pathname: string): AppView {
   return APP_VIEW_BY_PATH.get(pathname) ?? 'chat'
 }
 
+/** Decide where clicking a session in the sidebar should route the app, or
+ *  `null` for "stay put" (the caller already fronted the right pane).
+ *
+ *  `alreadyOpen` is the result of `focusOpenSession(sessionId)`: true when the
+ *  session is the main session or an open tile whose pane was just fronted.
+ *
+ *  - Not open yet → load it into main via its own route.
+ *  - Open, and we're already on the chat view → nothing to do (`null`).
+ *  - Open, but a full-page route (Plugins/Artifacts/Messaging/Skills) is
+ *    covering the chat layout → route back to chat so the fronted pane becomes
+ *    visible. Target the MAIN session so an open tile stays a tile rather than
+ *    being promoted to main; fall back to the clicked id when there is no main.
+ *
+ *  Regression guard for #66875 (clicking the most recent/main session from a
+ *  non-chat tab did nothing). */
+export function resumeSessionNavTarget(
+  sessionId: string,
+  alreadyOpen: boolean,
+  pathname: string,
+  mainSessionId: null | string
+): null | string {
+  if (!alreadyOpen) {
+    return sessionRoute(sessionId)
+  }
+
+  if (appViewForPath(pathname) !== 'chat') {
+    return sessionRoute(mainSessionId ?? sessionId)
+  }
+
+  return null
+}
+
 /** True while the workspace pane shows a FULL PAGE (skills/messaging/
  *  artifacts/plugin routes) instead of the chat. Published by the wiring
  *  (which owns the router location); the workspace pane contribution mirrors


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop-app dead click: selecting the **most recent session** in the sidebar did nothing when a full-page route (Plugins / Artifacts / Messaging / Skills) was on screen. Selecting an older session worked, which is what made the bug so confusing.

**Root cause.** `onResumeSession` (in `apps/desktop/src/app/contrib/wiring.tsx`) calls `focusOpenSession(sessionId)` and only navigates when it returns `false`:

```ts
onResumeSession: sessionId => {
  if (!focusOpenSession(sessionId)) {
    navigate(sessionRoute(sessionId))
  }
},
```

The most recent session is almost always the **main** session, so `focusOpenSession` returns `true` — it fronts that session's pane *inside the chat layout* (`revealTreePane('workspace')`). But when a full-page route is showing, the chat layout is hidden behind that page, so fronting a pane in it is invisible and the top-level route never leaves `/artifacts` (etc.). Older sessions are neither the main session nor an open tile, so `focusOpenSession` returns `false` and the handler navigates to chat — hence they worked.

**Fix.** Extract the navigation decision into a pure, tested `resumeSessionNavTarget` helper. When the session is already open *and* the current route isn't the chat view, route back to chat via the **main** session's own route. Targeting the main session (not the clicked id) keeps an already-open tile a tile — `focusOpenSession` has already fronted it — instead of promoting it to main. Navigating to the main session's own route is a view-only switch: `useRouteResume` treats it as `alreadyActive` and does not re-resume, so there is no reload.

## Related Issue

Fixes #66875

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/routes.ts` — new pure `resumeSessionNavTarget(sessionId, alreadyOpen, pathname, mainSessionId)` helper deciding where a sidebar session click should route (or `null` for "stay put").
- `apps/desktop/src/app/contrib/wiring.tsx` — `onResumeSession` now uses the helper, so an already-open session clicked from a full-page route routes back to chat.
- `apps/desktop/src/app/routes.resume-nav.test.ts` — regression tests for the helper (not-open → own route; open on chat → no-op; open main from a page → back to chat; open tile from a page → main, not the tile; no main → fall back to clicked id).

## How to Test

Automated (desktop workspace):

```
cd apps/desktop
npx vitest run src/app/routes.resume-nav.test.ts   # 5 passed
npx eslint src/app/routes.ts src/app/contrib/wiring.tsx src/app/routes.resume-nav.test.ts   # clean
npx tsc --noEmit -p tsconfig.json   # 0 errors
```

Manual reproduction (from the issue):

1. Open the Chat tab with an active session.
2. Click Plugins (or Artifacts / Messaging / Skills) in the left sidebar.
3. Click the topmost (most recent) session in the sessions list.
4. Before: nothing happens — the main screen stays on Plugins/Artifacts. After: the app switches back to Chat with that session.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, desktop-only TypeScript change; verified with `vitest` / `tsc` / `eslint` (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure routing logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
