### PR TITLE
fix(simplex): send DMs by numeric contactId via /_send, not bare @<id>

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -1209,8 +1209,13 @@ async def _standalone_send(
             )
             cmd_str = f"/_send #{group_id} json {composed}"
         else:
-            # Direct contacts are addressed by display name without brackets.
-            cmd_str = f"@{chat_id} {message}"
+            # Direct contacts addressed by numeric contactId via the structured
+            # form (same as send()); the bare "@<id> text" form is parsed as a
+            # display-name lookup and silently drops for numeric contactIds.
+            composed = json.dumps(
+                [{"msgContent": {"type": "text", "text": message}}]
+            )
+            cmd_str = f"/_send @{chat_id} json {composed}"
 
         payload = {
             "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -815,8 +815,13 @@ class SimplexAdapter(BasePlatformAdapter):
         because the bracket chat-command syntax (``#[<id>] text``) is
         parsed by the daemon as a display-name lookup, which silently
         drops when the group's display name isn't the literal ID. DMs
-        use the simple ``@<id> text`` form which has always worked in
-        production.
+        use the structured ``/_send @<id> json [...]`` form for the
+        same reason: the bare ``@<id> text`` chat-command form parses
+        ``@<n>`` as a *display-name* lookup, so a numeric ``contactId``
+        (e.g. ``6``) yields ``chatCmdError { contactNotFound }`` and the
+        reply silently drops (see ``test_send_dm``). Addressing by
+        numeric ID via ``/_send`` and escaping via ``json.dumps`` makes
+        the DM text path consistent with every other send path.
 
         The call is fire-and-forget at the WebSocket level: the daemon
         doesn't always return a corrId reply for chat commands, and
@@ -838,7 +843,13 @@ class SimplexAdapter(BasePlatformAdapter):
                 )
                 cmd_str = f"/_send #{chat_id[6:]} json {composed}"
             else:
-                cmd_str = f"@{chat_id} {content}"
+                # Structured form: address DMs by numeric contactId. The
+                # bare "@<id> text" form is parsed as a display-name lookup
+                # and silently drops for numeric contactIds.
+                composed = json.dumps(
+                    [{"msgContent": {"type": "text", "text": content}}]
+                )
+                cmd_str = f"/_send @{chat_id} json {composed}"
 
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -352,7 +352,9 @@ async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
 
     result = await _standalone_send(pconfig, "contact-42", "hi")
     assert result == {"success": True, "platform": "simplex", "chat_id": "contact-42"}
-    assert sent_payloads[0]["cmd"] == "@contact-42 hi"
+    assert sent_payloads[0]["cmd"] == "/_send @contact-42 json " + json.dumps(
+        [{"msgContent": {"type": "text", "text": "hi"}}]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -205,12 +205,13 @@ def test_corr_id_pending_set_self_trims():
 
 @pytest.mark.asyncio
 async def test_send_dm():
-    """DMs use the bare ``@<id> text`` chat-command form.
+    """DMs use the structured ``/_send @<id> json [...]`` form.
 
-    The bracketed form ``@[<id>] text`` is what the daemon's man page
-    documents, but in practice both addressing styles route through
-    the same chat-command parser; bare ``@<id>`` matches what every
-    Hermes deployment has been using in production for months.
+    The bare ``@<id> text`` chat-command form is parsed by the daemon as
+    a *display-name* lookup, so a numeric ``contactId`` (e.g. ``6``)
+    yields ``chatCmdError { contactNotFound }`` and the reply silently
+    drops. Addressing by numeric ID via ``/_send`` and escaping via
+    ``json.dumps`` matches every other send path in the adapter.
     """
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
@@ -222,7 +223,9 @@ async def test_send_dm():
     result = await adapter.send("contact-42", "Hello, SimpleX!")
     mock_ws.send.assert_called_once()
     payload = json.loads(mock_ws.send.call_args[0][0])
-    assert payload["cmd"] == "@contact-42 Hello, SimpleX!"
+    assert payload["cmd"] == "/_send @contact-42 json " + json.dumps(
+        [{"msgContent": {"type": "text", "text": "Hello, SimpleX!"}}]
+    )
     assert payload["corrId"].startswith(_CORR_PREFIX)
     assert result.success is True
 


### PR DESCRIPTION
## Summary
Fixes #66951 — silent loss of every outbound **direct message** in the SimpleX Chat gateway adapter.

The DM text path addressed recipients with the bare chat-command form `@<id> text`. `chat_id` is a numeric `contactId` (e.g. `6`); SimpleX parses `@<n>` as a display-**name** lookup, so the daemon replies with `chatCmdError { contactNotFound, contactName: "6" }`. Chat commands return no `corrId`, so the adapter never observed the error and logged success while the reply vanished.

Mirror the group/media/voice branches: address by numeric ID and escape via `json.dumps` using the structured `/_send @<id> json [...]` form.

## Changes
- `plugins/platforms/simplex/adapter.py`: DM text path now uses `/_send @{chat_id} json <composed>` (was `@{chat_id} {content}`). Updated docstring.
- `tests/gateway/test_simplex_plugin.py`: `test_send_dm` now asserts the structured form/payload.

## Validation
- `python3 -m pytest tests/gateway/test_simplex_plugin.py` → **30 passed**.

Closes #66951.