### PR TITLE
fix(agent): close Codex app-server subprocess on AIAgent.close() (#66671)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3354,6 +3354,22 @@ class AIAgent:
         except Exception:
             pass
 
+        # 5b. Close the Codex app-server subprocess + its MCP children.
+        # AIAgent.close() previously orphaned the codex app-server: the only
+        # _codex_session.close() calls lived in crash/retire paths inside
+        # agent/codex_runtime.py, so every closed Codex-route session leaked
+        # one codex app-server process and its MCP children.  Guarded +
+        # idempotent so the first call closes + clears the reference and any
+        # later call is a no-op (mirrors the openai-client step above).
+        # Issue #66671.
+        try:
+            codex_session = getattr(self, "_codex_session", None)
+            if codex_session is not None:
+                codex_session.close()
+                self._codex_session = None
+        except Exception:
+            pass
+
         # 6. Free conversation history.  Mirrors _release_evicted_agent_soft's
         # soft-eviction clear — close() is the hard teardown for true session
         # boundaries (/new, /reset, session expiry), so the message list won't

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -589,3 +589,42 @@ class TestCodexToolProgressBridge:
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
 
+
+class TestAIAgentCloseCodexSession:
+    """Regression coverage for #66671: AIAgent.close() must close + null out
+    the lazily-spawned _codex_session so long-running `hermes serve`
+    deployments don't leak `codex app-server` subprocess trees.
+
+    See PR #66904 for the close-path fix and the salvage material from
+    closed duplicate #66865 for the test shape."""
+
+    def test_close_closes_and_nulls_codex_session(self):
+        agent = _make_codex_agent()
+        fake_session = MagicMock()
+        agent._codex_session = fake_session
+
+        agent.close()
+
+        fake_session.close.assert_called_once()
+        assert getattr(agent, "_codex_session", None) is None
+
+    def test_close_noop_when_codex_session_attribute_missing(self):
+        # Non-codex agents never have _codex_session bound — close() must
+        # not raise AttributeError on the getattr fallback.
+        agent = _make_codex_agent()
+        assert not hasattr(agent, "_codex_session")
+
+        agent.close()  # must not raise
+
+    def test_close_idempotent_when_repeated(self):
+        # First call closes + nulls; second call sees getattr None and skips.
+        agent = _make_codex_agent()
+        fake_session = MagicMock()
+        agent._codex_session = fake_session
+
+        agent.close()
+        agent.close()
+
+        fake_session.close.assert_called_once()
+        assert agent._codex_session is None
+


### PR DESCRIPTION
## Summary

`AIAgent.close()` (in `run_agent.py`) cleaned up background processes, terminal sandboxes, browser daemons, child agents, the OpenAI/httpx client, conversation history, and the SQLite session row — but never closed `self._codex_session`.

The only `_codex_session.close()` calls in the codebase lived in crash/retire paths inside `agent/codex_runtime.py`. So every closed Codex-route session permanently leaked one `codex app-server` process plus its MCP children. Long-running `hermes serve` deployments accumulated one leaked process tree per closed session.

Live-verified on v0.18.2 (git c7e09f2) by counting `pgrep -fc "codex app-server"` before/after `session.close` cycles. Confirmed unchanged on current main by source inspection.

This matches the leak reported in #66671.

## Fix

Add a guarded, idempotent close step right after the OpenAI/httpx client close in `AIAgent.close()`, mirroring its `try/except` + reference-clearing pattern:

```python
# 5b. Close the Codex app-server subprocess + its MCP children.
try:
    codex_session = getattr(self, "_codex_session", None)
    if codex_session is not None:
        codex_session.close()
        self._codex_session = None
except Exception:
    pass
```

First call closes and clears the reference; any later call is a no-op. `CodexAppServerSession.close()` (in `agent/transports/codex_app_server_session.py`) already exists and tears down the subprocess tree + MCP children, so no new code in the transport is needed.

Single-file change in `run_agent.py::AIAgent.close`. No public API change. No new imports.

## Test plan

1. Configure a profile on the Codex app-server runtime with at least one MCP server.
2. Record baseline: `pgrep -fc "codex app-server"` and `pgrep -fc <MCP binary>`.
3. Start `hermes serve`, connect via the WebSocket API, `session.create`, submit one prompt, wait for `message.complete`.
4. Call `session.close`, wait ~3 seconds.
5. Re-run the process counts from step 2.
6. **Expected:** both counts return to baseline. Without the fix: counts increase by one per completed session and never return to baseline (issue's 15–16 codex / 17–18 MCP pattern).

Fixes #66671.
