### PR TITLE
fix(setup): skip camofox npm install in uv tool-install mode (#66044)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1282,18 +1282,33 @@ def _run_post_setup(post_setup_key: str):
         camofox_dir = PROJECT_ROOT / "node_modules" / "@askjo" / "camofox-browser"
         _npm_bin = shutil.which("npm")
         if not camofox_dir.exists() and _npm_bin:
-            _print_info("    Installing Camofox browser server...")
-            import subprocess
-            # Absolute npm path so .cmd shim executes on Windows.
-            result = subprocess.run(
-                # --workspaces=false avoids resolving apps/desktop. See #38772.
-                [_npm_bin, "install", "--silent", "--workspaces=false"],
-                capture_output=True, text=True, cwd=str(PROJECT_ROOT)
-            )
-            if result.returncode == 0:
-                _print_success("    Camofox installed")
+            # Skip the npm-install path when hermes itself was installed via
+            # `uv tool install`. In that mode PROJECT_ROOT points at the
+            # uv-managed package dir (~/.local/share/uv/tools/hermes-agent/)
+            # which has no package.json, so `npm install` errors out and the
+            # camofox post-setup crashes the whole installer.
+            # Users in that mode should run `npx @askjo/camofox-browser`
+            # directly — see the message below. Issue #66044.
+            _hermes_pkg_json = PROJECT_ROOT / "package.json"
+            if not _hermes_pkg_json.exists():
+                _print_info("    Skipping Camofox npm install (no source checkout found).")
+                _print_info("    Start the Camofox server directly:")
+                _print_info("      npx @askjo/camofox-browser")
+                _print_info("    Or use Docker:")
+                _print_info("      docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser")
             else:
-                _print_warning("    npm install failed - run manually: npm install --workspaces=false")
+                _print_info("    Installing Camofox browser server...")
+                import subprocess
+                # Absolute npm path so .cmd shim executes on Windows.
+                result = subprocess.run(
+                    # --workspaces=false avoids resolving apps/desktop. See #38772.
+                    [_npm_bin, "install", "--silent", "--workspaces=false"],
+                    capture_output=True, text=True, cwd=str(PROJECT_ROOT)
+                )
+                if result.returncode == 0:
+                    _print_success("    Camofox installed")
+                else:
+                    _print_warning("    npm install failed - run manually: npm install --workspaces=false")
         if camofox_dir.exists():
             _print_info("    Start the Camofox server:")
             _print_info("      npx @askjo/camofox-browser")


### PR DESCRIPTION
## Summary

`_run_post_setup('camofox')` in `hermes_cli/tools_config.py` always runs `npm install --workspaces=false` in `PROJECT_ROOT = Path(__file__).parent.parent.resolve()`. On a source checkout this resolves to the repo root (with `package.json`) and works fine.

On a `uv tool install` install, `PROJECT_ROOT` resolves to `~/.local/share/uv/tools/hermes-agent/` — a uv-managed package directory with **no `package.json`**. The `npm install` call then either errors out (`npm ERR! ... doesn't have any package.json`) or, depending on cwd, runs but fails.

Worse, `install.sh` deletes any pre-existing `~/.hermes/hermes-agent` source checkout **before** the new install completes. So a camofox-choice crash during setup leaves the user with neither an old nor a new install: `uv tool list` is empty, `~/.hermes/hermes-agent` is gone, the post-setup traceback ends in `FileNotFoundError` on the now-deleted checkout path. Issue #66044.

This affects every Linux user who picks camofox during `hermes setup` on a `uv tool install` install, plus every user who previously had a source-based install and tried to migrate via `install.sh`.

## Fix

Detect uv mode by the absence of `package.json` in `PROJECT_ROOT` and **skip the `npm install` step** entirely. Users in that mode get a clear message to run `npx @askjo/camofox-browser` directly (or use the Docker image).

Source-checkout behavior is unchanged — `package.json` is present, the existing install path runs as before.

Single-file change in `hermes_cli/tools_config.py::_run_post_setup('camofox')`. No public API change. No new imports.

## Test plan

1. Install via `uv tool install` (no `~/.hermes/hermes-agent` checkout).
2. Run `hermes setup`.
3. Pick `camofox` as the browser provider.
4. **Expected:** setup completes successfully (no `FileNotFoundError`); user sees a message saying "Skipping Camofox npm install (no source checkout found). Start the Camofox server directly: npx @askjo/camofox-browser".
5. **Without this fix:** setup crashes with `FileNotFoundError: '/home/<user>/.hermes/hermes-agent'` and the user is left with no working install.

Fixes #66044.
