### PR TITLE
fix(memory): detect existing-duplicate in ambiguous replace to break silent duplicate loop (#60089)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -342,6 +342,50 @@ class TestMemoryStoreReplace:
         assert result["success"] is False
         assert "Multiple" in result["error"]
 
+    def test_replace_ambiguous_match_when_new_content_already_exists_surfaces_duplicate(self, store):
+        """When an ambiguous replace's new_content is already a separate entry,
+        the response must say so and surface the existing duplicate — instead
+        of the generic 'Multiple entries matched' message that invites the
+        model to fall back to add() and create a duplicate (#60089).
+        """
+        store.add("memory", "User prefers dark mode (theme)")
+        store.add("memory", "User prefers dark mode (terminal)")
+        # The duplicate entry does NOT match old_text — it's a pre-existing
+        # unrelated entry whose content happens to equal new_content.
+        store.add("memory", "User likes cats")
+        result = store.replace(
+            "memory",
+            old_text="prefers dark mode",
+            new_content="User likes cats",
+        )
+        assert result["success"] is False
+        # Code-level contract: dedicated signal fields, not just the generic
+        # 'Multiple entries matched' message.
+        assert "already present" in result["error"]
+        assert "operations" in result["error"]  # pointer at batch API
+        assert result.get("existing_duplicate") == "User likes cats"
+        assert "matches" in result and len(result["matches"]) == 2
+
+    def test_replace_ambiguous_match_when_new_content_matches_one_of_the_matched_entries_still_generic(self, store):
+        """If new_content equals one of the *matched* (matched-by-old_text)
+        entries, the replace is a legitimate no-op against that single entry
+        — we should NOT misclassify this as the cross-entry duplicate case
+        and should still emit the generic ambiguity message (#60089 regression
+        guard for the `new_content not in unique_texts` clause).
+        """
+        store.add("memory", "server A runs nginx")
+        store.add("memory", "server B runs nginx")
+        # new_content equals one of the matched entries (server A runs nginx)
+        result = store.replace(
+            "memory",
+            old_text="nginx",
+            new_content="server A runs nginx",
+        )
+        assert result["success"] is False
+        assert "Multiple" in result["error"]
+        assert "already present" not in result["error"]
+        assert "existing_duplicate" not in result
+
     def test_replace_empty_old_text_rejected(self, store):
         result = store.replace("memory", "", "new")
         assert result["success"] is False

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -419,6 +419,29 @@ class MemoryStore:
                 unique_texts = {e for _, e in matches}
                 if len(unique_texts) > 1:
                     previews = self._previews([e for _, e in matches])
+                    # If the intended new_content already exists verbatim as a
+                    # separate entry, the generic "Multiple entries matched"
+                    # error is a trap: the model's natural fallback is `add()`,
+                    # which then creates a duplicate of the entry that already
+                    # says what it wanted to write. Surface the situation
+                    # explicitly and point at the batch `operations` API to
+                    # disambiguate, so the model doesn't fall into the
+                    # replace -> ambiguous -> add -> duplicate loop (#60089).
+                    if new_content in entries and new_content not in unique_texts:
+                        return {
+                            "success": False,
+                            "error": (
+                                f"Multiple entries matched '{old_text}', and the "
+                                f"new_content is already present as a separate entry. "
+                                f"The replacement is a no-op as written — use the "
+                                f"batch `operations` API to remove the matched entries "
+                                f"explicitly, or retry with a more specific old_text "
+                                f"that matches only one entry. Matches and the "
+                                f"existing duplicate are listed below."
+                            ),
+                            "matches": previews,
+                            "existing_duplicate": new_content,
+                        }
                     return {
                         "success": False,
                         "error": f"Multiple entries matched '{old_text}'. Be more specific.",


### PR DESCRIPTION
## Problem

Closes #60089.

When `MemoryStore.replace()` gets multiple substring matches for `old_text`, the generic `'Multiple entries matched' … Be more specific.` error is a trap: the model's natural fallback is `add()`, which then creates a duplicate of an entry that already says what the model wanted to write. `add()` already guards its simpler exact-duplicate case (`'Entry already exists (no duplicate added)'`), but the replace path gives no equivalent signal, so the duplicate arrives via the replace → add two-step.

Observed as a repeatable tool-misuse pattern running a local model against the file memory store: replace → ambiguous match → fallback add → duplicate entry.

## Fix

In `tools/memory_tool.py`, when `replace()` hits the ambiguous-match branch and the intended `new_content` is already present verbatim as a *separate* entry (not one of the matched entries), surface that explicitly instead of the generic message:

- dedicated error text: "Multiple entries matched … the new_content is already present as a separate entry. The replacement is a no-op as written — use the batch `operations` API to remove the matched entries explicitly, or retry with a more specific old_text that matches only one entry."
- new `existing_duplicate` field exposing the duplicate content
- `matches` preserved so the caller can still see what was ambiguous

The `new_content not in unique_texts` clause protects the legitimate no-op case where `new_content` equals one of the matched entries — that path still emits the generic ambiguity message (regression guard covered by the new `test_replace_ambiguous_match_when_new_content_matches_one_of_the_matched_entries_still_generic`).

## Test plan

```
=== before fix ===
test_replace_ambiguous_match                                                                     PASS  (existing)
test_replace_ambiguous_match_when_new_content_already_exists_surfaces_duplicate                   FAIL  (new — generic msg, no existing_duplicate)
test_replace_ambiguous_match_when_new_content_matches_one_of_the_matched_entries_still_generic   PASS  (new — guards the not-in-unique_texts clause)

=== after fix (full file) ===
87 passed in 0.87s
```

The fix is contained to the ambiguous branch; the unambiguous and identical-match paths are untouched.

## Scope checklist
- [x] Reproduces on current `main` (`c7eb0cd22`) — confirmed by reading `tools/memory_tool.py:417-426`
- [x] Single call site fixed (sibling `remove()` path keeps the generic message — out of scope for #60089, which is specifically about the replace → add duplicate loop)
- [x] No new env vars, no cache-breaking, no schema change
- [x] Tests verify the bug both with and without the fix (the assertion on `existing_duplicate` and `already present` fails on `main`)
