### PR TITLE
fix: harden Codex cache identity and chat-scoped session lists

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -518,6 +518,18 @@ class ResponsesApiTransport(ProviderTransport):
                 extra_body["prompt_cache_key"] = bounded
             else:
                 extra_body.pop("prompt_cache_key", None)
+        extra_headers = normalized.get("extra_headers")
+        if isinstance(extra_headers, dict):
+            extra_headers = dict(extra_headers)
+            for header_name in ("session_id", "x-client-request-id"):
+                if header_name not in extra_headers:
+                    continue
+                bounded = _bounded_prompt_cache_key(extra_headers[header_name])
+                if bounded:
+                    extra_headers[header_name] = bounded
+                else:
+                    extra_headers.pop(header_name, None)
+            normalized["extra_headers"] = extra_headers
         return normalized
 
     def map_finish_reason(self, raw_reason: str) -> str:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4044,6 +4044,7 @@ def get_sessions(
     archived: str = "exclude",
     order: str = "created",
     source: str = None,
+    chat_id: str = None,
     exclude_sources: str = None,
     cwd_prefix: str = None,
     full: bool = False,
@@ -4074,6 +4075,8 @@ def get_sessions(
             status_code=400,
             detail="order must be one of: created, recent",
         )
+    if chat_id is not None and (not chat_id or len(chat_id) > 256):
+        raise HTTPException(status_code=400, detail="chat_id must contain 1-256 characters")
     profile_name: Optional[str] = None
     if profile:
         profile_name, _ = _cron_profile_home(profile)
@@ -4090,6 +4093,7 @@ def get_sessions(
             exclude_list = [s for s in (exclude_sources or "").split(",") if s.strip()]
             sessions = db.list_sessions_rich(
                 source=source or None,
+                chat_id=chat_id,
                 exclude_sources=exclude_list or None,
                 cwd_prefix=(cwd_prefix or None),
                 limit=limit,
@@ -4105,6 +4109,7 @@ def get_sessions(
             )
             total = db.session_count(
                 source=source or None,
+                chat_id=chat_id,
                 cwd_prefix=(cwd_prefix or None),
                 exclude_sources=exclude_list or None,
                 min_message_count=min_message_count,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3679,6 +3679,7 @@ class SessionDB:
     def list_sessions_rich(
         self,
         source: str = None,
+        chat_id: str = None,
         exclude_sources: List[str] = None,
         cwd_prefix: str = None,
         limit: int = 20,
@@ -3756,6 +3757,9 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if chat_id:
+            where_clauses.append("s.chat_id = ?")
+            params.append(chat_id)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
@@ -5646,6 +5650,7 @@ class SessionDB:
     def session_count(
         self,
         source: str = None,
+        chat_id: str = None,
         cwd_prefix: str = None,
         min_message_count: int = 0,
         include_archived: bool = False,
@@ -5679,6 +5684,9 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if chat_id:
+            where_clauses.append("s.chat_id = ?")
+            params.append(chat_id)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -410,6 +410,31 @@ class TestCodexBuildKwargs:
         assert preflight["extra_body"]["prompt_cache_key"].startswith("pck_")
         assert len(preflight["extra_body"]["prompt_cache_key"]) <= 64
 
+    def test_preflight_rebounds_codex_cache_headers_after_middleware_mutation(self, transport):
+        raw_session_id = "code-on-the-run-codeontherun-" + "a" * 36
+        built = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            session_id=raw_session_id,
+            is_codex_backend=True,
+        )
+        expected = built["extra_headers"]["session_id"]
+
+        middleware_payload = dict(built)
+        middleware_payload["extra_headers"] = {
+            **built["extra_headers"],
+            "session_id": raw_session_id,
+            "x-client-request-id": raw_session_id,
+            "X-Keep-Me": "preserved",
+        }
+        preflight = transport.preflight_kwargs(middleware_payload)
+
+        assert preflight["extra_headers"]["session_id"] == expected
+        assert preflight["extra_headers"]["x-client-request-id"] == expected
+        assert len(preflight["extra_headers"]["session_id"]) <= 64
+        assert preflight["extra_headers"]["X-Keep-Me"] == "preserved"
+
     def test_codex_backend_no_headers_without_session_id(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1195,6 +1195,27 @@ class TestWebServerEndpoints:
         assert captured["list"] == 3
         assert captured["count"] == 3
 
+    def test_get_sessions_forwards_chat_id_before_pagination(self, monkeypatch):
+        captured = {}
+
+        class _FakeDB:
+            def list_sessions_rich(self, chat_id=None, **kwargs):
+                captured["list"] = chat_id
+                return []
+
+            def session_count(self, chat_id=None, **kwargs):
+                captured["count"] = chat_id
+                return 0
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr("hermes_state.SessionDB", _FakeDB)
+
+        resp = self.client.get("/api/sessions?source=signal&chat_id=home-chat&limit=1")
+        assert resp.status_code == 200
+        assert captured == {"list": "home-chat", "count": "home-chat"}
+
     def _create_session_with_heavy_fields(self, session_id: str) -> None:
         from hermes_state import SessionDB
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3976,6 +3976,22 @@ class TestTitleSqlWildcards:
 class TestListSessionsRich:
     """Tests for enhanced session listing with preview and last_active."""
 
+    def test_chat_id_filter_applies_before_pagination_and_count(self, db):
+        db.create_session("home-session", "signal", chat_id="home-chat")
+        db.create_session("foreign-session", "signal", chat_id="foreign-chat")
+        db.append_message("home-session", "user", "authorized")
+        db.append_message("foreign-session", "user", "foreign and newer")
+
+        rows = db.list_sessions_rich(
+            source="signal",
+            chat_id="home-chat",
+            limit=1,
+            order_by_last_active=True,
+        )
+
+        assert [row["id"] for row in rows] == ["home-session"]
+        assert db.session_count(source="signal", chat_id="home-chat", exclude_children=True) == 1
+
     def test_preview_from_first_user_message(self, db):
         db.create_session("s1", "cli")
         db.append_message("s1", "system", "You are a helpful assistant.")


### PR DESCRIPTION
## Summary
- re-bound Codex body and routing-header cache identities after request/execution middleware
- add optional exact `chat_id` filtering to dashboard `GET /api/sessions`
- push chat filtering into SQLite before pagination and keep session counts aligned
- preserve unrelated request headers and canonical Hermes session identity

## Verification
- Codex transport: 82 passed
- Codex run-agent Responses: 105 passed
- SessionDB: 371 passed
- Dashboard web server: 410 passed
- compileall and git diff --check: passed

Exact six-file manifest SHA-256: `ef1225de75a2675b93f22636906165ae160d651d2168114c71a2f7c3920bf49b`.