### PR TITLE
fix(redact): add Gemini AQ. prefix key pattern to secret redactor

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -80,6 +80,7 @@ _PREFIX_PATTERNS = [
     r"xapp-\d+-[A-Za-z0-9-]{10,}",      # Slack app-Level token
     r"xox[baprs]-[A-Za-z0-9-]{10,}",    # Slack bot/app/user tokens
     r"AIza[A-Za-z0-9_-]{30,}",          # Google API keys
+    r"AQ\.[A-Za-z0-9_-]{30,}",          # Gemini AQ. authorization keys
     r"pplx-[A-Za-z0-9]{10,}",           # Perplexity
     r"fal_[A-Za-z0-9_-]{10,}",          # Fal.ai
     r"fc-[A-Za-z0-9]{10,}",             # Firecrawl

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -66,6 +66,14 @@ class TestKnownPrefixes:
 
 
 
+    def test_gemini_aq_key(self):
+        """Gemini AQ. authorization keys must be redacted (issue #66920)."""
+        result = redact_sensitive_text("AQ.Abc123def456ghi789jklmno01234567890")
+        assert "Abc123def456" not in result
+
+    def test_perplexity_key(self):
+        result = redact_sensitive_text("pplx-abcdef123456789012345")
+        assert "abcdef12345" not in result
 
 
     def test_fireworks_keys(self):


### PR DESCRIPTION
## Summary

The secret redactor in `agent/redact.py` misses bare Gemini authorization keys using the `AQ.` prefix. While the generic environment-assignment detector catches the same value when labeled as `GEMINI_API_KEY=...`, unlabeled values in tool output, provider errors, or pasted text pass through unchanged — and can reach `state.db` before redaction.

## Changes

- **`agent/redact.py`**: Added `AQ.[A-Za-z0-9_-]{30,}` to `_PREFIX_PATTERNS` (right after the existing `AIza` pattern for standard Google API keys). The `_PREFIX_SUBSTRINGS` auto-generation picks up `AQ` as the pre-screen gate substring, so there's no performance regression.

- **`tests/agent/test_redact.py`**: Added `test_gemini_aq_key` to `TestKnownPrefixes` verifying that bare `AQ.`-prefixed tokens are redacted.

## Verification

```
>>> from agent.redact import redact_sensitive_text
>>> redact_sensitive_text('Using key AQ.Abc123def456ghi789jklmno01234567890')
'Using key AQ.Abc...7890'
>>> redact_sensitive_text('GEMINI_API_KEY=AQ.Abc123def456ghi789jklmno01234567890')
'GEMINI_API_KEY=***'
```

Closes #66920