### PR TITLE
fix(update): serialize native updates without breaking Windows

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9719,7 +9719,10 @@ def cmd_update(args):
     _update_io_state = _install_hangup_protection(gateway_mode=gateway_mode)
     try:
         request = UpdateRequest(args=args, gateway_mode=gateway_mode)
-        NativeUpdateEngine(legacy_runner=_run_legacy_native_update).run(request)
+        NativeUpdateEngine(
+            legacy_runner=_run_legacy_native_update,
+            update_lock_identity=str(PROJECT_ROOT),
+        ).run(request)
     finally:
         _finalize_update_output(_update_io_state)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -319,6 +319,7 @@ from hermes_cli.subcommands.pairing import build_pairing_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
 from hermes_cli.subcommands.mcp import build_mcp_parser
 from hermes_cli.subcommands.claw import build_claw_parser
+from hermes_cli.update_engine import NativeUpdateEngine, UpdateRequest, UpdateResult
 
 
 def _require_tty(command_name: str) -> None:
@@ -9655,6 +9656,12 @@ def _discard_lockfile_churn(git_cmd, repo_root):
         pass
 
 
+def _run_legacy_native_update(request: UpdateRequest) -> UpdateResult:
+    """Legacy implementation behind the native update seam."""
+    _cmd_update_impl(request.args, gateway_mode=request.gateway_mode)
+    return UpdateResult(exit_code=0, message="legacy update completed")
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -9711,7 +9718,8 @@ def cmd_update(args):
     # _install_hangup_protection for rationale.
     _update_io_state = _install_hangup_protection(gateway_mode=gateway_mode)
     try:
-        _cmd_update_impl(args, gateway_mode=gateway_mode)
+        request = UpdateRequest(args=args, gateway_mode=gateway_mode)
+        NativeUpdateEngine(legacy_runner=_run_legacy_native_update).run(request)
     finally:
         _finalize_update_output(_update_io_state)
 

--- a/hermes_cli/update_engine.py
+++ b/hermes_cli/update_engine.py
@@ -1,14 +1,29 @@
-"""Native update seam for Hermes CLI.
+"""Native update seam for the existing Hermes CLI updater.
 
-This module intentionally keeps the first slice tiny: pure request/result/event
-dataclasses plus a narrow delegation object that can be driven by legacy
-behavior for now.
+The engine deliberately wraps only the exercised legacy update flow. On
+platforms with the hardened POSIX lock backend, concurrent repository updates
+are serialized. Unsupported platforms (notably native Windows) retain the
+legacy updater behavior without attempting the POSIX-only lock.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable
+
+from hermes_cli.update_lock import (
+    acquire_shared_update_lock,
+    mark_shared_update_lock_post_mutation,
+    shared_update_lock_supported,
+)
+
+
+class UpdateMutationBoundary(str, Enum):
+    """Whether an update failure is known to precede repository mutation."""
+
+    PRE_MUTATION = "pre_mutation"
+    POST_MUTATION_UNCERTAIN = "post_mutation_uncertain"
 
 
 @dataclass(frozen=True)
@@ -28,19 +43,21 @@ class UpdateResult:
 
 
 @dataclass(frozen=True)
-class UpdateEvent:
-    """Structured event emitted by the update engine."""
-
-    kind: str
-    message: str = ""
-    details: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
-
-
-@dataclass(frozen=True)
 class NativeUpdateEngine:
-    """Tiny seam that delegates to an injected legacy runner for now."""
+    """Delegate the existing updater, serializing it when the lock is supported."""
 
     legacy_runner: Callable[[UpdateRequest], UpdateResult]
+    update_lock_identity: str | None = None
+    update_lock_timeout_seconds: float = 30.0
 
     def run(self, request: UpdateRequest) -> UpdateResult:
-        return self.legacy_runner(request)
+        if self.update_lock_identity is None or not shared_update_lock_supported():
+            return self.legacy_runner(request)
+        with acquire_shared_update_lock(
+            self.update_lock_identity,
+            timeout_seconds=self.update_lock_timeout_seconds,
+        ):
+            # The legacy updater can mutate immediately after entry. Mark the
+            # lock conservatively before handing over control.
+            mark_shared_update_lock_post_mutation()
+            return self.legacy_runner(request)

--- a/hermes_cli/update_engine.py
+++ b/hermes_cli/update_engine.py
@@ -1,0 +1,46 @@
+"""Native update seam for Hermes CLI.
+
+This module intentionally keeps the first slice tiny: pure request/result/event
+dataclasses plus a narrow delegation object that can be driven by legacy
+behavior for now.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class UpdateRequest:
+    """Request passed into the native update seam."""
+
+    args: Any
+    gateway_mode: bool = False
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    """Result produced by the update engine."""
+
+    exit_code: int = 0
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class UpdateEvent:
+    """Structured event emitted by the update engine."""
+
+    kind: str
+    message: str = ""
+    details: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class NativeUpdateEngine:
+    """Tiny seam that delegates to an injected legacy runner for now."""
+
+    legacy_runner: Callable[[UpdateRequest], UpdateResult]
+
+    def run(self, request: UpdateRequest) -> UpdateResult:
+        return self.legacy_runner(request)

--- a/hermes_cli/update_lock.py
+++ b/hermes_cli/update_lock.py
@@ -1,0 +1,329 @@
+"""Cross-process shared update lock for Hermes update lanes.
+
+The lock identity is derived from the canonical repository identity, while the
+lock file lives in a private per-user namespace outside the repository.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from enum import Enum
+import errno
+import hashlib
+import math
+import os
+from pathlib import Path
+import stat
+import tempfile
+import threading
+import time
+from types import ModuleType
+
+_fcntl: ModuleType | None
+try:
+    import fcntl as _fcntl_module
+except ModuleNotFoundError:  # pragma: no cover - exercised in import subprocess
+    _fcntl = None
+else:
+    _fcntl = _fcntl_module
+
+__all__ = [
+    "UpdateLockError",
+    "UpdateLockErrorCode",
+    "acquire_shared_update_lock",
+    "mark_shared_update_lock_post_mutation",
+    "shared_update_lock_identity",
+    "shared_update_lock_path",
+    "shared_update_lock_supported",
+]
+
+
+class UpdateLockErrorCode(str, Enum):
+    """Closed failure classes for the shared update lock."""
+
+    INVALID_IDENTITY = "invalid_identity"
+    INVALID_TIMEOUT = "invalid_timeout"
+    CONTENDED = "contended"
+    ACQUISITION_FAILED = "acquisition_failed"
+    RELEASE_FAILED = "release_failed"
+
+
+class UpdateLockError(RuntimeError):
+    """Sanitized lock failure with an explicit mutation boundary."""
+
+    def __init__(self, code: UpdateLockErrorCode, message: str, *, boundary=None) -> None:
+        from hermes_cli.update_engine import UpdateMutationBoundary
+
+        self.code = code
+        self.boundary = boundary or UpdateMutationBoundary.PRE_MUTATION
+        super().__init__(message)
+
+
+_LOCK_STATE = threading.local()
+_RUNTIME_UID = os.getuid() if hasattr(os, "getuid") else 0
+_LOCK_ROOT = Path(tempfile.gettempdir()) / f"hermes-agent-update-locks-{_RUNTIME_UID}"
+_MAX_TIMEOUT_SECONDS = 300.0
+
+
+def shared_update_lock_identity(repository_identity: os.PathLike[str] | str) -> str:
+    """Return the canonical identity used to key the shared update lock."""
+
+    if type(repository_identity) is not str:
+        repository_identity = os.fspath(repository_identity)
+    if type(repository_identity) is not str or not repository_identity:
+        raise UpdateLockError(
+            UpdateLockErrorCode.INVALID_IDENTITY,
+            "shared update lock requires a repository identity",
+        )
+
+    resolved = Path(os.path.realpath(repository_identity))
+    try:
+        st = resolved.stat()
+    except OSError:
+        raise UpdateLockError(
+            UpdateLockErrorCode.INVALID_IDENTITY,
+            "shared update lock requires an existing repository directory",
+        ) from None
+    if not stat.S_ISDIR(st.st_mode):
+        raise UpdateLockError(
+            UpdateLockErrorCode.INVALID_IDENTITY,
+            "shared update lock requires an existing repository directory",
+        )
+    return f"dir:{st.st_dev}:{st.st_ino}"
+
+
+def shared_update_lock_path(repository_identity: os.PathLike[str] | str) -> Path:
+    """Return the stable lock-file path for a canonical repository identity."""
+
+    identity = shared_update_lock_identity(repository_identity)
+    return _lock_path_for_identity(identity)
+
+
+def _lock_path_for_identity(identity: str) -> Path:
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    return _lock_namespace_root() / f"{digest}.lock"
+
+
+def shared_update_lock_supported() -> bool:
+    """Return whether the hardened POSIX lock backend is available."""
+
+    return _fcntl is not None and all(
+        hasattr(os, name) for name in ("O_CLOEXEC", "O_DIRECTORY", "O_NOFOLLOW")
+    )
+
+
+@contextmanager
+def acquire_shared_update_lock(
+    repository_identity: os.PathLike[str] | str,
+    *,
+    timeout_seconds: float = 30.0,
+):
+    """Acquire the shared update lock for one canonical repository identity."""
+
+    if (
+        type(timeout_seconds) not in {int, float}
+        or isinstance(timeout_seconds, bool)
+        or not math.isfinite(timeout_seconds)
+        or timeout_seconds < 0.0
+        or timeout_seconds > _MAX_TIMEOUT_SECONDS
+    ):
+        raise UpdateLockError(
+            UpdateLockErrorCode.INVALID_TIMEOUT,
+            "shared update lock timeout is invalid",
+        )
+    if not shared_update_lock_supported():
+        raise UpdateLockError(
+            UpdateLockErrorCode.ACQUISITION_FAILED,
+            "shared update lock is unavailable on this platform",
+        )
+
+    identity = shared_update_lock_identity(repository_identity)
+    depth = getattr(_LOCK_STATE, "depth", 0)
+    if depth > 0 and getattr(_LOCK_STATE, "identity", None) == identity:
+        _LOCK_STATE.depth = depth + 1
+        try:
+            yield
+        finally:
+            _LOCK_STATE.depth -= 1
+        return
+
+    lock_path = _lock_path_for_identity(identity)
+    namespace_fd = _open_lock_namespace(lock_path.parent)
+    try:
+        try:
+            fd = os.open(
+                lock_path.name,
+                os.O_RDWR | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=namespace_fd,
+            )
+        except OSError:
+            raise UpdateLockError(
+                UpdateLockErrorCode.ACQUISITION_FAILED,
+                "shared update lock could not be acquired",
+            ) from None
+    finally:
+        os.close(namespace_fd)
+
+    try:
+        _validate_lock_file(fd)
+        _lock_file_exclusive(fd, timeout_seconds=float(timeout_seconds))
+    except Exception:
+        os.close(fd)
+        raise
+
+    _LOCK_STATE.identity = identity
+    _LOCK_STATE.path = lock_path
+    _LOCK_STATE.fd = fd
+    _LOCK_STATE.depth = 1
+    _LOCK_STATE.boundary = None
+    try:
+        yield
+    finally:
+        boundary = getattr(_LOCK_STATE, "boundary", None)
+        _LOCK_STATE.depth = 0
+        _LOCK_STATE.identity = None
+        _LOCK_STATE.path = None
+        _LOCK_STATE.fd = None
+        _LOCK_STATE.boundary = None
+        try:
+            _close_lock_fd(fd)
+        except OSError:
+            from hermes_cli.update_engine import UpdateMutationBoundary
+
+            raise UpdateLockError(
+                UpdateLockErrorCode.RELEASE_FAILED,
+                "shared update lock release is uncertain",
+                boundary=boundary or UpdateMutationBoundary.PRE_MUTATION,
+            ) from None
+
+
+def mark_shared_update_lock_post_mutation() -> None:
+    """Mark a held lock as past checkout intent for release error mapping."""
+
+    if getattr(_LOCK_STATE, "depth", 0) <= 0:
+        return
+    from hermes_cli.update_engine import UpdateMutationBoundary
+
+    _LOCK_STATE.boundary = UpdateMutationBoundary.POST_MUTATION_UNCERTAIN
+
+
+def _lock_file_exclusive(fd: int, *, timeout_seconds: float) -> None:
+    if _fcntl is None:  # Defensive: acquisition rejects unsupported platforms.
+        raise UpdateLockError(
+            UpdateLockErrorCode.ACQUISITION_FAILED,
+            "shared update lock is unavailable on this platform",
+        )
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+            return
+        except (BlockingIOError, OSError) as exc:
+            if isinstance(exc, OSError) and exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                raise UpdateLockError(
+                    UpdateLockErrorCode.ACQUISITION_FAILED,
+                    "shared update lock could not be acquired",
+                ) from None
+            if time.monotonic() >= deadline:
+                raise UpdateLockError(
+                    UpdateLockErrorCode.CONTENDED,
+                    "shared update lock is busy",
+                ) from None
+            time.sleep(0.05)
+
+
+def _lock_namespace_root() -> Path:
+    _LOCK_ROOT.mkdir(mode=0o700, parents=True, exist_ok=True)
+    _validate_private_directory(_LOCK_ROOT)
+    return _LOCK_ROOT
+
+
+def _open_lock_namespace(path: Path) -> int:
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    expected = _validate_private_directory(path)
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    except OSError:
+        raise UpdateLockError(
+            UpdateLockErrorCode.ACQUISITION_FAILED,
+            "shared update lock namespace is unavailable",
+        ) from None
+    try:
+        opened = _validate_private_directory_fd(fd)
+        if (opened.st_dev, opened.st_ino) != (expected.st_dev, expected.st_ino):
+            raise UpdateLockError(
+                UpdateLockErrorCode.ACQUISITION_FAILED,
+                "shared update lock namespace is unavailable",
+            )
+    except Exception:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _validate_private_directory(path: Path) -> os.stat_result:
+    try:
+        st = os.stat(path, follow_symlinks=False)
+    except OSError:
+        raise UpdateLockError(
+            UpdateLockErrorCode.ACQUISITION_FAILED,
+            "shared update lock namespace is unavailable",
+        ) from None
+    if (
+        not stat.S_ISDIR(st.st_mode)
+        or st.st_uid != _current_uid()
+        or st.st_mode & 0o077
+    ):
+        raise UpdateLockError(
+            UpdateLockErrorCode.ACQUISITION_FAILED,
+            "shared update lock namespace is unavailable",
+        )
+    return st
+
+
+def _validate_private_directory_fd(fd: int) -> os.stat_result:
+    try:
+        st = os.fstat(fd)
+    except OSError:
+        raise UpdateLockError(
+            UpdateLockErrorCode.ACQUISITION_FAILED,
+            "shared update lock namespace is unavailable",
+        ) from None
+    if (
+        not stat.S_ISDIR(st.st_mode)
+        or st.st_uid != _current_uid()
+        or st.st_mode & 0o077
+    ):
+        raise UpdateLockError(
+            UpdateLockErrorCode.ACQUISITION_FAILED,
+            "shared update lock namespace is unavailable",
+        )
+    return st
+
+
+def _validate_lock_file(fd: int) -> None:
+    try:
+        st = os.fstat(fd)
+    except OSError:
+        raise UpdateLockError(
+            UpdateLockErrorCode.ACQUISITION_FAILED,
+            "shared update lock could not be acquired",
+        ) from None
+    if (
+        not stat.S_ISREG(st.st_mode)
+        or st.st_uid != _current_uid()
+        or st.st_mode & 0o077
+    ):
+        raise UpdateLockError(
+            UpdateLockErrorCode.ACQUISITION_FAILED,
+            "shared update lock could not be acquired",
+        )
+
+
+def _current_uid() -> int:
+    return _RUNTIME_UID
+
+
+def _close_lock_fd(fd: int) -> None:
+    os.close(fd)

--- a/tests/hermes_cli/test_update_engine_characterization.py
+++ b/tests/hermes_cli/test_update_engine_characterization.py
@@ -1,7 +1,7 @@
-"""Characterization tests for the native update seam.
+"""Characterization tests for the existing native update flow.
 
-These tests freeze the small request/result/event model and the delegation
-boundary that will sit in front of the legacy ``hermes update`` behavior.
+These tests freeze the small request/result model, legacy delegation boundary,
+repository lock, and native-Windows compatibility behavior.
 """
 
 from dataclasses import is_dataclass
@@ -11,22 +11,89 @@ from unittest.mock import patch
 import pytest
 
 
+def test_main_import_survives_without_posix_lock_primitives():
+    import subprocess
+    import sys
+
+    script = (
+        "import builtins, os\n"
+        "real_import = builtins.__import__\n"
+        "def guarded_import(name, *args, **kwargs):\n"
+        "    if name == 'fcntl':\n"
+        "        raise ModuleNotFoundError('simulated non-POSIX runtime')\n"
+        "    return real_import(name, *args, **kwargs)\n"
+        "builtins.__import__ = guarded_import\n"
+        "if hasattr(os, 'getuid'):\n"
+        "    delattr(os, 'getuid')\n"
+        "import hermes_cli.main\n"
+        "from hermes_cli.update_lock import acquire_shared_update_lock, UpdateLockError\n"
+        "try:\n"
+        "    with acquire_shared_update_lock('/unsupported-platform', timeout_seconds=0.0):\n"
+        "        raise AssertionError('lock must not fail open')\n"
+        "except UpdateLockError as exc:\n"
+        "    assert exc.code.value == 'acquisition_failed'\n"
+        "    assert exc.boundary.value == 'pre_mutation'\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_cmd_update_preserves_legacy_path_without_posix_lock_backend():
+    import subprocess
+    import sys
+
+    script = r'''
+import builtins
+from types import SimpleNamespace
+from unittest.mock import patch
+
+real_import = builtins.__import__
+def guarded_import(name, *args, **kwargs):
+    if name == "fcntl":
+        raise ModuleNotFoundError("simulated native Windows runtime")
+    return real_import(name, *args, **kwargs)
+builtins.__import__ = guarded_import
+
+from hermes_cli import main as hm
+calls = []
+args = SimpleNamespace(check=False, gateway=False, yes=False)
+with patch("hermes_cli.config.detect_install_method", return_value="git"), \
+     patch("hermes_cli.config.is_unsupported_install_method", return_value=False), \
+     patch("hermes_cli.config.is_managed", return_value=False), \
+     patch.object(hm, "_install_hangup_protection", return_value=object()), \
+     patch.object(hm, "_finalize_update_output"), \
+     patch.object(hm, "_cmd_update_impl", side_effect=lambda *a, **kw: calls.append((a, kw))):
+    hm.cmd_update(args)
+assert len(calls) == 1, calls
+'''
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_update_engine_dataclasses_are_pure():
-    from hermes_cli.update_engine import UpdateEvent, UpdateRequest, UpdateResult
+    from hermes_cli.update_engine import UpdateRequest, UpdateResult
 
     request = UpdateRequest(args=SimpleNamespace(branch="main"), gateway_mode=True)
     result = UpdateResult(exit_code=0, message="done")
-    event = UpdateEvent(kind="fetch", message="Fetching updates")
 
     assert is_dataclass(UpdateRequest)
     assert is_dataclass(UpdateResult)
-    assert is_dataclass(UpdateEvent)
     assert request.args.branch == "main"
     assert request.gateway_mode is True
     assert result.exit_code == 0
     assert result.message == "done"
-    assert event.kind == "fetch"
-    assert event.message == "Fetching updates"
 
 
 def test_native_update_engine_delegates_to_injected_legacy_runner():
@@ -55,9 +122,10 @@ def test_cmd_update_routes_through_native_update_seam(mock_args=None):
     ctor_calls = []
 
     class FakeEngine:
-        def __init__(self, legacy_runner):
-            ctor_calls.append(legacy_runner)
+        def __init__(self, legacy_runner, update_lock_identity=None):
+            ctor_calls.append((legacy_runner, update_lock_identity))
             self.legacy_runner = legacy_runner
+            self.update_lock_identity = update_lock_identity
 
         def run(self, request):
             engine_calls.append(request)
@@ -81,7 +149,7 @@ def test_cmd_update_routes_through_native_update_seam(mock_args=None):
         hm.cmd_update(mock_args)
 
     assert engine_calls == [UpdateRequest(args=mock_args, gateway_mode=False)]
-    assert ctor_calls == [hm._run_legacy_native_update]
+    assert ctor_calls == [(hm._run_legacy_native_update, str(hm.PROJECT_ROOT))]
     assert hangup_mock.call_count == 1
     finalize_mock.assert_called_once()
     managed_error_mock.assert_not_called()
@@ -92,8 +160,9 @@ def test_cmd_update_preserves_system_exit_and_finalizes_output():
     from hermes_cli import main as hm
 
     class ExitingEngine:
-        def __init__(self, legacy_runner):
+        def __init__(self, legacy_runner, update_lock_identity=None):
             assert legacy_runner is hm._run_legacy_native_update
+            assert update_lock_identity == str(hm.PROJECT_ROOT)
 
         def run(self, request):
             raise SystemExit(7)
@@ -119,8 +188,9 @@ def test_cmd_update_preserves_generic_exception_and_finalizes_output():
     failure = RuntimeError("boom")
 
     class FailingEngine:
-        def __init__(self, legacy_runner):
+        def __init__(self, legacy_runner, update_lock_identity=None):
             assert legacy_runner is hm._run_legacy_native_update
+            assert update_lock_identity == str(hm.PROJECT_ROOT)
 
         def run(self, request):
             raise failure
@@ -138,3 +208,86 @@ def test_cmd_update_preserves_generic_exception_and_finalizes_output():
 
     assert exc_info.value is failure
     finalize_mock.assert_called_once_with(io_state)
+
+
+def test_legacy_run_contends_on_shared_update_lock_when_locked(tmp_path):
+    import subprocess
+    import sys
+    import time
+
+    from hermes_cli.update_engine import NativeUpdateEngine, UpdateRequest, UpdateResult
+    from hermes_cli.update_lock import UpdateLockError, shared_update_lock_identity
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    identity = shared_update_lock_identity(repo)
+
+    script = (
+        "import sys, time\n"
+        "from hermes_cli.update_lock import acquire_shared_update_lock\n"
+        "with acquire_shared_update_lock(sys.argv[1], timeout_seconds=1.0):\n"
+        "    time.sleep(1.0)\n"
+    )
+    holder = subprocess.Popen(
+        [sys.executable, "-c", script, identity],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        time.sleep(0.2)
+        calls = []
+
+        def legacy_runner(request):
+            calls.append(request)
+            return UpdateResult(exit_code=0)
+
+        engine = NativeUpdateEngine(
+            legacy_runner=legacy_runner,
+            update_lock_identity=identity,
+            update_lock_timeout_seconds=0.1,
+        )
+        with pytest.raises(UpdateLockError):
+            engine.run(UpdateRequest(args={"branch": "main"}, gateway_mode=False))
+        assert calls == []
+    finally:
+        holder.wait(timeout=5)
+
+
+def test_legacy_release_failure_is_post_mutation_uncertain(tmp_path, monkeypatch):
+    from hermes_cli import update_lock
+    from hermes_cli.update_engine import (
+        NativeUpdateEngine,
+        UpdateMutationBoundary,
+        UpdateRequest,
+        UpdateResult,
+    )
+    from hermes_cli.update_lock import UpdateLockError, UpdateLockErrorCode
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    real_close = update_lock._close_lock_fd
+
+    def close_then_report_failure(fd):
+        real_close(fd)
+        raise OSError("simulated close uncertainty")
+
+    monkeypatch.setattr(update_lock, "_close_lock_fd", close_then_report_failure)
+    calls = []
+
+    def legacy_runner(request):
+        calls.append(request)
+        return UpdateResult(exit_code=0)
+
+    engine = NativeUpdateEngine(
+        legacy_runner=legacy_runner,
+        update_lock_identity=str(repo),
+    )
+    request = UpdateRequest(args={"yes": True}, gateway_mode=False)
+    with pytest.raises(UpdateLockError) as exc_info:
+        engine.run(request)
+
+    assert calls == [request]
+    assert exc_info.value.code is UpdateLockErrorCode.RELEASE_FAILED
+    assert exc_info.value.boundary is UpdateMutationBoundary.POST_MUTATION_UNCERTAIN

--- a/tests/hermes_cli/test_update_engine_characterization.py
+++ b/tests/hermes_cli/test_update_engine_characterization.py
@@ -1,0 +1,140 @@
+"""Characterization tests for the native update seam.
+
+These tests freeze the small request/result/event model and the delegation
+boundary that will sit in front of the legacy ``hermes update`` behavior.
+"""
+
+from dataclasses import is_dataclass
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def test_update_engine_dataclasses_are_pure():
+    from hermes_cli.update_engine import UpdateEvent, UpdateRequest, UpdateResult
+
+    request = UpdateRequest(args=SimpleNamespace(branch="main"), gateway_mode=True)
+    result = UpdateResult(exit_code=0, message="done")
+    event = UpdateEvent(kind="fetch", message="Fetching updates")
+
+    assert is_dataclass(UpdateRequest)
+    assert is_dataclass(UpdateResult)
+    assert is_dataclass(UpdateEvent)
+    assert request.args.branch == "main"
+    assert request.gateway_mode is True
+    assert result.exit_code == 0
+    assert result.message == "done"
+    assert event.kind == "fetch"
+    assert event.message == "Fetching updates"
+
+
+def test_native_update_engine_delegates_to_injected_legacy_runner():
+    from hermes_cli.update_engine import NativeUpdateEngine, UpdateRequest, UpdateResult
+
+    calls = []
+
+    def legacy_runner(request):
+        calls.append(request)
+        return UpdateResult(exit_code=17, message="legacy path")
+
+    engine = NativeUpdateEngine(legacy_runner=legacy_runner)
+    request = UpdateRequest(args=SimpleNamespace(force=True), gateway_mode=False)
+
+    result = engine.run(request)
+
+    assert result == UpdateResult(exit_code=17, message="legacy path")
+    assert calls == [request]
+
+
+def test_cmd_update_routes_through_native_update_seam(mock_args=None):
+    from hermes_cli import main as hm
+    from hermes_cli.update_engine import UpdateRequest, UpdateResult
+
+    engine_calls = []
+    ctor_calls = []
+
+    class FakeEngine:
+        def __init__(self, legacy_runner):
+            ctor_calls.append(legacy_runner)
+            self.legacy_runner = legacy_runner
+
+        def run(self, request):
+            engine_calls.append(request)
+            return UpdateResult(exit_code=0, message="ok")
+
+    if mock_args is None:
+        mock_args = SimpleNamespace(check=False, gateway=False, yes=False)
+    else:
+        mock_args.check = False
+        mock_args.gateway = False
+        mock_args.yes = False
+
+    with patch.object(hm, "NativeUpdateEngine", FakeEngine), \
+        patch.object(hm, "_install_hangup_protection", return_value=object()) as hangup_mock, \
+        patch.object(hm, "_finalize_update_output") as finalize_mock, \
+        patch("hermes_cli.config.detect_install_method", return_value="git"), \
+        patch("hermes_cli.config.is_unsupported_install_method", return_value=False), \
+        patch("hermes_cli.config.is_managed", return_value=False), \
+        patch("hermes_cli.config.managed_error") as managed_error_mock, \
+        patch("hermes_cli.main._cmd_update_check") as check_mock:
+        hm.cmd_update(mock_args)
+
+    assert engine_calls == [UpdateRequest(args=mock_args, gateway_mode=False)]
+    assert ctor_calls == [hm._run_legacy_native_update]
+    assert hangup_mock.call_count == 1
+    finalize_mock.assert_called_once()
+    managed_error_mock.assert_not_called()
+    check_mock.assert_not_called()
+
+
+def test_cmd_update_preserves_system_exit_and_finalizes_output():
+    from hermes_cli import main as hm
+
+    class ExitingEngine:
+        def __init__(self, legacy_runner):
+            assert legacy_runner is hm._run_legacy_native_update
+
+        def run(self, request):
+            raise SystemExit(7)
+
+    args = SimpleNamespace(check=False, gateway=False, yes=False)
+    io_state = object()
+    with patch.object(hm, "NativeUpdateEngine", ExitingEngine), \
+        patch.object(hm, "_install_hangup_protection", return_value=io_state), \
+        patch.object(hm, "_finalize_update_output") as finalize_mock, \
+        patch("hermes_cli.config.detect_install_method", return_value="git"), \
+        patch("hermes_cli.config.is_unsupported_install_method", return_value=False), \
+        patch("hermes_cli.config.is_managed", return_value=False), \
+        pytest.raises(SystemExit) as exc_info:
+        hm.cmd_update(args)
+
+    assert exc_info.value.code == 7
+    finalize_mock.assert_called_once_with(io_state)
+
+
+def test_cmd_update_preserves_generic_exception_and_finalizes_output():
+    from hermes_cli import main as hm
+
+    failure = RuntimeError("boom")
+
+    class FailingEngine:
+        def __init__(self, legacy_runner):
+            assert legacy_runner is hm._run_legacy_native_update
+
+        def run(self, request):
+            raise failure
+
+    args = SimpleNamespace(check=False, gateway=False, yes=False)
+    io_state = object()
+    with patch.object(hm, "NativeUpdateEngine", FailingEngine), \
+        patch.object(hm, "_install_hangup_protection", return_value=io_state), \
+        patch.object(hm, "_finalize_update_output") as finalize_mock, \
+        patch("hermes_cli.config.detect_install_method", return_value="git"), \
+        patch("hermes_cli.config.is_unsupported_install_method", return_value=False), \
+        patch("hermes_cli.config.is_managed", return_value=False), \
+        pytest.raises(RuntimeError) as exc_info:
+        hm.cmd_update(args)
+
+    assert exc_info.value is failure
+    finalize_mock.assert_called_once_with(io_state)

--- a/tests/hermes_cli/test_update_lock.py
+++ b/tests/hermes_cli/test_update_lock.py
@@ -1,0 +1,87 @@
+"""Focused tests for the repository-scoped legacy update lock."""
+
+from pathlib import Path
+
+import pytest
+
+
+def test_shared_lock_identity_normalizes_symlinked_repository(tmp_path: Path) -> None:
+    from hermes_cli.update_lock import shared_update_lock_identity, shared_update_lock_path
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    alias = tmp_path / "repo-alias"
+    alias.symlink_to(repo, target_is_directory=True)
+
+    assert shared_update_lock_identity(alias) == shared_update_lock_identity(repo)
+    assert shared_update_lock_path(alias) == shared_update_lock_path(repo)
+    assert repo not in shared_update_lock_path(repo).parents
+
+
+def test_shared_lock_rejects_missing_and_non_directory_identities(tmp_path: Path) -> None:
+    from hermes_cli.update_lock import UpdateLockError, shared_update_lock_identity
+
+    regular_file = tmp_path / "not-a-repository"
+    regular_file.write_text("x")
+
+    with pytest.raises(UpdateLockError):
+        shared_update_lock_identity(tmp_path / "missing")
+    with pytest.raises(UpdateLockError):
+        shared_update_lock_identity(regular_file)
+
+
+@pytest.mark.parametrize("timeout", [-1.0, float("nan"), float("inf"), 301.0])
+def test_shared_lock_rejects_unbounded_timeouts(tmp_path: Path, timeout: float) -> None:
+    from hermes_cli.update_lock import UpdateLockError, acquire_shared_update_lock
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(UpdateLockError):
+        with acquire_shared_update_lock(repo, timeout_seconds=timeout):
+            pytest.fail("invalid timeout must fail before acquisition")
+
+
+def test_shared_lock_is_reentrant_for_same_repository(tmp_path: Path, monkeypatch) -> None:
+    from hermes_cli import update_lock
+    from hermes_cli.update_lock import acquire_shared_update_lock
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(update_lock, "_LOCK_ROOT", tmp_path / "locks")
+
+    with acquire_shared_update_lock(repo, timeout_seconds=0.0):
+        with acquire_shared_update_lock(repo.resolve(), timeout_seconds=0.0):
+            pass
+
+
+def test_lock_namespace_swap_after_validation_fails_closed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from hermes_cli import update_lock
+    from hermes_cli.update_lock import UpdateLockError, acquire_shared_update_lock
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lock_root = tmp_path / "locks"
+    attacker_root = tmp_path / "attacker"
+    attacker_root.mkdir(mode=0o700)
+    monkeypatch.setattr(update_lock, "_LOCK_ROOT", lock_root)
+
+    real_validate = update_lock._validate_private_directory
+    validation_count = 0
+
+    def validate_then_swap(path: Path):
+        nonlocal validation_count
+        validated = real_validate(path)
+        validation_count += 1
+        if validation_count == 2:
+            path.rename(tmp_path / "parked-locks")
+            attacker_root.rename(path)
+        return validated
+
+    monkeypatch.setattr(update_lock, "_validate_private_directory", validate_then_swap)
+
+    with pytest.raises(UpdateLockError):
+        with acquire_shared_update_lock(repo, timeout_seconds=0.0):
+            pytest.fail("swapped lock namespace must never be acquired")
+    assert list(lock_root.iterdir()) == []


### PR DESCRIPTION
## Summary
- route the existing `hermes update` implementation through a small in-product native update seam
- serialize concurrent normal updates on supported POSIX systems with a repository-scoped hardened lock
- preserve the existing native-Windows/unsupported-backend updater path by bypassing the POSIX-only lock

## Scope after review
This PR was deliberately narrowed in response to review. All unconnected strict/exact-target/handoff/Git-adapter surfaces were removed. It adds no user-facing command, option, config, or environment variable.

## Compatibility regression
A command-level subprocess test removes `fcntl`, calls normal `cmd_update()`, and verifies `_cmd_update_impl()` is reached. The test fails on the prior PR head with `UpdateLockError` and passes on this revision.

## Validation
- focused engine/lock tests: **17 passed**
- complete update lane: **184 passed**
- Ruff, compileall, `ty`, and `git diff --check`: **passed**
- independent contract review: **PASS**
- independent quality/security review: **PASS**
- canonical full-suite wrapper: only 3 existing `HERMES_PYTHON`/TUI failures, reproduced exactly on an immutable checkout of the current upstream base; no delta-related failures

## Safety properties
- lock identity derives from the repository filesystem object (`st_dev` + `st_ino`)
- private per-user lock namespace outside the repository
- owner/mode, symlink, namespace-swap, timeout, contention, and release-failure checks
- unsupported lock backends retain legacy update behavior instead of failing before platform-specific update handling

Live runtime activation/install changes are intentionally out of scope.