### PR TITLE
fix(desktop): prevent stale JavaScript from shadowing TypeScript

### DIFF
--- a/apps/desktop/src/lib/vite-resolution.test.ts
+++ b/apps/desktop/src/lib/vite-resolution.test.ts
@@ -1,0 +1,13 @@
+import { DESKTOP_SOURCE_EXTENSIONS } from '../../vite.config'
+
+describe('desktop source resolution', () => {
+  it.each([
+    ['.mts', '.mjs'],
+    ['.ts', '.js'],
+    ['.tsx', '.jsx']
+  ])('prefers %s sources over stale %s siblings', (source, generated) => {
+    expect(DESKTOP_SOURCE_EXTENSIONS.indexOf(source)).toBeLessThan(
+      DESKTOP_SOURCE_EXTENSIONS.indexOf(generated)
+    )
+  })
+})

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -25,6 +25,16 @@ const fsAllow = [
   )
 ]
 
+export const DESKTOP_SOURCE_EXTENSIONS = [
+  '.mts',
+  '.ts',
+  '.tsx',
+  '.mjs',
+  '.js',
+  '.jsx',
+  '.json'
+]
+
 export default defineConfig({
   base: './',
   plugins: [react(), tailwindcss()],
@@ -56,6 +66,9 @@ export default defineConfig({
     }
   },
   resolve: {
+    // Generated JavaScript must never shadow the tracked TypeScript source.
+    // Stale source-tree output can survive an update in managed checkouts.
+    extensions: DESKTOP_SOURCE_EXTENSIONS,
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@hermes/plugin-sdk': path.resolve(__dirname, './src/sdk/index.ts'),


### PR DESCRIPTION
## Summary

- make Desktop Vite resolution prefer TypeScript source extensions over generated JavaScript siblings
- cover the source/generated extension precedence contract with Vitest

## Testing

- focused Vitest: `src/lib/vite-resolution.test.ts`
- Desktop TypeScript typecheck
- `git diff --check`

Fixes #65808