### PR TITLE
fix(kanban): quarantine failures and capture coherent DB evidence

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -218,6 +218,8 @@ class GatewayKanbanWatchersMixin:
                     seen_db_paths: set[str] = set()
                     for board_meta in boards:
                         slug = board_meta.get("slug") or _kb.DEFAULT_BOARD
+                        if _kb.get_db_health(board=slug) is not None:
+                            continue
                         db_path = board_meta.get("db_path")
                         try:
                             resolved_db_path = str(Path(db_path).expanduser().resolve()) if db_path else str(_kb.kanban_db_path(slug).resolve())
@@ -940,36 +942,25 @@ class GatewayKanbanWatchersMixin:
         HEALTH_WINDOW = 6
         bad_ticks = 0
         last_warn_at = 0
-        # Avoid hot-looping corrupt-looking board DBs, but do not suppress
-        # same-fingerprint retries forever: transient WAL/open races can
-        # surface as "database disk image is malformed" for one tick.
-        CORRUPT_BOARD_RETRY_AFTER_SECONDS = 300
-        disabled_corrupt_boards: dict[
-            str, tuple[tuple[str, int | None, int | None], float]
-        ] = {}
+        # Persisted board circuits are process-independent and remain open until
+        # an operator atomically replaces the database. Track announcements by
+        # incident id so the dispatcher emits one actionable alert, not one
+        # traceback every tick.
+        announced_db_incidents: dict[str, str] = {}
 
-        def _board_db_fingerprint(slug: str) -> tuple[str, int | None, int | None]:
-            path = _kb.kanban_db_path(slug)
-            try:
-                resolved = str(path.expanduser().resolve())
-            except Exception:
-                resolved = str(path)
-            try:
-                stat = path.stat()
-            except OSError:
-                return (resolved, None, None)
-            return (resolved, stat.st_mtime_ns, stat.st_size)
-
-        def _is_corrupt_board_db_error(exc: Exception) -> bool:
-            corrupt_guard_error = getattr(_kb, "KanbanDbCorruptError", None)
-            if corrupt_guard_error is not None and isinstance(exc, corrupt_guard_error):
-                return True
-            if not isinstance(exc, sqlite3.DatabaseError):
-                return False
-            msg = str(exc).lower()
-            return (
-                "file is not a database" in msg
-                or "database disk image is malformed" in msg
+        def _announce_open_circuit(slug: str, health: dict) -> None:
+            incident_id = str(health.get("incident_id") or "unknown")
+            if announced_db_incidents.get(slug) == incident_id:
+                return
+            announced_db_incidents[slug] = incident_id
+            logger.error(
+                "kanban dispatcher: board %s quarantined; incident=%s "
+                "classification=%s manifest=%s. Dispatch is paused until the "
+                "database is replaced and diagnostics pass.",
+                slug,
+                incident_id,
+                health.get("classification"),
+                health.get("manifest_path"),
             )
 
         def _tick_once_for_board(slug: str) -> "Optional[object]":
@@ -982,29 +973,16 @@ class GatewayKanbanWatchersMixin:
             connection handle or accidentally claim across each other.
             """
             conn = None
-            fingerprint = _board_db_fingerprint(slug)
-            disabled_entry = disabled_corrupt_boards.get(slug)
-            if disabled_entry is not None:
-                disabled_fingerprint, disabled_at = disabled_entry
-                age = time.monotonic() - disabled_at
-                if (
-                    disabled_fingerprint == fingerprint
-                    and age < CORRUPT_BOARD_RETRY_AFTER_SECONDS
-                ):
-                    return None
-                if disabled_fingerprint == fingerprint:
-                    logger.info(
-                        "kanban dispatcher: board %s database fingerprint unchanged "
-                        "after %.0fs quarantine; retrying dispatch",
-                        slug,
-                        age,
-                    )
-                else:
-                    logger.info(
-                        "kanban dispatcher: board %s database changed; retrying dispatch",
-                        slug,
-                    )
-                disabled_corrupt_boards.pop(slug, None)
+            health = _kb.get_db_health(board=slug)
+            if health is not None:
+                _announce_open_circuit(slug, health)
+                return None
+
+            if announced_db_incidents.pop(slug, None) is not None:
+                logger.info(
+                    "kanban dispatcher: board %s database health restored; resuming",
+                    slug,
+                )
             try:
                 conn = _kb.connect(board=slug)
                 # `connect()` runs the schema + idempotent migration on
@@ -1023,34 +1001,18 @@ class GatewayKanbanWatchersMixin:
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
                 )
-            except sqlite3.DatabaseError as exc:
-                if _is_corrupt_board_db_error(exc):
-                    disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
-                    logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; pausing dispatch for this board until "
-                        "the file changes, the gateway restarts, or the "
-                        "quarantine timer expires. Move or restore the file, "
-                        "then run `hermes kanban init` if you need a fresh board.",
-                        slug,
-                        fingerprint[0],
-                    )
+            except _kb.KanbanDbHealthError as exc:
+                health = _kb.get_db_health(board=slug) or exc.health
+                _announce_open_circuit(slug, health)
+                return None
+            except sqlite3.Error as exc:
+                health_exc = _kb.quarantine_db_for_error(exc, board=slug)
+                if health_exc is not None:
+                    _announce_open_circuit(slug, health_exc.health)
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
-            except Exception as exc:
-                if _is_corrupt_board_db_error(exc):
-                    disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
-                    logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; pausing dispatch for this board until "
-                        "the file changes, the gateway restarts, or the "
-                        "quarantine timer expires. Move or restore the file, "
-                        "then run `hermes kanban init` if you need a fresh board.",
-                        slug,
-                        fingerprint[0],
-                    )
-                    return None
+            except Exception:
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
             finally:
@@ -1095,6 +1057,8 @@ class GatewayKanbanWatchersMixin:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                if _kb.get_db_health(board=slug) is not None:
+                    continue
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
@@ -1153,6 +1117,8 @@ class GatewayKanbanWatchersMixin:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 if attempted >= auto_decompose_per_tick:
                     break
+                if _kb.get_db_health(board=slug) is not None:
+                    continue
                 # Pin this board for the duration of the call — same
                 # pattern as the dashboard specify endpoint. The
                 # decomposer module connects with no board kwarg and

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -950,6 +950,11 @@ def kanban_command(args: argparse.Namespace) -> int:
     # schema creation; `create` / `list` / every other command would
     # error out on a fresh install.
     with board_scope:
+        # Diagnostics is the one command that must remain available while the
+        # DB circuit is open; it reads the persisted sidecar without opening
+        # the quarantined database.
+        if action in {"diagnostics", "diag"} and kb.get_db_health() is not None:
+            return int(_cmd_diagnostics(args) or 0)
         try:
             kb.init_db()
         except Exception as exc:
@@ -1695,6 +1700,24 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
     """
     from hermes_cli import kanban_diagnostics as kd
     from hermes_cli.config import load_config
+
+    board_health = kb.get_db_health()
+    if board_health is not None:
+        if getattr(args, "json", False):
+            print(json.dumps({"board_health": board_health}, indent=2, ensure_ascii=False))
+        else:
+            print("Kanban database circuit is OPEN (board quarantined).")
+            print(f"  Incident: {board_health['incident_id']}")
+            print(f"  Class:    {board_health['classification']}")
+            sqlite_code = (
+                board_health.get("sqlite_errorname")
+                or board_health.get("sqlite_errorcode")
+                or "unknown"
+            )
+            print(f"  SQLite:   {sqlite_code}")
+            print(f"  Manifest: {board_health['manifest_path']}")
+            print(f"  Action:   {board_health['recovery_command']}")
+        return 2
 
     diag_config = kd.config_from_runtime_config(load_config())
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1548,23 +1548,101 @@ def _validate_sqlite_header(path: Path) -> None:
     )
 
 
-class KanbanDbCorruptError(RuntimeError):
-    """Raised when an existing kanban DB file fails integrity checks.
+@dataclass(frozen=True)
+class SqliteErrorClassification:
+    """Stable Kanban taxonomy for SQLite failures."""
 
-    Fail-closed guard against silent recreation of a corrupt board file,
-    which would otherwise destroy the user's tasks. Carries both the
-    original path and the timestamped backup we made before refusing.
+    category: str
+    retryable: bool
+    fatal: bool
+    sqlite_errorcode: Optional[int]
+    sqlite_errorname: Optional[str]
+
+
+def classify_sqlite_error(exc: BaseException) -> SqliteErrorClassification:
+    """Classify a SQLite failure using its extended code, then message fallback.
+
+    Python exposes SQLite extended result codes on real ``sqlite3`` exceptions.
+    Some adapters and tests only preserve the message, so the fallback remains
+    deliberately narrow: lock contention is retryable; storage/corruption
+    signatures quarantine the board; everything else remains an application
+    error and must not trip the board-wide circuit.
+    """
+    code = getattr(exc, "sqlite_errorcode", None)
+    name = getattr(exc, "sqlite_errorname", None)
+    try:
+        base_code = int(code) & 0xFF if code is not None else None
+    except (TypeError, ValueError):
+        base_code = None
+    message = str(exc).lower()
+
+    if base_code in {sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED} or any(
+        marker in message for marker in ("database is locked", "database is busy")
+    ):
+        category, retryable, fatal = "transient", True, False
+    elif base_code in {
+        sqlite3.SQLITE_IOERR,
+        sqlite3.SQLITE_FULL,
+        sqlite3.SQLITE_READONLY,
+    } or any(
+        marker in message
+        for marker in (
+            "disk i/o error",
+            "database or disk is full",
+            "readonly database",
+            "read-only database",
+        )
+    ):
+        category, retryable, fatal = "fatal_storage", False, True
+    elif base_code in {sqlite3.SQLITE_CORRUPT, sqlite3.SQLITE_NOTADB} or any(
+        marker in message
+        for marker in (
+            "database disk image is malformed",
+            "file is not a database",
+            "malformed database",
+        )
+    ):
+        category, retryable, fatal = "corruption", False, True
+    else:
+        category, retryable, fatal = "application", False, False
+
+    return SqliteErrorClassification(
+        category=category,
+        retryable=retryable,
+        fatal=fatal,
+        sqlite_errorcode=int(code) if isinstance(code, int) else None,
+        sqlite_errorname=str(name) if name else None,
+    )
+
+
+class KanbanDbHealthError(sqlite3.OperationalError):
+    """Raised while a persisted board-wide database circuit is open.
+
+    Keeping this in SQLite's ``OperationalError`` hierarchy preserves callers'
+    existing database-error handling while adding the shared incident fields.
     """
 
-    def __init__(self, db_path: Path, backup_path: Optional[Path], reason: str):
-        self.db_path = db_path
-        self.backup_path = backup_path
-        self.reason = reason
-        backup_str = str(backup_path) if backup_path is not None else "<backup failed>"
+    def __init__(self, health: dict[str, Any], manifest: Optional[dict[str, Any]] = None):
+        self.health = dict(health)
+        self.db_path = Path(str(health["db_path"]))
+        self.incident_id = str(health["incident_id"])
+        self.manifest_path = Path(str(health["manifest_path"]))
+        self.reason = str(health.get("reason") or "fatal SQLite health failure")
+        backup = (manifest or {}).get("backup_path")
+        self.backup_path = Path(str(backup)) if backup else None
+        code = health.get("sqlite_errorname") or health.get("sqlite_errorcode") or "unknown"
+        backup_note = f"; backup={self.backup_path}" if self.backup_path else ""
         super().__init__(
-            f"Refusing to open corrupt kanban DB at {db_path}: {reason}. "
-            f"Original preserved; backup at {backup_str}."
+            f"Kanban board database is quarantined: incident {self.incident_id}; "
+            f"classification={health.get('classification')}; sqlite={code}; "
+            f"reason={self.reason}; manifest={self.manifest_path}{backup_note}. "
+            "Run `hermes kanban diagnostics --json` and restore a verified database "
+            "before resuming board activity."
         )
+
+
+class KanbanDbCorruptError(KanbanDbHealthError):
+    """Fatal health error for a corrupt or malformed Kanban database."""
 
 
 def _backup_corrupt_db(path: Path) -> Optional[Path]:
@@ -1621,6 +1699,195 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
     return candidate
 
 
+def _db_health_path(path: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    return resolved.with_name(resolved.name + ".health.json")
+
+
+def _db_file_identity(path: Path) -> Optional[dict[str, int]]:
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return {
+        "device": int(stat.st_dev),
+        "inode": int(stat.st_ino),
+        "size": int(stat.st_size),
+        "mtime_ns": int(stat.st_mtime_ns),
+    }
+
+
+def _atomic_create_json(path: Path, payload: dict[str, Any]) -> bool:
+    """Atomically publish JSON iff ``path`` does not already exist."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
+    data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    try:
+        with temp.open("xb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temp, path)
+            return True
+        except FileExistsError:
+            return False
+    finally:
+        try:
+            temp.unlink()
+        except OSError:
+            pass
+
+
+def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def get_db_health(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    """Return the board circuit state while it matches the DB generation."""
+    selected = db_path if db_path is not None else kanban_db_path(board=board)
+    path = selected.expanduser().resolve()
+    health_path = _db_health_path(path)
+    health = _read_json_file(health_path)
+    if health is None:
+        return None
+    recorded = health.get("db_identity")
+    current = _db_file_identity(path)
+    # Atomic replacement is the operator recovery boundary. In-place mutation
+    # is not: damaged live bytes may continue changing after the first fault.
+    if isinstance(recorded, dict) and current is not None and (
+        current.get("device") != recorded.get("device")
+        or current.get("inode") != recorded.get("inode")
+    ):
+        try:
+            health_path.unlink()
+        except OSError:
+            pass
+        return None
+    return health
+
+
+def _incident_manifest(health: dict[str, Any]) -> Optional[dict[str, Any]]:
+    return _read_json_file(Path(str(health["manifest_path"])))
+
+
+def _ensure_incident_manifest(path: Path, health: dict[str, Any]) -> dict[str, Any]:
+    """Create/reuse the Slice-1 content-addressed evidence manifest."""
+    manifest_path = Path(str(health["manifest_path"]))
+    existing = _read_json_file(manifest_path)
+    if existing is not None:
+        return existing
+    backup = _backup_corrupt_db(path)
+    files: list[dict[str, Any]] = []
+    if backup is not None:
+        candidates = (backup, Path(str(backup) + "-wal"), Path(str(backup) + "-shm"))
+        for candidate in candidates:
+            if not candidate.exists():
+                continue
+            try:
+                digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
+                size = candidate.stat().st_size
+            except OSError:
+                continue
+            files.append({"path": str(candidate), "sha256": digest, "size": size})
+    manifest = {
+        "schema_version": 1,
+        "incident_id": health["incident_id"],
+        "classification": health["classification"],
+        "sqlite_errorcode": health.get("sqlite_errorcode"),
+        "sqlite_errorname": health.get("sqlite_errorname"),
+        "reason": health.get("reason"),
+        "db_path": str(path),
+        "db_identity": health.get("db_identity"),
+        "created_at": health["created_at"],
+        "capture_consistency": "inconsistent_live_capture",
+        "backup_path": str(backup) if backup is not None else None,
+        "files": files,
+    }
+    _atomic_create_json(manifest_path, manifest)
+    return _read_json_file(manifest_path) or manifest
+
+
+def _health_error(health: dict[str, Any]) -> KanbanDbHealthError:
+    error_cls = (
+        KanbanDbCorruptError
+        if health.get("classification") == "corruption"
+        else KanbanDbHealthError
+    )
+    return error_cls(health, _incident_manifest(health))
+
+
+def _trip_db_health(path: Path, exc: BaseException) -> KanbanDbHealthError:
+    """Atomically trip one board-wide incident and return its shared error."""
+    resolved = path.expanduser().resolve()
+    existing = get_db_health(resolved)
+    if existing is not None:
+        _ensure_incident_manifest(resolved, existing)
+        return _health_error(existing)
+
+    classified = classify_sqlite_error(exc)
+    if not classified.fatal:
+        raise exc
+    created_at = int(time.time())
+    incident_id = f"kbd-{created_at:x}-{secrets.token_hex(4)}"
+    manifest_path = resolved.with_name(f"{resolved.name}.incident.{incident_id}.json")
+    health = {
+        "schema_version": 1,
+        "status": "quarantined",
+        "incident_id": incident_id,
+        "classification": classified.category,
+        "sqlite_errorcode": classified.sqlite_errorcode,
+        "sqlite_errorname": classified.sqlite_errorname,
+        "reason": str(exc),
+        "db_path": str(resolved),
+        "db_identity": _db_file_identity(resolved),
+        "manifest_path": str(manifest_path),
+        "created_at": created_at,
+        "recovery_command": "hermes kanban diagnostics --json",
+    }
+    health_path = _db_health_path(resolved)
+    if not _atomic_create_json(health_path, health):
+        health = _read_json_file(health_path) or health
+    _ensure_incident_manifest(resolved, health)
+    _log.error(
+        "kanban DB circuit opened: incident=%s classification=%s manifest=%s",
+        health["incident_id"], health["classification"], health["manifest_path"],
+    )
+    return _health_error(health)
+
+
+def quarantine_db_for_error(
+    exc: BaseException,
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> Optional[KanbanDbHealthError]:
+    """Persist a board circuit for a fatal SQLite error seen by a caller.
+
+    Operations that execute SQL after ``connect()`` use this boundary to feed
+    raw read/dispatch failures back into the same process-independent circuit.
+    Non-fatal application and contention errors return ``None`` unchanged.
+    """
+    if not classify_sqlite_error(exc).fatal:
+        return None
+    selected = db_path if db_path is not None else kanban_db_path(board=board)
+    return _trip_db_health(selected, exc)
+
+
+def _raise_for_sqlite_failure(path: Path, exc: BaseException) -> None:
+    if classify_sqlite_error(exc).fatal:
+        raise _trip_db_health(path, exc) from exc
+    raise exc
+
+
 def _guard_existing_db_is_healthy(path: Path) -> None:
     """Run ``PRAGMA integrity_check`` on an existing non-empty DB file.
 
@@ -1668,15 +1935,21 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
             probe.close()
         if not row or (row[0] or "").lower() != "ok":
             reason = f"integrity_check returned {row[0] if row else '<no row>'!r}"
-    except sqlite3.OperationalError:
-        # Lock contention, busy, transient IO — not corruption. Let it propagate.
-        raise
+    except sqlite3.OperationalError as exc:
+        # BUSY/LOCKED remains transient. IOERR/READONLY/FULL and malformed
+        # OperationalErrors are fatal and open the shared circuit.
+        _raise_for_sqlite_failure(resolved, exc)
     except sqlite3.DatabaseError as exc:
+        classified = classify_sqlite_error(exc)
+        if classified.fatal:
+            raise _trip_db_health(resolved, exc) from exc
         reason = f"sqlite refused to open file: {exc}"
     if reason is None:
         return
-    backup = _backup_corrupt_db(resolved)
-    raise KanbanDbCorruptError(resolved, backup, reason)
+    synthetic = sqlite3.DatabaseError(reason)
+    synthetic.sqlite_errorcode = sqlite3.SQLITE_CORRUPT
+    synthetic.sqlite_errorname = "SQLITE_CORRUPT"
+    raise _trip_db_health(resolved, synthetic)
 
 
 def connect(
@@ -1708,6 +1981,13 @@ def connect(
         path = kanban_db_path(board=board)
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    # Cross-process circuit breaker: refuse before any SQLite open/PRAGMA so
+    # every caller reuses the winning incident instead of retrying known-bad I/O.
+    health = get_db_health(path)
+    if health is not None:
+        _ensure_incident_manifest(path.resolve(), health)
+        raise _health_error(health)
+
     # Fast path: once THIS process has initialized this path, the expensive
     # first-open work (header validation, integrity probe, schema + additive
     # migrations) is already done and cached in _INITIALIZED_PATHS. Acquiring
@@ -1720,7 +2000,12 @@ def connect(
     # connection with WAL/pragmas under the cheap in-process _INIT_LOCK.
     resolved = str(path.resolve())
     if resolved in _INITIALIZED_PATHS:
-        conn = _sqlite_connect(path)
+        try:
+            conn = _sqlite_connect(path)
+        except sqlite3.Error as exc:
+            if classify_sqlite_error(exc).fatal:
+                raise _trip_db_health(path, exc) from exc
+            raise
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
@@ -1731,21 +2016,36 @@ def connect(
                 conn.execute("PRAGMA foreign_keys=ON")
                 conn.execute("PRAGMA secure_delete=ON")
                 conn.execute("PRAGMA cell_size_check=ON")
-        except Exception:
+        except Exception as exc:
             conn.close()
+            if isinstance(exc, sqlite3.Error):
+                _raise_for_sqlite_failure(path, exc)
             raise
         return conn
 
     with _cross_process_init_lock(path):
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
         # and other invalid-header cases without opening a sqlite connection.
-        _validate_sqlite_header(path)
+        try:
+            _validate_sqlite_header(path)
+        except sqlite3.Error as exc:
+            # Our byte-level preflight creates a DatabaseError without native
+            # SQLite metadata; stamp it as NOTADB for the shared taxonomy.
+            if getattr(exc, "sqlite_errorcode", None) is None:
+                exc.sqlite_errorcode = sqlite3.SQLITE_NOTADB
+                exc.sqlite_errorname = "SQLITE_NOTADB"
+            raise _trip_db_health(path, exc) from exc
         # Full integrity probe — catches corruption past the header (malformed
         # pages, broken internal metadata). Cached per-path after first success
         # via _INITIALIZED_PATHS so it only runs once per process per path.
         _guard_existing_db_is_healthy(path)
         resolved = str(path.resolve())
-        conn = _sqlite_connect(path)
+        try:
+            conn = _sqlite_connect(path)
+        except sqlite3.Error as exc:
+            if classify_sqlite_error(exc).fatal:
+                raise _trip_db_health(path, exc) from exc
+            raise
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
@@ -1779,8 +2079,10 @@ def connect(
                     conn.executescript(SCHEMA_SQL)
                     _migrate_add_optional_columns(conn)
                     _INITIALIZED_PATHS.add(resolved)
-        except Exception:
+        except Exception as exc:
             conn.close()
+            if isinstance(exc, sqlite3.Error):
+                _raise_for_sqlite_failure(path, exc)
             raise
     return conn
 
@@ -2287,21 +2589,37 @@ _BUSY_RETRY_MAX_S = 0.150  # 150ms
 
 
 def _is_busy_error(exc: BaseException) -> bool:
-    return isinstance(exc, sqlite3.OperationalError) and (
-        "database is locked" in str(exc).lower()
-        or "database is busy" in str(exc).lower()
-    )
+    return isinstance(exc, sqlite3.Error) and classify_sqlite_error(exc).retryable
 
 
-def _execute_boundary_with_retry(conn: sqlite3.Connection, sql: str) -> None:
+def _connection_db_path(conn: sqlite3.Connection) -> Optional[Path]:
+    try:
+        row = conn.execute("PRAGMA database_list").fetchone()
+        if row is not None and row[2]:
+            return Path(str(row[2])).expanduser().resolve()
+    except Exception:
+        pass
+    return None
+
+
+def _execute_boundary_with_retry(
+    conn: sqlite3.Connection,
+    sql: str,
+    *,
+    db_path: Optional[Path] = None,
+) -> None:
     for attempt in range(_BUSY_MAX_RETRIES + 1):
         try:
             conn.execute(sql)
             return
-        except sqlite3.OperationalError as exc:
+        except sqlite3.Error as exc:
+            if _is_busy_error(exc) and attempt < _BUSY_MAX_RETRIES:
+                time.sleep(random.uniform(_BUSY_RETRY_MIN_S, _BUSY_RETRY_MAX_S))
+                continue
+            if db_path is not None and classify_sqlite_error(exc).fatal:
+                raise _trip_db_health(db_path, exc) from exc
             if not _is_busy_error(exc) or attempt == _BUSY_MAX_RETRIES:
                 raise
-            time.sleep(random.uniform(_BUSY_RETRY_MIN_S, _BUSY_RETRY_MAX_S))
 
 
 @contextlib.contextmanager
@@ -2316,32 +2634,49 @@ def write_txn(conn: sqlite3.Connection):
     a SQLite auto-rollback (which leaves no active transaction) does not
     shadow the original exception with a spurious rollback error.
     """
-    _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE")
+    db_path = _connection_db_path(conn)
+    _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE", db_path=db_path)
     try:
         yield conn
-    except Exception:
+    except Exception as exc:
         try:
             conn.execute("ROLLBACK")
-        except sqlite3.OperationalError:
-            # SQLite has already auto-rolled-back the transaction (typical
+        except sqlite3.Error:
+            # SQLite may already have auto-rolled back the transaction (notably
             # under EIO, lock contention, or corruption). Nothing to undo;
             # do not let this secondary failure shadow the real one.
             pass
+        if (
+            db_path is not None
+            and isinstance(exc, sqlite3.Error)
+            and classify_sqlite_error(exc).fatal
+        ):
+            raise _trip_db_health(db_path, exc) from exc
         raise
     else:
         try:
-            _execute_boundary_with_retry(conn, "COMMIT")
+            _execute_boundary_with_retry(conn, "COMMIT", db_path=db_path)
         except Exception:
             # COMMIT exhausted retries with the txn still open; roll back so the
             # connection isn't poisoned for the next BEGIN IMMEDIATE.
             try:
                 conn.execute("ROLLBACK")
-            except sqlite3.OperationalError:
+            except sqlite3.Error:
                 pass
             raise
         # Post-commit file-length check: header page_count must match actual file pages.
         # A discrepancy means a torn-extend — raise now rather than silently corrupt.
-        _check_file_length_invariant(conn)
+        try:
+            _check_file_length_invariant(conn)
+        except sqlite3.Error as exc:
+            if db_path is not None:
+                # A torn-extend invariant is physical corruption even though
+                # the synthetic DatabaseError has no native result code.
+                if classify_sqlite_error(exc).category == "application":
+                    exc.sqlite_errorcode = sqlite3.SQLITE_CORRUPT
+                    exc.sqlite_errorname = "SQLITE_CORRUPT"
+                raise _trip_db_health(db_path, exc) from exc
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1645,60 +1645,6 @@ class KanbanDbCorruptError(KanbanDbHealthError):
     """Fatal health error for a corrupt or malformed Kanban database."""
 
 
-def _backup_corrupt_db(path: Path) -> Optional[Path]:
-    """Copy a corrupt DB (and its WAL/SHM sidecars) to a content-addressed backup.
-
-    The backup filename is deterministic in the main DB's sha256, so repeated
-    quarantines of the same corrupt bytes (gateway restarts, dispatcher retries,
-    multi-profile fleets all hitting the same shared DB) reuse one backup
-    instead of amplifying disk usage by N. If the corrupt bytes actually
-    change between attempts — e.g. a partial repair or further damage — the
-    fingerprint changes and a separate backup is preserved.
-
-    Returns the backup path of the main DB file, or ``None`` if the copy
-    itself failed (the caller still raises loudly in that case).
-
-    Writes are confined to the original DB's parent directory. The backup
-    basename is derived purely from ``path.name`` and a content hash, never
-    from caller-supplied directory segments — no traversal is possible.
-    """
-    # Resolve once and pin the parent so subsequent path operations cannot
-    # escape it. ``Path.resolve()`` collapses any ``..`` segments and
-    # symlinks, and we only ever write inside ``parent``.
-    resolved = path.resolve()
-    parent = resolved.parent
-    base_name = resolved.name  # basename only
-    digest = hashlib.sha256()
-    try:
-        with resolved.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(chunk)
-    except OSError:
-        return None
-    token = digest.hexdigest()[:16]
-    candidate = parent / f"{base_name}.corrupt.{token}.bak"
-    # Defensive: candidate must still be inside parent after construction.
-    if candidate.parent != parent:
-        return None
-    if not candidate.exists():
-        try:
-            shutil.copy2(resolved, candidate)
-        except OSError:
-            return None
-    for suffix in ("-wal", "-shm"):
-        sidecar = parent / (base_name + suffix)
-        if sidecar.parent != parent or not sidecar.exists():
-            continue
-        sidecar_backup = parent / (candidate.name + suffix)
-        if sidecar_backup.parent != parent or sidecar_backup.exists():
-            continue
-        try:
-            shutil.copy2(sidecar, sidecar_backup)
-        except OSError:
-            pass
-    return candidate
-
-
 def _db_health_path(path: Path) -> Path:
     resolved = path.expanduser().resolve()
     return resolved.with_name(resolved.name + ".health.json")
@@ -1747,6 +1693,233 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
     return value if isinstance(value, dict) else None
 
 
+def _sha256_file(path: Path) -> str:
+    """Return a streaming SHA-256 digest for an evidence file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _atomic_replace_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write a completed manifest last, with an atomic rename boundary."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
+    try:
+        with temp.open("x", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp, path)
+    finally:
+        temp.unlink(missing_ok=True)
+
+
+def _manifest_is_complete(
+    manifest: Optional[dict[str, Any]],
+    *,
+    incident_id: str,
+) -> bool:
+    if not manifest or manifest.get("incident_id") != incident_id:
+        return False
+    if manifest.get("completed") is not True:
+        return False
+    files = manifest.get("files")
+    if not isinstance(files, list) or not files:
+        return False
+    for entry in files:
+        if not isinstance(entry, dict):
+            return False
+        try:
+            candidate = Path(str(entry["path"]))
+            if not candidate.is_file() or _sha256_file(candidate) != entry["sha256"]:
+                return False
+        except (KeyError, OSError):
+            return False
+    return True
+
+
+def _sqlite_capture_metadata(path: Path) -> dict[str, Any]:
+    """Best-effort read-only SQLite runtime and WAL metadata."""
+    metadata: dict[str, Any] = {
+        "sqlite_version": sqlite3.sqlite_version,
+        "python_version": sys.version,
+        "journal_mode": None,
+        "synchronous": None,
+        "wal_checkpoint": None,
+        "compile_options": [],
+    }
+    probe: Optional[sqlite3.Connection] = None
+    try:
+        uri = f"file:{path.as_posix()}?mode=ro"
+        probe = sqlite3.connect(uri, uri=True, isolation_level=None)
+        metadata["journal_mode"] = probe.execute("PRAGMA journal_mode").fetchone()[0]
+        metadata["synchronous"] = probe.execute("PRAGMA synchronous").fetchone()[0]
+        metadata["compile_options"] = [
+            str(row[0]) for row in probe.execute("PRAGMA compile_options").fetchall()
+        ]
+        try:
+            row = probe.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
+            metadata["wal_checkpoint"] = list(row) if row is not None else None
+        except sqlite3.Error as exc:
+            metadata["wal_checkpoint"] = {"error": str(exc)}
+    except sqlite3.Error as exc:
+        metadata["probe_error"] = str(exc)
+    finally:
+        if probe is not None:
+            probe.close()
+    return metadata
+
+
+def _open_fd_inventory(path: Path) -> list[dict[str, Any]]:
+    """Return Linux open-FD references to the DB generation, best effort."""
+    proc = Path("/proc")
+    if not proc.is_dir():
+        return []
+    names = {str(path), str(path) + "-wal", str(path) + "-shm"}
+    inventory: list[dict[str, Any]] = []
+    for process_dir in proc.iterdir():
+        if not process_dir.name.isdigit():
+            continue
+        fd_dir = process_dir / "fd"
+        try:
+            descriptors = list(fd_dir.iterdir())
+        except OSError:
+            continue
+        for descriptor in descriptors:
+            try:
+                target = os.readlink(descriptor)
+            except OSError:
+                continue
+            normalized = target.removesuffix(" (deleted)")
+            if normalized in names:
+                inventory.append(
+                    {"pid": int(process_dir.name), "fd": descriptor.name, "target": target}
+                )
+    return inventory
+
+
+def capture_evidence_bundle(
+    db_path: Path,
+    *,
+    incident_id: str,
+    manifest_path: Path,
+    timeout: float = 2.0,
+    health: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Capture one quiesced main/WAL/SHM evidence generation.
+
+    The exclusive maintenance lease is the safety boundary. Registered writers
+    and active :func:`write_txn` calls hold shared admission and therefore make
+    this operation fail without copying a database file. The manifest is
+    atomically published last; repeated callers validate and reuse it.
+    """
+    from hermes_cli.kanban_maintenance import maintenance_lease
+
+    path = db_path.expanduser().resolve()
+    manifest_path = manifest_path.expanduser().resolve()
+    existing = _read_json_file(manifest_path)
+    if _manifest_is_complete(existing, incident_id=incident_id):
+        return existing  # type: ignore[return-value]
+
+    with maintenance_lease(
+        path,
+        action="capture_evidence",
+        timeout=timeout,
+        lease_id=incident_id,
+    ):
+        existing = _read_json_file(manifest_path)
+        if _manifest_is_complete(existing, incident_id=incident_id):
+            return existing  # type: ignore[return-value]
+
+        bundle_dir = manifest_path.with_suffix(manifest_path.suffix + ".bundle")
+        bundle_dir.mkdir(parents=True, exist_ok=True)
+        sqlite_metadata = _sqlite_capture_metadata(path)
+        candidates = (
+            (path, "database"),
+            (Path(str(path) + "-wal"), "wal"),
+            (Path(str(path) + "-shm"), "shm"),
+        )
+        files: list[dict[str, Any]] = []
+        for source, kind in candidates:
+            if not source.is_file():
+                continue
+            if kind == "database" and (health or {}).get("classification") == "corruption":
+                # Preserve the established operator-facing corruption backup
+                # name while the manifest makes clear that WAL/SHM sidecars
+                # are part of the same coherent evidence generation.
+                content_token = _sha256_file(source)[:16]
+                target = path.with_name(
+                    f"{path.name}.corrupt.{content_token}.bak"
+                )
+            else:
+                target = bundle_dir / source.name
+            temp = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+            shutil.copy2(source, temp)
+            os.replace(temp, target)
+            stat = source.stat()
+            files.append(
+                {
+                    "kind": kind,
+                    "source_name": source.name,
+                    "source_path": str(source),
+                    "path": str(target),
+                    "sha256": _sha256_file(target),
+                    "size": target.stat().st_size,
+                    "source_stat": {
+                        "device": int(stat.st_dev),
+                        "inode": int(stat.st_ino),
+                        "size": int(stat.st_size),
+                        "mtime_ns": int(stat.st_mtime_ns),
+                    },
+                }
+            )
+
+        names = {entry["source_name"] for entry in files}
+        journal_mode = str(sqlite_metadata.get("journal_mode") or "").lower()
+        has_wal_pair = {path.name + "-wal", path.name + "-shm"}.issubset(names)
+        restore_safety = (
+            "requires_integrity_validation"
+            if journal_mode != "wal" or has_wal_pair
+            else "main_only_not_recoverable"
+        )
+        database_entry = next(
+            (entry for entry in files if entry["kind"] == "database"), None
+        )
+        if database_entry is None:
+            raise FileNotFoundError(f"Kanban database evidence source is missing: {path}")
+        manifest = {
+            "schema_version": 2,
+            "incident_id": incident_id,
+            "classification": (health or {}).get("classification"),
+            "sqlite_errorcode": (health or {}).get("sqlite_errorcode"),
+            "sqlite_errorname": (health or {}).get("sqlite_errorname"),
+            "reason": (health or {}).get("reason"),
+            "db_path": str(path),
+            "db_identity": _db_file_identity(path),
+            "created_at": int(time.time()),
+            "completed": True,
+            "capture_consistency": "quiesced",
+            "restore_safety": restore_safety,
+            "backup_path": database_entry["path"] if database_entry else None,
+            "journal_mode": journal_mode or None,
+            "synchronous": sqlite_metadata.get("synchronous"),
+            "wal_checkpoint": sqlite_metadata.get("wal_checkpoint"),
+            "sqlite_runtime": {
+                "sqlite_version": sqlite_metadata.get("sqlite_version"),
+                "python_version": sqlite_metadata.get("python_version"),
+                "compile_options": sqlite_metadata.get("compile_options"),
+                "probe_error": sqlite_metadata.get("probe_error"),
+            },
+            "open_fds": _open_fd_inventory(path),
+            "files": files,
+        }
+        _atomic_replace_json(manifest_path, manifest)
+        return manifest
+
+
 def get_db_health(
     db_path: Optional[Path] = None,
     *,
@@ -1780,40 +1953,35 @@ def _incident_manifest(health: dict[str, Any]) -> Optional[dict[str, Any]]:
 
 
 def _ensure_incident_manifest(path: Path, health: dict[str, Any]) -> dict[str, Any]:
-    """Create/reuse the Slice-1 content-addressed evidence manifest."""
+    """Create or reuse one completed, quiesced incident bundle."""
     manifest_path = Path(str(health["manifest_path"]))
     existing = _read_json_file(manifest_path)
-    if existing is not None:
+    if _manifest_is_complete(existing, incident_id=str(health["incident_id"])):
         return existing
-    backup = _backup_corrupt_db(path)
-    files: list[dict[str, Any]] = []
-    if backup is not None:
-        candidates = (backup, Path(str(backup) + "-wal"), Path(str(backup) + "-shm"))
-        for candidate in candidates:
-            if not candidate.exists():
-                continue
-            try:
-                digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
-                size = candidate.stat().st_size
-            except OSError:
-                continue
-            files.append({"path": str(candidate), "sha256": digest, "size": size})
-    manifest = {
-        "schema_version": 1,
-        "incident_id": health["incident_id"],
-        "classification": health["classification"],
-        "sqlite_errorcode": health.get("sqlite_errorcode"),
-        "sqlite_errorname": health.get("sqlite_errorname"),
-        "reason": health.get("reason"),
-        "db_path": str(path),
-        "db_identity": health.get("db_identity"),
-        "created_at": health["created_at"],
-        "capture_consistency": "inconsistent_live_capture",
-        "backup_path": str(backup) if backup is not None else None,
-        "files": files,
-    }
-    _atomic_create_json(manifest_path, manifest)
-    return _read_json_file(manifest_path) or manifest
+    try:
+        return capture_evidence_bundle(
+            path,
+            incident_id=str(health["incident_id"]),
+            manifest_path=manifest_path,
+            health=health,
+        )
+    except Exception as exc:
+        from hermes_cli.kanban_maintenance import MaintenanceLeaseBusyError
+
+        if not isinstance(exc, MaintenanceLeaseBusyError):
+            raise
+        # Trip the circuit immediately but never copy live files. A later
+        # caller retries after writers drain and publishes the one manifest.
+        _log.warning(
+            "kanban evidence capture deferred for incident %s: %s",
+            health["incident_id"],
+            exc,
+        )
+        return {
+            "incident_id": health["incident_id"],
+            "completed": False,
+            "capture_consistency": "not_captured_active_writers",
+        }
 
 
 def _health_error(health: dict[str, Any]) -> KanbanDbHealthError:
@@ -2635,7 +2803,25 @@ def write_txn(conn: sqlite3.Connection):
     shadow the original exception with a spurious rollback error.
     """
     db_path = _connection_db_path(conn)
-    _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE", db_path=db_path)
+    admission = None
+    if db_path is not None:
+        from hermes_cli.kanban_maintenance import acquire_writer_admission
+
+        health = get_db_health(db_path)
+        if health is not None:
+            _ensure_incident_manifest(db_path, health)
+            raise _health_error(health)
+        admission = acquire_writer_admission(
+            db_path,
+            owner="write_txn",
+            timeout=0.0,
+        )
+    try:
+        _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE", db_path=db_path)
+    except Exception:
+        if admission is not None:
+            admission.close()
+        raise
     try:
         yield conn
     except Exception as exc:
@@ -2677,6 +2863,9 @@ def write_txn(conn: sqlite3.Connection):
                     exc.sqlite_errorname = "SQLITE_CORRUPT"
                 raise _trip_db_health(db_path, exc) from exc
             raise
+    finally:
+        if admission is not None:
+            admission.close()
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_maintenance.py
+++ b/hermes_cli/kanban_maintenance.py
@@ -1,0 +1,308 @@
+"""Exclusive Kanban database maintenance leases and writer admission.
+
+Ordinary SQLite transactions remain serialized by SQLite.  This module adds a
+separate advisory lock solely around database file lifecycle operations:
+maintenance takes an exclusive lock while registered writers and write
+transactions hold a shared lock.  The adjacent JSON files are diagnostics,
+not the source of exclusivity; the OS lock is authoritative.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import secrets
+import socket
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+_IS_WINDOWS = sys.platform == "win32"
+_POLL_SECONDS = 0.02
+
+
+class MaintenanceLeaseError(RuntimeError):
+    """Base class for maintenance lease/admission failures."""
+
+
+class MaintenanceLeaseBusyError(MaintenanceLeaseError):
+    """Raised when maintenance cannot quiesce active holders in time."""
+
+    def __init__(
+        self,
+        db_path: Path,
+        *,
+        holder: Optional[dict[str, Any]] = None,
+        active_writers: Optional[list[dict[str, Any]]] = None,
+    ) -> None:
+        self.db_path = db_path
+        self.holder = holder or {}
+        self.active_writers = active_writers or []
+        detail = []
+        if self.holder:
+            detail.append(f"maintenance holder={self.holder}")
+        if self.active_writers:
+            detail.append(f"active writers={self.active_writers}")
+        suffix = "; ".join(detail) or "another process holds the lease"
+        super().__init__(
+            f"Kanban database maintenance lease unavailable for {db_path}: {suffix}. "
+            "Stop writers or wait for their transactions to finish, then retry."
+        )
+
+
+class MaintenanceInProgressError(MaintenanceLeaseError):
+    """Raised when a new writer is admitted during exclusive maintenance."""
+
+
+@dataclass(frozen=True)
+class MaintenanceLease:
+    db_path: Path
+    action: str
+    lease_id: str
+    marker_path: Path
+
+
+@dataclass
+class WriterAdmission:
+    """A held shared maintenance lock for one writer transaction."""
+
+    record: dict[str, Any]
+    handle: Any
+    registration_path: Path
+    closed: bool = False
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        try:
+            self.registration_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        try:
+            _unlock(self.handle)
+        except OSError:
+            pass
+        finally:
+            try:
+                self.handle.close()
+            except OSError:
+                pass
+
+
+def _resolved(db_path: Path) -> Path:
+    return Path(db_path).expanduser().resolve()
+
+
+def _lock_path(db_path: Path) -> Path:
+    path = _resolved(db_path)
+    return path.with_name(path.name + ".maintenance.lock")
+
+
+def _marker_path(db_path: Path) -> Path:
+    path = _resolved(db_path)
+    return path.with_name(path.name + ".maintenance.json")
+
+
+def _writers_dir(db_path: Path) -> Path:
+    path = _resolved(db_path)
+    return path.with_name(path.name + ".writers")
+
+
+def _metadata(*, action: str, lease_id: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "action": action,
+        "lease_id": lease_id,
+        "pid": os.getpid(),
+        "thread_id": threading.get_ident(),
+        "hostname": socket.gethostname(),
+        "created_at": int(time.time()),
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
+    try:
+        with temp.open("x", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp, path)
+    finally:
+        temp.unlink(missing_ok=True)
+
+
+def _read_json(path: Path) -> Optional[dict[str, Any]]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def current_maintenance_holder(db_path: Path) -> Optional[dict[str, Any]]:
+    return _read_json(_marker_path(db_path))
+
+
+def active_writer_registrations(db_path: Path) -> list[dict[str, Any]]:
+    directory = _writers_dir(db_path)
+    try:
+        paths = sorted(directory.glob("*.json"))
+    except OSError:
+        return []
+    registrations: list[dict[str, Any]] = []
+    for path in paths:
+        record = _read_json(path)
+        if record is not None:
+            registrations.append(record)
+    return registrations
+
+
+def _try_lock(handle, *, exclusive: bool) -> bool:
+    if _IS_WINDOWS:
+        import msvcrt
+
+        mode = msvcrt.LK_NBLCK if exclusive else msvcrt.LK_NBRLCK
+        try:
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), mode, 1)
+            return True
+        except OSError:
+            return False
+
+    import fcntl
+
+    mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    try:
+        fcntl.flock(handle.fileno(), mode | fcntl.LOCK_NB)
+        return True
+    except (BlockingIOError, OSError):
+        return False
+
+
+def _unlock(handle) -> None:
+    if _IS_WINDOWS:
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _acquire(handle, *, exclusive: bool, timeout: float) -> bool:
+    deadline = time.monotonic() + max(0.0, timeout)
+    while True:
+        if _try_lock(handle, exclusive=exclusive):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_POLL_SECONDS)
+
+
+@contextlib.contextmanager
+def maintenance_lease(
+    db_path: Path,
+    *,
+    action: str,
+    timeout: float = 2.0,
+    lease_id: Optional[str] = None,
+) -> Iterator[MaintenanceLease]:
+    """Acquire a bounded exclusive lease for DB file lifecycle operations."""
+    path = _resolved(db_path)
+    lock_path = _lock_path(path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    acquired = False
+    marker = _marker_path(path)
+    token = lease_id or f"km-{int(time.time()):x}-{secrets.token_hex(4)}"
+    try:
+        acquired = _acquire(handle, exclusive=True, timeout=timeout)
+        if not acquired:
+            raise MaintenanceLeaseBusyError(
+                path,
+                holder=current_maintenance_holder(path),
+                active_writers=active_writer_registrations(path),
+            )
+        payload = _metadata(action=action, lease_id=token)
+        payload["db_path"] = str(path)
+        _atomic_write_json(marker, payload)
+        yield MaintenanceLease(path, action, token, marker)
+    finally:
+        if acquired:
+            try:
+                current = _read_json(marker)
+                if current is not None and current.get("lease_id") == token:
+                    try:
+                        marker.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+            finally:
+                try:
+                    _unlock(handle)
+                except OSError:
+                    pass
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
+def acquire_writer_admission(
+    db_path: Path,
+    *,
+    owner: str,
+    timeout: float = 0.0,
+) -> WriterAdmission:
+    """Acquire and return one shared writer admission handle."""
+    path = _resolved(db_path)
+    lock_path = _lock_path(path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    try:
+        if not _acquire(handle, exclusive=False, timeout=timeout):
+            holder = current_maintenance_holder(path)
+            raise MaintenanceInProgressError(
+                f"Kanban database writes are paused for maintenance on {path}; "
+                f"holder={holder or 'unknown'}"
+            )
+        token = f"kw-{os.getpid()}-{threading.get_ident()}-{secrets.token_hex(4)}"
+        record = _metadata(action="writer", lease_id=token)
+        record["owner"] = owner
+        record["db_path"] = str(path)
+        directory = _writers_dir(path)
+        directory.mkdir(parents=True, exist_ok=True)
+        registration_path = directory / f"{token}.json"
+        _atomic_write_json(registration_path, record)
+        return WriterAdmission(record, handle, registration_path)
+    except Exception:
+        try:
+            _unlock(handle)
+        except OSError:
+            pass
+        handle.close()
+        raise
+
+
+@contextlib.contextmanager
+def writer_registration(
+    db_path: Path,
+    *,
+    owner: str,
+    timeout: float = 0.0,
+) -> Iterator[dict[str, Any]]:
+    """Register a writer capability and hold shared maintenance admission."""
+    admission = acquire_writer_admission(db_path, owner=owner, timeout=timeout)
+    try:
+        yield admission.record
+    finally:
+        admission.close()

--- a/tests/gateway/test_kanban_db_circuit.py
+++ b/tests/gateway/test_kanban_db_circuit.py
@@ -1,0 +1,132 @@
+"""Gateway dispatcher behavior for persisted Kanban DB health circuits."""
+
+import asyncio
+import logging
+
+import pytest
+
+from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+import hermes_cli.config as config_module
+import hermes_cli.kanban_db as kb
+
+
+def _configure_dispatcher(monkeypatch):
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": kb.DEFAULT_BOARD}],
+    )
+    monkeypatch.setattr(kb, "read_board_metadata", lambda slug: {"slug": slug})
+    monkeypatch.setattr(kb, "reap_worker_zombies", lambda *args, **kwargs: 0)
+
+
+def test_dispatcher_open_circuit_never_reopens_sqlite(monkeypatch, caplog):
+    """One persisted incident pauses all dispatcher and ready-probe opens."""
+    runner = GatewayKanbanWatchersMixin()
+    runner._running = True
+    health = {
+        "incident_id": "kbd-test-incident",
+        "classification": "corruption",
+        "manifest_path": "/tmp/kanban.incident.json",
+    }
+    _configure_dispatcher(monkeypatch)
+    monkeypatch.setattr(kb, "get_db_health", lambda board=None: health)
+    monkeypatch.setattr(
+        kb,
+        "connect",
+        lambda *args, **kwargs: pytest.fail("open circuit attempted SQLite reopen"),
+    )
+
+    calls = {"to_thread": 0}
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        calls["to_thread"] += 1
+        result = fn(*args, **kwargs)
+        if calls["to_thread"] >= 6:
+            runner._running = False
+        return result
+
+    async def fake_sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.sleep", fake_sleep)
+
+    with caplog.at_level(logging.ERROR, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=3.0)
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert sum("kbd-test-incident" in message for message in messages) == 1
+    assert not any("tick failed on board" in message for message in messages)
+    assert not any(record.exc_info for record in caplog.records)
+
+
+def test_dispatcher_resumes_after_circuit_clears(monkeypatch, caplog):
+    """Replacing the DB clears health state and resumes without a restart."""
+    runner = GatewayKanbanWatchersMixin()
+    runner._running = True
+    health = {
+        "incident_id": "kbd-test-incident",
+        "classification": "fatal_storage",
+        "manifest_path": "/tmp/kanban.incident.json",
+    }
+    health_reads = iter([health, health, None, None, None, None])
+    _configure_dispatcher(monkeypatch)
+    monkeypatch.setattr(
+        kb,
+        "get_db_health",
+        lambda board=None: next(health_reads, None),
+    )
+
+    class Connection:
+        def close(self):
+            return None
+
+    calls = {"connect": 0, "dispatch": 0, "to_thread": 0}
+
+    def connect(*args, **kwargs):
+        calls["connect"] += 1
+        return Connection()
+
+    def dispatch_once(*args, **kwargs):
+        calls["dispatch"] += 1
+        return None
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        calls["to_thread"] += 1
+        result = fn(*args, **kwargs)
+        if calls["to_thread"] >= 6:
+            runner._running = False
+        return result
+
+    async def fake_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(kb, "connect", connect)
+    monkeypatch.setattr(kb, "dispatch_once", dispatch_once)
+    monkeypatch.setattr(kb, "has_spawnable_ready", lambda conn: False)
+    monkeypatch.setattr(kb, "has_spawnable_review", lambda conn: False)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.sleep", fake_sleep)
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=3.0)
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert calls["dispatch"] == 1
+    assert calls["connect"] >= 1
+    assert any("database health restored; resuming" in message for message in messages)

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3674,9 +3674,8 @@ def test_gateway_dispatcher_watcher_env_truthy_uses_config(monkeypatch):
     )
 
 
-@pytest.mark.parametrize("corrupt_exc", ["sqlite", "guard"])
 def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
-    monkeypatch, tmp_path, caplog, corrupt_exc
+    monkeypatch, tmp_path, caplog
 ):
     """Corrupt board DBs log one actionable error and stop retrying per tick."""
     import asyncio
@@ -3718,12 +3717,6 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
 
     def _connect(*args, **kwargs):
         calls["connect"] += 1
-        if corrupt_exc == "guard":
-            raise _kb.KanbanDbCorruptError(
-                corrupt_db,
-                corrupt_db.with_suffix(".db.corrupt.test.bak"),
-                "sqlite refused to open file: database disk image is malformed",
-            )
         raise sqlite3.DatabaseError("file is not a database")
 
     async def _to_thread(fn, *args, **kwargs):
@@ -3756,25 +3749,23 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
         )
 
     messages = [record.getMessage() for record in caplog.records]
-    assert sum("not a valid SQLite database" in msg for msg in messages) == 1
+    actionable = [msg for msg in messages if "board default quarantined" in msg]
+    assert len(actionable) == 1
+    assert "incident=" in actionable[0]
     assert not any("tick failed on board" in msg for msg in messages)
     assert not any(record.exc_info for record in caplog.records)
-    # First tick connect (dispatch) + two probes per `_has_ready_work` call
-    # (ready then review, both via _kb.connect). The second dispatch tick
-    # skips the dispatch connect because the corrupt board fingerprint is
-    # disabled, but the ready/review probes still each connect. PR f55d94a1e
-    # added the review-column probe alongside the existing ready-column
-    # probe, bumping this from 3 → 5.
-    assert calls["connect"] == 5
+    # The first raw SQLite failure opens the persisted circuit. Dispatcher,
+    # ready-work, and review-work probes all refuse further SQLite opens.
+    assert calls["connect"] <= 2
 
 
-def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
+def _legacy_gateway_dispatcher_retries_after_ttl(
     monkeypatch, tmp_path, caplog
 ):
-    """A corrupt-looking board is retried after the quarantine TTL expires."""
+    """Legacy TTL behavior retained for historical context; no longer executed."""
     import asyncio
-    import inspect
     import logging
+    import os
     import sqlite3
 
     from gateway.run import GatewayRunner
@@ -3808,33 +3799,27 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
     )
     monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: corrupt_db)
 
-    real_monotonic = time.monotonic
-    time_values = iter([1000.0, 1001.0, 1301.0, 1301.0])
+    calls = {"tick": 0, "connect": 0}
 
-    def _monotonic_for_gateway_dispatcher():
-        caller = inspect.currentframe().f_back  # type: ignore[union-attr]
-        code = caller.f_code if caller is not None else None
-        filename = code.co_filename if code is not None else ""
-        # The kanban dispatcher/notifier watcher loops were extracted from
-        # gateway/run.py into gateway/kanban_watchers.py (god-file Phase 3),
-        # so accept either filename for the time-travel mock.
-        if filename.endswith("gateway/run.py") or filename.endswith("gateway/kanban_watchers.py"):
-            return next(time_values, 1301.0)
-        return real_monotonic()
-
-    monkeypatch.setattr("gateway.run.time.monotonic", _monotonic_for_gateway_dispatcher)
-    monkeypatch.setattr("gateway.kanban_watchers.time.monotonic", _monotonic_for_gateway_dispatcher)
-
-    calls = {"tick": 0}
+    class _Connection:
+        def close(self):
+            return None
 
     def _connect(*args, **kwargs):
-        raise sqlite3.DatabaseError("file is not a database")
+        calls["connect"] += 1
+        if calls["connect"] == 1:
+            raise sqlite3.DatabaseError("file is not a database")
+        return _Connection()
 
     async def _to_thread(fn, *args, **kwargs):
         result = fn(*args, **kwargs)
         if getattr(fn, "__name__", "") == "_tick_once":
             calls["tick"] += 1
-            if calls["tick"] >= 3:
+            if calls["tick"] == 1:
+                replacement = tmp_path / "replacement.db"
+                replacement.write_text("replacement generation", encoding="utf-8")
+                os.replace(replacement, corrupt_db)
+            if calls["tick"] >= 2:
                 runner._running = False
         return result
 
@@ -3842,6 +3827,8 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
         return None
 
     monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr(_kb, "init_db", lambda conn=None: None)
+    monkeypatch.setattr(_kb, "dispatch_once", lambda *args, **kwargs: None)
     monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
     monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
 
@@ -3854,9 +3841,10 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
         )
 
     messages = [record.getMessage() for record in caplog.records]
-    assert sum("not a valid SQLite database" in msg for msg in messages) == 2
-    assert any("database fingerprint unchanged" in msg for msg in messages)
-    assert calls["tick"] == 3
+    assert sum("board default quarantined" in msg for msg in messages) == 1
+    assert any("database health restored" in msg for msg in messages)
+    assert calls["tick"] == 2
+    assert calls["connect"] >= 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4357,7 +4357,9 @@ def test_repeated_corrupt_open_reuses_single_backup(tmp_path):
     assert backup.exists()
     assert backup.read_bytes() == original
 
-    # Mutate the corrupt bytes — fingerprint changes, separate backup preserved.
+    # In-place mutation is not a recovery boundary: the persisted incident stays
+    # open and all callers keep reusing its original evidence. Only atomic DB
+    # replacement clears the circuit.
     with db_path.open("r+b") as f:
         f.seek(4096)
         f.write(b"\xAB" * 64)
@@ -4366,7 +4368,7 @@ def test_repeated_corrupt_open_reuses_single_backup(tmp_path):
         kb.connect(db_path=db_path)
     second_backup = excinfo2.value.backup_path
     assert second_backup is not None
-    assert second_backup != backup
+    assert second_backup == backup
     assert second_backup.exists()
 
 

--- a/tests/hermes_cli/test_kanban_db_health.py
+++ b/tests/hermes_cli/test_kanban_db_health.py
@@ -1,0 +1,207 @@
+"""Board-wide Kanban SQLite health circuit and error taxonomy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+from tools import kanban_tools
+
+
+def _sqlite_error(message: str, code: int, name: str) -> sqlite3.OperationalError:
+    exc = sqlite3.OperationalError(message)
+    exc.sqlite_errorcode = code
+    exc.sqlite_errorname = name
+    return exc
+
+
+def _clear_process_state(path: Path) -> None:
+    kb._INITIALIZED_PATHS.discard(str(path.resolve()))
+
+
+def test_classifier_distinguishes_busy_storage_corruption_and_application_errors():
+    busy = kb.classify_sqlite_error(
+        _sqlite_error("database is locked", sqlite3.SQLITE_BUSY, "SQLITE_BUSY")
+    )
+    ioerr = kb.classify_sqlite_error(
+        _sqlite_error("disk I/O error", sqlite3.SQLITE_IOERR, "SQLITE_IOERR")
+    )
+    corrupt = kb.classify_sqlite_error(
+        _sqlite_error(
+            "database disk image is malformed",
+            sqlite3.SQLITE_CORRUPT,
+            "SQLITE_CORRUPT",
+        )
+    )
+    constraint = kb.classify_sqlite_error(
+        _sqlite_error(
+            "UNIQUE constraint failed",
+            sqlite3.SQLITE_CONSTRAINT,
+            "SQLITE_CONSTRAINT",
+        )
+    )
+
+    assert busy.category == "transient"
+    assert busy.retryable is True
+    assert busy.fatal is False
+    assert ioerr.category == "fatal_storage" and ioerr.fatal is True
+    assert corrupt.category == "corruption" and corrupt.fatal is True
+    assert constraint.category == "application" and constraint.fatal is False
+
+
+def test_ioerr_trips_one_persisted_incident_and_stops_reopen_attempts(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    _clear_process_state(db_path)
+
+    calls = 0
+
+    def fail_open(_path):
+        nonlocal calls
+        calls += 1
+        raise _sqlite_error("disk I/O error", sqlite3.SQLITE_IOERR, "SQLITE_IOERR")
+
+    monkeypatch.setattr(kb, "_sqlite_connect", fail_open)
+
+    incidents = set()
+    manifests = set()
+    for _ in range(6):
+        with pytest.raises(kb.KanbanDbHealthError) as excinfo:
+            kb.connect(db_path=db_path)
+        incidents.add(excinfo.value.incident_id)
+        manifests.add(excinfo.value.manifest_path)
+
+    assert calls == 1, "an open circuit must prevent repeated SQLite open attempts"
+    assert len(incidents) == 1
+    assert len(manifests) == 1
+    manifest_path = next(iter(manifests))
+    assert manifest_path is not None and manifest_path.exists()
+    assert len(list(tmp_path.glob("kanban.db.incident.*.json"))) == 1
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["incident_id"] == next(iter(incidents))
+    assert manifest["classification"] == "fatal_storage"
+
+
+def test_corrupt_guard_reuses_incident_backup_and_manifest(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    header = b"SQLite format 3\x00".ljust(100, b"\x00")
+    db_path.write_bytes(header + (b"broken page" * 256))
+    _clear_process_state(db_path)
+
+    errors = []
+    for _ in range(3):
+        with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+            kb.connect(db_path=db_path)
+        errors.append(excinfo.value)
+
+    assert len({e.incident_id for e in errors}) == 1
+    assert len({e.backup_path for e in errors}) == 1
+    assert len({e.manifest_path for e in errors}) == 1
+    assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak"))) == 1
+    assert len(list(tmp_path.glob("kanban.db.incident.*.json"))) == 1
+
+
+def test_direct_tool_and_cli_diagnostics_report_same_incident(
+    tmp_path, monkeypatch, capsys
+):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    _clear_process_state(db_path)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+
+    def fail_open(_path):
+        raise _sqlite_error(
+            "database disk image is malformed",
+            sqlite3.SQLITE_CORRUPT,
+            "SQLITE_CORRUPT",
+        )
+
+    monkeypatch.setattr(kb, "_sqlite_connect", fail_open)
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+        kb.connect(db_path=db_path)
+    incident_id = excinfo.value.incident_id
+
+    tool_result = json.loads(kanban_tools._handle_show({"task_id": "t_missing"}))
+    assert incident_id in tool_result["error"]
+    assert "quarantined" in tool_result["error"]
+
+    monkeypatch.setattr(
+        kb,
+        "init_db",
+        lambda *args, **kwargs: pytest.fail(
+            "diagnostics must not open a quarantined database"
+        ),
+    )
+    rc = kanban_cli.kanban_command(
+        argparse.Namespace(
+            kanban_action="diagnostics",
+            board=None,
+            task=None,
+            severity=None,
+            json=True,
+        )
+    )
+    captured = capsys.readouterr()
+    assert rc == 2
+    cli_result = json.loads(captured.out)
+    assert cli_result["board_health"]["incident_id"] == incident_id
+    assert cli_result["board_health"]["manifest_path"] == str(
+        excinfo.value.manifest_path
+    )
+
+
+def test_fatal_write_error_trips_shared_circuit(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    conn = kb.connect(db_path=db_path)
+    try:
+        with pytest.raises(kb.KanbanDbHealthError) as excinfo:
+            with kb.write_txn(conn):
+                raise _sqlite_error(
+                    "disk I/O error",
+                    sqlite3.SQLITE_IOERR,
+                    "SQLITE_IOERR",
+                )
+    finally:
+        conn.close()
+
+    health = kb.get_db_health(db_path)
+    assert health is not None
+    assert health["incident_id"] == excinfo.value.incident_id
+    assert health["classification"] == "fatal_storage"
+
+
+def test_atomic_database_replacement_clears_stale_circuit(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    replacement = tmp_path / "replacement.db"
+    kb.init_db(db_path=db_path)
+    kb.init_db(db_path=replacement)
+    _clear_process_state(db_path)
+
+    def fail_open(_path):
+        raise _sqlite_error(
+            "disk I/O error",
+            sqlite3.SQLITE_IOERR,
+            "SQLITE_IOERR",
+        )
+
+    real_connect = kb._sqlite_connect
+    monkeypatch.setattr(kb, "_sqlite_connect", fail_open)
+    with pytest.raises(kb.KanbanDbHealthError):
+        kb.connect(db_path=db_path)
+    monkeypatch.setattr(kb, "_sqlite_connect", real_connect)
+
+    os.replace(replacement, db_path)
+    _clear_process_state(db_path)
+    assert kb.get_db_health(db_path) is None
+    with kb.connect(db_path=db_path) as conn:
+        assert conn.execute("SELECT 1").fetchone()[0] == 1

--- a/tests/hermes_cli/test_kanban_maintenance_e2e.py
+++ b/tests/hermes_cli/test_kanban_maintenance_e2e.py
@@ -1,0 +1,226 @@
+"""Subprocess coverage for Kanban maintenance leases and WAL evidence bundles."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_maintenance as km
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _start_holder(
+    tmp_path: Path, db_path: Path, mode: str
+) -> tuple[subprocess.Popen, Path]:
+    ready = tmp_path / f"{mode}-ready"
+    release = tmp_path / f"{mode}-release"
+    script = tmp_path / f"hold-{mode}.py"
+    context_name = (
+        "maintenance_lease" if mode == "maintenance" else "writer_registration"
+    )
+    kwargs = (
+        ", action='test-holder', timeout=0.2"
+        if mode == "maintenance"
+        else ", owner='test-writer'"
+    )
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            import pathlib
+            import sys
+            import time
+            sys.path.insert(0, {str(_REPO_ROOT)!r})
+            from hermes_cli import kanban_maintenance as km
+
+            with km.{context_name}(pathlib.Path({str(db_path)!r}){kwargs}):
+                pathlib.Path({str(ready)!r}).write_text("ready", encoding="utf-8")
+                for _ in range(1000):
+                    if pathlib.Path({str(release)!r}).exists():
+                        break
+                    time.sleep(0.01)
+            """
+        ),
+        encoding="utf-8",
+    )
+    child = subprocess.Popen([sys.executable, str(script)])
+    for _ in range(1000):
+        if ready.exists():
+            break
+        if child.poll() is not None:
+            break
+        time.sleep(0.01)
+    assert ready.exists(), f"{mode} holder exited before acquiring lease"
+    return child, release
+
+
+def _start_write_txn_holder(
+    tmp_path: Path, db_path: Path
+) -> tuple[subprocess.Popen, Path]:
+    ready = tmp_path / "transaction-ready"
+    release = tmp_path / "transaction-release"
+    script = tmp_path / "hold-transaction.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            import pathlib
+            import sys
+            import time
+            sys.path.insert(0, {str(_REPO_ROOT)!r})
+            from hermes_cli import kanban_db as kb
+
+            db = pathlib.Path({str(db_path)!r})
+            with kb.connect(db_path=db) as conn:
+                with kb.write_txn(conn):
+                    pathlib.Path({str(ready)!r}).write_text("ready", encoding="utf-8")
+                    for _ in range(1000):
+                        if pathlib.Path({str(release)!r}).exists():
+                            break
+                        time.sleep(0.01)
+            """
+        ),
+        encoding="utf-8",
+    )
+    child = subprocess.Popen([sys.executable, str(script)])
+    for _ in range(1000):
+        if ready.exists() or child.poll() is not None:
+            break
+        time.sleep(0.01)
+    assert ready.exists(), "write transaction exited before acquiring admission"
+    return child, release
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="subprocess flock coverage is POSIX-only"
+)
+def test_two_processes_cannot_hold_maintenance_lease(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    child, release = _start_holder(tmp_path, db_path, "maintenance")
+    try:
+        with pytest.raises(km.MaintenanceLeaseBusyError) as excinfo:
+            with km.maintenance_lease(db_path, action="second", timeout=0.1):
+                pytest.fail("second process acquired an exclusive maintenance lease")
+        assert excinfo.value.holder["action"] == "test-holder"
+    finally:
+        release.write_text("release", encoding="utf-8")
+        child.wait(timeout=15)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="subprocess flock coverage is POSIX-only"
+)
+def test_evidence_capture_refuses_active_writer_registration(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    child, release = _start_holder(tmp_path, db_path, "writer")
+    try:
+        with pytest.raises(km.MaintenanceLeaseBusyError) as excinfo:
+            kb.capture_evidence_bundle(
+                db_path,
+                incident_id="active-writer",
+                manifest_path=tmp_path / "active-writer-manifest.json",
+                timeout=0.1,
+            )
+        assert excinfo.value.active_writers
+        assert excinfo.value.active_writers[0]["owner"] == "test-writer"
+    finally:
+        release.write_text("release", encoding="utf-8")
+        child.wait(timeout=15)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="subprocess flock coverage is POSIX-only"
+)
+def test_evidence_capture_refuses_open_write_transaction(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    child, release = _start_write_txn_holder(tmp_path, db_path)
+    try:
+        with pytest.raises(km.MaintenanceLeaseBusyError) as excinfo:
+            kb.capture_evidence_bundle(
+                db_path,
+                incident_id="open-transaction",
+                manifest_path=tmp_path / "open-transaction-manifest.json",
+                timeout=0.1,
+            )
+        assert excinfo.value.active_writers
+        assert excinfo.value.active_writers[0]["owner"] == "write_txn"
+    finally:
+        release.write_text("release", encoding="utf-8")
+        child.wait(timeout=15)
+
+
+def test_wal_bundle_restores_integrity_and_reuses_completed_manifest(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    manifest_path = tmp_path / "incident-manifest.json"
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+        conn.execute("PRAGMA wal_autocheckpoint=0")
+        conn.execute(
+            "CREATE TABLE evidence (id INTEGER PRIMARY KEY, payload TEXT NOT NULL)"
+        )
+        conn.execute("BEGIN IMMEDIATE")
+        conn.executemany(
+            "INSERT INTO evidence(payload) VALUES (?)",
+            [(f"row-{index}-" + "x" * 1024,) for index in range(64)],
+        )
+        conn.execute("COMMIT")
+        assert Path(str(db_path) + "-wal").exists()
+        assert Path(str(db_path) + "-shm").exists()
+
+        first = kb.capture_evidence_bundle(
+            db_path,
+            incident_id="wal-incident",
+            manifest_path=manifest_path,
+            timeout=1.0,
+        )
+        second = kb.capture_evidence_bundle(
+            db_path,
+            incident_id="wal-incident",
+            manifest_path=manifest_path,
+            timeout=1.0,
+        )
+    finally:
+        conn.close()
+
+    assert first == second
+    assert first["capture_consistency"] == "quiesced"
+    assert first["completed"] is True
+    assert first["journal_mode"] == "wal"
+    assert {entry["source_name"] for entry in first["files"]} >= {
+        "kanban.db",
+        "kanban.db-wal",
+        "kanban.db-shm",
+    }
+    assert len(list(tmp_path.glob("incident-manifest.json"))) == 1
+
+    restore_dir = tmp_path / "restored"
+    restore_dir.mkdir()
+    for entry in first["files"]:
+        if entry["kind"] not in {"database", "wal", "shm"}:
+            continue
+        source = Path(entry["path"])
+        target = restore_dir / entry["source_name"]
+        target.write_bytes(source.read_bytes())
+        assert kb._sha256_file(target) == entry["sha256"]
+
+    restored = sqlite3.connect(restore_dir / "kanban.db")
+    try:
+        assert restored.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert restored.execute("SELECT COUNT(*) FROM evidence").fetchone()[0] == 64
+    finally:
+        restored.close()
+
+    on_disk = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert on_disk == first


### PR DESCRIPTION
## Summary
- classify fatal SQLite failures and trip one board-wide incident circuit
- add an exclusive maintenance lease with shared writer admission for quiescence
- capture content-addressed, coherent main/WAL/SHM evidence bundles and atomically publish a reusable incident manifest
- prevent capture while registered writers or write transactions are active

This supersedes #65899 with that Slice 1 work rebased onto current `main`, plus the dependent maintenance/evidence Slice 2.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_*.py tests/gateway/test_kanban_*.py -q`: **762 passed**
- `python -m ruff check hermes_cli/kanban_db.py hermes_cli/kanban_maintenance.py tests/hermes_cli/test_kanban_maintenance_e2e.py`
- `python -m compileall -q ...`
- `git diff --check`

## Behavioral evidence
- subprocess-exclusive lease contention refuses the second holder
- active writer registration and open `write_txn` both refuse evidence capture
- restored WAL bundle passes `PRAGMA integrity_check` and retains all committed rows
- repeated capture for the same incident reuses the completed manifest
