### PR TITLE
fix(config): preserve list values from config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8435,7 +8435,20 @@ def set_config_value(key: str, value: str):
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
     coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
+    default_value = _default_value_for_key(key)
+    if isinstance(default_value, list) or value.lstrip().startswith("["):
+        try:
+            parsed_value = fast_safe_load(value)
+        except Exception:
+            parsed_value = None
+        if not isinstance(parsed_value, list):
+            print(
+                f"Invalid value for '{key}': expected a YAML/JSON list.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        coerced_value = parsed_value
+    elif not isinstance(default_value, str):
         if value.lower() in {'true', 'yes', 'on'}:
             coerced_value = True
         elif value.lower() in {'false', 'no', 'off'}:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2445,6 +2445,9 @@ DEFAULT_CONFIG = {
         #                     never crammed into a chat bubble), apply with
         #                     /skills approve <id> or drop with /skills reject <id>.
         "write_approval": False,
+        # Skill names disabled for this profile. Keep this in DEFAULT_CONFIG so
+        # `hermes config set skills.disabled '[...]'` preserves the list type.
+        "disabled": [],
     },
 
     # Curator — background skill maintenance.
@@ -8436,7 +8439,7 @@ def set_config_value(key: str, value: str):
     # retain the historical best-effort coercion behavior.
     coerced_value: Any = value
     default_value = _default_value_for_key(key)
-    if isinstance(default_value, list) or value.lstrip().startswith("["):
+    if isinstance(default_value, list):
         try:
             parsed_value = fast_safe_load(value)
         except Exception:

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -108,6 +108,21 @@ class TestConfigYamlRouting:
         assert "docker" in config
         assert "terminal" not in _read_env(_isolated_hermes_home)
 
+    def test_list_typed_key_parses_yaml_list(self, _isolated_hermes_home):
+        set_config_value(
+            "skills.disabled",
+            '["computer-use", "segment-anything", "vllm"]',
+        )
+
+        import yaml
+
+        config = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert config["skills"]["disabled"] == [
+            "computer-use",
+            "segment-anything",
+            "vllm",
+        ]
+
     def test_terminal_image_goes_to_config(self, _isolated_hermes_home):
         """TERMINAL_DOCKER_IMAGE doesn't match _API_KEY or _TOKEN, so config.yaml."""
         set_config_value("terminal.docker_image", "python:3.12")


### PR DESCRIPTION
## Summary
- declare `skills.disabled` as a list-typed default
- parse YAML/JSON arrays for list-typed `hermes config set` values
- reject invalid scalar input instead of silently storing the wrong type

## Problem
Running `hermes config set skills.disabled '["computer-use", "segment-anything", "vllm"]'` previously wrote the entire array as a quoted string. Downstream normalization could then iterate it character by character and produce a corrupted disabled-skill list.\n\n## Test plan\n- `uv run --with pytest pytest -q tests/hermes_cli/test_set_config_value.py`\n- Result: 58 passed