### PR TITLE
fix(cron): wait out live adapter rate-limit cooldown before standalone fallback (#66928)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1442,6 +1442,43 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _wait_for_live_adapter_rate_limit_cooldown(
+    runtime_adapter: Any,
+    *,
+    job_id: Optional[str] = None,
+) -> float:
+    """Sleep until the live adapter's rate-limit circuit breaker closes.
+
+    The standalone fallback path (see ``_deliver_result``) builds a fresh
+    adapter with its own (closed) circuit breaker, so it has no way to know
+    iLink is still server-side rate limited after the live adapter tripped.
+    Issuing an immediate fallback send hits the same -2 and opens the
+    standalone breaker too, double-failing the cron job (issue #66928).
+
+    Returns the number of seconds slept (0 if the breaker wasn't open or the
+    adapter didn't expose one). Exposed at module level so a unit test can
+    drive it directly without spinning up the full delivery state machine.
+    A 0.1s safety buffer is added so the local breaker closes *before* the
+    next send is issued, not simultaneously with it.
+    """
+    if runtime_adapter is None:
+        return 0.0
+    cooldown_until = getattr(runtime_adapter, "_rate_limit_circuit_until", None)
+    if not isinstance(cooldown_until, (int, float)) or cooldown_until <= 0:
+        return 0.0
+    remaining = cooldown_until - time.monotonic()
+    if remaining <= 0:
+        return 0.0
+    sleep_for = remaining + 0.1
+    logger.info(
+        "Job '%s': waiting %.1fs for live adapter rate-limit cooldown"
+        " before standalone fallback (issue #66928)",
+        job_id or "?", sleep_for,
+    )
+    time.sleep(sleep_for)
+    return sleep_for
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -1924,6 +1961,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 logger.warning(
                     "Job '%s': %s, falling back to standalone",
                     job["id"], err_msg,
+                )
+                # If the live adapter tripped its rate-limit circuit breaker,
+                # wait out the cooldown before falling back. The standalone
+                # path builds a fresh adapter with its own (closed) breaker,
+                # so it has no way to know iLink is still server-side rate
+                # limited — issuing an immediate fallback send hits the same
+                # -2 and opens the standalone breaker too, double-failing the
+                # job (issue #66928). Sleeping here both respects the local
+                # breaker and gives iLink's server-side window time to clear.
+                _wait_for_live_adapter_rate_limit_cooldown(
+                    runtime_adapter, job_id=job["id"]
                 )
 
         if not delivered:

--- a/tests/cron/test_cron_fallback_rate_limit_cooldown.py
+++ b/tests/cron/test_cron_fallback_rate_limit_cooldown.py
@@ -85,3 +85,140 @@ class TestWaitForLiveAdapterRateLimitCooldown:
 
         assert result == 0.0
         sleep_mock.assert_not_called()
+
+
+class TestDeliverResultWaitsBeforeStandaloneFallback:
+    """End-to-end: when live delivery fails, ``_deliver_result`` MUST wait out
+    the live adapter's rate-limit cooldown before invoking the standalone
+    fallback. Without this wait the standalone adapter — built fresh with its
+    own closed breaker — re-triggers the iLink -2 immediately and opens its
+    own breaker, double-failing the job (#66928).
+
+    Mirrors the integration pattern in
+    ``tests/cron/test_scheduler.py::TestDeliverResultTimeoutCancelsFuture``
+    so the assertion model is familiar to anyone who has debugged that path.
+    """
+
+    def test_live_failure_with_open_breaker_sleeps_then_falls_back(self):
+        from concurrent.futures import Future
+        from unittest.mock import AsyncMock, MagicMock
+
+        from gateway.config import Platform
+
+        from cron.scheduler import _deliver_result
+
+        # Live adapter carries an OPEN circuit breaker (10s remaining).
+        # Use a generous headroom so the assertion tolerates the few-ms
+        # elapsed between setting the cooldown and reading it inside the
+        # fallback path (mock setup runs real time.monotonic() once).
+        adapter = AsyncMock()
+        adapter._rate_limit_circuit_until = time.monotonic() + 10.0
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        # Live delivery raises a real exception so the fallback branch runs.
+        captured_future = Future()
+        captured_future.result = MagicMock(side_effect=RuntimeError("adapter exploded"))
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return captured_future
+
+        job = {
+            "id": "rl-cooldown-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        sleep_calls = []
+
+        def record_sleep(duration):
+            sleep_calls.append(duration)
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send), \
+             patch.object(scheduler.time, "sleep", side_effect=record_sleep):
+            _deliver_result(
+                job,
+                "Hello world",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        # 1. The wait ran (10.0s remaining + 0.1s buffer ≈ 10.1s, give or
+        #    take the few-ms drift between breaker-set and breaker-read).
+        assert len(sleep_calls) == 1, (
+            f"expected exactly one cooldown wait, got {sleep_calls!r}"
+        )
+        assert sleep_calls[0] == pytest.approx(10.1, abs=0.2), (
+            f"sleep duration {sleep_calls[0]} should match remaining + buffer"
+        )
+        # 2. The standalone fallback still ran (the wait does NOT swallow
+        #    the delivery — it just sequences it after the cooldown).
+        standalone_send.assert_awaited_once()
+
+    def test_live_failure_with_closed_breaker_skips_wait(self):
+        """A live adapter without an open breaker must NOT block the fallback.
+
+        Negative control for the integration contract — the helper is a
+        no-op when the breaker is closed, and ``_deliver_result`` must
+        honour that. Without the contract a healthy adapter would incur
+        a pointless sleep on every failed live send.
+        """
+        from concurrent.futures import Future
+        from unittest.mock import AsyncMock, MagicMock
+
+        from gateway.config import Platform
+
+        from cron.scheduler import _deliver_result
+
+        adapter = AsyncMock()
+        adapter._rate_limit_circuit_until = 0.0  # closed
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        captured_future = Future()
+        captured_future.result = MagicMock(side_effect=RuntimeError("adapter exploded"))
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return captured_future
+
+        job = {
+            "id": "rl-closed-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send), \
+             patch.object(scheduler.time, "sleep") as sleep_mock:
+            _deliver_result(
+                job,
+                "Hello world",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        sleep_mock.assert_not_called()
+        standalone_send.assert_awaited_once()

--- a/tests/cron/test_cron_fallback_rate_limit_cooldown.py
+++ b/tests/cron/test_cron_fallback_rate_limit_cooldown.py
@@ -1,0 +1,87 @@
+"""Regression tests for cron fallback waiting out the live adapter's
+rate-limit circuit breaker (issue #66928).
+
+The live adapter and the standalone fallback path each hold their own
+``WeixinAdapter`` instance — the standalone path has no way to see that
+the live adapter just tripped its circuit breaker, so without
+coordination it sends immediately, hits the same iLink -2, and opens
+its own breaker, double-failing the job. ``_deliver_result`` waits out
+the live adapter's cooldown before invoking the standalone path.
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from cron import scheduler
+
+
+class _FakeAdapter:
+    """Minimal stand-in for WeixinAdapter — only the cooldown attribute matters."""
+
+    def __init__(self, cooldown_until: float) -> None:
+        self._rate_limit_circuit_until = cooldown_until
+
+
+class TestWaitForLiveAdapterRateLimitCooldown:
+    def test_no_adapter_returns_zero_without_sleeping(self):
+        with patch.object(scheduler.time, "sleep") as sleep_mock:
+            result = scheduler._wait_for_live_adapter_rate_limit_cooldown(None)
+        assert result == 0.0
+        sleep_mock.assert_not_called()
+
+    def test_closed_breaker_returns_zero_without_sleeping(self):
+        adapter = _FakeAdapter(cooldown_until=0.0)
+        with patch.object(scheduler.time, "sleep") as sleep_mock:
+            result = scheduler._wait_for_live_adapter_rate_limit_cooldown(adapter)
+        assert result == 0.0
+        sleep_mock.assert_not_called()
+
+    def test_missing_attribute_returns_zero_without_sleeping(self):
+        # Adapters that don't even carry a breaker (Telegram, Slack, …) must
+        # not block the fallback path.
+        class _NoBreaker:
+            pass
+
+        with patch.object(scheduler.time, "sleep") as sleep_mock:
+            result = scheduler._wait_for_live_adapter_rate_limit_cooldown(_NoBreaker())
+        assert result == 0.0
+        sleep_mock.assert_not_called()
+
+    def test_open_breaker_sleeps_for_remaining_plus_buffer(self):
+        # Breaker scheduled to expire in 5.0s — helper should sleep 5.1s.
+        open_until = time.monotonic() + 5.0
+        adapter = _FakeAdapter(cooldown_until=open_until)
+
+        with patch.object(scheduler.time, "sleep") as sleep_mock:
+            result = scheduler._wait_for_live_adapter_rate_limit_cooldown(
+                adapter, job_id="job_test_001"
+            )
+
+        assert result == pytest.approx(5.1, abs=0.05)
+        sleep_mock.assert_called_once()
+        # The single sleep duration must match the returned duration.
+        assert sleep_mock.call_args.args[0] == pytest.approx(5.1, abs=0.05)
+
+    def test_already_expired_breaker_returns_zero(self):
+        # Breaker scheduled in the past — must NOT sleep (already safe).
+        adapter = _FakeAdapter(cooldown_until=time.monotonic() - 1.0)
+
+        with patch.object(scheduler.time, "sleep") as sleep_mock:
+            result = scheduler._wait_for_live_adapter_rate_limit_cooldown(adapter)
+
+        assert result == 0.0
+        sleep_mock.assert_not_called()
+
+    def test_non_numeric_breaker_value_returns_zero(self):
+        # Defensive: a mis-typed adapter attribute must not crash cron.
+        class _WeirdAdapter:
+            _rate_limit_circuit_until = "not-a-number"
+
+        with patch.object(scheduler.time, "sleep") as sleep_mock:
+            result = scheduler._wait_for_live_adapter_rate_limit_cooldown(_WeirdAdapter())
+
+        assert result == 0.0
+        sleep_mock.assert_not_called()


### PR DESCRIPTION
## Summary

The cron delivery fallback path in `_deliver_result` (`cron/scheduler.py`) issues an immediate standalone re-deliver whenever the live adapter hits iLink rate limiting. The standalone adapter is built fresh with its own (closed) circuit breaker, so it has no way to know the live adapter just opened one — issuing the fallback send hits the same iLink cooldown, opens the standalone breaker too, and **double-fails the job**.

Repro: any cron job with `deliver: weixin` (or any iLink-backed target) running more than once per ~30s. The job itself completes (`last_status: ok`) but the result never reaches the user. Consistent across 7/16-7/18 on the reporter's setup. Live interactive messaging on the same Weixin channel is unaffected — the issue is specific to the cron delivery code path not sharing circuit-breaker state across the live → fallback hop.

This matches the bug in #66928.

## Fix

Add a small `_wait_for_live_adapter_rate_limit_cooldown()` helper that reads the live adapter's `_rate_limit_circuit_until`, sleeps for the remaining window plus a 0.1s safety buffer (so the local breaker closes *before* the next send is issued, not simultaneously with it), and is a no-op when the breaker is closed, missing, or holds a non-numeric value.

Call it from `_deliver_result` right before the standalone fallback path takes over.

```python
# If the live adapter tripped its rate-limit circuit breaker, wait out
# the cooldown before falling back. The standalone path builds a fresh
# adapter with its own (closed) breaker, so it has no way to know iLink
# is still server-side rate limited — issuing an immediate fallback send
# hits the same -2 and opens the standalone breaker too, double-failing
# the job (issue #66928).
_wait_for_live_adapter_rate_limit_cooldown(runtime_adapter, job_id=job["id"])
```

The function is exposed at module level so the new unit test (`tests/cron/test_cron_fallback_rate_limit_cooldown.py`) can drive it directly without spinning up the full delivery state machine — 6 test cases cover: no adapter, closed breaker, missing attribute, open breaker with sleep, already-expired breaker, non-numeric breaker value.

## Out of scope

- **Not touching** `_rate_limit_circuit_until` ownership or the live adapter's breaker logic itself. The fix only waits; it doesn't try to share state, which would touch the platform-adapter boundary and balloon the diff. The wait is the minimum-blast-radius fix that matches the symptom.
- **Not refactoring** the broader fallback path. The single new call sits in the exact spot where the symptom occurs.
- **Not changing** iLink-side rate-limit windows. The 0.1s buffer is local-clock only.

## Test plan

1. On a setup with `deliver: weixin`, create a cron job that triggers manual delivery once. Wait ~30s, trigger again. Without the fix: the second send fails with the same "iLink sendmessage rate limited" error.
2. With the fix applied, the second send should observe the open breaker, log "waiting Ns for live adapter rate-limit cooldown before standalone fallback", and succeed after the cooldown.

The included unit tests already cover the helper's input space directly — they bypass the live iLink path and only assert the wait/skip decision logic.

Fixes #66928.
