### PR TITLE
fix(agent): consume every tool_call id variant when pairing tool results

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -528,6 +528,9 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     # ``_get_tool_call_id_static``'s ``call_id || id`` — a match set must
     # accept every legitimate reference, not just the canonical one (#58168).
     known_tool_ids: set = set()
+    # Maps every registered id variant back to the full variant set of the
+    # tool_call it came from, so consuming one variant consumes its siblings.
+    tool_id_siblings: Dict[str, set] = {}
     filtered: List[Dict] = []
     for msg in collapsed:
         if not isinstance(msg, dict):
@@ -536,13 +539,14 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         role = msg.get("role")
         if role == "assistant":
             known_tool_ids = set()
+            tool_id_siblings = {}
             for tc in (msg.get("tool_calls") or []):
                 if not isinstance(tc, dict):
                     continue
-                for key in ("id", "call_id"):
-                    tc_id = tc.get(key)
-                    if tc_id:
-                        known_tool_ids.add(tc_id)
+                variants = {tc.get(key) for key in ("id", "call_id") if tc.get(key)}
+                for tc_id in variants:
+                    known_tool_ids.add(tc_id)
+                    tool_id_siblings[tc_id] = variants
             filtered.append(msg)
         elif role == "tool":
             tc_id = msg.get("tool_call_id")
@@ -553,7 +557,16 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 # glitch) falls into the drop branch below instead of being
                 # replayed — strict providers (DeepSeek) reject a duplicate
                 # tool_call_id with HTTP 400 (#58327). Credit: #55436.
-                known_tool_ids.discard(tc_id)
+                #
+                # Consume EVERY variant of the matched call, not just the one
+                # this result referenced. A Codex/Responses tool_call registers
+                # both ``id`` (``fc_...``) and ``call_id`` (``call_...``) above
+                # (#58168), so discarding only the matched key leaves its
+                # sibling live — and a duplicate result keyed on that sibling
+                # sails straight through this guard, re-creating the very 400
+                # the consume step exists to prevent.
+                for sibling in tool_id_siblings.get(tc_id, {tc_id}):
+                    known_tool_ids.discard(sibling)
             else:
                 repairs += 1
         else:

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -770,3 +770,56 @@ def test_sanitize_preserves_populated_tool_calls():
     out = sanitize_api_messages(list(messages))
     assistant = [m for m in out if m.get("role") == "assistant"][0]
     assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_Z"]
+
+
+def test_repair_drops_duplicate_tool_result_keyed_on_sibling_id():
+    """A duplicate result must be dropped even when it uses the OTHER id variant.
+
+    A Codex/Responses ``tool_call`` carries both ``id`` (``fc_...``) and
+    ``call_id`` (``call_...``); both are registered so a result keyed on either
+    is recognised (#58168). The duplicate guard (#58327) consumed only the id
+    the first result referenced, leaving its sibling live — so a second result
+    keyed on that sibling sailed through and two tool messages were replayed
+    for a single call, re-creating the HTTP 400 the guard exists to prevent.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "fc_1", "call_id": "call_1", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "first"},
+        {"role": "tool", "tool_call_id": "fc_1", "content": "duplicate"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    tool_msgs = [m for m in messages if m.get("role") == "tool"]
+    assert [m["content"] for m in tool_msgs] == ["first"]
+
+
+def test_repair_keeps_both_results_for_two_codex_calls_mixed_keys():
+    """Consuming a call's sibling ids must not orphan a *different* call.
+
+    Two parallel Codex tool_calls answered via different id variants
+    (one by ``call_id``, one by ``id``) are both legitimate and must survive.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [
+             {"id": "fc_1", "call_id": "call_1", "type": "function",
+              "function": {"name": "f", "arguments": "{}"}},
+             {"id": "fc_2", "call_id": "call_2", "type": "function",
+              "function": {"name": "g", "arguments": "{}"}},
+         ]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "r1"},
+        {"role": "tool", "tool_call_id": "fc_2", "content": "r2"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 0
+    assert [m["content"] for m in messages if m.get("role") == "tool"] == ["r1", "r2"]


### PR DESCRIPTION
## What does this PR do?

`repair_message_sequence`'s Pass 1 combines two previously-merged behaviours that don't compose:

* **#58168** registers **both** `id` and `call_id` for each assistant `tool_call`, so a tool result keyed on either variant is recognised instead of being falsely orphaned.
* **#58327 / #55436** then **consumes** the matched id, so a second result for the same call is dropped rather than replayed (strict providers reject it with HTTP 400).

A Codex/Responses `tool_call` carries two **different** ids (`fc_...` and `call_...`), but only the id the first result referenced is discarded. Its sibling stays live in `known_tool_ids`, so a duplicate result keyed on that sibling still matches and is kept — two tool messages replayed for a single call, re-creating exactly the HTTP 400 the consume step exists to prevent:

```
A) duplicate, both keyed on call_id   -> repairs=1  kept=['first']            (guard works)
B) duplicate keyed on the sibling id  -> repairs=0  kept=['first','duplicate'] (guard defeated)
```

Duplicates of this kind are the retry / crash / session-resume glitch the guard was written for; the id-variant split simply lets them slip past it.

The fix tracks each registered id back to its `tool_call`'s full variant set and discards all of them on a match.

## Related Issue

Follow-up to the interaction between #58168 and #58327.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py` — in `repair_message_sequence` Pass 1, map every registered id variant back to its `tool_call`'s variant set (`tool_id_siblings`) and discard all siblings when a result matches, instead of only the referenced id.
- `tests/run_agent/test_message_sequence_repair.py` — add two tests: the sibling-keyed duplicate is dropped, and two parallel Codex calls answered via *different* variants are both preserved (guarding against over-consumption).

## How to Test

1. Run:

       pytest tests/run_agent/test_message_sequence_repair.py -q

   `test_repair_drops_duplicate_tool_result_keyed_on_sibling_id` fails without the fix and passes with it.

2. Behaviour that must not change is covered too — results keyed on `call_id` only, `id` only, or a plain single-key OpenAI `tool_call` are all still accepted, and mixed-variant answers to two parallel calls both survive.

3. No regressions: a `-k "repair or tool_call_id or sanitize_api or dedup"` sweep produces an identical set of 13 pre-existing failures on clean `main` and with this change (verified via a separate baseline worktree).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suites and verified no regressions against a clean `main` baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline comments) — the consume step now documents why siblings must go together
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure list/dict logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A