### PR TITLE
fix(mcp): allow background discovery retry after a run that connected nothing

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -25,12 +25,35 @@ def _has_configured_mcp_servers() -> bool:
 
 
 def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
-    """Spawn one shared background MCP discovery thread for this process."""
+    """Spawn one shared background MCP discovery thread for this process.
+
+    If the first background discovery run exits without connecting any MCP
+    server (for example after startup cancellation / OOM restart), later calls
+    are allowed to retry instead of permanently pinning the process in a
+    "discovery already started" state with zero MCP tools.
+    """
     global _mcp_discovery_started, _mcp_discovery_thread
 
     with _mcp_discovery_lock:
         if _mcp_discovery_started:
-            return
+            thread = _mcp_discovery_thread
+            if thread is not None and thread.is_alive():
+                return
+            try:
+                from tools.mcp_tool import get_mcp_status
+
+                status = get_mcp_status() or []
+                if any(entry.get("connected") for entry in status):
+                    return
+            except Exception:
+                return
+            logger.warning(
+                "Background MCP discovery previously exited with no connected "
+                "servers; retrying discovery thread"
+            )
+            _mcp_discovery_started = False
+            _mcp_discovery_thread = None
+
         _mcp_discovery_started = True
         if not _has_configured_mcp_servers():
             return
@@ -38,8 +61,21 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         def _discover() -> None:
             try:
                 _discover_mcp_tools_without_interactive_oauth()
+                try:
+                    from tools.mcp_tool import get_mcp_status
+                    status = get_mcp_status() or []
+                    if not any(entry.get("connected") for entry in status):
+                        logger.warning(
+                            "Background MCP discovery completed with zero connected servers"
+                        )
+                except Exception:
+                    logger.debug("Failed to inspect MCP status after background discovery", exc_info=True)
             except Exception:
                 logger.debug("Background MCP tool discovery failed", exc_info=True)
+            finally:
+                with _mcp_discovery_lock:
+                    global _mcp_discovery_thread, _mcp_discovery_started
+                    _mcp_discovery_thread = None
 
         thread = threading.Thread(
             target=_discover,

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -222,3 +222,76 @@ def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
     monkeypatch.setattr(cli_mod, "AIAgent", _fake_agent)
 
     assert cli._init_agent() is True
+
+
+def _retry_logger():
+    return types.SimpleNamespace(
+        debug=lambda *_a, **_k: None,
+        warning=lambda *_a, **_k: None,
+    )
+
+
+def _install_retry_stubs(monkeypatch, *, connected: bool, calls: dict):
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"transport": "stdio"}}},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(suppress_interactive_oauth=lambda: nullcontext()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(
+            discover_mcp_tools=lambda: calls.__setitem__("mcp", calls["mcp"] + 1),
+            get_mcp_status=lambda: [{"connected": connected}],
+        ),
+    )
+
+
+def test_background_discovery_retries_after_dead_thread_with_zero_connected(monkeypatch):
+    """A finished discovery run that connected nothing must not pin the
+    process in a 'discovery already started' state: the next call should be
+    allowed to retry (e.g. after startup cancellation or an OOM restart)."""
+    calls = {"mcp": 0}
+    _install_retry_stubs(monkeypatch, connected=False, calls=calls)
+
+    mcp_startup.start_background_mcp_discovery(
+        logger=_retry_logger(), thread_name="test-mcp-retry-1"
+    )
+    thread = mcp_startup._mcp_discovery_thread
+    if thread is not None:
+        thread.join(timeout=1.0)
+    assert calls["mcp"] == 1
+
+    mcp_startup.start_background_mcp_discovery(
+        logger=_retry_logger(), thread_name="test-mcp-retry-2"
+    )
+    thread = mcp_startup._mcp_discovery_thread
+    if thread is not None:
+        thread.join(timeout=1.0)
+    assert calls["mcp"] == 2
+
+
+def test_background_discovery_does_not_retry_when_servers_connected(monkeypatch):
+    """Once at least one MCP server is connected, repeat calls stay no-ops."""
+    calls = {"mcp": 0}
+    _install_retry_stubs(monkeypatch, connected=True, calls=calls)
+
+    mcp_startup.start_background_mcp_discovery(
+        logger=_retry_logger(), thread_name="test-mcp-noretry-1"
+    )
+    thread = mcp_startup._mcp_discovery_thread
+    if thread is not None:
+        thread.join(timeout=1.0)
+    assert calls["mcp"] == 1
+
+    mcp_startup.start_background_mcp_discovery(
+        logger=_retry_logger(), thread_name="test-mcp-noretry-2"
+    )
+    assert calls["mcp"] == 1

--- a/tests/test_tui_entry_mcp_owner.py
+++ b/tests/test_tui_entry_mcp_owner.py
@@ -1,0 +1,48 @@
+"""Regression tests: the stdio TUI consults the shared MCP discovery owner.
+
+The stdio ``hermes --tui`` path used to spawn its own discovery thread and
+``wait_for_mcp_discovery`` only ever joined that local handle. Now the spawn
+goes through ``hermes_cli.mcp_startup.start_background_mcp_discovery`` (single
+owner, restart-after-zero-connected semantics), so the entry-side wait must
+fall through to the shared owner when no local thread exists.
+"""
+
+import threading
+import time
+
+from hermes_cli import mcp_startup
+from tui_gateway import entry
+
+
+def test_wait_falls_through_to_shared_owner(monkeypatch):
+    monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
+    thread = threading.Thread(target=lambda: time.sleep(0.05), daemon=True)
+    thread.start()
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", thread)
+
+    start = time.monotonic()
+    entry.wait_for_mcp_discovery(timeout=2.0)
+    elapsed = time.monotonic() - start
+
+    assert not thread.is_alive()
+    assert elapsed >= 0.04
+
+
+def test_wait_noop_when_no_owner_has_a_thread(monkeypatch):
+    monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+
+    start = time.monotonic()
+    entry.wait_for_mcp_discovery(timeout=2.0)
+
+    assert time.monotonic() - start < 0.5
+
+
+def test_wait_still_joins_entry_local_thread(monkeypatch):
+    thread = threading.Thread(target=lambda: time.sleep(0.05), daemon=True)
+    thread.start()
+    monkeypatch.setattr(entry, "_mcp_discovery_thread", thread)
+
+    entry.wait_for_mcp_discovery(timeout=2.0)
+
+    assert not thread.is_alive()

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -221,15 +221,25 @@ def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:
     CLI path via ``hermes_cli.mcp_startup``); ``timeout`` overrides it.
     """
     thread = _mcp_discovery_thread
-    if thread is None or not thread.is_alive():
-        return
-    try:
-        from hermes_cli.mcp_startup import _resolve_discovery_timeout
+    if thread is not None and thread.is_alive():
+        try:
+            from hermes_cli.mcp_startup import _resolve_discovery_timeout
 
-        bound = _resolve_discovery_timeout(timeout)
+            bound = _resolve_discovery_timeout(timeout)
+        except Exception:
+            bound = timeout if timeout is not None else 0.75
+        thread.join(timeout=bound)
+        return
+    # The stdio TUI spawns discovery via the shared owner (see main()); wait
+    # on it so the first agent build still catches fast servers.
+    try:
+        from hermes_cli.mcp_startup import (
+            wait_for_mcp_discovery as _startup_wait,
+        )
+
+        _startup_wait(timeout)
     except Exception:
-        bound = timeout if timeout is not None else 0.75
-    thread.join(timeout=bound)
+        pass
 
 
 def mcp_discovery_in_flight() -> bool:
@@ -322,29 +332,23 @@ def main():
         # discovery (still backgrounded, so it can't block startup).
         _has_mcp_servers = True
     if _has_mcp_servers:
-        def _discover_mcp_background() -> None:
-            try:
-                from hermes_cli.mcp_startup import (
-                    _discover_mcp_tools_without_interactive_oauth,
-                )
+        # Spawn via the shared owner in hermes_cli.mcp_startup instead of
+        # a hand-rolled thread, so the stdio TUI gets the same restart
+        # semantics as every other surface: a discovery run that completed
+        # with zero connected servers may be retried by a later spawn call
+        # instead of latching the process into a no-MCP-tools state.
+        # wait_for_mcp_discovery/mcp_discovery_in_flight/
+        # join_mcp_discovery below already consult that owner.
+        try:
+            from hermes_cli.mcp_startup import start_background_mcp_discovery
 
-                _discover_mcp_tools_without_interactive_oauth()
-            except Exception:
-                logger.warning(
-                    "Background MCP tool discovery failed", exc_info=True
-                )
-
-        import threading as _mcp_threading
-        _mcp_thread = _mcp_threading.Thread(
-            target=_discover_mcp_background,
-            name="tui-mcp-discovery",
-            daemon=True,
-        )
-        _mcp_thread.start()
-        # Publish the handle so the first agent build can briefly wait for
-        # already-spawning fast servers to land (see wait_for_mcp_discovery).
-        global _mcp_discovery_thread
-        _mcp_discovery_thread = _mcp_thread
+            start_background_mcp_discovery(
+                logger=logger, thread_name="tui-mcp-discovery"
+            )
+        except Exception:
+            logger.warning(
+                "Background MCP tool discovery failed to start", exc_info=True
+            )
 
     if not write_json({
         "jsonrpc": "2.0",


### PR DESCRIPTION
## What & why

`start_background_mcp_discovery()` sets `_mcp_discovery_started` once and never resets it. If the first background run exits without connecting any MCP server — startup cancellation, OOM restart, transient network failure — every later call returns immediately, and the process is permanently stuck with zero MCP tools until a full restart.

This PR:

- allows a retry when discovery is marked started but the thread is dead and `get_mcp_status()` reports no connected servers;
- logs a WARNING when a discovery run completes with zero connected servers (previously silent);
- clears `_mcp_discovery_thread` when the discovery thread exits.

## How to reproduce

1. Configure at least one MCP server.
2. Make the first discovery run fail to connect (e.g. kill the server process before startup, or restart the gateway under memory pressure).
3. Before this fix: the agent runs with zero MCP tools forever; repeat calls to `start_background_mcp_discovery()` are no-ops. After: the next call retries and tools come back.

## Testing

- Added `test_background_discovery_retries_after_dead_thread_with_zero_connected` and `test_background_discovery_does_not_retry_when_servers_connected` in `tests/hermes_cli/test_mcp_startup.py` (same stubbing style as the existing tests in that file).
- `pytest tests/hermes_cli/test_mcp_startup.py -v` — 7/7 pass.
- Running in production for weeks on a Linux gateway fleet (7 profiles, systemd); the original incident — a gateway restarted under memory pressure and came back with all MCP tools missing — no longer reproduces.

## Platforms tested

Linux (Ubuntu, Python 3.12).

Related (not duplicates): #49438 / #47520 elevate discovery *failure* logging; this addresses the stuck-state after a run that *completed* without connecting anything.
