### PR TITLE
fix(qqbot): add AI Agent identity framing to platform hint (#66959)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -841,10 +841,12 @@ PLATFORM_HINTS = {
         "capability — use MEDIA: syntax whenever a file delivery is appropriate."
     ),
     "qqbot": (
-        "You are on QQ, a popular Chinese messaging platform. QQ supports markdown formatting "
-        "and emoji. You can send media files natively: include MEDIA:/absolute/path/to/file in "
-        "your response. Images are sent as native photos, and other files arrive as downloadable "
-        "documents."
+        "You are a QQ AI Agent. You are an autonomous assistant operating inside QQ, a popular "
+        "Chinese messaging platform. QQ supports markdown formatting and emoji. You can send "
+        "media files natively: include MEDIA:/absolute/path/to/file in your response. Images are "
+        "sent as native photos, and other files arrive as downloadable documents. Always use your "
+        "available skills (e.g. call skill_view to load a skill body before acting) rather than "
+        "relying only on the short skill description."
     ),
     "yuanbao": (
         "You are on Yuanbao (腾讯元宝), a Chinese AI assistant platform. "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1079,6 +1079,15 @@ class TestPromptBuilderConstants:
         assert "api_server" in PLATFORM_HINTS
         assert "webui" in PLATFORM_HINTS
 
+    def test_qqbot_hint_frames_agent_identity(self):
+        """#66959 — weaker models routed via aggregators skip skill_view() when
+        the QQ hint lacks explicit 'AI Agent' identity framing. Mirror the CLI
+        hint so the model loads skill bodies instead of relying on short
+        descriptions alone."""
+        hint = PLATFORM_HINTS["qqbot"]
+        assert "AI Agent" in hint
+        assert "skill" in hint
+
     def test_cli_and_tui_hints_flag_local_only_cron(self):
         """#51568 — cron jobs from CLI/TUI sessions don't deliver back into
         the session, so the agent must be told up front not to promise it."""

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -145,3 +145,20 @@ class TestTelegramRichMessagesHint:
             stable = _stable_prompt(agent)
         assert "Standard Markdown is automatically converted" in stable
         assert "lean into it" not in stable
+
+
+class TestQqbotHint:
+    """#66959 — the QQ platform hint must frame the model as an AI Agent so
+    weaker routed models load skill bodies via skill_view() instead of relying
+    on the short skill description alone."""
+
+    def test_qqbot_hint_inserted_into_system_prompt(self):
+        agent = _make_agent(platform="qqbot")
+        stable = _stable_prompt(agent)
+        assert "You are a QQ AI Agent" in stable
+
+    def test_qqbot_hint_absent_for_other_platforms(self):
+        agent = _make_agent(platform="cli")
+        stable = _stable_prompt(agent)
+        assert "You are a QQ AI Agent" not in stable
+


### PR DESCRIPTION
## Summary
Fixes #66959 — the QQ bot adapter works, but `PLATFORM_HINTS["qqbot"]` lacked explicit agent-identity framing. Weaker/free models routed via OmniRoute-style aggregators then skip `skill_view()` and rely only on the short `<available_skills>` description, e.g. failing to know the default transaction account.

Mirror the CLI hint (`You are a CLI AI Agent`) by leading the QQ hint with `You are a QQ AI Agent` and reminding the model to load skill bodies via `skill_view`.

## Changes
- `agent/prompt_builder.py`: qqbot hint now frames the model as an agent and references skills.
- `tests/agent/test_prompt_builder.py`: added `test_qqbot_hint_frames_agent_identity`.

## Validation
- `python3 -m pytest tests/agent/test_prompt_builder.py` → 165 passed (the 2 unrelated failures — `test_excludes_disabled_skills`, `test_walks_parents_inside_git_repo` — also fail on clean upstream `main` and are pre-existing/ordering-related, not introduced by this change).

Closes #66959.