### PR TITLE
fix(agent): persist the delivered response when the turn tail is a tool-call row

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -222,11 +222,25 @@ def finalize_turn(
         # holds regardless of which path produced it. (#43849 / #44100)
         if final_response and not interrupted:
             try:
-                _tail_role = messages[-1].get("role") if messages else None
+                _tail = messages[-1] if messages else None
             except Exception:
-                _tail_role = None
+                _tail = None
+            _tail_role = _tail.get("role") if isinstance(_tail, dict) else None
             if _tail_role != "assistant":
                 messages.append({"role": "assistant", "content": final_response})
+            elif _tail.get("tool_calls") and not (
+                _tail.get("content") if isinstance(_tail.get("content"), str) else ""
+            ).strip():
+                # The tail IS an assistant row, but a *pure tool-call turn*:
+                # tool_calls with no text of its own. It carries none of the
+                # delivered answer, so the role check alone leaves the invariant
+                # unmet — the user saw a response that never reached the
+                # transcript, and the next turn replays the user backlog and
+                # re-answers it (the very symptom this block was added for).
+                # Fill that row's empty content instead of appending, so the
+                # durable turn ends with the answer without disturbing the
+                # tool-call structure or creating an assistant→assistant pair.
+                _tail["content"] = final_response
 
         # The model has completed its request, so replace API-local
         # voice/model/skill guidance with the clean user input before writing the

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -196,3 +196,87 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
     assert result["messages"][-1] == {"role": "assistant", "content": "Done."}
     assert agent.persisted_messages is not None
     assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}
+
+
+def test_final_response_fills_pure_tool_call_tail(monkeypatch):
+    """A tail assistant row that is a *pure tool-call turn* carries no answer.
+
+    The role check alone ("tail is assistant ⇒ nothing to do") leaves the
+    #43849/#44100 invariant unmet when the tail is ``assistant(tool_calls)``
+    with no text of its own: the caller and the gateway already delivered
+    ``final_response``, but it never reaches the transcript. The next turn then
+    replays the user backlog and the model re-answers it — the exact symptom
+    that block exists to prevent.
+    """
+    agent = FakeAgent()
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "f", "arguments": "{}"}}
+            ],
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="Here is your answer.",
+        api_call_count=3,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="t",
+        turn_id="tid",
+        user_message="q",
+        original_user_message="q",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+    persisted = agent.persisted_messages
+    assert any(
+        m.get("role") == "assistant" and m.get("content") == result["final_response"]
+        for m in persisted
+    ), "delivered final_response never reached the durable transcript"
+    # Filled in place — no assistant→assistant pair, tool_calls preserved.
+    assert persisted[-1]["content"] == "Here is your answer."
+    assert persisted[-1]["tool_calls"]
+    assert sum(1 for m in persisted if m.get("role") == "assistant") == 1
+
+
+def test_final_response_does_not_clobber_tool_call_tail_with_text(monkeypatch):
+    """A tail tool-call turn that already carries model text must be left alone."""
+    agent = FakeAgent()
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "partial text",
+            "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "f", "arguments": "{}"}}
+            ],
+        },
+    ]
+
+    finalize_turn(
+        agent,
+        final_response="Here is your answer.",
+        api_call_count=3,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="t",
+        turn_id="tid",
+        user_message="q",
+        original_user_message="q",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+    assert agent.persisted_messages[-1]["content"] == "partial text"


### PR DESCRIPTION
## What does this PR do?

`finalize_turn` guarantees the invariant *"delivered `final_response` ⇒ assistant row in transcript"* (#43849 / #44100) for recovery paths that return a response without appending a closing assistant message. It enforces that by checking only the tail's **role**:

```python
if _tail_role != "assistant":
    messages.append({"role": "assistant", "content": final_response})
```

A tail that is a *pure tool-call turn* — `assistant(tool_calls=[...])` with no text of its own — satisfies that check while carrying none of the delivered answer. The append is skipped and the response is never persisted, so the durable transcript ends at an assistant row the user never saw as the reply.

On the next turn the model replays the user backlog and re-answers it — exactly the symptom the block was added to prevent, just reached through a different tail shape. The transcript also ends on an unanswered `tool_call`.

Observed against the real finalizer — messages ending `user → assistant(content="", tool_calls=[t1])` with `final_response="Here is your answer."`:

```
persisted tail              : [('user','q'), ('assistant','', tool_calls=True)]
delivered response persisted: False
```

The fix fills that row's empty content instead of appending. This restores the invariant without disturbing the tool-call structure and without creating an `assistant→assistant` pair. A tail tool-call row that already carries model text is left untouched, so no model output is ever overwritten.

## Related Issue

Follow-up to #43849 / #44100.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_finalizer.py` — when the tail is an assistant row that is a pure tool-call turn (has `tool_calls`, no non-blank string content), fill its content with `final_response` instead of skipping. Non-string (multimodal) content is treated as "already carries content" and left alone.
- `tests/agent/test_turn_finalizer_final_response_persistence.py` — add two tests: the empty tool-call tail is filled with the delivered response (single assistant row, `tool_calls` preserved), and a tool-call tail that already holds model text is not clobbered.

## How to Test

1. Run:

       pytest tests/agent/test_turn_finalizer_final_response_persistence.py -q

   `test_final_response_fills_pure_tool_call_tail` fails without the fix and passes with it.

2. Existing behaviour is unchanged — the tool-result tail path, the already-answered tail, and the tool-call-tail-with-text case are all covered.

3. No regressions: `pytest tests/agent/ -k "finalizer or persist or interrupt or alternation"` gives `1 failed, 95 passed` on clean `main` and `1 failed, 97 passed` with this change (+2 new tests); the single failure is pre-existing and unrelated.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suites and verified no regressions against a clean `main` baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline comments) — the tail check now documents why role alone is insufficient
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure dict/list logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A