### PR TITLE
fix(vertex): add curated model list so /model picker enumerates vertex models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -365,6 +365,17 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2.1",
         "MiniMax-M2",
     ],
+    # Vertex has no /models discovery endpoint (see plugins/model-providers/
+    # vertex: fetch_models returns None by design), so without a curated entry
+    # here provider_model_ids("vertex") returns [] and the /model picker's
+    # vertex row enumerates zero models. Exact publisher-qualified IDs only:
+    # bare aliases 404 on the Vertex OpenAI-compat surface.
+    "vertex": [
+        "google/gemini-3.5-flash",
+        "google/gemini-3.1-pro-preview",
+        "google/gemini-3-flash-preview",
+        "deepseek-ai/deepseek-v3.2-maas",
+    ],
     "anthropic": [
         "claude-fable-5",
         "claude-opus-4-8",

--- a/tests/hermes_cli/test_vertex_provider.py
+++ b/tests/hermes_cli/test_vertex_provider.py
@@ -98,3 +98,34 @@ def test_vertex_extra_body_empty_without_reasoning():
 
     p = get_provider_profile("vertex")
     assert p.build_extra_body(model="google/gemini-3-flash-preview") == {}
+
+
+def test_vertex_provider_model_ids_fallback():
+    """Verify provider_model_ids('vertex') falls back to the curated _PROVIDER_MODELS
+    since Vertex has no discovery endpoint, without snapshotting the exact model names."""
+    from hermes_cli.models import provider_model_ids
+    
+    models = provider_model_ids("vertex")
+    assert models is not None
+    assert isinstance(models, list)
+    assert len(models) > 0
+    assert all(isinstance(m, str) for m in models)
+
+def test_vertex_cached_provider_model_ids(tmp_path, monkeypatch):
+    """Verify the disk-cache wrapper handles the Vertex fallback correctly."""
+    from hermes_cli.models import cached_provider_model_ids, clear_provider_models_cache
+    import hermes_constants
+    
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    clear_provider_models_cache("vertex")
+    
+    models1 = cached_provider_model_ids("vertex")
+    assert models1 is not None
+    assert isinstance(models1, list)
+    assert len(models1) > 0
+    
+    cache_file = tmp_path / "provider_models_cache.json"
+    assert cache_file.exists()
+    
+    models2 = cached_provider_model_ids("vertex")
+    assert models1 == models2


### PR DESCRIPTION
## Symptom

For a user whose main model runs on `provider: vertex`, the configured model appears in the `/model` picker only intermittently — sometimes listed, sometimes absent, with no config change in between.

## Root cause

Three things line up:

1. Vertex's provider profile documents that the OpenAI-compat endpoint has **no `/models` discovery route** — `fetch_models()` returns `None` by design, with the comment *"The setup wizard ships a curated list."*
2. But `_PROVIDER_MODELS` in `hermes_cli/models.py` has **no `"vertex"` key**, so `provider_model_ids("vertex")` falls through every branch (the generic live-fetch path only covers `auth_type == "api_key"` providers; vertex is `auth_type="vertex"`) and returns `[]`.
3. The picker's vertex row therefore always enumerates zero models. The user's configured model only surfaces via unrelated cache paths (docs model catalog, other providers' curated lists), each with independent ~1h TTLs — hence the intermittency.

## Fix

Add the missing curated `"vertex"` entry, as the provider profile already promises. IDs are publisher-qualified (`google/...`, `deepseek-ai/...`) because bare aliases 404 on the Vertex OpenAI-compat surface.

Deliberately scoped to models upstream `main` can serve today (Gemini + MaaS via the OpenAI-compat path). Claude-on-Vertex IDs are left out since main's vertex path doesn't route Anthropic models; they can join the list if/when that lands.

## Verification

```python
from hermes_cli.models import provider_model_ids, cached_provider_model_ids
provider_model_ids('vertex')
# ['google/gemini-3.5-flash', 'google/gemini-3.1-pro-preview', 'google/gemini-3-flash-preview', 'deepseek-ai/deepseek-v3.2-maas']
# aliases google-vertex / vertex-ai / gcp-vertex resolve identically;
# cached_provider_model_ids('vertex', force_refresh=True) persists a vertex entry
# in provider_models_cache.json — picker row is now deterministic.
```