### PR TITLE
fix(error_classifier): narrow max_tokens pattern to avoid matching empty-response advisories (#66818)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -269,7 +269,7 @@ _CONTEXT_OVERFLOW_PATTERNS = [
     "context window",
     "prompt is too long",
     "prompt exceeds max length",
-    "max_tokens",
+    "max_tokens limit",
     "maximum number of tokens",
     # vLLM / local inference server patterns
     "exceeds the max_model_len",


### PR DESCRIPTION
## Summary

Empty-response advisories (e.g. nano-gpt / OpenRouter) include `very low max_tokens` as a possible cause. The literal substring `max_tokens` matched `_CONTEXT_OVERFLOW_PATTERNS`, causing Hermes to misclassify the error as context overflow, enter the compression loop, and end with `Cannot compress further`.

## Fix

Narrowed `max_tokens` → `max_tokens limit` in `_CONTEXT_OVERFLOW_PATTERNS`.

- Advisory text like `very low max_tokens` no longer matches (does not contain `limit`)
- Real overflow messages like `exceeds the max_tokens limit` still match

## Verification

- `python3 -m py_compile agent/error_classifier.py` ✅
- Existing tests pass (the GPT-5 `max_tokens is not supported` false positive is already guarded by the request-validation check that runs before context_overflow)
- No test asserted bare `max_tokens` alone matches an overflow

Closes #66818