### PR TITLE
fix(anthropic): preserve signed thinking blocks on Kimi For Coding replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2276,13 +2276,6 @@ def _manage_thinking_signatures(
     """
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
-    # Kimi / DeepSeek share a contract: strip signed Anthropic blocks
-    # (neither upstream can validate Anthropic signatures), preserve unsigned
-    # ones synthesised from reasoning_content.  See #13848, #16748.
-    _preserve_unsigned_thinking = (
-        _is_kimi_family_endpoint(base_url, model)
-        or _is_deepseek_anthropic_endpoint(base_url)
-    )
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -2294,8 +2287,12 @@ def _manage_thinking_signatures(
         if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
             continue
 
-        if _preserve_unsigned_thinking:
-            # Kimi / DeepSeek: strip signed, preserve unsigned.
+        if _is_kimi_family_endpoint(base_url, model):
+            # Kimi does not enforce thinking signatures — replay as-is
+            # (shared cleanup below still strips cache markers + the internal flag).
+            pass
+        elif _is_deepseek_anthropic_endpoint(base_url):
+            # DeepSeek: strip signed, preserve unsigned.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:

--- a/tests/agent/test_anthropic_kimi_signed_thinking_replay.py
+++ b/tests/agent/test_anthropic_kimi_signed_thinking_replay.py
@@ -1,0 +1,107 @@
+"""Kimi-family endpoints don't need thinking blocks stripped on replay; DeepSeek does."""
+
+from types import SimpleNamespace
+
+from agent.transports import get_transport
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+SIG = "sig-k3"
+
+KIMI = "https://api.kimi.com/coding"
+MOONSHOT = "https://api.moonshot.cn/anthropic"
+DEEPSEEK = "https://api.deepseek.com/anthropic"
+
+
+def _thinking_on_replay(base_url, signature=SIG):
+    """Normalize a thinking+text turn, store it, convert to the next-turn request,
+    and return its thinking blocks."""
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="thinking", thinking="five: 5 11 27 63 88", signature=signature),
+            SimpleNamespace(type="text", text="5 27 88"),
+        ],
+        stop_reason="end_turn",
+        usage=None,
+    )
+    normalized = get_transport("anthropic_messages").normalize_response(response)
+    stored = {
+        "role": "assistant",
+        "content": normalized.content or "",
+        "reasoning_details": (normalized.provider_data or {}).get("reasoning_details"),
+    }
+    messages = [
+        {"role": "user", "content": "q1"},
+        stored,
+        {"role": "user", "content": "q2"},
+    ]
+    _sys, out = convert_messages_to_anthropic(messages, base_url=base_url, model="k3")
+    assistant = [m for m in out if m.get("role") == "assistant"][0]
+    return [b for b in assistant["content"] if isinstance(b, dict) and b.get("type") == "thinking"]
+
+
+def test_kimi_coding_keeps_signed_thinking():
+    thinking = _thinking_on_replay(KIMI)
+    assert thinking and thinking[0].get("signature") == SIG
+
+
+def test_kimi_coding_keeps_unsigned_thinking():
+    assert _thinking_on_replay(KIMI, signature="")
+
+
+def test_moonshot_keeps_signed_thinking():
+    thinking = _thinking_on_replay(MOONSHOT)
+    assert thinking and thinking[0].get("signature") == SIG
+
+
+def test_deepseek_still_strips_signed_thinking():
+    assert not _thinking_on_replay(DEEPSEEK)
+
+
+def test_direct_anthropic_keeps_signed_on_latest():
+    assert _thinking_on_replay(None)
+
+
+def test_orphan_tool_turn_demotes_and_leaks_no_internal_marker():
+    """Signed thinking + parallel tool batch interrupted mid-flight (one orphan):
+    the internal _thinking_signature_invalidated marker must be popped —
+    never leak into the Kimi payload — while the thinking block itself
+    replays as-is (Kimi does not enforce signatures)."""
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="thinking", thinking="plan both reads", signature=SIG),
+            SimpleNamespace(type="tool_use", id="toolu_1", name="read_file", input={"path": "a.py"}),
+            SimpleNamespace(type="tool_use", id="toolu_2", name="read_file", input={"path": "b.py"}),
+        ],
+        stop_reason="tool_use",
+        usage=None,
+    )
+    normalized = get_transport("anthropic_messages").normalize_response(response)
+    provider_data = normalized.provider_data or {}
+    stored = {
+        "role": "assistant",
+        "content": normalized.content or "",
+        "reasoning_details": provider_data.get("reasoning_details"),
+        "tool_calls": [
+            {"id": tc.id, "type": "function", "function": {"name": tc.name, "arguments": tc.arguments}}
+            for tc in (normalized.tool_calls or [])
+        ],
+    }
+    if provider_data.get("anthropic_content_blocks"):
+        stored["anthropic_content_blocks"] = provider_data["anthropic_content_blocks"]
+    messages = [
+        {"role": "user", "content": "inspect both"},
+        stored,
+        {"role": "tool", "tool_call_id": "toolu_1", "content": "a.py: ok"},
+        # toolu_2 interrupted: no tool result follows (orphan)
+        {"role": "user", "content": "continue"},
+    ]
+    _sys, out = convert_messages_to_anthropic(messages, base_url=KIMI, model="k3")
+    assistant = [m for m in out if m.get("role") == "assistant"][0]
+    assert "_thinking_signature_invalidated" not in assistant, (
+        f"internal marker leaked into Kimi payload: {assistant.keys()}"
+    )
+    types = [b.get("type") for b in assistant["content"] if isinstance(b, dict)]
+    assert "thinking" in types, (
+        "Kimi does not enforce signatures — even orphan-invalidated blocks "
+        f"must replay as-is: {types}"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes silent loss of **signed** thinking blocks when replaying history to Kimi-family Anthropic endpoints.

`_manage_thinking_signatures` treats every Kimi-family endpoint with the #13848-era contract: *strip signed Anthropic thinking blocks from replayed history (the upstream can't validate Anthropic signatures), preserve unsigned ones synthesised from `reasoning_content`*. Live probing shows that contract is outdated **for the whole Kimi family**:

- **Kimi For Coding** (`api.kimi.com/coding`) issues AND validates its own thinking signatures (K3+): both verbatim and content-mutated signed blocks replay with HTTP 200;
- **Moonshot's Anthropic surface** (`api.moonshot.cn/anthropic`) accepts signed blocks the same way (200 on both verbatim and mutated);
- every other harness that replays signed blocks to KFC (Claude Code, pi, Kilo Code) round-trips fine.

So this PR applies **one uniform rule for the whole Kimi family** — no `/coding`-vs-Moonshot split: on `_is_kimi_family_endpoint`, keep signed and unsigned thinking blocks unchanged on replay.

Observable symptom (before): a two-turn recall probe — "think of five numbers in reasoning, tell me three" → "what are the other two?" — fails on canonical `kimi-coding` + K3: the model cannot recall what it reasoned in the previous turn even though the turn-1 thinking is fully persisted locally (`reasoning` / `reasoning_content` / `reasoning_details` all present in the session store). `agent.log` shows turn-2 input ≈ turn-1 input + a few dozen tokens (only the new user message), while every other harness that replays signed blocks to KFC round-trips fine.

DeepSeek keeps the #16748 contract (strip signed, preserve unsigned) — no evidence against it here. Third-party and direct-Anthropic behavior is untouched.

## Related Issue

N/A. In the same area as #36071 / #43943 / #35586 (interleaved replay order).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py` — `_manage_thinking_signatures`: Kimi-family endpoints now preserve thinking blocks in both signature states instead of stripping signed ones; DeepSeek/third-party/direct-Anthropic branches unchanged.
- `tests/agent/test_anthropic_kimi_signed_thinking_replay.py` — new regression tests: Kimi `/coding` and Moonshot keep signed and unsigned thinking; DeepSeek still strips; direct Anthropic still keeps signed on the latest assistant.

## How to Test

1. Unit: `pytest tests/agent/test_anthropic_kimi_signed_thinking_replay.py tests/agent/test_anthropic_thinking_block_order.py tests/agent/test_anthropic_adapter.py -q` → **185 passed**.
2. Live endpoint checks (safety of replaying signed blocks): both KFC (`/coding/v1/messages`) and Moonshot (`/anthropic/v1/messages`) return HTTP 200 for verbatim and content-mutated signed thinking blocks.
3. End-to-end behavior (canonical `kimi-coding` + K3, two-turn recall probe):
   - Before: turn 2 fabricates numbers; `agent.log` call #2 input = call #1 input + 42 tokens (no thinking replayed).
   - After: turn 2 recalls the exact hidden numbers from turn-1 thinking (answers `7 134`); call #2 input = call #1 input + 230 tokens.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (#54070 / #26802 are DeepSeek/MiMo relay fixes in adjacent code, no overlap)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run pytest and all tests pass (see above; repo-wide `tests/agent -q` shows pre-existing cross-test interference failures in unrelated files, reproducible with and without this change)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04 (Linux x86_64)

### Documentation & Housekeeping

- [x] Docs — N/A (code comment at the changed gate explains the contract)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (endpoint-type logic only)
