### PR TITLE
fix(acp): fall back to durable session when live history empty in list_sessions (#66881)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -284,12 +284,13 @@ class SessionManager:
 
         # Collect in-memory sessions first.
         with self._lock:
-            seen_ids = set(self._sessions.keys())
+            seen_ids = set()
             results = []
             for s in self._sessions.values():
                 history_len = len(s.history)
                 if history_len <= 0:
                     continue
+                seen_ids.add(s.session_id)
                 if normalized_cwd and _normalize_cwd_for_compare(s.cwd) != normalized_cwd:
                     continue
                 persisted = persisted_rows.get(s.session_id, {})

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -232,6 +232,27 @@ class TestListAndCleanup:
         manager.create_session(cwd="/empty")
         assert manager.list_sessions() == []
 
+    def test_list_sessions_falls_back_to_db_when_live_history_empty(self, tmp_path):
+        """Regression for #66881: an ACP session whose in-memory history is
+        empty (the agent persisted the transcript through its own DB handle)
+        must still surface via list_sessions() when SessionDB holds messages
+        for that same session ID. Initializing seen_ids from every live ID
+        used to skip the persisted row pass for that ID."""
+        db = SessionDB(tmp_path / "state.db")
+        manager = SessionManager(agent_factory=_mock_agent, db=db)
+        state = manager.create_session(cwd="/workspace")
+        # Persist messages directly through the DB, leaving live history empty
+        # (matches the ACP runtime path).
+        db.ensure_session(state.session_id, source="acp", model="mock")
+        db.append_message(state.session_id, "user", "hello")
+        db.append_message(state.session_id, "assistant", "hi there")
+
+        listing = manager.list_sessions()
+        ids = {s["session_id"] for s in listing}
+        assert state.session_id in ids
+        entry = next(s for s in listing if s["session_id"] == state.session_id)
+        assert entry["history_len"] >= 2
+
     def test_save_session_preserves_existing_messages_on_encode_failure(self, manager):
         """Regression for #13675: a bad message in state.history must not
         clobber the previously-persisted transcript.  replace_messages()


### PR DESCRIPTION
## Summary
`SessionManager.list_sessions()` hid a durable ACP session when the live `SessionState.history` was empty, even though `SessionDB` already contained messages for the same session ID. This broke clients that use `session/list` to verify a completed turn before resuming.

Root cause: `list_sessions()` initialized `seen_ids = set(self._sessions.keys())` — every live session ID, including empty-history mirrors — before filtering out live sessions whose in-memory history was empty. The later persisted-row pass then also skipped that session ID (line `if sid in seen_ids: continue`), so the only copy of the transcript (the DB) was never surfaced.

## Changes
- `acp_adapter/session.py`: initialize `seen_ids = set()` and add a live session's ID to it **only after** confirming its in-memory history is non-empty (and before the optional cwd filter). This lets an empty live mirror fall back to durable storage while keeping non-empty live metadata authoritative (including its current cwd) — exactly the semantics proposed in the issue.
- `tests/acp/test_session.py`: regression test `test_list_sessions_falls_back_to_db_when_live_history_empty` — creates a session, persists messages directly through `SessionDB` (empty live history, matching the ACP runtime path), and asserts `list_sessions()` returns it with `history_len >= 2`.

## How to Test
pytest tests/acp/test_session.py -q
# ✅ 46/46 passed (1 new regression test)

## Checklist
- [x] Tests pass — 46/46
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux) — none (pure session-listing logic)
- [x] profile-safe paths used
- [x] .env not used for non-credential settings

Risk & Impact: Low. Only changes when a live session with empty history falls back to its persisted DB row (previously hidden); non-empty live sessions are unchanged.

Type: Bug fix
Closes: #66881