### PR TITLE
fix(simplex): prepare outbound images off the gateway event loop

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -951,7 +951,15 @@ class SimplexAdapter(BasePlatformAdapter):
         if not file_path or not Path(file_path).exists():
             return SendResult(success=False, error="Image file not found")
 
-        png_path, thumb_uri = self._prepare_image(file_path)
+        # Off the event loop: _prepare_image re-encodes the full image and
+        # builds a thumbnail. With Pillow that is CPU-bound work on a
+        # possibly-large photo; without it, two `convert` spawns at
+        # timeout=30 each. Run inline it holds the shared gateway loop for
+        # that whole window, so every other platform's traffic stalls while
+        # one SimpleX image is prepared.
+        png_path, thumb_uri = await asyncio.to_thread(
+            self._prepare_image, file_path
+        )
 
         # /_send addresses by numeric ID; /f only accepts display names which
         # breaks for group IDs.

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -467,3 +467,44 @@ async def test_image_file_still_sets_photo_type():
 
     assert dispatched, "_handle_chat_item did not dispatch any event"
     assert dispatched[0].message_type == MessageType.PHOTO
+
+
+@pytest.mark.asyncio
+async def test_send_image_prepares_off_the_event_loop(tmp_path, monkeypatch):
+    """Image preparation must not block the shared gateway event loop.
+
+    ``_prepare_image`` re-encodes the full image and builds a thumbnail: with
+    Pillow that is CPU-bound work on a possibly-large photo, and without it
+    two ``convert`` spawns at ``timeout=30`` each. Run inline on the loop, one
+    SimpleX image send stalls every other platform's traffic on the same
+    gateway — the same off-the-loop class as the inbound-image decision.
+    """
+    import threading
+
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    img = tmp_path / "photo.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    main_thread = threading.current_thread()
+    seen = {}
+
+    def _fake_prepare(path):
+        seen["thread"] = threading.current_thread()
+        return str(path), "data:image/jpg;base64,AAAA"
+
+    monkeypatch.setattr(adapter, "_prepare_image", _fake_prepare)
+    adapter._send_command = AsyncMock(return_value={"ok": True})
+
+    result = await adapter.send_image("contact-42", f"file://{img}")
+
+    assert result.success is True
+    assert seen.get("thread") is not None, "_prepare_image never ran"
+    assert seen["thread"] is not main_thread, (
+        "_prepare_image ran on the event-loop thread; it must be dispatched "
+        "via asyncio.to_thread so image re-encoding (or a 30s `convert` "
+        "spawn) can't freeze every other platform on the gateway loop"
+    )


### PR DESCRIPTION
## What does this PR do?

`SimplexAdapter.send_image` is `async`, but it called `_prepare_image()` inline. That helper re-encodes the whole image and builds a thumbnail, so it blocks on real work on both of its paths:

* **Pillow present** (the common case): `Image.open` + a full PNG re-encode + a thumbnail encode — CPU-bound on a large photo.
* **Pillow missing**: two `subprocess.run(["convert", ...], timeout=30)` spawns, i.e. up to 60s.

Either way it runs on the shared gateway event loop, so preparing one SimpleX image stalls every other platform's messages, heartbeats and sessions for that whole window. Sending an image is an ordinary agent action, so this is a routine stall rather than an edge case.

The fix dispatches it via `asyncio.to_thread`. Pillow releases the GIL around its encode/decode work and the `convert` fallback is a subprocess wait, so both paths genuinely yield the loop once off-thread. `_prepare_image` itself is untouched — same conversion, same thumbnail, same return shape.

Same off-the-loop class as the inbound-image decision (#66688) and the cron-fire verifier.

## Related Issue

No separate issue — an event-loop-blocking gateway send path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py` — in `send_image`, dispatch `_prepare_image` via `asyncio.to_thread` so the re-encode / `convert` spawn runs on a worker thread. `asyncio` was already imported; this is the adapter's only `_prepare_image` call site.
- `tests/gateway/test_simplex_plugin.py` — add `test_send_image_prepares_off_the_event_loop`, asserting the preparation executes on a worker thread rather than the loop thread.

## How to Test

1. Run:

       pytest tests/gateway/test_simplex_plugin.py -q

   The new test passes with the fix and fails without it (it records `threading.current_thread()` inside a stubbed `_prepare_image` and asserts it is not the loop thread).

2. Suite is clean and unchanged apart from the added test: `30 passed` on `main` → `31 passed` with this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(simplex):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_simplex_plugin.py -q` and all tests pass, verified against a clean `main` baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline comments) — the call site now documents why it must stay off the loop
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (dispatch change only; conversion logic untouched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A