### PR TITLE
fix(redact): also catch bare AQ.-prefix Gemini authorization keys (#66920)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -88,6 +88,7 @@ _PREFIX_PATTERNS = [
     r"xapp-\d+-[A-Za-z0-9-]{10,}",      # Slack app-Level token
     r"xox[baprs]-[A-Za-z0-9-]{10,}",    # Slack bot/app/user tokens
     r"AIza[A-Za-z0-9_-]{30,}",          # Google API keys
+    r"AQ\.[A-Za-z0-9_-]{40,}",           # Google Gemini authorization keys (newer "AQ." prefix; AIza pattern doesn't catch them) — #66920
     r"pplx-[A-Za-z0-9]{10,}",           # Perplexity
     r"fal_[A-Za-z0-9_-]{10,}",          # Fal.ai
     r"fc-[A-Za-z0-9]{10,}",             # Firecrawl

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -85,6 +85,51 @@ class TestKnownPrefixes:
         assert redact_sensitive_text(text) == text
 
 
+    # --- #66920 Google Gemini authorization keys (AQ. prefix) ---
+
+    def test_google_gemini_aq_bare_key(self):
+        # Bare 48-char AQ.-prefix key must be redacted by the known-prefix
+        # list. Before the fix the bare value passed through verbatim;
+        # after the fix it must differ from the input. No real credential
+        # is needed; the inner key chars are placeholders.
+        key = "AQ." + "B" * 48
+        result = redact_sensitive_text(key, force=True)
+        assert result != key
+        assert key not in result
+
+    def test_google_gemini_aq_labeled_key(self):
+        # Regression net for the env-assignment detector: the same
+        # value, when labelled, is masked to "***". Guards against a
+        # future refactor accidentally over-broadening the env fallback.
+        key = "AQ." + "B" * 48
+        assigned = "GEMINI_API_KEY=" + key
+        result = redact_sensitive_text(assigned, force=True)
+        assert result != assigned
+
+    def test_google_gemini_aq_short_unprefixed_unchanged(self):
+        # Below the 40-char floor the prefix must NOT mask --- protects
+        # against over-eager matching of short fragments or variable
+        # names that happen to begin with "AQ.".
+        short = "AQ." + "B" * 10
+        result = redact_sensitive_text(short, force=True)
+        assert result == short
+
+    def test_google_gemini_aq_ordinary_prose_unchanged(self):
+        # A bare "AQ." substring inside natural text must NOT be masked
+        # --- protects against over-eager matching of prose such as
+        # "the AQ. project spec" or "see the AQ. section for details".
+        # The 40-char floor only matches when followed by a real key
+        # payload; short "AQ." prefixes carry no credentials.
+        prose_samples = (
+            "See the AQ. section for the full project spec.",
+            "AQ. is a placeholder variable we never log.",
+            "Reading the AQ. appendix to learn more.",
+        )
+        for prose in prose_samples:
+            result = redact_sensitive_text(prose, force=True)
+            assert result == prose, (
+                f"prose redacted unexpectedly: {prose!r} -> {result!r}"
+            )
 
 
 class TestEnvAssignments:


### PR DESCRIPTION
## Summary

`agent/redact.py` known-prefix list covers `AIza[A-Za-z0-9_-]{30,}` (Google API keys) but **not** the newer `AQ.` authorization-key format that Gemini uses. The generic environment-assignment detector catches the same value when labelled (`GEMINI_API_KEY=...`), but bare occurrences in tool output, provider error messages, or pasted text pass through unchanged and reach `state.db` unredacted.

Repro from #66920:

```python
from agent.redact import redact_sensitive_text
bare = "AQ." + "B" * 48
assigned = "GEMINI_API_KEY=" + bare
assert redact_sensitive_text(bare, force=True) == bare        # passes pre-fix — BUG
assert redact_sensitive_text(assigned, force=True) != assigned # passes pre-fix
```

## Fix

Add an explicit `AQ\.[A-Za-z0-9_-]{40,}` entry next to the existing `AIza` line:

```python
r"AQ\.[A-Za-z0-9_-]{40,}",  # Google Gemini authorization keys (newer "AQ." prefix; AIza pattern doesn't catch them) — #66920
```

Single-file change in `agent/redact.py`. No public API change. No new imports. No logic change elsewhere — the redactor already iterates the prefix list and applies each pattern's match.

## Test plan

1. Run the issue's repro on current `main` — `bare` passes through (FAILS).
2. Apply this fix — `bare` is redacted to a truncated form; `assigned` continues to redact to `***`.
3. Existing `AIza`-prefix cases continue to redact normally (regression check).

Verified locally: `bare` is now redacted, `AQ.` prefix kept but middle truncated. `assigned` form fully redacted to `***`. Both pass.

Fixes #66920.
