### PR TITLE
fix(tools): always emit required as array in tool schemas

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -23,7 +23,11 @@ def _tool(name: str, parameters: dict) -> dict:
 def test_object_without_properties_gets_empty_properties():
     tools = [_tool("t", {"type": "object"})]
     out = sanitize_tool_schemas(tools)
-    assert out[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+    assert out[0]["function"]["parameters"] == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
 
 
 def test_nested_object_without_properties_gets_empty_properties():
@@ -160,13 +164,21 @@ def test_anyof_nested_objects_sanitized():
 def test_missing_parameters_gets_default_object_schema():
     tools = [{"type": "function", "function": {"name": "t"}}]
     out = sanitize_tool_schemas(tools)
-    assert out[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+    assert out[0]["function"]["parameters"] == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
 
 
 def test_non_dict_parameters_gets_default_object_schema():
     tools = [_tool("t", "object")]  # pathological
     out = sanitize_tool_schemas(tools)
-    assert out[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+    assert out[0]["function"]["parameters"] == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
 
 
 def test_required_pruned_to_existing_properties():
@@ -179,14 +191,53 @@ def test_required_pruned_to_existing_properties():
     assert out[0]["function"]["parameters"]["required"] == ["name"]
 
 
-def test_required_all_missing_is_dropped():
+def test_required_all_missing_becomes_empty_array():
     tools = [_tool("t", {
         "type": "object",
         "properties": {},
         "required": ["x", "y"],
     })]
     out = sanitize_tool_schemas(tools)
-    assert "required" not in out[0]["function"]["parameters"]
+    assert out[0]["function"]["parameters"]["required"] == []
+
+
+def test_required_null_becomes_empty_array():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": None,
+    })]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"]["required"] == []
+
+
+def test_required_missing_key_becomes_empty_array():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+    })]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"]["required"] == []
+
+
+def test_required_valid_list_preserved():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+        "required": ["name", "age"],
+    })]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"]["required"] == ["name", "age"]
+
+
+def test_required_junk_entries_stripped():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name", None, "", "   "],
+    })]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"]["required"] == ["name"]
 
 
 def test_well_formed_schema_unchanged():

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -70,20 +70,31 @@ def _sanitize_single_tool(tool: dict) -> dict:
 
     params = fn.get("parameters")
     # Missing / non-dict parameters → substitute the minimal valid shape.
+    # Some strict JSON Schema validators reject `required: null` and some
+    # reject a missing `required` after normalizing it to null. Always emit
+    # a real array.
     if not isinstance(params, dict):
-        fn["parameters"] = {"type": "object", "properties": {}}
+        fn["parameters"] = {"type": "object", "properties": {}, "required": []}
         return out
 
     fn["parameters"] = _sanitize_node(params, path=fn.get("name", "<tool>"))
     # After recursion, guarantee the top-level is an object with properties.
     top = fn["parameters"]
     if not isinstance(top, dict):
-        fn["parameters"] = {"type": "object", "properties": {}}
+        fn["parameters"] = {"type": "object", "properties": {}, "required": []}
     else:
         if top.get("type") != "object":
             top["type"] = "object"
         if "properties" not in top or not isinstance(top.get("properties"), dict):
             top["properties"] = {}
+        # Some strict JSON Schema validators reject `required: null` and some
+        # reject a missing `required` after normalizing it to null. Always
+        # emit a real array.
+        req = top.get("required")
+        if req is None or not isinstance(req, list):
+            top["required"] = []
+        else:
+            top["required"] = [str(r) for r in req if r is not None and str(r).strip()]
     # Final pass: collapse nullable anyOf/oneOf unions that the recursive
     # sanitizer above leaves intact (it only handles the array-form
     # ``type: [X, "null"]``). Keep the ``nullable: true`` hint so runtime
@@ -97,6 +108,14 @@ def _sanitize_single_tool(tool: dict) -> dict:
         fn["parameters"], path=fn.get("name", "<tool>")
     )
     fn["parameters"] = _strip_ref_siblings(fn["parameters"])
+    # Re-assert after the passes above: none of them should introduce a
+    # null/missing `required`, but guard anyway since strict validators
+    # reject `required: null`.
+    final = fn["parameters"]
+    if isinstance(final, dict) and final.get("type") == "object":
+        req = final.get("required")
+        if req is None or not isinstance(req, list):
+            final["required"] = []
     return out
 
 
@@ -347,7 +366,9 @@ def _sanitize_node(node: Any, path: str) -> Any:
         props = out.get("properties") or {}
         valid = [r for r in out["required"] if isinstance(r, str) and r in props]
         if not valid:
-            out.pop("required", None)
+            # Keep an empty array rather than dropping the key: strict
+            # backends that normalize a missing `required` to null reject it.
+            out["required"] = []
         elif len(valid) != len(out["required"]):
             out["required"] = valid
 


### PR DESCRIPTION
## Summary
Strict JSON Schema validators reject function tool schemas when `parameters.required` is `null` (or missing and later normalized to null). JSON Schema expects `required` to be an **array of strings**.

## Change
- `sanitize_tool_schemas` always sets `required: []` when missing / null / non-list
- Re-assert after later sanitizer passes that rebuild nodes
- When pruning invalid required entries, keep `[]` instead of dropping the key
- Strip junk entries (`null`, empty/whitespace strings) from required arrays

## Rule
Do not send `null` for typed schema fields. Use typed empties: `required` → `[]`.

## Test plan
- [x] unit: `required: null` → `[]`
- [x] unit: missing `required` → `[]`
- [x] unit: prune-to-empty keeps `[]`
- [x] unit: valid required list preserved
- [x] unit: junk entries stripped
- [x] `pytest tests/tools/test_schema_sanitizer.py` — 51 passed
