### PR TITLE
fix(desktop): resolve local plugin root independent of remote backend (#66899)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8692,6 +8692,26 @@ ipcMain.handle('hermes:fs:openDir', async (_event, dirPath) => {
   }
 })
 
+// The LOCAL Desktop runtime-plugin root: `<HERMES_HOME>/desktop-plugins`,
+// resolved from the main-process HERMES_HOME (see resolveHermesHome) — NOT from
+// the connected backend. A remote backend reports its own `hermes_home` over
+// the gateway, which is a path on the REMOTE box; deriving the plugin dir from
+// it yields `undefined/desktop-plugins` (or a non-existent remote path) and the
+// on-disk plugin door silently breaks (#66899). Electron owns this resolution
+// so it stays valid in every connection mode. Created on demand, like openDir.
+ipcMain.handle('hermes:fs:desktopPluginsRoot', async () => {
+  const dir = path.join(HERMES_HOME, 'desktop-plugins')
+
+  try {
+    await fs.promises.mkdir(dir, { recursive: true })
+  } catch {
+    // Best-effort create; return the path regardless so the reveal action can
+    // still surface a real openPath error and the scanner can retry later.
+  }
+
+  return dir
+})
+
 // Rename a file/folder in place. The renderer passes the existing path + a new
 // base name; the destination is resolved in the SAME parent dir so a rename can
 // never move the item elsewhere or traverse out. Rejects on a name collision.

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -108,6 +108,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   gitRoot: startPath => ipcRenderer.invoke('hermes:fs:gitRoot', startPath),
   revealPath: targetPath => ipcRenderer.invoke('hermes:fs:reveal', targetPath),
   openDir: dirPath => ipcRenderer.invoke('hermes:fs:openDir', dirPath),
+  desktopPluginsRoot: () => ipcRenderer.invoke('hermes:fs:desktopPluginsRoot'),
   renamePath: (targetPath, newName) => ipcRenderer.invoke('hermes:fs:rename', targetPath, newName),
   writeTextFile: (filePath, content) => ipcRenderer.invoke('hermes:fs:writeText', filePath, content),
   trashPath: targetPath => ipcRenderer.invoke('hermes:fs:trash', targetPath),

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -6,7 +6,6 @@ import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
-import { getStatus } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Package } from '@/lib/icons'
@@ -22,10 +21,19 @@ function reveal(file: string) {
 
 async function revealPluginsDir() {
   try {
-    const { hermes_home } = await getStatus()
+    // Electron owns the local plugin root — deriving it from the backend's
+    // hermes_home breaks against a remote backend (#66899).
+    const dir = await window.hermesDesktop?.desktopPluginsRoot?.()
+
+    if (!dir) {
+      notifyError('Desktop plugins are unavailable', 'Could not resolve the plugins folder')
+
+      return
+    }
+
     // openDir (not reveal): the door often doesn't exist on first use, and
     // showItemInFolder on a missing path silently no-ops (esp. Windows).
-    const result = await window.hermesDesktop?.openDir?.(`${hermes_home}/desktop-plugins`)
+    const result = await window.hermesDesktop?.openDir?.(dir)
 
     if (result && !result.ok) {
       notifyError(result.error ?? 'unknown error', 'Could not open the plugins folder')

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesReadDirResult } from '@/global'
+import type * as HermesModule from '@/hermes'
+
+import { discoverRuntimePlugins } from './runtime-loader'
+
+// getStatus would supply the connected backend's hermes_home — a REMOTE path in
+// remote mode. The disk scanner must NOT derive the plugin root from it (#66899).
+const getStatus = vi.fn(async () => ({ hermes_home: '/remote/box/.hermes' }))
+
+vi.mock('@/hermes', async importActual => ({
+  ...(await importActual<typeof HermesModule>()),
+  getStatus: () => getStatus()
+}))
+
+const desktopPluginsRoot = vi.fn<() => Promise<string>>()
+const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
+
+beforeEach(() => {
+  desktopPluginsRoot.mockReset()
+  readDir.mockReset()
+  getStatus.mockClear()
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { desktopPluginsRoot, readDir }
+})
+
+afterEach(() => {
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('scanDiskPlugins (#66899)', () => {
+  it('scans the Electron-resolved local root, never the backend hermes_home', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    readDir.mockResolvedValue({ entries: [] })
+
+    await discoverRuntimePlugins()
+
+    expect(desktopPluginsRoot).toHaveBeenCalled()
+    expect(readDir).toHaveBeenCalledWith('/local/.hermes/desktop-plugins')
+    // The remote backend's hermes_home must never feed the local plugin scan.
+    expect(getStatus).not.toHaveBeenCalled()
+    expect(readDir).not.toHaveBeenCalledWith('/remote/box/.hermes/desktop-plugins')
+  })
+
+  it('no-ops when the resolver yields no local root', async () => {
+    desktopPluginsRoot.mockResolvedValue('')
+
+    await discoverRuntimePlugins()
+
+    expect(readDir).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -27,7 +27,6 @@
  * trust seam.
  */
 
-import { getStatus } from '@/hermes'
 import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { notifyError } from '@/store/notifications'
 
@@ -246,8 +245,16 @@ async function scanDiskPlugins(): Promise<void> {
   scanning = true
 
   try {
-    const { hermes_home } = await getStatus()
-    const { entries } = await desktop.readDir(`${hermes_home}/desktop-plugins`)
+    // The plugin root is a LOCAL Electron path, resolved independently of the
+    // connected backend — a remote backend's hermes_home is a remote path and
+    // yields `undefined/desktop-plugins` here (#66899).
+    const root = await desktop.desktopPluginsRoot?.()
+
+    if (!root) {
+      return
+    }
+
+    const { entries } = await desktop.readDir(root)
     const seen = new Set<string>()
 
     for (const dir of entries.filter(e => e.isDirectory)) {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -111,6 +111,10 @@ declare global {
       revealPath?: (path: string) => Promise<boolean>
       // Open a DIRECTORY (created if missing) in the OS file manager.
       openDir?: (path: string) => Promise<{ ok: boolean; error?: string }>
+      // Local Desktop runtime-plugin root (<HERMES_HOME>/desktop-plugins),
+      // resolved by Electron independently of the connected backend (#66899).
+      // Created on demand; returns the normalized absolute path.
+      desktopPluginsRoot?: () => Promise<string>
       // Rename a file/folder in place (new base name, same parent dir).
       renamePath?: (path: string, newName: string) => Promise<{ path: string }>
       // Write a small UTF-8 text file (hardened path, parent must exist).


### PR DESCRIPTION
## What does this PR do?

Desktop runtime plugins load from a **local** directory
(`<HERMES_HOME>/desktop-plugins/<name>/plugin.js`), but two code paths derived
that directory from `getStatus().hermes_home` — a value reported by the
**connected backend**. Against a remote backend, `hermes_home` is a path on the
remote box (or `undefined`), so:

- **Settings → Plugins → "Open plugins folder"** builds `undefined/desktop-plugins`
  and shows `Could not open the plugins folder undefined`.
- The **runtime disk scanner** (`scanDiskPlugins`, also the ⌘K "Reload desktop
  plugins" fallback) reads the same wrong path and silently discovers nothing,
  even when a valid local `plugin.js` exists.

The local Desktop plugin filesystem location must not be determined by a remote
backend. This moves plugin-root resolution into a single Electron-owned resolver
(the main process already computes the local `HERMES_HOME` independently of the
backend) and routes both call sites through it.

## Related Issue

Fixes #66899

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts` — new IPC handler `hermes:fs:desktopPluginsRoot`
  returning `<HERMES_HOME>/desktop-plugins` (computed from the main-process
  `HERMES_HOME`, created on demand), valid in every connection mode.
- `apps/desktop/electron/preload.ts` — expose `desktopPluginsRoot()` on
  `window.hermesDesktop`.
- `apps/desktop/src/global.d.ts` — type the new capability.
- `apps/desktop/src/app/settings/plugins-settings.tsx` — "Open plugins folder"
  resolves the root via the new IPC instead of `getStatus().hermes_home`.
- `apps/desktop/src/contrib/runtime-loader.ts` — `scanDiskPlugins` scans the
  Electron-resolved local root; drops the `getStatus` dependency.
- `apps/desktop/src/contrib/runtime-loader.test.ts` — regression test: the
  scanner uses the local resolver and never the backend `hermes_home`.

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/contrib/runtime-loader.test.ts`
   → 2 passed (scanner uses the Electron-resolved root; remote `hermes_home` is
   never used; no-ops when the resolver yields no root).
2. Manual: connect Desktop to a remote backend, open **Settings → Plugins**,
   click **Open plugins folder** — the local `<HERMES_HOME>/desktop-plugins` now
   opens instead of erroring, and a local `plugin.js` there is discovered.

(No Python touched — `pytest tests/` is N/A for this Electron/renderer change.)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (no Python changes; ran `vitest` + `eslint` + `tsc` on the changed desktop files)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing behavior/API doc change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — resolver uses `path.join`; the created-on-demand `openDir` behavior matches the existing Windows-safe folder action
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```
