### PR TITLE
feat(kanban): harden budget-aware execution recovery

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -400,6 +400,39 @@ def note_turn_persisted(agent):
     agent._inflight_turn_id = None
 
 
+REPAIRED_USER_PREFIX_KEY = "_hermes_repaired_user_prefix"
+
+
+def provider_visible_message_copy(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Copy one message exactly as provider and local sizing may observe it."""
+    api_message = message.copy()
+    repaired_user_prefix = api_message.get(REPAIRED_USER_PREFIX_KEY)
+    if (
+        message.get("role") == "user"
+        and isinstance(repaired_user_prefix, str)
+        and repaired_user_prefix
+    ):
+        content = api_message.get("content", "")
+        if isinstance(content, str):
+            api_message["content"] = (
+                repaired_user_prefix + "\n\n" + content
+                if content
+                else repaired_user_prefix
+            )
+    for internal_key in [
+        key for key in api_message if isinstance(key, str) and key.startswith("_")
+    ]:
+        api_message.pop(internal_key, None)
+    return api_message
+
+
+def provider_visible_messages(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Project an internal transcript into the provider-visible message shape."""
+    return [provider_visible_message_copy(message) for message in messages]
+
+
 def repair_message_sequence(agent, messages: List[Dict]) -> int:
     """Collapse malformed role-alternation left in the live history.
 
@@ -580,13 +613,31 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             new_content = msg.get("content", "")
             # Only merge plain-text content; leave multimodal (list)
             # content alone — collapsing image/audio blocks risks
-            # mangling the attachment structure.
+            # mangling the attachment structure. A marked current-turn user
+            # must remain the survivor: it owns the durable turn marker and
+            # its identity tells repair_message_sequence_with_cursor whether
+            # an unflushed input displaced a flushed row. Do not rewrite its
+            # transcript content after the crash-resilience persist, though:
+            # keep historical user text in private API-only metadata instead.
             if isinstance(prev_content, str) and isinstance(new_content, str):
-                prev["content"] = (
-                    (prev_content + "\n\n" + new_content)
-                    if prev_content and new_content
-                    else (prev_content or new_content)
-                )
+                from agent.iteration_budget import CURRENT_TURN_ID_KEY
+
+                if msg.get(CURRENT_TURN_ID_KEY):
+                    prefix_parts = [
+                        prev.get(REPAIRED_USER_PREFIX_KEY, ""),
+                        prev_content,
+                        msg.get(REPAIRED_USER_PREFIX_KEY, ""),
+                    ]
+                    msg[REPAIRED_USER_PREFIX_KEY] = "\n\n".join(
+                        part for part in prefix_parts if isinstance(part, str) and part
+                    )
+                    merged[-1] = msg
+                else:
+                    prev["content"] = (
+                        (prev_content + "\n\n" + new_content)
+                        if prev_content and new_content
+                        else (prev_content or new_content)
+                    )
                 repairs += 1
                 continue
         merged.append(msg)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -26,6 +26,7 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
+from agent.agent_runtime_helpers import provider_visible_messages
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
@@ -1872,14 +1873,37 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 
 
+def _iteration_limit_summary_request(*, is_kanban: bool) -> str:
+    """Return a general summary request or a reusable Kanban handoff contract."""
+    if not is_kanban:
+        return (
+            "You've reached the maximum number of tool-calling iterations allowed. "
+            "Please provide a final response summarizing what you've found and "
+            "accomplished so far, without calling any more tools."
+        )
+    return (
+        "You've reached the maximum number of tool-calling iterations allowed; "
+        "without calling any more tools, return a compact continuation record "
+        "using exactly these headings:\n\n"
+        "PARTIAL_UNVERIFIED_HANDOFF\n"
+        "COMPLETED: verified work actually finished\n"
+        "CHANGED_FILES: exact paths, or none\n"
+        "TESTS: exact commands/results already observed\n"
+        "REMAINING: unfinished work and required reviews\n"
+        "RESUME: the first concrete next action\n"
+        "INVARIANTS: safety boundaries and actions not taken\n\n"
+        "Do not claim PASS, approval, deployment, or completion unless it was "
+        "actually verified before exhaustion. Keep this handoff concise; it will "
+        "be marked partial_unverified and supplied to a continuation worker."
+    )
+
+
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
 
-    summary_request = (
-        "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
+    summary_request = _iteration_limit_summary_request(
+        is_kanban=bool(os.environ.get("HERMES_KANBAN_TASK"))
     )
     messages.append({"role": "user", "content": summary_request})
 
@@ -1888,8 +1912,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
         _needs_sanitize = agent._should_sanitize_tool_calls()
         api_messages = []
-        for msg in messages:
-            api_msg = msg.copy()
+        for msg, api_msg in zip(messages, provider_visible_messages(messages)):
             agent._copy_reasoning_content_for_api(msg, api_msg)
             for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
                 api_msg.pop(internal_field, None)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -27,11 +27,20 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+from agent.agent_runtime_helpers import (
+    provider_visible_message_copy,
+    provider_visible_messages,
+)
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.conversation_compression import conversation_history_after_compression
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
-from agent.iteration_budget import IterationBudget
+from agent.iteration_budget import (
+    _current_turn_user_index,
+    _latest_unseen_tool_result,
+    IterationBudget,
+    kanban_checkpoint_warning,
+)
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
@@ -683,6 +692,37 @@ def run_conversation(
     # user-facing result available; it must not be confused with error or
     # recovery text produced by unrelated exit paths.
     _pending_verification_response = None
+    _kanban_task_id = os.environ.get("HERMES_KANBAN_TASK")
+    _kanban_run_raw = os.environ.get("HERMES_KANBAN_RUN_ID")
+    try:
+        _kanban_run_id = int(_kanban_run_raw) if _kanban_run_raw else None
+    except (TypeError, ValueError):
+        _kanban_run_id = None
+    _is_kanban_worker = bool(_kanban_task_id and _kanban_run_id is not None)
+    _budget_checkpoint_emitted = False
+    _budget_checkpoint_text = None
+    _budget_checkpoint_tool_idx = None
+    _budget_checkpoint_tool_call_id = None
+    _budget_checkpoint_seen_tool_call_ids: set[str] = set()
+    _budget_checkpoint_seen_legacy_message_ids: set[int] = set()
+    for _seen_message in messages:
+        if _seen_message.get("role") != "tool":
+            continue
+        _seen_call_id = _seen_message.get("tool_call_id")
+        if _seen_call_id:
+            _budget_checkpoint_seen_tool_call_ids.add(str(_seen_call_id))
+        else:
+            _budget_checkpoint_seen_legacy_message_ids.add(id(_seen_message))
+    _budget_warning_ratio = 0.75
+    if _is_kanban_worker:
+        try:
+            from hermes_cli.config import load_config as _load_config
+
+            _budget_warning_ratio = _load_config().get("kanban", {}).get(
+                "budget_warning_ratio", 0.75
+            )
+        except Exception:
+            _budget_warning_ratio = 0.75
 
     # Per-turn tally of consecutive successful credential-pool token refreshes,
     # keyed by (provider, pool-entry-id). A persistent upstream 401 lets
@@ -731,6 +771,14 @@ def run_conversation(
             if not agent.quiet_mode:
                 agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
             break
+
+        _new_budget_checkpoint = kanban_checkpoint_warning(
+            used=api_call_count,
+            max_total=agent.max_iterations,
+            ratio=_budget_warning_ratio,
+            is_kanban=_is_kanban_worker,
+            already_emitted=_budget_checkpoint_emitted,
+        )
 
         # Fire step_callback for gateway hooks (agent:step event)
         if agent.step_callback is not None:
@@ -854,9 +902,102 @@ def run_conversation(
                 agent.session_id or "-",
             )
 
+        _turn_boundary_idx = _current_turn_user_index(messages, turn_id)
+        if _turn_boundary_idx is not None:
+            current_turn_user_idx = _turn_boundary_idx
+            agent._persist_user_message_idx = _turn_boundary_idx
+
+        if _new_budget_checkpoint:
+            _checkpoint_candidate = (
+                _latest_unseen_tool_result(
+                    messages,
+                    seen_tool_call_ids=_budget_checkpoint_seen_tool_call_ids,
+                    seen_legacy_message_ids=_budget_checkpoint_seen_legacy_message_ids,
+                    min_index=_turn_boundary_idx + 1,
+                    require_tool_call_id=True,
+                )
+                if _turn_boundary_idx is not None
+                else None
+            )
+            if _checkpoint_candidate is not None:
+                _budget_checkpoint_text = _new_budget_checkpoint
+                _budget_checkpoint_tool_idx = _checkpoint_candidate[0]
+                _budget_checkpoint_tool_call_id = _checkpoint_candidate[1]
+
+        # Later defensive sequence repairs may insert/drop messages after the
+        # checkpoint is selected. Resolve its current position by the stable
+        # tool-call id; use the original index only for legacy tool messages
+        # that do not carry one. Provider tool-call ids are unique within a
+        # request chain, and the reverse scan keeps malformed duplicates from
+        # receiving more than one marker.
+        _budget_checkpoint_request_idx = None
+        if _budget_checkpoint_text and _budget_checkpoint_tool_call_id:
+            for _checkpoint_idx in range(len(messages) - 1, -1, -1):
+                _checkpoint_message = messages[_checkpoint_idx]
+                if (
+                    _checkpoint_message.get("role") == "tool"
+                    and _checkpoint_message.get("tool_call_id")
+                    == _budget_checkpoint_tool_call_id
+                    and _turn_boundary_idx is not None
+                    and _checkpoint_idx > _turn_boundary_idx
+                ):
+                    _budget_checkpoint_request_idx = _checkpoint_idx
+                    break
+        elif (
+            _budget_checkpoint_text
+            and _budget_checkpoint_tool_idx is not None
+            and _budget_checkpoint_tool_idx < len(messages)
+            and _turn_boundary_idx is not None
+            and _budget_checkpoint_tool_idx > _turn_boundary_idx
+            and messages[_budget_checkpoint_tool_idx].get("role") == "tool"
+        ):
+            _budget_checkpoint_request_idx = _budget_checkpoint_tool_idx
+        if (
+            _budget_checkpoint_text
+            and _budget_checkpoint_request_idx is None
+            and _turn_boundary_idx is not None
+        ):
+            # Context compression is the one allowed prefix rewrite and may
+            # remove the originally selected tail before it reaches the API.
+            # Re-anchor only to another still-unseen tool result; if none
+            # exists, omit the marker rather than mutating a cached message.
+            _replacement_checkpoint = _latest_unseen_tool_result(
+                messages,
+                seen_tool_call_ids=_budget_checkpoint_seen_tool_call_ids,
+                seen_legacy_message_ids=_budget_checkpoint_seen_legacy_message_ids,
+                min_index=_turn_boundary_idx + 1,
+                require_tool_call_id=True,
+            )
+            if _replacement_checkpoint is not None:
+                _budget_checkpoint_tool_idx = _replacement_checkpoint[0]
+                _budget_checkpoint_tool_call_id = _replacement_checkpoint[1]
+                _budget_checkpoint_request_idx = _replacement_checkpoint[0]
+
         api_messages = []
+        _budget_checkpoint_attached_to_request = False
         for idx, msg in enumerate(messages):
-            api_msg = msg.copy()
+            api_msg = provider_visible_message_copy(msg)
+
+            if (
+                _budget_checkpoint_text
+                and idx == _budget_checkpoint_request_idx
+                and msg.get("role") == "tool"
+            ):
+                _checkpoint_marker = (
+                    "\n\n<kanban-budget-checkpoint>\n"
+                    + _budget_checkpoint_text
+                    + "\n</kanban-budget-checkpoint>"
+                )
+                _checkpoint_base = api_msg.get("content", "")
+                if isinstance(_checkpoint_base, str):
+                    api_msg["content"] = _checkpoint_base + _checkpoint_marker
+                    _budget_checkpoint_attached_to_request = True
+                elif isinstance(_checkpoint_base, list):
+                    api_msg["content"] = [
+                        *_checkpoint_base,
+                        {"type": "text", "text": _checkpoint_marker},
+                    ]
+                    _budget_checkpoint_attached_to_request = True
 
             # Inject ephemeral context into the current turn's user message.
             # Sources: memory manager prefetch + plugin pre_llm_call hooks
@@ -887,8 +1028,6 @@ def run_conversation(
             # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
             if "finish_reason" in api_msg:
                 api_msg.pop("finish_reason")
-            # Strip internal thinking-prefill marker
-            api_msg.pop("_thinking_prefill", None)
             # Strip Codex Responses API fields (call_id, response_item_id) for
             # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
             # Uses new dicts so the internal messages list retains the fields
@@ -1400,17 +1539,66 @@ def run_conversation(
                         _use_streaming = False
 
                 def _perform_api_call(next_api_kwargs):
+                    nonlocal _budget_checkpoint_emitted
                     if agent.api_mode == "codex_responses":
                         next_api_kwargs = agent._get_transport().preflight_kwargs(
                             next_api_kwargs,
                             allow_stream=False,
                             is_github_responses=agent._is_copilot_url(),
                         )
+                    if (
+                        _budget_checkpoint_text
+                        and _budget_checkpoint_attached_to_request
+                        and not _budget_checkpoint_emitted
+                    ):
+                        # Commit only at the transport boundary. Earlier
+                        # pressure checks may compact and ``continue`` without
+                        # sending the request; recording before this point
+                        # creates a durable checkpoint event the model never
+                        # received.
+                        _budget_checkpoint_emitted = True
+                        agent._emit_status(_budget_checkpoint_text)
+                        try:
+                            from hermes_cli import kanban_db as _checkpoint_kb
+
+                            _checkpoint_conn = _checkpoint_kb.connect()
+                            try:
+                                _checkpoint_kb.record_iteration_budget_checkpoint(
+                                    _checkpoint_conn,
+                                    _kanban_task_id,
+                                    expected_run_id=_kanban_run_id,
+                                    budget_used=api_call_count,
+                                    budget_max=agent.max_iterations,
+                                )
+                            finally:
+                                _checkpoint_conn.close()
+                        except Exception:
+                            logger.warning(
+                                "Failed to persist pre-exhaustion Kanban checkpoint",
+                                exc_info=True,
+                            )
                     if _use_streaming:
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
                         )
                     return agent._interruptible_api_call(next_api_kwargs)
+
+                # From this point the request may reach middleware or the
+                # provider. Mark every included tool result as seen before
+                # execution so a later retry can never rewrite an established
+                # prompt-cache prefix.
+                for _sent_tool_message in messages:
+                    if _sent_tool_message.get("role") != "tool":
+                        continue
+                    _sent_call_id = _sent_tool_message.get("tool_call_id")
+                    if _sent_call_id:
+                        _budget_checkpoint_seen_tool_call_ids.add(
+                            str(_sent_call_id)
+                        )
+                    else:
+                        _budget_checkpoint_seen_legacy_message_ids.add(
+                            id(_sent_tool_message)
+                        )
 
                 from hermes_cli.middleware import run_llm_execution_middleware
 
@@ -3517,7 +3705,9 @@ def run_conversation(
                     agent._buffer_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                     original_len = len(messages)
-                    original_tokens = estimate_messages_tokens_rough(messages)
+                    original_tokens = estimate_messages_tokens_rough(
+                        provider_visible_messages(messages)
+                    )
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message, approx_tokens=approx_tokens,
                         task_id=effective_task_id,
@@ -3526,11 +3716,13 @@ def run_conversation(
                         agent, messages
                     )
 
-                    # Re-estimate tokens after compression.  Same-message-count
-                    # compression (tool-result pruning, in-place summarization)
-                    # can materially reduce request size without reducing the
-                    # message array.  (#39550)
-                    new_tokens = estimate_messages_tokens_rough(messages)
+                    # Re-estimate provider-visible tokens after compression.
+                    # Same-message-count compression (tool-result pruning,
+                    # in-place summarization) can materially reduce request
+                    # size. Private markers cannot: they never reach the wire.
+                    new_tokens = estimate_messages_tokens_rough(
+                        provider_visible_messages(messages)
+                    )
                     approx_tokens = new_tokens  # update for downstream logging
 
                     if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95):
@@ -3758,7 +3950,9 @@ def run_conversation(
                     agent._buffer_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
 
                     original_len = len(messages)
-                    original_tokens = estimate_messages_tokens_rough(messages)
+                    original_tokens = estimate_messages_tokens_rough(
+                        provider_visible_messages(messages)
+                    )
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message, approx_tokens=approx_tokens,
                         task_id=effective_task_id,
@@ -3767,11 +3961,11 @@ def run_conversation(
                         agent, messages
                     )
 
-                    # Re-estimate tokens after compression.  Same-message-count
-                    # compression (tool-result pruning, in-place summarization)
-                    # can materially reduce request size without reducing the
-                    # message array.  (#39550)
-                    new_tokens = estimate_messages_tokens_rough(messages)
+                    # Re-estimate provider-visible tokens after compression.
+                    # Private message metadata is not request-size progress.
+                    new_tokens = estimate_messages_tokens_rough(
+                        provider_visible_messages(messages)
+                    )
                     approx_tokens = new_tokens  # update for downstream logging
 
                     if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95) or (new_ctx and new_ctx < old_ctx):
@@ -5086,7 +5280,8 @@ def run_conversation(
                     # estimate misses, which can skip compression
                     # past the configured threshold (#14695).
                     _real_tokens = estimate_request_tokens_rough(
-                        messages, tools=agent.tools or None
+                        provider_visible_messages(messages),
+                        tools=agent.tools or None,
                     )
 
                 if agent.compression_enabled and _compressor.should_compress(_real_tokens):

--- a/agent/iteration_budget.py
+++ b/agent/iteration_budget.py
@@ -12,6 +12,90 @@ subagent) holds an :class:`IterationBudget`; the parent's cap comes from
 from __future__ import annotations
 
 import threading
+from typing import Any, Optional
+
+
+CURRENT_TURN_ID_KEY = "_hermes_turn_id"
+
+
+def _current_turn_user_index(
+    messages: list[dict[str, Any]], turn_id: str
+) -> Optional[int]:
+    """Return the current user-message index across context compaction.
+
+    Context compression rebuilds retained messages as fresh dictionaries, so
+    Python object identity cannot delimit the active turn.  The private turn
+    marker survives those copies and is stripped by the existing wire
+    sanitizers together with every other underscore-prefixed message key.
+    """
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if (
+            message.get("role") == "user"
+            and message.get(CURRENT_TURN_ID_KEY) == turn_id
+        ):
+            return index
+    return None
+
+
+def _latest_unseen_tool_result(
+    messages: list[dict[str, Any]],
+    *,
+    seen_tool_call_ids: set[str],
+    seen_legacy_message_ids: set[int],
+    min_index: int = 0,
+    require_tool_call_id: bool = False,
+) -> Optional[tuple[int, Optional[str]]]:
+    """Return the latest tool result absent from every prior API request.
+
+    Provider tool-call ids are the stable identity. Object identity is only a
+    compatibility fallback for legacy tool messages without an id; a repaired
+    or reconstructed legacy message is deliberately treated as new rather than
+    risking mutation of a known cached prefix.
+    """
+    first_index = max(0, int(min_index))
+    for index in range(len(messages) - 1, first_index - 1, -1):
+        message = messages[index]
+        if message.get("role") != "tool":
+            continue
+        raw_call_id = message.get("tool_call_id")
+        if raw_call_id:
+            call_id = str(raw_call_id)
+            if call_id not in seen_tool_call_ids:
+                return index, call_id
+        elif not require_tool_call_id and id(message) not in seen_legacy_message_ids:
+            return index, None
+    return None
+
+
+def kanban_checkpoint_warning(
+    *,
+    used: int,
+    max_total: int,
+    ratio: float,
+    is_kanban: bool,
+    already_emitted: bool,
+) -> Optional[str]:
+    """Return one API-only pre-exhaustion warning when its threshold is met."""
+    if not is_kanban or already_emitted or max_total <= 0:
+        return None
+    try:
+        normalized_ratio = float(ratio)
+    except (TypeError, ValueError):
+        normalized_ratio = 0.75
+    if not 0.5 <= normalized_ratio < 1.0:
+        normalized_ratio = 0.75
+    if used < max_total * normalized_ratio or used >= max_total:
+        return None
+    return (
+        f"[KANBAN_BUDGET_CHECKPOINT {used}/{max_total}] "
+        "The execution budget is entering its closure window. Stop expanding "
+        "scope. Finish and verify the current atomic claim if feasible; "
+        "otherwise preserve a concise partial handoff covering completed work, "
+        "changed files, exact tests, remaining work, resume action, and safety "
+        "invariants. Do not claim PASS, approval, or deployment without actual "
+        "verification. Do not create duplicate review or handoff cards."
+    )
 
 
 class IterationBudget:
@@ -59,4 +143,8 @@ class IterationBudget:
             return max(0, self.max_total - self._used)
 
 
-__all__ = ["IterationBudget"]
+__all__ = [
+    "CURRENT_TURN_ID_KEY",
+    "IterationBudget",
+    "kanban_checkpoint_warning",
+]

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -28,8 +28,13 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from agent.agent_runtime_helpers import provider_visible_messages
 from agent.conversation_compression import conversation_history_after_compression
-from agent.iteration_budget import IterationBudget
+from agent.iteration_budget import (
+    CURRENT_TURN_ID_KEY,
+    _current_turn_user_index,
+    IterationBudget,
+)
 from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
@@ -86,7 +91,10 @@ def _should_run_preflight_estimate(
     """
     if len(messages) > protect_first_n + protect_last_n + 1:
         return True
-    return estimate_messages_tokens_rough(messages) >= threshold_tokens
+    return (
+        estimate_messages_tokens_rough(provider_visible_messages(messages))
+        >= threshold_tokens
+    )
 
 
 @dataclass
@@ -300,6 +308,7 @@ def build_turn_context(
         user_msg = {"role": "user", "content": user_message}
         if isinstance(pending_cli_message, dict):
             agent._pending_cli_user_message = None
+    user_msg[CURRENT_TURN_ID_KEY] = turn_id
 
     # Hydrate todo store from conversation history.
     if conversation_history and not agent._todo_store.has_items():
@@ -418,7 +427,7 @@ def build_turn_context(
         agent.context_compressor.threshold_tokens,
     ):
         _preflight_tokens = estimate_request_tokens_rough(
-            messages,
+            provider_visible_messages(messages),
             system_prompt=active_system_prompt or "",
             tools=agent.tools or None,
         )
@@ -502,7 +511,7 @@ def build_turn_context(
                 # recognised as progress instead of being misread as
                 # "Cannot compress further". Fixes #39548.
                 _preflight_tokens = estimate_request_tokens_rough(
-                    messages,
+                    provider_visible_messages(messages),
                     system_prompt=active_system_prompt or "",
                     tools=agent.tools or None,
                 )
@@ -609,6 +618,14 @@ def build_turn_context(
             ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
         except Exception:
             pass
+
+    # Compression rebuilds protected tail messages as fresh dictionaries and
+    # may move the current user turn. Recompute the cursor from its private,
+    # wire-stripped turn marker instead of returning the pre-compression index.
+    resolved_turn_user_idx = _current_turn_user_index(messages, turn_id)
+    if resolved_turn_user_idx is not None:
+        current_turn_user_idx = resolved_turn_user_idx
+        agent._persist_user_message_idx = resolved_turn_user_idx
 
     return TurnContext(
         user_message=user_message,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -103,31 +103,33 @@ def finalize_turn(
         # came from the summary call or an explicitly pending continuation;
         # both exhausted the task budget and must advance the failure circuit.
         #
-        # We route through ``_record_task_failure(outcome="timed_out")``
-        # rather than ``kanban_block`` so this counts toward the dispatcher's
-        # consecutive-failure circuit breaker (#29747 gap 2).
+        # We route through ``record_iteration_budget_exhaustion`` rather than
+        # ``kanban_block`` so the policy can persist one bounded handoff, avoid
+        # duplicate terminal events, and still advance the failure circuit.
         _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
-        if _kanban_task:
+        _kanban_run_raw = os.environ.get("HERMES_KANBAN_RUN_ID")
+        try:
+            _kanban_run_id = int(_kanban_run_raw) if _kanban_run_raw else None
+        except (TypeError, ValueError):
+            _kanban_run_id = None
+        if _kanban_task and _kanban_run_id is not None:
             try:
                 from hermes_cli import kanban_db as _kb
                 _conn = _kb.connect()
                 try:
-                    _kb._record_task_failure(
+                    _kb.record_iteration_budget_exhaustion(
                         _conn,
                         _kanban_task,
+                        expected_run_id=_kanban_run_id,
                         error=(
                             f"Iteration budget exhausted "
                             f"({api_call_count}/{agent.max_iterations}) — "
                             "task could not complete within the allowed "
                             "iterations"
                         ),
-                        outcome="timed_out",
-                        release_claim=True,
-                        end_run=True,
-                        event_payload_extra={
-                            "budget_used": api_call_count,
-                            "budget_max": agent.max_iterations,
-                        },
+                        partial_summary=final_response,
+                        budget_used=api_call_count,
+                        budget_max=agent.max_iterations,
                     )
                     logger.info(
                         "recorded budget-exhausted failure for task %s (%d/%d)",

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1126,6 +1126,18 @@ delegation:
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
 
 # =============================================================================
+# Kanban Execution Contract
+# =============================================================================
+# Defaults preserve the existing task lifecycle and full worker context. The
+# opt-in modes reduce repeated work without removing tools, tests, or review
+# gates. See website/docs/user-guide/features/kanban.md for the full contract.
+kanban:
+  granularity_guard: warn       # off | warn | triage | allow
+  context_profile: full         # full | compact (48 KiB aggregate UTF-8 cap)
+  budget_exhaustion_policy: retry  # retry | block | triage_once
+  budget_warning_ratio: 0.75    # One API-only checkpoint in [0.5, 1.0)
+
+# =============================================================================
 # Honcho Integration (Cross-Session User Modeling)
 # =============================================================================
 # AI-native persistent memory via Honcho (https://honcho.dev/).

--- a/docs/benchmarks/kanban-context-synthetic-v1.json
+++ b/docs/benchmarks/kanban-context-synthetic-v1.json
@@ -1,0 +1,42 @@
+{
+  "benchmark": "kanban_worker_context_synthetic_v1",
+  "caveat": "Token counts are a transparent 4-UTF-8-bytes/token approximation; provider tokenizers and cache behavior vary.",
+  "compact": {
+    "approx_tokens_at_4_bytes_per_token": 12288,
+    "utf8_bytes": 49152
+  },
+  "contracts": {
+    "attempt_omission_marker_present": true,
+    "cli_recovery_marker_present": true,
+    "comment_omission_marker_present": true,
+    "compact_under_48k_utf8": true,
+    "compact_under_half_of_full": true,
+    "model_tool_recovery_marker_present": true,
+    "parent_omission_marker_present": true,
+    "task_body_preserved": true
+  },
+  "fixture": {
+    "comments": 40,
+    "parents": 20,
+    "prior_attempts": 8,
+    "task_body_chars": 8012
+  },
+  "full": {
+    "approx_tokens_at_4_bytes_per_token": 85217,
+    "utf8_bytes": 340866
+  },
+  "omissions": {
+    "comments": 34,
+    "parents": 12,
+    "prior_attempts": 7
+  },
+  "recovery": {
+    "cli": "hermes kanban context <task_id> --run-id <run_id> --field partial_summary_full",
+    "model_tool": "kanban_show(task_id=<task_id>, full_context=true)"
+  },
+  "savings": {
+    "approx_tokens_at_4_bytes_per_token": 72929,
+    "percent": 85.58,
+    "utf8_bytes": 291714
+  }
+}

--- a/docs/plans/2026-07-17-kanban-execution-contract.md
+++ b/docs/plans/2026-07-17-kanban-execution-contract.md
@@ -1,0 +1,192 @@
+# Kanban Execution Contract Implementation Plan
+
+> **For Hermes:** implement task-by-task with TDD; use deterministic tooling for inspection/benchmarks and one independent review only after the postimage is frozen.
+
+**Goal:** Reduce Kanban token waste from oversized cards, repeated context, redundant reviews, iteration exhaustion, and blind retries without weakening safety gates, tools, model capability, or evidence quality.
+
+**Architecture:** Add a deterministic **Kanban Execution Contract (KEC)** around the existing task/run schema. A pure analyzer classifies scope before dispatch; oversized work can be routed to existing triage/decomposition. Compact context remains reversible through a full-context escape hatch. Exact-postimage reviews use existing idempotency storage through a first-class `review_key`. Kanban workers receive one advisory, cache-stable checkpoint warning and budget-exhausted runs persist one bounded, explicitly unverified continuation handoff; an opt-in `triage_once` policy replaces blind same-card retries with decomposition.
+
+**Tech Stack:** Python 3.11+, stdlib dataclasses/regex, SQLite-backed Kanban, argparse, pytest.
+
+**Compatibility and safety defaults:**
+
+- Lifecycle and context behavior remain compatible by default: `granularity_guard: warn`, `context_profile: full`, and `budget_exhaustion_policy: retry`.
+- `kanban.budget_warning_ratio: 0.75` adds only an advisory API-tail marker and idempotent audit event; it does not alter lifecycle, the cached system prompt, or persisted conversation history.
+- Operators can opt into `triage`, `compact`, `block`, or `triage_once`; `allow` remains an explicit per-card broad-scope override.
+- Compact context never deletes evidence. `kanban context --full` and
+  `kanban_show(full_context=true)` expose the historical bounded profile; an
+  exact full budget handoff is recovered with its hash-bound `CONTEXT_REF`
+  command (`context <task> --run-id <run> --field partial_summary_full`).
+- Review deduplication is exact and explicit (`review_key`), not inferred from prose.
+- No automatic approval, review PASS, controller decision, deployment, or external action is introduced.
+
+---
+
+### Task 1: Establish deterministic scope assessment
+
+**Objective:** Classify a card as `ok`, `caution`, or `split` using structural signals rather than an LLM call.
+
+**Files:**
+- Create: `hermes_cli/kanban_budget.py`
+- Create: `tests/hermes_cli/test_kanban_budget.py`
+
+**Steps:**
+1. Write RED tests for a narrow bugfix, a broad Nexo-style lifecycle card, Spanish action verbs, many acceptance criteria, and deterministic JSON output.
+2. Run `python -m pytest -q tests/hermes_cli/test_kanban_budget.py`; expect import/test failures.
+3. Implement `TaskBudgetAssessment` and `assess_task(title, body, max_turns=60)` with explicit action-family/reason counters and no network/model dependency.
+4. Re-run the focused tests; expect PASS.
+5. Commit `feat(kanban): add deterministic task budget assessment`.
+
+### Task 2: Apply the granularity guard at creation
+
+**Objective:** Persist every assessment and optionally route `split` cards to existing Triage before any worker spends tokens.
+
+**Files:**
+- Modify: `hermes_cli/kanban_db.py:create_task`
+- Modify: `hermes_cli/config.py:DEFAULT_CONFIG["kanban"]`
+- Modify: `hermes_cli/kanban.py:create parser/handler`
+- Modify: `tests/hermes_cli/test_kanban_db.py`
+- Modify: `tests/hermes_cli/test_kanban_cli.py` or nearest create-command tests
+
+**Steps:**
+1. Write RED tests proving `warn` records `granularity_assessed` without changing status, `triage` parks an oversized task in Triage, and `allow` preserves an intentional broad card.
+2. Run focused tests and confirm RED.
+3. Add `granularity_policy` to `create_task`; resolve `off|warn|triage|allow` fail-closed to `warn` on invalid config.
+4. Append a bounded `granularity_assessed` event with verdict, score, reasons, action families, estimated context tokens, and suggested shards.
+5. Add CLI `--allow-broad`; keep default compatibility.
+6. Re-run focused tests; expect PASS.
+7. Commit `feat(kanban): preflight oversized tasks before dispatch`.
+
+### Task 3: Add exact-postimage review deduplication
+
+**Objective:** Prevent duplicate reviews of the same immutable postimage and claim contract without suppressing deliberate new review rounds.
+
+**Files:**
+- Modify: `hermes_cli/kanban_db.py:create_task`
+- Modify: `hermes_cli/kanban.py`
+- Modify: `tools/kanban_tools.py`
+- Modify: `plugins/kanban/dashboard/plugin_api.py`
+- Modify: relevant CLI/tool/API tests
+
+**Steps:**
+1. Write RED tests: identical `review_key` returns the existing non-archived task; a different hash/round creates a new task; conflicting explicit idempotency/review keys are rejected.
+2. Run focused tests; confirm RED.
+3. Validate the postimage and claims SHA-256 values, then map `review_key` onto the reserved, versioned `idempotency_key` namespace (`review:v1:<postimage>:<claims>[:round-N]`), avoiding a schema migration and preventing generic keys from reserving review identities.
+4. Expose `--review-key`, model-tool `review_key`, and dashboard API `review_key`.
+5. Re-run tests; expect PASS.
+6. Commit `feat(kanban): deduplicate exact-postimage reviews`.
+
+### Task 4: Add a reversible compact worker-context profile
+
+**Objective:** Bound retry/parent/comment context while retaining a full-context escape hatch.
+
+**Files:**
+- Modify: `hermes_cli/kanban_db.py:build_worker_context`
+- Modify: `hermes_cli/config.py`
+- Modify: `hermes_cli/kanban.py:context`
+- Modify: `tools/kanban_tools.py:kanban_show`
+- Modify: `tests/hermes_cli/test_kanban_db.py`
+- Modify: `tests/tools/test_kanban_tools.py`
+
+**Steps:**
+1. Write RED tests with large run summaries, comments, and >8 parents. Assert compact mode keeps bounded title/body/latest handoff and `CONTEXT_REF`, lists omitted parent IDs, and is materially shorter; assert the explicit run-field reader recovers the full handoff exactly.
+2. Run focused tests; confirm RED.
+3. Add context-limit profiles: current values for `full`; bounded attempts/comments/parents/field sizes plus an aggregate 48 KiB UTF-8 ceiling for `compact`.
+4. Add explicit omission markers that distinguish bounded full-profile retrieval from exact hash-bound handoff recovery.
+5. Add `kanban context --full`, `kanban_show(full_context=true)`, and the read-only exact field surface `kanban context <task> --run-id <run> --field partial_summary_full`.
+6. Re-run tests; expect PASS.
+7. Commit `feat(kanban): add reversible compact worker context`.
+
+### Task 5: Preserve a compact continuation handoff at exhaustion
+
+**Objective:** Ensure a budget-exhausted worker never forces the next worker to rediscover completed work.
+
+**Files:**
+- Modify: `agent/chat_completion_helpers.py:handle_max_iterations`
+- Modify: `agent/turn_finalizer.py:finalize_turn`
+- Modify: `hermes_cli/kanban_db.py:_record_task_failure`
+- Create: `tests/agent/test_iteration_limit_handoff_prompt.py`
+- Modify: `tests/agent/test_turn_finalizer_iteration_limit_exit.py`
+- Create: `tests/hermes_cli/test_kanban_execution_contract.py`
+
+**Steps:**
+1. Write RED tests proving one bounded `[partial_unverified]` run summary is stored, no duplicate comment is injected, and retry context sees the handoff exactly once.
+2. Run focused tests; confirm RED.
+3. For Kanban workers, request a compact fixed-section continuation summary (`completed`, `changed`, `tests`, `remaining`, `resume`, `invariants`) on the existing toolless summary call.
+4. Add optional `partial_summary` plumbing to `_record_task_failure`; persist one structured 4 KiB UTF-8 summary with all required sections and retain the hash-bound full source once in run metadata.
+5. Forward the summary from `turn_finalizer`; retain existing circuit-breaker semantics.
+6. Re-run tests; expect PASS.
+7. Commit `fix(kanban): preserve bounded exhaustion handoffs`.
+
+### Task 6: Add opt-in checkpoint pressure and triage-once recovery
+
+**Objective:** Warn before the hard wall and replace blind same-card retries with one decomposition opportunity.
+
+**Files:**
+- Modify: `agent/iteration_budget.py`
+- Modify: `agent/conversation_loop.py`
+- Modify: `agent/turn_finalizer.py`
+- Modify: `hermes_cli/kanban_db.py`
+- Modify: `hermes_cli/config.py`
+- Create: `tests/agent/test_iteration_budget_checkpoint.py`
+- Modify: `tests/run_agent/test_run_agent.py`
+- Modify: Kanban DB/finalizer tests
+
+**Steps:**
+1. Write RED tests for non-Kanban isolation, one ephemeral Kanban checkpoint message at the configured ratio, no persistent transcript mutation, and no premature “stop now” language.
+2. Write RED tests for `retry` compatibility, first `triage_once` exhaustion routing to Triage, and second exhaustion staying blocked.
+3. Run focused tests; confirm RED.
+4. Implement the pure pressure-message policy and attach it only to the latest previously unseen tool-result tail in the per-call API copy, preserving a byte-stable prefix thereafter.
+5. Add `budget_exhaustion_policy: retry|block|triage_once`; fail invalid values to `retry`.
+6. Add a bounded `budget_triaged` event and one-shot guard.
+7. Re-run tests; expect PASS.
+8. Commit `feat(kanban): checkpoint and decompose budget-exhausted work`.
+
+### Task 7: Make decomposition budget-aware
+
+**Objective:** Ensure Triage creates atomic implementation → closure → review → controller graphs and reuses the saved handoff.
+
+**Files:**
+- Modify: `hermes_cli/kanban_decompose.py`
+- Modify: `tests/hermes_cli/test_kanban_decompose.py`
+
+**Steps:**
+1. Write RED tests that the decomposer request contains latest partial handoff, scope assessment, immutable-review guidance, review-key guidance, and “full matrix only at closure”.
+2. Run focused tests; confirm RED.
+3. Update prompt/template construction with bounded handoff and assessment data.
+4. Add lifecycle/sharding constraints without increasing decomposer call count.
+5. Re-run tests; expect PASS.
+6. Commit `feat(kanban): make decomposition execution-budget aware`.
+
+### Task 8: Add operator visibility and documentation
+
+**Objective:** Make the method measurable through existing task events, explicit CLI/API knobs, documentation, and a reproducible benchmark.
+
+**Files:**
+- Modify: `hermes_cli/kanban.py`
+- Modify: `website/docs/user-guide/features/kanban.md`
+- Add/modify CLI tests
+- Add: `scripts/benchmark_kanban_context.py`
+- Add: `docs/benchmarks/kanban-context-synthetic-v1.json`
+
+**Steps:**
+1. Surface the deterministic assessment through the existing `granularity_assessed` event on every created task.
+2. Document safe defaults, opt-in settings, review keys, full-context escape hatch, and lifecycle examples.
+3. Add a deterministic synthetic full-versus-compact context benchmark with transparent token approximation.
+4. Run docs/config/schema tests.
+
+### Task 9: Verify and benchmark
+
+**Objective:** Prove correctness and quantify the improvement without claiming unmeasured model-cost savings.
+
+**Steps:**
+1. Run all focused tests for agent finalization, Kanban DB, CLI, tools, dashboard API, decomposer, config, and gateway watcher.
+2. Run `git diff --check`, formatter/linter required by repository guidance, and compile the changed modules.
+3. Run a synthetic benchmark comparing current/full versus optimized/compact contexts:
+   - context chars and 4-char token estimate;
+   - compact-size and full-recovery contracts;
+   - byte-identical regeneration of the JSON artifact.
+   Retry, review-deduplication, and granularity-policy behavior remain executable test contracts rather than synthetic cost claims.
+4. Run one independent code/security review on the frozen diff; remediate findings once, then rerun focused tests.
+5. Persist the deterministic benchmark JSON under `docs/benchmarks/`; keep exact test and review commands in the pull request receipt.
+6. Do not activate the patch in the live gateway while unrelated workers are running. Install/restart only after a clean drain and explicit runtime verification.

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1171,6 +1171,26 @@ class GatewayKanbanWatchersMixin:
                     for tid in triage_ids:
                         if attempted >= auto_decompose_per_tick:
                             break
+                        try:
+                            with _kb.connect_closing() as _attempt_conn:
+                                cause, generation = _kb.auto_decompose_scope(
+                                    _attempt_conn,
+                                    tid,
+                                )
+                                reserved = _kb.claim_auto_decompose_attempt(
+                                    _attempt_conn,
+                                    tid,
+                                    cause=cause,
+                                    generation=generation,
+                                )
+                        except Exception:
+                            logger.exception(
+                                "kanban auto-decompose: attempt claim failed on %s",
+                                tid,
+                            )
+                            continue
+                        if not reserved:
+                            continue
                         attempted += 1
                         try:
                             outcome = _decomp.decompose_task(
@@ -1181,7 +1201,28 @@ class GatewayKanbanWatchersMixin:
                                 "kanban auto-decompose: decompose_task crashed on %s",
                                 tid,
                             )
+                            with _kb.connect_closing() as _finish_conn:
+                                _kb.finish_auto_decompose_attempt(
+                                    _finish_conn,
+                                    tid,
+                                    cause=cause,
+                                    generation=generation,
+                                    success=False,
+                                    transient=True,
+                                )
                             continue
+                        transient_failure = outcome.reason.startswith(
+                            ("LLM error:", "auxiliary client unavailable")
+                        )
+                        with _kb.connect_closing() as _finish_conn:
+                            _kb.finish_auto_decompose_attempt(
+                                _finish_conn,
+                                tid,
+                                cause=cause,
+                                generation=generation,
+                                success=outcome.ok,
+                                transient=transient_failure,
+                            )
                         if outcome.ok:
                             successes += 1
                             if outcome.fanout and outcome.child_ids:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2829,6 +2829,22 @@ DEFAULT_CONFIG = {
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
+        # Deterministic task-scope preflight. ``warn`` records the assessment
+        # without changing lifecycle (backward compatible); ``triage`` routes
+        # cards classified as split to the existing decomposer before dispatch;
+        # ``off``/``allow`` keep intentional broad cards runnable.
+        "granularity_guard": "warn",
+        # Worker-context rendering profile. ``full`` preserves the historical
+        # caps. ``compact`` keeps the latest handoff and a bounded parent/comment
+        # envelope; operators can always request full context explicitly.
+        "context_profile": "full",
+        # Budget-exhaustion recovery. ``retry`` preserves the historical circuit
+        # breaker. ``block`` stops after the first exhausted run. ``triage_once``
+        # preserves a handoff and gives the decomposer one opportunity to shard.
+        "budget_exhaustion_policy": "retry",
+        # One API-only, cache-stable closure marker per Kanban run. Values
+        # outside [0.5, 1.0) fail safely to 0.75 at runtime.
+        "budget_warning_ratio": 0.75,
         # Worker stdout/stderr logs rotate at spawn time. Defaults preserve
         # the historical 2 MiB + one-backup behavior; long-running workers can
         # raise these to keep more early failure evidence.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -324,8 +324,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--triage", action="store_true",
                           help="Park in triage — a specifier will flesh out the spec and promote to todo")
     p_create.add_argument("--idempotency-key", default=None,
-                          help="Dedup key. If a non-archived task with this key exists, "
+                          help="Dedup key. If a non-archived task with the same key exists, "
                                "its id is returned instead of creating a duplicate.")
+    p_create.add_argument(
+        "--review-key",
+        default=None,
+        help="Exact review dedup key, normally "
+             "<postimage-sha256>:<claims-sha256>[:round-N]. A non-archived "
+             "review with the same key is reused.",
+    )
+    p_create.add_argument(
+        "--allow-broad",
+        action="store_true",
+        help="Explicitly bypass kanban.granularity_guard=triage for an "
+             "intentional broad card. The assessment is still recorded.",
+    )
     p_create.add_argument("--max-runtime", default=None,
                           help="Per-task runtime cap. Accepts seconds (300) or "
                                "durations (90s, 30m, 2h, 1d). When exceeded, "
@@ -797,6 +810,24 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
              "(title + body + parent results + comments).",
     )
     p_ctx.add_argument("task_id")
+    p_ctx.add_argument(
+        "--full",
+        action="store_true",
+        help="Bypass kanban.context_profile=compact and print every bounded "
+             "attempt, parent handoff, and comment available in full mode.",
+    )
+    p_ctx.add_argument(
+        "--run-id",
+        type=int,
+        default=None,
+        help="With --field, read one hash-bound field from this task run.",
+    )
+    p_ctx.add_argument(
+        "--field",
+        choices=("partial_summary_full",),
+        default=None,
+        help="With --run-id, emit the exact referenced value without truncation.",
+    )
 
     # --- specify --- (triage → todo via auxiliary LLM)
     p_specify = sub.add_parser(
@@ -1365,6 +1396,10 @@ def _cmd_create(args: argparse.Namespace) -> int:
             parents=tuple(args.parent or ()),
             triage=bool(getattr(args, "triage", False)),
             idempotency_key=getattr(args, "idempotency_key", None),
+            review_key=getattr(args, "review_key", None),
+            granularity_policy=(
+                "allow" if bool(getattr(args, "allow_broad", False)) else None
+            ),
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
@@ -2641,8 +2676,33 @@ def _cmd_runs(args: argparse.Namespace) -> int:
 
 
 def _cmd_context(args: argparse.Namespace) -> int:
+    run_id = getattr(args, "run_id", None)
+    field = getattr(args, "field", None)
+    if (run_id is None) != (field is None):
+        print("kanban context: --run-id and --field must be passed together", file=sys.stderr)
+        return 2
+    if run_id is not None and bool(getattr(args, "full", False)):
+        print("kanban context: --full cannot be combined with --run-id/--field", file=sys.stderr)
+        return 2
     with kb.connect_closing() as conn:
-        text = kb.build_worker_context(conn, args.task_id)
+        if run_id is not None:
+            try:
+                text = kb.read_run_metadata_field(
+                    conn,
+                    task_id=args.task_id,
+                    run_id=run_id,
+                    field=field,
+                )
+            except ValueError as exc:
+                print(f"kanban context: {exc}", file=sys.stderr)
+                return 2
+            sys.stdout.write(text)
+            return 0
+        text = kb.build_worker_context(
+            conn,
+            args.task_id,
+            compact=False if bool(getattr(args, "full", False)) else None,
+        )
     print(text)
     return 0
 

--- a/hermes_cli/kanban_budget.py
+++ b/hermes_cli/kanban_budget.py
@@ -1,0 +1,371 @@
+"""Deterministic execution-budget preflight for Kanban tasks.
+
+The analyzer is intentionally lexical and side-effect free: it never calls an
+LLM, reads the filesystem, or mutates the board.  It is a conservative routing
+signal, not a quality verdict.  ``split`` means the card spans enough lifecycle
+families that dispatching it as one worker run is likely to waste iterations;
+it does *not* mean any requested operation is forbidden.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import unicodedata
+from dataclasses import asdict, dataclass
+from typing import Iterable
+
+
+CAUTION_THRESHOLD = 3
+SPLIT_THRESHOLD = 6
+_REVIEW_KEY_RE = re.compile(
+    r"^(?P<postimage>[0-9a-f]{64}):(?P<claims>[0-9a-f]{64})"
+    r"(?::round-(?P<round>[1-9][0-9]*))?$"
+)
+_FILE_REF_RE = re.compile(
+    r"(?<![\w.-])(?:[\w.-]+/)*[\w.-]+\."
+    r"(?:py|pyi|js|jsx|ts|tsx|go|rs|java|kt|swift|rb|php|sh|bash|zsh|"
+    r"json|ya?ml|toml|md|sql|html|css|scss|xml|plist)\b",
+    re.IGNORECASE,
+)
+_ACCEPTANCE_RE = re.compile(
+    r"(?m)^\s*(?:[-*+]\s+|\d+[.)]\s+|\[[ xX]\]\s+)",
+)
+
+
+def _plain(text: str) -> str:
+    normalized = unicodedata.normalize("NFKD", text or "")
+    return "".join(ch for ch in normalized if not unicodedata.combining(ch)).lower()
+
+
+def _signal_text(title: str, body: str) -> str:
+    text = _plain(f"{title}\n{body}")
+    # A safety constraint such as "without activating" must not make a
+    # report-only card look like it also contains a deployment phase.
+    return re.sub(
+        r"\b(?:without|do not|dont|never|sin|no)\s+"
+        r"(?:\w+\s+){0,3}(?:activat\w*|deploy\w*|publish\w*|"
+        r"roll\s+out|make\s+(?:\w+\s+){0,2}live|go\s+live|"
+        r"make\s+(?:\w+\s+){0,2}available|send\w*|submit\w*|"
+        r"despl(?:eg|ieg)\w*|"
+        r"public(?:ar\w*|acion\w*|ad[oa]s?|and[oa]\w*|[oa]s?|an)|"
+        r"publiqu\w*|lanz\w*|"
+        r"(?:hacer(?:la|lo|las|los)?|hace\w*|haz(?:la|lo|las|los)?|dejar)\s+"
+        r"(?:\w+\s+){0,2}disponible|"
+        r"enviar\w*|presentar\w*)",
+        "",
+        text,
+    )
+
+
+_ACTION_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "discovery",
+        re.compile(
+            r"\b(?:investig\w*|inspect\w*|diagnos\w*|analys\w*|analyz\w*|"
+            r"disen\w*|design\w*|architect\w*|planif\w*|plan\w*)\b"
+        ),
+    ),
+    (
+        "implementation",
+        re.compile(
+            r"\b(?:implement\w*|fix\w*|corrig\w*|correct\w*|patch\w*|"
+            r"modif\w*|creat\w*|regener\w*|harden\w*|remedi\w*|escrib\w*)\b"
+        ),
+    ),
+    (
+        "verification",
+        re.compile(
+            r"\b(?:test\w*|prueb\w*|verif\w*|valid\w*|pytest|suite\w*|"
+            r"matrix|matriz|dual[- ]?runtime|compil\w*|lint\w*|ruff)\b"
+        ),
+    ),
+    (
+        "evidence",
+        re.compile(
+            r"\b(?:receipt\w*|recibo\w*|hash\w*|freeze\w*|congel\w*|"
+            r"manifest\w*|artifact\w*|artefact\w*|report\w*|informe\w*|"
+            r"binding\w*|evidenc\w*|checkpoint\w*)\b"
+        ),
+    ),
+    (
+        "review",
+        re.compile(
+            r"\b(?:review\w*|revision\w*|rereview\w*|adversarial\w*|"
+            r"audit\w*|independent\w*|independiente\w*)\b"
+        ),
+    ),
+    (
+        "controller",
+        re.compile(
+            r"\b(?:controller\w*|controlador\w*|approv\w*|aprob\w*|"
+            r"verdict\w*|gate\w*|go/no-go)\b"
+        ),
+    ),
+    (
+        "activation",
+        re.compile(
+            r"\b(?:deploy\w*|despl(?:eg|ieg)\w*|activat\w*|activar\w*|publish\w*|"
+            r"public(?:ar\w*|acion\w*|ad[oa]s?|and[oa]\w*|[oa]s?|an)|"
+            r"publiqu\w*|roll\s+out|rollout\w*|"
+            r"make\s+(?:\w+\s+){0,2}live|go\s+live|"
+            r"make\s+(?:\w+\s+){0,2}available|"
+            r"(?:hacer(?:la|lo|las|los)?|hace\w*|haz(?:la|lo|las|los)?|dejar)\s+"
+            r"(?:\w+\s+){0,2}disponible|"
+            r"releas\w*\s+(?:(?:version|build|package|release)\b|"
+            r"(?:\w+\s+){0,4}(?:to|into)\s+production)|"
+            r"ship\w*\s+(?:(?:version|build|package|release)\b|"
+            r"(?:\w+\s+){0,4}(?:to\s+production|live))|"
+            r"promot\w*\s+(?:\w+\s+){0,4}(?:to\s+production|live)|"
+            r"send\w*|submit\w*|enviar\w*|presentar\w*|"
+            r"lanz\w*\s+(?:\w+\s+){0,3}(?:version|produccion|usuarios)|"
+            r"liberar\w*\s+(?:\w+\s+){0,4}(?:version|produccion)|"
+            r"promover\w*\s+(?:\w+\s+){0,4}(?:a\s+produccion|entorno\s+vivo)|"
+            r"poner\s+(?:\w+\s+){0,3}en\s+produccion|"
+            r"pasar\s+(?:\w+\s+){0,3}a\s+produccion)\b"
+        ),
+    ),
+)
+
+
+_SENSITIVE_FAMILY_KINDS: dict[str, frozenset[str]] = {
+    "review": frozenset({"review", "review_scheduler", "controller"}),
+    "controller": frozenset({"review", "review_scheduler", "controller", "activation"}),
+    "activation": frozenset({"activation"}),
+}
+
+
+def incompatible_decomposition_family(
+    kind: str,
+    action_families: Iterable[str],
+) -> str | None:
+    """Return the first sensitive family incompatible with ``kind``.
+
+    Decomposition kinds are an authorization boundary, not descriptive labels.
+    Lexically detected review/controller/activation work must therefore never be
+    materialized as generic ``work`` merely because an LLM supplied that label.
+    ``activation`` is additionally explicit: callers may choose it even when
+    conservative lexical detection finds no activation phrase, and the DB will
+    still hold the task behind human approval.
+    """
+    normalized_kind = str(kind or "work").strip().lower()
+    present = set(action_families)
+    for family in ("activation", "controller", "review"):
+        allowed_kinds = _SENSITIVE_FAMILY_KINDS[family]
+        if family in present and normalized_kind not in allowed_kinds:
+            return family
+    return None
+
+
+@dataclass(frozen=True)
+class TaskBudgetAssessment:
+    """Stable, JSON-friendly result of a task scope preflight."""
+
+    verdict: str
+    score: int
+    caution_threshold: int
+    split_threshold: int
+    estimated_context_tokens: int
+    estimated_turns: int
+    max_turns: int
+    body_chars: int
+    acceptance_items: int
+    file_references: int
+    action_families: tuple[str, ...]
+    reasons: tuple[str, ...]
+    suggested_shards: tuple[str, ...]
+
+    def to_dict(self) -> dict:
+        value = asdict(self)
+        # asdict preserves tuples; lists are friendlier and stable at JSON/API
+        # boundaries, and avoid consumers relying on Python-only tuple semantics.
+        for key in ("action_families", "reasons", "suggested_shards"):
+            value[key] = list(value[key])
+        return value
+
+
+def _ordered_families(text: str) -> tuple[str, ...]:
+    return tuple(name for name, pattern in _ACTION_PATTERNS if pattern.search(text))
+
+
+def _suggest_shards(families: Iterable[str]) -> tuple[str, ...]:
+    present = set(families)
+    shards: list[str] = []
+    if "discovery" in present:
+        shards.append("discovery")
+    if "implementation" in present:
+        shards.append("implementation")
+    if {"verification", "evidence"} & present:
+        shards.append("verification_and_evidence")
+    if "review" in present:
+        shards.append("independent_review")
+    if "controller" in present:
+        shards.append("controller")
+    if "activation" in present:
+        shards.append("human_activation_gate")
+    return tuple(shards)
+
+
+def assess_task(
+    title: str, body: str | None, *, max_turns: int = 60
+) -> TaskBudgetAssessment:
+    """Assess semantic task breadth without spending model tokens.
+
+    The score deliberately keys on *lifecycle diversity* more heavily than raw
+    text length.  A concise card can still be oversized when it asks one worker
+    to discover, implement, run a full matrix, write receipts, review itself,
+    and make a controller decision.
+    """
+
+    safe_title = str(title or "")
+    safe_body = str(body or "")
+    signals = _signal_text(safe_title, safe_body)
+    families = _ordered_families(signals)
+    family_set = set(families)
+    acceptance_items = len(_ACCEPTANCE_RE.findall(safe_body))
+    file_references = len({
+        m.group(0).lower() for m in _FILE_REF_RE.finditer(safe_body)
+    })
+    body_chars = len(safe_body)
+    arrow_count = safe_body.count("→") + safe_body.count("->")
+
+    score = 0
+    reasons: list[str] = []
+
+    if body_chars > 6000:
+        score += 2
+        reasons.append("large_body")
+    elif body_chars > 3000:
+        score += 1
+        reasons.append("medium_body")
+
+    if acceptance_items > 10:
+        score += 3
+        reasons.append("many_acceptance_items")
+    elif acceptance_items > 6:
+        score += 1
+        reasons.append("several_acceptance_items")
+
+    if file_references > 8:
+        score += 2
+        reasons.append("many_file_surfaces")
+    elif file_references > 4:
+        score += 1
+        reasons.append("several_file_surfaces")
+
+    family_count = len(families)
+    if family_count >= 6:
+        score += 5
+        reasons.append("many_lifecycle_families")
+    elif family_count == 5:
+        score += 4
+        reasons.append("many_lifecycle_families")
+    elif family_count == 4:
+        score += 3
+        reasons.append("multiple_lifecycle_families")
+    elif family_count == 3:
+        score += 1
+        reasons.append("multiple_lifecycle_families")
+
+    # Four lifecycle owners already imply at least one handoff boundary. Keep
+    # this structural rule independent of prose length and available budget:
+    # more turns do not make self-review or controller coupling atomic.
+    if family_count >= 4:
+        score = max(score, SPLIT_THRESHOLD)
+        reasons.append("four_or_more_lifecycle_families")
+
+    if {"implementation", "verification", "review"}.issubset(family_set):
+        score += 2
+        reasons.append("compound_lifecycle")
+    if {"review", "controller"}.issubset(family_set):
+        score += 1
+        reasons.append("review_controller_coupled")
+    if {"implementation", "activation"}.issubset(family_set):
+        score += 1
+        reasons.append("implementation_activation_coupled")
+
+    if arrow_count >= 4:
+        score += 2
+        reasons.append("long_explicit_pipeline")
+    elif arrow_count >= 2:
+        score += 1
+        reasons.append("explicit_pipeline")
+
+    full_matrix = bool(
+        re.search(
+            r"\b(?:full (?:project )?suite|suite completa|matriz completa|full matrix)\b",
+            signals,
+        )
+    )
+    if full_matrix and "implementation" in family_set:
+        score += 1
+        reasons.append("implementation_plus_full_matrix")
+
+    normalized_max_turns = max(1, int(max_turns))
+    # This is a planning estimate, not a hard cap.  It intentionally errs on
+    # the high side for lifecycle handoffs and acceptance-heavy cards.
+    estimated_turns = (
+        4
+        + (4 * family_count)
+        + math.ceil(acceptance_items / 2)
+        + min(file_references, 10)
+        + (4 if full_matrix else 0)
+    )
+    if estimated_turns > normalized_max_turns:
+        reasons.append("estimated_turns_exceed_budget")
+        if estimated_turns > normalized_max_turns * 1.5:
+            score = max(score, SPLIT_THRESHOLD)
+        else:
+            score = max(score, CAUTION_THRESHOLD)
+
+    if score >= SPLIT_THRESHOLD:
+        verdict = "split"
+    elif score >= CAUTION_THRESHOLD:
+        verdict = "caution"
+    else:
+        verdict = "ok"
+
+    estimated_context_tokens = math.ceil((len(safe_title) + body_chars) / 4)
+
+    return TaskBudgetAssessment(
+        verdict=verdict,
+        score=score,
+        caution_threshold=CAUTION_THRESHOLD,
+        split_threshold=SPLIT_THRESHOLD,
+        estimated_context_tokens=estimated_context_tokens,
+        estimated_turns=estimated_turns,
+        max_turns=normalized_max_turns,
+        body_chars=body_chars,
+        acceptance_items=acceptance_items,
+        file_references=file_references,
+        action_families=families,
+        reasons=tuple(reasons),
+        suggested_shards=_suggest_shards(families),
+    )
+
+
+def canonical_review_idempotency_key(review_key: str) -> str:
+    """Map an exact-postimage review key onto Kanban's existing dedup key.
+
+    A caller should normally use ``<postimage-sha256>:<claims-sha256>`` or a
+    canonical composite digest, with an optional ``:round-N`` suffix. Review
+    rounds stay possible, while accidental duplicate reviewers for the exact
+    same immutable postimage and claim contract collapse to one non-archived task.
+    """
+
+    value = str(review_key or "").strip().lower()
+    if not _REVIEW_KEY_RE.fullmatch(value):
+        raise ValueError(
+            "review_key must bind postimage and claims as "
+            "<postimage-sha256>:<claims-sha256>[:round-N]"
+        )
+    return f"review:v1:{value}"
+
+
+__all__ = [
+    "CAUTION_THRESHOLD",
+    "SPLIT_THRESHOLD",
+    "TaskBudgetAssessment",
+    "assess_task",
+    "canonical_review_idempotency_key",
+]

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -287,6 +287,118 @@ _CTX_MAX_FIELD_BYTES    = 4 * 1024   # 4 KB per summary/error/metadata/result
 _CTX_MAX_BODY_BYTES     = 8 * 1024   # 8 KB per task.body (opening post)
 _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 
+# Opt-in compact profile. Full mode above remains the compatibility default;
+# compact mode trades repeated prompt payload for explicit retrieval pointers.
+_CTX_COMPACT_MAX_PRIOR_ATTEMPTS = 1
+_CTX_COMPACT_MAX_COMMENTS = 6
+_CTX_COMPACT_MAX_PARENTS = 8
+_CTX_COMPACT_MAX_ATTACHMENTS = 8
+_CTX_COMPACT_MAX_ATTACHMENT_FIELD_BYTES = 512
+_CTX_COMPACT_MAX_TITLE_BYTES = 1024
+_CTX_COMPACT_MAX_IDENTITY_FIELD_BYTES = 512
+_CTX_COMPACT_MAX_AUTHOR_BYTES = 256
+_CTX_COMPACT_MAX_ROLE_HISTORY = 3
+_CTX_COMPACT_MAX_FIELD_BYTES = 2 * 1024
+_CTX_COMPACT_MAX_COMMENT_BYTES = 1 * 1024
+_CTX_COMPACT_MAX_TOTAL_BYTES = 48 * 1024
+_KANBAN_PARTIAL_SUMMARY_MAX_BYTES = 4 * 1024
+_HANDOFF_SECTION_RE = re.compile(
+    r"(?im)^(COMPLETED|CHANGED_FILES|TESTS|REMAINING|RESUME|INVARIANTS)\s*:\s*"
+)
+_HANDOFF_SECTION_LIMITS = {
+    "COMPLETED": 600,
+    "CHANGED_FILES": 400,
+    "TESTS": 500,
+    "REMAINING": 700,
+    "RESUME": 450,
+    "INVARIANTS": 600,
+}
+
+
+def _compact_worker_context_enabled(explicit: Optional[bool] = None) -> bool:
+    """Resolve the reversible worker-context profile.
+
+    ``None`` follows ``kanban.context_profile``. Invalid/missing config falls
+    back to full context so an optimization setting can never silently remove
+    evidence. Callers can always force either mode explicitly.
+    """
+    if explicit is not None:
+        return bool(explicit)
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        value = str((cfg.get("kanban") or {}).get("context_profile", "full"))
+        return value.strip().lower() == "compact"
+    except Exception:
+        return False
+
+
+def _truncate_utf8(value: str, max_bytes: int, *, marker: str) -> str:
+    """Truncate text without splitting a UTF-8 code point."""
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    marker_bytes = marker.encode("utf-8")
+    keep = max(0, max_bytes - len(marker_bytes))
+    return encoded[:keep].decode("utf-8", errors="ignore") + marker
+
+
+def _normalize_partial_handoff_source(value: Optional[str]) -> Optional[str]:
+    """Return the unclassified source text bound by handoff metadata."""
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    if raw.startswith("[partial_unverified]"):
+        raw = raw[len("[partial_unverified]") :].lstrip()
+    return raw or None
+
+
+def _bounded_partial_handoff(
+    value: Optional[str],
+    *,
+    run_id: Optional[int] = None,
+) -> Optional[str]:
+    """Persist a typed, section-preserving exhaustion handoff within 4 KiB."""
+    raw = _normalize_partial_handoff_source(value)
+    if not raw:
+        return None
+
+    sections: dict[str, str] = {}
+    matches = list(_HANDOFF_SECTION_RE.finditer(raw))
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(raw)
+        content = raw[match.end() : end].strip()
+        name = match.group(1).upper()
+        if content:
+            sections[name] = "\n".join(filter(None, (sections.get(name), content)))
+    if not matches:
+        sections["REMAINING"] = raw
+
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    run_ref = str(run_id) if run_id is not None else "active"
+    lines = [
+        "[partial_unverified]",
+        "FORMAT: kanban_partial_handoff/v1",
+        f"FULL_HANDOFF_SHA256: {digest}",
+        "FULL_HANDOFF_REF: "
+        f"task_runs:{run_ref}.metadata.partial_summary_full",
+    ]
+    for name, limit in _HANDOFF_SECTION_LIMITS.items():
+        content = sections.get(name) or "not reported"
+        content = _truncate_utf8(
+            content,
+            limit,
+            marker="… [section truncated]",
+        )
+        lines.append(f"{name}: {content}")
+    text = "\n".join(lines)
+    return _truncate_utf8(
+        text,
+        _KANBAN_PARTIAL_SUMMARY_MAX_BYTES,
+        marker="\n… [handoff truncated]",
+    )
+
 
 def _relative_age(ts: Optional[int], now: Optional[int] = None) -> str:
     """Render the age of an epoch-seconds timestamp as a coarse, human-
@@ -859,6 +971,9 @@ class Task:
     project_id: Optional[str] = None
     result: Optional[str] = None
     idempotency_key: Optional[str] = None
+    review_contract: Optional[str] = None
+    review_postimage_sha256: Optional[str] = None
+    review_claims_sha256: Optional[str] = None
     # Unified non-success counter. Incremented on any of:
     #   * spawn failure (dispatcher couldn't launch the worker)
     #   * timed_out outcome (worker exceeded max_runtime_seconds)
@@ -948,6 +1063,17 @@ class Task:
             tenant=row["tenant"] if "tenant" in keys else None,
             result=row["result"] if "result" in keys else None,
             idempotency_key=row["idempotency_key"] if "idempotency_key" in keys else None,
+            review_contract=(
+                row["review_contract"] if "review_contract" in keys else None
+            ),
+            review_postimage_sha256=(
+                row["review_postimage_sha256"]
+                if "review_postimage_sha256" in keys else None
+            ),
+            review_claims_sha256=(
+                row["review_claims_sha256"]
+                if "review_claims_sha256" in keys else None
+            ),
             consecutive_failures=(
                 row["consecutive_failures"] if "consecutive_failures" in keys
                 # Pre-migration fallback: ``_migrate_add_optional_columns`` always
@@ -1117,6 +1243,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     tenant               TEXT,
     result               TEXT,
     idempotency_key      TEXT,
+    -- Durable exact-review discriminator and canonical source hashes. Legacy
+    -- rows keep NULL and are never trusted solely because their generic
+    -- idempotency_key happens to use the reserved review:v1 namespace.
+    review_contract      TEXT,
+    review_postimage_sha256 TEXT,
+    review_claims_sha256 TEXT,
     -- Unified consecutive-failure counter. Incremented on spawn
     -- failure, timeout, or crash; reset only on successful completion.
     -- The circuit breaker in _record_task_failure trips when this
@@ -1868,6 +2000,24 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
         )
+    if "review_contract" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "review_contract", "review_contract TEXT"
+        )
+    if "review_postimage_sha256" not in cols:
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "review_postimage_sha256",
+            "review_postimage_sha256 TEXT",
+        )
+    if "review_claims_sha256" not in cols:
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "review_claims_sha256",
+            "review_claims_sha256 TEXT",
+        )
     # ``idx_tasks_idempotency`` is created unconditionally below alongside
     # the other additive-column indexes — see the block after the
     # legacy-column migration. Creating it here too would be redundant.
@@ -2384,6 +2534,135 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+_VALID_GRANULARITY_POLICIES = {"off", "warn", "triage", "allow"}
+
+
+def _resolve_granularity_policy(explicit: Optional[str]) -> tuple[str, bool, int]:
+    """Return ``(policy, invalid, max_turns)`` for task-scope preflight.
+
+    ``create_task`` is used by the CLI, model tools, dashboard API, and the
+    decomposer.  Resolving the policy here keeps every creation surface on the
+    same contract.  Invalid config is intentionally conservative but
+    compatibility-preserving: warn and record, never silently auto-triage.
+    """
+    raw = explicit
+    max_turns = 60
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        kanban_cfg = cfg.get("kanban") or {}
+        agent_cfg = cfg.get("agent") or {}
+        max_turns = int(agent_cfg.get("max_turns") or 60)
+        if raw is None:
+            raw = kanban_cfg.get("granularity_guard", "warn")
+    except Exception:
+        if raw is None:
+            raw = "warn"
+    value = str(raw or "warn").strip().lower()
+    invalid = value not in _VALID_GRANULARITY_POLICIES
+    if invalid:
+        value = "warn"
+    return value, invalid, max(1, max_turns)
+
+
+_EXACT_REVIEW_CONTRACT = "exact_review_v1"
+_REVIEW_KEY_LINE_RE = re.compile(
+    r"^\s*REVIEW_KEY:\s*(?P<review_key>\S(?:.*\S)?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _review_key_body_values(body: Optional[str]) -> list[str]:
+    """Return every structured REVIEW_KEY discriminator in a task body."""
+    return [
+        match.group("review_key")
+        for match in _REVIEW_KEY_LINE_RE.finditer(str(body or ""))
+    ]
+
+
+def _exact_review_identity(
+    review_key: str,
+    *,
+    body: Optional[str] = None,
+    idempotency_key: Optional[str] = None,
+    review_contract: Optional[str] = None,
+    review_postimage_sha256: Optional[str] = None,
+    review_claims_sha256: Optional[str] = None,
+    require_durable: bool = False,
+) -> tuple[str, str, str, str]:
+    """Validate every exact-review discriminator and return one identity."""
+    from hermes_cli.kanban_budget import canonical_review_idempotency_key
+
+    canonical_key = canonical_review_idempotency_key(review_key)
+    parts = canonical_key.split(":")
+    identity = canonical_key, _EXACT_REVIEW_CONTRACT, parts[2], parts[3]
+    body_values = _review_key_body_values(body)
+    if len(body_values) > 1:
+        raise ValueError("exact review body must contain at most one REVIEW_KEY line")
+    if body_values:
+        body_key = canonical_review_idempotency_key(body_values[0])
+        if body_key != canonical_key:
+            raise ValueError(
+                "REVIEW_KEY in exact review body conflicts with structured review_key"
+            )
+
+    supplied_identity = (
+        idempotency_key,
+        review_contract,
+        review_postimage_sha256,
+        review_claims_sha256,
+    )
+    if require_durable and any(value is None for value in supplied_identity):
+        raise ValueError("exact review durable identity contains NULL fields")
+    for label, supplied, expected in zip(
+        (
+            "idempotency_key",
+            "review_contract",
+            "review_postimage_sha256",
+            "review_claims_sha256",
+        ),
+        supplied_identity,
+        identity,
+    ):
+        if supplied is not None and str(supplied).strip().lower() != expected:
+            raise ValueError(f"exact review {label} conflicts with canonical identity")
+    return identity
+
+
+def _reusable_idempotency_incumbent(
+    rows: list[sqlite3.Row],
+    *,
+    exact_review_identity: Optional[tuple[str, str, str, str]] = None,
+) -> Optional[str]:
+    """Resolve one reusable incumbent, failing closed for exact reviews."""
+    if not rows:
+        return None
+    if exact_review_identity is not None:
+        canonical_key = exact_review_identity[0]
+        review_key = ":".join(canonical_key.split(":")[2:])
+        try:
+            if len(rows) != 1:
+                raise ValueError("multiple exact-review incumbents")
+            row = rows[0]
+            _exact_review_identity(
+                review_key,
+                body=row["body"],
+                idempotency_key=canonical_key,
+                review_contract=row["review_contract"],
+                review_postimage_sha256=row["review_postimage_sha256"],
+                review_claims_sha256=row["review_claims_sha256"],
+                require_durable=True,
+            )
+        except ValueError as exc:
+            raise ValueError(
+                "ambiguous legacy exact-review incumbent uses the reserved "
+                "idempotency key without one matching durable review contract "
+                "and canonical hashes"
+            ) from exc
+    return rows[0]["id"]
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -2408,6 +2687,8 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    granularity_policy: Optional[str] = None,
+    review_key: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2435,6 +2716,29 @@ def create_task(
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
+
+    exact_review_identity: Optional[tuple[str, str, str, str]] = None
+    review_contract: Optional[str] = None
+    review_postimage_sha256: Optional[str] = None
+    review_claims_sha256: Optional[str] = None
+    if review_key is not None:
+        if idempotency_key is not None:
+            raise ValueError(
+                "review_key and idempotency_key are mutually exclusive; "
+                "review_key already provides exact-postimage deduplication"
+            )
+        exact_review_identity = _exact_review_identity(review_key, body=body)
+        (
+            idempotency_key,
+            review_contract,
+            review_postimage_sha256,
+            review_claims_sha256,
+        ) = exact_review_identity
+    elif idempotency_key is not None and str(idempotency_key).startswith("review:v1:"):
+        raise ValueError(
+            "idempotency_key uses the reserved review namespace; pass review_key "
+            "with postimage and claims digests instead"
+        )
     if initial_status not in VALID_INITIAL_STATUSES:
         raise ValueError(
             f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}"
@@ -2492,6 +2796,25 @@ def create_task(
 
     parents = tuple(p for p in parents if p)
 
+    from hermes_cli.kanban_budget import assess_task
+
+    resolved_granularity_policy, policy_invalid, assessment_max_turns = (
+        _resolve_granularity_policy(granularity_policy)
+    )
+    granularity_assessment = assess_task(
+        title,
+        body,
+        max_turns=assessment_max_turns,
+    )
+    auto_triaged = bool(
+        granularity_assessment.verdict == "split"
+        and resolved_granularity_policy == "triage"
+        and not triage
+        and initial_status != "blocked"
+    )
+    if auto_triaged:
+        triage = True
+
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
     # (preserving order). Refuse commas inside a single name so we don't
     # invisibly splatter a comma-joined string into one argv slot — the
@@ -2537,20 +2860,26 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
+    # Idempotency fast path. The check is repeated inside the write
+    # transaction below so two connections racing on the same key
+    # cannot both insert after observing the same empty preimage.
+    def _reusable_incumbent(rows: list[sqlite3.Row]) -> Optional[str]:
+        return _reusable_idempotency_incumbent(
+            rows,
+            exact_review_identity=exact_review_identity,
+        )
+
     if idempotency_key:
-        row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
+        incumbent_rows = conn.execute(
+            "SELECT id, body, review_contract, review_postimage_sha256, "
+            "review_claims_sha256 FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
+            "ORDER BY created_at DESC, id DESC",
             (idempotency_key,),
-        ).fetchone()
-        if row:
-            return row["id"]
+        ).fetchall()
+        incumbent_id = _reusable_incumbent(incumbent_rows)
+        if incumbent_id is not None:
+            return incumbent_id
 
     now = int(time.time())
 
@@ -2579,6 +2908,17 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
+                if idempotency_key:
+                    incumbent_rows = conn.execute(
+                        "SELECT id, body, review_contract, review_postimage_sha256, "
+                        "review_claims_sha256 FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC, id DESC",
+                        (idempotency_key,),
+                    ).fetchall()
+                    incumbent_id = _reusable_incumbent(incumbent_rows)
+                    if incumbent_id is not None:
+                        return incumbent_id
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -2635,9 +2975,11 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
+                        review_contract, review_postimage_sha256,
+                        review_claims_sha256,
                         max_runtime_seconds,
                         skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2654,6 +2996,9 @@ def create_task(
                         project_id,
                         tenant,
                         idempotency_key,
+                        review_contract,
+                        review_postimage_sha256,
+                        review_claims_sha256,
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
@@ -2679,7 +3024,22 @@ def create_task(
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
                         "goal_mode": bool(goal_mode) or None,
+                        "review_contract": review_contract,
                     },
+                )
+                assessment_payload = granularity_assessment.to_dict()
+                assessment_payload.update(
+                    {
+                        "policy": resolved_granularity_policy,
+                        "policy_invalid": policy_invalid,
+                        "auto_triaged": auto_triaged,
+                    }
+                )
+                _append_event(
+                    conn,
+                    task_id,
+                    "granularity_assessed",
+                    assessment_payload,
                 )
             return task_id
         except sqlite3.IntegrityError:
@@ -5316,6 +5676,132 @@ def specify_triage_task(
     return True
 
 
+def claim_auto_decompose_attempt(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    cause: str = "legacy",
+    generation: str = "task",
+) -> bool:
+    """Atomically reserve a bounded automatic decomposition attempt.
+
+    Claims are scoped by cause and generation so a later ``triage_once`` run is
+    not consumed by an older granularity attempt. A transient failure may be
+    explicitly released once via :func:`finish_auto_decompose_attempt`; the
+    second failure is terminal for that scope and prevents spend loops.
+    """
+    cause = str(cause or "").strip()
+    generation = str(generation or "").strip()
+    if not cause or len(cause) > 80:
+        raise ValueError("auto-decompose cause must be 1..80 characters")
+    if not generation or len(generation) > 160:
+        raise ValueError("auto-decompose generation must be 1..160 characters")
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None or row["status"] != "triage":
+            return False
+        scoped = [
+            event
+            for event in list_events(conn, task_id)
+            if event.kind.startswith("auto_decompose_")
+            and isinstance(event.payload, dict)
+            and event.payload.get("cause") == cause
+            and event.payload.get("generation") == generation
+        ]
+        attempts = sum(event.kind == "auto_decompose_attempted" for event in scoped)
+        releases = sum(event.kind == "auto_decompose_released" for event in scoped)
+        terminal = any(
+            event.kind in {"auto_decompose_completed", "auto_decompose_abandoned"}
+            for event in scoped
+        )
+        if terminal or attempts >= 2 or attempts > releases:
+            return False
+        _append_event(
+            conn,
+            task_id,
+            "auto_decompose_attempted",
+            {
+                "source": "gateway",
+                "cause": cause,
+                "generation": generation,
+                "attempt": attempts + 1,
+            },
+        )
+    return True
+
+
+def finish_auto_decompose_attempt(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    cause: str,
+    generation: str,
+    success: bool,
+    transient: bool = False,
+) -> str:
+    """Close one claimed auto-decompose scope idempotently."""
+    cause = str(cause or "").strip()
+    generation = str(generation or "").strip()
+    with write_txn(conn):
+        scoped = [
+            event
+            for event in list_events(conn, task_id)
+            if event.kind.startswith("auto_decompose_")
+            and isinstance(event.payload, dict)
+            and event.payload.get("cause") == cause
+            and event.payload.get("generation") == generation
+        ]
+        attempts = sum(event.kind == "auto_decompose_attempted" for event in scoped)
+        releases = sum(event.kind == "auto_decompose_released" for event in scoped)
+        if any(event.kind == "auto_decompose_completed" for event in scoped):
+            return "completed"
+        if any(event.kind == "auto_decompose_abandoned" for event in scoped):
+            return "abandoned"
+        if attempts <= releases:
+            return "not_claimed"
+        payload = {
+            "source": "gateway",
+            "cause": cause,
+            "generation": generation,
+            "attempt": attempts,
+        }
+        if success:
+            _append_event(conn, task_id, "auto_decompose_completed", payload)
+            return "completed"
+        if transient and attempts < 2:
+            _append_event(conn, task_id, "auto_decompose_released", payload)
+            return "released"
+        payload["transient"] = bool(transient)
+        _append_event(conn, task_id, "auto_decompose_abandoned", payload)
+        return "abandoned"
+
+
+def auto_decompose_scope(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> tuple[str, str]:
+    """Bind an automatic attempt to the latest triage-producing evidence."""
+    for event in reversed(list_events(conn, task_id)):
+        if event.kind == "budget_triaged":
+            run_id = event.run_id
+            if run_id is None and isinstance(event.payload, dict):
+                run_id = event.payload.get("run_id")
+            return "budget_triage_once", f"run:{run_id or 'unknown'}"
+        if event.kind == "granularity_assessed" and isinstance(event.payload, dict):
+            digest = hashlib.sha256(
+                json.dumps(
+                    event.payload,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()
+            return "granularity", f"assessment:{digest}"
+    return "legacy", "task"
+
+
 def decompose_triage_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5353,8 +5839,29 @@ def decompose_triage_task(
     """
     if not children:
         return None
+    if len(children) > 6:
+        raise ValueError("decomposition may contain at most 6 children")
+    root_state = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if root_state is None or root_state["status"] != "triage":
+        return None
+    children = [dict(child) if isinstance(child, dict) else child for child in children]
     if root_assignee is not None:
         root_assignee = _canonical_assignee(root_assignee)
+
+    from hermes_cli.kanban_budget import (
+        assess_task,
+        incompatible_decomposition_family,
+    )
+
+    granularity_policy, policy_invalid, assessment_max_turns = (
+        _resolve_granularity_policy(None)
+    )
+    child_assessments = []
+    review_identities: list[Optional[tuple[str, str, str, str]]] = []
+    seen_review_keys: set[str] = set()
 
     # Pre-validate the children list shape outside the txn. Cheap checks
     # that don't need DB access. Bad input aborts before we touch the DB.
@@ -5374,6 +5881,110 @@ def decompose_triage_task(
                 )
             if p == idx:
                 raise ValueError(f"child[{idx}] cannot list itself as a parent")
+        kind = str(child.get("kind") or "work").strip().lower()
+        if kind not in {
+            "work",
+            "closure",
+            "review_scheduler",
+            "review",
+            "controller",
+            "activation",
+        }:
+            raise ValueError(f"child[{idx}].kind is invalid: {kind!r}")
+        child["kind"] = kind
+        assessment = assess_task(
+            str(title),
+            str(child.get("body") or ""),
+            max_turns=assessment_max_turns,
+        )
+        if assessment.verdict == "split":
+            raise ValueError(
+                f"child[{idx}] remains too broad after decomposition; "
+                "decompose it into atomic work before promotion"
+            )
+        incompatible_family = incompatible_decomposition_family(
+            kind,
+            assessment.action_families,
+        )
+        if incompatible_family is not None:
+            raise ValueError(
+                f"child[{idx}] has {incompatible_family} semantics incompatible "
+                f"with kind={kind!r}"
+            )
+        requires_human_activation = (
+            kind == "activation" or "activation" in assessment.action_families
+        )
+        child["requires_human_activation"] = requires_human_activation
+        raw_review_key = child.get("review_key")
+        review_identity = None
+        if kind == "review":
+            body = str(child.get("body") or "").strip()
+            review_identity = _exact_review_identity(
+                str(raw_review_key or ""),
+                body=body,
+                idempotency_key=child.get("idempotency_key"),
+                review_contract=child.get("review_contract"),
+                review_postimage_sha256=child.get("review_postimage_sha256"),
+                review_claims_sha256=child.get("review_claims_sha256"),
+            )
+            review_idempotency_key = review_identity[0]
+            if review_idempotency_key in seen_review_keys:
+                raise ValueError("duplicate review_key in decomposed children")
+            seen_review_keys.add(review_idempotency_key)
+            review_key = str(raw_review_key).strip().lower()
+            if not _review_key_body_values(body):
+                child["body"] = f"REVIEW_KEY: {review_key}\n\n{body}".rstrip()
+        elif raw_review_key not in (None, ""):
+            raise ValueError(
+                f"child[{idx}].review_key is allowed only for kind='review'"
+            )
+        body = str(child.get("body") or "").strip()
+        if kind == "review_scheduler" and not body.startswith(
+            "REVIEW_SCHEDULER_GATE:"
+        ):
+            child["body"] = (
+                "REVIEW_SCHEDULER_GATE: after closure, compute the immutable "
+                "postimage SHA-256 and claims SHA-256, then create or reuse the "
+                "keyed review. Do not claim the semantic review verdict.\n\n"
+                + body
+            ).rstrip()
+        elif kind == "controller" and not body.startswith("CONTROLLER_GATE:"):
+            child["body"] = (
+                "CONTROLLER_GATE: consume the completed keyed review's semantic "
+                "verdict. Never review your own input or release on scheduling "
+                "evidence alone.\n\n"
+                + body
+            ).rstrip()
+        if requires_human_activation:
+            body = str(child.get("body") or "").strip()
+            if not body.startswith("HUMAN_ACTIVATION_GATE:"):
+                child["body"] = (
+                    "HUMAN_ACTIVATION_GATE: PREPARE_ONLY. This shard must remain "
+                    "blocked until a human explicitly approves and unblocks the "
+                    "activation/deployment. Never self-approve.\n\n" + body
+                ).rstrip()
+        review_identities.append(review_identity)
+        child_assessments.append(assessment)
+
+    if len(children) < 2:
+        raise ValueError("decomposition must contain at least 2 children")
+
+    for idx, child in enumerate(children):
+        parent_kinds = {
+            children[parent_idx]["kind"]
+            for parent_idx in (child.get("parents") or [])
+        }
+        if (
+            child["kind"] in {"review", "review_scheduler"}
+            and "closure" not in parent_kinds
+        ):
+            raise ValueError(
+                f"child[{idx}] {child['kind']} must depend on a closure child"
+            )
+        if child["kind"] == "controller" and "review" not in parent_kinds:
+            raise ValueError(
+                f"child[{idx}] controller must depend directly on a keyed review child"
+            )
 
     # Detect cycles in the sibling parent graph (Kahn's topological sort).
     # link_tasks() calls _would_cycle() for every new edge; here we check
@@ -5407,6 +6018,7 @@ def decompose_triage_task(
     # _append_event calls.
     now = int(time.time())
     child_ids: list[str] = []
+    reused_review_statuses: dict[int, str] = {}
     with write_txn(conn):
         root_row = conn.execute(
             "SELECT id, status, tenant, workspace_kind, workspace_path "
@@ -5430,6 +6042,34 @@ def decompose_triage_task(
         # sees a coherent state, and recompute_ready() at the end
         # promotes parent-free children to 'ready'.
         for idx, child in enumerate(children):
+            review_identity = review_identities[idx]
+            review_idempotency_key = review_identity[0] if review_identity else None
+            if review_identity is not None:
+                existing_reviews = conn.execute(
+                    "SELECT id, status, body, review_contract, review_postimage_sha256, "
+                    "review_claims_sha256 FROM tasks WHERE idempotency_key = ? "
+                    "AND status != 'archived' ORDER BY created_at DESC, id DESC",
+                    (review_idempotency_key,),
+                ).fetchall()
+                existing_id = _reusable_idempotency_incumbent(
+                    existing_reviews,
+                    exact_review_identity=review_identity,
+                )
+                if existing_id is not None:
+                    existing_status = str(existing_reviews[0]["status"])
+                    child_ids.append(existing_id)
+                    reused_review_statuses[idx] = existing_status
+                    _append_event(
+                        conn,
+                        task_id,
+                        "review_reused",
+                        {
+                            "child_id": existing_id,
+                            "review_key": review_idempotency_key,
+                            "status": existing_status,
+                        },
+                    )
+                    continue
             new_id = _new_task_id()
             title = child["title"].strip()
             body = child.get("body")
@@ -5446,26 +6086,66 @@ def decompose_triage_task(
                 child_ws_path = root_ws_path
             else:
                 child_ws_path = None
+            requires_human_activation = bool(child.get("requires_human_activation"))
+            initial_status = "blocked" if requires_human_activation else "todo"
+            block_kind = "needs_input" if requires_human_activation else None
+            review_contract = review_identity[1] if review_identity else None
+            review_postimage_sha256 = review_identity[2] if review_identity else None
+            review_claims_sha256 = review_identity[3] if review_identity else None
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, idempotency_key, "
+                " block_kind, review_contract, review_postimage_sha256, "
+                " review_claims_sha256) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
                     body if isinstance(body, str) else None,
                     assignee,
+                    initial_status,
                     child_ws_kind,
                     child_ws_path,
                     tenant,
                     now,
                     (author or "decomposer"),
+                    review_idempotency_key,
+                    block_kind,
+                    review_contract,
+                    review_postimage_sha256,
+                    review_claims_sha256,
                 ),
             )
             _append_event(
                 conn, new_id, "created",
                 {"by": author or "decomposer", "from_decompose_of": task_id},
+            )
+            if requires_human_activation:
+                _append_event(
+                    conn,
+                    new_id,
+                    "blocked",
+                    {
+                        "reason": "human activation approval required",
+                        "kind": "needs_input",
+                        "source": "decomposer",
+                    },
+                )
+            assessment_payload = child_assessments[idx].to_dict()
+            assessment_payload.update(
+                {
+                    "policy": granularity_policy,
+                    "policy_invalid": policy_invalid,
+                    "auto_triaged": False,
+                    "source": "decomposer",
+                }
+            )
+            _append_event(
+                conn,
+                new_id,
+                "granularity_assessed",
+                assessment_payload,
             )
             child_ids.append(new_id)
 
@@ -5474,6 +6154,54 @@ def decompose_triage_task(
             for p_idx in child.get("parents") or []:
                 parent_id = child_ids[p_idx]
                 child_id = child_ids[idx]
+                reused_status = reused_review_statuses.get(idx)
+                if reused_status in {"running", "review", "done"}:
+                    # This exact reviewer already started or finished. Its
+                    # immutable input graph cannot acquire a new parent. Any
+                    # controller that consumes it must instead wait directly
+                    # on both the reused review and this graph's prerequisites.
+                    for controller_idx, controller in enumerate(children):
+                        if (
+                            controller.get("kind") != "controller"
+                            or idx not in (controller.get("parents") or [])
+                        ):
+                            continue
+                        controller_id = child_ids[controller_idx]
+                        if _would_cycle(conn, parent_id, controller_id):
+                            raise ValueError(
+                                f"link {parent_id}->{controller_id} would create a cycle"
+                            )
+                        inserted = conn.execute(
+                            "INSERT OR IGNORE INTO task_links (parent_id, child_id) "
+                            "VALUES (?, ?)",
+                            (parent_id, controller_id),
+                        )
+                        if inserted.rowcount:
+                            _append_event(
+                                conn,
+                                controller_id,
+                                "linked",
+                                {"parent": parent_id, "child": controller_id},
+                            )
+                    continue
+                if reused_status == "ready":
+                    parent_status_row = conn.execute(
+                        "SELECT status FROM tasks WHERE id = ?",
+                        (parent_id,),
+                    ).fetchone()
+                    if (
+                        parent_status_row is not None
+                        and parent_status_row["status"] != "done"
+                    ):
+                        conn.execute(
+                            "UPDATE tasks SET status = 'todo' "
+                            "WHERE id = ? AND status = 'ready'",
+                            (child_id,),
+                        )
+                if _would_cycle(conn, parent_id, child_id):
+                    raise ValueError(
+                        f"link {parent_id}->{child_id} would create a cycle"
+                    )
                 conn.execute(
                     "INSERT OR IGNORE INTO task_links (parent_id, child_id) "
                     "VALUES (?, ?)",
@@ -5489,6 +6217,8 @@ def decompose_triage_task(
         # link root under every child. Cycle-free because the root is
         # only ever a child here, never a parent of children.
         for cid in child_ids:
+            if _would_cycle(conn, cid, task_id):
+                raise ValueError(f"link {cid}->{task_id} would create a cycle")
             conn.execute(
                 "INSERT OR IGNORE INTO task_links (parent_id, child_id) "
                 "VALUES (?, ?)",
@@ -7029,6 +7759,11 @@ def _record_task_failure(
     force_trip: bool = False,
     release_claim: bool = False,
     end_run: bool = False,
+    partial_summary: Optional[str] = None,
+    trip_status: str = "blocked",
+    trip_event_kind: str = "gave_up",
+    require_running: bool = False,
+    expected_run_id: Optional[int] = None,
     event_payload_extra: Optional[dict] = None,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
@@ -7039,8 +7774,8 @@ def _record_task_failure(
     through here so the ``consecutive_failures`` counter and the
     auto-block threshold stay consistent.
 
-    Returns True when the task was auto-blocked (counter reached
-    ``failure_limit``), False when it was just updated in place.
+    Returns True when the task tripped to ``blocked`` or ``triage``, False
+    when it was just updated in place.
 
     Modes:
 
@@ -7059,6 +7794,9 @@ def _record_task_failure(
     when the breaker trips, so callers can include outcome-specific
     context (e.g. pid on crash, elapsed on timeout).
 
+    ``require_running=True`` adds an in-transaction lifecycle guard for
+    finalizers whose earlier status read may race another terminal transition.
+
     Resolution order for the effective threshold:
       1. per-task ``max_retries`` if set (nothing else overrides)
       2. caller-supplied ``failure_limit`` (gateway passes the config
@@ -7074,18 +7812,47 @@ def _record_task_failure(
     ``max_retries`` override against the violation streak itself. The
     failure is still counted into ``consecutive_failures``.
     """
+    if trip_status not in {"blocked", "triage"}:
+        raise ValueError("trip_status must be 'blocked' or 'triage'")
+    if trip_event_kind not in {"gave_up", "budget_triaged", "blocked"}:
+        raise ValueError(
+            "trip_event_kind must be 'gave_up', 'budget_triaged', or 'blocked'"
+        )
+    raw_handoff = _normalize_partial_handoff_source(partial_summary)
+    bounded_handoff = _bounded_partial_handoff(
+        raw_handoff,
+        run_id=expected_run_id,
+    )
+    handoff_metadata = (
+        {
+            "partial_summary_format": "kanban_partial_handoff/v1",
+            "partial_summary_full": raw_handoff,
+            "partial_summary_sha256": hashlib.sha256(
+                raw_handoff.encode("utf-8")
+            ).hexdigest(),
+        }
+        if raw_handoff is not None
+        else {}
+    )
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     blocked = False
     with write_txn(conn):
         row = conn.execute(
-            "SELECT consecutive_failures, status, max_retries "
+            "SELECT consecutive_failures, status, max_retries, current_run_id "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
             return False
         failures = int(row["consecutive_failures"]) + 1
         cur_status = row["status"]
+        # Budget finalization first inspects task state outside this helper for
+        # a useful return value, but a second finalizer can race that read. The
+        # transaction-local guard makes the lifecycle transition idempotent.
+        if require_running and cur_status != "running":
+            return False
+        if expected_run_id is not None and row["current_run_id"] != expected_run_id:
+            return False
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
@@ -7104,21 +7871,21 @@ def _record_task_failure(
             if release_claim:
                 # Spawn path: still running, also clear claim state.
                 conn.execute(
-                    "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
+                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('running', 'ready')",
-                    (failures, error[:500], task_id),
+                    (trip_status, failures, error[:500], task_id),
                 )
             else:
                 # Timeout/crash path: task is already at ``ready``
                 # with claim cleared; just flip to blocked + update
                 # counter fields.
                 conn.execute(
-                    "UPDATE tasks SET status = 'blocked', "
+                    "UPDATE tasks SET status = ?, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('ready', 'running')",
-                    (failures, error[:500], task_id),
+                    (trip_status, failures, error[:500], task_id),
                 )
             run_id = None
             if end_run:
@@ -7126,12 +7893,19 @@ def _record_task_failure(
                 run_id = _end_run(
                     conn, task_id,
                     outcome="gave_up", status="gave_up",
+                    summary=bounded_handoff,
                     error=error[:500],
                     metadata={
                         "failures": failures,
                         "trigger_outcome": outcome,
                         "effective_limit": effective_limit,
                         "limit_source": limit_source,
+                        **(dict(event_payload_extra) if event_payload_extra else {}),
+                        **handoff_metadata,
+                        **(
+                            {"partial_summary_saved": True}
+                            if bounded_handoff is not None else {}
+                        ),
                     },
                 )
             payload = {
@@ -7143,8 +7917,12 @@ def _record_task_failure(
             }
             if event_payload_extra:
                 payload.update(event_payload_extra)
+            if bounded_handoff is not None:
+                payload["partial_summary_saved"] = True
+            if trip_status != "blocked":
+                payload["routed_status"] = trip_status
             _append_event(
-                conn, task_id, "gave_up", payload, run_id=run_id,
+                conn, task_id, trip_event_kind, payload, run_id=run_id,
             )
             blocked = True
         else:
@@ -7171,16 +7949,184 @@ def _record_task_failure(
                 run_id = _end_run(
                     conn, task_id,
                     outcome=outcome, status=outcome,
+                    summary=bounded_handoff,
                     error=error[:500],
-                    metadata={"failures": failures},
+                    metadata={
+                        "failures": failures,
+                        **(dict(event_payload_extra) if event_payload_extra else {}),
+                        **handoff_metadata,
+                        **(
+                            {"partial_summary_saved": True}
+                            if bounded_handoff is not None else {}
+                        ),
+                    },
                 )
                 _append_event(
                     conn, task_id, outcome,
-                    {"error": error[:500], "failures": failures},
+                    {
+                        "error": error[:500],
+                        "failures": failures,
+                        **(dict(event_payload_extra) if event_payload_extra else {}),
+                        **(
+                            {"partial_summary_saved": True}
+                            if bounded_handoff is not None else {}
+                        ),
+                    },
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.
     return blocked
+
+
+_BUDGET_EXHAUSTION_POLICIES = {"retry", "block", "triage_once"}
+
+
+def record_iteration_budget_checkpoint(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: int,
+    budget_used: int,
+    budget_max: int,
+) -> bool:
+    """Record one durable, summary-free closure marker for the active run."""
+    used = max(0, int(budget_used))
+    maximum = max(0, int(budget_max))
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if (
+            row is None
+            or row["status"] != "running"
+            or row["current_run_id"] != int(expected_run_id)
+        ):
+            return False
+        run_id = int(expected_run_id)
+        exists = conn.execute(
+            "SELECT 1 FROM task_events WHERE task_id = ? AND run_id = ? "
+            "AND kind = 'budget_checkpoint' LIMIT 1",
+            (task_id, run_id),
+        ).fetchone()
+        if exists is not None:
+            return False
+        _append_event(
+            conn,
+            task_id,
+            "budget_checkpoint",
+            {
+                "budget_used": used,
+                "budget_max": maximum,
+                "remaining": max(0, maximum - used),
+            },
+            run_id=run_id,
+        )
+    return True
+
+
+def _budget_exhaustion_policy(explicit: Optional[str] = None) -> str:
+    """Resolve the exhaustion policy; unknown values preserve legacy retry."""
+    if explicit is not None:
+        value = str(explicit).strip().lower()
+        return value if value in _BUDGET_EXHAUSTION_POLICIES else "retry"
+    try:
+        from hermes_cli.config import load_config
+
+        value = str(
+            load_config().get("kanban", {}).get(
+                "budget_exhaustion_policy", "retry"
+            )
+        ).strip().lower()
+        return value if value in _BUDGET_EXHAUSTION_POLICIES else "retry"
+    except Exception:
+        return "retry"
+
+
+def record_iteration_budget_exhaustion(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: int,
+    error: str,
+    partial_summary: Optional[str],
+    budget_used: int,
+    budget_max: int,
+    policy: Optional[str] = None,
+) -> str:
+    """Persist a compact handoff and apply one bounded exhaustion policy.
+
+    ``triage_once`` routes the first exhausted attempt to Triage and blocks a
+    repeated exhaustion, preventing recursive decompose/retry loops. ``retry``
+    is the backward-compatible default; ``block`` fails closed immediately.
+    Returns the task's resulting status.
+    """
+    resolved = _budget_exhaustion_policy(policy)
+    current = get_task(conn, task_id)
+    # A worker may have already called kanban_block/complete before the agent's
+    # own turn finalizer runs. Never increment the circuit breaker or append a
+    # second terminal event after that authoritative lifecycle transition.
+    if current is None:
+        return "missing"
+    if current.status != "running":
+        return current.status
+    if current.current_run_id != int(expected_run_id):
+        return "stale_run"
+
+    already_triaged = conn.execute(
+        "SELECT 1 FROM task_events WHERE task_id = ? AND kind = "
+        "'budget_triaged' LIMIT 1",
+        (task_id,),
+    ).fetchone() is not None
+    event_extra = {
+        "budget_used": int(budget_used),
+        "budget_max": int(budget_max),
+        "budget_exhaustion_policy": resolved,
+    }
+
+    if resolved == "triage_once" and not already_triaged:
+        _record_task_failure(
+            conn,
+            task_id,
+            error,
+            outcome="timed_out",
+            force_trip=True,
+            release_claim=True,
+            end_run=True,
+            partial_summary=partial_summary,
+            trip_status="triage",
+            trip_event_kind="budget_triaged",
+            require_running=True,
+            expected_run_id=int(expected_run_id),
+            event_payload_extra=event_extra,
+        )
+    else:
+        if resolved == "triage_once" and already_triaged:
+            event_extra["triage_once_repeat_blocked"] = True
+        sticky_budget_block = resolved in {"block", "triage_once"}
+        _record_task_failure(
+            conn,
+            task_id,
+            error,
+            outcome="timed_out",
+            force_trip=resolved in {"block", "triage_once"},
+            release_claim=True,
+            end_run=True,
+            partial_summary=partial_summary,
+            trip_event_kind="blocked" if sticky_budget_block else "gave_up",
+            require_running=True,
+            expected_run_id=int(expected_run_id),
+            event_payload_extra=event_extra,
+        )
+
+    task = get_task(conn, task_id)
+    if (
+        task is not None
+        and task.status == "running"
+        and task.current_run_id != int(expected_run_id)
+    ):
+        return "stale_run"
+    return task.status if task is not None else "missing"
 
 
 # Backward-compat alias. Old name is referenced from tests and possibly
@@ -8418,7 +9364,12 @@ def run_daemon(
 # Worker context builder (what a spawned worker sees)
 # ---------------------------------------------------------------------------
 
-def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
+def build_worker_context(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    compact: Optional[bool] = None,
+) -> str:
     """Return the full text a worker should read to understand its task.
 
     Order:
@@ -8438,9 +9389,22 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
          collapsed).
 
     All caps exist so worker prompts stay bounded even on pathological
-    boards (retry-heavy tasks, comment storms). The per-field char cap
-    prevents a single 1 MB summary from dominating context.
+    boards (retry-heavy tasks, comment storms). Byte-based field and aggregate
+    caps prevent Unicode-heavy values or high fan-in metadata from dominating
+    compact context.
     """
+    compact_mode = _compact_worker_context_enabled(compact)
+    max_prior_attempts = (
+        _CTX_COMPACT_MAX_PRIOR_ATTEMPTS if compact_mode else _CTX_MAX_PRIOR_ATTEMPTS
+    )
+    max_comments = _CTX_COMPACT_MAX_COMMENTS if compact_mode else _CTX_MAX_COMMENTS
+    max_parents = _CTX_COMPACT_MAX_PARENTS if compact_mode else None
+    max_role_history = _CTX_COMPACT_MAX_ROLE_HISTORY if compact_mode else 5
+    field_limit = _CTX_COMPACT_MAX_FIELD_BYTES if compact_mode else _CTX_MAX_FIELD_BYTES
+    comment_limit = (
+        _CTX_COMPACT_MAX_COMMENT_BYTES if compact_mode else _CTX_MAX_COMMENT_BYTES
+    )
+
     task = get_task(conn, task_id)
     if not task:
         raise ValueError(f"unknown task {task_id}")
@@ -8450,23 +9414,102 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     # by the seconds it takes to build the block).
     _now = int(time.time())
 
-    def _cap(s: Optional[str], limit: int = _CTX_MAX_FIELD_BYTES) -> str:
-        """Truncate a string to `limit` chars with a visible ellipsis."""
+    def _cap(s: Optional[str], limit: Optional[int] = None) -> str:
+        """Use UTF-8 caps only in compact mode; preserve full-mode chars."""
         if not s:
             return ""
+        if limit is None:
+            limit = field_limit
         s = s.strip()
-        if len(s) <= limit:
+        if compact_mode:
+            return _truncate_utf8(s, int(limit), marker="… [field truncated]")
+        if len(s) <= int(limit):
             return s
-        return s[:limit] + f"… [truncated, {len(s) - limit} chars omitted]"
+        return s[: int(limit)] + f"… [truncated, {len(s) - int(limit)} chars omitted]"
+
+    def _metadata_context_lines(
+        metadata: Optional[dict],
+        *,
+        run_id: Optional[int],
+        owner_task_id: Optional[str] = None,
+    ) -> list[str]:
+        if not metadata:
+            return []
+        visible = dict(metadata)
+        context_ref = None
+        if compact_mode and "partial_summary_full" in visible:
+            source = str(visible.pop("partial_summary_full") or "")
+            digest = str(visible.get("partial_summary_sha256") or "")
+            actual_digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+            exact_recovery = bool(
+                source
+                and re.fullmatch(r"[0-9a-f]{64}", digest)
+                and digest == actual_digest
+                and run_id is not None
+            )
+            context_ref = {
+                "field": "partial_summary_full",
+                "integrity": "verified" if exact_recovery else "unverified",
+                "kind": "task_run_metadata",
+                "recover_with": (
+                    f"hermes kanban context {owner_task_id or task.id} "
+                    f"--run-id {run_id} "
+                    "--field partial_summary_full"
+                    if exact_recovery else None
+                ),
+                "run_id": run_id,
+                "sha256": digest if exact_recovery else None,
+            }
+        rendered: list[str] = []
+        if visible:
+            meta_str = json.dumps(visible, ensure_ascii=False, sort_keys=True)
+            rendered.append(f"_metadata_: `{_cap(meta_str)}`")
+        if context_ref is not None:
+            rendered.append(
+                "CONTEXT_REF: "
+                + json.dumps(
+                    context_ref,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+        return rendered
+
+    all_prior = [r for r in list_runs(conn, task_id) if r.ended_at is not None]
+    latest_durable_handoff = None
+    if compact_mode:
+        latest_durable_handoff = next(
+            (
+                run
+                for run in reversed(all_prior)
+                if isinstance(run.metadata, dict)
+                and "partial_summary_full" in run.metadata
+            ),
+            None,
+        )
+
+    def _identity(value: Optional[str]) -> str:
+        raw = value or ""
+        if compact_mode:
+            return _cap(raw, _CTX_COMPACT_MAX_IDENTITY_FIELD_BYTES)
+        return raw
 
     lines: list[str] = []
-    lines.append(f"# Kanban task {task.id}: {task.title}")
+    rendered_title = (
+        _cap(task.title, _CTX_COMPACT_MAX_TITLE_BYTES)
+        if compact_mode else task.title
+    )
+    lines.append(f"# Kanban task {task.id}: {rendered_title}")
     lines.append("")
-    lines.append(f"Assignee: {task.assignee or '(unassigned)'}")
-    lines.append(f"Status:   {task.status}")
+    lines.append(f"Assignee: {_identity(task.assignee) or '(unassigned)'}")
+    lines.append(f"Status:   {_identity(task.status)}")
     if task.tenant:
-        lines.append(f"Tenant:   {task.tenant}")
-    lines.append(f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}")
+        lines.append(f"Tenant:   {_identity(task.tenant)}")
+    lines.append(
+        f"Workspace: {_identity(task.workspace_kind)} @ "
+        f"{_identity(task.workspace_path) or '(unresolved)'}"
+    )
     if task.max_runtime_seconds is not None:
         terminal_timeout = _worker_terminal_timeout_env(
             task.max_runtime_seconds,
@@ -8477,12 +9520,86 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
         if effective_terminal_timeout:
             lines.append(f"Terminal timeout: {effective_terminal_timeout}s")
     if task.branch_name:
-        lines.append(f"Branch:   {task.branch_name}")
+        lines.append(f"Branch:   {_identity(task.branch_name)}")
     lines.append("")
+
+    if compact_mode:
+        lines.append(
+            "> Compact context profile active. "
+            f"`hermes kanban context {task.id} --full` and "
+            f"`kanban_show(task_id=\"{task.id}\", full_context=true)` expose "
+            "the historical bounded profile. Exact full handoff sources use "
+            "the hash-bound recovery command carried in their CONTEXT_REF."
+        )
+        lines.append("")
+        compact_counts = {
+            "attachments": int(conn.execute(
+                "SELECT COUNT(*) FROM task_attachments WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()[0]),
+            "attempts": int(conn.execute(
+                "SELECT COUNT(*) FROM task_runs "
+                "WHERE task_id = ? AND ended_at IS NOT NULL",
+                (task_id,),
+            ).fetchone()[0]),
+            "comments": int(conn.execute(
+                "SELECT COUNT(*) FROM task_comments WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()[0]),
+            "parents": int(conn.execute(
+                "SELECT COUNT(*) FROM task_links WHERE child_id = ?",
+                (task_id,),
+            ).fetchone()[0]),
+        }
+        compact_omissions = {
+            "attachments": max(
+                0,
+                compact_counts["attachments"] - _CTX_COMPACT_MAX_ATTACHMENTS,
+            ),
+            "attempts": max(
+                0,
+                compact_counts["attempts"] - _CTX_COMPACT_MAX_PRIOR_ATTEMPTS,
+            ),
+            "comments": max(
+                0,
+                compact_counts["comments"] - _CTX_COMPACT_MAX_COMMENTS,
+            ),
+            "parents": max(
+                0,
+                compact_counts["parents"] - _CTX_COMPACT_MAX_PARENTS,
+            ),
+        }
+        if any(compact_omissions.values()):
+            lines.append("## Compact context manifest")
+            for label in ("attempts", "parents", "comments", "attachments"):
+                omitted_count = compact_omissions[label]
+                if omitted_count:
+                    lines.append(
+                        f"- {omitted_count} earlier {label} omitted; "
+                        "recover with full_context=true."
+                    )
+            lines.append("")
 
     if task.body and task.body.strip():
         lines.append("## Body")
         lines.append(_cap(task.body, _CTX_MAX_BODY_BYTES))
+        lines.append("")
+
+    # Priority-reserved compact block. It is emitted before attachments,
+    # parents, role history, and comments, while every field before it is
+    # byte-capped. Aggregate truncation therefore cannot starve the latest
+    # durable handoff or its hash-bound CONTEXT_REF.
+    if compact_mode and latest_durable_handoff is not None:
+        run = latest_durable_handoff
+        outcome = run.outcome or run.status
+        lines.append("## Latest durable handoff (priority-reserved)")
+        lines.append(f"### Run {run.id} — {_identity(outcome)}")
+        if run.summary and run.summary.strip():
+            lines.append(_cap(run.summary))
+        try:
+            lines.extend(_metadata_context_lines(run.metadata, run_id=run.id))
+        except Exception:
+            pass
         lines.append("")
 
     # Attachments — files uploaded to this task (PDFs, source docs,
@@ -8492,16 +9609,42 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     # as-is; remote backends need the kanban attachments dir mounted.
     attachments = list_attachments(conn, task_id)
     if attachments:
+        omitted_attachments = 0
+        if compact_mode and len(attachments) > _CTX_COMPACT_MAX_ATTACHMENTS:
+            omitted_attachments = len(attachments) - _CTX_COMPACT_MAX_ATTACHMENTS
+            attachments = attachments[-_CTX_COMPACT_MAX_ATTACHMENTS:]
         lines.append("## Attachments")
         lines.append(
             "Files attached to this task. Read them with the file/terminal "
             "tools at the absolute paths below:"
         )
+        if omitted_attachments:
+            lines.append(
+                f"_({omitted_attachments} earlier attachments omitted; "
+                "request full_context=true to recover the complete list.)_"
+            )
         for att in attachments:
             size_kb = max(1, (att.size + 1023) // 1024) if att.size else 0
             size_str = f", {size_kb} KB" if size_kb else ""
-            ctype = f", {att.content_type}" if att.content_type else ""
-            lines.append(f"- `{att.filename}`{ctype}{size_str} → `{att.stored_path}`")
+            if compact_mode:
+                filename = _cap(
+                    att.filename,
+                    _CTX_COMPACT_MAX_ATTACHMENT_FIELD_BYTES,
+                )
+                stored_path = _cap(
+                    att.stored_path,
+                    _CTX_COMPACT_MAX_ATTACHMENT_FIELD_BYTES,
+                )
+                content_type = _cap(
+                    att.content_type,
+                    _CTX_COMPACT_MAX_ATTACHMENT_FIELD_BYTES,
+                )
+            else:
+                filename = att.filename
+                stored_path = att.stored_path
+                content_type = att.content_type or ""
+            ctype = f", {content_type}" if content_type else ""
+            lines.append(f"- `{filename}`{ctype}{size_str} → `{stored_path}`")
         lines.append("")
 
     # Prior attempts — show closed runs so a retrying worker sees the
@@ -8509,24 +9652,28 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     # Cap at _CTX_MAX_PRIOR_ATTEMPTS most-recent closed runs; older
     # attempts get collapsed into a one-line marker so the worker knows
     # more exist without bloating the prompt.
-    all_prior = [r for r in list_runs(conn, task_id) if r.ended_at is not None]
     # list_runs returns ascending by started_at; "most recent" = last N
-    if len(all_prior) > _CTX_MAX_PRIOR_ATTEMPTS:
-        omitted = len(all_prior) - _CTX_MAX_PRIOR_ATTEMPTS
-        shown = all_prior[-_CTX_MAX_PRIOR_ATTEMPTS:]
+    if len(all_prior) > max_prior_attempts:
+        omitted = len(all_prior) - max_prior_attempts
+        shown = all_prior[-max_prior_attempts:]
         first_shown_idx = omitted + 1
     else:
         omitted = 0
         shown = all_prior
         first_shown_idx = 1
-    if shown:
+    shown_attempts = [
+        run
+        for run in shown
+        if latest_durable_handoff is None or run.id != latest_durable_handoff.id
+    ]
+    if shown_attempts:
         lines.append("## Prior attempts on this task")
         if omitted:
             lines.append(
                 f"_({omitted} earlier attempt{'s' if omitted != 1 else ''} "
-                f"omitted; showing most recent {len(shown)})_"
+                f"omitted; showing most recent {len(shown_attempts)})_"
             )
-        for offset, run in enumerate(shown):
+        for offset, run in enumerate(shown_attempts):
             idx = first_shown_idx + offset
             ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(run.started_at))
             age = _relative_age(run.started_at, _now)
@@ -8540,8 +9687,9 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
                 lines.append(f"_error_: {_cap(run.error)}")
             if run.metadata:
                 try:
-                    meta_str = json.dumps(run.metadata, ensure_ascii=False, sort_keys=True)
-                    lines.append(f"_metadata_: `{_cap(meta_str)}`")
+                    lines.extend(
+                        _metadata_context_lines(run.metadata, run_id=run.id)
+                    )
                 except Exception:
                     pass
             lines.append("")
@@ -8556,8 +9704,14 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     parent_ids = [r["parent_id"] for r in parent_rows]
 
     if parent_ids:
+        if max_parents is not None and len(parent_ids) > max_parents:
+            omitted_parent_ids = parent_ids[:-max_parents]
+            shown_parent_ids = parent_ids[-max_parents:]
+        else:
+            omitted_parent_ids = []
+            shown_parent_ids = parent_ids
         wrote_header = False
-        for pid in parent_ids:
+        for pid in shown_parent_ids:
             pt = get_task(conn, pid)
             if not pt or pt.status != "done":
                 continue
@@ -8574,6 +9728,18 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
                     "current work and it's not recent, re-verify against the "
                     "source before acting on it as current._"
                 )
+                if omitted_parent_ids:
+                    omitted_digest = hashlib.sha256(
+                        "\n".join(omitted_parent_ids).encode("utf-8")
+                    ).hexdigest()[:16]
+                    sample_ids = omitted_parent_ids[:2] + omitted_parent_ids[-2:]
+                    lines.append(
+                        "_(Compact profile omitted full handoffs for "
+                        f"{len(omitted_parent_ids)} earlier parents; sample ids: "
+                        + ", ".join(sample_ids)
+                        + f"; id-list sha256 prefix: {omitted_digest}. "
+                        "Request full_context=true to recover them.)_"
+                    )
                 wrote_header = True
 
             # When did this parent's result get produced? Prefer the
@@ -8596,8 +9762,13 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
 
             if run is not None and run.metadata:
                 try:
-                    meta_str = json.dumps(run.metadata, ensure_ascii=False, sort_keys=True)
-                    body_lines.append(f"_metadata_: `{_cap(meta_str)}`")
+                    body_lines.extend(
+                        _metadata_context_lines(
+                            run.metadata,
+                            run_id=run.id,
+                            owner_task_id=pid,
+                        )
+                    )
                 except Exception:
                     pass
             lines.extend(body_lines)
@@ -8615,11 +9786,11 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             "FROM task_runs r JOIN tasks t ON r.task_id = t.id "
             "WHERE r.profile = ? AND r.task_id != ? "
             "  AND r.outcome = 'completed' "
-            "ORDER BY r.ended_at DESC LIMIT 5",
+            f"ORDER BY r.ended_at DESC LIMIT {int(max_role_history)}",
             (task.assignee, task_id),
         ).fetchall()
         if role_rows:
-            lines.append(f"## Recent work by @{task.assignee}")
+            lines.append(f"## Recent work by @{_identity(task.assignee)}")
             for row in role_rows:
                 ts = time.strftime(
                     "%Y-%m-%d %H:%M", time.localtime(int(row["ended_at"]))
@@ -8627,17 +9798,22 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
                 age = _relative_age(row["ended_at"], _now)
                 ts_disp = f"{ts}, {age}" if age else ts
                 s = (row["summary"] or "").strip().splitlines()
-                first = s[0][:200] if s else "(no summary)"
-                lines.append(f"- {row['id']} — {row['title']} ({ts_disp}): {first}")
+                if compact_mode:
+                    first = _cap(s[0], 512) if s else "(no summary)"
+                    role_title = _cap(str(row["title"]), 512)
+                else:
+                    first = s[0][:200] if s else "(no summary)"
+                    role_title = str(row["title"])
+                lines.append(f"- {row['id']} — {role_title} ({ts_disp}): {first}")
             lines.append("")
 
     # Comments: cap at the most-recent _CTX_MAX_COMMENTS so
     # comment-storm tasks don't blow out the worker's prompt. Older
     # comments summarised in a one-line marker like prior attempts.
     all_comments = list_comments(conn, task_id)
-    if len(all_comments) > _CTX_MAX_COMMENTS:
-        omitted_c = len(all_comments) - _CTX_MAX_COMMENTS
-        shown_c = all_comments[-_CTX_MAX_COMMENTS:]
+    if len(all_comments) > max_comments:
+        omitted_c = len(all_comments) - max_comments
+        shown_c = all_comments[-max_comments:]
     else:
         omitted_c = 0
         shown_c = all_comments
@@ -8659,11 +9835,23 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             # Defense-in-depth — the LLM-controlled author-forgery surface
             # was already closed in #22435. See #22452.
             safe_author = (c.author or "").replace("`", "")
+            if compact_mode:
+                safe_author = _cap(safe_author, _CTX_COMPACT_MAX_AUTHOR_BYTES)
             lines.append(f"comment from worker `{safe_author}` at {ts_disp}:")
-            lines.append(_cap(c.body, _CTX_MAX_COMMENT_BYTES))
+            lines.append(_cap(c.body, comment_limit))
             lines.append("")
 
-    return "\n".join(lines).rstrip() + "\n"
+    rendered = "\n".join(lines).rstrip() + "\n"
+    if compact_mode:
+        rendered = _truncate_utf8(
+            rendered,
+            _CTX_COMPACT_MAX_TOTAL_BYTES,
+            marker=(
+                "\n… [compact context truncated; recover omitted evidence with "
+                "the bounded full profile; exact handoffs use CONTEXT_REF]\n"
+            ),
+        )
+    return rendered
 
 
 # ---------------------------------------------------------------------------
@@ -9176,6 +10364,47 @@ def get_run(conn: sqlite3.Connection, run_id: int) -> Optional[Run]:
         "SELECT * FROM task_runs WHERE id = ?", (int(run_id),),
     ).fetchone()
     return Run.from_row(row) if row else None
+
+
+def read_run_metadata_field(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    run_id: int,
+    field: str,
+) -> str:
+    """Return one integrity-checked, explicitly recoverable run field.
+
+    This is intentionally not a generic metadata reader. Compact worker context
+    may reference the full, unverified budget handoff stored in
+    ``partial_summary_full``; that one field is recoverable byte-for-byte only
+    when its sibling SHA-256 is present and matches. The task/run ownership check
+    prevents a reference for one task from being replayed against another.
+    """
+
+    if field != "partial_summary_full":
+        raise ValueError("field must be 'partial_summary_full'")
+    run = get_run(conn, run_id)
+    if run is None:
+        raise ValueError(f"run {int(run_id)} not found")
+    if run.task_id != task_id:
+        raise ValueError(f"run {int(run_id)} does not belong to task {task_id}")
+    metadata = run.metadata if isinstance(run.metadata, dict) else {}
+    value = metadata.get(field)
+    expected = metadata.get("partial_summary_sha256")
+    if not isinstance(value, str):
+        raise ValueError(f"run {int(run_id)} has no string field {field}")
+    if not isinstance(expected, str) or not re.fullmatch(r"[0-9a-f]{64}", expected):
+        raise ValueError(
+            f"run {int(run_id)} has no canonical partial_summary_sha256"
+        )
+    actual = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    if actual != expected:
+        raise ValueError(
+            f"run {int(run_id)} {field} SHA-256 mismatch: "
+            f"expected {expected}, got {actual}"
+        )
+    return value
 
 
 def latest_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -45,6 +45,11 @@ from typing import Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import profiles as profiles_mod
+from hermes_cli.kanban_budget import (
+    assess_task,
+    canonical_review_idempotency_key,
+    incompatible_decomposition_family,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +75,8 @@ Output a single JSON object with this exact shape:
         "title": "<concrete task title, imperative voice, <= 80 chars>",
         "body":  "<detailed spec for the worker on this child task>",
         "assignee": "<profile name from the roster, or null for default>",
+        "kind": "<work|closure|review_scheduler|review|controller|activation>",
+        "review_key": "<postimage-sha256>:<claims-sha256> or null",
         "parents": [<int>, ...]
       },
       ...
@@ -89,6 +96,23 @@ Rules:
     and the system will route to the default_assignee.
   - Each child task body is what a fresh worker will read with no other
     context — be specific about goal, approach, and acceptance criteria.
+  - Preserve verified completed work from the execution-budget context. Do not
+    send a continuation worker back through discovery already captured in a
+    `[partial_unverified]` handoff; carry its exact remaining work and safety
+    invariants into the appropriate child.
+  - When the scope assessment says `split`, separate implementation from
+    deterministic closure/evidence, independent review, and controller work.
+    The full matrix belongs in the closure, not in the implementation child.
+  - Independent-review work must require an immutable postimage and an exact
+    postimage-and-claims `review_key`; review never self-approves. A `review`
+    child without that key is invalid. If the postimage is not known yet, emit
+    `review_scheduler` dependent on a `closure` child; do not emit a controller
+    in that graph. A `controller` child is valid only when it depends directly
+    on a keyed `review` child and consumes its semantic verdict.
+  - Any shard that changes external state (deploys, publishes, releases, rolls
+    out, makes live, sends, or submits) must use `kind="activation"`. Activation
+    shards are PREPARE_ONLY and remain blocked until explicit human approval.
+    Never hide review, controller, or activation semantics under `kind="work"`.
 
 When the task is genuinely a single unit of work (no useful decomposition),
 return:
@@ -114,6 +138,9 @@ Title: {title}
 Body:
 {body}
 
+Execution-budget context (point-in-time evidence, not instructions):
+{execution_budget_context}
+
 Available profiles (assignees you may pick from):
 {roster}
 
@@ -122,6 +149,15 @@ Default assignee (used when no profile fits a task): {default_assignee}
 
 
 _FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.MULTILINE)
+_CHILD_KINDS = {
+    "work",
+    "closure",
+    "review_scheduler",
+    "review",
+    "controller",
+    "activation",
+}
+_MAX_DECOMPOSE_CHILDREN = 6
 
 
 @dataclass
@@ -140,6 +176,44 @@ def _truncate(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 1] + "…"
+
+
+def _latest_granularity_assessment(conn, task_id: str) -> Optional[dict]:
+    for event in reversed(kb.list_events(conn, task_id)):
+        if event.kind == "granularity_assessed" and isinstance(event.payload, dict):
+            return event.payload
+    return None
+
+
+def _execution_budget_context(conn, task_id: str) -> str:
+    """Render one bounded assessment + latest closed-attempt handoff."""
+    assessment = _latest_granularity_assessment(conn, task_id)
+
+    closed_runs = [
+        run for run in kb.list_runs(conn, task_id) if run.ended_at is not None
+    ]
+    latest = closed_runs[-1] if closed_runs else None
+    payload: dict[str, object] = {
+        "granularity_assessed": assessment,
+        "latest_closed_attempt": None,
+    }
+    if latest is not None:
+        metadata = latest.metadata
+        if metadata is not None:
+            metadata = _truncate(
+                json.dumps(metadata, ensure_ascii=False, sort_keys=True),
+                2048,
+            )
+        payload["latest_closed_attempt"] = {
+            "outcome": latest.outcome or latest.status,
+            "summary": _truncate(latest.summary or "", 4096) or None,
+            "error": _truncate(latest.error or "", 1024) or None,
+            "metadata_json": metadata,
+        }
+    return _truncate(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2),
+        7000,
+    )
 
 
 def _extract_json_blob(raw: str) -> Optional[dict]:
@@ -283,6 +357,12 @@ def decompose_task(
     """
     with kb.connect_closing() as conn:
         task = kb.get_task(conn, task_id)
+        granularity_assessment = (
+            _latest_granularity_assessment(conn, task_id) if task is not None else None
+        )
+        execution_budget_context = (
+            _execution_budget_context(conn, task_id) if task is not None else "{}"
+        )
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
     if task.status != "triage":
@@ -307,6 +387,7 @@ def decompose_task(
         task_id=task.id,
         title=_truncate(task.title or "", 400),
         body=_truncate(task.body or "(no body)", 4000),
+        execution_budget_context=execution_budget_context,
         roster=_format_roster(roster),
         default_assignee=default_assignee,
     )
@@ -345,11 +426,33 @@ def decompose_task(
     audit_author = author or _profile_author()
 
     if not fanout:
-        # Fall back to single-task spec promotion (same effect as specify).
         new_title = parsed.get("title")
         new_body = parsed.get("body")
-        title_val = new_title.strip() if isinstance(new_title, str) and new_title.strip() else None
+        title_val = (
+            new_title.strip()
+            if isinstance(new_title, str) and new_title.strip()
+            else None
+        )
         body_val = new_body if isinstance(new_body, str) and new_body.strip() else None
+        effective_assessment = assess_task(
+            title_val or task.title or "",
+            body_val if body_val is not None else task.body or "",
+            max_turns=60,
+        )
+        if (
+            (
+                isinstance(granularity_assessment, dict)
+                and str(granularity_assessment.get("verdict") or "").strip().lower()
+                == "split"
+            )
+            or effective_assessment.verdict == "split"
+        ):
+            return DecomposeOutcome(
+                task_id,
+                False,
+                "granularity verdict is split; decomposer must return a valid DAG",
+            )
+        # Fall back to single-task spec promotion (same effect as specify).
         assignee_val = None
         if not task.assignee:
             assignee_val = _normalize_assignee_choice(
@@ -383,6 +486,18 @@ def decompose_task(
     if not isinstance(raw_tasks, list) or not raw_tasks:
         return DecomposeOutcome(
             task_id, False, "decomposer returned fanout=true with empty tasks list",
+        )
+    if len(raw_tasks) < 2:
+        return DecomposeOutcome(
+            task_id,
+            False,
+            "decomposer fanout must contain at least 2 atomic tasks",
+        )
+    if len(raw_tasks) > _MAX_DECOMPOSE_CHILDREN:
+        return DecomposeOutcome(
+            task_id,
+            False,
+            f"decomposer may return at most {_MAX_DECOMPOSE_CHILDREN} tasks",
         )
 
     # Rewrite invalid assignees to the default fallback. Never leave a
@@ -422,12 +537,101 @@ def decompose_task(
             parents = []
         # Clean parent indices: drop non-int and out-of-range.
         clean_parents = [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx]
+        kind = str(entry.get("kind") or "work").strip().lower()
+        if kind not in _CHILD_KINDS:
+            return DecomposeOutcome(
+                task_id, False, f"tasks[{idx}].kind is invalid: {kind!r}",
+            )
+        child_assessment = assess_task(title, body, max_turns=60)
+        if child_assessment.verdict == "split":
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"tasks[{idx}] remains split; every decomposed child must be atomic",
+            )
+        incompatible_family = incompatible_decomposition_family(
+            kind,
+            child_assessment.action_families,
+        )
+        if incompatible_family is not None:
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"tasks[{idx}] has {incompatible_family} semantics incompatible "
+                f"with kind={kind!r}",
+            )
+        requires_human_activation = (
+            kind == "activation"
+            or "activation" in child_assessment.action_families
+        )
+        review_key = entry.get("review_key")
+        if kind == "review":
+            try:
+                canonical_review_idempotency_key(str(review_key or ""))
+            except ValueError as exc:
+                return DecomposeOutcome(
+                    task_id,
+                    False,
+                    f"tasks[{idx}].review_key is required and invalid: {exc}",
+                )
+            review_key = str(review_key).strip().lower()
+            body = (
+                f"REVIEW_KEY: {review_key}\n"
+                "Review only the immutable postimage and exact claims bound by "
+                "that key. Never modify the reviewed sources or self-approve.\n\n"
+                + body.strip()
+            )
+        elif review_key not in (None, ""):
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"tasks[{idx}].review_key is allowed only for kind='review'",
+            )
+        elif kind == "review_scheduler":
+            body = (
+                "REVIEW_SCHEDULER_GATE: after closure, compute the immutable "
+                "postimage SHA-256 and claims SHA-256, then create or reuse the "
+                "keyed review. Do not claim the semantic review verdict.\n\n"
+                + body.strip()
+            )
+        elif kind == "controller":
+            body = (
+                "CONTROLLER_GATE: consume the completed keyed review's semantic "
+                "verdict. Never review your own input or release on scheduling "
+                "evidence alone.\n\n"
+                + body.strip()
+            )
+        if requires_human_activation:
+            body = (
+                "HUMAN_ACTIVATION_GATE: PREPARE_ONLY. This shard must remain "
+                "blocked until a human explicitly approves and unblocks the "
+                "activation/deployment. Never self-approve.\n\n"
+                + body.strip()
+            )
         children.append({
             "title": title.strip()[:200],
             "body": body.strip(),
             "assignee": chosen,
             "parents": clean_parents,
+            "kind": kind,
+            "review_key": review_key,
+            "requires_human_activation": requires_human_activation,
         })
+
+    for idx, child in enumerate(children):
+        parent_kinds = {children[p]["kind"] for p in child["parents"]}
+        if child["kind"] in {"review", "review_scheduler"} and "closure" not in parent_kinds:
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"tasks[{idx}] {child['kind']} must depend on a closure child",
+            )
+        if child["kind"] == "controller" and "review" not in parent_kinds:
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"tasks[{idx}] controller must depend directly on a keyed review child",
+            )
 
     try:
         with kb.connect_closing() as conn:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -604,6 +604,8 @@ class CreateTaskBody(BaseModel):
     parents: list[str] = Field(default_factory=list)
     triage: bool = False
     idempotency_key: Optional[str] = None
+    review_key: Optional[str] = None
+    allow_broad: bool = False
     max_runtime_seconds: Optional[int] = None
     skills: Optional[list[str]] = None
     goal_mode: bool = False
@@ -628,6 +630,8 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             parents=payload.parents,
             triage=payload.triage,
             idempotency_key=payload.idempotency_key,
+            review_key=payload.review_key,
+            granularity_policy="allow" if payload.allow_broad else None,
             max_runtime_seconds=payload.max_runtime_seconds,
             skills=payload.skills,
             goal_mode=payload.goal_mode,

--- a/scripts/benchmark_kanban_context.py
+++ b/scripts/benchmark_kanban_context.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Deterministic synthetic benchmark for Kanban worker-context profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def run_benchmark() -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="hermes-kanban-context-bench-") as tmp:
+        home = Path(tmp) / ".hermes"
+        os.environ["HERMES_HOME"] = str(home)
+        os.environ["HERMES_KANBAN_BOARD"] = "context-benchmark"
+
+        from hermes_cli import kanban_db as kb
+
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn,
+                title="Synthetic broad lifecycle benchmark",
+                body="BODY_MARKER\n" + ("B" * 8_000),
+                assignee="benchmark-worker",
+                granularity_policy="allow",
+            )
+
+            for index in range(20):
+                parent_id = kb.create_task(
+                    conn,
+                    title=f"Synthetic parent {index}",
+                    body="PARENT_BODY\n" + ("P" * 2_000),
+                    assignee="benchmark-worker",
+                    granularity_policy="allow",
+                )
+                conn.execute(
+                    "UPDATE tasks SET status = 'done', result = ? WHERE id = ?",
+                    (f"parent-result-{index}-" + ("R" * 5_000), parent_id),
+                )
+                conn.execute(
+                    """INSERT INTO task_runs
+                       (task_id, profile, status, started_at, ended_at, outcome,
+                        summary, metadata, error)
+                       VALUES (?, 'benchmark-worker', 'done', 1, 2, 'completed',
+                               ?, ?, NULL)""",
+                    (
+                        parent_id,
+                        f"parent-summary-{index}-" + ("S" * 6_000),
+                        '{"blob":"' + ("M" * 6_000) + '"}',
+                    ),
+                )
+                conn.execute(
+                    "INSERT INTO task_links(parent_id, child_id) VALUES (?, ?)",
+                    (parent_id, task_id),
+                )
+
+            for index in range(8):
+                conn.execute(
+                    """INSERT INTO task_runs
+                       (task_id, profile, status, started_at, ended_at, outcome,
+                        summary, metadata, error)
+                       VALUES (?, 'benchmark-worker', 'failed', ?, ?, 'timed_out',
+                               ?, ?, ?)""",
+                    (
+                        task_id,
+                        10 + index,
+                        20 + index,
+                        f"attempt-summary-{index}-" + ("A" * 7_000),
+                        '{"blob":"' + ("D" * 7_000) + '"}',
+                        f"attempt-error-{index}-" + ("E" * 7_000),
+                    ),
+                )
+
+            for index in range(40):
+                kb.add_comment(
+                    conn,
+                    task_id,
+                    author="benchmark-worker",
+                    body=f"comment-{index}-" + ("C" * 3_000),
+                )
+            conn.commit()
+
+            full = kb.build_worker_context(conn, task_id, compact=False)
+            compact = kb.build_worker_context(conn, task_id, compact=True)
+
+        full_bytes = len(full.encode("utf-8"))
+        compact_bytes = len(compact.encode("utf-8"))
+        reduced_bytes = full_bytes - compact_bytes
+        reduction_pct = round((reduced_bytes / full_bytes) * 100, 2)
+        omissions = {
+            "comments": 40 - kb._CTX_COMPACT_MAX_COMMENTS,
+            "parents": 20 - kb._CTX_COMPACT_MAX_PARENTS,
+            "prior_attempts": 8 - kb._CTX_COMPACT_MAX_PRIOR_ATTEMPTS,
+        }
+        recovery = {
+            "cli": (
+                "hermes kanban context <task_id> --run-id <run_id> "
+                "--field partial_summary_full"
+            ),
+            "model_tool": "kanban_show(task_id=<task_id>, full_context=true)",
+        }
+        return {
+            "benchmark": "kanban_worker_context_synthetic_v1",
+            "fixture": {
+                "parents": 20,
+                "prior_attempts": 8,
+                "comments": 40,
+                "task_body_chars": 8_012,
+            },
+            "full": {
+                "utf8_bytes": full_bytes,
+                "approx_tokens_at_4_bytes_per_token": math.ceil(full_bytes / 4),
+            },
+            "compact": {
+                "utf8_bytes": compact_bytes,
+                "approx_tokens_at_4_bytes_per_token": math.ceil(compact_bytes / 4),
+            },
+            "savings": {
+                "utf8_bytes": reduced_bytes,
+                "approx_tokens_at_4_bytes_per_token": math.ceil(reduced_bytes / 4),
+                "percent": reduction_pct,
+            },
+            "omissions": omissions,
+            "recovery": recovery,
+            "contracts": {
+                "compact_under_48k_utf8": compact_bytes <= 48 * 1024,
+                "compact_under_half_of_full": compact_bytes < full_bytes / 2,
+                "cli_recovery_marker_present": "hermes kanban context" in compact,
+                "model_tool_recovery_marker_present": "kanban_show" in compact,
+                "parent_omission_marker_present": "12 earlier parents" in compact,
+                "attempt_omission_marker_present": "7 earlier attempts" in compact,
+                "comment_omission_marker_present": "34 earlier comments" in compact,
+                "task_body_preserved": "BODY_MARKER" in compact,
+            },
+            "caveat": (
+                "Token counts are a transparent 4-UTF-8-bytes/token approximation; "
+                "provider tokenizers and cache behavior vary."
+            ),
+        }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    report = run_benchmark()
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0 if all(report["contracts"].values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_iteration_budget_checkpoint.py
+++ b/tests/agent/test_iteration_budget_checkpoint.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from agent.iteration_budget import (
+    CURRENT_TURN_ID_KEY,
+    _current_turn_user_index,
+    _latest_unseen_tool_result,
+    kanban_checkpoint_warning,
+)
+
+
+def test_warning_fires_once_at_configured_budget_ratio() -> None:
+    assert (
+        kanban_checkpoint_warning(
+            used=44,
+            max_total=60,
+            ratio=0.75,
+            is_kanban=True,
+            already_emitted=False,
+        )
+        is None
+    )
+
+    warning = kanban_checkpoint_warning(
+        used=45,
+        max_total=60,
+        ratio=0.75,
+        is_kanban=True,
+        already_emitted=False,
+    )
+    assert warning is not None
+    assert "45/60" in warning
+    assert "atomic claim" in warning
+    assert "Do not claim PASS" in warning
+    assert len(warning) < 700
+
+    assert (
+        kanban_checkpoint_warning(
+            used=46,
+            max_total=60,
+            ratio=0.75,
+            is_kanban=True,
+            already_emitted=True,
+        )
+        is None
+    )
+
+
+def test_warning_never_changes_non_kanban_turns() -> None:
+    assert (
+        kanban_checkpoint_warning(
+            used=59,
+            max_total=60,
+            ratio=0.75,
+            is_kanban=False,
+            already_emitted=False,
+        )
+        is None
+    )
+
+
+def test_checkpoint_targets_only_a_tool_result_not_sent_before() -> None:
+    old = {"role": "tool", "tool_call_id": "old", "content": "old result"}
+    new = {"role": "tool", "tool_call_id": "new", "content": "new result"}
+    messages = [
+        {"role": "user", "content": "task"},
+        old,
+        {"role": "assistant", "content": "continuing"},
+        new,
+    ]
+
+    assert _latest_unseen_tool_result(
+        messages,
+        seen_tool_call_ids={"old"},
+        seen_legacy_message_ids={id(old)},
+    ) == (3, "new")
+    assert (
+        _latest_unseen_tool_result(
+            messages,
+            seen_tool_call_ids={"old", "new"},
+            seen_legacy_message_ids={id(old), id(new)},
+        )
+        is None
+    )
+
+
+def test_checkpoint_never_reanchors_before_current_turn_or_to_legacy_result() -> None:
+    historical = {
+        "role": "tool",
+        "tool_call_id": "historical",
+        "content": "old result",
+    }
+    legacy = {"role": "tool", "content": "rebuilt old result"}
+    current = {
+        "role": "tool",
+        "tool_call_id": "current",
+        "content": [{"type": "text", "text": "new multimodal result"}],
+    }
+    messages = [
+        historical,
+        legacy,
+        {"role": "user", "content": "current turn"},
+        current,
+    ]
+
+    assert _latest_unseen_tool_result(
+        messages,
+        seen_tool_call_ids=set(),
+        seen_legacy_message_ids=set(),
+        min_index=3,
+        require_tool_call_id=True,
+    ) == (3, "current")
+    assert (
+        _latest_unseen_tool_result(
+            messages[:3],
+            seen_tool_call_ids=set(),
+            seen_legacy_message_ids=set(),
+            min_index=2,
+            require_tool_call_id=True,
+        )
+        is None
+    )
+
+
+def test_current_turn_boundary_survives_compaction_copies() -> None:
+    historical = {
+        "role": "user",
+        "content": "same text",
+        CURRENT_TURN_ID_KEY: "old-turn",
+    }
+    current = {
+        "role": "user",
+        "content": "same text",
+        CURRENT_TURN_ID_KEY: "current-turn",
+    }
+    compressed = [message.copy() for message in [historical, current]]
+
+    assert _current_turn_user_index(compressed, "current-turn") == 1
+    assert _current_turn_user_index(compressed, "missing-turn") is None

--- a/tests/agent/test_iteration_limit_handoff_prompt.py
+++ b/tests/agent/test_iteration_limit_handoff_prompt.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from agent.chat_completion_helpers import _iteration_limit_summary_request
+
+
+def test_kanban_iteration_limit_requests_compact_continuation_handoff() -> None:
+    prompt = _iteration_limit_summary_request(is_kanban=True)
+
+    assert "PARTIAL_UNVERIFIED_HANDOFF" in prompt
+    for heading in (
+        "COMPLETED",
+        "CHANGED_FILES",
+        "TESTS",
+        "REMAINING",
+        "RESUME",
+        "INVARIANTS",
+    ):
+        assert heading in prompt
+    assert "Do not claim PASS" in prompt
+    assert "without calling any more tools" in prompt
+    assert len(prompt) < 1600
+
+
+def test_non_kanban_iteration_limit_keeps_general_summary_contract() -> None:
+    prompt = _iteration_limit_summary_request(is_kanban=False)
+
+    assert "summarizing what you've found and accomplished so far" in prompt
+    assert "PARTIAL_UNVERIFIED_HANDOFF" not in prompt

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.context_compressor import ContextCompressor
+from agent.iteration_budget import CURRENT_TURN_ID_KEY
 from agent.turn_context import TurnContext, build_turn_context
 from hermes_state import SessionDB
 
@@ -174,9 +175,61 @@ def test_returns_turn_context_with_user_message_appended():
     assert isinstance(ctx, TurnContext)
     assert ctx.user_message == "hello"
     # The user turn was appended and indexed.
-    assert ctx.messages[-1] == {"role": "user", "content": "hello"}
+    assert ctx.messages[-1]["role"] == "user"
+    assert ctx.messages[-1]["content"] == "hello"
+    assert ctx.messages[-1][CURRENT_TURN_ID_KEY] == ctx.turn_id
     assert ctx.current_turn_user_idx == len(ctx.messages) - 1
     assert ctx.active_system_prompt == "SYSTEM"
+
+
+def test_preflight_sizing_observes_only_provider_visible_messages():
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent.context_compressor = types.SimpleNamespace(
+        protect_first_n=2,
+        protect_last_n=2,
+        threshold_tokens=1,
+        last_prompt_tokens=0,
+        last_real_prompt_tokens=0,
+        context_length=1000,
+        should_defer_preflight_to_real_usage=lambda _tokens: False,
+        get_active_compression_failure_cooldown=lambda: None,
+        should_compress=MagicMock(side_effect=[True, False]),
+    )
+    setattr(
+        agent,
+        "_compress_context",
+        MagicMock(
+            side_effect=lambda messages, *_args, **_kwargs: (
+                [dict(message) for message in messages],
+                "SYSTEM",
+            )
+        ),
+    )
+    cheap_seen = []
+    request_seen = []
+
+    def cheap_spy(messages):
+        cheap_seen.append(messages)
+        return 100
+
+    request_values = iter((100, 50))
+
+    def request_spy(messages, **_kwargs):
+        request_seen.append(messages)
+        return next(request_values)
+
+    with (
+        patch("agent.turn_context.estimate_messages_tokens_rough", cheap_spy),
+        patch("agent.turn_context.estimate_request_tokens_rough", request_spy),
+    ):
+        ctx = _build(agent)
+
+    assert len(cheap_seen) == 1
+    assert len(request_seen) == 2
+    for observed in [*cheap_seen, *request_seen]:
+        assert all(not key.startswith("_") for message in observed for key in message)
+    assert CURRENT_TURN_ID_KEY in ctx.messages[-1]
 
 
 def test_applies_agent_side_effects():

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -270,10 +270,13 @@ def test_pending_response_does_not_mask_later_terminal_exit(
 def test_pending_response_records_kanban_timeout(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
-    record = MagicMock(name="record_task_failure")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "9")
+    record = MagicMock(name="record_iteration_budget_exhaustion")
     conn = SimpleNamespace(close=lambda: None)
     monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
-    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.record_iteration_budget_exhaustion", record
+    )
     agent = _LimitAgent()
 
     result = _finalize(
@@ -287,12 +290,12 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
     record.assert_called_once_with(
         conn,
         "task-123",
+        expected_run_id=9,
         error=(
             "Iteration budget exhausted (60/60) — task could not complete "
             "within the allowed iterations"
         ),
-        outcome="timed_out",
-        release_claim=True,
-        end_run=True,
-        event_payload_extra={"budget_used": 60, "budget_max": 60},
+        partial_summary="composed report",
+        budget_used=60,
+        budget_max=60,
     )

--- a/tests/hermes_cli/test_kanban_budget.py
+++ b/tests/hermes_cli/test_kanban_budget.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_cli.kanban_budget import (
+    TaskBudgetAssessment,
+    assess_task,
+    canonical_review_idempotency_key,
+)
+
+
+def test_narrow_bugfix_is_ok() -> None:
+    assessment = assess_task(
+        "Fix None handling in parser",
+        "Add one regression test, patch parser.py, and run that test.",
+        max_turns=60,
+    )
+
+    assert isinstance(assessment, TaskBudgetAssessment)
+    assert assessment.verdict == "ok"
+    assert assessment.score < assessment.split_threshold
+    assert "implementation" in assessment.action_families
+    assert "verification" in assessment.action_families
+
+
+def test_compound_security_lifecycle_requires_split() -> None:
+    body = """
+    Inspect the current authority implementation and diagnose the bypass.
+    Implement the remediation across installer.py and bootstrap.py.
+    Run focused RED/GREEN tests, dual-runtime provisioning tests, Ruff,
+    compilation, and the full project suite. Freeze hashes and create receipts.
+    Launch one independent adversarial review over the immutable postimage.
+    After PASS, run a separate controller and prepare the sudo gate without
+    activating it.
+    """
+
+    assessment = assess_task("Close S3R7 remediation, review, and controller", body)
+
+    assert assessment.verdict == "split"
+    assert {
+        "discovery",
+        "implementation",
+        "verification",
+        "evidence",
+        "review",
+        "controller",
+    }.issubset(set(assessment.action_families))
+    assert "compound_lifecycle" in assessment.reasons
+    assert assessment.suggested_shards == (
+        "discovery",
+        "implementation",
+        "verification_and_evidence",
+        "independent_review",
+        "controller",
+    )
+
+
+def test_spanish_scope_markers_are_detected() -> None:
+    assessment = assess_task(
+        "Investigar, corregir, verificar y revisar el gate",
+        """
+        Investiga la causa, diseña la arquitectura, implementa la corrección,
+        ejecuta pruebas focales y la matriz completa, congela hashes y recibos,
+        realiza una revisión adversarial independiente y después un controller.
+        """,
+    )
+
+    assert assessment.verdict == "split"
+    assert "discovery" in assessment.action_families
+    assert "review" in assessment.action_families
+    assert "controller" in assessment.action_families
+
+
+def test_many_acceptance_items_raise_scope_without_model_call() -> None:
+    body = "\n".join(f"{n}. Acceptance criterion {n}" for n in range(1, 13))
+    assessment = assess_task("Validate migration", body)
+
+    assert assessment.acceptance_items >= 12
+    assert "many_acceptance_items" in assessment.reasons
+    assert assessment.verdict in {"caution", "split"}
+
+
+def test_estimated_turns_are_compared_with_the_actual_budget() -> None:
+    assessment = assess_task(
+        "Implement and verify one parser correction",
+        "Patch parser.py and run its focused pytest regression.",
+        max_turns=8,
+    )
+
+    assert assessment.estimated_turns > assessment.max_turns
+    assert assessment.verdict in {"caution", "split"}
+    assert "estimated_turns_exceed_budget" in assessment.reasons
+
+
+def test_four_distinct_lifecycle_families_always_require_split() -> None:
+    assessment = assess_task(
+        "Investigate, implement, verify, and independently review",
+        "Inspect the bug, patch parser.py, run focused tests, then audit the postimage.",
+        max_turns=120,
+    )
+
+    assert len(assessment.action_families) == 4
+    assert assessment.verdict == "split"
+    assert assessment.score >= assessment.split_threshold
+
+
+@pytest.mark.parametrize(
+    ("title", "body"),
+    [
+        (
+            "Release version 12 to production",
+            "Ship the approved build now.",
+        ),
+        (
+            "Promote version 12 to production",
+            "Move the approved build into the live environment.",
+        ),
+        (
+            "Roll out the production release",
+            "Make the new build live for all users now.",
+        ),
+        (
+            "Poner la versión en producción",
+            "Lanza la nueva versión para todos los usuarios.",
+        ),
+        (
+            "Liberar la versión 12 en producción",
+            "Promover el build aprobado al entorno vivo.",
+        ),
+        (
+            "Submit the approved package",
+            "Send it to the external registry now.",
+        ),
+        (
+            "Publica la aplicación en producción ahora",
+            "Hazla disponible para todos los usuarios externos.",
+        ),
+    ],
+)
+def test_activation_euphemisms_are_classified_fail_closed(title, body) -> None:
+    assessment = assess_task(title, body)
+
+    assert "activation" in assessment.action_families
+
+
+def test_public_english_adjective_is_not_an_activation_verb() -> None:
+    assessment = assess_task(
+        "Document the public API",
+        "Write local documentation for the public interface.",
+    )
+
+    assert "activation" not in assessment.action_families
+
+
+def test_assessment_serialization_is_deterministic() -> None:
+    first = assess_task("Implement and test", "Patch x.py and run pytest.")
+    second = assess_task("Implement and test", "Patch x.py and run pytest.")
+
+    assert first.to_dict() == second.to_dict()
+    assert json.dumps(first.to_dict(), sort_keys=True) == json.dumps(
+        second.to_dict(), sort_keys=True
+    )
+
+
+def test_review_key_maps_to_existing_idempotency_surface() -> None:
+    digest = "a" * 64
+    claims = "b" * 64
+    assert (
+        canonical_review_idempotency_key(f"  {digest.upper()}:{claims.upper()}  ")
+        == f"review:v1:{digest}:{claims}"
+    )
+    assert canonical_review_idempotency_key(f"{digest}:{claims}") == (
+        f"review:v1:{digest}:{claims}"
+    )
+    assert canonical_review_idempotency_key(f"{digest}:{claims}:round-2") == (
+        f"review:v1:{digest}:{claims}:round-2"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "../escape", "contains spaces", "x" * 201, "review:already-prefixed"],
+)
+def test_review_key_rejects_ambiguous_or_unsafe_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        canonical_review_idempotency_key(value)
+
+
+def test_review_key_requires_postimage_and_claim_contract_digests() -> None:
+    with pytest.raises(ValueError, match="postimage.*claims"):
+        canonical_review_idempotency_key("a" * 64)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -91,6 +91,44 @@ def test_run_slash_create_and_list(kanban_home):
     assert "alice" in out
 
 
+def test_context_reads_exact_hash_bound_run_field(kanban_home, capsys):
+    source = "FULL_SOURCE:" + ("🧭" * 20_000) + ":SOURCE_TAIL_SENTINEL"
+    digest = __import__("hashlib").sha256(source.encode("utf-8")).hexdigest()
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="Recovery target")
+        cursor = conn.execute(
+            """INSERT INTO task_runs
+               (task_id, status, started_at, ended_at, outcome, metadata)
+               VALUES (?, 'done', 1, 2, 'completed', ?)""",
+            (task_id, json.dumps({
+                "partial_summary_full": source,
+                "partial_summary_sha256": digest,
+            })),
+        )
+        assert cursor.lastrowid is not None
+        run_id = int(cursor.lastrowid)
+        conn.commit()
+
+    args = argparse.Namespace(
+        task_id=task_id,
+        full=False,
+        run_id=run_id,
+        field="partial_summary_full",
+    )
+    assert kc._cmd_context(args) == 0
+    captured = capsys.readouterr()
+
+    assert captured.err == ""
+    assert captured.out == source
+    assert (
+        kc.run_slash(
+            f"context {task_id} --run-id {run_id} "
+            "--field partial_summary_full"
+        )
+        == source
+    )
+
+
 def test_run_slash_create_worktree_path_and_branch(kanban_home, tmp_path):
     target = tmp_path / ".worktrees" / "t6-wire"
     target_arg = target.as_posix()

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -835,6 +835,54 @@ def test_cli_create_with_idempotency_key(kanban_home):
     assert tid1 == tid2
 
 
+def test_cli_create_with_review_key(kanban_home):
+    digest = "c" * 64
+    review_key = f"{digest}:{'d' * 64}"
+    tid1 = json.loads(run_slash(
+        f"create 'review one' --review-key {review_key} --json"
+    ))["id"]
+    tid2 = json.loads(run_slash(
+        f"create 'review duplicate' --review-key {review_key} --json"
+    ))["id"]
+    assert tid1 == tid2
+
+
+def test_cli_allow_broad_records_explicit_override(kanban_home):
+    broad = (
+        "Investigate, implement, run full suite, freeze receipts, "
+        "independent review, then controller"
+    )
+    task_id = json.loads(run_slash(
+        f"create 'broad card' --body '{broad}' --allow-broad --json"
+    ))["id"]
+    conn = kb.connect()
+    try:
+        event = next(
+            e for e in kb.list_events(conn, task_id)
+            if e.kind == "granularity_assessed"
+        )
+    finally:
+        conn.close()
+    assert event.payload["policy"] == "allow"
+    assert event.payload["auto_triaged"] is False
+
+
+def test_cli_context_full_forces_recoverable_full_mode(kanban_home, monkeypatch):
+    task_id = json.loads(run_slash("create 'context target' --json"))["id"]
+    original = kb.build_worker_context
+    seen: list[bool | None] = []
+
+    def capture(conn, requested_id, *, compact=None):
+        seen.append(compact)
+        return original(conn, requested_id, compact=compact)
+
+    monkeypatch.setattr(kb, "build_worker_context", capture)
+    out = run_slash(f"context {task_id} --full")
+
+    assert f"Kanban task {task_id}" in out
+    assert seen == [False]
+
+
 # ---------------------------------------------------------------------------
 # CLI stats / watch / log / notify / daemon parity
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -200,6 +200,9 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     assert "session_id" in task_columns
     assert "tenant" in task_columns
     assert "idempotency_key" in task_columns
+    assert "review_contract" in task_columns
+    assert "review_postimage_sha256" in task_columns
+    assert "review_claims_sha256" in task_columns
     assert "run_id" in event_columns
     # And their indexes — the regression scope of this test:
     assert "idx_tasks_session_id" in indexes

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -113,6 +113,388 @@ def test_decompose_with_fanout_creates_children(kanban_home):
     assert c1.assignee == "engineer"
 
 
+def test_decomposer_receives_budget_assessment_and_rejects_split_single_task(
+    kanban_home,
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Implement, verify, review, and control a migration",
+            body=(
+                "Implement the change, run the full suite, freeze receipts, "
+                "request an independent review, then run a controller."
+            ),
+            assignee="orchestrator",
+            triage=True,
+        )
+        conn.execute(
+            """INSERT INTO task_runs
+               (task_id, profile, status, started_at, ended_at, outcome,
+                summary, metadata, error)
+               VALUES (?, 'worker', 'gave_up', 1, 2, 'gave_up', ?, ?, NULL)""",
+            (
+                tid,
+                "[partial_unverified]\nCOMPLETED: parser patch\n"
+                "REMAINING: closure and review",
+                '{"changed_files":["parser.py"]}',
+            ),
+        )
+        conn.commit()
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit for fixture",
+        "title": "Tightened task",
+        "body": "Continue safely.",
+        "assignee": "orchestrator",
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for item in patches:
+        item.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=_fake_aux_response(llm_payload),
+        ) as call_llm:
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert not outcome.ok
+    assert "split" in outcome.reason
+    request = call_llm.call_args.kwargs["messages"]
+    system_prompt = request[0]["content"]
+    user_prompt = request[1]["content"]
+    assert "full matrix belongs in the closure" in system_prompt
+    assert "review_key" in system_prompt
+    assert "granularity_assessed" in user_prompt
+    assert '"verdict": "split"' in user_prompt
+    assert "[partial_unverified]" in user_prompt
+    assert "COMPLETED: parser patch" in user_prompt
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_decompose_rejects_fanout_above_six_without_mutation(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="bounded fanout", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "tasks": [
+            {"title": f"shard {index}", "body": "one unit", "parents": []}
+            for index in range(7)
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert not outcome.ok
+    assert "at most 6" in outcome.reason
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+        assert kb.child_ids(conn, tid) == []
+
+
+def test_decompose_rejects_single_child_fanout_that_remains_split(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="broad split", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "tasks": [
+            {
+                "kind": "work",
+                "parents": [],
+                "title": "Implement, verify, review, and control",
+                "body": (
+                    "Implement patch.py, run the full suite, freeze receipts, "
+                    "conduct an independent review, and issue a controller verdict."
+                ),
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert not outcome.ok
+    assert "2" in outcome.reason or "split" in outcome.reason
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        children = kb.child_ids(conn, tid)
+    assert task is not None and task.status == "triage"
+    assert children == []
+
+
+def test_decompose_rejects_split_child_inside_valid_fanout(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="broad split", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "tasks": [
+            {
+                "kind": "work",
+                "parents": [],
+                "title": "Implement, verify, review, and control",
+                "body": (
+                    "Implement patch.py, run the full suite, freeze receipts, "
+                    "conduct an independent review, and issue a controller verdict."
+                ),
+            },
+            {
+                "kind": "work",
+                "parents": [],
+                "title": "Prepare notes",
+                "body": "Summarize one atomic set of notes.",
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert not outcome.ok
+    assert "remains split" in outcome.reason
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        children = kb.child_ids(conn, tid)
+    assert task is not None and task.status == "triage"
+    assert children == []
+
+
+def test_decompose_rejects_controller_semantics_mislabeled_as_work(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="gated work", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "tasks": [
+            {
+                "kind": "work",
+                "parents": [],
+                "title": "Issue controller verdict",
+                "body": "Decide GO or NO-GO immediately from the card.",
+            },
+            {
+                "kind": "work",
+                "parents": [],
+                "title": "Prepare notes",
+                "body": "Summarize the scoped implementation notes.",
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert not outcome.ok
+    assert "controller" in outcome.reason
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        children = kb.child_ids(conn, tid)
+    assert task is not None and task.status == "triage"
+    assert children == []
+
+
+def test_decompose_rejects_activation_semantics_mislabeled_as_work(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="release plan", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "tasks": [
+            {
+                "kind": "work",
+                "parents": [],
+                "title": "Roll out the production release",
+                "body": "Make the new build live for all users now.",
+            },
+            {
+                "kind": "work",
+                "parents": [],
+                "title": "Prepare notes",
+                "body": "Summarize one atomic set of notes.",
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert not outcome.ok
+    assert "activation" in outcome.reason
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        children = kb.child_ids(conn, tid)
+    assert task is not None and task.status == "triage"
+    assert children == []
+
+
+def test_decompose_explicit_activation_kind_blocks_euphemistic_release(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="release plan", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "tasks": [
+            {
+                "kind": "activation",
+                "parents": [],
+                "title": "Roll out the production release",
+                "body": "Make the new build live for all users now.",
+            },
+            {
+                "kind": "work",
+                "parents": [],
+                "title": "Prepare rollback notes",
+                "body": "Document the rollback checklist without activating it.",
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.child_ids and len(outcome.child_ids) == 2
+    with kb.connect() as conn:
+        activation = kb.get_task(conn, outcome.child_ids[0])
+    assert activation is not None and activation.status == "blocked"
+    assert activation.block_kind == "needs_input"
+    assert (activation.body or "").startswith("HUMAN_ACTIVATION_GATE:")
+
+
+def test_decompose_reassesses_title_only_legacy_postimage(kanban_home):
+    broad_body = (
+        "Implement the migration, run the full suite, freeze receipts, "
+        "request independent review, and run the controller."
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Broad legacy task",
+            body=broad_body,
+            assignee="orchestrator",
+            triage=True,
+        )
+        conn.execute(
+            "DELETE FROM task_events WHERE task_id = ? "
+            "AND kind = 'granularity_assessed'",
+            (tid,),
+        )
+        conn.commit()
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "rename only",
+        "title": "Tightened title",
+        "assignee": "orchestrator",
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert not outcome.ok
+    assert "split" in outcome.reason
+    with kb.connect() as conn:
+        kb.recompute_ready(conn)
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.status == "triage"
+    assert task.title == "Broad legacy task"
+    assert task.body == broad_body
+
+
+def test_decompose_activation_shard_requires_human_unblock(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="release preparation", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "tasks": [
+            {
+                "title": "Deploy the release",
+                "body": "Publish and activate the release in production.",
+                "kind": "activation",
+                "parents": [],
+            },
+            {
+                "title": "Prepare rollback notes",
+                "body": "Document rollback steps without activating them.",
+                "parents": [],
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.child_ids and len(outcome.child_ids) == 2
+    with kb.connect() as conn:
+        child = kb.get_task(conn, outcome.child_ids[0])
+        promoted = kb.recompute_ready(conn)
+        after = kb.get_task(conn, outcome.child_ids[0])
+
+    assert child is not None and child.status == "blocked"
+    assert child.block_kind == "needs_input"
+    assert (child.body or "").startswith("HUMAN_ACTIVATION_GATE:")
+    assert promoted == 0
+    assert after is not None and after.status == "blocked"
+
+
 def test_decompose_fanout_false_assigns_default_when_unassigned(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="just one thing", triage=True)
@@ -261,6 +643,12 @@ def test_decompose_unknown_assignee_falls_back_to_default(kanban_home):
         "rationale": "test",
         "tasks": [
             {"title": "do X", "body": "", "assignee": "made_up", "parents": []},
+            {
+                "title": "do Y",
+                "body": "",
+                "assignee": "fallback",
+                "parents": [],
+            },
         ],
     })
 
@@ -286,11 +674,117 @@ def test_decompose_unknown_assignee_falls_back_to_default(kanban_home):
             p.stop()
 
     assert outcome.ok, outcome.reason
-    assert outcome.child_ids and len(outcome.child_ids) == 1
+    assert outcome.child_ids and len(outcome.child_ids) == 2
     with kb.connect() as conn:
         child = kb.get_task(conn, outcome.child_ids[0])
     # 'made_up' wasn't in roster, so assignee rewritten to 'fallback'
     assert child.assignee == "fallback"
+
+
+def test_decomposer_rejects_direct_review_without_exact_review_key(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="close and review", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "closure then review",
+        "tasks": [
+            {
+                "title": "Freeze closure postimage",
+                "body": "Run tests and freeze hashes.",
+                "assignee": "engineer",
+                "kind": "closure",
+                "parents": [],
+            },
+            {
+                "title": "Review closure",
+                "body": "Review the immutable postimage.",
+                "assignee": "reviewer",
+                "kind": "review",
+                "parents": [0],
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator", "engineer", "reviewer"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert outcome.ok is False
+    assert "review_key" in outcome.reason
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_decomposer_persists_keyed_review_and_controller_dependencies(kanban_home):
+    postimage = "a" * 64
+    claims = "b" * 64
+    review_key = f"{postimage}:{claims}"
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="close, review, and control", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "gated lifecycle",
+        "tasks": [
+            {
+                "title": "Freeze closure postimage",
+                "body": "Run the matrix and freeze exact hashes.",
+                "assignee": "engineer",
+                "kind": "closure",
+                "parents": [],
+            },
+            {
+                "title": "Review frozen postimage",
+                "body": "Review only the immutable postimage and claims.",
+                "assignee": "reviewer",
+                "kind": "review",
+                "review_key": review_key,
+                "parents": [0],
+            },
+            {
+                "title": "Issue controller verdict",
+                "body": "Consume the semantic review verdict without self-approval.",
+                "assignee": "controller",
+                "kind": "controller",
+                "parents": [1],
+            },
+        ],
+    })
+    patches = _patch_list_profiles(
+        ["orchestrator", "engineer", "reviewer", "controller"]
+    )
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.child_ids and len(outcome.child_ids) == 3
+    closure_id, review_id, controller_id = outcome.child_ids
+    with kb.connect() as conn:
+        review = kb.get_task(conn, review_id)
+        links = {
+            (row["parent_id"], row["child_id"])
+            for row in conn.execute(
+                "SELECT parent_id, child_id FROM task_links"
+            ).fetchall()
+        }
+
+    assert review is not None
+    assert review.idempotency_key == f"review:v1:{review_key}"
+    assert "REVIEW_KEY:" in (review.body or "")
+    assert (closure_id, review_id) in links
+    assert (review_id, controller_id) in links
 
 
 def test_decompose_handles_malformed_llm_json(kanban_home):

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -66,6 +66,350 @@ def test_decompose_creates_children_and_promotes_root(kanban_home):
     # Second child has parents=[0] → stays in todo until c0 completes.
     assert c1.status == "todo"
     assert c1.assignee == "engineer"
+    with kb.connect() as conn:
+        for child_id in child_ids:
+            assessments = [
+                event
+                for event in kb.list_events(conn, child_id)
+                if event.kind == "granularity_assessed"
+            ]
+            assert len(assessments) == 1
+            assert assessments[0].payload["source"] == "decomposer"
+
+
+def test_decompose_db_persists_review_scheduler_gate(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn, title="freeze then schedule review")
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[
+                {
+                    "title": "Freeze postimage",
+                    "body": "Run closure and compute exact hashes.",
+                    "kind": "closure",
+                    "parents": [],
+                },
+                {
+                    "title": "Schedule exact review",
+                    "body": "Create the reviewer after hashes exist.",
+                    "kind": "review_scheduler",
+                    "parents": [0],
+                },
+            ],
+            author="decomposer",
+        )
+
+    assert child_ids is not None
+    with kb.connect() as conn:
+        scheduler = kb.get_task(conn, child_ids[1])
+    assert scheduler is not None
+    assert (scheduler.body or "").startswith("REVIEW_SCHEDULER_GATE:")
+    assert scheduler.idempotency_key is None
+
+
+def _exact_review_children(review_key):
+    return [
+        {"title": "Freeze exact postimage", "kind": "closure", "parents": []},
+        {
+            "title": "Review exact postimage",
+            "kind": "review",
+            "review_key": review_key,
+            "parents": [0],
+        },
+    ]
+
+
+def test_decompose_persists_durable_exact_review_identity(kanban_home):
+    postimage = "a" * 64
+    claims = "b" * 64
+    review_key = f"{postimage}:{claims}"
+
+    with kb.connect() as conn:
+        root_id = _create_triage(conn, title="create durable exact review")
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root_id,
+            root_assignee="orchestrator",
+            children=_exact_review_children(review_key),
+            author="decomposer",
+        )
+        assert child_ids is not None
+        row = conn.execute(
+            """SELECT idempotency_key, review_contract,
+                      review_postimage_sha256, review_claims_sha256
+                 FROM tasks WHERE id = ?""",
+            (child_ids[1],),
+        ).fetchone()
+
+    assert row["idempotency_key"] == f"review:v1:{review_key}"
+    assert row["review_contract"] == "exact_review_v1"
+    assert row["review_postimage_sha256"] == postimage
+    assert row["review_claims_sha256"] == claims
+
+
+def test_decompose_rejects_legacy_exact_review_incumbent_atomically(kanban_home):
+    postimage = "c" * 64
+    claims = "d" * 64
+    review_key = f"{postimage}:{claims}"
+    reserved = f"review:v1:{review_key}"
+
+    with kb.connect() as conn:
+        conn.execute(
+            """INSERT INTO tasks
+               (id, title, status, created_at, idempotency_key)
+               VALUES ('poisoned', 'legacy incumbent', 'ready', 1, ?)""",
+            (reserved,),
+        )
+        root_id = _create_triage(conn, title="reject legacy exact review")
+        conn.commit()
+
+        with pytest.raises(ValueError, match="ambiguous legacy exact-review"):
+            kb.decompose_triage_task(
+                conn,
+                root_id,
+                root_assignee="orchestrator",
+                children=_exact_review_children(review_key),
+                author="decomposer",
+            )
+        root = kb.get_task(conn, root_id)
+        linked = kb.child_ids(conn, root_id)
+
+    assert root is not None and root.status == "triage"
+    assert linked == []
+
+
+def test_decompose_rejects_duplicate_exact_review_incumbents_atomically(kanban_home):
+    postimage = "e" * 64
+    claims = "f" * 64
+    review_key = f"{postimage}:{claims}"
+    reserved = f"review:v1:{review_key}"
+
+    with kb.connect() as conn:
+        conn.executemany(
+            """INSERT INTO tasks
+               (id, title, status, created_at, idempotency_key,
+                review_contract, review_postimage_sha256, review_claims_sha256)
+               VALUES (?, 'duplicate exact review', 'ready', 1, ?,
+                       'exact_review_v1', ?, ?)""",
+            (
+                ("duplicate-a", reserved, postimage, claims),
+                ("duplicate-b", reserved, postimage, claims),
+            ),
+        )
+        root_id = _create_triage(conn, title="reject duplicate exact reviews")
+        conn.commit()
+
+        with pytest.raises(ValueError, match="ambiguous legacy exact-review"):
+            kb.decompose_triage_task(
+                conn,
+                root_id,
+                root_assignee="orchestrator",
+                children=_exact_review_children(review_key),
+                author="decomposer",
+            )
+        root = kb.get_task(conn, root_id)
+        linked = kb.child_ids(conn, root_id)
+
+    assert root is not None and root.status == "triage"
+    assert linked == []
+
+
+@pytest.mark.parametrize(
+    "review_body",
+    [
+        f"REVIEW_KEY: {'c' * 64}:{'d' * 64}\n\nReview the wrong postimage.",
+        (
+            f"REVIEW_KEY: {'a' * 64}:{'b' * 64}\n"
+            f"REVIEW_KEY: {'a' * 64}:{'b' * 64}\n\nReview the postimage."
+        ),
+    ],
+)
+def test_decompose_rejects_conflicting_or_multiple_review_body_identity_atomically(
+    kanban_home,
+    review_body,
+):
+    review_key = f"{'a' * 64}:{'b' * 64}"
+    children = _exact_review_children(review_key)
+    children[1]["body"] = review_body
+
+    with kb.connect() as conn:
+        root_id = _create_triage(conn, title="reject contradictory review identity")
+        with pytest.raises(ValueError, match="REVIEW_KEY"):
+            kb.decompose_triage_task(
+                conn,
+                root_id,
+                root_assignee="orchestrator",
+                children=children,
+                author="decomposer",
+            )
+        root = kb.get_task(conn, root_id)
+        linked = kb.child_ids(conn, root_id)
+
+    assert root is not None and root.status == "triage"
+    assert linked == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("idempotency_key", f"review:v1:{'c' * 64}:{'d' * 64}"),
+        ("review_contract", "legacy_review"),
+        ("review_postimage_sha256", "c" * 64),
+        ("review_claims_sha256", "d" * 64),
+    ],
+)
+def test_decompose_rejects_conflicting_durable_review_discriminator_atomically(
+    kanban_home,
+    field,
+    value,
+):
+    review_key = f"{'a' * 64}:{'b' * 64}"
+    children = _exact_review_children(review_key)
+    children[1][field] = value
+
+    with kb.connect() as conn:
+        root_id = _create_triage(conn, title="reject conflicting review discriminator")
+        with pytest.raises(ValueError, match="exact review"):
+            kb.decompose_triage_task(
+                conn,
+                root_id,
+                root_assignee="orchestrator",
+                children=children,
+                author="decomposer",
+            )
+        root = kb.get_task(conn, root_id)
+        linked = kb.child_ids(conn, root_id)
+
+    assert root is not None and root.status == "triage"
+    assert linked == []
+
+
+def test_decompose_rejects_reused_review_with_conflicting_body_identity_atomically(
+    kanban_home,
+):
+    review_key = f"{'a' * 64}:{'b' * 64}"
+    conflicting_key = f"{'c' * 64}:{'d' * 64}"
+
+    with kb.connect() as conn:
+        review_id = kb.create_task(
+            conn,
+            title="Existing exact review",
+            body=f"REVIEW_KEY: {review_key}",
+            review_key=review_key,
+        )
+        conn.execute(
+            "UPDATE tasks SET body = ? WHERE id = ?",
+            (f"REVIEW_KEY: {conflicting_key}", review_id),
+        )
+        root_id = _create_triage(conn, title="reject conflicting reused review")
+        conn.commit()
+
+        with pytest.raises(ValueError, match="ambiguous legacy exact-review"):
+            kb.decompose_triage_task(
+                conn,
+                root_id,
+                root_assignee="orchestrator",
+                children=_exact_review_children(review_key),
+                author="decomposer",
+            )
+        root = kb.get_task(conn, root_id)
+        linked = kb.child_ids(conn, root_id)
+
+    assert root is not None and root.status == "triage"
+    assert linked == []
+
+
+@pytest.mark.parametrize("review_status", ["running", "done"])
+def test_reused_exact_review_keeps_input_parents_immutable(
+    kanban_home,
+    review_status,
+):
+    review_key = f"{'a' * 64}:{'b' * 64}"
+    with kb.connect() as conn:
+        review_id = kb.create_task(
+            conn,
+            title="Existing exact review",
+            review_key=review_key,
+        )
+        conn.execute(
+            "UPDATE tasks SET status = ? WHERE id = ?",
+            (review_status, review_id),
+        )
+        root_id = _create_triage(conn, title="reuse exact review")
+        conn.commit()
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root_id,
+            root_assignee="orchestrator",
+            children=[
+                {
+                    "title": "Freeze exact postimage",
+                    "kind": "closure",
+                    "parents": [],
+                },
+                {
+                    "title": "Review exact postimage",
+                    "kind": "review",
+                    "review_key": review_key,
+                    "parents": [0],
+                },
+                {
+                    "title": "Controller",
+                    "kind": "controller",
+                    "parents": [1],
+                },
+            ],
+            author="decomposer",
+        )
+
+        assert child_ids is not None
+        closure_id, reused_id, controller_id = child_ids
+        review = kb.get_task(conn, review_id)
+        review_parents = kb.parent_ids(conn, review_id)
+        controller_parents = kb.parent_ids(conn, controller_id)
+
+    assert reused_id == review_id
+    assert review is not None and review.status == review_status
+    assert closure_id not in review_parents
+    assert review_id in controller_parents
+    assert closure_id in controller_parents
+
+
+def test_reused_ready_review_is_demoted_behind_new_closure(kanban_home):
+    review_key = f"{'c' * 64}:{'d' * 64}"
+    with kb.connect() as conn:
+        review_id = kb.create_task(
+            conn,
+            title="Ready exact review",
+            review_key=review_key,
+        )
+        root_id = _create_triage(conn, title="gate ready review")
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root_id,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "Freeze", "kind": "closure", "parents": []},
+                {
+                    "title": "Review",
+                    "kind": "review",
+                    "review_key": review_key,
+                    "parents": [0],
+                },
+            ],
+            author="decomposer",
+        )
+
+        assert child_ids is not None
+        closure_id, reused_id = child_ids
+        review = kb.get_task(conn, review_id)
+        review_parents = kb.parent_ids(conn, review_id)
+
+    assert reused_id == review_id
+    assert review is not None and review.status == "todo"
+    assert closure_id in review_parents
 
 
 def test_decompose_returns_none_when_task_missing(kanban_home):
@@ -104,6 +448,241 @@ def test_decompose_empty_children_returns_none(kanban_home):
             author="me",
         )
     assert result is None
+
+
+def test_decompose_db_rejects_single_child_fanout_without_mutation(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        with pytest.raises(ValueError, match="at least 2"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orch",
+                children=[{"title": "one child", "body": "one atomic task"}],
+                author="me",
+            )
+        task = kb.get_task(conn, tid)
+
+    assert task is not None and task.status == "triage"
+
+
+def test_decompose_db_rejects_split_child_even_under_warn_policy(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        with pytest.raises(ValueError, match="remains too broad"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orch",
+                children=[
+                    {
+                        "title": "Implement, verify, review, and control",
+                        "body": (
+                            "Implement patch.py, run the full suite, freeze receipts, "
+                            "conduct an independent review, and issue a controller verdict."
+                        ),
+                    },
+                    {"title": "Prepare notes", "body": "Summarize atomic notes."},
+                ],
+                author="me",
+            )
+        task = kb.get_task(conn, tid)
+
+    assert task is not None and task.status == "triage"
+
+
+def test_decompose_db_rejects_controller_semantics_mislabeled_as_work(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        with pytest.raises(ValueError, match="controller.*kind"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orch",
+                children=[
+                    {
+                        "title": "Issue controller verdict",
+                        "body": "Decide GO or NO-GO immediately.",
+                        "kind": "work",
+                    },
+                    {"title": "Prepare notes", "body": "Summarize atomic notes."},
+                ],
+                author="me",
+            )
+        task = kb.get_task(conn, tid)
+
+    assert task is not None and task.status == "triage"
+
+
+def test_decompose_db_rejects_activation_semantics_mislabeled_as_work(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        with pytest.raises(ValueError, match="activation.*kind"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orch",
+                children=[
+                    {
+                        "title": "Release version 12 to production",
+                        "body": "Ship the approved build now.",
+                        "kind": "work",
+                    },
+                    {"title": "Prepare notes", "body": "Summarize atomic notes."},
+                ],
+                author="me",
+            )
+        task = kb.get_task(conn, tid)
+        children = kb.child_ids(conn, tid)
+
+    assert task is not None and task.status == "triage"
+    assert children == []
+
+
+def test_decompose_db_rejects_localized_activation_mislabeled_as_work(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        with pytest.raises(ValueError, match="activation.*kind"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orch",
+                children=[
+                    {
+                        "title": "Publica la aplicación en producción ahora",
+                        "body": "Hazla disponible para todos los usuarios externos.",
+                        "kind": "work",
+                    },
+                    {"title": "Documenta el resultado", "body": "Resume el resultado."},
+                ],
+                author="me",
+            )
+        task = kb.get_task(conn, tid)
+        children = kb.child_ids(conn, tid)
+
+    assert task is not None and task.status == "triage"
+    assert children == []
+
+
+def test_decompose_db_explicit_activation_kind_is_always_blocked(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orch",
+            children=[
+                {
+                    "title": "Release version 12 to production",
+                    "body": "Ship the approved build now.",
+                    "kind": "activation",
+                },
+                {"title": "Prepare notes", "body": "Summarize atomic notes."},
+            ],
+            author="me",
+        )
+        assert child_ids is not None
+        activation = kb.get_task(conn, child_ids[0])
+
+    assert activation is not None and activation.status == "blocked"
+    assert activation.block_kind == "needs_input"
+    assert "PREPARE_ONLY" in (activation.body or "")
+
+
+def test_auto_decompose_attempt_is_claimed_once_per_triage_card(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+
+        assert kb.claim_auto_decompose_attempt(conn, tid) is True
+        assert kb.claim_auto_decompose_attempt(conn, tid) is False
+        events = kb.list_events(conn, tid)
+
+    attempts = [event for event in events if event.kind == "auto_decompose_attempted"]
+    assert len(attempts) == 1
+
+
+def test_auto_decompose_claims_are_cause_scoped_and_transient_retry_is_bounded(
+    kanban_home,
+):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+
+        assert kb.claim_auto_decompose_attempt(
+            conn,
+            tid,
+            cause="granularity",
+            generation="assessment:a",
+        ) is True
+        assert kb.finish_auto_decompose_attempt(
+            conn,
+            tid,
+            cause="granularity",
+            generation="assessment:a",
+            success=False,
+            transient=True,
+        ) == "released"
+        assert kb.claim_auto_decompose_attempt(
+            conn,
+            tid,
+            cause="granularity",
+            generation="assessment:a",
+        ) is True
+        assert kb.finish_auto_decompose_attempt(
+            conn,
+            tid,
+            cause="granularity",
+            generation="assessment:a",
+            success=False,
+            transient=True,
+        ) == "abandoned"
+        assert kb.claim_auto_decompose_attempt(
+            conn,
+            tid,
+            cause="granularity",
+            generation="assessment:a",
+        ) is False
+
+        # A later budget-triage generation is not consumed by the earlier
+        # granularity claim on the same card.
+        assert kb.claim_auto_decompose_attempt(
+            conn,
+            tid,
+            cause="budget_triage_once",
+            generation="run:42",
+        ) is True
+        events = kb.list_events(conn, tid)
+
+    attempts = [event for event in events if event.kind == "auto_decompose_attempted"]
+    assert all(isinstance(event.payload, dict) for event in attempts)
+    scopes = [
+        (event.payload.get("cause"), event.payload.get("generation"))
+        for event in attempts
+        if isinstance(event.payload, dict)
+    ]
+    assert scopes == [
+        ("granularity", "assessment:a"),
+        ("granularity", "assessment:a"),
+        ("budget_triage_once", "run:42"),
+    ]
+
+
+def test_auto_decompose_scope_advances_to_latest_budget_triage_run(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        first_cause, first_generation = kb.auto_decompose_scope(conn, tid)
+        kb._append_event(
+            conn,
+            tid,
+            "budget_triaged",
+            {"run_id": 42},
+            run_id=42,
+        )
+        second_cause, second_generation = kb.auto_decompose_scope(conn, tid)
+
+    assert first_cause == "granularity"
+    assert first_generation.startswith("assessment:")
+    assert second_cause == "budget_triage_once"
+    assert second_generation == "run:42"
 
 
 def test_decompose_rejects_self_parent(kanban_home):
@@ -155,7 +734,10 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
             conn,
             tid,
             root_assignee="orch",
-            children=[{"title": "task A", "assignee": "researcher"}],
+            children=[
+                {"title": "task A", "assignee": "researcher"},
+                {"title": "task B", "assignee": "researcher"},
+            ],
             author="alice",
         )
     assert child_ids is not None
@@ -198,12 +780,14 @@ def test_decompose_children_stay_scratch_when_root_scratch(kanban_home):
         )
         child_ids = kb.decompose_triage_task(
             conn, tid, root_assignee="orchestrator",
-            children=[{"title": "s1"}], author="decomposer",
+            children=[{"title": "s1"}, {"title": "s2"}], author="decomposer",
         )
+        assert child_ids is not None
     with kb.connect() as conn:
-        t = kb.get_task(conn, child_ids[0])
-    assert t.workspace_kind == "scratch"
-    assert t.workspace_path is None
+        tasks = [kb.get_task(conn, child_id) for child_id in child_ids]
+    assert all(task is not None for task in tasks)
+    assert all(task.workspace_kind == "scratch" for task in tasks if task is not None)
+    assert all(task.workspace_path is None for task in tasks if task is not None)
 
 
 def test_decompose_per_child_workspace_override(kanban_home):

--- a/tests/hermes_cli/test_kanban_execution_contract.py
+++ b/tests/hermes_cli/test_kanban_execution_contract.py
@@ -1,0 +1,1100 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+from pathlib import Path
+import threading
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+BROAD_BODY = """
+Investigate and diagnose the current implementation. Implement the remediation.
+Run focused tests, dual-runtime tests, Ruff, compilation, and the full suite.
+Freeze hashes and receipts. Run one independent adversarial review. After PASS,
+run a separate controller and prepare the gate without activating it.
+"""
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _assessment_event(conn, task_id: str):
+    events = [
+        e for e in kb.list_events(conn, task_id) if e.kind == "granularity_assessed"
+    ]
+    assert len(events) == 1
+    return events[0]
+
+
+def _active_run_id(conn, task_id: str) -> int:
+    task = kb.get_task(conn, task_id)
+    assert task is not None and task.current_run_id is not None
+    return int(task.current_run_id)
+
+
+def test_warn_policy_records_assessment_without_changing_status(kanban_home) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Close implementation, review, and controller",
+            body=BROAD_BODY,
+            assignee="worker",
+            granularity_policy="warn",
+        )
+        task = kb.get_task(conn, task_id)
+        event = _assessment_event(conn, task_id)
+
+    assert task is not None
+    assert task.status == "ready"
+    assert event.payload["verdict"] == "split"
+    assert event.payload["policy"] == "warn"
+    assert event.payload["auto_triaged"] is False
+
+
+def test_triage_policy_stops_oversized_card_before_dispatch(kanban_home) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Close implementation, review, and controller",
+            body=BROAD_BODY,
+            assignee="worker",
+            granularity_policy="triage",
+        )
+        task = kb.get_task(conn, task_id)
+        event = _assessment_event(conn, task_id)
+
+    assert task is not None
+    assert task.status == "triage"
+    assert event.payload["auto_triaged"] is True
+
+
+def test_allow_policy_preserves_intentional_broad_card(kanban_home) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Intentional broad migration",
+            body=BROAD_BODY,
+            assignee="worker",
+            granularity_policy="allow",
+        )
+        task = kb.get_task(conn, task_id)
+        event = _assessment_event(conn, task_id)
+
+    assert task is not None
+    assert task.status == "ready"
+    assert event.payload["verdict"] == "split"
+    assert event.payload["policy"] == "allow"
+    assert event.payload["auto_triaged"] is False
+
+
+def test_explicit_policy_still_uses_configured_agent_max_turns(
+    kanban_home,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "agent": {"max_turns": 8},
+            "kanban": {"granularity_guard": "triage"},
+        },
+    )
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Implement and verify parser correction",
+            body="Patch parser.py and run its focused pytest regression.",
+            granularity_policy="warn",
+        )
+        event = _assessment_event(conn, task_id)
+
+    assert event.payload["policy"] == "warn"
+    assert event.payload["max_turns"] == 8
+    assert "estimated_turns_exceed_budget" in event.payload["reasons"]
+
+
+def test_invalid_granularity_policy_fails_closed_to_warn(kanban_home) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Broad card",
+            body=BROAD_BODY,
+            assignee="worker",
+            granularity_policy="surprise",
+        )
+        task = kb.get_task(conn, task_id)
+        event = _assessment_event(conn, task_id)
+
+    assert task is not None
+    assert task.status == "ready"
+    assert event.payload["policy"] == "warn"
+    assert event.payload["policy_invalid"] is True
+
+
+def test_review_key_deduplicates_same_postimage(kanban_home) -> None:
+    digest = "a" * 64
+    claims = "b" * 64
+    review_key = f"{digest}:{claims}"
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="Independent review",
+            assignee="reviewer-a",
+            review_key=review_key,
+        )
+        second = kb.create_task(
+            conn,
+            title="Duplicate independent review",
+            assignee="reviewer-b",
+            review_key=review_key,
+        )
+
+    assert second == first
+
+
+def test_review_key_deduplication_is_atomic_across_concurrent_creators(
+    kanban_home,
+    monkeypatch,
+) -> None:
+    digest = "f" * 64
+    claims = "e" * 64
+    review_key = f"{digest}:{claims}"
+    enter_write = threading.Barrier(2)
+    original_write_txn = kb.write_txn
+
+    @contextlib.contextmanager
+    def synchronized_write_txn(conn):
+        enter_write.wait(timeout=5)
+        with original_write_txn(conn) as transaction:
+            yield transaction
+
+    monkeypatch.setattr(kb, "write_txn", synchronized_write_txn)
+    results: list[str] = []
+    errors: list[BaseException] = []
+
+    def create_review() -> None:
+        try:
+            with kb.connect() as conn:
+                results.append(
+                    kb.create_task(
+                        conn,
+                        title="Concurrent exact review",
+                        review_key=review_key,
+                    )
+                )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    workers = [threading.Thread(target=create_review) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=10)
+
+    assert not errors
+    assert all(not worker.is_alive() for worker in workers)
+    assert len(results) == 2
+    assert len(set(results)) == 1
+
+    with kb.connect() as conn:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ?",
+            (f"review:v1:{review_key}",),
+        ).fetchall()
+    assert len(rows) == 1
+
+
+def test_review_key_allows_new_hash_or_explicit_round(kanban_home) -> None:
+    digest = "b" * 64
+    claims = "c" * 64
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="Review",
+            review_key=f"{digest}:{claims}",
+        )
+        second = kb.create_task(
+            conn,
+            title="Review new hash",
+            review_key=f"{'d' * 64}:{claims}",
+        )
+        round_two = kb.create_task(
+            conn,
+            title="Review same hash round two",
+            review_key=f"{digest}:{claims}:round-2",
+        )
+
+    assert len({first, second, round_two}) == 3
+
+
+def test_review_key_rejects_conflicting_idempotency_key(kanban_home) -> None:
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="review_key.*idempotency_key"):
+            kb.create_task(
+                conn,
+                title="Ambiguous dedup contract",
+                review_key=f"{'d' * 64}:{'e' * 64}",
+                idempotency_key="other",
+            )
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        f"REVIEW_KEY: {'c' * 64}:{'d' * 64}\n\nReview the wrong postimage.",
+        (
+            f"REVIEW_KEY: {'a' * 64}:{'b' * 64}\n"
+            f"REVIEW_KEY: {'a' * 64}:{'b' * 64}\n\nReview the postimage."
+        ),
+    ],
+)
+def test_exact_review_rejects_conflicting_or_multiple_body_identity(
+    kanban_home,
+    body,
+) -> None:
+    review_key = f"{'a' * 64}:{'b' * 64}"
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="REVIEW_KEY"):
+            kb.create_task(
+                conn,
+                title="Contradictory exact review",
+                body=body,
+                review_key=review_key,
+            )
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE title = 'Contradictory exact review'"
+        ).fetchall()
+
+    assert rows == []
+
+
+def test_generic_idempotency_key_cannot_reserve_review_namespace(kanban_home) -> None:
+    postimage = "e" * 64
+    claims = "f" * 64
+    reserved = f"review:v1:{postimage}:{claims}"
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="reserved review namespace"):
+            kb.create_task(
+                conn,
+                title="Not actually a review",
+                idempotency_key=reserved,
+            )
+        review_id = kb.create_task(
+            conn,
+            title="Independent review",
+            review_key=f"{postimage}:{claims}",
+        )
+        task = kb.get_task(conn, review_id)
+
+    assert task is not None
+    assert task.idempotency_key == reserved
+
+
+def test_exact_review_rejects_ambiguous_legacy_reserved_incumbent(kanban_home) -> None:
+    postimage = "a" * 64
+    claims = "b" * 64
+    review_key = f"{postimage}:{claims}"
+    reserved = f"review:v1:{review_key}"
+
+    with kb.connect() as conn:
+        conn.execute(
+            """INSERT INTO tasks
+               (id, title, status, created_at, idempotency_key)
+               VALUES ('poisoned', 'generic incumbent', 'ready', 1, ?)""",
+            (reserved,),
+        )
+        conn.commit()
+
+        with pytest.raises(ValueError, match="ambiguous legacy exact-review"):
+            kb.create_task(
+                conn,
+                title="Real exact review",
+                review_key=review_key,
+                granularity_policy="allow",
+            )
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? ORDER BY id",
+            (reserved,),
+        ).fetchall()
+
+    assert [row["id"] for row in rows] == ["poisoned"]
+
+
+def test_exact_review_persists_durable_contract_and_canonical_hashes(
+    kanban_home,
+) -> None:
+    postimage = "C" * 64
+    claims = "D" * 64
+    review_key = f" {postimage}:{claims}:ROUND-2 "
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Exact review",
+            review_key=review_key,
+        )
+        duplicate = kb.create_task(
+            conn,
+            title="Duplicate exact review",
+            review_key=review_key.lower(),
+        )
+        row = conn.execute(
+            """SELECT idempotency_key, review_contract,
+                      review_postimage_sha256, review_claims_sha256
+                 FROM tasks WHERE id = ?""",
+            (task_id,),
+        ).fetchone()
+
+    assert duplicate == task_id
+    assert (
+        row["idempotency_key"]
+        == f"review:v1:{postimage.lower()}:{claims.lower()}:round-2"
+    )
+    assert row["review_contract"] == "exact_review_v1"
+    assert row["review_postimage_sha256"] == postimage.lower()
+    assert row["review_claims_sha256"] == claims.lower()
+
+
+def test_exact_review_rejects_multiple_non_archived_incumbents(kanban_home) -> None:
+    postimage = "e" * 64
+    claims = "f" * 64
+    review_key = f"{postimage}:{claims}"
+    reserved = f"review:v1:{review_key}"
+
+    with kb.connect() as conn:
+        conn.executemany(
+            """INSERT INTO tasks
+               (id, title, status, created_at, idempotency_key,
+                review_contract, review_postimage_sha256, review_claims_sha256)
+               VALUES (?, 'duplicate incumbent', 'ready', 1, ?,
+                       'exact_review_v1', ?, ?)""",
+            (
+                ("duplicate-a", reserved, postimage, claims),
+                ("duplicate-b", reserved, postimage, claims),
+            ),
+        )
+        conn.commit()
+
+        with pytest.raises(ValueError, match="ambiguous legacy exact-review"):
+            kb.create_task(
+                conn,
+                title="Exact review",
+                review_key=review_key,
+            )
+
+
+def test_compact_context_is_bounded_and_full_context_is_recoverable(
+    kanban_home,
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Child with large inherited context",
+            body="Mandatory body marker. " + ("B" * 6000),
+            assignee="worker",
+        )
+        parent_ids: list[str] = []
+        for index in range(12):
+            parent_id = kb.create_task(conn, title=f"parent-{index}")
+            parent_ids.append(parent_id)
+            conn.execute(
+                "UPDATE tasks SET status = 'done', result = ? WHERE id = ?",
+                (f"parent-result-{index}-" + ("R" * 4000), parent_id),
+            )
+            conn.execute(
+                """INSERT INTO task_runs
+                   (task_id, profile, status, started_at, ended_at, outcome,
+                    summary, metadata, error)
+                   VALUES (?, 'worker', 'done', 1, 2, 'completed', ?, ?, NULL)""",
+                (
+                    parent_id,
+                    f"parent-summary-{index}-" + ("S" * 4000),
+                    '{"evidence":"' + ("M" * 4000) + '"}',
+                ),
+            )
+            conn.execute(
+                "INSERT INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                (parent_id, task_id),
+            )
+
+        for attempt in range(6):
+            conn.execute(
+                """INSERT INTO task_runs
+                   (task_id, profile, status, started_at, ended_at, outcome,
+                    summary, metadata, error)
+                   VALUES (?, 'worker', 'failed', ?, ?, 'crashed', ?, ?, ?)""",
+                (
+                    task_id,
+                    10 + attempt,
+                    20 + attempt,
+                    f"attempt-summary-{attempt}-" + ("A" * 4000),
+                    '{"attempt":' + str(attempt) + ',"blob":"' + ("X" * 4000) + '"}',
+                    f"attempt-error-{attempt}-" + ("E" * 3000),
+                ),
+            )
+
+        for index in range(20):
+            kb.add_comment(
+                conn,
+                task_id,
+                author="worker",
+                body=f"comment-{index}-" + ("C" * 1500),
+            )
+
+        full = kb.build_worker_context(conn, task_id, compact=False)
+        compact = kb.build_worker_context(conn, task_id, compact=True)
+
+    assert "Mandatory body marker" in compact
+    assert "attempt-summary-5" in compact
+    assert "attempt-summary-0" not in compact
+    assert parent_ids[0] in compact
+    assert parent_ids[-1] in compact
+    assert "full_context=true" in compact
+    assert len(compact) <= 60_000
+    assert len(compact) < len(full) // 2
+    assert "attempt-summary-0" in full
+    assert "comment-0" in full
+
+
+def test_compact_context_has_aggregate_utf8_budget_with_many_parents(
+    kanban_home,
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="High fan-in child",
+            body="bounded body",
+            assignee="worker",
+        )
+        parent_rows = [
+            (
+                f"p{index:07d}",
+                f"parent-{index}",
+                "done" if index >= 7992 else "todo",
+                1,
+            )
+            for index in range(8000)
+        ]
+        with kb.write_txn(conn):
+            conn.executemany(
+                "INSERT INTO tasks (id, title, status, created_at) VALUES (?, ?, ?, ?)",
+                parent_rows,
+            )
+            conn.executemany(
+                "INSERT INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                ((row[0], task_id) for row in parent_rows),
+            )
+
+        compact = kb.build_worker_context(conn, task_id, compact=True)
+
+    assert len(compact.encode("utf-8")) <= kb._CTX_COMPACT_MAX_TOTAL_BYTES
+    assert "full_context=true" in compact
+    assert "7992 earlier parents" in compact
+
+
+def test_budget_failure_persists_one_bounded_unverified_handoff(kanban_home) -> None:
+    source = "completed: schema work\nremaining: independent review\n" + ("X" * 9000)
+    partial = "[partial_unverified]\n" + source
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Budget handoff target",
+            assignee="worker",
+            max_retries=2,
+        )
+        assert kb.claim_task(conn, task_id) is not None
+
+        blocked = kb._record_task_failure(
+            conn,
+            task_id,
+            error="Iteration budget exhausted (60/60)",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+            partial_summary=partial,
+            event_payload_extra={"budget_used": 60, "budget_max": 60},
+        )
+
+        task = kb.get_task(conn, task_id)
+        runs = kb.list_runs(conn, task_id)
+        comments = kb.list_comments(conn, task_id)
+        context = kb.build_worker_context(conn, task_id, compact=True)
+
+    assert blocked is False
+    assert task is not None and task.status == "ready"
+    assert len(runs) == 1
+    assert runs[0].summary is not None
+    assert runs[0].metadata is not None
+    assert runs[0].summary.startswith("[partial_unverified]")
+    assert "COMPLETED: schema work" in runs[0].summary
+    assert len(runs[0].summary) <= 4200
+    assert runs[0].metadata["partial_summary_full"] == source
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    assert runs[0].metadata["partial_summary_sha256"] == digest
+    assert f"FULL_HANDOFF_SHA256: {digest}" in runs[0].summary
+    assert comments == []
+    assert context.count("[partial_unverified]") == 1
+    assert '_metadata_: `{"partial_summary_full"' not in context
+    assert "CONTEXT_REF:" in context
+    assert f'"sha256":"{digest}"' in context
+
+
+def test_full_context_preserves_historical_character_caps(kanban_home) -> None:
+    body = "é" * (kb._CTX_MAX_BODY_BYTES + 5)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="Full compatibility", body=body)
+        full = kb.build_worker_context(conn, task_id, compact=False)
+
+    expected = "é" * kb._CTX_MAX_BODY_BYTES + "… [truncated, 5 chars omitted]"
+    assert expected in full
+
+
+def test_compact_context_prioritizes_latest_handoff_over_attachment_fanout(
+    kanban_home,
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="Attachment-heavy retry")
+        conn.executemany(
+            """INSERT INTO task_attachments
+               (task_id, filename, stored_path, content_type, size, uploaded_by, created_at)
+               VALUES (?, ?, ?, NULL, 1, 'fixture', 1)""",
+            (
+                (
+                    task_id,
+                    f"attachment-{index}.txt",
+                    "/tmp/" + (f"path-{index}-" * 80),
+                )
+                for index in range(150)
+            ),
+        )
+        conn.execute(
+            """INSERT INTO task_runs
+               (task_id, profile, status, started_at, ended_at, outcome,
+                summary, metadata, error)
+               VALUES (?, 'worker', 'gave_up', 2, 3, 'gave_up', ?, ?, NULL)""",
+            (
+                task_id,
+                "[partial_unverified]\nCOMPLETED: LATEST_HANDOFF_SENTINEL",
+                '{"partial_summary_full":"private full source",'
+                '"partial_summary_sha256":"' + ("a" * 64) + '"}',
+            ),
+        )
+        conn.commit()
+        compact = kb.build_worker_context(conn, task_id, compact=True)
+
+    assert len(compact.encode("utf-8")) <= kb._CTX_COMPACT_MAX_TOTAL_BYTES
+    assert "LATEST_HANDOFF_SENTINEL" in compact
+    assert "CONTEXT_REF:" in compact
+    assert '_metadata_: `{"partial_summary_full"' not in compact
+
+
+def test_compact_context_reserves_latest_handoff_under_early_field_starvation(
+    kanban_home,
+) -> None:
+    source = "FULL_SOURCE:" + ("🧭" * 20_000) + ":SOURCE_TAIL_SENTINEL"
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="T" * 60_000,
+            body="B" * 60_000,
+            assignee="worker",
+            granularity_policy="allow",
+        )
+        conn.executemany(
+            """INSERT INTO task_attachments
+               (task_id, filename, stored_path, content_type, size, uploaded_by, created_at)
+               VALUES (?, ?, ?, ?, 1, 'fixture', 1)""",
+            (
+                (
+                    task_id,
+                    "F" * 20_000,
+                    "/tmp/" + ("P" * 20_000),
+                    "application/" + ("C" * 20_000),
+                )
+                for _ in range(20)
+            ),
+        )
+        conn.execute(
+            """INSERT INTO task_comments
+               (task_id, author, body, created_at) VALUES (?, ?, ?, 1)""",
+            (task_id, "A" * 20_000, "COMMENT:" + ("M" * 20_000)),
+        )
+        cursor = conn.execute(
+            """INSERT INTO task_runs
+               (task_id, profile, status, started_at, ended_at, outcome,
+                summary, metadata, error)
+               VALUES (?, 'worker', 'gave_up', 2, 3, 'gave_up', ?, ?, NULL)""",
+            (
+                task_id,
+                "[partial_unverified]\nCOMPLETED: LATEST_HANDOFF_SENTINEL",
+                json.dumps({
+                    "partial_summary_full": source,
+                    "partial_summary_sha256": digest,
+                }),
+            ),
+        )
+        assert cursor.lastrowid is not None
+        run_id = int(cursor.lastrowid)
+        conn.commit()
+        compact = kb.build_worker_context(conn, task_id, compact=True)
+
+    assert len(compact.encode("utf-8")) <= kb._CTX_COMPACT_MAX_TOTAL_BYTES
+    assert "LATEST_HANDOFF_SENTINEL" in compact
+    assert "CONTEXT_REF:" in compact
+    assert f'"run_id":{run_id}' in compact
+    assert f'"sha256":"{digest}"' in compact
+    assert "--field partial_summary_full" in compact
+    assert "[field truncated]" in compact
+
+
+def test_read_run_metadata_field_recovers_exact_hash_bound_source(kanban_home) -> None:
+    source = "FULL_SOURCE:" + ("🧭" * 20_000) + ":SOURCE_TAIL_SENTINEL"
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="Recovery target")
+        other_task_id = kb.create_task(conn, title="Other task")
+        cursor = conn.execute(
+            """INSERT INTO task_runs
+               (task_id, status, started_at, ended_at, outcome, metadata)
+               VALUES (?, 'done', 1, 2, 'completed', ?)""",
+            (
+                task_id,
+                json.dumps({
+                    "partial_summary_full": source,
+                    "partial_summary_sha256": digest,
+                }),
+            ),
+        )
+        assert cursor.lastrowid is not None
+        run_id = int(cursor.lastrowid)
+        conn.commit()
+
+        recovered = kb.read_run_metadata_field(
+            conn,
+            task_id=task_id,
+            run_id=run_id,
+            field="partial_summary_full",
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'done', completed_at = 2 WHERE id = ?",
+            (task_id,),
+        )
+        child_task_id = kb.create_task(
+            conn,
+            title="Child consuming parent handoff",
+            parents=[task_id],
+        )
+        parent_context = kb.build_worker_context(
+            conn,
+            child_task_id,
+            compact=True,
+        )
+        with pytest.raises(ValueError, match="does not belong"):
+            kb.read_run_metadata_field(
+                conn,
+                task_id=other_task_id,
+                run_id=run_id,
+                field="partial_summary_full",
+            )
+        conn.execute(
+            "UPDATE task_runs SET metadata = ? WHERE id = ?",
+            (
+                json.dumps({
+                    "partial_summary_full": source,
+                    "partial_summary_sha256": "0" * 64,
+                }),
+                run_id,
+            ),
+        )
+        conn.commit()
+        with pytest.raises(ValueError, match="SHA-256 mismatch"):
+            kb.read_run_metadata_field(
+                conn,
+                task_id=task_id,
+                run_id=run_id,
+                field="partial_summary_full",
+            )
+
+    assert recovered == source
+    assert recovered.endswith("SOURCE_TAIL_SENTINEL")
+    assert (
+        f"hermes kanban context {task_id} --run-id {run_id} "
+        "--field partial_summary_full"
+    ) in parent_context
+
+
+def test_budget_handoff_limit_is_utf8_bytes_not_codepoints() -> None:
+    for payload in ("x" * 9000, "é" * 9000, "🧭" * 9000):
+        handoff = kb._bounded_partial_handoff(payload)
+
+        assert handoff is not None
+        assert handoff.startswith("[partial_unverified]\n")
+        assert "[section truncated]" in handoff
+        assert len(handoff.encode("utf-8")) <= kb._KANBAN_PARTIAL_SUMMARY_MAX_BYTES
+
+
+def test_budget_handoff_preserves_every_required_section_under_truncation() -> None:
+    raw = "\n".join([
+        "COMPLETED: " + ("discovery " * 2000),
+        "CHANGED_FILES: parser.py",
+        "TESTS: focused regression passed",
+        "REMAINING: independent review",
+        "RESUME: run the reviewer on the frozen postimage",
+        "INVARIANTS: no production activation",
+    ])
+
+    handoff = kb._bounded_partial_handoff(raw, run_id=42)
+
+    assert handoff is not None
+    assert len(handoff.encode("utf-8")) <= kb._KANBAN_PARTIAL_SUMMARY_MAX_BYTES
+    for section in (
+        "COMPLETED:",
+        "CHANGED_FILES:",
+        "TESTS:",
+        "REMAINING:",
+        "RESUME:",
+        "INVARIANTS:",
+    ):
+        assert section in handoff
+    assert "FULL_HANDOFF_REF: task_runs:42.metadata.partial_summary_full" in handoff
+    assert "FULL_HANDOFF_SHA256:" in handoff
+
+
+def test_triage_once_replaces_first_blind_retry_then_blocks_repeat(kanban_home) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Oversized lifecycle card",
+            assignee="worker",
+            max_retries=5,
+        )
+        assert kb.claim_task(conn, task_id) is not None
+        first_status = kb.record_iteration_budget_exhaustion(
+            conn,
+            task_id,
+            expected_run_id=_active_run_id(conn, task_id),
+            error="Iteration budget exhausted (60/60)",
+            partial_summary="COMPLETED: implementation\nREMAINING: review",
+            budget_used=60,
+            budget_max=60,
+            policy="triage_once",
+        )
+
+        first_task = kb.get_task(conn, task_id)
+        first_events = kb.list_events(conn, task_id)
+        assert first_status == "triage"
+        assert first_task is not None and first_task.status == "triage"
+        assert len([e for e in first_events if e.kind == "budget_triaged"]) == 1
+
+        # A second exhausted attempt cannot recurse through decomposition
+        # forever. Simulate a later re-promoted/reclaimed execution.
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (task_id,))
+        conn.commit()
+        assert kb.claim_task(conn, task_id) is not None
+        second_status = kb.record_iteration_budget_exhaustion(
+            conn,
+            task_id,
+            expected_run_id=_active_run_id(conn, task_id),
+            error="Iteration budget exhausted (60/60)",
+            partial_summary="REMAINING: still too broad",
+            budget_used=60,
+            budget_max=60,
+            policy="triage_once",
+        )
+
+        second_task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+        assert kb.recompute_ready(conn) == 0
+        after_recompute = kb.get_task(conn, task_id)
+
+    assert second_status == "blocked"
+    assert second_task is not None and second_task.status == "blocked"
+    assert after_recompute is not None and after_recompute.status == "blocked"
+    assert len([e for e in events if e.kind == "budget_triaged"]) == 1
+    assert any(e.kind == "blocked" for e in events)
+
+
+def test_budget_exhaustion_retry_policy_preserves_legacy_retry(kanban_home) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Retry-compatible card",
+            assignee="worker",
+            max_retries=2,
+        )
+        assert kb.claim_task(conn, task_id) is not None
+        status = kb.record_iteration_budget_exhaustion(
+            conn,
+            task_id,
+            expected_run_id=_active_run_id(conn, task_id),
+            error="Iteration budget exhausted (60/60)",
+            partial_summary="REMAINING: one atomic check",
+            budget_used=60,
+            budget_max=60,
+            policy="retry",
+        )
+        task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+
+    assert status == "ready"
+    assert task is not None and task.status == "ready"
+    timed_out = [event for event in events if event.kind == "timed_out"]
+    assert len(timed_out) == 1
+    assert timed_out[0].payload["budget_used"] == 60
+    assert timed_out[0].payload["budget_max"] == 60
+    assert timed_out[0].payload["budget_exhaustion_policy"] == "retry"
+
+
+def test_budget_exhaustion_block_policy_stops_first_retry(kanban_home) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Fail-closed card",
+            assignee="worker",
+            max_retries=10,
+        )
+        assert kb.claim_task(conn, task_id) is not None
+        status = kb.record_iteration_budget_exhaustion(
+            conn,
+            task_id,
+            expected_run_id=_active_run_id(conn, task_id),
+            error="Iteration budget exhausted (60/60)",
+            partial_summary="REMAINING: operator decision",
+            budget_used=60,
+            budget_max=60,
+            policy="block",
+        )
+        task = kb.get_task(conn, task_id)
+        assert kb.recompute_ready(conn) == 0
+        after_recompute = kb.get_task(conn, task_id)
+
+    assert status == "blocked"
+    assert task is not None and task.status == "blocked"
+    assert after_recompute is not None and after_recompute.status == "blocked"
+
+
+def test_budget_finalizer_is_idempotent_after_worker_already_blocked(
+    kanban_home,
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Worker-blocked before finalizer",
+            assignee="worker",
+            max_retries=2,
+        )
+        claim = kb.claim_task(conn, task_id)
+        assert claim is not None
+        worker_run_id = _active_run_id(conn, task_id)
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="review required",
+            kind="needs_input",
+        )
+        before = kb.get_task(conn, task_id)
+        before_events = kb.list_events(conn, task_id)
+        before_runs = kb.list_runs(conn, task_id)
+
+        status = kb.record_iteration_budget_exhaustion(
+            conn,
+            task_id,
+            expected_run_id=worker_run_id,
+            error="Iteration budget exhausted (60/60)",
+            partial_summary="late duplicate finalizer summary",
+            budget_used=60,
+            budget_max=60,
+            policy="retry",
+        )
+        after = kb.get_task(conn, task_id)
+        after_events = kb.list_events(conn, task_id)
+        after_runs = kb.list_runs(conn, task_id)
+
+    assert status == "blocked"
+    assert before is not None and after is not None
+    assert after.consecutive_failures == before.consecutive_failures
+    assert len(after_events) == len(before_events)
+    assert len(after_runs) == len(before_runs) == 1
+    assert after_runs[0].summary == before_runs[0].summary
+
+
+def test_stale_worker_cannot_checkpoint_or_finalize_successor_run(
+    kanban_home,
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Generation-scoped finalizer",
+            assignee="worker",
+            max_retries=3,
+        )
+        assert kb.claim_task(conn, task_id) is not None
+        first = kb.get_task(conn, task_id)
+        assert first is not None and first.current_run_id is not None
+        stale_run_id = first.current_run_id
+
+        with kb.write_txn(conn):
+            assert (
+                kb._end_run(
+                    conn,
+                    task_id,
+                    outcome="reclaimed",
+                    status="reclaimed",
+                )
+                == stale_run_id
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "claim_expires = NULL WHERE id = ?",
+                (task_id,),
+            )
+
+        assert kb.claim_task(conn, task_id) is not None
+        successor = kb.get_task(conn, task_id)
+        assert successor is not None and successor.current_run_id is not None
+        successor_run_id = successor.current_run_id
+        assert successor_run_id != stale_run_id
+        events_before = kb.list_events(conn, task_id)
+        runs_before = kb.list_runs(conn, task_id)
+
+        assert (
+            kb.record_iteration_budget_checkpoint(
+                conn,
+                task_id,
+                expected_run_id=stale_run_id,
+                budget_used=45,
+                budget_max=60,
+            )
+            is False
+        )
+        assert (
+            kb.record_iteration_budget_exhaustion(
+                conn,
+                task_id,
+                expected_run_id=stale_run_id,
+                error="stale run exhausted",
+                partial_summary="REMAINING: belongs to stale run",
+                budget_used=60,
+                budget_max=60,
+                policy="block",
+            )
+            == "stale_run"
+        )
+
+        after = kb.get_task(conn, task_id)
+        events_after = kb.list_events(conn, task_id)
+        runs_after = kb.list_runs(conn, task_id)
+
+    assert after is not None
+    assert after.status == "running"
+    assert after.current_run_id == successor_run_id
+    assert after.consecutive_failures == 0
+    assert len(events_after) == len(events_before)
+    assert len(runs_after) == len(runs_before)
+    successor_run = next(run for run in runs_after if run.id == successor_run_id)
+    assert successor_run.ended_at is None
+    assert successor_run.summary is None
+
+
+def test_budget_failure_guard_is_atomic_against_a_stale_second_finalizer(
+    kanban_home,
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Concurrent finalizer target",
+            assignee="worker",
+            max_retries=3,
+        )
+        assert kb.claim_task(conn, task_id) is not None
+        assert (
+            kb._record_task_failure(
+                conn,
+                task_id,
+                error="first budget finalizer",
+                outcome="timed_out",
+                release_claim=True,
+                end_run=True,
+                require_running=True,
+            )
+            is False
+        )
+
+        # Model a second finalizer that passed an earlier out-of-transaction
+        # status check while the first one still owned the running claim.
+        assert (
+            kb._record_task_failure(
+                conn,
+                task_id,
+                error="stale duplicate finalizer",
+                outcome="timed_out",
+                release_claim=True,
+                end_run=True,
+                require_running=True,
+            )
+            is False
+        )
+        task = kb.get_task(conn, task_id)
+        runs = kb.list_runs(conn, task_id)
+        events = kb.list_events(conn, task_id)
+
+    assert task is not None
+    assert task.status == "ready"
+    assert task.consecutive_failures == 1
+    assert len(runs) == 1
+    assert len([event for event in events if event.kind == "timed_out"]) == 1
+
+
+def test_pre_exhaustion_checkpoint_event_is_idempotent_per_run(kanban_home) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Checkpoint marker target",
+            assignee="worker",
+        )
+        assert kb.claim_task(conn, task_id) is not None
+        run_id = _active_run_id(conn, task_id)
+        assert (
+            kb.record_iteration_budget_checkpoint(
+                conn,
+                task_id,
+                expected_run_id=run_id,
+                budget_used=45,
+                budget_max=60,
+            )
+            is True
+        )
+        assert (
+            kb.record_iteration_budget_checkpoint(
+                conn,
+                task_id,
+                expected_run_id=run_id,
+                budget_used=46,
+                budget_max=60,
+            )
+            is False
+        )
+        events = kb.list_events(conn, task_id)
+
+    checkpoints = [event for event in events if event.kind == "budget_checkpoint"]
+    assert len(checkpoints) == 1
+    assert checkpoints[0].payload == {
+        "budget_used": 45,
+        "budget_max": 60,
+        "remaining": 15,
+    }

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -115,6 +115,23 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_create_task_review_key_deduplicates_exact_postimage(client):
+    digest = "b" * 64
+    review_key = f"{digest}:{'c' * 64}"
+    first = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Review postimage", "review_key": review_key},
+    )
+    second = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Duplicate review", "review_key": review_key},
+    )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert second.json()["task"]["id"] == first.json()["task"]["id"]
+
+
 def test_board_list_recommends_persistent_workspace_for_configured_workdir(
     client, tmp_path
 ):

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -135,10 +135,8 @@ def test_current_user_turn_is_persisted_before_provider_call(agent):
     assert observed[0][0] == "persist"
     assert observed[1][0] == "provider"
     persisted_messages = observed[0][1]
-    assert persisted_messages[-1] == {
-        "role": "user",
-        "content": "new message that must survive a crash",
-    }
+    assert persisted_messages[-1]["role"] == "user"
+    assert persisted_messages[-1]["content"] == "new message that must survive a crash"
 
 
 class TestHTTP413Compression:
@@ -487,6 +485,29 @@ class TestHTTP413Compression:
             "role": "user",
             "content": "compressed summary",
         }
+
+    def test_context_length_ignores_internal_marker_removal_as_progress(self, agent):
+        """Private turn metadata cannot justify a context-overflow retry."""
+        err_400 = Exception("Error code: 400 - Please reduce the length of the messages")
+        err_400.status_code = 400
+        ok_resp = _mock_response(content="unexpected retry", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}],
+                "compressed prompt",
+            )
+            result = agent.run_conversation("hello")
+
+        assert agent.client.chat.completions.create.call_count == 1
+        assert result["compression_exhausted"] is True
+        assert result["failed"] is True
 
     def test_413_cannot_compress_further(self, agent):
         """When compression can't reduce messages, return partial result."""

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -93,6 +93,27 @@ def test_repair_merges_consecutive_user_messages():
     assert messages[0]["content"] == "first\n\nsecond"
 
 
+def test_repair_preserves_current_turn_identity_when_merging_users():
+    from agent.iteration_budget import CURRENT_TURN_ID_KEY, _current_turn_user_index
+
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "pending prior input"},
+        {
+            "role": "user",
+            "content": "current input",
+            CURRENT_TURN_ID_KEY: "turn-current",
+        },
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert len(messages) == 1
+    assert messages[0][CURRENT_TURN_ID_KEY] == "turn-current"
+    assert _current_turn_user_index(messages, "turn-current") == 0
+
+
 def test_repair_preserves_user_content_when_one_side_empty():
     agent = _bare_agent()
     messages = [
@@ -318,6 +339,36 @@ def test_cursor_clamped_when_compaction_shrinks_below_cursor():
     assert repairs == 1
     assert len(messages) == 1
     assert agent._last_flushed_db_idx == 1
+
+
+def test_cursor_rewinds_when_current_user_merges_into_flushed_user():
+    from agent.agent_runtime_helpers import (
+        REPAIRED_USER_PREFIX_KEY,
+        provider_visible_message_copy,
+    )
+    from agent.iteration_budget import CURRENT_TURN_ID_KEY
+
+    agent = _bare_agent()
+    flushed_user = {"role": "user", "content": "already persisted"}
+    current_user = {
+        "role": "user",
+        "content": "current input",
+        CURRENT_TURN_ID_KEY: "turn-current",
+    }
+    messages = [flushed_user, current_user]
+    agent._last_flushed_db_idx = 1
+
+    repairs = repair_message_sequence_with_cursor(agent, messages)
+
+    assert repairs == 1
+    assert messages == [current_user]
+    assert messages[0]["content"] == "current input"
+    assert messages[0][REPAIRED_USER_PREFIX_KEY] == "already persisted"
+    assert provider_visible_message_copy(messages[0]) == {
+        "role": "user",
+        "content": "already persisted\n\ncurrent input",
+    }
+    assert agent._last_flushed_db_idx == 0
 
 
 def test_cursor_rewinds_when_compaction_happens_before_cursor():

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3976,6 +3976,52 @@ class TestHandleMaxIterations:
         assert messages[2]["tool_name"] == "execute_code"
         assert messages[1]["codex_reasoning_items"] == [{"id": "rs_1"}]
 
+    def test_summary_materializes_repaired_user_prefix_on_initial_and_retry(
+        self, agent
+    ):
+        from agent.agent_runtime_helpers import provider_visible_message_copy
+
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=""),
+            _mock_response(content="Recovered summary"),
+        ]
+        agent._cached_system_prompt = "You are helpful."
+        repaired_user = {
+            "role": "user",
+            "content": "current user input",
+            "_hermes_turn_id": "turn-probe",
+            "_hermes_repaired_user_prefix": "queued prior user input",
+        }
+        messages = [repaired_user, {"role": "assistant", "content": "Working."}]
+        expected_user_content = provider_visible_message_copy(repaired_user)["content"]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Recovered summary"
+        assert agent.client.chat.completions.create.call_count == 2
+        sent_payloads = [
+            call.kwargs["messages"]
+            for call in agent.client.chat.completions.create.call_args_list
+        ]
+        assert sent_payloads[0] == sent_payloads[1]
+        for sent_messages in sent_payloads:
+            serialized = json.dumps(sent_messages, ensure_ascii=False)
+            assert serialized.count("queued prior user input") == 1
+            assert serialized.count("current user input") == 1
+            assert (
+                sum(
+                    message.get("role") == "user"
+                    and message.get("content") == expected_user_content
+                    for message in sent_messages
+                )
+                == 1
+            )
+            assert not any(
+                isinstance(key, str) and key.startswith("_")
+                for message in sent_messages
+                for key in message
+            )
+
     def test_summary_omits_provider_preferences_for_non_openrouter(self, agent):
         agent.base_url = "https://api.openai.com/v1"
         agent._base_url_lower = agent.base_url.lower()
@@ -5561,17 +5607,16 @@ class TestRunConversation:
         forever without ever tripping the failure_limit circuit breaker
         (issue #23216 / #29747 gap 2).
 
-        As of #29747, the exhaustion path routes through
-        ``kanban_db._record_task_failure(outcome="timed_out")`` so the
-        ``consecutive_failures`` counter increments and the dispatcher's
-        ``failure_limit`` breaker eventually trips. The legacy
-        ``kanban_block`` call was replaced because blocked-outcome runs
-        bypass the failure counter.
+        The exhaustion path routes through
+        ``kanban_db.record_iteration_budget_exhaustion`` so a bounded handoff
+        is persisted and the configured retry/triage/block policy advances the
+        failure circuit without duplicate terminal events.
         """
         self._setup_agent(agent)
         agent.max_iterations = 2
 
         monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test_task_123")
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "41")
 
         # Return a tool call for every iteration to exhaust the budget.
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
@@ -5586,13 +5631,13 @@ class TestRunConversation:
             tool_resp, tool_resp, summary_resp,
         ]
 
-        mock_record_failure = MagicMock(return_value=False)
+        mock_record_exhaustion = MagicMock(return_value="ready")
         mock_connect = MagicMock(return_value=MagicMock())
 
         with (
             patch("run_agent.handle_function_call", return_value="ok"),
-            patch("hermes_cli.kanban_db._record_task_failure",
-                  mock_record_failure),
+            patch("hermes_cli.kanban_db.record_iteration_budget_exhaustion",
+                  mock_record_exhaustion),
             patch("hermes_cli.kanban_db.connect", mock_connect),
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
@@ -5603,19 +5648,21 @@ class TestRunConversation:
         # The agent should have reported the task as not completed.
         assert result["completed"] is False
 
-        # _record_task_failure should have been called exactly once for
-        # the exhaustion event, with outcome="timed_out".
-        assert mock_record_failure.call_count == 1, (
-            f"Expected exactly 1 _record_task_failure call, "
-            f"got {mock_record_failure.call_count}. "
-            f"Calls: {mock_record_failure.call_args_list}"
+        # The exhaustion policy should run exactly once with the final handoff.
+        assert mock_record_exhaustion.call_count == 1, (
+            f"Expected exactly 1 budget exhaustion call, "
+            f"got {mock_record_exhaustion.call_count}. "
+            f"Calls: {mock_record_exhaustion.call_args_list}"
         )
-        call = mock_record_failure.call_args_list[0]
+        call = mock_record_exhaustion.call_args_list[0]
         # Positional: (conn, task_id, ...)
         assert call.args[1] == "t_test_task_123"
-        assert call.kwargs.get("outcome") == "timed_out"
-        assert call.kwargs.get("release_claim") is True
-        assert call.kwargs.get("end_run") is True
+        assert call.kwargs.get("expected_run_id") == 41
+        assert call.kwargs.get("partial_summary") == (
+            "Could not finish — budget exhausted."
+        )
+        assert call.kwargs.get("budget_used") == 2
+        assert call.kwargs.get("budget_max") == 2
         assert "Iteration budget exhausted" in call.kwargs.get("error", "")
 
     def test_no_kanban_block_when_not_in_kanban_mode(self, agent, monkeypatch):
@@ -5637,21 +5684,255 @@ class TestRunConversation:
             tool_resp, tool_resp, summary_resp,
         ]
 
-        mock_record_failure = MagicMock(return_value=False)
+        mock_record_exhaustion = MagicMock(return_value="ready")
 
         with (
             patch("run_agent.handle_function_call", return_value="ok"),
-            patch("hermes_cli.kanban_db._record_task_failure",
-                  mock_record_failure),
+            patch("hermes_cli.kanban_db.record_iteration_budget_exhaustion",
+                  mock_record_exhaustion),
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
             agent.run_conversation("do stuff")
 
-        assert mock_record_failure.call_count == 0, (
-            "_record_task_failure should not be called outside kanban mode"
+        assert mock_record_exhaustion.call_count == 0, (
+            "budget exhaustion persistence should not run outside kanban mode"
         )
+
+    def test_kanban_budget_checkpoint_is_ephemeral_and_emitted_once(
+        self, agent, monkeypatch
+    ):
+        self._setup_agent(agent)
+        agent.max_iterations = 4
+        agent.valid_tool_names.update({"execute_code", "kanban_complete"})
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_checkpoint_task")
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "17")
+
+        first_tc = _mock_tool_call(
+            name="execute_code", arguments="{}", call_id="c1"
+        )
+        second_tc = _mock_tool_call(
+            name="execute_code", arguments="{}", call_id="c2"
+        )
+        complete_tc = _mock_tool_call(
+            name="kanban_complete",
+            arguments='{"summary":"verified atomic completion"}',
+            call_id="c3",
+        )
+        first_tool_resp = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[first_tc],
+        )
+        second_tool_resp = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[second_tc],
+        )
+        complete_resp = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[complete_tc],
+        )
+        final_resp = _mock_response(
+            content="verified atomic completion", finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            first_tool_resp, second_tool_resp, complete_resp, final_resp,
+        ]
+
+        checkpoint = MagicMock(return_value=True)
+        fake_conn = MagicMock()
+        repair_shifted = False
+
+        def shift_prefix_during_checkpoint(_agent, messages):
+            nonlocal repair_shifted
+            if repair_shifted:
+                return 0
+            if any(
+                message.get("role") == "tool"
+                and message.get("tool_call_id") == "c2"
+                for message in messages
+            ):
+                messages.insert(0, {"role": "system", "content": "repaired-prefix"})
+                repair_shifted = True
+                return 1
+            return 0
+
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch(
+                "agent.agent_runtime_helpers.repair_message_sequence_with_cursor",
+                side_effect=shift_prefix_during_checkpoint,
+            ),
+            patch("hermes_cli.kanban_db.connect", return_value=fake_conn),
+            patch(
+                "hermes_cli.kanban_db.record_iteration_budget_checkpoint",
+                checkpoint,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("finish one atomic kanban claim")
+
+        request_payloads = [
+            json.dumps(call.kwargs.get("messages", []), ensure_ascii=False)
+            for call in agent.client.chat.completions.create.call_args_list
+        ]
+        marker_positions = [
+            index
+            for index, payload in enumerate(request_payloads)
+            if "KANBAN_BUDGET_CHECKPOINT" in payload
+        ]
+        # The marker first appears on the previously unseen tool-result tail,
+        # then stays byte-stable for later calls so prompt caching is preserved.
+        assert marker_positions == [2, 3]
+        assert all(
+            request_payloads[index].count("KANBAN_BUDGET_CHECKPOINT") == 1
+            for index in marker_positions
+        )
+        third_messages = agent.client.chat.completions.create.call_args_list[2].kwargs[
+            "messages"
+        ]
+        fourth_messages = agent.client.chat.completions.create.call_args_list[3].kwargs[
+            "messages"
+        ]
+        third_checkpoint_result = next(
+            message["content"]
+            for message in third_messages
+            if message.get("tool_call_id") == "c2"
+        )
+        fourth_checkpoint_result = next(
+            message["content"]
+            for message in fourth_messages
+            if message.get("tool_call_id") == "c2"
+        )
+        assert third_checkpoint_result == fourth_checkpoint_result
+        assert "KANBAN_BUDGET_CHECKPOINT" in third_checkpoint_result
+        assert "KANBAN_BUDGET_CHECKPOINT" not in json.dumps(
+            result["messages"], ensure_ascii=False
+        )
+        checkpoint.assert_called_once()
+        assert checkpoint.call_args.kwargs == {
+            "expected_run_id": 17,
+            "budget_used": 3,
+            "budget_max": 4,
+        }
+        # execute_code-only calls refund IterationBudget, but the hard loop cap
+        # is API-call based; the checkpoint must use that same denominator.
+        assert agent.iteration_budget.used == 2
+        assert result["completed"] is True
+
+    def test_kanban_budget_checkpoint_survives_pre_api_compression(
+        self, agent, monkeypatch
+    ):
+        """Compression must not consume the one-shot checkpoint before send.
+
+        The pre-API pressure gate runs after the ephemeral request has been
+        assembled.  Compaction clones the live message dictionaries and then
+        restarts the iteration without calling the provider.  The current-turn
+        boundary therefore needs durable identity, and the checkpoint DB event
+        must not be committed until the post-compaction request is actually
+        about to run.
+        """
+        self._setup_agent(agent)
+        agent.max_iterations = 4
+        agent.compression_enabled = True
+        agent.valid_tool_names.update({"execute_code", "kanban_complete"})
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_compressed_checkpoint")
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "23")
+
+        first_tc = _mock_tool_call(
+            name="execute_code", arguments="{}", call_id="compressed-c1"
+        )
+        second_tc = _mock_tool_call(
+            name="execute_code", arguments="{}", call_id="compressed-c2"
+        )
+        complete_tc = _mock_tool_call(
+            name="kanban_complete",
+            arguments='{"summary":"verified after compression"}',
+            call_id="compressed-c3",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[first_tc]),
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[second_tc]),
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[complete_tc]),
+            _mock_response(content="verified after compression", finish_reason="stop"),
+        ]
+
+        # Trigger pressure only for the ephemeral pre-API payload that already
+        # contains the checkpoint marker. The persisted message list used by
+        # the post-tool gate never contains that marker, so this cannot
+        # accidentally exercise the wrong compression site.
+        compressed_once = False
+
+        def estimate_request(messages, **_kwargs):
+            payload = json.dumps(messages, ensure_ascii=False)
+            if "KANBAN_BUDGET_CHECKPOINT" in payload and not compressed_once:
+                return 999_999
+            return 1
+
+        def should_compress(tokens):
+            return tokens == 999_999
+
+        def clone_during_compression(messages, _system, **_kwargs):
+            nonlocal compressed_once
+            compressed_once = True
+            return [message.copy() for message in messages], "compressed-system"
+
+        checkpoint = MagicMock(return_value=True)
+        fake_conn = MagicMock()
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch.object(
+                agent.context_compressor,
+                "should_compress",
+                side_effect=should_compress,
+            ),
+            patch(
+                "agent.conversation_loop.estimate_request_tokens_rough",
+                side_effect=estimate_request,
+            ),
+            patch.object(
+                agent,
+                "_compress_context",
+                side_effect=clone_during_compression,
+            ) as compress,
+            patch("hermes_cli.kanban_db.connect", return_value=fake_conn),
+            patch(
+                "hermes_cli.kanban_db.record_iteration_budget_checkpoint",
+                checkpoint,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "finish after compacting this turn",
+                conversation_history=[
+                    {"role": "user", "content": "queued prior user input"}
+                ],
+            )
+
+        assert compress.call_count == 1
+        request_payloads = [
+            json.dumps(call.kwargs.get("messages", []), ensure_ascii=False)
+            for call in agent.client.chat.completions.create.call_args_list
+        ]
+        marker_positions = [
+            index
+            for index, payload in enumerate(request_payloads)
+            if "KANBAN_BUDGET_CHECKPOINT" in payload
+        ]
+        assert marker_positions == [2, 3]
+        assert all(payload.count("KANBAN_BUDGET_CHECKPOINT") <= 1 for payload in request_payloads)
+        assert all("_hermes_turn_id" not in payload for payload in request_payloads)
+        assert "queued prior user input" in request_payloads[0]
+        assert "finish after compacting this turn" in request_payloads[0]
+        checkpoint.assert_called_once_with(
+            fake_conn,
+            "t_compressed_checkpoint",
+            expected_run_id=23,
+            budget_used=3,
+            budget_max=4,
+        )
+        assert result["completed"] is True
 
     # ── Output-cap retry: safe_out uses provider available_out + request estimate ──
 

--- a/tests/scripts/test_benchmark_kanban_context.py
+++ b/tests/scripts/test_benchmark_kanban_context.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_benchmark_module():
+    path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "benchmark_kanban_context.py"
+    )
+    spec = importlib.util.spec_from_file_location("benchmark_kanban_context", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_kanban_context_benchmark_reports_utf8_omissions_and_recovery():
+    report = _load_benchmark_module().run_benchmark()
+
+    assert report["full"]["utf8_bytes"] > report["compact"]["utf8_bytes"]
+    assert report["savings"]["utf8_bytes"] == (
+        report["full"]["utf8_bytes"] - report["compact"]["utf8_bytes"]
+    )
+    assert report["omissions"] == {
+        "comments": 34,
+        "parents": 12,
+        "prior_attempts": 7,
+    }
+    assert report["recovery"] == {
+        "cli": (
+            "hermes kanban context <task_id> --run-id <run_id> "
+            "--field partial_summary_full"
+        ),
+        "model_tool": "kanban_show(task_id=<task_id>, full_context=true)",
+    }
+    assert all(report["contracts"].values())

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1006,6 +1006,250 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_review_key_deduplicates_exact_postimage(worker_env):
+    from tools import kanban_tools as kt
+
+    digest = "a" * 64
+    review_key = f"{digest}:{'b' * 64}"
+    first = json.loads(kt._handle_create({
+        "title": "review postimage",
+        "assignee": "reviewer-a",
+        "review_key": review_key,
+    }))
+    second = json.loads(kt._handle_create({
+        "title": "redundant review postimage",
+        "assignee": "reviewer-b",
+        "review_key": review_key,
+    }))
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert second["task_id"] == first["task_id"]
+
+
+def test_create_schema_exposes_review_and_broadness_contracts():
+    from tools.kanban_tools import KANBAN_CREATE_SCHEMA
+
+    props = KANBAN_CREATE_SCHEMA["parameters"]["properties"]
+    assert props["review_key"]["type"] == "string"
+    assert props["allow_broad"]["type"] == "boolean"
+
+
+def test_show_full_context_is_an_explicit_escape_hatch(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    original = kb.build_worker_context
+    seen: list[bool | None] = []
+
+    def capture(conn, task_id, *, compact=None):
+        seen.append(compact)
+        return original(conn, task_id, compact=compact)
+
+    monkeypatch.setattr(kb, "build_worker_context", capture)
+    payload = json.loads(kt._handle_show({
+        "task_id": worker_env,
+        "full_context": True,
+    }))
+
+    assert "error" not in payload
+    assert seen == [False]
+    props = kt.KANBAN_SHOW_SCHEMA["parameters"]["properties"]
+    assert props["full_context"]["type"] == "boolean"
+
+
+def test_show_compact_profile_does_not_duplicate_context_payload(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET body = ? WHERE id = ?",
+            ("body-marker-" + ("B" * 5000), worker_env),
+        )
+        for index in range(10):
+            kb.add_comment(
+                conn,
+                worker_env,
+                author="worker",
+                body=f"comment-{index}-" + ("C" * 1500),
+            )
+        conn.execute(
+            """INSERT INTO task_runs
+               (task_id, profile, status, started_at, ended_at, outcome,
+                summary, metadata, error)
+               VALUES (?, 'worker', 'failed', 1, 2, 'crashed', ?, ?, ?)""",
+            (
+                worker_env,
+                "closed-summary-" + ("S" * 4000),
+                '{"blob":"' + ("M" * 4000) + '"}',
+                "closed-error-" + ("E" * 4000),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    def compact_policy(explicit=None):
+        return True if explicit is None else bool(explicit)
+
+    monkeypatch.setattr(kb, "_compact_worker_context_enabled", compact_policy)
+    payload = json.loads(kt._handle_show({"task_id": worker_env}))
+
+    assert payload["context_profile"] == "compact"
+    assert payload["task"]["body"] is None
+    assert payload["task"]["body_in_worker_context"] is True
+    assert all(comment["body"] is None for comment in payload["comments"])
+    assert all(run["summary"] is None for run in payload["runs"])
+    active_run = next(run for run in payload["runs"] if run["ended_at"] is None)
+    closed_run = next(run for run in payload["runs"] if run["ended_at"] is not None)
+    assert active_run["details_in_worker_context"] is False
+    assert closed_run["details_in_worker_context"] is True
+    assert payload["raw_omissions"]["comments"] >= 4
+    assert "body-marker" in payload["worker_context"]
+
+
+def test_show_compact_profile_bounds_complete_json_payload(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        parent_rows = [
+            (f"p{index:04d}", f"parent-{index}", "done", 1)
+            for index in range(200)
+        ]
+        child_rows = [
+            (f"c{index:04d}", f"child-{index}", "todo", 1)
+            for index in range(200)
+        ]
+        conn.executemany(
+            "INSERT INTO tasks (id, title, status, created_at) VALUES (?, ?, ?, ?)",
+            parent_rows + child_rows,
+        )
+        conn.executemany(
+            "INSERT INTO task_links(parent_id, child_id) VALUES (?, ?)",
+            [(row[0], worker_env) for row in parent_rows]
+            + [(worker_env, row[0]) for row in child_rows],
+        )
+        conn.executemany(
+            """INSERT INTO task_events(task_id, kind, payload, created_at)
+               VALUES (?, 'fixture_event', ?, ?)""",
+            [
+                (worker_env, json.dumps({"blob": "E" * 5000}), index + 10)
+                for index in range(20)
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        kb,
+        "_compact_worker_context_enabled",
+        lambda explicit=None: True if explicit is None else bool(explicit),
+    )
+    rendered = kt._handle_show({"task_id": worker_env})
+    payload = json.loads(rendered)
+
+    assert len(rendered.encode("utf-8")) <= 48 * 1024
+    assert payload["parent_count"] == 200
+    assert payload["child_count"] == 200
+    assert payload["raw_omissions"]["parents"] > 0
+    assert payload["raw_omissions"]["children"] > 0
+    assert payload["raw_omissions"]["events"] > 0
+
+
+def test_show_compact_profile_reserves_handoff_under_envelope_starvation(
+    monkeypatch,
+    worker_env,
+):
+    import hashlib
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    source = "FULL_SOURCE:" + ("🧭" * 20_000) + ":SOURCE_TAIL"
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    huge = "界" * 30_000
+    conn = kb.connect()
+    try:
+        conn.execute(
+            """UPDATE tasks
+                  SET title = ?, body = ?, created_by = ?, workspace_kind = ?,
+                      workspace_path = ?
+                WHERE id = ?""",
+            (huge, huge, huge, huge, huge, worker_env),
+        )
+        kb.add_comment(conn, worker_env, author=huge, body=huge)
+        kb.add_attachment(
+            conn,
+            worker_env,
+            filename=huge,
+            stored_path="/tmp/" + huge,
+            content_type="application/octet-stream;" + huge,
+            size=1,
+            uploaded_by=huge,
+        )
+        conn.execute(
+            """INSERT INTO task_runs
+               (task_id, profile, status, started_at, ended_at, outcome,
+                summary, metadata, error)
+               VALUES (?, ?, 'gave_up', 2, 3, 'gave_up', ?, ?, NULL)""",
+            (
+                worker_env,
+                huge,
+                "[partial_unverified]\nCOMPLETED: LATEST_HANDOFF_SENTINEL",
+                json.dumps({
+                    "partial_summary_full": source,
+                    "partial_summary_sha256": digest,
+                }),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        kb,
+        "_compact_worker_context_enabled",
+        lambda explicit=None: True if explicit is None else bool(explicit),
+    )
+    rendered = kt._handle_show({"task_id": worker_env})
+    payload = json.loads(rendered)
+
+    assert "error" not in payload
+    assert len(rendered.encode("utf-8")) <= 48 * 1024
+    assert "LATEST_HANDOFF_SENTINEL" in payload["worker_context"]
+    assert "CONTEXT_REF:" in payload["worker_context"]
+
+
+def test_compact_renderer_never_replaces_priority_evidence_with_size_error():
+    from tools import kanban_tools as kt
+
+    huge = "界" * 30_000
+    rendered = kt._render_compact_show_payload({
+        "context_profile": "compact",
+        "task": {"id": huge, "status": huge, "title": huge},
+        "comments": [{"author": huge}],
+        "events": [{"payload": huge}],
+        "runs": [{"profile": huge}],
+        "parents": [huge],
+        "children": [huge],
+        "raw_omissions": {},
+        "worker_context": (
+            huge + "\nLATEST_HANDOFF: " + huge + "\nCONTEXT_REF: " + huge
+        ),
+    })
+    payload = json.loads(rendered)
+
+    assert "error" not in payload
+    assert len(rendered.encode("utf-8")) <= 48 * 1024
+    assert "LATEST_HANDOFF" in payload["worker_context"]
+    assert "CONTEXT_REF:" in payload["worker_context"]
+
+
 def test_create_inherits_worker_dir_workspace(monkeypatch, worker_env):
     """A worker scoped to a dir: task that spawns a child without a
     workspace arg inherits the dir, not scratch (so follow-up code-gen

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -28,6 +28,7 @@ through the board.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -47,6 +48,10 @@ logger = logging.getLogger(__name__)
 
 KANBAN_LIST_DEFAULT_LIMIT = 50
 KANBAN_LIST_MAX_LIMIT = 200
+KANBAN_SHOW_COMPACT_MAX_BYTES = 48 * 1024
+KANBAN_SHOW_COMPACT_MAX_LINK_IDS = 8
+KANBAN_SHOW_COMPACT_MAX_EVENTS = 8
+KANBAN_SHOW_COMPACT_MAX_FIELD_BYTES = 1024
 
 
 def _profile_has_kanban_toolset() -> bool:
@@ -103,6 +108,125 @@ def _default_task_id(arg: Optional[str]) -> Optional[str]:
         return arg
     env_tid = os.environ.get("HERMES_KANBAN_TASK")
     return env_tid or None
+
+
+def _render_compact_show_payload(payload: dict) -> str:
+    """Serialize the compact envelope while reserving priority evidence."""
+
+    def _cap_text(value: str, max_bytes: int) -> str:
+        encoded = value.encode("utf-8")
+        if len(encoded) <= max_bytes:
+            return value
+        marker = "…"
+        budget = max(0, max_bytes - len(marker.encode("utf-8")))
+        return encoded[:budget].decode("utf-8", errors="ignore") + marker
+
+    def _bound(value: Any) -> Any:
+        if isinstance(value, str):
+            return _cap_text(value, KANBAN_SHOW_COMPACT_MAX_FIELD_BYTES)
+        if isinstance(value, list):
+            return [_bound(item) for item in value]
+        if isinstance(value, dict):
+            return {key: _bound(item) for key, item in value.items()}
+        return value
+
+    worker_context = str(payload.get("worker_context") or "")
+    bounded_payload = {
+        key: (worker_context if key == "worker_context" else _bound(value))
+        for key, value in payload.items()
+    }
+
+    def _render() -> str:
+        return json.dumps(
+            bounded_payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+
+    rendered = _render()
+    if len(rendered.encode("utf-8")) <= KANBAN_SHOW_COMPACT_MAX_BYTES:
+        return rendered
+
+    marker = "\n… [worker context truncated to bound compact kanban_show response]\n"
+    priority_end = 0
+    for priority_marker in ("LATEST_HANDOFF", "CONTEXT_REF:"):
+        index = worker_context.find(priority_marker)
+        if index >= 0:
+            line_end = worker_context.find("\n", index)
+            priority_end = max(
+                priority_end,
+                len(worker_context) if line_end < 0 else line_end + 1,
+            )
+
+    low, high = priority_end, len(worker_context)
+    best = ""
+    while low <= high:
+        mid = (low + high) // 2
+        bounded_payload["worker_context"] = worker_context[:mid] + marker
+        candidate = _render()
+        if len(candidate.encode("utf-8")) <= KANBAN_SHOW_COMPACT_MAX_BYTES:
+            best = candidate
+            low = mid + 1
+        else:
+            high = mid - 1
+    if best:
+        return best
+
+    priority_context = worker_context[:priority_end] + marker
+    for low_priority_key in ("events", "comments", "runs", "parents", "children"):
+        bounded_payload[low_priority_key] = []
+        bounded_payload["worker_context"] = priority_context
+        rendered = _render()
+        if len(rendered.encode("utf-8")) <= KANBAN_SHOW_COMPACT_MAX_BYTES:
+            return rendered
+
+    bounded_task = bounded_payload.get("task")
+    if not isinstance(bounded_task, dict):
+        bounded_task = {}
+    minimal_payload = {
+        "context_profile": "compact",
+        "task": {
+            "id": _cap_text(
+                str(bounded_task.get("id") or ""),
+                KANBAN_SHOW_COMPACT_MAX_FIELD_BYTES,
+            ),
+            "status": _cap_text(
+                str(bounded_task.get("status") or ""),
+                KANBAN_SHOW_COMPACT_MAX_FIELD_BYTES,
+            ),
+        },
+        "raw_omissions": bounded_payload.get("raw_omissions", {}),
+        "worker_context": priority_context,
+    }
+    rendered = json.dumps(
+        minimal_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    if len(rendered.encode("utf-8")) <= KANBAN_SHOW_COMPACT_MAX_BYTES:
+        return rendered
+
+    reserved_lines = []
+    for priority_marker in ("LATEST_HANDOFF", "CONTEXT_REF:"):
+        matching_line = next(
+            (line for line in worker_context.splitlines() if priority_marker in line),
+            "",
+        )
+        if matching_line:
+            reserved_lines.append(
+                _cap_text(matching_line, KANBAN_SHOW_COMPACT_MAX_FIELD_BYTES * 8)
+            )
+    emergency_payload = {
+        "context_profile": "compact",
+        "task": minimal_payload["task"],
+        "raw_omissions": minimal_payload["raw_omissions"],
+        "worker_context": "\n".join(reserved_lines),
+    }
+    return json.dumps(
+        emergency_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
 
 
 def _worker_run_id(task_id: str) -> Optional[int]:
@@ -373,21 +497,54 @@ def _handle_show(args: dict, **kw) -> str:
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
     board = args.get("board")
+    full_context, bool_error = _parse_bool_arg(args, "full_context")
+    if bool_error:
+        return tool_error(bool_error)
     try:
         kb, conn = _connect(board=board)
         try:
             task = kb.get_task(conn, tid)
             if task is None:
                 return tool_error(f"task {tid} not found")
+            compact_mode = kb._compact_worker_context_enabled(
+                False if full_context else None
+            )
             comments = kb.list_comments(conn, tid)
             events = kb.list_events(conn, tid)
             runs = kb.list_runs(conn, tid)
-            parents = kb.parent_ids(conn, tid)
-            children = kb.child_ids(conn, tid)
+            all_parents = kb.parent_ids(conn, tid)
+            all_children = kb.child_ids(conn, tid)
+
+            def _sample_ids(values):
+                if (
+                    not compact_mode
+                    or len(values) <= KANBAN_SHOW_COMPACT_MAX_LINK_IDS
+                ):
+                    return values
+                half = KANBAN_SHOW_COMPACT_MAX_LINK_IDS // 2
+                return values[:half] + values[-half:]
+
+            parents = _sample_ids(all_parents)
+            children = _sample_ids(all_children)
+
+            max_comments = int(getattr(kb, "_CTX_COMPACT_MAX_COMMENTS", 6))
+            max_attempts = int(getattr(kb, "_CTX_COMPACT_MAX_PRIOR_ATTEMPTS", 1))
+            if compact_mode:
+                shown_comments = comments[-max_comments:]
+                active_runs = [r for r in runs if r.ended_at is None]
+                closed_runs = [r for r in runs if r.ended_at is not None][-max_attempts:]
+                selected = {r.id: r for r in (*closed_runs, *active_runs)}
+                shown_runs = [selected[key] for key in sorted(selected)]
+                shown_events = events[-KANBAN_SHOW_COMPACT_MAX_EVENTS:]
+            else:
+                shown_comments = comments
+                shown_runs = runs
+                shown_events = events[-50:]
 
             def _task_dict(t):
-                return {
-                    "id": t.id, "title": t.title, "body": t.body,
+                value = {
+                    "id": t.id, "title": t.title,
+                    "body": None if compact_mode else t.body,
                     "assignee": t.assignee, "status": t.status,
                     "tenant": t.tenant, "priority": t.priority,
                     "workspace_kind": t.workspace_kind,
@@ -395,41 +552,88 @@ def _handle_show(args: dict, **kw) -> str:
                     "created_by": t.created_by, "created_at": t.created_at,
                     "started_at": t.started_at,
                     "completed_at": t.completed_at,
-                    "result": t.result,
+                    "result": None if compact_mode else t.result,
                     "current_run_id": t.current_run_id,
                     "model_override": t.model_override,
+                    "review_contract": t.review_contract,
+                    "review_postimage_sha256": t.review_postimage_sha256,
+                    "review_claims_sha256": t.review_claims_sha256,
                 }
+                if compact_mode:
+                    value["body_in_worker_context"] = bool(t.body)
+                    value["result_available_in_full_context"] = bool(t.result)
+                return value
 
             def _run_dict(r):
                 return {
                     "id": r.id, "profile": r.profile,
                     "status": r.status, "outcome": r.outcome,
-                    "summary": r.summary, "error": r.error,
-                    "metadata": r.metadata,
+                    "summary": None if compact_mode else r.summary,
+                    "error": None if compact_mode else r.error,
+                    "metadata": None if compact_mode else r.metadata,
+                    "details_in_worker_context": r.ended_at is not None,
                     "started_at": r.started_at, "ended_at": r.ended_at,
                 }
 
-            return json.dumps({
+            def _event_dict(event):
+                value = {
+                    "kind": event.kind,
+                    "created_at": event.created_at,
+                    "run_id": event.run_id,
+                }
+                if compact_mode:
+                    encoded = json.dumps(
+                        event.payload,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                    value.update({
+                        "payload": None,
+                        "payload_available_in_full_context": event.payload is not None,
+                        "payload_sha256": hashlib.sha256(encoded).hexdigest(),
+                    })
+                else:
+                    value["payload"] = event.payload
+                return value
+
+            payload = {
+                "context_profile": "compact" if compact_mode else "full",
                 "task": _task_dict(task),
                 "parents": parents,
                 "children": children,
+                "parent_count": len(all_parents),
+                "child_count": len(all_children),
                 "comments": [
-                    {"author": c.author, "body": c.body,
+                    {"author": c.author, "body": None if compact_mode else c.body,
+                     "body_in_worker_context": compact_mode,
                      "created_at": c.created_at}
-                    for c in comments
+                    for c in shown_comments
                 ],
-                "events": [
-                    {"kind": e.kind, "payload": e.payload,
-                     "created_at": e.created_at, "run_id": e.run_id}
-                    for e in events[-50:]   # cap; full log via CLI
-                ],
-                "runs": [_run_dict(r) for r in runs],
+                "events": [_event_dict(event) for event in shown_events],
+                "runs": [_run_dict(r) for r in shown_runs],
+                "raw_omissions": {
+                    "comments": len(comments) - len(shown_comments),
+                    "runs": len(runs) - len(shown_runs),
+                    "events": max(0, len(events) - len(shown_events)),
+                    "parents": len(all_parents) - len(parents),
+                    "children": len(all_children) - len(children),
+                    "details_elided_into_worker_context": compact_mode,
+                    "recover_with_full_context": compact_mode,
+                },
                 # Also surface the worker's own context block so the
                 # agent can include it directly if it wants. This is
                 # the same string build_worker_context returns to the
                 # dispatcher at spawn time.
-                "worker_context": kb.build_worker_context(conn, tid),
-            })
+                "worker_context": kb.build_worker_context(
+                    conn,
+                    tid,
+                    compact=compact_mode,
+                ),
+            }
+            if compact_mode:
+                return _render_compact_show_payload(payload)
+            return json.dumps(payload)
         finally:
             conn.close()
     except ValueError as e:
@@ -1097,6 +1301,10 @@ def _handle_create(args: dict, **kw) -> str:
     if bool_error:
         return tool_error(bool_error)
     idempotency_key = args.get("idempotency_key")
+    review_key = args.get("review_key")
+    allow_broad, allow_broad_error = _parse_bool_arg(args, "allow_broad")
+    if allow_broad_error:
+        return tool_error(allow_broad_error)
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
     skills = args.get("skills")
@@ -1147,6 +1355,8 @@ def _handle_create(args: dict, **kw) -> str:
                 project_id=project_id,
                 triage=triage,
                 idempotency_key=idempotency_key,
+                review_key=review_key,
+                granularity_policy="allow" if allow_broad else None,
                 max_runtime_seconds=(
                     int(max_runtime_seconds)
                     if max_runtime_seconds is not None else None
@@ -1369,6 +1579,15 @@ KANBAN_SHOW_SCHEMA = {
             "task_id": {
                 "type": "string",
                 "description": _DESC_TASK_ID_DEFAULT,
+            },
+            "full_context": {
+                "type": "boolean",
+                "description": (
+                    "Bypass kanban.context_profile=compact and expose the "
+                    "historical bounded attempts, parent handoffs, and comments. "
+                    "Exact partial_summary_full recovery follows the hash-bound "
+                    "CONTEXT_REF instruction."
+                ),
             },
             "board": _board_schema_prop(),
         },
@@ -1810,6 +2029,23 @@ KANBAN_CREATE_SCHEMA = {
                     "If a non-archived task with this key already "
                     "exists, return that task's id instead of creating "
                     "a duplicate. Useful for retry-safe automation."
+                ),
+            },
+            "review_key": {
+                "type": "string",
+                "description": (
+                    "Exact review dedup key, normally <postimage-sha256>:"
+                    "<claims-sha256>[:round-N]. A non-archived review with "
+                    "the same key is reused instead of spawning a redundant reviewer. "
+                    "Do not combine with idempotency_key."
+                ),
+            },
+            "allow_broad": {
+                "type": "boolean",
+                "description": (
+                    "Explicitly bypass kanban.granularity_guard=triage for an "
+                    "intentional broad card. The deterministic assessment is "
+                    "still recorded. Defaults to false."
                 ),
             },
             "max_runtime_seconds": {

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -61,7 +61,10 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   word "board" outside this docs section.
 - **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
 - **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are `done`.
-- **Comment** — the inter-agent protocol. Agents and humans append comments; when a worker is (re-)spawned it reads the full comment thread as part of its context.
+- **Comment** — the inter-agent protocol. Agents and humans append comments. The
+  default `full` context profile includes the bounded historical thread; the
+  opt-in `compact` profile includes the latest comments and an explicit full
+  recovery command instead of repeating the entire thread on every retry.
 - **Workspace** — the directory a worker operates in. Three kinds:
   - `scratch` (default) — fresh tmp dir under `~/.hermes/kanban/workspaces/<id>/` (or `~/.hermes/kanban/boards/<slug>/workspaces/<id>/` on non-default boards). **Deleted when the task completes** — scratch is ephemeral by design. Files explicitly declared through `kanban_complete(artifacts=[...])` are copied into durable per-task attachment storage before cleanup; existing deliverable paths in legacy completion summaries receive the same treatment. Other scratch files are removed. A missing declared scratch artifact keeps the task in-flight so the worker can correct the path and retry. Use `worktree:` or `dir:<path>` when the whole workspace should remain available. The first time a scratch workspace is created on an install, the dispatcher logs a warning and emits a `tip_scratch_workspace` event on the task (visible via `hermes kanban show <id>`).
   - `dir:<path>` — an existing shared directory (Obsidian vault, mail ops dir, per-account folder). **Must be an absolute path.** Relative paths like `dir:../tenants/foo/` are rejected at dispatch because they'd resolve against whatever CWD the dispatcher happens to be in, which is ambiguous and a confused-deputy escape vector. The path is otherwise trusted — it's your box, your filesystem, the worker runs with your uid. This is the trusted-local-user threat model; kanban is single-host by design. **Preserved on completion.**
@@ -533,6 +536,17 @@ The kanban board has two ways to handle a task you drop into the Triage column:
 
 **Auto (default)** — `kanban.auto_decompose: true`. The gateway-embedded dispatcher runs the **decomposer** on each tick, capped by `kanban.auto_decompose_per_tick` (default 3 tasks per tick) so a bulk-load of triage tasks doesn't burst-spend the auxiliary LLM. The decomposer uses the built-in decomposition prompt plus the `auxiliary.kanban_decomposer` model path, reads your installed profiles + their descriptions, and asks the LLM to produce a JSON task graph: which tasks to spawn, who they go to, and which depend on which. The original triage task becomes the parent of every leaf in the graph, so it stays alive until the whole graph completes - and then promotes back to `ready` so its assignee (`kanban.orchestrator_profile`, or the active default profile when unset) can judge completion and add more tasks if the work isn't done. This is the "drop a one-liner, walk away" flow.
 
+Fan-out is fail-closed: a graph must contain 2-6 children, and every child is
+reassessed as atomic before anything is inserted. A child that still needs
+splitting rejects the entire graph even when the board's general granularity
+policy is `warn`. Security-sensitive semantics must also match the declared
+child kind: exact-review work uses `review`/`review_scheduler`, release verdicts
+use `controller`, and any deploy, publish, rollout, send, submit, or other
+external-state change uses `activation`. Activation children are created
+`blocked` with `block_kind=needs_input` and remain PREPARE_ONLY until a human
+explicitly unblocks them; disguising those semantics as ordinary `work`
+rejects the whole decomposition without creating children.
+
 **Manual** — `kanban.auto_decompose: false`. Triage tasks stay in triage until you act. Click the **⚗ Decompose** button on a card, run `hermes kanban decompose <id>` (or `--all`), or use `/kanban decompose <id>` from a chat. This matches the pre-decomposer behavior of the board, useful when you want full control over what runs when.
 
 Flip between the two modes from the **Orchestration: Auto/Manual** pill at the top of the kanban page (emerald = Auto, muted gray = Manual), or by editing `config.yaml` directly. Both modes coexist with `hermes kanban specify` — that's still available as a single-task spec rewrite when you don't want fan-out.
@@ -661,6 +675,7 @@ hermes kanban create "<title>" [--body ...] [--assignee <profile>]
                                 [--workspace scratch|worktree|worktree:<path>|dir:<path>]
                                 [--branch <name>]
                                 [--priority N] [--triage] [--idempotency-key KEY]
+                                [--review-key POSTIMAGE_SHA256:CLAIMS_SHA256[:round-N]] [--allow-broad]
                                 [--max-runtime 30m|2h|1d|<seconds>]
                                 [--max-retries N]
                                 [--goal] [--goal-max-turns N]
@@ -706,7 +721,8 @@ hermes kanban notify-subscribe <id>                    # gateway bridge hook (us
 hermes kanban notify-list [<id>] [--json]
 hermes kanban notify-unsubscribe <id>
         --platform <name> --chat-id <id> [--thread-id <id>]
-hermes kanban context <id>                             # what a worker sees
+hermes kanban context <id> [--full]                    # bounded worker profile
+        [--run-id N --field partial_summary_full]      # exact hash-bound handoff
 hermes kanban specify [<id> | --all] [--tenant T]      # flesh out a triage-column idea
         [--author NAME] [--json]                       #   into a full spec and promote to todo
 hermes kanban gc [--event-retention-days N]            # workspaces + old events + old logs
@@ -716,6 +732,71 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
 
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
+
+### Scope, context, and budget controls
+
+These controls reduce repeated model work without removing tools, tests, or
+review gates. Their defaults preserve lifecycle compatibility.
+
+| Config key | Default | What it does |
+|------------|---------|--------------|
+| `kanban.granularity_guard` | `warn` | Runs a deterministic, no-LLM scope assessment at task creation. `warn` records it only; `triage` routes cards classified `split` to Triage before dispatch. `--allow-broad` is an explicit, auditable per-card override. |
+| `kanban.context_profile` | `full` | `compact` keeps the task contract, priority-reserved latest durable handoff and `CONTEXT_REF`, plus bounded attachments/parent handoffs/comments within an aggregate 48 KiB UTF-8 worker-context budget. The compact `kanban_show` JSON envelope is independently capped at 48 KiB. `hermes kanban context <id> --full` and `kanban_show(full_context=true)` expose the historical bounded profile; exact handoff source recovery uses the command embedded in `CONTEXT_REF`. |
+| `kanban.budget_warning_ratio` | `0.75` | Records one `budget_checkpoint` event and adds one API-only, cache-stable closure marker to the latest previously unseen tool-result tail for the rest of that run. It does not mutate persisted conversation history or the cached system prompt. Invalid values fail safely to `0.75`. |
+| `kanban.budget_exhaustion_policy` | `retry` | `retry` preserves the existing breaker; `block` stops on the first exhausted run; `triage_once` stores a bounded `[partial_unverified]` handoff and routes the first exhaustion to Triage, then blocks a repeated exhaustion to prevent recursive retry/decomposition loops. |
+
+When `triage_once` routes a task back through decomposition, the existing
+decomposer call receives the persisted assessment and latest closed-attempt
+handoff. It is instructed to preserve completed work, put full-matrix testing
+in a closure child, and keep independent review and controller decisions in
+separate dependent cards. Each generated child receives its own deterministic
+scope assessment before insertion. A direct review child is accepted only with
+an exact postimage-and-claims key and must depend on closure. If closure has not
+yet produced that key, the decomposer emits a dependent review-scheduling gate
+instead; controllers can depend only on a real keyed review, never on scheduling
+evidence.
+
+The decomposer accepts two to six children, and every child must reassess as
+atomic even when the board's generic granularity policy is `warn`. A source card
+already classified `split` cannot be collapsed back to `fanout=false`; malformed
+output leaves the card in Triage without partial writes. Sensitive semantics are
+checked against the declared child kind. Review/controller mismatches are
+rejected; external state changes require `kind=activation` and are created as
+`blocked` with a `needs_input` human gate, never auto-promoted. Automatic
+decomposition claims are scoped to the triage cause and generation, so a later
+`triage_once` run is not consumed by an older granularity claim; transient
+auxiliary failures get one bounded retry.
+
+Use `--review-key <postimage-sha256>:<claims-sha256>` when creating an independent
+review card. Requests with the same exact
+postimage and claim contract reuse one non-archived card, including concurrent
+creators. A deliberate second review round remains possible with a distinct
+suffix such as `:round-2`. This deduplicates scheduling only: it never infers
+PASS, approval, or deployment.
+
+Exact-review identity is durable in the task row: an `exact_review_v1`
+discriminator and the canonical postimage and claims SHA-256 values accompany
+the reserved `review:v1:` idempotency key. A legacy or generic incumbent that
+has only the reserved key is ambiguous and fails closed instead of being reused.
+
+Reusing an exact review is status-aware. A `running`, `review`, or `done` review
+keeps its input parents immutable; a new controller waits directly on both that
+review and the new closure prerequisites. An unstarted `ready` review may accept
+the new closure parent and is demoted to `todo` until that parent completes.
+
+Budget-exhausted runs store a `kanban_partial_handoff/v1` summary capped at
+4 KiB UTF-8. The visible summary always retains `COMPLETED`, `CHANGED_FILES`,
+`TESTS`, `REMAINING`, `RESUME`, and `INVARIANTS`; the full source text is bound
+by SHA-256 and retained once in the run metadata for explicit recovery. It is
+always marked `[partial_unverified]` and never counts as a review verdict.
+Compact context does not reserialize that full source: it carries the bounded
+handoff plus a priority-reserved structured `CONTEXT_REF` containing task id,
+run id, field, SHA-256 and the exact read-only recovery command:
+`hermes kanban context <task-id> --run-id <run-id> --field partial_summary_full`.
+The command verifies that the run belongs to the task and that the recovered
+UTF-8 source matches the stored SHA-256 before emitting it byte-for-byte.
+The default `full` profile preserves the historical character-based field caps;
+UTF-8 byte and aggregate caps apply only to the opt-in compact profile.
 
 ### Concurrency, scheduling, and child promotion config
 


### PR DESCRIPTION
## Summary

This PR hardens Kanban execution so long-running work can use fewer context tokens and iterations without increasing `max_turns`.

- adds durable iteration-budget checkpoints and exactly-once compression/repair behavior
- makes compact Kanban context bounded to 48 KiB UTF-8 while reserving `LATEST_HANDOFF` and `CONTEXT_REF`
- keeps handoffs reversible through hash-bound recovery of `partial_summary_full`
- adds run CAS/ownership checks so stale workers cannot mutate a newer run
- makes exact-review provenance durable and fail-closed across direct creation and decomposition
- constrains decomposition to atomic 2–6 child fanout and blocks hidden activation/release work as `PREPARE_ONLY`
- strips private Hermes metadata before provider sizing and wire serialization, while preserving repaired user input exactly once
- documents configuration and ships a reproducible synthetic context benchmark

Builds on the timeout-salvage work in #52511 and implements the preventive budget-warning contract from #54153. The original contribution remains credited in the commit trailer.

## Verification

Verification on the final integrated candidate:

- Kanban matrix plus benchmark tests: **822 passed**
- agent/run-loop, 413 recovery, checkpoint, role-repair, compression, streaming, multimodal, and Bedrock tests: **782 passed**
- configuration matrix: **300 passed**
- combined canonical run: **1,904 passed, 0 failed**, subprocess return code 0
- Ruff, `git diff --check`, Python 3.11 compile, and focused Python 3.9 compile: **PASS**
- YAML/JSON parsing, deterministic benchmark, and security/privacy scans: **PASS**

Synthetic benchmark:

- full context: **340,866 bytes**
- compact context: **49,152 bytes**
- reduction: **85.58%**
- repeated and versioned artifacts: **byte-identical**

## Review receipts

- final candidate: `efa7a991148be122e93f7c898f5adf98d4f55083`
- base reviewed for overlapping integration: `c78aa0bad5dc96c8080b1d16def868f1ab039b0c`
- tree: `b6b04c8eaa3be35c4a6d895d7d2e6f6b5dfefa33`
- binary diff SHA-256: `9f3dea8ac55998cf9302ccab61a55c3c5a47e4b9843de4e86095121ee2122d90`
- bundle SHA-256: `1cbf19e12bc68b1a515706ce9ae8f0883f5c05409c292666ae8447ede02fd55e`
- independent material controller: **PASS**
- overlapping-integration controller: **PASS**
- canonical PRE/POST interlock: **PASS / NO_MUTATION**
- candidate history: one privacy-safe squash commit

After the frozen review, `main` advanced by four commits touching three paths. The intersection with the feature's 36 paths is empty; the reviewed base remains an ancestor, and `git merge-tree` reports a clean merge against current `main`.
