### PR TITLE
fix(cron): persist no_agent runs to the profile session DB

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -87,6 +87,132 @@ def _set_cron_session_title(session_db, session_id, base_title):
         return deduped
 
 
+def _open_cron_session_db(job_id: str):
+    """Open the profile SQLite session store for a cron run, or return None.
+
+    Shared by both run_job paths (agent and no_agent) so a cron run is
+    persisted the same way regardless of whether an LLM was involved.
+
+    SessionDB.__init__ opens/migrates state.db synchronously and has no timeout
+    of its own against a wedged sqlite3.connect (e.g. a stale flock left by a
+    crashed sibling process), so the construction is bounded here:
+    env override → config.yaml → default 10s. A timeout is not fatal — the run
+    proceeds without a session store rather than blocking forever.
+    """
+    from hermes_state import SessionDB
+
+    # Resolve timeout: env override → config.yaml → default 10s.
+    # Mirrors the script_timeout_seconds resolution pattern.
+    session_db_timeout: float | None = None
+    raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
+    if raw_env_timeout:
+        try:
+            session_db_timeout = float(raw_env_timeout)
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
+                raw_env_timeout,
+            )
+    if session_db_timeout is None:
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config() or {}
+            cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+            configured = cron_cfg.get("session_db_timeout_seconds")
+            if configured is not None:
+                session_db_timeout = float(configured)
+        except Exception as exc:
+            logger.debug(
+                "Failed to load cron.session_db_timeout_seconds from config: %s",
+                exc,
+            )
+    if session_db_timeout is None:
+        session_db_timeout = 10.0
+
+    if session_db_timeout <= 0:
+        # 0 = unlimited (legacy behavior, opt-in for debugging)
+        return SessionDB()
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        return pool.submit(SessionDB).result(timeout=session_db_timeout)
+    except concurrent.futures.TimeoutError:
+        logger.error(
+            "Job '%s': SessionDB init did not return within %.0fs — proceeding "
+            "without a session store for this run instead of blocking it "
+            "forever",
+            job_id, session_db_timeout,
+        )
+        return None
+    finally:
+        # Don't wait for a wedged connect() to unwind — abandon the worker
+        # thread (same pattern as the agent inactivity timeout further down)
+        # rather than blocking shutdown on it too.
+        pool.shutdown(wait=False)
+
+
+def _persist_no_agent_cron_session(
+    job_id: str,
+    job_name: str,
+    session_id: str,
+    *,
+    invocation: str,
+    result_text: str,
+    succeeded: bool,
+) -> None:
+    """Record a no_agent script run as a cron session in the profile state.db.
+
+    no_agent runs never construct an AIAgent, so nothing calls the agent's
+    ``_ensure_db_session`` — without this the run exists only in
+    ``cron/output/*.md`` and ``executions.db``, and the Desktop "Cron Jobs"
+    sidebar (``SessionDB.list_cron_job_runs``, which matches ``source='cron'``
+    AND an id prefixed ``cron_{job_id}_``) shows nothing for the job. Failed
+    watchdog runs going silently missing there is the worst case, since an
+    alerting job that breaks is exactly the one you need to see.
+
+    This mirrors the agent path's lifecycle — create → messages → title →
+    end_session — using the same canonical SessionDB APIs, so a script run and
+    an agent run look and open identically in Desktop.
+
+    Best-effort by design: any failure here is logged and swallowed. Persisting
+    the run must never turn a working script into a failed cron run.
+    """
+    session_db = None
+    try:
+        session_db = _open_cron_session_db(job_id)
+        if session_db is None:
+            return
+
+        session_db.create_session(session_id=session_id, source="cron")
+        # The script invocation stands in for the user turn, so the sidebar's
+        # `preview` column (first user message) is populated. The result is the
+        # assistant turn, so opening the run in Desktop shows the stdout /
+        # failure detail rather than an empty transcript.
+        session_db.append_message(session_id, "user", content=invocation)
+        session_db.append_message(session_id, "assistant", content=result_text)
+
+        title_base = " ".join(job_name.split())[:60].strip() or f"cron {job_id}"
+        title = f"{title_base} · {_hermes_now().strftime('%b %d %H:%M')}"
+        if not _set_cron_session_title(session_db, session_id, title):
+            _set_cron_session_title(session_db, session_id, f"cron {job_id}")
+
+        session_db.end_session(
+            session_id, "cron_complete" if succeeded else "cron_failed"
+        )
+    except (Exception, KeyboardInterrupt) as e:
+        logger.debug(
+            "Job '%s': failed to persist no_agent cron session: %s", job_id, e
+        )
+    finally:
+        if session_db is not None:
+            try:
+                session_db.close()
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug(
+                    "Job '%s': failed to close SQLite session store: %s", job_id, e
+                )
+
+
 def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     """Return a compact one-line failure message for chat delivery.
 
@@ -2685,9 +2811,16 @@ def run_job(
     # stdout to telegram" watchdog pattern. The agent path is skipped
     # entirely: no AIAgent, no prompt, no tool loop, no token spend.
     #
-    # We check this BEFORE importing run_agent / constructing SessionDB so
-    # a pure-script tick never pays for the agent machinery it isn't going
-    # to use. Keep this block self-contained.
+    # We check this BEFORE importing run_agent so a pure-script tick never
+    # pays for the agent machinery it isn't going to use. Keep this block
+    # self-contained.
+    #
+    # It DOES still open the session store at the end (see
+    # _persist_no_agent_cron_session): skipping that is what made every
+    # no_agent run invisible in the Desktop "Cron Jobs" sidebar, which lists
+    # runs out of the profile state.db. The cost is one SQLite open per tick,
+    # paid after the script has already run, and it is best-effort — never
+    # fatal to the run.
     #
     # Semantics:
     #   - script stdout (trimmed) → delivered verbatim as the final message
@@ -2724,13 +2857,25 @@ def run_job(
                 except OSError:
                     pass
 
-        now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+        now = _hermes_now()
+        now_iso = now.strftime("%Y-%m-%d %H:%M:%S")
+
+        # Every outcome below funnels through a single persistence call rather
+        # than returning early, so success, silent, and failure runs are all
+        # recorded in the profile state.db the same way. Microseconds are in
+        # the id because a fast script can run twice inside one second (a
+        # manual trigger landing on a scheduled fire); at the agent path's
+        # second resolution the second run would upsert onto the first row and
+        # silently vanish — the exact class of bug this block exists to fix.
+        # Nothing parses this stamp; consumers match the `cron_{job_id}_`
+        # prefix and read the started_at/last_active columns.
+        session_id = f"cron_{job_id}_{now.strftime('%Y%m%d_%H%M%S_%f')}"
 
         if not ok:
             # Script crashed / timed out / exited non-zero.  Deliver the
             # error so the user knows the watchdog itself broke — silent
             # failure for an alerting job is the worst-case outcome.
-            alert = (
+            final_response = (
                 f"⚠ Cron watchdog '{job_name}' script failed\n\n"
                 f"{output}\n\n"
                 f"Time: {now_iso}"
@@ -2743,11 +2888,12 @@ def run_job(
                 f"**Status:** script failed\n\n"
                 f"{output}\n"
             )
-            return False, doc, alert, output
+            result = (False, doc, final_response, output)
+            session_body = final_response
 
         # Honour the wakeAgent gate as a silent signal — `wakeAgent: false`
         # means "nothing to report this tick", same as empty stdout.
-        if not _parse_wake_gate(output):
+        elif not _parse_wake_gate(output):
             logger.info(
                 "Job '%s' (no_agent): wakeAgent=false gate — silent run", job_id
             )
@@ -2758,9 +2904,10 @@ def run_job(
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (wakeAgent=false)\n"
             )
-            return True, silent_doc, SILENT_MARKER, None
+            result = (True, silent_doc, SILENT_MARKER, None)
+            session_body = "Silent run — script returned wakeAgent=false."
 
-        if not output.strip():
+        elif not output.strip():
             logger.info("Job '%s' (no_agent): empty stdout — silent run", job_id)
             silent_doc = (
                 f"# Cron Job: {job_name}\n\n"
@@ -2769,17 +2916,30 @@ def run_job(
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (empty output)\n"
             )
-            return True, silent_doc, SILENT_MARKER, None
+            result = (True, silent_doc, SILENT_MARKER, None)
+            session_body = "Silent run — script produced no output."
 
-        doc = (
-            f"# Cron Job: {job_name}\n\n"
-            f"**Job ID:** {job_id}\n"
-            f"**Run Time:** {now_iso}\n"
-            f"**Mode:** no_agent (script)\n\n"
-            f"---\n\n"
-            f"{output}\n"
+        else:
+            doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {now_iso}\n"
+                f"**Mode:** no_agent (script)\n\n"
+                f"---\n\n"
+                f"{output}\n"
+            )
+            result = (True, doc, output, None)
+            session_body = output
+
+        _persist_no_agent_cron_session(
+            job_id,
+            job_name,
+            session_id,
+            invocation=f"Ran cron script `{script_path}` (no_agent mode).",
+            result_text=session_body,
+            succeeded=result[0],
         )
-        return True, doc, output, None
+        return result
 
     # ---------------------------------------------------------------
     # Default (LLM) path — import and construct the agent machinery now
@@ -2804,55 +2964,7 @@ def run_job(
     # scheduled fire in between with "already running — skipping".
     _session_db = None
     try:
-        from hermes_state import SessionDB
-
-        # Resolve timeout: env override → config.yaml → default 10s.
-        # Mirrors the script_timeout_seconds resolution pattern.
-        _session_db_timeout: float | None = None
-        _raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
-        if _raw_env_timeout:
-            try:
-                _session_db_timeout = float(_raw_env_timeout)
-            except (ValueError, TypeError):
-                logger.warning(
-                    "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
-                    _raw_env_timeout,
-                )
-        if _session_db_timeout is None:
-            try:
-                from hermes_cli.config import load_config
-                _cfg = load_config() or {}
-                _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
-                _configured = _cron_cfg.get("session_db_timeout_seconds")
-                if _configured is not None:
-                    _session_db_timeout = float(_configured)
-            except Exception as exc:
-                logger.debug(
-                    "Failed to load cron.session_db_timeout_seconds from config: %s",
-                    exc,
-                )
-        if _session_db_timeout is None:
-            _session_db_timeout = 10.0
-
-        if _session_db_timeout > 0:
-            _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                _session_db = _session_db_pool.submit(SessionDB).result(timeout=_session_db_timeout)
-            finally:
-                # Don't wait for a wedged connect() to unwind — abandon the
-                # worker thread (same pattern as the agent inactivity timeout
-                # further down) rather than blocking shutdown on it too.
-                _session_db_pool.shutdown(wait=False)
-        else:
-            # 0 = unlimited (legacy behavior, opt-in for debugging)
-            _session_db = SessionDB()
-    except concurrent.futures.TimeoutError:
-        logger.error(
-            "Job '%s': SessionDB init did not return within %.0fs — proceeding "
-            "without a session store for this run instead of blocking it "
-            "forever",
-            job.get("id", "?"), _session_db_timeout,
-        )
+        _session_db = _open_cron_session_db(job.get("id", "?"))
     except Exception as e:
         logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -31,6 +31,11 @@ def hermes_env(tmp_path, monkeypatch):
     import importlib
     import hermes_constants
     importlib.reload(hermes_constants)
+    # hermes_state.DEFAULT_DB_PATH is computed at import time, so it must be
+    # reloaded after HERMES_HOME is set — otherwise run_job would persist cron
+    # sessions into the developer's real profile state.db instead of tmp_path.
+    import hermes_state
+    importlib.reload(hermes_state)
     import cron.jobs
     importlib.reload(cron.jobs)
     import cron.scheduler
@@ -278,6 +283,175 @@ def test_run_job_no_agent_never_invokes_aiagent(hermes_env):
         run_job(job)
 
     ai_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run_job: no_agent runs must land in the profile state.db so the Desktop
+# "Cron Jobs" sidebar can list and open them.
+#
+# The sidebar's run history calls SessionDB.list_cron_job_runs(job_id), which
+# only matches rows with source='cron' AND id starting 'cron_{job_id}_'. The
+# no_agent short-circuit used to return before any SessionDB was constructed,
+# so *no* script run — success, silent, or failure — was ever visible there,
+# even though cron/output/*.md and executions.db both recorded it.
+# ---------------------------------------------------------------------------
+
+
+def _runs_for(home, job_id):
+    """Read the cron run sessions the Desktop sidebar would show for a job."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        return db.list_cron_job_runs(job_id)
+    finally:
+        db.close()
+
+
+def _session_text(home, session_id):
+    """Concatenated message content for a session, as Desktop would render it."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        return "\n".join(
+            str(m.get("content") or "") for m in db.get_messages(session_id)
+        )
+    finally:
+        db.close()
+
+
+def test_run_job_no_agent_failure_is_visible_in_sidebar(hermes_env):
+    """A failed script run must appear in the profile state.db run history.
+
+    This is the reported bug: the run was written to cron/output and
+    executions.db, but the Desktop sidebar (which reads state.db) showed
+    nothing, so the failure was invisible.
+    """
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "broken.sh"
+    script_path.write_text("#!/bin/bash\necho oops >&2\nexit 3\n")
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="broken.sh",
+        no_agent=True,
+        deliver="local",
+        name="gigarepo-weekly-cleanup",
+    )
+    success, _doc, _final_response, error = run_job(job)
+    assert success is False
+    assert error is not None
+
+    runs = _runs_for(hermes_env, job["id"])
+    assert len(runs) == 1, "failed no_agent run is missing from the sidebar query"
+
+    run = runs[0]
+    # Opening the run from the sidebar navigates by session id.
+    assert run["id"].startswith(f"cron_{job['id']}_")
+    # A useful title, not a blank row.
+    assert "gigarepo-weekly-cleanup" in (run.get("title") or "")
+    # The failure must be inspectable, not just recorded as "ended".
+    assert run.get("end_reason") == "cron_failed"
+
+    body = _session_text(hermes_env, run["id"])
+    assert "exited with code 3" in body or "oops" in body
+
+
+def test_run_job_no_agent_success_is_visible_in_sidebar(hermes_env):
+    """Success shares the same persistence path — assert it too, not just failure."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "alert.sh"
+    script_path.write_text("#!/bin/bash\necho 'RAM 92% on host'\n")
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="alert.sh",
+        no_agent=True,
+        deliver="local",
+        name="ram-watchdog",
+    )
+    success, _doc, _final_response, error = run_job(job)
+    assert success is True
+    assert error is None
+
+    runs = _runs_for(hermes_env, job["id"])
+    assert len(runs) == 1
+    assert runs[0].get("end_reason") == "cron_complete"
+    assert "ram-watchdog" in (runs[0].get("title") or "")
+    assert "RAM 92% on host" in _session_text(hermes_env, runs[0]["id"])
+
+
+def test_run_job_no_agent_silent_run_is_visible_in_sidebar(hermes_env):
+    """Silent runs are recorded too — the agent path creates a session for a
+    [SILENT] response, and save_job_output writes markdown for every tick, so
+    the run history stays consistent across all three outcomes."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "quiet.sh"
+    script_path.write_text("#!/bin/bash\n# nothing to say\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="quiet.sh", no_agent=True, deliver="local"
+    )
+    success, _doc, _final_response, error = run_job(job)
+    assert success is True
+    assert error is None
+
+    runs = _runs_for(hermes_env, job["id"])
+    assert len(runs) == 1
+    assert runs[0].get("end_reason") == "cron_complete"
+
+
+def test_run_job_no_agent_creates_one_session_per_run(hermes_env):
+    """No duplicate/synthetic sessions: each tick yields exactly one row."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "alert.sh"
+    script_path.write_text("#!/bin/bash\necho tick\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="alert.sh", no_agent=True, deliver="local"
+    )
+    run_job(job)
+    assert len(_runs_for(hermes_env, job["id"])) == 1
+
+    # Distinct ids across ticks — the id carries a second-resolution stamp, so
+    # a same-second rerun must still not collapse onto the first row.
+    run_job(job)
+    runs = _runs_for(hermes_env, job["id"])
+    assert len(runs) == 2
+    assert len({r["id"] for r in runs}) == 2
+
+
+def test_run_job_no_agent_session_failure_does_not_break_the_run(hermes_env):
+    """Session persistence is best-effort — a broken state.db must not turn a
+    working script run into a failed one."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "alert.sh"
+    script_path.write_text("#!/bin/bash\necho 'still delivered'\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="alert.sh", no_agent=True, deliver="local"
+    )
+
+    with patch("cron.scheduler._open_cron_session_db", side_effect=RuntimeError("db down")):
+        success, doc, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert "still delivered" in final_response
+    assert "still delivered" in doc
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -30,6 +30,7 @@ Hermes calls this **no-agent mode**. It's the cron system minus the LLM.
 - **Script is the job.** The script decides whether to alert. Emit output → message gets sent. Emit nothing → silent tick.
 - **Bash or Python.** `.sh` / `.bash` files run under `/bin/bash`; any other extension runs under the current Python interpreter. Anything in `~/.hermes/scripts/` is accepted.
 - **Same scheduler.** Lives in `cronjob` alongside LLM jobs — pausing, resuming, listing, logs, and delivery targeting all work the same way.
+- **Same run history.** Every tick — output, silent, or failed — is recorded as a cron session, so script-only runs show up in the Desktop **Cron Jobs** run history next to agent-backed ones. Open a failed run there to read the script's exit code, stdout, and stderr. A silent tick is recorded too, so "did it even run?" is always answerable.
 
 ## When to Use It
 


### PR DESCRIPTION
## Problem

`no_agent` (script-only) cron runs are invisible in the Desktop "Cron Jobs" sidebar. A failed watchdog run writes `cron/output/<job>/<ts>.md` and an `executions.db` row, but the run history shows nothing, so the failure can't be opened or inspected.

## Root cause

`run_job()`'s `no_agent` short-circuit returns before any `SessionDB` is constructed — that happens ~200 lines later, on the agent path only — so no `cron_{job_id}_{ts}` session row is ever written to the profile `state.db`. The sidebar reads `SessionDB.list_cron_job_runs()`, which matches exactly `source='cron'` AND an id prefixed `cron_{job_id}_`, so every script run is filtered out. This affects all four no_agent outcomes (success, failure, silent tick, timeout), not just failures.

## Fix

- Funnel all no_agent outcomes through one `_persist_no_agent_cron_session()` that mirrors the agent path's lifecycle (`create_session` → messages → title → `end_session`) using the same canonical SessionDB APIs. Failures end as `cron_failed` and carry exit code, stdout, and stderr as the assistant turn.
- Extract SessionDB construction (with its bounded-init timeout) into a shared `_open_cron_session_db()` used by both paths so they can't drift again.
- Persistence is best-effort: a broken `state.db` logs and is swallowed rather than failing a working script run. Session ids carry microseconds so a manual trigger and a scheduled fire in the same second don't collide.
- Return-tuple contract, markdown output, and `executions.db` are unchanged.

## Test evidence

New `tests/cron/test_cron_no_agent.py` (23 tests) proves a failed no_agent run creates an inspectable `source='cron'` session with the `cron_{job_id}_` prefix (surfaced via `list_cron_job_runs`), ending as `cron_failed`; success/silent-tick behavior and best-effort DB-failure swallowing are covered too. Tests isolate `state.db` under `tmp_path` — no real profile data is touched.

Local run: `python -m pytest tests/cron -q` → **734 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)