### PR TITLE
feat(api): add request-scoped ephemeral agent turns

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -336,6 +336,9 @@ def init_agent(
     skip_context_files: bool = False,
     load_soul_identity: bool = False,
     skip_memory: bool = False,
+    persist_disabled: bool = False,
+    memory_read_only: bool = False,
+    tools_disabled: bool = False,
     session_db=None,
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
@@ -1356,7 +1359,9 @@ def init_agent(
     # (state.db) or the JSON snapshot, regardless of session_id. Set on the
     # background skill/memory review fork so its harness turn can't leak into
     # the user's real session and hijack the next live turn. Default False.
-    agent._persist_disabled = False
+    agent._persist_disabled = bool(persist_disabled)
+    agent._memory_read_only = bool(memory_read_only)
+    agent._tools_disabled = bool(tools_disabled)
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,
@@ -1513,8 +1518,25 @@ def init_agent(
             _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)
             agent._memory_manager = None
 
-    from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools
-    _inject_memory_provider_tools(agent)
+    if agent._memory_read_only:
+        # Keep loaded memory available to prompt construction and pre-turn
+        # recall, but remove every model-callable memory mutation surface.
+        agent._memory_nudge_interval = 0
+        agent.tools = [
+            tool for tool in agent.tools
+            if tool.get("function", {}).get("name") != "memory"
+        ]
+        agent.valid_tool_names.discard("memory")
+    else:
+        from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools
+        _inject_memory_provider_tools(agent)
+
+    if agent._tools_disabled:
+        # Persistence suppression is not a capability sandbox by itself.
+        # Ephemeral callers must not be able to invoke file, shell, messaging,
+        # scheduling, skill, memory, or plugin tools as an incidental effect.
+        agent.tools = []
+        agent.valid_tool_names.clear()
 
     # Skills config: nudge interval for skill creation reminders
     agent._skill_nudge_interval = 10
@@ -1523,6 +1545,10 @@ def init_agent(
         agent._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
     except Exception:
         pass
+    if agent._memory_read_only:
+        # Do not let an ephemeral turn auto-promote room content through the
+        # memory or skill curator paths.
+        agent._skill_nudge_interval = 0
 
     # Tool-use enforcement config: "auto" (default — matches hardcoded
     # model list), true (always), false (never), or list of substrings.
@@ -1990,7 +2016,8 @@ def init_agent(
     # same local-model latency penalty.
     agent._context_engine_tool_names: set = set()
     if (
-        hasattr(agent, "context_compressor")
+        not agent._tools_disabled
+        and hasattr(agent, "context_compressor")
         and agent.context_compressor
         and agent.tools is not None
         and (

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1306,7 +1306,10 @@ def init_agent(
     try:
         from hermes_cli.config import load_config as _load_sess_cfg
         _sess_cfg = (_load_sess_cfg().get("sessions") or {})
-        agent._session_json_enabled = bool(_sess_cfg.get("write_json_snapshots", False))
+        agent._session_json_enabled = (
+            bool(_sess_cfg.get("write_json_snapshots", False))
+            and not bool(persist_disabled)
+        )
     except Exception:
         pass
     # logs_dir is retained unconditionally for request_dump_*.json (debug
@@ -1453,7 +1456,7 @@ def init_agent(
     # Memory provider plugin (external — one at a time, alongside built-in)
     # Reads memory.provider from config to select which plugin to activate.
     agent._memory_manager = None
-    if not skip_memory:
+    if not skip_memory and not agent._memory_read_only:
         try:
             _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1524,6 +1524,8 @@ def dump_api_request_debug(
     like timeout). Intended for debugging provider-side 4xx failures where
     retries are not useful.
     """
+    if getattr(agent, "_persist_disabled", False):
+        return None
     try:
         body = copy.deepcopy(api_kwargs)
         body.pop("timeout", None)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2606,6 +2606,15 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
+        if ephemeral and stream:
+            return web.json_response(
+                _openai_error(
+                    "Ephemeral requests require a non-streaming response so "
+                    "Hermes can verify and return complete runtime provenance.",
+                    code="ephemeral_streaming_unsupported",
+                ),
+                status=400,
+            )
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
@@ -2921,13 +2930,33 @@ class APIServerAdapter(BasePlatformAdapter):
         }
         if ephemeral:
             runtime = result.get("_hermes_runtime", {})
+            required_runtime = ("profile", "provider", "model")
+            missing_runtime = [name for name in required_runtime if not runtime.get(name)]
+            if missing_runtime:
+                logger.error(
+                    "Ephemeral request missing runtime provenance: %s",
+                    ", ".join(missing_runtime),
+                )
+                return web.json_response(
+                    _openai_error(
+                        "Unable to establish ephemeral runtime provenance.",
+                        err_type="server_error",
+                        code="ephemeral_provenance_unavailable",
+                    ),
+                    status=500,
+                    headers=response_headers,
+                )
             response_data["hermes"] = {
                 "ephemeral": True,
-                "profile": model_name,
-                "provider": runtime.get("provider"),
-                "model": runtime.get("model"),
+                "profile": runtime["profile"],
+                "requested_model": model_name,
+                "provider": runtime["provider"],
+                "model": runtime["model"],
                 "persistence": "disabled",
-                "memory": "read-only",
+                "memory": {
+                    "local": "read-only",
+                    "external_provider": "disabled",
+                },
                 "tools": "disabled",
             }
         if is_partial or is_failed or not completed:
@@ -4618,6 +4647,12 @@ class APIServerAdapter(BasePlatformAdapter):
             from gateway.session_context import clear_session_vars
 
             with self._profile_scope(request_profile):
+                try:
+                    from hermes_cli.profiles import get_active_profile_name
+
+                    resolved_profile = str(get_active_profile_name() or "").strip() or None
+                except Exception:
+                    resolved_profile = None
                 tokens = self._bind_api_server_session(
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
@@ -4656,6 +4691,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         result["session_id"] = _eff_sid
                     if ephemeral:
                         result["_hermes_runtime"] = {
+                            "profile": resolved_profile,
                             "provider": getattr(agent, "provider", None),
                             "model": getattr(agent, "model", None),
                         }

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1712,6 +1712,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        ephemeral: bool = False,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1827,10 +1828,13 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
-            session_db=self._ensure_session_db(),
+            session_db=None if ephemeral else self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
             gateway_session_key=gateway_session_key,
+            persist_disabled=ephemeral,
+            memory_read_only=ephemeral,
+            tools_disabled=ephemeral,
         )
         return agent
 
@@ -2001,6 +2005,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
+                "ephemeral_chat_completions": True,
+                "ephemeral_header": "X-Hermes-Ephemeral",
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
@@ -2556,6 +2562,36 @@ class APIServerAdapter(BasePlatformAdapter):
         if limited is not None:
             return limited
 
+        raw_ephemeral = request.headers.get("X-Hermes-Ephemeral")
+        if raw_ephemeral is not None and raw_ephemeral != "true":
+            return web.json_response(
+                _openai_error(
+                    "X-Hermes-Ephemeral must be exactly 'true' when present",
+                    code="invalid_ephemeral_mode",
+                ),
+                status=400,
+            )
+        ephemeral = raw_ephemeral == "true"
+        if ephemeral and (
+            request.headers.get("X-Hermes-Session-Id")
+            or request.headers.get("X-Hermes-Session-Key")
+        ):
+            return web.json_response(
+                _openai_error(
+                    "Ephemeral requests cannot use durable session headers",
+                    code="ephemeral_session_conflict",
+                ),
+                status=400,
+            )
+        if ephemeral and request.headers.get("Idempotency-Key"):
+            return web.json_response(
+                _openai_error(
+                    "Ephemeral requests cannot use response caching",
+                    code="ephemeral_cache_conflict",
+                ),
+                status=400,
+            )
+
         # Parse request body
         try:
             body = await request.json()
@@ -2661,6 +2697,10 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
                 history = []
+        elif ephemeral:
+            # The caller supplies the full transcript. A random, non-reusable
+            # task identity prevents accidental continuity across room turns.
+            session_id = f"api-ephemeral-{uuid.uuid4().hex}"
         else:
             # Derive a stable session ID from the conversation fingerprint so
             # that consecutive messages from the same Open WebUI (or similar)
@@ -2766,6 +2806,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                ephemeral=ephemeral,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2775,6 +2816,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 request, completion_id, model_name, created, _stream_q,
                 agent_task, agent_ref, session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                ephemeral=ephemeral,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -2786,6 +2828,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                ephemeral=ephemeral,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -2826,9 +2869,11 @@ class APIServerAdapter(BasePlatformAdapter):
         else:
             finish_reason = "stop"
 
-        response_headers = {
-            "X-Hermes-Session-Id": result.get("session_id", session_id),
-        }
+        response_headers = {}
+        if ephemeral:
+            response_headers["X-Hermes-Ephemeral"] = "true"
+        else:
+            response_headers["X-Hermes-Session-Id"] = result.get("session_id", session_id)
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
 
@@ -2874,14 +2919,25 @@ class APIServerAdapter(BasePlatformAdapter):
                 "total_tokens": usage.get("total_tokens", 0),
             },
         }
-        if is_partial or is_failed or not completed:
+        if ephemeral:
+            runtime = result.get("_hermes_runtime", {})
             response_data["hermes"] = {
+                "ephemeral": True,
+                "profile": model_name,
+                "provider": runtime.get("provider"),
+                "model": runtime.get("model"),
+                "persistence": "disabled",
+                "memory": "read-only",
+                "tools": "disabled",
+            }
+        if is_partial or is_failed or not completed:
+            response_data.setdefault("hermes", {}).update({
                 "completed": completed,
                 "partial": is_partial,
                 "failed": is_failed,
                 "error": err_msg,
                 "error_code": "output_truncated" if finish_reason == "length" else "agent_error",
-            }
+            })
             response_headers["X-Hermes-Completed"] = "false"
             response_headers["X-Hermes-Partial"] = "true" if is_partial else "false"
             if err_msg:
@@ -2892,7 +2948,7 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,
         created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
-        gateway_session_key: str = None,
+        gateway_session_key: str = None, ephemeral: bool = False,
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -2913,7 +2969,9 @@ class APIServerAdapter(BasePlatformAdapter):
         cors = self._cors_headers_for_origin(origin) if origin else None
         if cors:
             sse_headers.update(cors)
-        if session_id:
+        if ephemeral:
+            sse_headers["X-Hermes-Ephemeral"] = "true"
+        elif session_id:
             sse_headers["X-Hermes-Session-Id"] = session_id
         if gateway_session_key:
             sse_headers["X-Hermes-Session-Key"] = gateway_session_key
@@ -4533,6 +4591,7 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        ephemeral: bool = False,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -4574,6 +4633,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key,
                         route=route,
+                        ephemeral=ephemeral,
                     )
                     if agent_ref is not None:
                         agent_ref[0] = agent
@@ -4594,6 +4654,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     _eff_sid = getattr(agent, "session_id", session_id)
                     if isinstance(_eff_sid, str) and _eff_sid:
                         result["session_id"] = _eff_sid
+                    if ephemeral:
+                        result["_hermes_runtime"] = {
+                            "provider": getattr(agent, "provider", None),
+                            "model": getattr(agent, "model", None),
+                        }
                     return result, usage
                 finally:
                     clear_session_vars(tokens)

--- a/run_agent.py
+++ b/run_agent.py
@@ -479,6 +479,9 @@ class AIAgent:
         skip_context_files: bool = False,
         load_soul_identity: bool = False,
         skip_memory: bool = False,
+        persist_disabled: bool = False,
+        memory_read_only: bool = False,
+        tools_disabled: bool = False,
         session_db=None,
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
@@ -555,6 +558,9 @@ class AIAgent:
             skip_context_files=skip_context_files,
             load_soul_identity=load_soul_identity,
             skip_memory=skip_memory,
+            persist_disabled=persist_disabled,
+            memory_read_only=memory_read_only,
+            tools_disabled=tools_disabled,
             session_db=session_db,
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
@@ -3403,10 +3409,11 @@ class AIAgent:
         session expiry, etc.
         """
         if self._memory_manager:
-            try:
-                self._memory_manager.on_session_end(messages or [])
-            except Exception as e:
-                logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
+            if not getattr(self, "_memory_read_only", False):
+                try:
+                    self._memory_manager.on_session_end(messages or [])
+                except Exception as e:
+                    logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
             try:
                 self._memory_manager.shutdown_all()
             except Exception:
@@ -3480,7 +3487,7 @@ class AIAgent:
         providers are strictly best-effort — a misconfigured or offline
         backend must not block the user from seeing their response.
         """
-        if interrupted:
+        if interrupted or getattr(self, "_memory_read_only", False):
             return
         if not (self._memory_manager and final_response and original_user_message):
             return

--- a/run_agent.py
+++ b/run_agent.py
@@ -2657,6 +2657,8 @@ class AIAgent:
         fewer messages") is preserved so resume + branch don't clobber a
         fuller existing snapshot.
         """
+        if getattr(self, "_persist_disabled", False):
+            return
         if not getattr(self, "_session_json_enabled", False):
             return
         messages = messages or self._session_messages
@@ -3408,12 +3410,13 @@ class AIAgent:
         NOT called per-turn — only at CLI exit, /reset, gateway
         session expiry, etc.
         """
+        if getattr(self, "_memory_read_only", False):
+            return
         if self._memory_manager:
-            if not getattr(self, "_memory_read_only", False):
-                try:
-                    self._memory_manager.on_session_end(messages or [])
-                except Exception as e:
-                    logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
+            try:
+                self._memory_manager.on_session_end(messages or [])
+            except Exception as e:
+                logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
             try:
                 self._memory_manager.shutdown_all()
             except Exception:
@@ -3433,6 +3436,8 @@ class AIAgent:
         Called when session_id rotates (e.g. /new, context compression);
         providers keep their state and continue running under the old
         session_id — they just flush pending extraction now."""
+        if getattr(self, "_memory_read_only", False):
+            return
         if self._memory_manager:
             try:
                 self._memory_manager.on_session_end(messages or [])

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1670,7 +1670,16 @@ class TestChatCompletionsEndpoint:
     @pytest.mark.asyncio
     async def test_ephemeral_completion_is_explicit_and_rejects_durable_session_headers(self, adapter):
         app = _create_app(adapter)
-        mock_result = {"final_response": "present", "messages": [], "api_calls": 1}
+        mock_result = {
+            "final_response": "present",
+            "messages": [],
+            "api_calls": 1,
+            "_hermes_runtime": {
+                "profile": "room-profile",
+                "provider": "effective-provider",
+                "model": "effective-model",
+            },
+        }
         async with TestClient(TestServer(app)) as cli:
             with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
                 mock_run.return_value = (
@@ -1689,10 +1698,19 @@ class TestChatCompletionsEndpoint:
             assert resp.status == 200
             assert resp.headers["X-Hermes-Ephemeral"] == "true"
             data = await resp.json()
-            assert data["hermes"]["ephemeral"] is True
-            assert data["hermes"]["persistence"] == "disabled"
-            assert data["hermes"]["memory"] == "read-only"
-            assert data["hermes"]["tools"] == "disabled"
+            assert data["hermes"] == {
+                "ephemeral": True,
+                "profile": "room-profile",
+                "requested_model": "hermes-agent",
+                "provider": "effective-provider",
+                "model": "effective-model",
+                "persistence": "disabled",
+                "memory": {
+                    "local": "read-only",
+                    "external_provider": "disabled",
+                },
+                "tools": "disabled",
+            }
             assert mock_run.call_args.kwargs["ephemeral"] is True
 
             for forbidden in ("X-Hermes-Session-Id", "X-Hermes-Session-Key"):
@@ -1715,6 +1733,44 @@ class TestChatCompletionsEndpoint:
                 },
             )
             assert cached.status == 400
+
+            streamed = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Ephemeral": "true"},
+                json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "stream": True,
+                },
+            )
+            assert streamed.status == 400
+            streamed_data = await streamed.json()
+            assert streamed_data["error"]["code"] == "ephemeral_streaming_unsupported"
+            assert mock_run.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_completion_fails_closed_without_runtime_provenance(self, adapter):
+        app = _create_app(adapter)
+        mock_result = {"final_response": "present", "messages": [], "api_calls": 1}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Ephemeral": "true"},
+                    json={
+                        "model": "client-selected-route",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+                assert resp.status == 500
+                data = await resp.json()
+
+        assert data["error"]["code"] == "ephemeral_provenance_unavailable"
+        assert "hermes" not in data
 
     @pytest.mark.asyncio
     async def test_ephemeral_header_rejects_ambiguous_values(self, adapter):
@@ -3333,7 +3389,11 @@ class TestChatCompletionsAgentIncomplete:
             "error": "Response truncated due to output length limit",
             "messages": [],
             "api_calls": 1,
-            "_hermes_runtime": {"provider": "runtime-provider", "model": "runtime-model"},
+            "_hermes_runtime": {
+                "profile": "default",
+                "provider": "runtime-provider",
+                "model": "runtime-model",
+            },
         }
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -3353,7 +3413,10 @@ class TestChatCompletionsAgentIncomplete:
             assert data["hermes"]["error_code"] == "output_truncated"
             assert data["hermes"]["ephemeral"] is True
             assert data["hermes"]["persistence"] == "disabled"
-            assert data["hermes"]["memory"] == "read-only"
+            assert data["hermes"]["memory"] == {
+                "local": "read-only",
+                "external_provider": "disabled",
+            }
             assert data["hermes"]["tools"] == "disabled"
             assert resp.headers.get("X-Hermes-Completed") == "false"
             assert resp.headers.get("X-Hermes-Partial") == "true"

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -987,6 +987,8 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
+            assert data["features"]["ephemeral_chat_completions"] is True
+            assert data["features"]["ephemeral_header"] == "X-Hermes-Ephemeral"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
@@ -1664,6 +1666,70 @@ class TestChatCompletionsEndpoint:
             assert data["choices"][0]["message"]["content"] == "Hello! How can I help you today?"
             assert data["choices"][0]["finish_reason"] == "stop"
             assert "usage" in data
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_completion_is_explicit_and_rejects_durable_session_headers(self, adapter):
+        app = _create_app(adapter)
+        mock_result = {"final_response": "present", "messages": [], "api_calls": 1}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Ephemeral": "true"},
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+
+            assert resp.status == 200
+            assert resp.headers["X-Hermes-Ephemeral"] == "true"
+            data = await resp.json()
+            assert data["hermes"]["ephemeral"] is True
+            assert data["hermes"]["persistence"] == "disabled"
+            assert data["hermes"]["memory"] == "read-only"
+            assert data["hermes"]["tools"] == "disabled"
+            assert mock_run.call_args.kwargs["ephemeral"] is True
+
+            for forbidden in ("X-Hermes-Session-Id", "X-Hermes-Session-Key"):
+                denied = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Ephemeral": "true", forbidden: "durable-scope"},
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+                assert denied.status == 400
+
+            cached = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Ephemeral": "true", "Idempotency-Key": "retain-room-output"},
+                json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+            assert cached.status == 400
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_header_rejects_ambiguous_values(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            for value in ("1", "yes", "false", "TRUE", " true "):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Ephemeral": value},
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+                assert resp.status == 400
 
     @pytest.mark.asyncio
     async def test_system_prompt_extracted(self, adapter):
@@ -3267,6 +3333,7 @@ class TestChatCompletionsAgentIncomplete:
             "error": "Response truncated due to output length limit",
             "messages": [],
             "api_calls": 1,
+            "_hermes_runtime": {"provider": "runtime-provider", "model": "runtime-model"},
         }
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -3274,6 +3341,7 @@ class TestChatCompletionsAgentIncomplete:
                 mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
                 resp = await cli.post(
                     "/v1/chat/completions",
+                    headers={"X-Hermes-Ephemeral": "true"},
                     json={"model": "hermes-agent", "messages": [{"role": "user", "content": "tell me everything"}]},
                 )
             assert resp.status == 200
@@ -3283,6 +3351,10 @@ class TestChatCompletionsAgentIncomplete:
             assert data["hermes"]["partial"] is True
             assert data["hermes"]["completed"] is False
             assert data["hermes"]["error_code"] == "output_truncated"
+            assert data["hermes"]["ephemeral"] is True
+            assert data["hermes"]["persistence"] == "disabled"
+            assert data["hermes"]["memory"] == "read-only"
+            assert data["hermes"]["tools"] == "disabled"
             assert resp.headers.get("X-Hermes-Completed") == "false"
             assert resp.headers.get("X-Hermes-Partial") == "true"
 

--- a/tests/gateway/test_api_server_ephemeral_integration.py
+++ b/tests/gateway/test_api_server_ephemeral_integration.py
@@ -102,10 +102,23 @@ async def test_ephemeral_turn_reads_identity_and_memory_without_writing_stores(m
     memory.write_text("- Memory marker: EXISTING_MEMORY_PROOF\n", encoding="utf-8")
     user.write_text("- User marker: EXISTING_USER_PROOF\n", encoding="utf-8")
     (home / "config.yaml").write_text(
-        "memory:\n  memory_enabled: true\n  user_profile_enabled: true\n",
+        "memory:\n"
+        "  memory_enabled: true\n"
+        "  user_profile_enabled: true\n"
+        "  provider: lifecycle-tripwire\n"
+        "sessions:\n"
+        "  write_json_snapshots: true\n",
         encoding="utf-8",
     )
     before = {path: path.read_bytes() for path in (soul, memory, user)}
+
+    external_provider_loads = []
+
+    def load_external_provider(name):
+        external_provider_loads.append(name)
+        return None
+
+    monkeypatch.setattr("plugins.memory.load_memory_provider", load_external_provider)
 
     _ProviderHandler.captured = []
     provider = ThreadingHTTPServer(("127.0.0.1", 0), _ProviderHandler)
@@ -133,6 +146,7 @@ async def test_ephemeral_turn_reads_identity_and_memory_without_writing_stores(m
         staticmethod(lambda: None),
     )
     monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+    monkeypatch.setattr("hermes_cli.profiles.get_active_profile_name", lambda: "room-profile")
 
     adapter = APIServerAdapter(PlatformConfig(enabled=True))
     created_agents = []
@@ -165,9 +179,13 @@ async def test_ephemeral_turn_reads_identity_and_memory_without_writing_stores(m
             assert payload["hermes"] == {
                 "ephemeral": True,
                 "persistence": "disabled",
-                "memory": "read-only",
+                "memory": {
+                    "local": "read-only",
+                    "external_provider": "disabled",
+                },
                 "tools": "disabled",
-                "profile": "hermes-agent",
+                "profile": "room-profile",
+                "requested_model": "hermes-agent",
                 "provider": "custom",
                 "model": "mock-runtime-model",
             }
@@ -194,3 +212,4 @@ async def test_ephemeral_turn_reads_identity_and_memory_without_writing_stores(m
     assert {path: path.read_bytes() for path in before} == before
     assert _database_rows(state_db) == database_before
     assert not list(home.glob("sessions/*.json"))
+    assert external_provider_loads == []

--- a/tests/gateway/test_api_server_ephemeral_integration.py
+++ b/tests/gateway/test_api_server_ephemeral_integration.py
@@ -1,0 +1,196 @@
+"""End-to-end privacy proof for ephemeral API-server room turns."""
+
+import json
+import os
+import sqlite3
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.platforms.base import PlatformConfig
+from tests.gateway.test_api_server import _create_app
+
+
+def _database_rows(path: Path):
+    if not path.exists():
+        return {}
+    with sqlite3.connect(path) as connection:
+        tables = [
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+            )
+        ]
+        return {
+            table: rows
+            for table in tables
+            if (rows := connection.execute(f'SELECT * FROM "{table}"').fetchall())
+        }
+
+
+class _ProviderHandler(BaseHTTPRequestHandler):
+    captured = []
+
+    def do_POST(self):  # noqa: N802 - stdlib handler contract
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length))
+        type(self).captured.append(payload)
+        if payload.get("stream"):
+            chunks = [
+                {
+                    "id": "chatcmpl-ephemeral-proof",
+                    "object": "chat.completion.chunk",
+                    "created": int(time.time()),
+                    "model": "mock-runtime-model",
+                    "choices": [{
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": "deterministic room reply"},
+                        "finish_reason": None,
+                    }],
+                },
+                {
+                    "id": "chatcmpl-ephemeral-proof",
+                    "object": "chat.completion.chunk",
+                    "created": int(time.time()),
+                    "model": "mock-runtime-model",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 3, "total_tokens": 13},
+                },
+            ]
+            body = b"".join(
+                f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks
+            ) + b"data: [DONE]\n\n"
+            content_type = "text/event-stream"
+        else:
+            body = json.dumps({
+                "id": "chatcmpl-ephemeral-proof",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": "mock-runtime-model",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "deterministic room reply"},
+                    "finish_reason": "stop",
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 3, "total_tokens": 13},
+            }).encode()
+            content_type = "application/json"
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *_args):
+        return
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_turn_reads_identity_and_memory_without_writing_stores(monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    memories = home / "memories"
+    memories.mkdir(parents=True, exist_ok=True)
+    soul = home / "SOUL.md"
+    memory = memories / "MEMORY.md"
+    user = memories / "USER.md"
+    soul.write_text("Identity marker: AGENT_IDENTITY_PROOF\n", encoding="utf-8")
+    memory.write_text("- Memory marker: EXISTING_MEMORY_PROOF\n", encoding="utf-8")
+    user.write_text("- User marker: EXISTING_USER_PROOF\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "memory:\n  memory_enabled: true\n  user_profile_enabled: true\n",
+        encoding="utf-8",
+    )
+    before = {path: path.read_bytes() for path in (soul, memory, user)}
+
+    _ProviderHandler.captured = []
+    provider = ThreadingHTTPServer(("127.0.0.1", 0), _ProviderHandler)
+    thread = threading.Thread(target=provider.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{provider.server_port}/v1"
+
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "custom",
+            "base_url": base_url,
+            "api_key": "test-only",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "mock-runtime-model")
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_reasoning_config",
+        staticmethod(lambda: {}),
+    )
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_fallback_model",
+        staticmethod(lambda: None),
+    )
+    monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    created_agents = []
+    create_agent = adapter._create_agent
+
+    def capture_agent(*args, **kwargs):
+        agent = create_agent(*args, **kwargs)
+        created_agents.append(agent)
+        return agent
+
+    monkeypatch.setattr(adapter, "_create_agent", capture_agent)
+    app = _create_app(adapter)
+    state_db = home / "state.db"
+    database_before = _database_rows(state_db)
+    try:
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Ephemeral": "true"},
+                json={
+                    "model": "hermes-agent",
+                    "messages": [
+                        {"role": "user", "content": "ROOM_TRANSCRIPT_PROOF"},
+                    ],
+                },
+            )
+            assert response.status == 200, await response.text()
+            payload = await response.json()
+            assert payload["choices"][0]["message"]["content"] == "deterministic room reply"
+            assert payload["hermes"] == {
+                "ephemeral": True,
+                "persistence": "disabled",
+                "memory": "read-only",
+                "tools": "disabled",
+                "profile": "hermes-agent",
+                "provider": "custom",
+                "model": "mock-runtime-model",
+            }
+    finally:
+        provider.shutdown()
+        provider.server_close()
+        thread.join(timeout=2)
+
+    assert _ProviderHandler.captured
+    assert len(created_agents) == 1
+    assert created_agents[0].tools == []
+    assert created_agents[0].valid_tool_names == set()
+    provider_request = next(
+        payload for payload in _ProviderHandler.captured if "messages" in payload
+    )
+    assert "tools" not in provider_request
+    provider_messages = provider_request["messages"]
+    serialized = json.dumps(provider_messages)
+    assert "AGENT_IDENTITY_PROOF" in serialized
+    assert "EXISTING_MEMORY_PROOF" in serialized
+    assert "EXISTING_USER_PROOF" in serialized
+    assert "ROOM_TRANSCRIPT_PROOF" in serialized
+
+    assert {path: path.read_bytes() for path in before} == before
+    assert _database_rows(state_db) == database_before
+    assert not list(home.glob("sessions/*.json"))

--- a/tests/run_agent/test_memory_read_only.py
+++ b/tests/run_agent/test_memory_read_only.py
@@ -1,0 +1,100 @@
+"""Read-only memory isolation for ephemeral agent turns."""
+
+from unittest.mock import Mock
+
+from agent.agent_runtime_helpers import dump_api_request_debug
+from run_agent import AIAgent
+
+
+def _agent_with_memory_manager(*, read_only: bool):
+    agent = object.__new__(AIAgent)
+    agent._memory_read_only = read_only
+    agent._memory_manager = Mock()
+    agent.context_compressor = None
+    agent.session_id = "ephemeral-room-turn"
+    return agent
+
+
+def test_read_only_turn_skips_external_memory_sync_and_prefetch():
+    agent = _agent_with_memory_manager(read_only=True)
+
+    agent._sync_external_memory_for_turn(
+        original_user_message="private room input",
+        final_response="private room response",
+        interrupted=False,
+        messages=[{"role": "user", "content": "private room input"}],
+    )
+
+    agent._memory_manager.sync_all.assert_not_called()
+    agent._memory_manager.queue_prefetch_all.assert_not_called()
+
+
+def test_read_only_shutdown_does_not_submit_session_end_observations():
+    agent = _agent_with_memory_manager(read_only=True)
+
+    agent.shutdown_memory_provider(
+        [{"role": "user", "content": "private room input"}],
+    )
+
+    agent._memory_manager.on_session_end.assert_not_called()
+    agent._memory_manager.shutdown_all.assert_called_once_with()
+
+
+def test_normal_shutdown_preserves_session_end_observation():
+    agent = _agent_with_memory_manager(read_only=False)
+    messages = [{"role": "user", "content": "ordinary input"}]
+
+    agent.shutdown_memory_provider(messages)
+
+    agent._memory_manager.on_session_end.assert_called_once_with(messages)
+    agent._memory_manager.shutdown_all.assert_called_once_with()
+
+
+def test_read_only_agent_loads_builtin_memory_without_exposing_memory_tool(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    memories = hermes_home / "memories"
+    memories.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text(
+        "memory:\n  memory_enabled: true\n  user_profile_enabled: true\n",
+        encoding="utf-8",
+    )
+    (memories / "MEMORY.md").write_text("- stable identity marker\n", encoding="utf-8")
+    (memories / "USER.md").write_text("- stable user marker\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    agent = AIAgent(
+        provider="openai",
+        api_key="test-only",
+        base_url="http://127.0.0.1:1/v1",
+        model="test-model",
+        enabled_toolsets=["memory"],
+        quiet_mode=True,
+        persist_disabled=True,
+        memory_read_only=True,
+        tools_disabled=True,
+    )
+
+    snapshot = agent._memory_store._system_prompt_snapshot
+    assert "stable identity marker" in snapshot["memory"]
+    assert "stable user marker" in snapshot["user"]
+    assert agent.tools == []
+    assert agent.valid_tool_names == set()
+    assert agent._memory_nudge_interval == 0
+    assert agent._skill_nudge_interval == 0
+    assert agent._persist_disabled is True
+
+
+def test_persistence_disabled_agent_never_writes_request_debug_dump(tmp_path):
+    agent = Mock()
+    agent._persist_disabled = True
+    agent.logs_dir = tmp_path
+
+    result = dump_api_request_debug(
+        agent,
+        {"messages": [{"role": "user", "content": "private room input"}]},
+        reason="provider_error",
+        error=RuntimeError("mock failure"),
+    )
+
+    assert result is None
+    assert list(tmp_path.glob("request_dump_*.json")) == []

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -107,6 +107,36 @@ def test_active_context_engine_tools_survive_explicit_platform_toolsets():
     }
 
 
+def test_tools_disabled_agent_does_not_inject_context_engine_tools():
+    """Plugin recovery schemas must not bypass the tools-disabled boundary."""
+    engine = _ToolEngine()
+    cfg = {"context": {"engine": "stub"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            enabled_toolsets=["context_engine"],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            tools_disabled=True,
+        )
+
+    assert engine.get_tool_schemas()
+    assert getattr(agent, "tools", None) == []
+    assert getattr(agent, "valid_tool_names", None) == set()
+
+
 def test_plugin_engine_update_model_args():
     """Verify update_model() receives model, context_length, base_url, api_key, provider."""
     engine = _StubEngine()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -779,6 +779,13 @@ class TestSessionJsonSnapshotOptIn:
         # No session_*.json must appear under logs_dir.
         assert list(tmp_path.glob("session_*.json")) == []
 
+    def test_save_session_log_noops_when_persistence_is_disabled(self, agent, tmp_path):
+        agent._session_json_enabled = True
+        agent._persist_disabled = True
+        agent.logs_dir = tmp_path
+        agent._save_session_log([{"role": "user", "content": "private room turn"}])
+        assert list(tmp_path.glob("session_*.json")) == []
+
     def test_save_session_log_writes_when_enabled(self, agent, tmp_path):
         # Opt-in path: with the flag on and a session_id, the writer must
         # produce ``session_{sid}.json`` under logs_dir.
@@ -797,6 +804,31 @@ class TestSessionJsonSnapshotOptIn:
         # request_dump_*.json there (debug breadcrumb path), independent of
         # the session JSON opt-in.
         assert hasattr(agent, "logs_dir")
+
+    def test_shutdown_skips_all_session_end_hooks(self, agent):
+        agent._memory_read_only = True
+        agent._memory_manager = MagicMock()
+        agent.context_compressor = MagicMock()
+
+        agent.shutdown_memory_provider(
+            [{"role": "user", "content": "private room turn"}]
+        )
+
+        agent._memory_manager.on_session_end.assert_not_called()
+        agent._memory_manager.shutdown_all.assert_not_called()
+        agent.context_compressor.on_session_end.assert_not_called()
+
+    def test_commit_skips_all_session_end_hooks(self, agent):
+        agent._memory_read_only = True
+        agent._memory_manager = MagicMock()
+        agent.context_compressor = MagicMock()
+
+        agent.commit_memory_session(
+            [{"role": "user", "content": "private room turn"}]
+        )
+
+        agent._memory_manager.on_session_end.assert_not_called()
+        agent.context_compressor.on_session_end.assert_not_called()
 
     def test_traversal_session_id_cannot_escape_logs_dir(self, agent, tmp_path):
         # Security regression (#5958): a traversal-shaped session ID (which can

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -112,6 +112,47 @@ Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs re
 - **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool-start visibility without polluting persisted assistant text.
 - **Responses**: Hermes emits spec-native `function_call` and `function_call_output` output items during the SSE stream, so clients can render structured tool UI in real time.
 
+#### Ephemeral read-only-memory turns
+
+Clients that own the canonical conversation transcript can request an isolated
+agent turn by adding `X-Hermes-Ephemeral: true` to a Chat Completions request.
+Hermes still loads the active profile's identity and existing memory for
+context, but does not expose model-callable tools for the ephemeral request. For
+that request, Hermes:
+
+- does not create or update a session transcript;
+- does not expose memory-provider or built-in memory mutation tools;
+- does not expose file, shell, messaging, scheduling, skill, plugin, or other model-callable tools;
+- does not run automatic memory/skill curator nudges;
+- does not sync the turn or session-end observations to external memory;
+- does not write provider-error request dumps; and
+- does not place the result in the idempotency cache.
+
+The mode fails closed. The header value must be exactly `true`, and the request
+must not include `X-Hermes-Session-Id`, `X-Hermes-Session-Key`, or
+`Idempotency-Key`. A non-streaming response includes an `X-Hermes-Ephemeral:
+true` header and a machine-readable `hermes` object:
+
+```json
+{
+  "hermes": {
+    "ephemeral": true,
+    "persistence": "disabled",
+    "memory": "read-only",
+    "tools": "disabled",
+    "profile": "hermes-agent",
+    "provider": "configured-provider",
+    "model": "configured-runtime-model"
+  }
+}
+```
+
+`profile` is the stable Hermes agent identity advertised by the API server;
+`provider` and `model` record the actual inference route used for that turn.
+This mode controls Hermes persistence, not an upstream model provider's own
+logging or retention. Clients handling sensitive context must review that
+separate boundary.
+
 ### POST /v1/responses
 
 OpenAI Responses API format. Supports server-side conversation state via `previous_response_id` — the server stores full conversation history (including tool calls and results) so multi-turn context is preserved without the client managing it.
@@ -214,7 +255,9 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
-    "run_stop": true
+    "run_stop": true,
+    "ephemeral_chat_completions": true,
+    "ephemeral_header": "X-Hermes-Ephemeral"
   }
 }
 ```

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -112,43 +112,55 @@ Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs re
 - **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool-start visibility without polluting persisted assistant text.
 - **Responses**: Hermes emits spec-native `function_call` and `function_call_output` output items during the SSE stream, so clients can render structured tool UI in real time.
 
-#### Ephemeral read-only-memory turns
+#### Ephemeral local-memory turns
 
 Clients that own the canonical conversation transcript can request an isolated
 agent turn by adding `X-Hermes-Ephemeral: true` to a Chat Completions request.
-Hermes still loads the active profile's identity and existing memory for
-context, but does not expose model-callable tools for the ephemeral request. For
-that request, Hermes:
+Hermes still loads the active profile's identity and built-in local memory files
+for context, but does not initialize or contact external memory providers and
+does not expose model-callable tools for the ephemeral request. For that request,
+Hermes:
 
-- does not create or update a session transcript;
+- does not create or update a SessionDB transcript or optional JSON session snapshot;
+- loads built-in local identity and memory files read-only;
+- does not load, initialize, prefetch from, sync to, or end a session with an external memory provider;
 - does not expose memory-provider or built-in memory mutation tools;
 - does not expose file, shell, messaging, scheduling, skill, plugin, or other model-callable tools;
 - does not run automatic memory/skill curator nudges;
-- does not sync the turn or session-end observations to external memory;
 - does not write provider-error request dumps; and
 - does not place the result in the idempotency cache.
 
 The mode fails closed. The header value must be exactly `true`, and the request
 must not include `X-Hermes-Session-Id`, `X-Hermes-Session-Key`, or
-`Idempotency-Key`. A non-streaming response includes an `X-Hermes-Ephemeral:
-true` header and a machine-readable `hermes` object:
+`Idempotency-Key`. Ephemeral requests must also set `"stream": false` (or omit
+`stream`): Hermes rejects streaming ephemeral requests because an SSE response
+cannot fail closed before returning a complete, verified provenance envelope.
+An accepted response includes an `X-Hermes-Ephemeral: true` header and a
+machine-readable `hermes` object:
 
 ```json
 {
   "hermes": {
     "ephemeral": true,
     "persistence": "disabled",
-    "memory": "read-only",
+    "memory": {
+      "local": "read-only",
+      "external_provider": "disabled"
+    },
     "tools": "disabled",
-    "profile": "hermes-agent",
+    "profile": "room-profile",
+    "requested_model": "client-route-alias",
     "provider": "configured-provider",
     "model": "configured-runtime-model"
   }
 }
 ```
 
-`profile` is the stable Hermes agent identity advertised by the API server;
-`provider` and `model` record the actual inference route used for that turn.
+`profile` is the stable Hermes profile identity that served the request;
+`requested_model` is the client-supplied model or route alias; and `provider`
+and `model` record the actual inference route used for that turn. If Hermes
+cannot establish all three runtime provenance fields, the ephemeral request
+fails closed instead of returning guessed or incomplete provenance.
 This mode controls Hermes persistence, not an upstream model provider's own
 logging or retention. Clients handling sensitive context must review that
 separate boundary.


### PR DESCRIPTION
## What does this PR do?

Adds an explicit request-scoped ephemeral mode to the OpenAI-compatible API server for external orchestrators that need a temporary agent turn without creating durable Hermes state.

A caller opts in with exact `X-Hermes-Ephemeral: true`. The request is rejected if it also supplies durable session or idempotency headers, or requests streaming, because Hermes must verify complete runtime provenance before returning an accepted response. Accepted turns load the selected stable Hermes profile and existing context read-only, while disabling session persistence, memory writes/sync, and every model-callable tool—including context-engine/plugin tools added during agent initialization.

The response includes explicit Hermes provenance so an orchestrator can fail closed unless it observes the expected profile, runtime provider/model, persistence, memory, and tool state.

This is complementary to, but distinct from, the session-scoped `/incognito` work in #19448. It is an API-boundary contract for one request, not a user-facing session toggle, and does not claim to fix #52341.

## Related Issue

Related: #19448, #52341

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add strict `X-Hermes-Ephemeral: true` parsing and reject conflicting durable headers, response caching, and streaming in `gateway/platforms/api_server.py`.
- Construct ephemeral agents with persistence disabled, existing memory read-only, and model-callable tools disabled.
- Prevent context-engine/plugin schemas from reintroducing tools after the disabled-tool gate.
- Preserve stable profile identity separately from observed runtime provider/model provenance.
- Return explicit ephemeral privacy and runtime provenance in non-streaming API responses.
- Document the request/response contract and its streaming limitation.
- Add deterministic API, memory-isolation, plugin-context-engine, and real local SSE-provider regression coverage.

## How to Test

1. Run the affected canonical suite:
   ```bash
   ./scripts/run_tests.sh -j 1 \
     tests/gateway/test_api_server.py \
     tests/gateway/test_api_server_ephemeral_integration.py \
     tests/run_agent/test_run_agent.py
   ```
2. Confirm an exact ephemeral request reaches the deterministic local provider with profile context but no tool schema.
3. Confirm conflicting session/idempotency headers fail closed and no session DB, JSON snapshot, memory write/sync, or request dump is created.

Observed after the final rebase onto current `main`: **645 passed, 0 failed** (205 API, 1 end-to-end ephemeral integration, 439 run-agent).

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs, including #19448.
- [x] My PR contains only changes related to this feature.
- [x] I've run the complete affected canonical suite: 645 passed.
- [x] I've added regression and integration tests.
- [x] I've tested on Linux.

### Documentation & Housekeeping

- [x] I've updated the API server documentation.
- [x] `cli-config.yaml.example` is N/A; no configuration key was added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A.
- [x] Cross-platform impact considered: behavior is platform-neutral Python/API logic; deterministic tests ran on Linux.
- [x] Tool descriptions/schemas are N/A; this changes API construction policy rather than a tool schema.

## Screenshots / Logs

Not applicable. The deterministic HTTP-to-provider integration test exercises the complete API → agent → local SSE provider path and asserts the absence of durable state and outbound tool schemas.
