### PR TITLE
feat(desktop): add session task history

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -55,6 +55,7 @@ import {
 import { useComposerScope } from './scope'
 import { ComposerStatusStack } from './status-stack'
 import { CodingStatusRow } from './status-stack/coding-row'
+import { SessionTaskHistoryPopover } from './task-history-popover'
 import { extractClipboardImageBlobs } from './text-utils'
 import { ComposerTriggerPopover } from './trigger-popover'
 import type { ChatBarProps } from './types'
@@ -997,6 +998,7 @@ export function ChatBar({
                 >
                   <div className="flex translate-y-[3px] items-start gap-(--composer-control-gap) self-start [grid-area:menu]">
                     {contextMenu}
+                    <SessionTaskHistoryPopover busy={busy} sessionId={statusSessionId} />
                     <ContribSlot area={COMPOSER_AREAS.leading} />
                   </div>
                   <div className="min-w-0 [grid-area:input]">{input}</div>

--- a/apps/desktop/src/app/chat/composer/task-history-popover.test.tsx
+++ b/apps/desktop/src/app/chat/composer/task-history-popover.test.tsx
@@ -1,0 +1,186 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+import type { TodoItem } from '@/lib/todos'
+import { $messages } from '@/store/session'
+import { $todosBySession, clearSessionTodos, setSessionTodos } from '@/store/todos'
+
+import { SessionTaskHistoryPopover, TaskHistoryPopover } from './task-history-popover'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => vi.stubGlobal('ResizeObserver', TestResizeObserver))
+
+const list = (status: TodoItem['status'], content = 'Ship feature'): TodoItem[] => [{ content, id: content, status }]
+
+const message = (id: string, todos: TodoItem[], timestamp?: number): ChatMessage => ({
+  id,
+  parts: [
+    {
+      args: { todos: todos.map(({ content, id: todoId, status }) => ({ content, id: todoId, status })) },
+      toolCallId: `${id}-todo`,
+      toolName: 'todo',
+      type: 'tool-call'
+    }
+  ],
+  role: 'assistant',
+  timestamp
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  $messages.set([])
+  clearSessionTodos('linger')
+})
+
+describe('TaskHistoryPopover', () => {
+  it('does not render a button when neither transcript nor live state has a list', () => {
+    render(<TaskHistoryPopover busy={false} liveTodos={null} messages={[]} sessionId="a" />)
+
+    expect(screen.queryByRole('button', { name: /Tasks/ })).toBeNull()
+  })
+
+  it('opens, closes from the UI, and reopens without deleting transcript history', () => {
+    render(
+      <TaskHistoryPopover
+        busy={false}
+        liveTodos={null}
+        messages={[message('turn-1', list('completed'))]}
+        sessionId="a"
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Tasks 1/1' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(trigger)
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(screen.getByRole('dialog', { name: 'Task history' })).not.toBeNull()
+    expect(screen.getByText('Ship feature')).not.toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close task history' }))
+    expect(screen.queryByRole('dialog', { name: 'Task history' })).toBeNull()
+
+    fireEvent.click(trigger)
+    expect(screen.getByText('Ship feature')).not.toBeNull()
+  })
+
+  it('scopes open presentation state to each runtime session', () => {
+    const { rerender } = render(
+      <TaskHistoryPopover
+        busy={false}
+        liveTodos={null}
+        messages={[message('a-turn', list('completed', 'A task'))]}
+        sessionId="a"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tasks 1/1' }))
+    expect(screen.getByRole('dialog', { name: 'Task history' })).not.toBeNull()
+
+    rerender(
+      <TaskHistoryPopover
+        busy={false}
+        liveTodos={null}
+        messages={[message('b-turn', list('completed', 'B task'))]}
+        sessionId="b"
+      />
+    )
+    expect(screen.queryByRole('dialog', { name: 'Task history' })).toBeNull()
+    expect(screen.queryByText('A task')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tasks 1/1' }))
+    expect(screen.getByText('B task')).not.toBeNull()
+
+    rerender(
+      <TaskHistoryPopover
+        busy={false}
+        liveTodos={null}
+        messages={[message('a-turn', list('completed', 'A task'))]}
+        sessionId="a"
+      />
+    )
+    expect(screen.getByText('A task')).not.toBeNull()
+    expect(screen.queryByText('B task')).toBeNull()
+  })
+
+  it('reconstructs history when a resumed transcript arrives', () => {
+    const { rerender } = render(<TaskHistoryPopover busy={false} liveTodos={null} messages={[]} sessionId="resume" />)
+    expect(screen.queryByRole('button', { name: /Tasks/ })).toBeNull()
+
+    rerender(
+      <TaskHistoryPopover
+        busy={false}
+        liveTodos={null}
+        messages={[message('old-turn', list('in_progress', 'Interrupted task'))]}
+        sessionId="resume"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tasks 0/1' }))
+    expect(screen.getByText('Unfinished from previous turn')).not.toBeNull()
+    expect(screen.queryByText('Running')).toBeNull()
+  })
+
+  it('shows turn timestamps so older lists remain understandable', () => {
+    const firstTimestamp = 1_752_840_000
+    const secondTimestamp = 1_752_843_600
+    const latestTimestamp = 1_752_847_200
+
+    render(
+      <TaskHistoryPopover
+        busy={false}
+        liveTodos={null}
+        messages={[
+          message('turn-1', list('completed', 'First list'), firstTimestamp),
+          message('turn-2', list('completed', 'Second list'), secondTimestamp),
+          message('turn-3', list('completed', 'Latest list task'), latestTimestamp)
+        ]}
+        sessionId="history"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tasks 1/1' }))
+
+    expect(screen.getByRole('heading', { name: 'Latest list' })).not.toBeNull()
+    expect(screen.getByText(new Date(latestTimestamp * 1000).toLocaleString())).not.toBeNull()
+    expect(screen.getByText(new Date(secondTimestamp * 1000).toLocaleString())).not.toBeNull()
+    expect(screen.getByText(new Date(firstTimestamp * 1000).toLocaleString())).not.toBeNull()
+  })
+
+  it('keeps completed history after the four-second live linger clears', () => {
+    vi.useFakeTimers()
+    $messages.set([message('turn-1', list('completed'))])
+    setSessionTodos('linger', list('completed'))
+    render(<SessionTaskHistoryPopover busy={false} sessionId="linger" />)
+
+    expect(screen.getByRole('button', { name: 'Tasks 1/1' })).not.toBeNull()
+
+    act(() => vi.advanceTimersByTime(4_000))
+
+    expect($todosBySession.get().linger).toBeUndefined()
+    expect(screen.getByRole('button', { name: 'Tasks 1/1' })).not.toBeNull()
+  })
+
+  it('reveals long history progressively', () => {
+    const messages = Array.from({ length: 12 }, (_, index) =>
+      message(`turn-${index}`, list('completed', `List ${index}`), 1_752_840_000 + index * 60)
+    )
+
+    render(<TaskHistoryPopover busy={false} liveTodos={null} messages={messages} sessionId="long" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Tasks 1/1' }))
+
+    expect(screen.getByText('List 11')).not.toBeNull()
+    expect(screen.queryByText('List 0')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load older lists' }))
+
+    expect(screen.getByText('List 0')).not.toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/task-history-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/task-history-popover.tsx
@@ -1,0 +1,203 @@
+import { useStore } from '@nanostores/react'
+import { computed } from 'nanostores'
+import { useId, useMemo, useState } from 'react'
+
+import { useSessionView } from '@/app/chat/session-view'
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import {
+  createTodoHistoryMessagesSelector,
+  sessionTodoHistory,
+  type TodoHistoryMessage,
+  type TodoHistorySnapshot,
+  type TodoItem
+} from '@/lib/todos'
+import { cn } from '@/lib/utils'
+import { $todosBySession } from '@/store/todos'
+
+interface TaskHistoryPopoverProps {
+  busy: boolean
+  liveTodos: readonly TodoItem[] | null
+  messages: readonly TodoHistoryMessage[]
+  sessionId: string | null
+}
+
+const INITIAL_HISTORY_LIMIT = 10
+
+const doneCount = (todos: readonly TodoItem[]) =>
+  todos.filter(todo => todo.status === 'completed' || todo.status === 'cancelled').length
+
+function TodoGlyph({ snapshot, todo }: { snapshot: TodoHistorySnapshot; todo: TodoItem }) {
+  const completed = todo.status === 'completed'
+  const cancelled = todo.status === 'cancelled'
+
+  if (completed || cancelled) {
+    return (
+      <Codicon
+        aria-hidden
+        className={completed ? 'text-emerald-500/80' : 'text-muted-foreground/45'}
+        name={completed ? 'pass-filled' : 'circle-slash'}
+        size="0.8rem"
+      />
+    )
+  }
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'box-border size-[0.7rem] rounded-full border border-dashed',
+        snapshot.state === 'running' ? 'border-primary/70' : 'border-muted-foreground/55'
+      )}
+    />
+  )
+}
+
+function SnapshotSection({ label, snapshot }: { label: string; snapshot: TodoHistorySnapshot }) {
+  const copy = useI18n().t.statusStack.taskHistory
+  const timestamp = snapshot.timestamp ? new Date(snapshot.timestamp * 1000) : null
+
+  const stateLabel =
+    snapshot.state === 'running' ? copy.running : snapshot.state === 'unfinished' ? copy.unfinished : copy.completed
+
+  return (
+    <section aria-label={label} className="grid gap-1.5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-xs font-medium text-(--ui-text-primary)">{label}</h3>
+          {timestamp && (
+            <time
+              className="block text-[0.65rem] leading-4 text-(--ui-text-tertiary)"
+              dateTime={timestamp.toISOString()}
+            >
+              {timestamp.toLocaleString()}
+            </time>
+          )}
+        </div>
+        <span
+          className={cn(
+            'text-[0.65rem] leading-4',
+            snapshot.state === 'running' ? 'text-primary' : 'text-(--ui-text-tertiary)'
+          )}
+        >
+          {stateLabel}
+        </span>
+      </div>
+      <ul className="grid gap-1">
+        {snapshot.todos.map(todo => (
+          <li className="flex min-w-0 items-start gap-2 text-[0.72rem] leading-4" key={todo.id}>
+            <span className="mt-[0.15rem] grid size-3.5 shrink-0 place-items-center">
+              <TodoGlyph snapshot={snapshot} todo={todo} />
+            </span>
+            <span
+              className={cn(
+                'min-w-0 wrap-break-word',
+                todo.status === 'completed' || todo.status === 'cancelled'
+                  ? 'text-(--ui-text-tertiary)'
+                  : 'text-(--ui-text-primary)'
+              )}
+            >
+              {todo.content}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+/** Transcript-derived history plus the existing live todo store as a temporary overlay. */
+export function TaskHistoryPopover({ busy, liveTodos, messages, sessionId }: TaskHistoryPopoverProps) {
+  const { t } = useI18n()
+  const copy = t.statusStack.taskHistory
+  const generatedId = useId()
+  const panelId = `task-history-${generatedId.replaceAll(':', '')}`
+  const [openBySession, setOpenBySession] = useState<Record<string, boolean>>({})
+  const [visibleBySession, setVisibleBySession] = useState<Record<string, number>>({})
+  const history = useMemo(() => sessionTodoHistory(messages, liveTodos, busy), [busy, liveTodos, messages])
+  const latest = history.current ?? history.snapshots[0]
+
+  if (!sessionId || !latest) {
+    return null
+  }
+
+  const open = openBySession[sessionId] ?? false
+  const setOpen = (next: boolean) => setOpenBySession(current => ({ ...current, [sessionId]: next }))
+  const snapshots = history.current ? [history.current, ...history.snapshots] : history.snapshots
+  const visibleCount = visibleBySession[sessionId] ?? INITIAL_HISTORY_LIMIT
+  const visibleSnapshots = snapshots.slice(0, visibleCount)
+  const label = t.statusStack.todos(doneCount(latest.todos), latest.todos.length)
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger asChild>
+        <Button
+          aria-controls={panelId}
+          aria-expanded={open}
+          aria-label={label}
+          size="xs"
+          type="button"
+          variant="outline"
+        >
+          {label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" aria-label={copy.title} id={panelId} role="dialog" side="top">
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <h2 className="text-xs font-semibold text-(--ui-text-primary)">{copy.title}</h2>
+          <Tip label={copy.close}>
+            <Button aria-label={copy.close} onClick={() => setOpen(false)} size="icon-xs" type="button" variant="ghost">
+              <Codicon name="close" size="0.75rem" />
+            </Button>
+          </Tip>
+        </div>
+        <div className="grid max-h-80 gap-3 overflow-y-auto pr-1">
+          {visibleSnapshots.map((snapshot, index) => (
+            <SnapshotSection
+              key={`${snapshot.state}:${snapshot.id}`}
+              label={snapshot.state === 'running' ? copy.current : index === 0 ? copy.latest : copy.previous}
+              snapshot={snapshot}
+            />
+          ))}
+          {visibleSnapshots.length < snapshots.length && (
+            <Button
+              className="justify-self-start"
+              onClick={() =>
+                setVisibleBySession(current => ({ ...current, [sessionId]: visibleCount + INITIAL_HISTORY_LIMIT }))
+              }
+              size="xs"
+              type="button"
+              variant="ghost"
+            >
+              {copy.loadOlder}
+            </Button>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export function SessionTaskHistoryPopover({ busy, sessionId }: { busy: boolean; sessionId: string | null }) {
+  const view = useSessionView()
+
+  const todoMessagesStore = useMemo(
+    () => computed(view.$messages, createTodoHistoryMessagesSelector()),
+    [view.$messages]
+  )
+
+  const messages = useStore(todoMessagesStore)
+  const todosBySession = useStore($todosBySession)
+
+  return (
+    <TaskHistoryPopover
+      busy={busy}
+      liveTodos={sessionId ? (todosBySession[sessionId] ?? null) : null}
+      messages={messages}
+      sessionId={sessionId}
+    />
+  )
+}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1814,6 +1814,17 @@ export const en: Translations = {
     background: count => `${count} Background`,
     subagents: count => `${count} Subagent${count === 1 ? '' : 's'}`,
     todos: (done, total) => `Tasks ${done}/${total}`,
+    taskHistory: {
+      close: 'Close task history',
+      completed: 'Completed',
+      current: 'Current tasks',
+      latest: 'Latest list',
+      loadOlder: 'Load older lists',
+      previous: 'Previous list',
+      running: 'Running',
+      title: 'Task history',
+      unfinished: 'Unfinished from previous turn'
+    },
     running: 'Running',
     stop: 'Stop',
     dismiss: 'Dismiss',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1731,6 +1731,17 @@ export const ja = defineLocale({
     background: count => `バックグラウンド ${count} 件`,
     subagents: count => `サブエージェント ${count} 件`,
     todos: (done, total) => `タスク ${done}/${total}`,
+    taskHistory: {
+      close: 'タスク履歴を閉じる',
+      completed: '完了',
+      current: '現在のタスク',
+      latest: '最新のリスト',
+      loadOlder: '古いリストを読み込む',
+      previous: '以前のリスト',
+      running: '実行中',
+      title: 'タスク履歴',
+      unfinished: '前のターンから未完了'
+    },
     running: '実行中',
     stop: '停止',
     dismiss: '閉じる',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1489,6 +1489,17 @@ export interface Translations {
     background: (count: number) => string
     subagents: (count: number) => string
     todos: (done: number, total: number) => string
+    taskHistory: {
+      close: string
+      completed: string
+      current: string
+      latest: string
+      loadOlder: string
+      previous: string
+      running: string
+      title: string
+      unfinished: string
+    }
     running: string
     stop: string
     dismiss: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1680,6 +1680,17 @@ export const zhHant = defineLocale({
     background: count => `${count} 個背景任務`,
     subagents: count => `${count} 個子代理`,
     todos: (done, total) => `任務 ${done}/${total}`,
+    taskHistory: {
+      close: '關閉任務歷史',
+      completed: '已完成',
+      current: '目前任務',
+      latest: '最新清單',
+      loadOlder: '載入較早的清單',
+      previous: '先前清單',
+      running: '執行中',
+      title: '任務歷史',
+      unfinished: '上一輪尚未完成'
+    },
     running: '執行中',
     stop: '停止',
     dismiss: '關閉',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1990,6 +1990,17 @@ export const zh: Translations = {
     background: count => `${count} 个后台任务`,
     subagents: count => `${count} 个子代理`,
     todos: (done, total) => `任务 ${done}/${total}`,
+    taskHistory: {
+      close: '关闭任务历史',
+      completed: '已完成',
+      current: '当前任务',
+      latest: '最新列表',
+      loadOlder: '加载更早的列表',
+      previous: '之前的列表',
+      running: '运行中',
+      title: '任务历史',
+      unfinished: '上一轮未完成'
+    },
     running: '运行中',
     stop: '停止',
     dismiss: '关闭',

--- a/apps/desktop/src/lib/todos.test.ts
+++ b/apps/desktop/src/lib/todos.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { latestSessionTodos, parseTodos } from './todos'
+import { createTodoHistoryMessagesSelector, latestSessionTodos, parseTodos, sessionTodoHistory } from './todos'
 
 describe('parseTodos', () => {
   it('parses todo arrays with valid ids, content, and statuses', () => {
@@ -76,5 +76,147 @@ describe('latestSessionTodos', () => {
   it('returns null when no todo tool calls exist', () => {
     expect(latestSessionTodos([{ parts: [{ type: 'text', text: 'hi' }] }])).toBeNull()
     expect(latestSessionTodos([])).toBeNull()
+  })
+})
+
+describe('sessionTodoHistory', () => {
+  const list = (status: 'completed' | 'in_progress' | 'pending', content = 'Ship') => [{ content, id: 'ship', status }]
+
+  const todoPart = (todos: unknown) => ({
+    args: { todos },
+    toolCallId: crypto.randomUUID(),
+    toolName: 'todo',
+    type: 'tool-call'
+  })
+
+  const assistant = (id: string, snapshots: unknown[], pending = false) => ({
+    id,
+    parts: snapshots.map(todoPart),
+    pending,
+    role: 'assistant' as const
+  })
+
+  it('keeps only the final todo update from each assistant turn', () => {
+    const history = sessionTodoHistory([assistant('turn-1', [list('pending'), list('in_progress'), list('completed')])])
+
+    expect(history.snapshots).toEqual([
+      expect.objectContaining({ id: 'turn-1', state: 'completed', todos: list('completed') })
+    ])
+  })
+
+  it('retains distinct snapshots from multiple turns newest first', () => {
+    const history = sessionTodoHistory([
+      assistant('turn-1', [list('completed', 'Plan')]),
+      { id: 'user-2', parts: [], role: 'user' as const },
+      assistant('turn-2', [list('completed', 'Build')])
+    ])
+
+    expect(history.snapshots.map(snapshot => snapshot.todos[0]?.content)).toEqual(['Build', 'Plan'])
+  })
+
+  it('deduplicates identical snapshots across turns', () => {
+    const history = sessionTodoHistory([
+      assistant('turn-1', [list('completed')]),
+      assistant('turn-2', [list('completed')])
+    ])
+
+    expect(history.snapshots).toHaveLength(1)
+    expect(history.snapshots[0]?.id).toBe('turn-2')
+  })
+
+  it('renders stale open snapshots as unfinished history, never running', () => {
+    const history = sessionTodoHistory([assistant('turn-1', [list('in_progress')])])
+
+    expect(history.current).toBeNull()
+    expect(history.snapshots[0]?.state).toBe('unfinished')
+  })
+
+  it('uses the live turn as current and moves it into history when the turn ends', () => {
+    const messages = [assistant('turn-1', [list('in_progress')], true)]
+
+    expect(sessionTodoHistory(messages, list('in_progress'), true).current).toEqual(
+      expect.objectContaining({ state: 'running', todos: list('in_progress') })
+    )
+    expect(sessionTodoHistory(messages, null, false)).toEqual(
+      expect.objectContaining({ current: null, snapshots: [expect.objectContaining({ state: 'unfinished' })] })
+    )
+  })
+
+  it('keeps completed transcript history after the live overlay disappears', () => {
+    const messages = [assistant('turn-1', [list('completed')])]
+
+    expect(sessionTodoHistory(messages, list('completed'), false).snapshots).toHaveLength(1)
+    expect(sessionTodoHistory(messages, null, false).snapshots).toHaveLength(1)
+  })
+
+  it('does not promote old history while a new user turn is busy without todos', () => {
+    const history = sessionTodoHistory(
+      [assistant('turn-1', [list('completed')]), { id: 'user-2', parts: [], role: 'user' }],
+      list('completed'),
+      true
+    )
+
+    expect(history.current).toBeNull()
+    expect(history.snapshots).toEqual([expect.objectContaining({ id: 'turn-1', state: 'completed' })])
+  })
+
+  it('does not promote old history when the pending assistant has no todo call', () => {
+    const history = sessionTodoHistory(
+      [
+        assistant('turn-1', [list('completed')]),
+        { id: 'user-2', parts: [], role: 'user' },
+        { id: 'turn-2', parts: [{ text: 'Working', type: 'text' }], pending: true, role: 'assistant' }
+      ],
+      list('completed'),
+      true
+    )
+
+    expect(history.current).toBeNull()
+    expect(history.snapshots).toEqual([expect.objectContaining({ id: 'turn-1', state: 'completed' })])
+  })
+
+  it('treats an explicit empty todo list in the pending turn as no current tasks', () => {
+    const history = sessionTodoHistory(
+      [assistant('turn-1', [list('completed')]), assistant('turn-2', [[]], true)],
+      list('completed'),
+      true
+    )
+
+    expect(history.current).toBeNull()
+    expect(history.snapshots).toEqual([expect.objectContaining({ id: 'turn-1', state: 'completed' })])
+  })
+
+  it('ignores the previous live linger when a new pending turn has no todo', () => {
+    const history = sessionTodoHistory(
+      [assistant('turn-1', [list('completed')]), { id: 'turn-2', parts: [], pending: true, role: 'assistant' }],
+      list('completed'),
+      true
+    )
+
+    expect(history.current).toBeNull()
+    expect(history.snapshots[0]?.id).toBe('turn-1')
+  })
+})
+
+describe('createTodoHistoryMessagesSelector', () => {
+  it('preserves reference identity across non-todo streaming deltas', () => {
+    const select = createTodoHistoryMessagesSelector()
+
+    const todo = {
+      args: { todos: [{ content: 'Ship', id: 'ship', status: 'in_progress' }] },
+      toolCallId: 'todo-1',
+      toolName: 'todo',
+      type: 'tool-call'
+    }
+
+    const first = select([
+      { id: 'turn-1', parts: [todo, { text: 'A', type: 'text' }], pending: true, role: 'assistant' }
+    ])
+
+    const afterTextDelta = select([
+      { id: 'turn-1', parts: [todo, { text: 'A longer delta', type: 'text' }], pending: true, role: 'assistant' }
+    ])
+
+    expect(afterTextDelta).toBe(first)
   })
 })

--- a/apps/desktop/src/lib/todos.ts
+++ b/apps/desktop/src/lib/todos.ts
@@ -86,3 +86,149 @@ export function latestSessionTodos(messages: readonly { parts?: unknown }[]): nu
 
   return null
 }
+
+export interface TodoHistorySnapshot {
+  id: string
+  state: 'completed' | 'running' | 'unfinished'
+  timestamp?: number
+  todos: TodoItem[]
+}
+
+export interface SessionTodoHistory {
+  current: TodoHistorySnapshot | null
+  snapshots: TodoHistorySnapshot[]
+}
+
+export interface TodoHistoryMessage {
+  id?: string
+  pending?: boolean
+  parts?: unknown
+  role?: string
+  timestamp?: number
+}
+
+const todosSignature = (todos: readonly TodoItem[]) =>
+  JSON.stringify(todos.map(({ content, id, status }) => ({ content, id, status })))
+
+/**
+ * Preserve reference identity while streaming changes only non-todo text. The
+ * composer can subscribe to this coarse derivation without re-rendering on
+ * every token. Pending assistant turns are retained before their first todo
+ * call so stale live-store linger cannot be promoted into the new turn.
+ */
+export function createTodoHistoryMessagesSelector() {
+  let previousKey = ''
+  let previous: readonly TodoHistoryMessage[] = []
+
+  return (messages: readonly TodoHistoryMessage[]): readonly TodoHistoryMessage[] => {
+    const relevant: TodoHistoryMessage[] = []
+    const keyParts: string[] = []
+
+    messages.forEach((message, index) => {
+      if (message.role !== 'assistant') {
+        return
+      }
+
+      const todos = todosFromMessageContent(message.parts)
+      const pending = message.pending === true
+
+      if (todos === null && !pending) {
+        return
+      }
+
+      relevant.push(message)
+      keyParts.push(
+        `${message.id || index}:${message.timestamp ?? ''}:${pending ? 1 : 0}:${todos === null ? 'none' : todosSignature(todos)}`
+      )
+    })
+
+    const key = keyParts.join('|')
+
+    if (key === previousKey) {
+      return previous
+    }
+
+    previousKey = key
+    previous = relevant
+
+    return previous
+  }
+}
+
+/**
+ * Reconstruct task-list history from the authoritative session transcript.
+ * Each assistant message is one turn, so intermediate todo calls collapse to
+ * that message's final snapshot. Identical lists retain only their newest
+ * occurrence. The optional live store is presentation-only overlay data and is
+ * never copied into durable state.
+ */
+export function sessionTodoHistory(
+  messages: readonly TodoHistoryMessage[],
+  liveTodos: readonly TodoItem[] | null = null,
+  running = false
+): SessionTodoHistory {
+  const turnSnapshots = messages.flatMap((message, index) => {
+    if (message.role !== 'assistant') {
+      return []
+    }
+
+    const todos = todosFromMessageContent(message.parts)
+
+    return todos !== null
+      ? [
+          {
+            id: message.id || `assistant-turn-${index}`,
+            pending: message.pending === true,
+            timestamp: message.timestamp,
+            todos
+          }
+        ]
+      : []
+  })
+
+  const liveTranscriptSnapshot = running ? turnSnapshots.findLast(snapshot => snapshot.pending) : undefined
+
+  const currentTodos = liveTranscriptSnapshot?.todos.length
+    ? liveTodos === null
+      ? liveTranscriptSnapshot.todos
+      : liveTodos
+    : undefined
+
+  const current = currentTodos?.length
+    ? {
+        id: liveTranscriptSnapshot?.id || 'live',
+        state: 'running' as const,
+        timestamp: liveTranscriptSnapshot?.timestamp,
+        todos: [...currentTodos]
+      }
+    : null
+
+  const seen = new Set<string>()
+  const snapshots: TodoHistorySnapshot[] = []
+
+  for (let index = turnSnapshots.length - 1; index >= 0; index -= 1) {
+    const snapshot = turnSnapshots[index]
+
+    if (!snapshot || snapshot.todos.length === 0 || (running && snapshot === liveTranscriptSnapshot)) {
+      continue
+    }
+
+    const signature = todosSignature(snapshot.todos)
+
+    if (seen.has(signature)) {
+      continue
+    }
+
+    seen.add(signature)
+    snapshots.push({
+      id: snapshot.id,
+      state: snapshot.todos.some(todo => todo.status === 'pending' || todo.status === 'in_progress')
+        ? 'unfinished'
+        : 'completed',
+      timestamp: snapshot.timestamp,
+      todos: [...snapshot.todos]
+    })
+  }
+
+  return { current, snapshots }
+}

--- a/contributors/emails/nicholas.mariani@hotmail.it
+++ b/contributors/emails/nicholas.mariani@hotmail.it
@@ -1,0 +1,1 @@
+null-runner


### PR DESCRIPTION
## Summary
- preserve every todo-tool snapshot in the current Desktop session
- show historical task lists from the composer with running/completed status
- keep long sessions responsive with stable todo derivation and progressive loading
- scope history strictly to the selected session and restore it on resume

## Behavior
- the latest todo list remains the current list
- older snapshots are available from the task-history popover
- a list is marked Running only while its own assistant turn is pending
- explicit empty lists and lingered previous snapshots are not misclassified
- older history loads 10 lists at a time

## Test plan
- `VITEST_MAX_WORKERS=1 npm run check`
- 36 targeted todo/history tests
- TypeScript typecheck, ESLint, Prettier, Electron tests and production build all pass locally

## Scope
Desktop renderer only. No todo persistence format, gateway lifecycle, or task cleanup behavior changes.