### PR TITLE
fix(redact): preserve closing quote after redacted auth/x-api-key headers

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -202,11 +202,20 @@ _AUTH_HEADER_RE = re.compile(
 # Anthropic and many providers authenticate with ``x-api-key``; values without
 # a known vendor prefix (custom/local backends) would otherwise leak when a
 # request or curl command is logged or echoed into tool output / transcripts.
+#
+# The credential class excludes quote characters (``"`` / ``'``) for the same
+# reason as _AUTH_HEADER_RE (#43083): a token sitting flush against a closing
+# quote (``curl -H "x-api-key: sk-..."``) must not pull that quote into the
+# match, or masking turns value corruption into *syntax* corruption (the
+# closing quote vanishes → unterminated quote → shell EOF / Python
+# SyntaxError). Real credentials never contain ``"`` or ``'``, so excluding
+# them is safe. The sibling _AUTH_HEADER_RE was fixed in #43083 but this rule
+# still used greedy ``\S+`` and exhibited the same corruption.
 _SECRET_HEADER_NAMES = (
     r"(?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)"
 )
 _SECRET_HEADER_RE = re.compile(
-    rf"({_SECRET_HEADER_NAMES}\s*:\s*)(\S+)",
+    rf"({_SECRET_HEADER_NAMES}\s*:\s*)([^\s\"']+)",
     re.IGNORECASE,
 )
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -304,6 +304,26 @@ class TestApiKeyHeaders:
         result = redact_sensitive_text(text)
         assert "anotherOpaqueSecret" not in result
 
+    def test_x_api_key_flush_against_double_quote_preserves_quote(self):
+        # Regression for #43083 extended to _SECRET_HEADER_RE: the sibling
+        # _AUTH_HEADER_RE was fixed to exclude quotes from the credential
+        # class, but this rule still used greedy \S+ and ate the closing
+        # double quote, turning value corruption into syntax corruption
+        # (unterminated quote → shell EOF).
+        text = 'curl -H "x-api-key: sk-local-VERYsecret-999888"'
+        result = redact_sensitive_text(text)
+        assert "VERYsecret" not in result
+        assert result.count('"') == 2, result  # both quotes survive
+        assert result.endswith('"'), result
+
+    def test_x_api_key_flush_against_single_quote_preserves_quote(self):
+        # Same as above with single quotes (Python f-string context).
+        text = "hdr = 'x-api-key: sk-local-VERYsecret-999888'"
+        result = redact_sensitive_text(text)
+        assert "VERYsecret" not in result
+        assert result.count("'") == 2, result
+        assert result.endswith("'"), result
+
 
 class TestTelegramTokens:
     def test_bot_token(self):


### PR DESCRIPTION
## Summary

When `_SECRET_HEADER_RE` (in `agent/redact.py`) matched a credential like `x-api-key: ***` flush against a closing quote (`curl -H "x-api-key: ***"`), its greedy `\S+` credential class consumed the trailing double quote. That turns value corruption into **syntax** corruption: an unterminated quote propagates downstream as shell EOF / Python SyntaxError when the redacted text is reused or echoed.

The sibling `_AUTH_HEADER_RE` was already fixed for the same class in #43083 (the rule below this one). This rule still used the greedy `\S+` and exhibited the identical corruption — the comment block above the rule even spells out why quotes must be excluded.

## Fix

Replace the credential class in `_SECRET_HEADER_RE` with `[^\s"']+` — excludes whitespace and the two quote characters. Neither can legitimately appear inside a real credential, so the exclusion is safe.

```python
_SECRET_HEADER_RE = re.compile(
    rf"({_SECRET_HEADER_NAMES}\s*:\s*)([^\s"']+)",
    re.IGNORECASE,
)
```

Two regression tests added in `tests/agent/test_redact.py::TestApiKeyHeaders` to pair with the existing `TestAuthHeaders` cases from #43083:
- `test_x_api_key_flush_against_double_quote_preserves_quote`
- `test_x_api_key_flush_against_single_quote_preserves_quote`

Verified locally:

```
tests/agent/test_redact.py::TestAuthHeaders::test_token_flush_against_double_quote_preserves_quote PASSED
tests/agent/test_redact.py::TestAuthHeaders::test_token_flush_against_single_quote_preserves_quote PASSED
tests/agent/test_redact.py::TestApiKeyHeaders::test_x_api_key_flush_against_double_quote_preserves_quote PASSED
tests/agent/test_redact.py::TestApiKeyHeaders::test_x_api_key_flush_against_single_quote_preserves_quote PASSED
```

All 4 quote-flush cases pass; broader 151-case test_redact.py suite unchanged.

Single-file functional change in `agent/redact.py` (+10 / −1) plus a paired test file. No public API change.
