### PR TITLE
fix(desktop): re-apply persisted zoom on every full load (#46429)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7175,9 +7175,12 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
     installZoomShortcuts(win)
     // Re-apply persisted zoom on show/restore/cross-display move (Windows can
     // drop webContents zoom after minimize or a monitor-scale change) and on
-    // first load (reloads / crash recovery).
+    // EVERY full load — not once. The crash-recovery path calls
+    // webContents.reload(), which fires did-finish-load again after a `once`
+    // listener is spent, so zoom was silently lost on renderer crash
+    // recovery and any in-place reload/navigation (#46429).
     installZoomReassertOnWindowEvents(win, () => restorePersistedZoomLevel(win))
-    win.webContents.once('did-finish-load', () => restorePersistedZoomLevel(win))
+    win.webContents.on('did-finish-load', () => restorePersistedZoomLevel(win))
   }
 
   installContextMenu(win)

--- a/contributors/emails/songotenukraine@gmail.com
+++ b/contributors/emails/songotenukraine@gmail.com
@@ -1,0 +1,1 @@
+SongotenU


### PR DESCRIPTION
## Summary

Salvage of #46429 (@SongotenU) — persisted zoom is now re-applied on every completed page load, not just the first, so it survives crash-recovery reloads and in-place navigations.

The original branch predates the ts-ify migration (targets `main.cjs`, which no longer exists), so the surviving delta was surgically reapplied under @SongotenU's authorship. Half of the original PR — moving zoom restore into `wireCommonWindowHandlers` so session windows are covered — was independently adopted on main (57dfebe3d); this PR ships the remaining half.

## Root cause

The zoom-restore listener was registered with `once('did-finish-load')`. The first load spends it; any later full load in the same webContents — the crash-recovery `webContents.reload()`, a manual reload, or a navigation that lands on a fresh Chromium per-host zoom entry — came up at default zoom while the settings Scale control still displayed the persisted percentage.

## Changes

- `apps/desktop/electron/main.ts`: `once('did-finish-load', ...)` → `on('did-finish-load', ...)` in `wireCommonWindowHandlers` (+ comment). Restore routes through the `applyZoomLevel` funnel, so window zoom and settings UI cannot drift.

AUTHOR_MAP entry added for songotenukraine@gmail.com → @SongotenU.

## Validation

| Check | Result |
|---|---|
| Full desktop electron suite | 432 passed, 1 skipped |
| Restore path already behavior-tested | `zoom.test.ts` funnel tests |

Credit: @SongotenU (#46429), authorship preserved on the commit.

## Infographic

![zoom-every-load](https://v3b.fal.media/files/b/0aa2c294/i9YU6ncyk_hSJGqLlkKWp_cLvfYq7Y.png)
