### PR TITLE
fix(gateway): resolve service-managed gateway PID when ExecStart is wrapped (#66900)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -136,6 +136,14 @@ def _get_service_pids() -> set:
                         pid = int(show.stdout.strip())
                         if pid > 0:
                             pids.add(pid)
+                            # MainPID may point at a wrapper (``doppler run``,
+                            # ``direnv exec``, …) rather than the gateway, in
+                            # which case the real gateway is a descendant of
+                            # that PID. Pull it in so hermes update does not
+                            # sweep the service-managed gateway as a manual
+                            # process and relaunch a competing detached
+                            # ``--replace`` watcher (#66900).
+                            pids |= _gateway_descendants_of(pid)
                     except (ValueError, subprocess.TimeoutExpired):
                         pass
             except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -156,6 +164,9 @@ def _get_service_pids() -> set:
                 pid = _parse_launchd_pid_from_list_output(result.stdout)
                 if pid is not None and pid > 0:
                     pids.add(pid)
+                    # Same wrapper-descendant case as systemd (#66900): a
+                    # wrapped launchd ExecStart reports the launcher PID.
+                    pids |= _gateway_descendants_of(pid)
                 else:
                     # Fall back to legacy tab-separated format:
                     # "PID\tStatus\tLabel"
@@ -166,12 +177,56 @@ def _get_service_pids() -> set:
                                 pid = int(parts[0])
                                 if pid > 0:
                                     pids.add(pid)
+                                    pids |= _gateway_descendants_of(pid)
                             except ValueError:
                                 pass
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
     return pids
+
+
+def _gateway_descendants_of(pid: int) -> set:
+    """Gateway-runtime PIDs descended from a service manager's tracked PID.
+
+    A service unit whose ``ExecStart`` is wrapped by a launcher
+    (``doppler run``, ``direnv exec``, …) reports the *wrapper* as its
+    MainPID / launchd PID rather than the gateway. The real gateway runs as
+    a descendant of that wrapper. Walk the subtree and return any process
+    whose command line looks like an actual ``gateway run`` so callers treat
+    the service-managed gateway as managed instead of sweeping it as a
+    manual process (#66900).
+
+    When ``ExecStart`` runs the gateway directly there are no gateway
+    descendants and nothing is added — the tracked PID already is the
+    gateway. Returns an empty set if psutil is unavailable or the process
+    tree cannot be walked.
+    """
+    if pid <= 1:
+        return set()
+    try:
+        import psutil  # type: ignore
+
+        from gateway.status import looks_like_gateway_command_line
+    except ImportError:
+        return set()
+    try:
+        children = psutil.Process(pid).children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        return set()
+    except Exception:
+        return set()
+    found: set = set()
+    for child in children:
+        try:
+            cmdline = " ".join(child.cmdline() or [])
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+        except Exception:
+            continue
+        if cmdline and looks_like_gateway_command_line(cmdline):
+            found.add(child.pid)
+    return found
 
 
 def _get_parent_pid(pid: int) -> int | None:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1169,3 +1169,185 @@ def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")
     assert gateway.logger.name == "hermes_cli.gateway"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #66900: a service unit whose ExecStart is wrapped by a
+# launcher (doppler run, direnv exec, …) reports the wrapper as MainPID, not
+# the gateway.  _get_service_pids() must resolve the real gateway (a descendant
+# of the wrapper) so hermes update does not sweep it as a manual gateway and
+# relaunch a competing detached --replace watcher.
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Minimal stand-in for a psutil Process used by the descendant walk."""
+
+    def __init__(self, pid, cmdline=None, children=()):
+        self.pid = pid
+        self._cmdline = list(cmdline or [])
+        self._children = list(children)
+
+    def children(self, recursive=False):
+        if not recursive:
+            return list(self._children)
+        out, stack = [], list(self._children)
+        while stack:
+            node = stack.pop()
+            out.append(node)
+            stack.extend(node._children)
+        return out
+
+    def cmdline(self):
+        return list(self._cmdline)
+
+
+def _fake_systemctl_run(cmd, **kwargs):
+    """Fake subprocess.run for the systemd list-units / show MainPID calls."""
+    cmd = list(cmd)
+    if "list-units" in cmd:
+        # Only the --user scope owns a unit in this fixture.
+        if "--user" in cmd:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="hermes-gateway.service loaded active running Hermes Gateway\n",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+    if "show" in cmd and any("MainPID" in arg for arg in cmd):
+        # MainPID is the *wrapper* (doppler), not the gateway.
+        return SimpleNamespace(returncode=0, stdout="4321\n", stderr="")
+    raise AssertionError(f"unexpected systemctl command: {cmd}")
+
+
+def _setup_wrapped_systemd_unit(monkeypatch, descendants):
+    """Wire a systemd unit whose MainPID (4321) is a wrapper with descendants."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway.subprocess, "run", _fake_systemctl_run)
+    import psutil
+
+    monkeypatch.setattr(
+        psutil, "Process", lambda pid: _FakeProc(pid, children=descendants)
+    )
+
+
+def test_service_pids_resolves_wrapped_systemd_mainpid_to_gateway_descendant(monkeypatch):
+    """Layer 1: systemd MainPID is a wrapper → real gateway descendant returned.
+
+    On current main this fails: _get_service_pids() returns only the wrapper
+    (4321) and misses the gateway (5500), so hermes update sweeps the
+    service-managed gateway as a manual one and relaunches a detached
+    --replace watcher that races systemd's own restart (#66900).
+    """
+    gateway_descendant = _FakeProc(
+        5500, cmdline=["python", "-m", "hermes_cli.main", "gateway", "run"]
+    )
+    _setup_wrapped_systemd_unit(monkeypatch, descendants=[gateway_descendant])
+
+    pids = gateway._get_service_pids()
+
+    assert 4321 in pids  # wrapper MainPID still present (harmless to exclude)
+    assert 5500 in pids  # the actual service-managed gateway — the fix
+
+
+def test_service_pids_resolves_wrapped_launchd_pid_to_gateway_descendant(monkeypatch):
+    """Layer 2: launchd PID is a wrapper → real gateway descendant returned.
+
+    Same bug class as systemd: launchctl reports the wrapper's PID. The fix
+    must close the whole class, not just the systemd site the reporter hit.
+    """
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: True)
+    monkeypatch.setattr(gateway, "get_launchd_label", lambda: "com.hermes.gateway")
+    monkeypatch.setattr(
+        gateway,
+        "_parse_launchd_pid_from_list_output",
+        lambda output: 4321,  # wrapper PID
+    )
+    monkeypatch.setattr(
+        gateway.subprocess,
+        "run",
+        lambda cmd, **kw: SimpleNamespace(returncode=0, stdout="ignored", stderr=""),
+    )
+    import psutil
+
+    gateway_descendant = _FakeProc(
+        5500, cmdline=["python", "-m", "hermes_cli.main", "gateway", "run"]
+    )
+    monkeypatch.setattr(
+        psutil, "Process", lambda pid: _FakeProc(pid, children=[gateway_descendant])
+    )
+
+    pids = gateway._get_service_pids()
+
+    assert 4321 in pids  # wrapper
+    assert 5500 in pids  # the actual gateway
+
+
+def test_service_pids_unwrapped_unit_keeps_mainpid_only(monkeypatch):
+    """Layer 3: no wrapper → MainPID already is the gateway, no spurious PIDs.
+
+    When ExecStart runs the gateway directly, MainPID points at the gateway
+    itself and there are no gateway descendants. The fix must add nothing.
+    """
+    # The MainPID process has a child, but it is NOT a gateway runtime
+    # (e.g. a helper the gateway spawned) — it must not be pulled in.
+    non_gateway_child = _FakeProc(9988, cmdline=["/usr/bin/some-helper", "--watch"])
+    _setup_wrapped_systemd_unit(monkeypatch, descendants=[non_gateway_child])
+
+    pids = gateway._get_service_pids()
+
+    assert pids == {4321}
+    assert 9988 not in pids
+
+
+def test_service_pids_descendant_resolution_tolerates_dead_wrapper(monkeypatch):
+    """Layer 4: if the MainPID process is gone, fall back gracefully — no raise.
+
+    psutil raises NoSuchProcess when the wrapper exited between the MainPID
+    query and the descendant walk. _get_service_pids() must still return the
+    MainPID it already observed and never propagate the exception.
+    """
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway.subprocess, "run", _fake_systemctl_run)
+    import psutil
+
+    def _raise(_pid):
+        raise psutil.NoSuchProcess(_pid)
+
+    monkeypatch.setattr(psutil, "Process", _raise)
+
+    pids = gateway._get_service_pids()
+
+    assert pids == {4321}  # MainPID preserved, descendant walk skipped cleanly
+
+
+def test_wrapped_service_gateway_excluded_from_manual_sweep(monkeypatch):
+    """Reported impact: a wrapped service gateway must not be swept as manual.
+
+    hermes update builds manual_pids = find_gateway_pids(exclude_pids=
+    service_pids). When _get_service_pids() includes the real gateway, the
+    manual sweep excludes it and _prepare_profile_gateway_update_restart is
+    never called for it — no detached --replace watcher races systemd.
+    """
+    gateway_descendant = _FakeProc(
+        5500, cmdline=["python", "-m", "hermes_cli.main", "gateway", "run"]
+    )
+    _setup_wrapped_systemd_unit(monkeypatch, descendants=[gateway_descendant])
+
+    service_pids = gateway._get_service_pids()
+
+    # Simulate the process-table scan finding the real gateway (5500) as a
+    # candidate manual gateway, exactly as find_gateway_pids() would via the
+    # gateway.pid file + cmdline scan.
+    monkeypatch.setattr(gateway, "_scan_gateway_pids", lambda *a, **k: [5500])
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+
+    manual_pids = gateway.find_gateway_pids(
+        exclude_pids=service_pids, all_profiles=True
+    )
+
+    assert 5500 not in manual_pids  # service-managed → not swept as manual


### PR DESCRIPTION
## What

When a service unit's `ExecStart` is wrapped by a launcher (`doppler run`, `direnv exec`, …), systemd reports the **wrapper** as `MainPID` (and launchd reports the launcher PID), not the gateway. `_get_service_pids()` therefore returned only the wrapper, so during `hermes update` the real gateway (a descendant of the wrapper) was excluded neither from the stale-process sweep nor from `find_gateway_pids(exclude_pids=service_pids)`. That path then treated the service-managed gateway as a manual one and spawned a detached `--replace` watcher that raced systemd's own `Restart=always`, producing hundreds of relaunches (#66900: 7 profiles, ~52 failures/min, 500+ NRestarts in ~90 min).

## Fix

New helper `_gateway_descendants_of(pid)` walks the tracked PID's descendant tree (psutil — already a core dependency, same pattern as `_get_parent_pid`/`_get_ancestor_pids`) and returns any process whose command line matches the strict `looks_like_gateway_command_line` (`gateway run`). It is applied at all three PID-add sites in `_get_service_pids()`: the systemd `MainPID` read and both launchd paths (plist format + legacy tab-separated format), closing the whole bug class rather than just the systemd site the reporter hit.

- **No wrapper (direct `ExecStart`)**: no gateway descendants → nothing added → behavior unchanged (the tracked PID already is the gateway).
- **psutil unavailable / process gone** (`NoSuchProcess`/`AccessDenied`/`ZombieProcess`/generic): degrades to an empty set, MainPID preserved, never raises.

## Why this scope

The reported launch storm is specifically the `hermes update` → `_get_service_pids()` → manual sweep → detached `--replace` watcher path. Two other PID-read sites are intentionally left untouched: `_systemd_main_pid()` (feeds `hermes gateway restart`, which uses `get_running_pid()` from `gateway.pid` as its primary source and has a non-catastrophic fallback), and the `launchd_status()` display path (read-only, dedupes with `get_running_pid()`).

## How verified

- **RED (independently re-verified on a fresh `upstream/main` worktree, no production change):** 3 of 5 regression tests fail — `assert 5500 in {4321}` (systemd wrapper), `assert 5500 in {4321}` (launchd wrapper), `assert 5500 not in [5500]` (manual sweep still catches the gateway).
- **GREEN (with fix):** all 5 regression tests pass — covers all 4 layers (systemd-wrapped, launchd-wrapped, no-wrapper no-op, psutil-unavailable graceful degradation).
- **Full file:** `tests/hermes_cli/test_gateway.py` → 58 passed.
- **Lint:** `ruff check` clean. `git diff --check` clean.
- **Branch:** exactly one focused commit ahead of `upstream/main` (`0 1`).

## Test notes

Pre-existing macOS-only failures in `test_gateway_service.py::TestGatewaySystemServiceRouting` (`UserSystemdUnavailableError`, systemd services require a user D-Bus session absent on macOS) are unrelated to this change and reproduce identically on clean `upstream/main`.

Closes #66900.

---

Auto-published by Moonsong via Path B automated pipeline.
