### PR TITLE
fix(fallback): strip Hermes provider prefix before aggregator normalization

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -108,6 +108,7 @@ _HERMES_PROVIDER_PREFIXES_NOT_VENDOR_SLUGS: frozenset[str] = frozenset({
     "minimax-cn",
     "qwen-oauth",
     "alibaba",
+    "arcee",
     "vertex",
     "azure-foundry",
     "bedrock",

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -63,11 +63,57 @@ _VENDOR_PREFIXES: dict[str, str] = {
     "trinity": "arcee-ai",
 }
 
+# The set of vendor slugs aggregator APIs (OpenRouter, Nous, Kilo Code)
+# actually accept as the left-hand side of a ``vendor/model`` slug. Derived
+# from the values of ``_VENDOR_PREFIXES`` so the two stay in sync.
+#
+# This is distinct from Hermes' own *provider ids* (``openai-codex``,
+# ``xai``, ``copilot``, ``zai``, ``kimi-coding``, ``gemini``, ...) — several
+# of those look like plausible vendor/model prefixes but are NOT the slug an
+# aggregator expects. When one of those leaks into ``fb_model`` (e.g. a
+# fallback-chain entry keeps the provider-scoped literal
+# ``openai-codex/gpt-5.6-sol`` instead of the bare model), the old
+# ``"/" in model_name -> return as-is`` short-circuit sent that raw string
+# straight to OpenRouter, which rejects it with HTTP 400 "not a valid model
+# ID". See the openai-codex -> fallback -> openrouter failure chain.
+_AGGREGATOR_VENDOR_SLUGS: frozenset[str] = frozenset(_VENDOR_PREFIXES.values())
+
 # Providers whose APIs consume vendor/model slugs.
 _AGGREGATOR_PROVIDERS: frozenset[str] = frozenset({
     "openrouter",
     "nous",
     "kilocode",
+})
+
+# Hermes provider ids that are NOT valid aggregator vendor slugs but are
+# easy to mistake for one because they sit in the same ``prefix/model``
+# shape.  When a fallback/config entry's model string carries one of these
+# as its prefix, it must be stripped (and the vendor re-detected from the
+# bare model name) rather than passed through untouched.  Kept explicit
+# (rather than "any non-_AGGREGATOR_VENDOR_SLUGS prefix") so a genuinely
+# unknown vendor slug from a new aggregator model still passes through
+# untouched instead of being silently mangled.
+_HERMES_PROVIDER_PREFIXES_NOT_VENDOR_SLUGS: frozenset[str] = frozenset({
+    "openai-codex",
+    "openai-api",
+    "copilot",
+    "copilot-acp",
+    "xai",
+    "xai-oauth",
+    "zai",
+    "gemini",
+    "kimi-coding",
+    "kimi-coding-cn",
+    "minimax-oauth",
+    "minimax-cn",
+    "qwen-oauth",
+    "alibaba",
+    "vertex",
+    "azure-foundry",
+    "bedrock",
+    "ollama-cloud",
+    "opencode-zen",
+    "opencode-go",
 })
 
 # Providers that want bare names with dots replaced by hyphens.
@@ -298,9 +344,19 @@ def _prepend_vendor(model_name: str) -> str:
     """Prepend the detected ``vendor/`` prefix if missing.
 
     Used for aggregator providers that require ``vendor/model`` format.
-    If the name already contains a ``/``, it is returned as-is.
-    If no vendor can be detected, the name is returned unchanged
-    (aggregators may still accept it or return an error).
+    If the name already contains a ``/`` AND the prefix is a real
+    aggregator vendor slug (``anthropic``, ``openai``, ``google``, ...),
+    it is returned as-is. If no vendor can be detected, the name is
+    returned unchanged (aggregators may still accept it or return an
+    error).
+
+    If the prefix is instead a Hermes *provider id* that leaked in from a
+    fallback-chain/config entry (e.g. ``openai-codex/gpt-5.6-sol``,
+    ``xai/grok-4.3``) rather than a genuine aggregator vendor slug, it is
+    stripped and the vendor is re-detected from the bare model name. This
+    is the fix for the fallback path sending ``openai-codex/gpt-5.6-sol``
+    verbatim to OpenRouter, which rejects it with HTTP 400 "not a valid
+    model ID" instead of receiving ``openai/gpt-5.6-sol``.
 
     Examples::
 
@@ -310,8 +366,25 @@ def _prepend_vendor(model_name: str) -> str:
         'anthropic/claude-sonnet-4.6'
         >>> _prepend_vendor("my-custom-thing")
         'my-custom-thing'
+        >>> _prepend_vendor("openai-codex/gpt-5.6-sol")
+        'openai/gpt-5.6-sol'
+        >>> _prepend_vendor("xai/grok-4.3")
+        'x-ai/grok-4.3'
     """
     if "/" in model_name:
+        prefix, remainder = model_name.split("/", 1)
+        if prefix in _AGGREGATOR_VENDOR_SLUGS:
+            return model_name
+        normalized_prefix = _normalize_provider_alias(prefix)
+        if (
+            normalized_prefix in _HERMES_PROVIDER_PREFIXES_NOT_VENDOR_SLUGS
+            and remainder.strip()
+        ):
+            # Prefix is a Hermes provider id, not an aggregator vendor
+            # slug — strip it and re-run vendor detection on the bare
+            # model name instead of passing the provider-scoped literal
+            # straight through to the aggregator's API.
+            return _prepend_vendor(remainder.strip())
         return model_name
 
     vendor = detect_vendor(model_name)

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -263,3 +263,61 @@ class TestDeepseekCanonicalAndReasonerMapping:
     ])
     def test_unknown_names_fall_back_to_chat(self, model):
         assert _normalize_for_deepseek(model) == "deepseek-chat"
+
+
+# ── Regression: fallback chain sends unstripped Hermes provider id to
+#    an aggregator (OpenRouter/Nous/Kilo Code), which then rejects the
+#    literal ``openai-codex/gpt-5.6-sol`` with HTTP 400 "not a valid
+#    model ID" and cascades further down the fallback chain instead of
+#    landing cleanly on the intended fallback model. ─────────────────────
+
+class TestHermesProviderPrefixNotMistakenForAggregatorVendor:
+    """A ``fb_model`` string carrying a Hermes provider id prefix (not a
+    real aggregator vendor slug like ``anthropic/`` or ``openai/``) must
+    be stripped and re-normalized, not passed straight through because it
+    happens to contain a ``/``.
+    """
+
+    @pytest.mark.parametrize("model,target_provider,expected", [
+        # The exact reported failure: openai-codex primary falls back to
+        # OpenRouter while fb_model still carries the codex provider
+        # prefix instead of the bare model name.
+        ("openai-codex/gpt-5.6-sol", "openrouter", "openai/gpt-5.6-sol"),
+        ("openai-codex/gpt-5.5", "openrouter", "openai/gpt-5.5"),
+        # Same failure mode via other direct providers that aren't
+        # themselves valid aggregator vendor slugs.
+        ("xai/grok-4.3", "openrouter", "x-ai/grok-4.3"),
+        ("copilot/claude-sonnet-4.6", "openrouter", "anthropic/claude-sonnet-4.6"),
+        ("gemini/gemini-3-pro", "openrouter", "google/gemini-3-pro"),
+        # Works identically for the other aggregator providers.
+        ("openai-codex/gpt-5.6-sol", "nous", "openai/gpt-5.6-sol"),
+        ("openai-codex/gpt-5.6-sol", "kilocode", "openai/gpt-5.6-sol"),
+    ])
+    def test_provider_prefixed_fallback_model_is_stripped_and_renormalized(
+        self, model, target_provider, expected,
+    ):
+        result = normalize_model_for_provider(model, target_provider)
+        assert result == expected, f"Expected {expected!r}, got {result!r}"
+
+    @pytest.mark.parametrize("model,target_provider,expected", [
+        # A genuine aggregator vendor slug must still pass through
+        # unchanged -- this guards against over-correcting the fix.
+        ("anthropic/claude-sonnet-5", "openrouter", "anthropic/claude-sonnet-5"),
+        ("minimax/minimax-m3", "openrouter", "minimax/minimax-m3"),
+        ("meta-llama/llama-4-scout", "openrouter", "meta-llama/llama-4-scout"),
+        ("google/gemini-3-pro", "openrouter", "google/gemini-3-pro"),
+        # An unrecognized prefix (neither a known vendor slug nor a known
+        # Hermes provider id) is left untouched -- the aggregator may
+        # still accept it or return its own error.
+        ("some-unknown-vendor/some-model", "openrouter", "some-unknown-vendor/some-model"),
+    ])
+    def test_real_vendor_slugs_still_pass_through_unchanged(
+        self, model, target_provider, expected,
+    ):
+        result = normalize_model_for_provider(model, target_provider)
+        assert result == expected, f"Expected {expected!r}, got {result!r}"
+
+    def test_bare_model_still_gets_vendor_prepended(self):
+        """Sanity check the existing bare-name path wasn't broken."""
+        assert normalize_model_for_provider("gpt-5.6-sol", "openrouter") == "openai/gpt-5.6-sol"
+        assert normalize_model_for_provider("claude-sonnet-4.6", "openrouter") == "anthropic/claude-sonnet-4.6"

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -289,6 +289,7 @@ class TestHermesProviderPrefixNotMistakenForAggregatorVendor:
         ("xai/grok-4.3", "openrouter", "x-ai/grok-4.3"),
         ("copilot/claude-sonnet-4.6", "openrouter", "anthropic/claude-sonnet-4.6"),
         ("gemini/gemini-3-pro", "openrouter", "google/gemini-3-pro"),
+        ("arcee/trinity-large", "openrouter", "arcee-ai/trinity-large"),
         # Works identically for the other aggregator providers.
         ("openai-codex/gpt-5.6-sol", "nous", "openai/gpt-5.6-sol"),
         ("openai-codex/gpt-5.6-sol", "kilocode", "openai/gpt-5.6-sol"),


### PR DESCRIPTION
## Bug

When a live agent turn's primary call to a direct provider (e.g. `openai-codex/gpt-5.6-sol`) fails and the fallback chain activates onto an aggregator (OpenRouter, Nous, Kilo Code), `fb_model` can still carry the **Hermes provider id prefix** instead of the bare model name or a real aggregator vendor slug.

`normalize_model_for_provider()` -> `_prepend_vendor()` (in `hermes_cli/model_normalize.py`) previously treated *any* string containing `/` as already-valid `vendor/model` format and returned it unchanged:

```python
if "/" in model_name:
    return model_name
```

So a fallback entry configured as `openai-codex/gpt-5.6-sol` (or similarly `xai/grok-4.3`, `gemini/gemini-3-pro`, `copilot/claude-sonnet-4.6`, ...) gets sent to OpenRouter's API **verbatim**, which rejects it with `HTTP 400: openai-codex/gpt-5.6-sol is not a valid model ID`. The fallback chain then cascades further (skipping the intended OpenRouter fallback entirely) instead of landing cleanly on it.

Reproduced against current `main` via `agent/chat_completion_helpers.py::try_activate_fallback` (line ~1532, the `normalize_model_for_provider(fb_model, fb_provider)` call) — this is the exact call site affected.

## Fix

Two new sets in `hermes_cli/model_normalize.py`:

- `_AGGREGATOR_VENDOR_SLUGS` — the vendor slugs aggregators actually accept (derived from `_VENDOR_PREFIXES.values()`, e.g. `anthropic`, `openai`, `google`, `x-ai`, `minimax`, ...).
- `_HERMES_PROVIDER_PREFIXES_NOT_VENDOR_SLUGS` — Hermes provider ids that look like plausible vendor prefixes but aren't (`openai-codex`, `xai`, `copilot`, `gemini`, `zai`, `kimi-coding`, etc).

`_prepend_vendor()` now branches on which bucket a `/`-prefixed model string falls into:

1. Real aggregator vendor slug -> pass through unchanged (existing correct behavior preserved).
2. Hermes provider id -> strip the prefix and re-run vendor detection on the bare model name (fixes the bug).
3. Anything else (unrecognized prefix) -> pass through unchanged, same as before -- a genuinely unknown/future aggregator vendor slug is never mangled.

## Testing

- Added `TestHermesProviderPrefixNotMistakenForAggregatorVendor` in `tests/hermes_cli/test_model_normalize.py`: 12 new parametrized cases covering the exact reported failure (`openai-codex/gpt-5.6-sol` -> openrouter/nous/kilocode), sibling provider prefixes (`xai`, `copilot`, `gemini`), and a guard-rail set confirming real vendor slugs (`anthropic/`, `minimax/`, `meta-llama/`, `google/`) and unrecognized prefixes still pass through unchanged.
- Full targeted suite green on `venv/bin/python3.11` (project's pinned 3.11 venv): `pytest tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_fallback_cmd.py tests/hermes_cli/test_fallback_config.py tests/run_agent/test_provider_fallback.py tests/gateway/test_fallback_chain_reload.py tests/gateway/test_auth_fallback.py` -> **169 passed**.
- Broader sweep `pytest tests/ -k "fallback or normalize or model_switch"` -> **2014 passed, 7 skipped**, zero regressions.
- One pre-existing doctest failure in this module (`deepseek-v3` example, stale relative to the later V-series feature) reproduces identically on unmodified `main` via `git stash` -- unrelated to this change, not introduced by it.
