### PR TITLE
feat(slack): add DM-scoped user allowlist

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -31,6 +31,20 @@ from gateway.whatsapp_identity import (
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
+    @staticmethod
+    def _is_slack_one_to_one_dm(source: SessionSource) -> bool:
+        """Return True for Slack 1:1 IMs, but not MPIM/group-DM channels."""
+        if source.platform != Platform.SLACK:
+            return False
+        chat_type = str(source.chat_type or "").strip().lower()
+        if chat_type == "im":
+            return True
+        if chat_type != "dm":
+            return False
+        # Slack 1:1 IM channel IDs start with D. MPIM/group-DM IDs start with G,
+        # but the adapter still uses chat_type="dm" for session continuity.
+        return str(source.chat_id or "").startswith("D")
+
     def _authorization_adapter(
         self,
         platform: Optional[Platform],
@@ -382,6 +396,9 @@ class GatewayAuthorizationMixin:
             Platform.QQBOT: "QQ_ALLOWED_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
         }
+        platform_dm_user_env_map = {
+            Platform.SLACK: "SLACK_DM_ALLOWED_USERS",
+        }
         platform_group_user_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_USERS",
         }
@@ -418,6 +435,8 @@ class GatewayAuthorizationMixin:
                 if entry:
                     if entry.allowed_users_env:
                         platform_env_map[source.platform] = entry.allowed_users_env
+                    if getattr(entry, "dm_allowed_users_env", ""):
+                        platform_dm_user_env_map[source.platform] = entry.dm_allowed_users_env
                     if entry.allow_all_env:
                         platform_allow_all_map[source.platform] = entry.allow_all_env
             except Exception:
@@ -457,12 +476,24 @@ class GatewayAuthorizationMixin:
 
         # Check platform-specific and global allowlists
         platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
+        dm_user_allowlist = ""
+        if self._is_slack_one_to_one_dm(source):
+            dm_user_allowlist = os.getenv(
+                platform_dm_user_env_map.get(source.platform, ""),
+                "",
+            ).strip()
+            if dm_user_allowlist:
+                # A non-empty Slack DM allowlist is deliberately stricter than
+                # SLACK_ALLOWED_USERS / GATEWAY_ALLOWED_USERS. It gates only
+                # 1:1 IMs; channels, threads, and MPIMs keep the platform-wide
+                # allowlist behavior below.
+                platform_allowlist = dm_user_allowlist
         group_user_allowlist = ""
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:
             group_user_allowlist = os.getenv(platform_group_user_env_map.get(source.platform, ""), "").strip()
             group_chat_allowlist = os.getenv(platform_group_chat_env_map.get(source.platform, ""), "").strip()
-        global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+        global_allowlist = "" if dm_user_allowlist else os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
             # No env allowlist configured. Adapters that own their own
@@ -699,6 +730,8 @@ class GatewayAuthorizationMixin:
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
             if os.getenv(platform_env_map.get(platform, ""), "").strip():
+                return "ignore"
+            if platform == Platform.SLACK and os.getenv("SLACK_DM_ALLOWED_USERS", "").strip():
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):
                 if os.getenv(env_key, "").strip():

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -86,6 +86,9 @@ class PlatformEntry:
     # ── Auth env var names (for _is_user_authorized integration) ──
     # E.g. "IRC_ALLOWED_USERS" — checked for comma-separated user IDs.
     allowed_users_env: str = ""
+    # Optional 1:1-DM-scoped allowlist env var. Most platforms leave this
+    # empty; Slack uses it to restrict direct IMs more tightly than channels.
+    dm_allowed_users_env: str = ""
     # E.g. "IRC_ALLOW_ALL_USERS" — if truthy, all users authorized.
     allow_all_env: str = ""
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6699,7 +6699,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _builtin_allowed_vars = (
             "TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",
             "WHATSAPP_ALLOWED_USERS", "WHATSAPP_CLOUD_ALLOWED_USERS",
-            "SLACK_ALLOWED_USERS",
+            "SLACK_ALLOWED_USERS", "SLACK_DM_ALLOWED_USERS",
             "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
             "TELEGRAM_GROUP_ALLOWED_USERS",
             "TELEGRAM_GROUP_ALLOWED_CHATS",
@@ -6738,8 +6738,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             from gateway.platform_registry import platform_registry
             _plugin_allowed_vars = tuple(
-                e.allowed_users_env for e in platform_registry.plugin_entries()
-                if e.allowed_users_env
+                env_key
+                for e in platform_registry.plugin_entries()
+                for env_key in (e.allowed_users_env, getattr(e, "dm_allowed_users_env", ""))
+                if env_key
             )
             _plugin_allow_all_vars = tuple(
                 e.allow_all_env for e in platform_registry.plugin_entries()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2344,6 +2344,7 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        "dm_allowed_users": "",        # If set, stricter Slack 1:1-DM user allowlist
         "channel_prompts": {},         # Per-channel ephemeral system prompts
     },
 
@@ -4052,6 +4053,14 @@ OPTIONAL_ENV_VARS = {
         "description": "Comma-separated Slack member IDs allowed to use Hermes, e.g. U01ABC2DEF3. Without this, Slack may connect but deny messages by default.",
         "prompt": "Allowed Slack member IDs",
         "help": "In Slack, open your profile, choose More or the three-dot menu, then Copy member ID. Add multiple IDs comma-separated.",
+        "url": "https://api.slack.com/apps",
+        "password": False,
+        "category": "messaging",
+    },
+    "SLACK_DM_ALLOWED_USERS": {
+        "description": "Comma-separated Slack member IDs allowed to use Hermes in 1:1 DMs. When set, this is stricter than SLACK_ALLOWED_USERS for DMs only; channels and threads still use SLACK_ALLOWED_USERS.",
+        "prompt": "Allowed Slack DM member IDs",
+        "help": "Use Slack member IDs (e.g. U01ABC2DEF3). Leave unset to let 1:1 DMs fall back to SLACK_ALLOWED_USERS.",
         "url": "https://api.slack.com/apps",
         "password": False,
         "category": "messaging",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4516,6 +4516,11 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
+    dm_allowed = slack_cfg.get("dm_allowed_users")
+    if dm_allowed is not None and not os.getenv("SLACK_DM_ALLOWED_USERS"):
+        if isinstance(dm_allowed, list):
+            dm_allowed = ",".join(str(v) for v in dm_allowed)
+        os.environ["SLACK_DM_ALLOWED_USERS"] = str(dm_allowed)
     return None  # all settings flow through env; nothing to merge into extras
 
 
@@ -4558,6 +4563,7 @@ def register(ctx) -> None:
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration
         allowed_users_env="SLACK_ALLOWED_USERS",
+        dm_allowed_users_env="SLACK_DM_ALLOWED_USERS",
         allow_all_env="SLACK_ALLOW_ALL_USERS",
         # Cron home-channel delivery
         cron_deliver_env_var="SLACK_HOME_CHANNEL",

--- a/plugins/platforms/slack/plugin.yaml
+++ b/plugins/platforms/slack/plugin.yaml
@@ -25,6 +25,10 @@ optional_env:
     description: "Comma-separated Slack member IDs allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"
     password: false
+  - name: SLACK_DM_ALLOWED_USERS
+    description: "Comma-separated Slack member IDs allowed to talk to the bot in 1:1 DMs"
+    prompt: "Allowed 1:1 DM users (comma-separated)"
+    password: false
   - name: SLACK_ALLOW_ALL_USERS
     description: "Allow any Slack user to trigger the bot (dev only)"
     prompt: "Allow all users? (true/false)"

--- a/tests/gateway/test_allowlist_startup_check.py
+++ b/tests/gateway/test_allowlist_startup_check.py
@@ -9,7 +9,7 @@ def _would_warn():
     _any_allowlist = any(
         os.getenv(v)
         for v in ("TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",
-                   "WHATSAPP_ALLOWED_USERS", "SLACK_ALLOWED_USERS",
+                   "WHATSAPP_ALLOWED_USERS", "SLACK_ALLOWED_USERS", "SLACK_DM_ALLOWED_USERS",
                    "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
                    "EMAIL_ALLOWED_USERS",
                    "SMS_ALLOWED_USERS", "MATTERMOST_ALLOWED_USERS",
@@ -35,6 +35,10 @@ class TestAllowlistStartupCheck:
 
     def test_signal_group_allowed_users_suppresses_warning(self):
         with patch.dict(os.environ, {"SIGNAL_GROUP_ALLOWED_USERS": "user1"}, clear=True):
+            assert _would_warn() is False
+
+    def test_slack_dm_allowed_users_suppresses_warning(self):
+        with patch.dict(os.environ, {"SLACK_DM_ALLOWED_USERS": "U123"}, clear=True):
             assert _would_warn() is False
 
     def test_telegram_allow_all_users_suppresses_warning(self):

--- a/tests/gateway/test_slack_dm_allowed_users.py
+++ b/tests/gateway/test_slack_dm_allowed_users.py
@@ -1,0 +1,137 @@
+"""Regression tests for Slack 1:1-DM-scoped user authorization."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from plugins.platforms.slack.adapter import _apply_yaml_config
+
+
+_SLACK_AUTH_ENV = (
+    "SLACK_ALLOWED_USERS",
+    "SLACK_DM_ALLOWED_USERS",
+    "SLACK_ALLOW_ALL_USERS",
+    "GATEWAY_ALLOWED_USERS",
+    "GATEWAY_ALLOW_ALL_USERS",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_slack_auth_env(monkeypatch):
+    for key in _SLACK_AUTH_ENV:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.SLACK: PlatformConfig(enabled=True)},
+    )
+    runner.adapters = {Platform.SLACK: SimpleNamespace(send=AsyncMock())}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    return runner
+
+
+def _slack_source(user_id: str, *, chat_id: str = "D_OWNER", chat_type: str = "dm"):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name=user_id,
+    )
+
+
+def test_owner_dm_allowed_by_dm_allowlist(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_OWNER,U_COLLAB")
+    monkeypatch.setenv("SLACK_DM_ALLOWED_USERS", "U_OWNER")
+
+    assert _make_runner()._is_user_authorized(_slack_source("U_OWNER")) is True
+
+
+def test_channel_only_collaborator_dm_denied_by_nonempty_dm_allowlist(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_OWNER,U_COLLAB")
+    monkeypatch.setenv("SLACK_DM_ALLOWED_USERS", "U_OWNER")
+
+    assert _make_runner()._is_user_authorized(_slack_source("U_COLLAB")) is False
+
+
+def test_collaborator_channel_mention_still_uses_slack_allowed_users(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_OWNER,U_COLLAB")
+    monkeypatch.setenv("SLACK_DM_ALLOWED_USERS", "U_OWNER")
+
+    source = _slack_source("U_COLLAB", chat_id="C_SHARED", chat_type="group")
+
+    assert _make_runner()._is_user_authorized(source) is True
+
+
+def test_empty_dm_allowlist_falls_back_to_slack_allowed_users(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_OWNER,U_COLLAB")
+    monkeypatch.setenv("SLACK_DM_ALLOWED_USERS", "")
+
+    assert _make_runner()._is_user_authorized(_slack_source("U_COLLAB")) is True
+
+
+def test_mpim_keeps_platform_allowlist_even_with_dm_allowlist(monkeypatch):
+    """Slack MPIMs are shared surfaces; only 1:1 IMs use DM auth."""
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_COLLAB")
+    monkeypatch.setenv("SLACK_DM_ALLOWED_USERS", "U_OWNER")
+
+    source = _slack_source("U_COLLAB", chat_id="G_MPIM", chat_type="dm")
+
+    assert _make_runner()._is_user_authorized(source) is True
+
+
+@pytest.mark.asyncio
+async def test_active_thread_continuation_still_runs_authz(monkeypatch):
+    """Busy/active Slack thread follow-ups must not bypass authz."""
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_OWNER")
+
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._is_user_authorized = MagicMock(return_value=False)
+    event = MessageEvent(
+        text="thread follow-up",
+        source=_slack_source("U_COLLAB", chat_id="C_SHARED", chat_type="group"),
+        message_id="1700000000.000002",
+    )
+    event.source.thread_id = "1700000000.000001"
+
+    handled = await runner._handle_active_session_busy_message(
+        event,
+        "agent:main:slack:group:C_SHARED:1700000000.000001",
+    )
+
+    assert handled is True
+    runner._is_user_authorized.assert_called_once_with(event.source)
+
+
+def test_slack_dm_allowlist_makes_unauthorized_dm_behavior_ignore(monkeypatch):
+    monkeypatch.setenv("SLACK_DM_ALLOWED_USERS", "U_OWNER")
+
+    assert _make_runner()._get_unauthorized_dm_behavior(Platform.SLACK) == "ignore"
+
+
+def test_yaml_config_bridges_dm_allowed_users_to_env(monkeypatch):
+    monkeypatch.delenv("SLACK_DM_ALLOWED_USERS", raising=False)
+
+    _apply_yaml_config({}, {"dm_allowed_users": ["U_OWNER", "U_ASSISTANT"]})
+
+    assert os.environ["SLACK_DM_ALLOWED_USERS"] == "U_OWNER,U_ASSISTANT"
+
+
+def test_yaml_config_does_not_override_explicit_dm_allowed_users_env(monkeypatch):
+    monkeypatch.setenv("SLACK_DM_ALLOWED_USERS", "U_ENV")
+
+    _apply_yaml_config({}, {"dm_allowed_users": "U_YAML"})
+
+    assert os.environ["SLACK_DM_ALLOWED_USERS"] == "U_ENV"


### PR DESCRIPTION
## Summary
- Add `slack.dm_allowed_users` / `SLACK_DM_ALLOWED_USERS` for stricter Slack 1:1 IM authorization.
- Keep empty/unset DM allowlist behavior falling back to `SLACK_ALLOWED_USERS` exactly as before.
- Preserve Slack channel/thread/MPIM authorization on `SLACK_ALLOWED_USERS`, mention gating, allowed-channel filters, and thread engagement semantics.
- Register the new DM env through Slack plugin metadata and YAML→env bridging, plus startup allowlist warning awareness.

## Current model preserved
- `gateway/authz_mixin.py::_is_user_authorized` maps `Platform.SLACK` to `SLACK_ALLOWED_USERS` and previously applied it uniformly to DMs/channels based on `source.user_id`.
- `platform_group_user_env_map` / `platform_group_chat_env_map` still cover Telegram/QQ only.
- Slack still has no own `dm_policy` / `enforces_own_access_policy`; base defaults remain false.
- Slack mention gating and `allowed_channels` remain engagement/channel filters, not user authorization.
- Slack config defaults remain in `hermes_cli/config.py`; YAML→env bridge and plugin registry remain in `plugins/platforms/slack/adapter.py`, now including `dm_allowed_users_env="SLACK_DM_ALLOWED_USERS"` beside `allowed_users_env="SLACK_ALLOWED_USERS"`.

## Tests
- `scripts/run_tests.sh tests/gateway/test_slack_dm_allowed_users.py tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/gateway/test_slack_channel_session_scope.py tests/gateway/test_slack_plugin_setup.py` — 344 passed.
- `scripts/run_tests.sh tests/gateway/test_allowlist_startup_check.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_bot_auth_bypass.py tests/hermes_cli/test_config.py` — 180 passed.
- `scripts/run_tests.sh tests/gateway/test_slack_dm_allowed_users.py tests/gateway/test_allowlist_startup_check.py tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/gateway/test_slack_channel_session_scope.py tests/gateway/test_slack_plugin_setup.py tests/hermes_cli/test_config.py` — 494 passed.
- `uv run ruff check gateway/authz_mixin.py gateway/platform_registry.py gateway/run.py hermes_cli/config.py plugins/platforms/slack/adapter.py tests/gateway/test_slack_dm_allowed_users.py tests/gateway/test_allowlist_startup_check.py` — passed.
- Broader check attempted: `scripts/run_tests.sh tests/gateway` ran 454 files / ~8299 tests and failed on pre-existing/environmental unrelated issues: macOS `/private/tmp` vs `/tmp` path expectation in `test_background_command.py`, `test_api_server.py` hit `OSError: [Errno 24] Too many open files`, and `test_wecom_callback.py` failed with `ET is None` in WeCom callback XML parsing. Slack/authz/config targeted suites above passed.

## Deploy plan after merge
1. Refresh/rebuild the VM Hermes install from the reviewed source.
2. Cleetus performs the sudo install step.
3. Restart the Morgan gateway.
4. Configure runtime custody values outside this PR/task.
5. Verify Brian DM allow, Luke channel allow, and Luke DM deny through the configured unauthorized-DM behavior.
