### PR TITLE
test(agent): regression coverage for plain-turn Anthropic thinking replay

### DIFF
--- a/tests/agent/test_anthropic_plain_turn_thinking_replay.py
+++ b/tests/agent/test_anthropic_plain_turn_thinking_replay.py
@@ -1,0 +1,174 @@
+"""Regression test: plain-turn (no tool_use) Anthropic thinking must replay.
+
+Scope
+-----
+The Anthropic Messages path has two replay mechanisms for assistant thinking:
+
+1. ``anthropic_content_blocks`` — a verbatim, order-preserving block list,
+   populated only for turns that interleave SIGNED thinking with tool_use
+   (covered by tests/agent/test_anthropic_thinking_block_order.py).
+2. ``reasoning_details`` — the preserved-thinking channel every turn should
+   hit: ``AnthropicTransport.normalize_response`` collects each thinking block
+   (with signature) into ``provider_data["reasoning_details"]``,
+   ``build_assistant_message`` copies it onto the stored assistant message, and
+   ``_convert_assistant_message`` replays it through
+   ``_extract_preserved_thinking_blocks``.
+
+The plain-turn path (thinking + text, no tool_use) depends *entirely* on (2):
+if the stored turn loses ``reasoning_details``, the next-turn request ships the
+previous assistant turn as bare text — the model silently loses its prior
+chain-of-thought (observed live: a two-turn "remember what you reasoned"
+conversation fails on the second turn).
+
+These tests pin the whole chain for plain turns so the silent-loss shape cannot
+regress: normalize -> stored message -> converted replay request.
+"""
+
+from types import SimpleNamespace
+
+from agent.transports import get_transport
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+SIG = "sig-plain-4340"
+
+
+def _plain_turn_response() -> SimpleNamespace:
+    """A thinking+text assistant turn with NO tool_use (shaped like the SDK object)."""
+    return SimpleNamespace(
+        content=[
+            SimpleNamespace(
+                type="thinking",
+                thinking="Picking five numbers: 7, 23, 41, 56, 88. Reveal three: 7, 23, 56.",
+                signature=SIG,
+            ),
+            SimpleNamespace(type="text", text="7 23 56"),
+        ],
+        stop_reason="end_turn",
+        usage=None,
+    )
+
+
+def _stored_assistant_message(normalized) -> dict:
+    """Rebuild the stored assistant message the way build_assistant_message does
+    (content + reasoning_details from provider_data, no tool_calls for plain turns)."""
+    provider_data = normalized.provider_data or {}
+    tool_calls = []
+    for tc in (normalized.tool_calls or []):
+        tool_calls.append({
+            "id": tc.id,
+            "type": "function",
+            "function": {"name": tc.name, "arguments": tc.arguments},
+        })
+    msg = {
+        "role": "assistant",
+        "content": normalized.content or "",
+        "reasoning_details": provider_data.get("reasoning_details"),
+    }
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    blocks = provider_data.get("anthropic_content_blocks")
+    if blocks:
+        msg["anthropic_content_blocks"] = blocks
+    return msg
+
+
+class TestPlainTurnThinkingCapture:
+    def test_normalize_captures_plain_thinking_into_reasoning_details(self):
+        """normalize_response must preserve the plain thinking block (with
+        signature) in provider_data.reasoning_details — this is the ONLY channel
+        that can carry it across turns when there is no tool_use."""
+        transport = get_transport("anthropic_messages")
+        normalized = transport.normalize_response(_plain_turn_response())
+
+        details = (normalized.provider_data or {}).get("reasoning_details")
+        assert details, "plain-turn thinking block was not captured in reasoning_details"
+        thinking = [b for b in details if isinstance(b, dict) and b.get("type") == "thinking"]
+        assert thinking, f"no thinking block in reasoning_details: {details!r}"
+        assert thinking[0].get("signature") == SIG
+
+        # No tool_use in the turn -> no ordered-blocks channel is expected;
+        # replay must therefore succeed via reasoning_details alone.
+        assert not (normalized.provider_data or {}).get("anthropic_content_blocks")
+
+    def test_plain_turn_thinking_replayed_on_next_turn(self):
+        """Full chain: normalize -> stored message -> next-turn request.
+
+        The converted request must carry the previous turn's thinking block
+        (same signature, positioned before the text per the Messages contract).
+        If reasoning_details is dropped anywhere along the chain, this test
+        fails exactly the way the silent live failure looked."""
+        transport = get_transport("anthropic_messages")
+        normalized = transport.normalize_response(_plain_turn_response())
+        assistant_msg = _stored_assistant_message(normalized)
+
+        messages = [
+            {"role": "user", "content": "想五个随机数字，告诉我其中三个。"},
+            assistant_msg,
+            {"role": "user", "content": "另外两个是什么？"},
+        ]
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            messages,
+            base_url=None,
+            model="claude-opus-4-8",
+        )
+
+        assistant_out = [m for m in anthropic_messages if m.get("role") == "assistant"]
+        assert len(assistant_out) == 1
+        content = assistant_out[0]["content"]
+        assert isinstance(content, list), (
+            "assistant turn was flattened to bare text — plain-turn thinking lost: "
+            f"{content!r}"
+        )
+        types = [b.get("type") for b in content if isinstance(b, dict)]
+        assert "thinking" in types, (
+            "no thinking block replayed for the plain assistant turn; "
+            f"converted content types: {types}"
+        )
+        thinking_block = next(b for b in content if isinstance(b, dict) and b.get("type") == "thinking")
+        assert thinking_block.get("signature") == SIG, (
+            "thinking block replayed without its original signature — Anthropic "
+            "would reject tampered thinking with a 400"
+        )
+        # Protocol order: thinking precedes text.
+        assert types.index("thinking") < types.index("text")
+
+    def test_unsigned_thinking_block_survives_as_text_not_lost(self):
+        """Unsigned thinking (e.g. Moonshot/Kimi empty signature) must NOT be
+        silently dropped: the intended fallback on direct Anthropic is demotion
+        to a text block so the reasoning content still reaches the next turn.
+        This pins that contract — a regression to "content lost" fails here."""
+        response = SimpleNamespace(
+            content=[
+                SimpleNamespace(type="thinking", thinking="reasoning without signature", signature=""),
+                SimpleNamespace(type="text", text="answer"),
+            ],
+            stop_reason="end_turn",
+            usage=None,
+        )
+        transport = get_transport("anthropic_messages")
+        normalized = transport.normalize_response(response)
+        assistant_msg = _stored_assistant_message(normalized)
+
+        messages = [
+            {"role": "user", "content": "q"},
+            assistant_msg,
+            {"role": "user", "content": "q2"},
+        ]
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            messages,
+            base_url=None,
+            model="claude-opus-4-8",
+        )
+        assistant_out = [m for m in anthropic_messages if m.get("role") == "assistant"]
+        content = assistant_out[0]["content"]
+        assert isinstance(content, list)
+        types = [b.get("type") for b in content if isinstance(b, dict)]
+        assert "thinking" not in types, (
+            "unsigned thinking must not be replayed as a thinking block "
+            f"(Anthropic cannot validate a missing signature): {types}"
+        )
+        texts = [b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text"]
+        assert any("reasoning without signature" in t for t in texts), (
+            "unsigned thinking was silently LOST instead of demoted to text; "
+            f"text blocks on replay: {texts}"
+        )


### PR DESCRIPTION
## What does this PR do?

Adds regression coverage for the **plain-turn** (thinking + text, no `tool_use`) Anthropic thinking replay path, which was uncovered by existing tests.

The Anthropic Messages path has two thinking-replay channels:

1. `anthropic_content_blocks` — the verbatim, order-preserving channel for turns that interleave SIGNED thinking with `tool_use`. This is covered by `tests/agent/test_anthropic_thinking_block_order.py` (fixes from #36071 / #43943).
2. `reasoning_details` — the preserve channel every *other* turn must use: `AnthropicTransport.normalize_response` collects each thinking block (with signature) into `provider_data["reasoning_details"]`, `build_assistant_message` copies it onto the stored assistant message, and `_convert_assistant_message` replays it via `_extract_preserved_thinking_blocks`.

For plain turns the turn depends **entirely** on channel 2: if `reasoning_details` is lost anywhere along normalize → store → convert, the next-turn request silently ships the previous assistant turn as bare text, and the model loses its prior chain-of-thought. This failure mode is silent (no exception, no log) and only shows up behaviorally in multi-turn conversations where the model must recall what it reasoned.

## Related Issue

N/A — test-only change, no behavior change. Complements the interleaved replay fixes in #36071 / #43943 / #35586.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/agent/test_anthropic_plain_turn_thinking_replay.py` — 3 new tests pinning:
  1. `normalize_response` captures the plain thinking block (with signature) into `provider_data.reasoning_details`, and does **not** create the ordered-blocks channel for a no-tool_use turn;
  2. the full normalize → stored message → `convert_messages_to_anthropic` chain replays the signed thinking block on the next turn, positioned before text (per the Messages contract);
  3. unsigned thinking (e.g. Moonshot/Kimi empty signature) is demoted to a text block instead of being silently dropped — the intended "reasoning isn't lost" fallback in `_strip_invalid_thinking_signatures`.

## How to Test

```bash
pytest tests/agent/test_anthropic_plain_turn_thinking_replay.py -q
# 3 passed

pytest tests/agent/test_anthropic_plain_turn_thinking_replay.py \
       tests/agent/test_anthropic_thinking_block_order.py \
       tests/agent/test_anthropic_adapter.py -q
# 183 passed
```

Notes on the full suite: `pytest tests/agent -q` on this checkout shows 154 pre-existing failures in unrelated areas (`test_title_generator`, `test_model_metadata`, `test_verification_stop`, `test_models_dev`, `lsp/test_client_e2e`, etc.). They reproduce only inside the giant combined run (cross-test state interference): the same files pass standalone and in small groups, with and without this PR's file (verified: `test_title_generator` 42/42 alone; the three largest failing groups 214/214 together without this PR's file present).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (closest: #54070, #26802 — those are behavior fixes for DeepSeek/MiMo relay replay; this PR is pure test coverage of the plain-turn path, no overlap)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest and all related tests pass (see "How to Test")
- [x] I've added tests for my changes (this PR is the tests)
- [x] I've tested on my platform: Ubuntu 22.04 (Linux x86_64)

### Documentation & Housekeeping

- [x] Docs — N/A (test file is self-documenting via module docstring)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure unit tests, no platform-specific code)
