### PR TITLE
fix(providers): add Cerebras reasoning compatibility

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -317,6 +317,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "moonshotai/kimi-k2.6",
         "minimaxai/minimax-m3",
     ],
+    "cerebras": [
+        "gpt-oss-120b",
+        "zai-glm-4.7",
+        "gemma-4-31b",
+    ],
     "kimi-coding": [
         "kimi-k2.7-code",
         "kimi-k2.6",

--- a/plugins/model-providers/cerebras/__init__.py
+++ b/plugins/model-providers/cerebras/__init__.py
@@ -1,0 +1,65 @@
+"""Cerebras Inference provider profile.
+
+Cerebras' OpenAI-compatible API calls the replayable assistant reasoning field
+``reasoning``. Hermes also stores provider-specific ``reasoning_content`` and
+``reasoning_details`` fields, which Cerebras rejects as unknown input fields.
+"""
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class CerebrasProfile(ProviderProfile):
+    """Cerebras chat completions with strict reasoning-field replay."""
+
+    def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        prepared = list(messages)
+        for index, message in enumerate(messages):
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+            cleaned = dict(message)
+            if not cleaned.get("reasoning") and isinstance(
+                cleaned.get("reasoning_content"), str
+            ):
+                cleaned["reasoning"] = cleaned["reasoning_content"]
+            cleaned.pop("reasoning_content", None)
+            cleaned.pop("reasoning_details", None)
+            prepared[index] = cleaned
+        return prepared
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if not isinstance(reasoning_config, dict):
+            return {}, {}
+        effort = str(reasoning_config.get("effort") or "").strip().lower()
+        if effort == "none":
+            # Cerebras gpt-oss cannot disable reasoning; omitting the field
+            # leaves the documented server default intact. GLM supports none.
+            if "glm-4.7" in (model or "").lower():
+                return {}, {"reasoning_effort": "none"}
+            return {}, {}
+        if effort in {"low", "medium", "high"}:
+            return {}, {"reasoning_effort": effort}
+        if effort in {"xhigh", "max", "ultra"}:
+            return {}, {"reasoning_effort": "high"}
+        return {}, {}
+
+
+cerebras = CerebrasProfile(
+    name="cerebras",
+    display_name="Cerebras",
+    description="Cerebras Inference API",
+    signup_url="https://cloud.cerebras.ai/",
+    env_vars=("CEREBRAS_API_KEY", "CEREBRAS_BASE_URL"),
+    base_url="https://api.cerebras.ai/v1",
+    fallback_models=("gpt-oss-120b", "zai-glm-4.7", "gemma-4-31b"),
+)
+
+register_provider(cerebras)

--- a/plugins/model-providers/cerebras/plugin.yaml
+++ b/plugins/model-providers/cerebras/plugin.yaml
@@ -1,0 +1,4 @@
+name: cerebras
+kind: model-provider
+version: 1.0.0
+description: Cerebras Inference API provider.

--- a/tests/hermes_cli/test_cerebras_provider.py
+++ b/tests/hermes_cli/test_cerebras_provider.py
@@ -1,0 +1,33 @@
+"""Cerebras provider profile contracts."""
+
+from providers import get_provider_profile
+
+
+def test_cerebras_strips_internal_reasoning_fields_and_preserves_reasoning():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "done",
+            "reasoning_content": "plan",
+            "reasoning_details": [{"type": "summary_text", "text": "plan"}],
+        }
+    ]
+
+    profile = get_provider_profile("cerebras")
+    assert profile is not None
+    prepared = profile.prepare_messages(messages)
+
+    assert prepared == [{"role": "assistant", "content": "done", "reasoning": "plan"}]
+    assert messages[0]["reasoning_content"] == "plan"
+
+
+def test_cerebras_reasoning_effort_maps_to_supported_wire_values():
+    profile = get_provider_profile("cerebras")
+    assert profile is not None
+
+    assert profile.build_api_kwargs_extras(
+        reasoning_config={"effort": "xhigh"}, model="gpt-oss-120b"
+    )[1] == {"reasoning_effort": "high"}
+    assert profile.build_api_kwargs_extras(
+        reasoning_config={"effort": "none"}, model="gpt-oss-120b"
+    ) == ({}, {})


### PR DESCRIPTION
## Summary

- add Cerebras as a first-class provider using `CEREBRAS_API_KEY` and `https://api.cerebras.ai/v1`
- translate replayed assistant reasoning to Cerebras’ documented `reasoning` field
- strip incompatible Hermes/OpenRouter reasoning fields before follow-up requests
- constrain `reasoning_effort` to values supported by the selected Cerebras model
- expose current Cerebras reasoning models in the fallback catalog

## Why

Follow-up turns configured through the generic custom-provider path could replay `reasoning_content` / `reasoning_details`, which Cerebras rejects as unsupported message fields. Cerebras documents `message.reasoning` as its replay field.

Official API reference: https://inference-docs.cerebras.ai/api-reference/chat-completions

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_cerebras_provider.py -q` (2 passed)
- Ruff on changed Python files
- `git diff --check`