### PR TITLE
fix(clarify): unwrap 'value' key in _flatten_choice for provider compatibility

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -184,10 +184,15 @@ class TestClarifyDictChoices:
     def test_flatten_unwrap_order_label_over_description(self):
         assert _flatten_choice({"description": "verbose", "label": "tight"}) == "tight"
 
-    def test_flatten_drops_name_value_only_dict(self):
-        # name/value are component-shaped fields, not user-facing labels —
-        # picking them would leak raw enum values / short model ids.
-        assert _flatten_choice({"name": "tight", "value": "x"}) == ""
+    def test_flatten_drops_name_only_dict(self):
+        # name is a component-shaped field, not a user-facing label —
+        # picking it would leak raw enum values / short model ids.
+        assert _flatten_choice({"name": "tight"}) == ""
+
+    def test_flatten_unwraps_value_key(self):
+        # Some providers (e.g. GLM/ZhipuAI) emit choices as [{"value": "..."}].
+        # Without unwrapping "value", the entire choice is dropped to "".
+        assert _flatten_choice({"value": "Option A"}) == "Option A"
 
     def test_flatten_prefers_canonical_key_over_name(self):
         assert _flatten_choice({"name": "tight", "description": "Tight desc"}) == "Tight desc"
@@ -213,7 +218,7 @@ class TestClarifyDictChoices:
             choices=[
                 {"choice": "Tight", "description": "Tight, covers all 3 points"},
                 {"description": "Loose layout"},
-                {"name": "modelid", "value": "abc"},  # dropped, not leaked
+                {"name": "modelid"},  # dropped, not leaked (name is excluded)
                 "A plain string choice",
             ],
             callback=cb,

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -32,18 +32,22 @@ def _flatten_choice(c) -> str:
     fixes the whole class in one place instead of per-adapter.
 
     Dict unwrap order is the canonical LLM tool-call user-facing keys:
-    ``label`` → ``description`` → ``text`` → ``title``. ``name`` and ``value``
-    are deliberately excluded — they're component-shaped fields that could
-    carry raw enum values or short identifiers, not human-readable labels. A
-    dict with none of the canonical keys is dropped (returns ""), since a
-    garbage label is worse than no choice at all.
+    ``label`` → ``description`` → ``text`` → ``title`` → ``value``.
+    ``name`` is deliberately excluded — it's a component-shaped field that
+    could carry raw enum values or short identifiers, not human-readable
+    labels. ``value`` is included because some providers (e.g. GLM/ZhipuAI)
+    emit choices as ``[{"value": "A. ..."}]``, and without it the entire
+    choice is dropped to ``""`` — breaking interactive selection on every
+    platform (CLI, Discord, Telegram, Feishu). A dict with none of the
+    canonical keys is dropped (returns ""), since a garbage label is worse
+    than no choice at all.
     """
     if c is None:
         return ""
     if isinstance(c, str):
         return c.strip()
     if isinstance(c, dict):
-        for key in ("label", "description", "text", "title"):
+        for key in ("label", "description", "text", "title", "value"):
             v = c.get(key)
             if isinstance(v, str) and v.strip():
                 return v.strip()


### PR DESCRIPTION
## Problem

Some LLM providers (e.g. GLM/ZhipuAI) emit clarify choices as `[{"value": "A. ..."}]` instead of the expected `[{"label": "..."}]` format or bare strings. The `_flatten_choice` function in `tools/clarify_tool.py` deliberately excluded `value` as a "component-shaped field", but this causes the **entire choice to be dropped to `""`** — breaking interactive selection on every platform (CLI, Discord, Telegram, Feishu). Users see blank options instead of clickable choices.

## Root Cause

The dict unwrap logic only checked 4 keys in order: label, description, text, title. A choice dict with only `value` (no canonical keys) falls through and returns empty string.

```python
# Before — "value" excluded
for key in ("label", "description", "text", "title"):
```

## Fix

Add `value` as the **last** key in the unwrap order:

```python
# After — "value" included at the end
for key in ("label", "description", "text", "title", "value"):
```

- **Backward-compatible**: existing choices with label/description/text/title keys are unaffected — `value` is only checked when none of the canonical keys are present.
- **`name` remains excluded**: it's a true component-shaped field (model IDs, enum values), unlike `value` which some providers use as the primary choice label.

## Test Plan

- [x] Updated `test_flatten_drops_name_value_only_dict` → split into `test_flatten_drops_name_only_dict` (name still dropped) + `test_flatten_unwraps_value_key` (value now unwrapped)
- [x] Fixed `test_dict_choices_reach_callback_as_clean_text` e2e test input (was `{"name": "modelid", "value": "abc"}`, changed to `{"name": "modelid"}` since value is now unwrapped)
- [x] All 29 tests in `tests/tools/test_clarify_tool.py` pass
- [x] `py_compile` passes

## Context

This was discovered running GLM-5.2 (via ZhipuAI provider) as the primary model — every `clarify` call produced blank choices, making the interactive question feature completely unusable. The fix is a one-line addition that restores functionality for this provider class without affecting any existing behavior.
