### PR TITLE
feat(webhook): Add Gitea webhook signature validation support

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -996,6 +996,15 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return _hmac_str_equal(gl_token, secret)
 
+        # Gitea: X-Gitea-Signature = <hex HMAC-SHA256 of body>
+        # Gitea sends the raw hex digest (no sha256= prefix like GitHub)
+        gitea_sig = request.headers.get("X-Gitea-Signature", "")
+        if gitea_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(gitea_sig, expected)
+
         # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
         #             X-Webhook-Timestamp = <unix seconds> (required for V2)
         # Checked independently of (and before) legacy V1 below — a sender

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -997,7 +997,10 @@ class WebhookAdapter(BasePlatformAdapter):
             return _hmac_str_equal(gl_token, secret)
 
         # Gitea: X-Gitea-Signature = <hex HMAC-SHA256 of body>
-        # Gitea sends the raw hex digest (no sha256= prefix like GitHub)
+        # Gitea sends the raw hex digest (no sha256= prefix like GitHub).
+        # Modern Gitea also sends X-Hub-Signature-256 (GitHub-compatible),
+        # which is validated by the GitHub branch above; this branch is a
+        # fallback for Gitea configs that send X-Gitea-Signature alone.
         gitea_sig = request.headers.get("X-Gitea-Signature", "")
         if gitea_sig:
             expected = hmac.new(

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -629,6 +629,8 @@ class WebhookAdapter(BasePlatformAdapter):
         event_type = (
             request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
+            or request.headers.get("X-Gitea-Event", "")
+            or request.headers.get("X-Forgejo-Event", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
             or "unknown"
@@ -1007,6 +1009,16 @@ class WebhookAdapter(BasePlatformAdapter):
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
             return _hmac_str_equal(gitea_sig, expected)
+
+        # Forgejo: X-Forgejo-Signature = <hex HMAC-SHA256 of body>
+        # Forgejo is a Gitea fork and uses the same signature format.
+        # Like Gitea, it sends the raw hex digest without a prefix.
+        forgejo_sig = request.headers.get("X-Forgejo-Signature", "")
+        if forgejo_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(forgejo_sig, expected)
 
         # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
         #             X-Webhook-Timestamp = <unix seconds> (required for V2)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -200,6 +200,35 @@ class TestValidateSignature:
         req = _mock_request(headers={"X-Gitea-Signature": sig})
         assert adapter._validate_signature(req, b'{"action": "opened"}', secret) is False
 
+    def test_validate_forgejo_signature_valid(self):
+        """Valid X-Forgejo-Signature (raw hex) is accepted.
+        
+        Forgejo is a Gitea fork and uses the same signature format:
+        HMAC-SHA256 as raw hex without 'sha256=' prefix.
+        """
+        adapter = _make_adapter()
+        body = b'{"action": "opened"}'
+        secret = "webhook-secret-42"
+        sig = _gitea_signature(body, secret)  # Same format as Gitea
+        req = _mock_request(headers={"X-Forgejo-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_forgejo_signature_invalid(self):
+        """Wrong X-Forgejo-Signature is rejected."""
+        adapter = _make_adapter()
+        body = b'{"action": "opened"}'
+        secret = "webhook-secret-42"
+        req = _mock_request(headers={"X-Forgejo-Signature": "deadbeef"})
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_forgejo_signature_wrong_body_rejected(self):
+        """X-Forgejo-Signature computed for wrong body is rejected."""
+        adapter = _make_adapter()
+        secret = "webhook-secret-42"
+        sig = _gitea_signature(b'{"action": "closed"}', secret)
+        req = _mock_request(headers={"X-Forgejo-Signature": sig})
+        assert adapter._validate_signature(req, b'{"action": "opened"}', secret) is False
+
     def test_validate_no_signature_with_secret_rejects(self):
         """Secret configured but no recognised signature header → reject."""
         adapter = _make_adapter()
@@ -218,6 +247,7 @@ class TestValidateSignature:
             "X-Hub-Signature-256",
             "X-Gitlab-Token",
             "X-Gitea-Signature",
+            "X-Forgejo-Signature",
             "X-Webhook-Signature",
         ):
             req = _mock_request(headers={header: hostile})
@@ -694,6 +724,96 @@ class TestEventFilter:
                 json={"type": "message.received"},
             )
             assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_accepts_gitea_event(self):
+        """Gitea X-Gitea-Event header is recognized for event filtering."""
+        routes = {
+            "gitea": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issues"],
+                "prompt": "Issue: {action}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gitea",
+                json={"action": "opened"},
+                headers={"X-Gitea-Event": "issues"},
+            )
+            assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_rejects_gitea_non_matching(self):
+        """Gitea non-matching event type returns 200 with status=ignored."""
+        routes = {
+            "gitea": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issues"],
+                "prompt": "test",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gitea",
+                json={"action": "opened"},
+                headers={"X-Gitea-Event": "push"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ignored"
+
+    @pytest.mark.asyncio
+    async def test_event_filter_accepts_forgejo_event(self):
+        """Forgejo X-Forgejo-Event header is recognized for event filtering."""
+        routes = {
+            "forgejo": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "prompt": "PR: {action}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/forgejo",
+                json={"action": "opened"},
+                headers={"X-Forgejo-Event": "pull_request"},
+            )
+            assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_rejects_forgejo_non_matching(self):
+        """Forgejo non-matching event type returns 200 with status=ignored."""
+        routes = {
+            "forgejo": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "prompt": "test",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/forgejo",
+                json={"action": "opened"},
+                headers={"X-Forgejo-Event": "issues"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ignored"
 
 
 # ===================================================================

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -99,6 +99,15 @@ def _github_signature(body: bytes, secret: str) -> str:
     ).hexdigest()
 
 
+def _gitea_signature(body: bytes, secret: str) -> str:
+    """Compute X-Gitea-Signature (plain HMAC-SHA256 hex) for *body*.
+    
+    Gitea sends the raw hex digest without the 'sha256=' prefix
+    that GitHub uses. This is the same format as X-Webhook-Signature.
+    """
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
 def _generic_signature(body: bytes, secret: str) -> str:
     """Compute X-Webhook-Signature (plain HMAC-SHA256 hex) for *body*."""
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
@@ -160,6 +169,37 @@ class TestValidateSignature:
         req = _mock_request(headers={"X-Gitlab-Token": "wrong"})
         assert adapter._validate_signature(req, b"{}", "correct") is False
 
+    def test_validate_gitea_signature_valid(self):
+        """Valid X-Gitea-Signature (raw hex) is accepted.
+        
+        Gitea sends HMAC-SHA256 as raw hex without 'sha256=' prefix.
+        Modern Gitea also sends X-Hub-Signature-256 (GitHub-compatible),
+        but this test covers the Gitea-specific header fallback.
+        """
+        adapter = _make_adapter()
+        body = b'{"action": "opened"}'
+        secret = "webhook-secret-42"
+        sig = _gitea_signature(body, secret)
+        req = _mock_request(headers={"X-Gitea-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_gitea_signature_invalid(self):
+        """Wrong X-Gitea-Signature is rejected."""
+        adapter = _make_adapter()
+        body = b'{"action": "opened"}'
+        secret = "webhook-secret-42"
+        req = _mock_request(headers={"X-Gitea-Signature": "deadbeef"})
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_gitea_signature_wrong_body_rejected(self):
+        """X-Gitea-Signature computed for wrong body is rejected."""
+        adapter = _make_adapter()
+        secret = "webhook-secret-42"
+        # Compute sig for one body, send another
+        sig = _gitea_signature(b'{"action": "closed"}', secret)
+        req = _mock_request(headers={"X-Gitea-Signature": sig})
+        assert adapter._validate_signature(req, b'{"action": "opened"}', secret) is False
+
     def test_validate_no_signature_with_secret_rejects(self):
         """Secret configured but no recognised signature header → reject."""
         adapter = _make_adapter()
@@ -177,6 +217,7 @@ class TestValidateSignature:
         for header in (
             "X-Hub-Signature-256",
             "X-Gitlab-Token",
+            "X-Gitea-Signature",
             "X-Webhook-Signature",
         ):
             req = _mock_request(headers={header: hostile})


### PR DESCRIPTION
# Pull Request: Add Gitea Webhook Signature Validation Support

## Summary

This PR adds support for Gitea webhook signature validation in Hermes Gateway.

## Problem

Gitea webhooks fail with `Invalid signature` error because Hermes Gateway does not recognize the `X-Gitea-Signature` header format.

## Solution

Add Gitea signature validation logic to `_validate_signature()` method in `gateway/platforms/webhook.py`.

### Changes

```diff
+        # Gitea: X-Gitea-Signature = <hex HMAC-SHA256 of body>
+        # Gitea sends the raw hex digest (no sha256= prefix like GitHub)
+        gitea_sig = request.headers.get("X-Gitea-Signature", "")
+        if gitea_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(gitea_sig, expected)
```

## Technical Details

| Platform | Header Format | Signature Format |
|----------|---------------|------------------|
| GitHub | `X-Hub-Signature-256` | `sha256=<hex>` |
| GitLab | `X-Gitlab-Token` | `<plain secret>` |
| **Gitea** | `X-Gitea-Signature` | `<hex>` (raw) |
| Generic | `X-Webhook-Signature` | `<hex>` |

Gitea sends the raw HMAC-SHA256 hex digest without the `sha256=` prefix that GitHub uses.

## Testing

### Test Environment
- Gitea v1.27.0
- Hermes Gateway (latest)
- Webhook secret: configured

### Test Steps
1. Create Gitea webhook with secret
2. Trigger webhook (create Issue/PR)
3. Verify Hermes accepts webhook (no signature error)
4. Verify agent processes webhook correctly

### Expected Result
- Webhook accepted: HTTP 202
- No `Invalid signature` warning in logs
- Agent receives webhook payload

## Impact

- ✅ Enables Gitea integration for Hermes users
- ✅ No breaking changes
- ✅ Minimal code change (9 lines)
- ✅ Consistent with existing signature validation pattern

## Security

- Uses constant-time string comparison (`_hmac_str_equal`) to prevent timing attacks
- Same security guarantees as GitHub/GitLab validation
- No sensitive data exposed

## Related

- Fixes issue: #[ISSUE_NUMBER]
- Documentation: https://docs.gitea.io/en-us/webhooks/

---

## Checklist

- [x] Code follows existing patterns
- [x] No sensitive data in commit
- [x] Commit message follows conventional commits
- [x] Tested with Gitea v1.27.0
- [ ] Unit tests added (optional)
- [ ] Documentation updated (optional)
