### PR TITLE
fix(desktop): new session inherits active project cwd when not entered (#66686)

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -25,6 +25,7 @@ import {
   refreshProjects,
   refreshProjectTree,
   refreshWorktrees,
+  resolveNewSessionCwd,
   scanAndRecordRepos,
   tombstoneSessions
 } from './projects'
@@ -107,6 +108,82 @@ describe('project scope', () => {
   it('persists the scope to localStorage', () => {
     enterProject('p_abc')
     expect(window.localStorage.getItem('hermes.desktop.projectScope')).toBe('p_abc')
+  })
+})
+
+describe('resolveNewSessionCwd', () => {
+  const treeNode = (
+    over: Partial<SidebarProjectTree> & Pick<SidebarProjectTree, 'id' | 'label'>
+  ): SidebarProjectTree => ({
+    path: null,
+    repos: [],
+    sessionCount: 0,
+    ...over
+  })
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    $projectScope.set(ALL_PROJECTS)
+    $activeProjectId.set(null)
+    $projectTree.set([])
+  })
+
+  it('returns the view-scope project cwd when $projectScope is set', () => {
+    $projectTree.set([
+      treeNode({ id: 'p_web', label: 'Website', path: '/repos/website' }),
+      treeNode({ id: 'p_api', label: 'API', path: '/repos/api' })
+    ])
+    $projectScope.set('p_web')
+
+    expect(resolveNewSessionCwd()).toBe('/repos/website')
+  })
+
+  it('falls back to $activeProjectId when $projectScope is ALL_PROJECTS', () => {
+    $projectTree.set([
+      treeNode({ id: 'p_web', label: 'Website', path: '/repos/website' }),
+      treeNode({ id: 'p_api', label: 'API', path: '/repos/api' })
+    ])
+    $projectScope.set(ALL_PROJECTS)
+    $activeProjectId.set('p_api')
+
+    // Without the $activeProjectId fallback this returns the default workspace
+    // (detached), not the active project's root — see issue #66686.
+    expect(resolveNewSessionCwd()).toBe('/repos/api')
+  })
+
+  it('view scope takes precedence over $activeProjectId', () => {
+    $projectTree.set([
+      treeNode({ id: 'p_web', label: 'Website', path: '/repos/website' }),
+      treeNode({ id: 'p_api', label: 'API', path: '/repos/api' })
+    ])
+    $projectScope.set('p_web')
+    $activeProjectId.set('p_api')
+
+    expect(resolveNewSessionCwd()).toBe('/repos/website')
+  })
+
+  it('uses the first repo path when the project has no direct path', () => {
+    $projectTree.set([
+      treeNode({
+        id: 'p_mono',
+        label: 'Monorepo',
+        path: null,
+        repos: [{ id: 'r1', label: 'mono', path: '/repos/mono', sessionCount: 0, groups: [] }]
+      })
+    ])
+    $activeProjectId.set('p_mono')
+
+    expect(resolveNewSessionCwd()).toBe('/repos/mono')
+  })
+
+  it('falls back to default workspace when neither scope nor activeId matches a project', () => {
+    $projectTree.set([])
+    $projectScope.set(ALL_PROJECTS)
+    $activeProjectId.set('p_nonexistent')
+
+    // Returns the default workspace cwd (mocked via @/store/session)
+    const cwd = resolveNewSessionCwd()
+    expect(typeof cwd).toBe('string')
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -157,17 +157,39 @@ export function exitProjectScope(): void {
   $projectScope.set(ALL_PROJECTS)
 }
 
-// The cwd a NEW chat should start in. The "active project" is just an atom
-// ($projectScope) — so when you're inside a project, a new session (cmd-n, the
-// trunk "+") starts at that project's root (its primary repo = the default-branch
-// checkout) instead of inheriting whatever unrelated worktree the live cwd
-// drifted into. Outside a project it falls back to the plain default (detached),
-// so a bare new chat shows no branch.
+// The cwd a NEW chat should start in. The "active project" can live in two
+// places: $projectScope (view state — set when the user enters a project from
+// the sidebar overview) and $activeProjectId (durable pointer in projects.db,
+// set when a project is created/selected via the project RPC). New sessions
+// inherit whichever is set, in that order — so a user with an active project
+// they've never "entered" still lands new chats inside that project instead
+// of the default workspace. Outside both, falls back to the plain default
+// (detached), so a bare new chat shows no branch.
+// See issue #66686.
 export function resolveNewSessionCwd(): string {
+  const tree = $projectTree.get()
+
+  // 1. View scope: the project the sidebar is currently drilled into.
   const scope = $projectScope.get()
 
   if (scope !== ALL_PROJECTS) {
-    const project = $projectTree.get().find(node => node.id === scope)
+    const project = tree.find(node => node.id === scope)
+    const cwd = (project?.path || project?.repos.find(repo => repo.path)?.path || '').trim()
+
+    if (cwd) {
+      return cwd
+    }
+  }
+
+  // 2. Durable active project (projects.db). Covers users who have an active
+  // project but never explicitly entered it from the sidebar — the common
+  // case after `project_create` / `project_switch`. Without this fallback,
+  // new sessions silently drop back to the default workspace even when the
+  // user has an active project bound to a real directory.
+  const activeId = $activeProjectId.get()
+
+  if (activeId) {
+    const project = tree.find(node => node.id === activeId)
     const cwd = (project?.path || project?.repos.find(repo => repo.path)?.path || '').trim()
 
     if (cwd) {


### PR DESCRIPTION
## Summary

 in  only consulted  (view state, set when the user enters a project from the sidebar overview). It ignored  (durable pointer in , set by  / ).

When a user has an active project but never explicitly enters it from the sidebar overview,  stays at  — so new sessions silently fall back to  instead of the active project directory.

This matches the regression reported in #66686 (desktop build stamp ).

## Fix

After the existing  check fails (or scope is ), fall back to  against the same . Only after both miss do we return .



The scope check still wins (entering a project is more specific), so the new path only fires for users with an active project they haven'''t drilled into from the sidebar.

## Test plan

1. Create a project:  (or via sidebar UI).
2. **Do NOT** click into the project from the sidebar overview — leave  at .
3. Click "+ New Session" in the sidebar.
4. Confirm new session cwd is  (and the sidebar file tree shows that directory), not .

Fixes #66686.
