### PR TITLE
fix(cron): only install profile secret scope when multiplexing is active (#66868)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -11,6 +11,7 @@ runs at a time if multiple processes overlap.
 import asyncio
 import atexit
 import concurrent.futures
+import contextlib
 import contextvars
 import json
 import logging
@@ -3703,6 +3704,46 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
+@contextlib.contextmanager
+def _cron_secret_scope():
+    """Install the profile secret scope for a cron run — but ONLY when profile
+    multiplexing is active.
+
+    ``get_secret()`` fails closed outside a scope once multiplexing is on, so a
+    cron run must install the profile scope before ``resolve_runtime_provider``
+    reads provider credentials (the earlier ``UnscopedSecretError`` fix).
+
+    But installing the scope *unconditionally* broke single-profile deployments
+    (#66868): once a scope is installed, ``get_secret`` treats it as
+    authoritative and does NOT fall through to ``os.environ`` — so provider keys
+    supplied as container/process env vars (``OLLAMA_API_KEY``, ``GROQ_API_KEY``,
+    …) that live only in ``os.environ`` and not in the profile ``.env`` resolved
+    to empty, and every cron job failed HTTP 401 while interactive turns (which
+    run unscoped in single-profile mode) authenticated fine.
+
+    This mirrors gateway/run.py's ``_profile_runtime_scope``, which is "only used
+    on the multiplexed inbound path": single-profile gateways never enter a
+    scope. When multiplexing is off we install nothing, so ``get_secret`` reads
+    ``os.environ`` exactly as the interactive single-profile path does.
+    """
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        is_multiplex_active,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+
+    if not is_multiplex_active():
+        yield
+        return
+
+    token = set_secret_scope(build_profile_secret_scope(_get_hermes_home()))
+    try:
+        yield
+    finally:
+        reset_secret_scope(token)
+
+
 def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
@@ -3745,22 +3786,17 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # becomes running only immediately before the actual run.
         mark_execution_running(execution_id)
 
-        # Run the job under the profile's secret scope. get_secret() fails
-        # closed outside a scope once profile isolation is in play (multiple
-        # gateway profiles / room→profile multiplexing), and cron fires from
-        # the ticker thread where no per-turn scope is installed — so
-        # resolve_runtime_provider() raised UnscopedSecretError before model
-        # selection, breaking every cron job. Mirrors the per-turn pattern in
-        # gateway/run.py (_profile_runtime_scope).
-        from agent.secret_scope import (
-            build_profile_secret_scope,
-            reset_secret_scope,
-            set_secret_scope,
-        )
-
-        _scope_token = set_secret_scope(
-            build_profile_secret_scope(_get_hermes_home())
-        )
+        # Run the job under the profile's secret scope when — and only when —
+        # profile multiplexing is active. get_secret() fails closed outside a
+        # scope once profile isolation is in play (multiple gateway profiles /
+        # room→profile multiplexing), and cron fires from the ticker thread
+        # where no per-turn scope is installed — so resolve_runtime_provider()
+        # raised UnscopedSecretError before model selection. But installing a
+        # scope in a single-profile deployment shadowed os.environ and broke
+        # cron auth for container/process-env credentials (#66868), so the
+        # scope decision lives in _cron_secret_scope (mirroring
+        # gateway/run.py's _profile_runtime_scope).
+        #
         # Defer the cron agent's async-resource teardown until AFTER delivery.
         # run_job normally closes the agent (and reaps stale async clients) in
         # its finally block; doing that before _deliver_result runs means the
@@ -3770,9 +3806,10 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
         try:
-            success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents
-            )
+            with _cron_secret_scope():
+                success, output, final_response, error = run_job(
+                    job, defer_agent_teardown=_deferred_agents
+                )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
             # it down here so a failed run never leaks its async resources
@@ -3782,8 +3819,6 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
             raise
-        finally:
-            reset_secret_scope(_scope_token)
 
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -10,6 +10,8 @@ The first test characterizes the sequence as driven through `tick()` (proving
 the extraction didn't change `tick`'s behavior); the rest unit-test the
 extracted helper directly.
 """
+import pytest
+
 import cron.scheduler as s
 
 
@@ -274,3 +276,52 @@ def test_run_one_job_tears_down_deferred_agent_when_save_raises(monkeypatch):
     assert ok is False
     assert "deliver" not in order
     assert order == ["save-raise", "agent.close", "cleanup_stale"], order
+
+
+# ── _cron_secret_scope credential-resolution scoping (#66868) ────────────────
+# A cron run must be able to read provider credentials the same way an
+# interactive turn does. The scope must be installed ONLY when profile
+# multiplexing is active; installing it unconditionally made the profile
+# .env-only scope authoritative and shadowed os.environ, so container/process
+# env credentials (OLLAMA_API_KEY, GROQ_API_KEY, …) resolved to empty and every
+# cron job failed HTTP 401 — while interactive single-profile turns worked.
+
+def test_cron_secret_scope_noop_when_not_multiplexed(monkeypatch):
+    """Single-profile deployment: no scope is installed, so get_secret falls
+    through to os.environ and container/process env credentials resolve.
+    Regression guard for #66868."""
+    import agent.secret_scope as ss
+
+    monkeypatch.setattr(ss, "_MULTIPLEX_ACTIVE", False)
+    monkeypatch.setenv("OLLAMA_API_KEY", "env-key-123")
+    # Even if a profile home with a .env existed, it must not be consulted while
+    # multiplexing is off — os.environ stays authoritative.
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: __import__("pathlib").Path("/nonexistent-home"))
+
+    with s._cron_secret_scope():
+        assert ss.current_secret_scope() is None
+        assert ss.get_secret("OLLAMA_API_KEY") == "env-key-123"
+
+    assert ss.current_secret_scope() is None
+
+
+def test_cron_secret_scope_installs_profile_scope_when_multiplexed(monkeypatch, tmp_path):
+    """Multiplexed deployment: the profile scope is installed and is
+    authoritative — get_secret reads the profile .env, NOT os.environ — and the
+    scope is reset on exit."""
+    import agent.secret_scope as ss
+
+    (tmp_path / ".env").write_text("GROQ_API_KEY=profile-key-abc\n", encoding="utf-8")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(ss, "_MULTIPLEX_ACTIVE", True)
+    # An os.environ value must be shadowed by the profile scope under multiplex.
+    monkeypatch.setenv("GROQ_API_KEY", "cross-profile-leak")
+
+    with s._cron_secret_scope():
+        assert ss.current_secret_scope() is not None
+        assert ss.get_secret("GROQ_API_KEY") == "profile-key-abc"
+
+    # Scope cleared on exit; the fail-closed contract is back in force.
+    assert ss.current_secret_scope() is None
+    with pytest.raises(ss.UnscopedSecretError):
+        ss.get_secret("GROQ_API_KEY")


### PR DESCRIPTION
## What does this PR do?

Fixes cron jobs failing **HTTP 401 on their primary model call** in single-profile deployments where provider credentials are supplied as container/process env vars — even though the exact same key works for interactive gateway (Telegram/Discord) turns.

**Root cause.** `run_one_job` installed the profile secret scope **unconditionally** before running a job:

```python
_scope_token = set_secret_scope(build_profile_secret_scope(_get_hermes_home()))
```

`build_profile_secret_scope` builds the scope **solely from the profile's `.env`** (`load_env_file(<home>/.env)`). Once a scope is installed, `agent/secret_scope.py::get_secret` treats it as authoritative and, by design, does **not** fall through to `os.environ` (that fail-closed rule is what prevents cross-profile credential leaks under multiplexing). So a provider key set as a container/process env var (`OLLAMA_API_KEY`, `GROQ_API_KEY`, …) that lives in `os.environ` but not in the profile `.env` resolved to empty → the HTTP client was built with no key → 401.

Interactive turns worked because the gateway only installs a scope on the **multiplexed** inbound path — `gateway/run.py::_profile_runtime_scope` is documented as *"Only used on the multiplexed inbound path. Single-profile gateways never enter this scope."* In single-profile mode `get_secret` reads `os.environ` directly (and `.env` is already loaded into `os.environ` via `load_hermes_dotenv`), so credentials resolve. Cron installed the scope even when multiplexing was off, so it diverged from that path.

This also explains two things the issue flagged:
- **Both providers fail identically** (`ollama` and `custom:groq`) — it isn't provider-specific; neither key is in the profile `.env`, and the scope shadows `os.environ` for both.
- **`provider=custom` in the logs** is expected, not the bug: `ollama` is a provider alias that resolves to `custom` (see `_resolve_named_custom_runtime` / GH #27132). The base_url and provider resolved correctly; only the API key was missing.

**Fix.** Gate the scope install on `is_multiplex_active()`, mirroring `_profile_runtime_scope`. Single-profile deployments install no scope and read `os.environ` exactly like interactive turns; multiplexed deployments keep the isolated per-profile scope (so the original `UnscopedSecretError` fix — which only fires under multiplexing — is preserved). The decision is extracted into a `_cron_secret_scope()` context manager.

## Related Issue

Fixes #66868

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — add `_cron_secret_scope()` context manager that installs the profile secret scope only when `is_multiplex_active()`; `run_one_job` now wraps `run_job` in it instead of installing the scope unconditionally. (`import contextlib` added.)
- `tests/cron/test_run_one_job.py` — regression tests: (1) multiplex inactive → no scope installed, `get_secret` reads `os.environ` (the #66868 case); (2) multiplex active → profile `.env` scope installed and authoritative (shadows `os.environ`), reset on exit with the fail-closed contract restored.

## How to Test

```
scripts/run_tests.sh tests/cron/test_run_one_job.py tests/cron/test_scheduler.py
```

Result: `247 tests passed, 0 failed` (12 in `test_run_one_job.py`, including the 2 new scope tests). `ruff` and the Windows-footgun check pass via `hermes-pr-preflight.sh`.

Manual: on a single-profile gateway with `OLLAMA_API_KEY` set only as a container env var (not in `~/.hermes/.env`), a cron job pinned to `provider: ollama` now authenticates instead of returning HTTP 401.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/cron/...` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
