### PR TITLE
fix(agent): handle multimodal interim text safely

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4828,7 +4828,25 @@ class AIAgent:
         if visible:
             return visible
         content = assistant_msg.get("content")
-        return self._strip_think_blocks(content or "").strip()
+        if _is_multimodal_tool_result(content):
+            content = _multimodal_text_summary(content)
+        elif isinstance(content, list):
+            text_parts: List[str] = []
+            for part in content:
+                if isinstance(part, str):
+                    text_parts.append(part)
+                    continue
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") not in {"text", "input_text", "output_text"}:
+                    continue
+                text = part.get("text")
+                if isinstance(text, str):
+                    text_parts.append(text)
+            content = "\n".join(text_parts)
+        if not isinstance(content, str):
+            return ""
+        return self._strip_think_blocks(content).strip()
 
     def _interim_text_was_delivered(self, text: str) -> bool:
         normalized = self._normalize_interim_visible_text(text)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -769,6 +769,19 @@ def test_consume_codex_stream_keeps_final_answer_phase_deltas(monkeypatch):
     assert response.output_text == "visible answer"
 
 
+def test_interim_visible_text_handles_multimodal_content_parts(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    message = {
+        "role": "tool",
+        "content": [
+            {"type": "text", "text": "Image loaded for analysis."},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,abc"}},
+        ],
+    }
+
+    assert agent._interim_assistant_visible_text(message) == "Image loaded for analysis."
+
+
 def test_run_codex_stream_delivers_redacted_commentary_once(monkeypatch):
     from agent.codex_responses_adapter import _normalize_codex_response
 


### PR DESCRIPTION
## Summary
- normalize multimodal/list assistant content before interim text processing
- preserve text parts while ignoring image and unknown structured parts
- return an empty string for unsupported non-text content instead of passing it into regex processing

## Problem
`_interim_assistant_visible_text` passed structured `content` directly to `_strip_think_blocks`. Multimodal content is a list, so interim delivery could raise a type error instead of extracting its visible text.

## Test plan
- `uv run --with pytest pytest -q tests/run_agent/test_run_agent_codex_responses.py -k interim_visible_text_handles_multimodal_content_parts`
- Result: 1 passed