### PR TITLE
fix(codex): bridge gateway approvals safely

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -27,6 +27,44 @@ from agent.stream_single_writer import claim_stream_writer, stream_writer_is_cur
 logger = logging.getLogger(__name__)
 
 
+def _resolve_codex_approval_callback():
+    """Resolve Codex approvals through CLI or the active gateway session."""
+    try:
+        from tools.terminal_tool import _get_approval_callback
+
+        callback = _get_approval_callback()
+        if callback is not None:
+            return callback
+    except Exception:
+        logger.debug("failed to resolve CLI approval callback", exc_info=True)
+
+    try:
+        from tools.approval import has_gateway_notify, prompt_gateway_approval
+
+        if not has_gateway_notify():
+            return None
+
+        def _gateway_callback(
+            command: str,
+            description: str,
+            *,
+            allow_permanent: bool = True,
+            smart_denied: bool = False,
+        ) -> str:
+            return prompt_gateway_approval(
+                command,
+                description,
+                pattern_key="codex_app_server",
+                pattern_keys=["codex_app_server"],
+                allow_permanent=allow_permanent and not smart_denied,
+            )
+
+        return _gateway_callback
+    except Exception:
+        logger.debug("failed to resolve gateway approval callback", exc_info=True)
+        return None
+
+
 def _coerce_usage_int(value: Any) -> int:
     if isinstance(value, bool):
         return 0
@@ -643,24 +681,15 @@ def run_codex_app_server_turn(
         from agent.runtime_cwd import resolve_agent_cwd
 
         cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
-        # Approval callback: defer to Hermes' standard prompt flow if a
-        # CLI thread has installed one. Gateway / cron contexts get the
-        # codex-side fail-closed default.
-        try:
-            from tools.terminal_tool import _get_approval_callback
-            approval_callback = _get_approval_callback()
-        except Exception:
-            approval_callback = None
+        # CLI sessions use prompt-toolkit; gateway sessions bridge Codex
+        # requests into the shared Hermes approval queue; cron and other
+        # non-interactive contexts remain fail-closed.
+        approval_callback = _resolve_codex_approval_callback()
 
         # Gateway / cron contexts have no UI to surface codex's approval
         # requests through, so codex app-server exec / apply_patch requests
-        # fail closed (silently decline) by default. When the user has
-        # explicitly opted out of Hermes approvals — via `approvals.mode: off`
-        # in config, the /yolo session toggle, or --yolo / HERMES_YOLO_MODE —
-        # honor that and let codex's own sandbox permission profile
-        # (~/.codex/config.toml) be the policy gate instead of double-gating
-        # with a missing Hermes UI. Defaults (manual/smart/unset) preserve the
-        # current fail-closed behavior — this is a no-op for those users.
+        # fail closed by default. Explicit Hermes approval bypass settings are
+        # still honored through Codex's own sandbox permission profile.
         auto_approve_requests = False
         try:
             from tools.approval import is_approval_bypass_active

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -1066,9 +1066,14 @@ class CodexAppServerSession:
         gate (mode + ``approvals.timeout``) in ``tools/approval.py``.
         Keep it that way — do not re-read approval config here.
         """
+        command = params.get("command") or ""
+        from tools.approval import check_unconditional_command_guards
+
+        blocked, _blocked_description = check_unconditional_command_guards(command)
+        if blocked:
+            return "decline"
         if self._routing.auto_approve_exec:
             return "accept"
-        command = params.get("command") or ""
         # Codex's CommandExecutionRequestApprovalParams has cwd as Optional —
         # fall back to the session's cwd when codex doesn't include it so the
         # approval prompt is never empty (quirk #10 fix).
@@ -1095,34 +1100,38 @@ class CodexAppServerSession:
         resolution is delegated to ``tools/approval.py`` upstream — see
         the docstring on ``_decide_exec_approval``.
         """
+        # FileChangeRequestApprovalParams gives us reason + grantRoot. The
+        # actual changeset lives on the corresponding fileChange item which
+        # the projector has already cached for us.
+        reason = params.get("reason")
+        grant_root = params.get("grantRoot")
+        item_id = params.get("itemId") or ""
+        change_summary = self._lookup_pending_file_change(item_id)
+        description_parts = []
+        if reason:
+            description_parts.append(reason)
+        if change_summary:
+            description_parts.append(change_summary)
+        if grant_root:
+            description_parts.append(f"grants write to {grant_root}")
+        description = (
+            "; ".join(description_parts)
+            if description_parts
+            else "Codex requests to apply a patch"
+        )
+        command_label = (
+            f"apply_patch: {change_summary}" if change_summary
+            else f"apply_patch: {reason}" if reason
+            else "apply_patch"
+        )
+        from tools.approval import check_unconditional_command_guards
+
+        blocked, _blocked_description = check_unconditional_command_guards(command_label)
+        if blocked:
+            return "decline"
         if self._routing.auto_approve_apply_patch:
             return "accept"
         if self._approval_callback is not None:
-            # FileChangeRequestApprovalParams gives us reason + grantRoot.
-            # The actual changeset lives on the corresponding fileChange
-            # item which the projector has already cached for us — look it
-            # up by item_id so the user sees what's actually changing.
-            reason = params.get("reason")
-            grant_root = params.get("grantRoot")
-            item_id = params.get("itemId") or ""
-            change_summary = self._lookup_pending_file_change(item_id)
-            description_parts = []
-            if reason:
-                description_parts.append(reason)
-            if change_summary:
-                description_parts.append(change_summary)
-            if grant_root:
-                description_parts.append(f"grants write to {grant_root}")
-            description = (
-                "; ".join(description_parts)
-                if description_parts
-                else "Codex requests to apply a patch"
-            )
-            command_label = (
-                f"apply_patch: {change_summary}" if change_summary
-                else f"apply_patch: {reason}" if reason
-                else "apply_patch"
-            )
             try:
                 choice = self._approval_callback(
                     command_label,

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -596,6 +596,58 @@ class TestServerRequestRouting:
         s.run_turn("hi", turn_timeout=1.0)
         assert ("r1", {"decision": "accept"}) in client.responses
 
+    def test_routing_auto_approve_apply_patch_without_callback(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/fileChange/requestApproval",
+            request_id="r-patch",
+            itemId="fc-1",
+            reason="update documentation",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        s = make_session(client, request_routing=_ServerRequestRouting(
+            auto_approve_apply_patch=True))
+        s.run_turn("hi", turn_timeout=1.0)
+        assert ("r-patch", {"decision": "accept"}) in client.responses
+
+    def test_routing_auto_approve_still_enforces_unconditional_guards(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="r-hardline",
+            command="rm -rf /",
+            cwd="/",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        s = make_session(client, request_routing=_ServerRequestRouting(
+            auto_approve_exec=True))
+        s.run_turn("hi", turn_timeout=1.0)
+        assert ("r-hardline", {"decision": "decline"}) in client.responses
+
+    def test_callback_raises_falls_back_to_decline(self):
+        client = FakeClient()
+        client.queue_server_request("item/commandExecution/requestApproval", request_id="r1",
+                                    command="ls", cwd="/")
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        def boom(*a, **kw):
+            raise RuntimeError("ui crashed")
+
+        s = make_session(client, approval_callback=boom)
+        s.run_turn("hi", turn_timeout=1.0)
+        # Fail-closed: deny on callback exception
+        assert ("r1", {"decision": "decline"}) in client.responses
 
 
 # ---- enriched approval prompts ----

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -86,6 +86,90 @@ class TestRunConversationCodexPath:
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
 
+    def test_gateway_approval_callback_reaches_shared_queue(self, monkeypatch):
+        from agent.codex_runtime import _resolve_codex_approval_callback
+        from tools.approval import (
+            register_gateway_notify,
+            reset_current_session_key,
+            resolve_gateway_approval,
+            set_current_session_key,
+            unregister_gateway_notify,
+        )
+
+        session_key = "test-codex-gateway-approval"
+        seen = {}
+
+        token_value = "gho_1234567890abcdefghijklmnopqrstuv"
+        redaction_calls = []
+        from agent import redact as redact_module
+
+        original_redact = redact_module.redact_sensitive_text
+
+        def recording_redact(text, **kwargs):
+            redaction_calls.append(kwargs)
+            return original_redact(text, **kwargs)
+
+        monkeypatch.setattr(redact_module, "redact_sensitive_text", recording_redact)
+
+        def notify(data):
+            seen.update(data)
+            resolve_gateway_approval(session_key, "once")
+
+        monkeypatch.setattr("tools.approval._get_approval_mode", lambda: "manual")
+        token = set_current_session_key(session_key)
+        register_gateway_notify(session_key, notify)
+        try:
+            callback = _resolve_codex_approval_callback()
+            assert callback is not None
+            assert callback(
+                f"printf 'token={token_value}'",
+                "Codex requests exec",
+                allow_permanent=False,
+            ) == "once"
+            assert token_value not in seen["command"]
+            assert seen["description"] == "Codex requests exec"
+            assert len(redaction_calls) == 2
+            assert all(call.get("force") is True for call in redaction_calls)
+        finally:
+            unregister_gateway_notify(session_key)
+            reset_current_session_key(token)
+
+    def test_gateway_approval_honors_smart_and_hardline_policy(self, monkeypatch):
+        from agent.codex_runtime import _resolve_codex_approval_callback
+        from tools import approval as approval_module
+        from tools.approval import (
+            register_gateway_notify,
+            reset_current_session_key,
+            set_current_session_key,
+            unregister_gateway_notify,
+        )
+
+        session_key = "test-codex-gateway-smart"
+        prompted = []
+        token = set_current_session_key(session_key)
+        register_gateway_notify(session_key, lambda data: prompted.append(data))
+        try:
+            monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "smart")
+            monkeypatch.setattr(approval_module, "_smart_approve", lambda *_: "approve")
+            callback = _resolve_codex_approval_callback()
+            assert callback is not None
+            assert callback("git status", "read-only inspection") == "once"
+            assert prompted == []
+
+            assert callback("rm -rf /", "destructive command") == "deny"
+            assert prompted == []
+        finally:
+            unregister_gateway_notify(session_key)
+            reset_current_session_key(token)
+
+    def test_gateway_approval_without_notifier_fails_closed(self, monkeypatch):
+        from agent.codex_runtime import _resolve_codex_approval_callback
+        from tools import approval as approval_module
+
+        monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
+        callback = _resolve_codex_approval_callback()
+        assert callback is None
+
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
             return TurnResult(

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -170,6 +170,77 @@ class TestRunConversationCodexPath:
         callback = _resolve_codex_approval_callback()
         assert callback is None
 
+    def test_gateway_session_approval_persists_through_full_turn_construction(
+        self, monkeypatch
+    ):
+        """Lifecycle coverage (not just the resolver in isolation): drive a
+        REAL run_conversation() turn so agent_codex_runtime constructs an
+        actual CodexAppServerSession with the gateway-resolved
+        approval_callback wired in exactly as production does, simulate a
+        mid-turn Codex exec-approval request through that stored callback,
+        and prove a "session" choice is persisted — a second request for the
+        same pattern must NOT re-prompt the notifier.
+        """
+        from tools.approval import (
+            register_gateway_notify,
+            reset_current_session_key,
+            resolve_gateway_approval,
+            set_current_session_key,
+            unregister_gateway_notify,
+        )
+
+        session_key = "test-codex-gateway-session-persist"
+        notify_calls = []
+
+        def notify(data):
+            notify_calls.append(data)
+            resolve_gateway_approval(session_key, "session")
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            # Simulate Codex asking for exec approval mid-turn, exactly as
+            # codex_app_server_session._decide_exec_approval would via
+            # self._approval_callback — using the REAL callback the real
+            # constructor stored, not a hand-built stand-in.
+            first = self._approval_callback(
+                "git status", "Codex requests exec", allow_permanent=False
+            )
+            second = self._approval_callback(
+                "git status", "Codex requests exec", allow_permanent=False
+            )
+            return TurnResult(
+                final_text=f"first={first} second={second}",
+                projected_messages=[
+                    {"role": "assistant", "content": f"first={first} second={second}"}
+                ],
+                tool_iterations=1,
+                interrupted=False,
+                error=None,
+                turn_id="turn-persist-1",
+                thread_id="thread-persist-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-persist-1"
+        )
+        monkeypatch.setattr("tools.approval._get_approval_mode", lambda: "manual")
+
+        token = set_current_session_key(session_key)
+        register_gateway_notify(session_key, notify)
+        try:
+            agent = _make_codex_agent()
+            with patch.object(agent, "_spawn_background_review", return_value=None):
+                result = agent.run_conversation("check status")
+            assert agent._codex_session._approval_callback is not None
+            assert result["final_response"] == "first=session second=session"
+            # The notifier must have fired exactly once — the second request
+            # for the same pattern_key was resolved from persisted state
+            # (is_approved), not re-prompted.
+            assert len(notify_calls) == 1
+        finally:
+            unregister_gateway_notify(session_key)
+            reset_current_session_key(token)
+
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
             return TurnResult(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2553,7 +2553,20 @@ def prompt_gateway_approval(
 
     choice = decision.get("choice") or "deny"
     if choice == "always" and not approval_data["allow_permanent"]:
-        return "session"
+        choice = "session"
+
+    # Persist the resolved choice — mirrors the identical convention used by
+    # every other gateway/CLI approval call site in this module (see the
+    # "session"/"always" handling after prompt_dangerous_approval() above).
+    # Without this, is_approved(session_key, pattern_key) above never finds
+    # a prior approval, so every subsequent Codex exec/apply_patch request
+    # in the same session re-prompts even after the user picked "session".
+    if choice == "session":
+        approve_session(session_key, pattern_key)
+    elif choice == "always":
+        approve_session(session_key, pattern_key)
+        approve_permanent(pattern_key)
+        save_permanent_allowlist(_permanent_approved)
     return choice
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2462,6 +2462,101 @@ _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, 
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
 
 
+def has_gateway_notify(session_key: Optional[str] = None) -> bool:
+    """Return whether a live gateway approval notifier is registered."""
+    key = session_key if session_key is not None else get_current_session_key(default="")
+    if not key:
+        return False
+    with _lock:
+        return key in _gateway_notify_cbs
+
+
+def check_unconditional_command_guards(command: str) -> tuple[bool, str | None]:
+    """Apply approval policy floors that no bypass may override."""
+    is_hardline, description = detect_hardline_command(command)
+    if is_hardline:
+        return True, description
+
+    is_sudo_guess, description = _check_sudo_stdin_guard(command)
+    if is_sudo_guess:
+        return True, description
+
+    deny_pattern = _match_user_deny_rule(command)
+    if deny_pattern is not None:
+        return True, f"blocked by approvals.deny rule: {deny_pattern}"
+
+    return False, None
+
+
+def prompt_gateway_approval(
+    command: str,
+    description: str,
+    *,
+    pattern_key: str = "codex_app_server",
+    pattern_keys: Optional[list[str]] = None,
+    allow_permanent: bool = False,
+) -> str:
+    """Resolve an approval request through the shared gateway approval path.
+
+    External runtimes such as Codex app-server do not pass through Hermes'
+    normal terminal guard, but their approval requests must retain the same
+    hardline, smart-approval, redaction, queue, timeout, hook, and interrupt
+    semantics.
+    """
+    session_key = get_current_session_key(default="")
+    all_keys = list(pattern_keys or [pattern_key])
+
+    blocked, _blocked_description = check_unconditional_command_guards(command)
+    if blocked:
+        return "deny"
+
+    if is_approval_bypass_active():
+        return "once"
+    if is_approved(session_key, pattern_key):
+        return "session"
+
+    smart_denied = False
+    if _get_approval_mode() == "smart":
+        verdict = _smart_approve(command, description)
+        if verdict == "approve":
+            return "once"
+        if verdict == "deny":
+            # An interactive owner may still override a Smart DENY for this
+            # operation, but permanent approval is never offered.
+            smart_denied = True
+
+    with _lock:
+        notify_cb = _gateway_notify_cbs.get(session_key)
+    if notify_cb is None:
+        return "deny"
+
+    from agent.redact import redact_sensitive_text
+
+    approval_data = {
+        "command": redact_sensitive_text(command, force=True),
+        "pattern_key": pattern_key,
+        "pattern_keys": all_keys,
+        "description": redact_sensitive_text(description, force=True),
+        "allow_permanent": bool(allow_permanent and not smart_denied),
+    }
+    if smart_denied:
+        approval_data["smart_denied"] = True
+
+    decision = _await_gateway_decision(
+        session_key,
+        notify_cb,
+        approval_data,
+        surface="gateway",
+    )
+    if decision.get("notify_failed") or not decision.get("resolved"):
+        return "deny"
+
+    choice = decision.get("choice") or "deny"
+    if choice == "always" and not approval_data["allow_permanent"]:
+        return "session"
+    return choice
+
+
 def register_gateway_notify(session_key: str, cb) -> None:
     """Register a per-session callback for sending approval requests to the user.
 


### PR DESCRIPTION
## Summary

Bridge Codex app-server exec and file-change approval requests into Hermes' existing gateway approval queue when a live gateway session is available.

This preserves CLI approval behavior, keeps cron/non-interactive contexts fail-closed, and reuses the shared timeout, interrupt, cleanup, heartbeat, and approval-hook machinery.

## Problem

`run_codex_app_server_turn()` currently only resolves the CLI approval callback. Gateway sessions therefore have no callback for Codex `item/commandExecution/requestApproval` and `item/fileChange/requestApproval` requests, so they are silently declined even though the user is present on Telegram, Discord, or Desktop.

This is the remaining interactive-gateway case discussed in #26530 and the draft approach in #27636. The merged YOLO/mode-off behavior does not provide an interactive approval bridge for manual or smart mode.

## Implementation

- Prefer the existing CLI callback when one is installed.
- Otherwise, expose a callback only when the active session has a registered gateway notifier.
- Send requests through `prompt_gateway_approval()`, which:
  - applies hardline, sudo-stdin, and `approvals.deny` floors before any bypass;
  - honors mode-off, YOLO, permanent/session approval, and smart approval;
  - force-redacts command and description before crossing the gateway boundary;
  - delegates queueing, timeout, interruption, cleanup, and hooks to `_await_gateway_decision()`;
  - fails closed on missing notifier, notification failure, timeout, or unresolved decisions.
- Apply unconditional command-policy floors before Codex's `auto_approve_exec` and `auto_approve_apply_patch` shortcuts.

## Safety properties

- Hardline commands cannot be approved through YOLO/mode-off auto-routing.
- `sudo -S` guessing and user-defined deny rules remain unconditional.
- Gateway payload redaction uses `force=True`, independent of `security.redact_secrets`.
- No notifier means no interactive callback; requests remain fail-closed unless the existing explicit bypass routing applies.
- Permanent approval remains disabled for Codex exec and apply-patch requests.

## Tests

```text
410 passed, 1 deselected
ruff: passed
git diff --check: passed
```

The deselected test is `TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, which also fails on clean `main` on macOS because `/tmp` resolves through `/private/tmp`; it is unrelated to this change.

New regression coverage includes:

- Gateway queue approval and decision mapping
- Forced secret redaction
- Smart auto-approval without prompting
- Hardline denial
- Missing-notifier fail-closed behavior
- Hardline denial before Codex exec auto-approval
- Safe apply-patch auto-approval without a callback

## Related work

- #26530
- #27636
- #25889
- #56534
