### PR TITLE
fix: handle multimodal content in interim text and avoid retrying local processing errors

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -643,16 +643,16 @@ def strip_think_blocks(agent, content: str) -> str:
     """Remove reasoning/thinking blocks from content, returning only visible text.
 
     Handles four cases:
-      1. Closed tag pairs (`` 执教… ``) — the common path when
+      1. Closed tag pairs (`` <think>… ``) — the common path when
          the provider emits complete reasoning blocks.
       2. Unterminated open tag at a block boundary (start of text or
          after a newline) — e.g. MiniMax M2.7 / NIM endpoints where the
          closing tag is dropped.  Everything from the open tag to end
          of string is stripped.  The block-boundary check mirrors
          ``gateway/stream_consumer.py``'s filter so models that mention
-         `` 执教`` in prose aren't over-stripped.
+         `` <think>`` in prose aren't over-stripped.
       3. Stray orphan open/close tags that slip through.
-      4. Tag variants: `` 执教``, ``<thinking>``, ``<reasoning>``,
+      4. Tag variants: `` <think>``, ``<thinking>``, ``<reasoning>``,
          ``<REASONING_SCRATCHPAD>``, ``<thought>`` (Gemma 4), all
          case-insensitive.
 
@@ -670,21 +670,6 @@ def strip_think_blocks(agent, content: str) -> str:
     after punctuation and carries a ``name="..."`` attribute) so prose
     mentions like "Use <function> in JavaScript" are preserved.
     """
-    # Defensive coercion: callers may pass multimodal content-parts lists
-    # (e.g. after vision turns or context compaction). Extract any text
-    # blocks and drop non-text parts before running regexes.
-    if isinstance(content, list):
-        parts = []
-        for part in content:
-            if isinstance(part, str):
-                parts.append(part)
-            elif isinstance(part, dict) and part.get("type") == "text":
-                text = part.get("text")
-                if isinstance(text, str):
-                    parts.append(text)
-        content = "\n".join(parts)
-    elif not isinstance(content, str):
-        content = str(content) if content is not None else ""
     if not content:
         return ""
     # Coerce non-string content to text before any regex runs.  Providers

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -643,16 +643,16 @@ def strip_think_blocks(agent, content: str) -> str:
     """Remove reasoning/thinking blocks from content, returning only visible text.
 
     Handles four cases:
-      1. Closed tag pairs (``<think>…</think>``) — the common path when
+      1. Closed tag pairs (`` 执教… ``) — the common path when
          the provider emits complete reasoning blocks.
       2. Unterminated open tag at a block boundary (start of text or
          after a newline) — e.g. MiniMax M2.7 / NIM endpoints where the
          closing tag is dropped.  Everything from the open tag to end
          of string is stripped.  The block-boundary check mirrors
          ``gateway/stream_consumer.py``'s filter so models that mention
-         ``<think>`` in prose aren't over-stripped.
+         `` 执教`` in prose aren't over-stripped.
       3. Stray orphan open/close tags that slip through.
-      4. Tag variants: ``<think>``, ``<thinking>``, ``<reasoning>``,
+      4. Tag variants: `` 执教``, ``<thinking>``, ``<reasoning>``,
          ``<REASONING_SCRATCHPAD>``, ``<thought>`` (Gemma 4), all
          case-insensitive.
 
@@ -670,6 +670,21 @@ def strip_think_blocks(agent, content: str) -> str:
     after punctuation and carries a ``name="..."`` attribute) so prose
     mentions like "Use <function> in JavaScript" are preserved.
     """
+    # Defensive coercion: callers may pass multimodal content-parts lists
+    # (e.g. after vision turns or context compaction). Extract any text
+    # blocks and drop non-text parts before running regexes.
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        content = "\n".join(parts)
+    elif not isinstance(content, str):
+        content = str(content) if content is not None else ""
     if not content:
         return ""
     # Coerce non-string content to text before any regex runs.  Providers

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -32,6 +32,7 @@ from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
 from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
+from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
@@ -1126,7 +1127,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # reasoning fields are present (some models/providers embed thinking
     # directly in the content rather than returning separate API fields).
     if not reasoning_text:
-        content = assistant_message.content or ""
+        content = flatten_message_text(getattr(assistant_message, "content", None))
         think_blocks = re.findall(r'<think>(.*?)</think>', content, flags=re.DOTALL)
         if think_blocks:
             combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
@@ -1152,7 +1153,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
     # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
     # can return invalid surrogate code points that crash json.dumps() on persist.
-    _raw_content = assistant_message.content or ""
+    _raw_content = flatten_message_text(getattr(assistant_message, "content", None))
     _san_content = _sanitize_surrogates(_raw_content)
     if reasoning_text:
         reasoning_text = _sanitize_surrogates(reasoning_text)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -24,7 +24,6 @@ import re
 import ssl
 import threading
 import time
-import traceback
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -78,6 +77,25 @@ logger = logging.getLogger(__name__)
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
 # to treat it as cancellation metadata rather than assistant prose.
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
+
+# Modules that indicate a deterministic local processing error when they
+# appear in an exception traceback WITHOUT any API-call module. Used by the
+# outer-loop error classifier to avoid retrying bugs that will fail
+# identically every time (e.g. TypeError from passing list content into a
+# regex helper).  IMPORTANT: do NOT include "conversation_loop" or
+# "run_agent" here — those are the container modules for the try/except
+# itself, so every exception passes through them, which would make
+# _hit_local always True and misclassify transient API/network errors as
+# non-retryable local bugs. (#66267)
+_LOCAL_PROCESSING_MODULES = frozenset({
+    "agent_runtime_helpers",
+    "message_content",
+    "message_sanitization",
+    "chat_completion_helpers",  # only local when NOT also an API-call module
+})
+_API_CALL_MODULES = frozenset({
+    "chat_completion_helpers",
+})
 
 
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
@@ -5609,23 +5627,15 @@ def run_conversation(
             # local post-processing helpers and never entered the interruptible
             # API-call helpers, it is almost certainly a local processing bug.
             # (#66267)
-            _local_processing_modules = {
-                "agent_runtime_helpers",
-                "conversation_loop",
-                "message_content",
-                "run_agent",
-            }
-            _api_call_modules = {
-                "chat_completion_helpers",
-            }
+            tb_module_names: set[str] = set()
+            _tb = e.__traceback__
+            while _tb is not None:
+                _fname = os.path.splitext(os.path.basename(_tb.tb_frame.f_code.co_filename))[0]
+                tb_module_names.add(_fname)
+                _tb = _tb.tb_next
 
-            tb_stack = traceback.extract_tb(e.__traceback__)
-            tb_module_names = {
-                os.path.splitext(os.path.basename(frame.filename))[0]
-                for frame in tb_stack
-            }
-            _hit_local = bool(tb_module_names & _local_processing_modules)
-            _hit_api = bool(tb_module_names & _api_call_modules)
+            _hit_local = bool(tb_module_names & _LOCAL_PROCESSING_MODULES)
+            _hit_api = bool(tb_module_names & _API_CALL_MODULES)
 
             _is_local_processing_error = _hit_local and not _hit_api
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -24,6 +24,7 @@ import re
 import ssl
 import threading
 import time
+import traceback
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -5597,7 +5598,44 @@ def run_conversation(
                 break
             
         except Exception as e:
-            error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
+            # Phase-aware error classification. The huge outer try/except spans
+            # both the actual API request and all local post-processing of the
+            # returned assistant message. Deterministic local bugs (e.g.
+            # passing a multimodal content list into a regex helper after a
+            # vision turn or context compaction) should not be retried: they
+            # will fail identically on every iteration and only burn the
+            # iteration budget. We classify an error as local by inspecting the
+            # traceback: if the exception propagated through any of the known
+            # local post-processing helpers and never entered the interruptible
+            # API-call helpers, it is almost certainly a local processing bug.
+            # (#66267)
+            _local_processing_modules = {
+                "agent_runtime_helpers",
+                "conversation_loop",
+                "message_content",
+                "run_agent",
+            }
+            _api_call_modules = {
+                "chat_completion_helpers",
+            }
+
+            tb_stack = traceback.extract_tb(e.__traceback__)
+            tb_module_names = {
+                os.path.splitext(os.path.basename(frame.filename))[0]
+                for frame in tb_stack
+            }
+            _hit_local = bool(tb_module_names & _local_processing_modules)
+            _hit_api = bool(tb_module_names & _api_call_modules)
+
+            _is_local_processing_error = _hit_local and not _hit_api
+
+            if _is_local_processing_error:
+                error_msg = (
+                    f"Error during local message processing after "
+                    f"OpenAI-compatible API call #{api_call_count}: {str(e)}"
+                )
+            else:
+                error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
             try:
                 print(f"❌ {error_msg}")
             except (OSError, ValueError):
@@ -5644,10 +5682,19 @@ def run_conversation(
             # message pollutes history, burns tokens, and risks violating
             # role-alternation invariants.
 
-            # If we're near the limit, break to avoid infinite loops
-            if api_call_count >= agent.max_iterations - 1:
-                _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
-                final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
+            # If we're near the limit, break to avoid infinite loops.
+            # Local processing errors are deterministic — stop immediately
+            # rather than retrying until the budget is exhausted.
+            if (
+                _is_local_processing_error
+                or api_call_count >= agent.max_iterations - 1
+            ):
+                if _is_local_processing_error:
+                    _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
+                    final_response = f"I apologize, but I encountered an error while processing the model response: {error_msg}"
+                else:
+                    _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
+                    final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
                 # Append as assistant so the history stays valid for
                 # session resume (avoids consecutive user messages).
                 messages.append({"role": "assistant", "content": final_response})

--- a/run_agent.py
+++ b/run_agent.py
@@ -148,6 +148,7 @@ from tools.browser_tool import cleanup_browser
 from agent.memory_manager import sanitize_context
 from agent.error_classifier import FailoverReason
 from agent.redact import redact_sensitive_text
+from agent.message_content import flatten_message_text
 from agent.model_metadata import (
     estimate_request_tokens_rough,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.estimate_request_tokens_rough")
     is_local_endpoint,
@@ -4823,12 +4824,15 @@ class AIAgent:
         response can contain both commentary and a partial/final-answer message
         while tools are still pending; treating top-level content as progress
         in that shape leaks the answer before the tool call runs.
+
+        Content may be a string or a structured parts list (e.g. after vision
+        turns or context compaction), so flatten it before stripping reasoning.
         """
         visible = self._extract_codex_interim_visible_text(assistant_msg)
         if visible:
             return visible
         content = assistant_msg.get("content")
-        return self._strip_think_blocks(content or "").strip()
+        return self._strip_think_blocks(flatten_message_text(content)).strip()
 
     def _interim_text_was_delivered(self, text: str) -> bool:
         normalized = self._normalize_interim_visible_text(text)

--- a/tests/run_agent/test_66267_multimodal_interim.py
+++ b/tests/run_agent/test_66267_multimodal_interim.py
@@ -1,0 +1,254 @@
+"""Tests for issue #66267 — multimodal (list) tool-result content must not
+crash interim-assistant-message handling or non-streaming message building.
+
+Root cause (from the issue discussion): after a vision/tool turn the
+``tool`` message's ``content`` can be a list of parts (e.g. an image plus
+text). Several code paths fed that raw ``content`` straight into regex /
+string helpers that assumed ``str``, raising ``TypeError`` on the
+list. Because the failure happened inside the per-turn loop *before* the
+``role == "assistant"`` guard, the error was retried repeatedly, producing
+the "retry loop" symptom.
+
+These tests pin the two fixed surfaces:
+
+* ``chat_completion_helpers.build_assistant_message`` (non-streaming /
+  gateway path) — now normalizes ``content`` with ``flatten_message_text``
+  before the inline ``<think>`` regex and the surrogate sanitizer.
+* ``run_agent.AIAgent._interim_assistant_visible_text`` (used by the
+  duplicate-previous-interim dedup in the tool-call path) — now safe for
+  any role/content shape because ``flatten_message_text`` handles lists.
+
+They also assert the *behavior* the fix preserves: a tool message never
+produces interim text, and list content with an inline ``<think>`` block is
+flattened + stripped correctly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Agent fixture — real methods bound where the fix depends on them
+# ---------------------------------------------------------------------------
+
+
+def _make_agent():
+    """Minimal AIAgent with the real text helpers the fix relies on."""
+    from agent.message_sanitization import _sanitize_surrogates
+    from run_agent import AIAgent
+
+    agent = MagicMock(spec=AIAgent)
+    agent._extract_reasoning = lambda msg: AIAgent._extract_reasoning(agent, msg)
+    agent._extract_codex_interim_visible_text = (
+        lambda msg: AIAgent._extract_codex_interim_visible_text(agent, msg)
+    )
+    agent._strip_think_blocks = lambda text: AIAgent._strip_think_blocks(agent, text)
+    agent._sanitize_surrogates = lambda text: _sanitize_surrogates(text)
+    agent.show_commentary = True
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+def _vision_tool_result(text="The image shows a red stop sign."):
+    """A realistic tool message whose content is a list (vision result)."""
+    return {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_assistant_message — non-streaming / gateway path (site 2)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAssistantMessageMultimodal:
+    def test_list_content_does_not_crash(self):
+        """A list content (vision result) must build without TypeError."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        agent = _make_agent()
+        sdk_msg = SimpleNamespace(
+            content=[
+                {"type": "text", "text": "answer after seeing the screenshot"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            tool_calls=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+        )
+
+        msg = build_assistant_message(agent, sdk_msg, "stop")
+
+        assert msg["role"] == "assistant"
+        assert isinstance(msg["content"], str)
+        assert "answer after seeing the screenshot" in msg["content"]
+
+    def test_inline_think_in_list_content_is_extracted_and_stripped(self):
+        """Inline <think> inside a list content: reasoning captured, content clean."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        agent = _make_agent()
+        sdk_msg = SimpleNamespace(
+            content=[
+                {"type": "text", "text": "<think>hidden reasoning</think>visible answer"},
+            ],
+            tool_calls=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+        )
+
+        msg = build_assistant_message(agent, sdk_msg, "stop")
+
+        assert "hidden reasoning" in (msg.get("reasoning") or "")
+        assert "<think>" not in msg["content"]
+        assert "visible answer" in msg["content"]
+
+    def test_str_content_still_works(self):
+        """Regression guard: plain string content is unchanged in behavior."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        agent = _make_agent()
+        sdk_msg = SimpleNamespace(
+            content="plain text answer",
+            tool_calls=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+        )
+
+        msg = build_assistant_message(agent, sdk_msg, "stop")
+
+        assert msg["content"] == "plain text answer"
+
+
+# ---------------------------------------------------------------------------
+# _interim_assistant_visible_text — dedup path (site 1)
+# ---------------------------------------------------------------------------
+
+
+class TestInterimVisibleTextMultimodal:
+    def test_tool_list_content_does_not_crash(self):
+        """A tool message with list content must return a string, not raise."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        tool_msg = _vision_tool_result()
+        # The helper must not raise on a tool message whose content is a list.
+        visible = AIAgent._interim_assistant_visible_text(agent, tool_msg)
+        assert isinstance(visible, str)
+
+    def test_tool_message_yields_no_interim_text(self):
+        """Tool messages carry no user-facing interim text (role guard)."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        tool_msg = _vision_tool_result("some description")
+        visible = AIAgent._interim_assistant_visible_text(agent, tool_msg)
+        # No codex_message_items -> no commentary -> flattened content is still
+        # text, but it's a tool result, not assistant interim. The dedup guard
+        # (role == "assistant") excludes it from ever being emitted.
+        assert isinstance(visible, str)
+
+    def test_assistant_list_content_flattened(self):
+        """An assistant message with list content yields flattened visible text."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        assistant_msg = {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me look at the screenshot."},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            "finish_reason": "incomplete",
+        }
+        visible = AIAgent._interim_assistant_visible_text(agent, assistant_msg)
+        assert "Let me look at the screenshot." in visible
+
+
+# ---------------------------------------------------------------------------
+# duplicate_previous_interim dedup — the exact shape from conversation_loop.py
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicatePreviousInterimDedup:
+    def test_previous_tool_list_content_safe_and_not_duplicate(self):
+        """Replicates conversation_loop.py:4871-4885.
+
+        ``previous_msg`` is a tool message with a *list* content (the exact
+        crash shape from #66267). The dedup must compute
+        ``previous_interim_visible`` without raising and must NOT mark the
+        current assistant message as a duplicate of a tool message.
+        """
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        assistant_msg = {
+            "role": "assistant",
+            "content": "Let me check the repo first.",
+            "finish_reason": "incomplete",
+        }
+        previous_msg = _vision_tool_result("some tool output")
+
+        current_interim_visible = AIAgent._interim_assistant_visible_text(agent, assistant_msg)
+        previous_interim_visible = (
+            AIAgent._interim_assistant_visible_text(agent, previous_msg)
+            if isinstance(previous_msg, dict)
+            else ""
+        )
+        duplicate_previous_interim = (
+            bool(current_interim_visible)
+            and isinstance(previous_msg, dict)
+            and previous_msg.get("role") == "assistant"
+            and previous_msg.get("finish_reason") == "incomplete"
+            and previous_interim_visible == current_interim_visible
+        )
+
+        # Must not raise, and a tool message can never be a duplicate source.
+        assert isinstance(previous_interim_visible, str)
+        assert duplicate_previous_interim is False
+
+    def test_identical_assistant_interim_is_flagged_duplicate(self):
+        """Two identical incomplete assistant interim messages ARE duplicates."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        assistant_msg = {
+            "role": "assistant",
+            "content": "Let me check the repo first.",
+            "finish_reason": "incomplete",
+        }
+        previous_msg = {
+            "role": "assistant",
+            "content": "Let me check the repo first.",
+            "finish_reason": "incomplete",
+        }
+
+        current_interim_visible = AIAgent._interim_assistant_visible_text(agent, assistant_msg)
+        previous_interim_visible = AIAgent._interim_assistant_visible_text(agent, previous_msg)
+        duplicate_previous_interim = (
+            bool(current_interim_visible)
+            and isinstance(previous_msg, dict)
+            and previous_msg.get("role") == "assistant"
+            and previous_msg.get("finish_reason") == "incomplete"
+            and previous_interim_visible == current_interim_visible
+        )
+
+        assert duplicate_previous_interim is True


### PR DESCRIPTION
## Summary
Hardens multimodal list-content handling in `build_assistant_message` and `_interim_assistant_visible_text`, and adds a traceback-based error classifier that stops retrying deterministic local processing errors instead of burning the iteration budget.

Closes #66267
Supersedes #66341 (cherry-picked with authorship preserved)

## Changes
- `agent/chat_completion_helpers.py`: Use `flatten_message_text()` in `build_assistant_message` before the inline `domath` regex and surrogate sanitizer — protects the non-streaming/gateway path from list content that bypasses the normalization at `conversation_loop.py:4387`.
- `run_agent.py`: Use `flatten_message_text()` in `_interim_assistant_visible_text` before `_strip_think_blocks` — belt-and-suspenders alongside Teknium's fix (296494db0) at the shared chokepoint.
- `agent/conversation_loop.py`: Traceback-based error classifier — deterministic local processing errors (TypeError from regex on list content) stop immediately instead of retrying until `max_iterations`. Module sets are module-level `frozenset` constants; `conversation_loop` and `run_agent` are intentionally excluded from `_LOCAL_PROCESSING_MODULES` because they're container modules that every exception passes through.
- `tests/run_agent/test_66267_multimodal_interim.py`: 8 new tests pinning the regression (list content in build_assistant_message, interim text, dedup path).

## Salvage notes
- Removed PR's redundant `strip_think_blocks` coercion (Teknium's 296494db0 already handles this with superior logic that drops thinking/reasoning blocks).
- Restored `if not content: return ""` guard lost during cherry-pick auto-merge.
- Fixed docstring corruption (think tags replaced with Chinese characters).
- Fixed error classifier C1/C2: removed `conversation_loop` and `run_agent` from `_LOCAL_PROCESSING_MODULES` (were making `_hit_local` always True, misclassifying transient API errors as non-retryable).
- Replaced `traceback.extract_tb()` with raw `tb` walk (avoids disk I/O).

## Validation
| | Tests | E2E |
|---|---|---|
| Targeted suite | 70/70 passed | 5/5 real-import checks passed |
| `test_none_returns_empty` | Fixed (was returning "None") | — |
| Error classifier | — | Network error → not local; TypeError → local |

## Attribution
@nanami7777777's commits cherry-picked with authorship preserved. Follow-up fixes by maintainer.
