### PR TITLE
fix(state): stop a lone surrogate from silently killing session persistence

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -26,10 +26,22 @@ import time
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
+from agent.message_sanitization import _sanitize_surrogates
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
+
+
+def _scrub_surrogates(value: Any) -> Any:
+    """Replace lone surrogates when *value* is text; pass anything else through.
+
+    sqlite3 encodes bound ``str`` parameters as UTF-8 and raises
+    ``UnicodeEncodeError`` on lone surrogates (U+D800..U+DFFF), so a single
+    such code point anywhere in a message aborts the whole write. No-op for
+    well-formed text.
+    """
+    return _sanitize_surrogates(value) if isinstance(value, str) else value
 
 
 def workspace_key(row: Dict[str, Any]) -> Optional[str]:
@@ -4097,13 +4109,26 @@ class SessionDB:
         sentinel-prefixed JSON string for lists/dicts. Paired with
         :meth:`_decode_content` on read.
         """
-        if content is None or isinstance(content, (str, bytes, int, float)):
+        if isinstance(content, str):
+            # Lone UTF-16 surrogates reach here inside tool results scraped
+            # from the web/social platforms (the same input that crashed the
+            # guardrail hasher). The proactive sanitizer upstream only cleans
+            # the *api_messages* copy, and the recovery sanitizer only runs
+            # after the API call itself raises — which it no longer does — so
+            # the canonical history keeps them and this write is where they
+            # land. Left raw, sqlite3 raises UnicodeEncodeError, the flush is
+            # abandoned, and the session silently stops persisting for the
+            # rest of its life. Scrub so persistence never fails.
+            return _sanitize_surrogates(content)
+        if content is None or isinstance(content, (bytes, int, float)):
             return content
         try:
+            # json.dumps defaults to ensure_ascii=True, which escapes any
+            # surrogate as \udXXX — already safe to bind.
             return cls._CONTENT_JSON_PREFIX + json.dumps(content)
         except (TypeError, ValueError):
             # Last-resort fallback: stringify so persistence never fails.
-            return str(content)
+            return _sanitize_surrogates(str(content))
 
     @classmethod
     def _decode_content(cls, content: Any) -> Any:
@@ -4202,8 +4227,8 @@ class SessionDB:
                     message_timestamp,
                     token_count,
                     finish_reason,
-                    reasoning,
-                    reasoning_content,
+                    _scrub_surrogates(reasoning),
+                    _scrub_surrogates(reasoning_content),
                     reasoning_details_json,
                     codex_items_json,
                     codex_message_items_json,
@@ -4295,8 +4320,8 @@ class SessionDB:
                     message_timestamp,
                     msg.get("token_count"),
                     msg.get("finish_reason"),
-                    msg.get("reasoning") if role == "assistant" else None,
-                    msg.get("reasoning_content") if role == "assistant" else None,
+                    _scrub_surrogates(msg.get("reasoning")) if role == "assistant" else None,
+                    _scrub_surrogates(msg.get("reasoning_content")) if role == "assistant" else None,
                     reasoning_details_json,
                     codex_items_json,
                     codex_message_items_json,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -6151,3 +6151,67 @@ class TestGetMessagesPagination:
         self._seed(db, n=5)
         rows = db.get_messages("s1", offset=3)
         assert [m["content"] for m in rows] == ["msg-3", "msg-4"]
+
+
+# =========================================================================
+# Lone-surrogate persistence
+# =========================================================================
+
+class TestLoneSurrogatePersistence:
+    """sqlite3 encodes bound str params as UTF-8 and raises UnicodeEncodeError
+    on lone surrogates (U+D800..U+DFFF). Tool results scraped from the web can
+    carry them, so a single such code point aborted the whole message write —
+    and because run_agent swallows the failure with a warning, the session then
+    silently stopped persisting for the rest of its life.
+    """
+
+    DIRTY = "scraped \ud835 price"
+
+    def test_append_message_survives_lone_surrogate_content(self, db):
+        db.create_session("s1", source="cli")
+        db.append_message("s1", "assistant", "hello world")
+        db.append_message("s1", "tool", self.DIRTY, tool_name="web_search")
+
+        rows = db.get_messages("s1")
+        assert len(rows) == 2
+        # Surrogate replaced with U+FFFD; the surrounding text is intact.
+        assert rows[1]["content"] == "scraped � price"
+
+    def test_append_message_survives_lone_surrogate_reasoning(self, db):
+        db.create_session("s1", source="cli")
+        db.append_message("s1", "assistant", "fine", reasoning=self.DIRTY)
+        assert len(db.get_messages("s1")) == 1
+
+    def test_replace_messages_keeps_persisting_after_dirty_row(self, db):
+        """The regression that mattered: one poisoned row froze the session.
+
+        replace_messages re-sends the full history each turn, so once a dirty
+        tool result entered it, every later save raised and nothing after it
+        was ever written.
+        """
+        db.create_session("s1", source="cli")
+        history = [
+            {"role": "user", "content": "turn 1"},
+            {"role": "assistant", "content": "answer 1"},
+            {"role": "tool", "content": self.DIRTY, "tool_name": "web_search"},
+            {"role": "assistant", "content": "answer 2"},
+        ]
+        db.replace_messages("s1", history)
+        assert len(db.get_messages("s1")) == 4
+
+        # Later turns still persist rather than freezing at the poisoned row.
+        history += [
+            {"role": "user", "content": "turn 3"},
+            {"role": "assistant", "content": "answer 3"},
+        ]
+        db.replace_messages("s1", history)
+        rows = db.get_messages("s1")
+        assert len(rows) == 6
+        assert rows[-1]["content"] == "answer 3"
+
+    def test_well_formed_unicode_is_unchanged(self, db):
+        """Accents, CJK and emoji must round-trip byte-identically."""
+        db.create_session("s1", source="cli")
+        benign = "Ünïcödé ok — 日本語 🎉 emoji fine"
+        db.append_message("s1", "assistant", benign)
+        assert db.get_messages("s1")[0]["content"] == benign


### PR DESCRIPTION
## What does this PR do?

`sqlite3` encodes bound `str` parameters as UTF-8 and raises `UnicodeEncodeError` on lone surrogates (U+D800..U+DFFF), but `SessionDB._encode_content` returned `str` content untouched. A single such code point anywhere in a message aborted the **entire** message write.

This is reachable with ordinary input — the same scraped web/social text that crashed the guardrail hasher in `fb0217c65`:

1. A tool result carrying a lone surrogate is appended to the canonical `messages` history unsanitized.
2. The proactive sanitizer only cleans the **`api_messages` copy** (`conversation_loop.py`), so the API call **succeeds**.
3. Because the API never raises, the recovery sanitizer — guarded by `isinstance(api_error, UnicodeEncodeError)` — **never runs**, and the history keeps the surrogate.
4. The DB flush hits it, and `run_agent` swallows the failure with `logger.warning("Session DB append_message failed")`.

Since `replace_messages` re-sends the whole history every turn, the poisoned row stays and every later save raises too. The session **freezes at its last good state** while the live conversation grows, and everything after that point is gone on resume:

```
turn 2: FAILED; persisted 2 (history 4)
turn 3: FAILED; persisted 2 (history 6)
...
turn 6: FAILED; persisted 2 (history 12)
```

Only a warning in the log — no user-visible signal until the session is resumed and the turns are missing. (Pre-existing history is not destroyed: the transaction rolls back correctly.)

The fix scrubs at the DB write boundary using the canonical `_sanitize_surrogates` (surrogate → U+FFFD), matching `_encode_content`'s own stated intent that persistence never fails.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` — add a `_scrub_surrogates` helper over the canonical `agent.message_sanitization._sanitize_surrogates`; scrub `str` content in `_encode_content` (shared by **both** `INSERT INTO messages` sites) and the raw-bound `reasoning` / `reasoning_content` columns at both sites. The JSON branch already defaults to `ensure_ascii=True` and was safe, so it is left alone.
- `tests/test_hermes_state.py` — add `TestLoneSurrogatePersistence`: surrogate in tool-result content, surrogate in `reasoning`, the multi-turn freeze via `replace_messages`, and a benign-Unicode passthrough guard.

## How to Test

1. Reproduce on current `main`:

       db.create_session("s1", source="cli")
       db.append_message("s1", "tool", "scraped \ud835 price", tool_name="web_search")
       # UnicodeEncodeError: 'utf-8' codec can't encode character '\ud835': surrogates not allowed

   Then the freeze — re-send the growing history each turn via `replace_messages`; persisted rows stay pinned while history grows.

2. Apply the fix: the surrogate is stored as U+FFFD, surrounding text intact, and every later turn persists.
3. Run:

       pytest tests/test_hermes_state.py -q

   New tests pass with the fix and fail without it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(state):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suites and all tests pass — `tests/test_hermes_state.py`, `tests/hermes_state/`, `tests/state/`: **450 passed**; surrogate suites: 60 passed. A broad `-k "surrogate or persist"` sweep shows an **identical** 9 pre-existing failures on clean `main` and with this change (verified via a separate baseline worktree) — no regressions.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the helper and `_encode_content` document the failure mode; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure string handling, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A