### PR TITLE
fix(desktop): prevent stale session recovery across profile switches

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -30,7 +30,7 @@ import { latestSessionTodos } from '@/lib/todos'
 import { setCronFocusJobId } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $filePreviewTarget, $previewTarget } from '@/store/preview'
-import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActiveProfile } from '@/store/profile'
+import { $activeGatewayProfile, $profileScope, refreshActiveProfile } from '@/store/profile'
 import { $startWorkSessionRequest, followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
 import {
   $activeSessionId,
@@ -65,6 +65,7 @@ import { useComposerActions } from '../chat/hooks/use-composer-actions'
 import { CommandPalette } from '../command-palette'
 import { useGatewayBoot } from '../gateway/hooks/use-gateway-boot'
 import { useGatewayRequest } from '../gateway/hooks/use-gateway-request'
+import { useFreshSessionRequests } from '../hooks/use-fresh-session-requests'
 import { useKeybinds } from '../hooks/use-keybinds'
 import { ModelPickerOverlay } from '../model-picker-overlay'
 import { ModelVisibilityOverlay } from '../model-visibility-overlay'
@@ -407,18 +408,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   })
 
   // A profile switch/create drops to a fresh new-session draft so the
-  // previously open session doesn't bleed across contexts. Skip initial value.
-  const freshSessionRequest = useStore($freshSessionRequest)
-  const lastFreshRef = useRef(freshSessionRequest)
-
-  useEffect(() => {
-    if (freshSessionRequest === lastFreshRef.current) {
-      return
-    }
-
-    lastFreshRef.current = freshSessionRequest
-    startFreshSessionDraft()
-  }, [freshSessionRequest, startFreshSessionDraft])
+  // previously open session doesn't bleed across contexts. This listener is
+  // deliberately synchronous: selectProfile requests the reset immediately
+  // before it can repoint the active gateway to another profile.
+  useFreshSessionRequests(startFreshSessionDraft)
 
   // Swapping the live gateway to another profile must re-pull that profile's
   // global model + active-profile pill (both are nanostores — the blanket

--- a/apps/desktop/src/app/hooks/use-fresh-session-requests.test.tsx
+++ b/apps/desktop/src/app/hooks/use-fresh-session-requests.test.tsx
@@ -1,0 +1,37 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $freshSessionRequest, requestFreshSession } from '@/store/profile'
+
+import { useFreshSessionRequests } from './use-fresh-session-requests'
+
+function Harness({ onRequest }: { onRequest: () => void }) {
+  useFreshSessionRequests(onRequest)
+
+  return null
+}
+
+describe('useFreshSessionRequests', () => {
+  afterEach(() => {
+    cleanup()
+    $freshSessionRequest.set(0)
+    vi.restoreAllMocks()
+  })
+
+  it('clears the foreground synchronously before profile activation can continue', () => {
+    const order: string[] = []
+    const onRequest = vi.fn(() => order.push('foreground-cleared'))
+
+    render(<Harness onRequest={onRequest} />)
+
+    expect(onRequest).not.toHaveBeenCalled()
+
+    act(() => {
+      requestFreshSession()
+      order.push('gateway-activation')
+    })
+
+    expect(onRequest).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(['foreground-cleared', 'gateway-activation'])
+  })
+})

--- a/apps/desktop/src/app/hooks/use-fresh-session-requests.ts
+++ b/apps/desktop/src/app/hooks/use-fresh-session-requests.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react'
+
+import { $freshSessionRequest } from '@/store/profile'
+
+/**
+ * Deliver fresh-session requests synchronously once the listener is mounted.
+ *
+ * Profile selection bumps the store immediately before it repoints the active
+ * gateway. A reactive render/effect bridge is too late here: the new gateway
+ * can become active while the foreground refs still identify the old profile's
+ * session. Nanostores listeners run inside the originating `.set`, so the
+ * foreground teardown completes before gateway activation can continue.
+ */
+export function useFreshSessionRequests(onRequest: () => void): void {
+  const onRequestRef = useRef(onRequest)
+
+  onRequestRef.current = onRequest
+
+  useEffect(() => $freshSessionRequest.listen(() => onRequestRef.current()), [])
+}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1193,6 +1193,52 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
   })
 
+  it('does not resume the old session when a profile switch finishes during prompt.submit', async () => {
+    const calls: string[] = []
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_ID }
+    let routeToken = 'profile-a/session-a'
+    let rejectSubmit: (error: Error) => void = () => undefined
+
+    const requestGateway = vi.fn(async (method: string) => {
+      calls.push(method)
+
+      if (method === 'prompt.submit') {
+        return await new Promise<never>((_resolve, reject) => {
+          rejectSubmit = reject
+        })
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+
+    const submitting = handle!.submitText('message already leaving profile A')
+    await waitFor(() => expect(calls).toEqual(['prompt.submit']))
+
+    // Mirrors startFreshSessionDraft's synchronous identity teardown.
+    selectedStoredSessionIdRef.current = null
+    routeToken = 'profile-b/new'
+    rejectSubmit(new Error('4007 session not found'))
+
+    expect(await submitting).toBe(false)
+    expect(calls).toEqual(['prompt.submit'])
+  })
+
   it('background queue resume uses the queued stored id and leaves foreground runtime selected', async () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     let submitAttempts = 0

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -460,6 +460,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             requestGateway('prompt.submit', { session_id: sessionId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
           )
         } catch (firstErr) {
+          // A profile/session switch can finish while prompt.submit is in
+          // flight. Its 4007 belongs to the abandoned context; never try to
+          // resume that old durable id through the newly active gateway.
+          if (sessionContextDrifted()) {
+            return abortForSessionSwitch(sessionId)
+          }
+
           const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
 
           if ((isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) && recoverStoredSessionId) {
@@ -468,10 +475,23 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // backend loop (#55578 symptom d) rejects the submit even though
             // the stored session is fine — resume + retry instead of erroring
             // out and losing the session binding.
-            const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: recoverStoredSessionId,
-              source: 'desktop'
-            })
+            let resumed: { session_id: string } | undefined
+
+            try {
+              resumed = await requestGateway<{ session_id: string }>('session.resume', {
+                session_id: recoverStoredSessionId,
+                source: 'desktop'
+              })
+            } catch (resumeErr) {
+              // The switch may have happened after the pre-resume guard while
+              // this RPC was awaiting its response. Treat that as a silent
+              // cancellation; otherwise preserve the original error behavior.
+              if (sessionContextDrifted()) {
+                return abortForSessionSwitch(sessionId)
+              }
+
+              throw resumeErr
+            }
 
             if (sessionContextDrifted()) {
               return abortForSessionSwitch(sessionId)


### PR DESCRIPTION
## Summary

Fixes a Desktop race that could show `Prompt failed: session not found` when switching profiles.

- Clears the foreground session identity synchronously before activating the next profile gateway.
- Cancels an in-flight prompt if its profile/session context changes.
- Prevents recovery from resuming the previous profile's stored session through the newly active gateway.
- Adds regression coverage for both timing paths.

## Root cause

The fresh-session request was handled through a passive React effect. Profile activation could therefore complete before the old foreground session references were cleared.

If an earlier `prompt.submit` subsequently returned `4007 session not found`, the recovery path could attempt `session.resume` with the previous profile's durable session ID against the new profile gateway.

## Behavior after this change

Profile switching tears down the old foreground identity before gateway activation continues. Any prompt or recovery already in flight for the abandoned context is silently cancelled instead of producing an error or crossing profile boundaries.

This does not modify or delete chats, profiles, or configuration data.

## Scope

Desktop-only change across five files:

- `apps/desktop/src/app/contrib/wiring.tsx`
- `apps/desktop/src/app/hooks/use-fresh-session-requests.ts`
- `apps/desktop/src/app/hooks/use-fresh-session-requests.test.tsx`
- `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts`
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx`

## Validation

- 106 focused profile/session tests passed.
- Desktop typecheck passed.
- Production build passed.
- Full parallel UI suite passed 1,343 / 1,347; the four unrelated timeout/cleanup flakes passed when their two files were rerun in isolation (5 / 5).