### PR TITLE
fix(photon): inspect port listeners off the gateway event loop

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -882,9 +882,20 @@ class PhotonAdapter(BasePlatformAdapter):
                 )
         except httpx.RequestError:
             return  # nothing listening — the normal case
-        pids = self._find_listener_pids(self._sidecar_port)
-        stale = [pid for pid in pids if self._pid_is_sidecar(pid)]
-        foreign = [pid for pid in pids if pid not in stale]
+        # Off the event loop: _find_listener_pids shells out to `lsof`
+        # (timeout=5s) and _pid_is_sidecar runs a `ps` per candidate pid
+        # (timeout=5s each), so this inspection can hold the loop for
+        # 5 + 5·N seconds. _reap_stale_sidecar is awaited from
+        # _start_sidecar, which runs on every reconnect — exactly when a
+        # crashed gateway left an orphan behind — so the stall lands on a
+        # live gateway that is still serving every other platform. One hop
+        # covers the whole inspection instead of N+1 round trips.
+        def _inspect():
+            found = self._find_listener_pids(self._sidecar_port)
+            mine = [pid for pid in found if self._pid_is_sidecar(pid)]
+            return mine, [pid for pid in found if pid not in mine]
+
+        stale, foreign = await asyncio.to_thread(_inspect)
         if not stale:
             raise RuntimeError(
                 f"port {self._sidecar_port} is in use by another process "

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -188,3 +188,50 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
     assert kwargs["env"]["PHOTON_SIDECAR_WATCH_STDIN"] == "1"
     assert spawned["patch_kwargs"]["creationflags"] == hidden_flags
     assert kwargs["creationflags"] == hidden_flags
+
+
+@pytest.mark.asyncio
+async def test_reap_inspects_listeners_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Listener inspection must not block the shared gateway event loop.
+
+    ``_find_listener_pids`` shells out to ``lsof`` (timeout=5s) and
+    ``_pid_is_sidecar`` runs a ``ps`` per candidate pid (timeout=5s each), so
+    inline this holds the loop for 5 + 5·N seconds. ``_reap_stale_sidecar`` is
+    awaited from ``_start_sidecar``, which runs on every reconnect — exactly
+    when a crashed gateway left an orphan — so the stall lands on a live
+    gateway still serving every other platform.
+    """
+    import threading
+
+    adapter = _make_adapter(monkeypatch)
+    monkeypatch.setattr(photon_adapter.sys, "platform", "linux")
+    monkeypatch.setattr(photon_adapter.httpx, "AsyncClient", _ProbeClient)
+
+    main_thread = threading.current_thread()
+    seen: Dict[str, Any] = {}
+
+    def _fake_find(port: int) -> List[int]:
+        seen["find"] = threading.current_thread()
+        return [4242]
+
+    def _fake_is_sidecar(pid: int) -> bool:
+        seen["ps"] = threading.current_thread()
+        return True
+
+    monkeypatch.setattr(adapter, "_find_listener_pids", _fake_find)
+    monkeypatch.setattr(adapter, "_pid_is_sidecar", _fake_is_sidecar)
+    monkeypatch.setattr(adapter, "_pid_alive", lambda pid: False)
+    _capture_kills(monkeypatch)
+
+    await adapter._reap_stale_sidecar()
+
+    assert seen.get("find") is not None, "lsof lookup never ran"
+    assert seen.get("ps") is not None, "ps check never ran"
+    for label in ("find", "ps"):
+        assert seen[label] is not main_thread, (
+            f"{label} ran on the event-loop thread; the listener inspection "
+            "must be dispatched via asyncio.to_thread so a 5s lsof/ps spawn "
+            "can't freeze every other platform on the gateway loop"
+        )


### PR DESCRIPTION
## What does this PR do?

`_reap_stale_sidecar` is `async`, but it identified the processes holding the sidecar port with two blocking helpers called inline:

* `_find_listener_pids` → `subprocess.run(["lsof", ...], timeout=5.0)`
* `_pid_is_sidecar` → `subprocess.run(["ps", ...], timeout=5.0)`, once per candidate pid

so the inspection can hold the shared gateway event loop for **5 + 5·N seconds** while nothing else on it is serviced.

It only runs once the `/healthz` probe finds something already listening — the orphaned-sidecar recovery path — and `_reap_stale_sidecar` is awaited from `_start_sidecar`, which runs on every reconnect (`connect(is_reconnect=True)`). The stall therefore lands on a live gateway that is still serving every other platform, right when a crashed sidecar has already left an orphan behind.

The fix moves the whole inspection into a single `asyncio.to_thread` hop (one hop rather than N+1 round trips). Reaping semantics are untouched.

Same off-the-loop class as the inbound-image decision (#66688) and the cron-fire verifier.

## Related Issue

No separate issue — an event-loop-blocking gateway path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/photon/adapter.py` — in `_reap_stale_sidecar`, run the `lsof` lookup and the per-pid `ps` checks inside one `asyncio.to_thread` call, returning the `(stale, foreign)` split. No change to the reaping logic itself.
- `tests/plugins/platforms/photon/test_sidecar_lifecycle.py` — add `test_reap_inspects_listeners_off_the_event_loop`, asserting both the lsof lookup and the per-pid ps check run on a worker thread rather than the loop thread.

## How to Test

1. Run:

       pytest tests/plugins/platforms/photon/test_sidecar_lifecycle.py -q

   The new test passes with the fix and fails without it.

2. Reaping behaviour is unchanged. The existing reap tests short-circuit on Windows (`sys.platform == "win32"` early return), so the POSIX path was exercised directly with `sys.platform` patched — verified identical before/after:

   | scenario | result |
   | --- | --- |
   | verified orphan → SIGTERM | unchanged |
   | still alive → SIGKILL escalation | unchanged |
   | foreign listener → `RuntimeError` | unchanged |
   | mixed sidecar + foreign | unchanged |

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(photon):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suite and verified no regressions against a clean `main` baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline comments) — the call site now documents why the inspection must stay off the loop
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the POSIX-only guard is preserved; only the dispatch changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A