### PR TITLE
fix(photon): run the Spectrum patch spawn off the gateway event loop

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -955,7 +955,14 @@ class PhotonAdapter(BasePlatformAdapter):
         from hermes_cli._subprocess_compat import windows_hide_flags
 
         try:
-            patch = subprocess.run(  # noqa: S603
+            # Off the event loop, for the same reason the dep reinstall above
+            # hops to a thread: this spawns node and *waits* for it (up to 10s).
+            # Run inline it holds the shared gateway loop for that whole window,
+            # so every other platform's traffic stalls — and _start_sidecar runs
+            # on every reconnect (connect(is_reconnect=True)), not just startup,
+            # so the stall recurs on a live gateway.
+            patch = await asyncio.to_thread(
+                subprocess.run,  # noqa: S603
                 [
                     self._node_bin,
                     str(_SIDECAR_DIR / "patch-spectrum-mixed-attachments.mjs"),

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -188,3 +188,70 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
     assert kwargs["env"]["PHOTON_SIDECAR_WATCH_STDIN"] == "1"
     assert spawned["patch_kwargs"]["creationflags"] == hidden_flags
     assert kwargs["creationflags"] == hidden_flags
+
+
+@pytest.mark.asyncio
+async def test_spectrum_patch_runs_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The node patch run must not block the shared gateway event loop.
+
+    ``_start_sidecar`` spawns the Spectrum patch script and *waits* for it
+    (``timeout=10``). Run inline it holds the loop for that whole window, so
+    every other platform's traffic stalls — and ``_start_sidecar`` runs on
+    every reconnect (``connect(is_reconnect=True)``), not just startup, so the
+    stall recurs on a live gateway. The dep reinstall a few lines above already
+    hops to a thread for exactly this reason; the patch run must too.
+    """
+    import threading
+
+    adapter = _make_adapter(monkeypatch)
+    main_thread = threading.current_thread()
+    seen: Dict[str, Any] = {}
+
+    # node_modules present + deps fresh, so we reach the patch run.
+    monkeypatch.setattr(photon_adapter.Path, "exists", lambda self: True)
+    monkeypatch.setattr(photon_adapter, "_sidecar_deps_stale", lambda: False)
+
+    async def _no_reap() -> None:
+        return None
+
+    monkeypatch.setattr(adapter, "_reap_stale_sidecar", _no_reap)
+
+    def _fake_run(*a: Any, **k: Any) -> Any:
+        seen["thread"] = threading.current_thread()
+
+        class _Done:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Done()
+
+    monkeypatch.setattr(photon_adapter.subprocess, "run", _fake_run)
+
+    class _FakeProc:
+        pid = 4242
+        stdin = None
+        stdout = None
+
+        def poll(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        photon_adapter.subprocess, "Popen", lambda *a, **k: _FakeProc()
+    )
+
+    try:
+        await adapter._start_sidecar()
+    except Exception:
+        # Readiness/handshake past the patch run may fail under the fakes —
+        # irrelevant here; we only assert where the patch run executed.
+        pass
+
+    assert seen.get("thread") is not None, "patch run never executed"
+    assert seen["thread"] is not main_thread, (
+        "Spectrum patch subprocess ran on the event-loop thread; it must be "
+        "dispatched via asyncio.to_thread so a 10s node spawn can't freeze "
+        "every other platform on the gateway loop"
+    )


### PR DESCRIPTION
## What does this PR do?

`PhotonAdapter._start_sidecar` is `async`, but it ran the Spectrum mixed-attachment patch script with a bare `subprocess.run(...)`: it spawns node and *waits* for it, with `timeout=10`. Executed inline that holds the shared gateway event loop for the whole window, so no other platform's messages, heartbeats, or sessions are serviced until it returns.

The same function already establishes this exact invariant twenty lines above, where the stale-dependency reinstall hops to a worker thread:

```python
# Runs off the event loop so a cold install can't freeze every other
# platform's traffic.
if _sidecar_deps_stale():
    await asyncio.to_thread(_reinstall_sidecar_deps)
```

The patch spawn never got the same treatment.

It is **not startup-only**, either: `_start_sidecar` is called from `connect()`, which takes `is_reconnect`, so an ordinary Photon reconnect (network blip, sidecar death) re-runs it and stalls a gateway that is actively serving Discord/Telegram/Slack traffic.

Same off-the-loop class as the inbound-image decision (#66688) and the cron-fire verifier.

## Related Issue

No separate issue — an event-loop-blocking gateway path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/photon/adapter.py` — in `_start_sidecar`, dispatch the Spectrum patch `subprocess.run` via `asyncio.to_thread` so the node spawn/wait runs on a worker thread, mirroring the dep-reinstall hop directly above it. Behavior, arguments, timeout, and Windows console-hiding flags are unchanged.
- `tests/plugins/platforms/photon/test_sidecar_lifecycle.py` — add `test_spectrum_patch_runs_off_the_event_loop`, asserting the spawn executes on a worker thread rather than the loop thread.

## How to Test

1. Run:

       pytest tests/plugins/platforms/photon/test_sidecar_lifecycle.py -q

   The new test passes with the fix and fails without it (it records `threading.current_thread()` inside a faked `subprocess.run` and asserts it is not the loop thread).

2. Full photon suite is unchanged apart from the added test: baseline `4 failed, 107 passed` → `4 failed, 108 passed` (the 4 failures are pre-existing on `main` in this environment and unrelated to this change).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(photon):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/plugins/platforms/photon/ -q` and verified no regressions against a clean `main` baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline comments) — the call site now documents why it must stay off the loop
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — `windows_hide_flags()` is still applied; only the dispatch changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A