### PR TITLE
feat: Custom Endpoint provider — env-var driven, auto-discover models

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -178,6 +178,12 @@ export const PROVIDER_GROUPS: ProviderPrefix[] = [
     priority: 17
   },
   {
+    prefix: 'CUSTOM_',
+    name: '自定义端点',
+    description: 'Ollama、vLLM、llama.cpp 或其他 OpenAI 兼容服务',
+    priority: 18
+  },
+  {
     prefix: 'STEPFUN_',
     name: 'StepFun',
     description: 'StepFun Step Plan coding models',

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -21,7 +21,7 @@ import { Check, ChevronDown, ChevronRight, KeyRound, Loader2, Terminal, Trash2 }
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
-import { $desktopOnboarding, startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
+import { $desktopOnboarding, startManualProviderOAuth } from '@/store/onboarding'
 import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
 import { isKeyVar, ProviderKeyRows } from './credential-key-ui'
@@ -300,36 +300,6 @@ function NoProviderKeys() {
   )
 }
 
-// Surfaces the "Local / custom endpoint" entry point directly in the API-keys
-// tab so users can add any OpenAI-compatible endpoint (Zyphra, vLLM, Ollama…)
-// from the GUI. The composer pill and the providers "have an API key" affordance
-// both dead-end on the env-var-driven key catalog, which never lists a custom
-// endpoint — so without this row there is no reachable Desktop path to it.
-// The whole row is the button so the click target and a11y focus match the
-// visible area (the chevron + gutter are inside the button, not beside it).
-// Pass reason: null — the onboarding overlay renders an unmapped reason string
-// verbatim as a banner (see ReasonNotice in onboarding/index.tsx), and we don't
-// want a raw identifier like "providers-keys-tab" showing as literal text.
-function LocalEndpointRow({ onOpen }: { onOpen: (reason: null | string) => void }) {
-  const { t } = useI18n()
-  const copy = t.settings.providers.localEndpoint
-
-  return (
-    <RowButton
-      className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-[6px] px-3 py-2.5 text-left transition-colors hover:bg-(--ui-control-hover-background)"
-      onClick={() => onOpen(null)}
-    >
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <span className="truncate text-[length:var(--conversation-text-font-size)] font-semibold">{copy.title}</span>
-        <span className="truncate text-[length:var(--conversation-caption-font-size)] leading-5 text-muted-foreground">
-          {copy.description}
-        </span>
-      </div>
-      <ChevronRight className="size-4 text-muted-foreground transition group-hover:text-foreground" />
-    </RowButton>
-  )
-}
-
 export function ProvidersSettings({ onClose, onViewChange, view }: ProvidersSettingsProps) {
   const { t } = useI18n()
   const { rowProps, vars } = useEnvCredentials()
@@ -447,7 +417,6 @@ export function ProvidersSettings({ onClose, onViewChange, view }: ProvidersSett
 
     return (
       <SettingsContent>
-        <LocalEndpointRow onOpen={startManualLocalEndpoint} />
         {keyGroups.length > 0 ? (
           <div className="grid gap-3">
             <SearchField

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -217,6 +217,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("LM_API_KEY",),
         base_url_env_var="LM_BASE_URL",
     ),
+    "custom": ProviderConfig(
+        id="custom",
+        name="Custom Endpoint",
+        auth_type="api_key",
+        inference_base_url="",
+        api_key_env_vars=("CUSTOM_API_KEY",),
+        base_url_env_var="CUSTOM_BASE_URL",
+    ),
     "copilot": ProviderConfig(
         id="copilot",
         name="GitHub Copilot",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3565,6 +3565,20 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "CUSTOM_BASE_URL": {
+        "description": "Custom endpoint base URL (Ollama, vLLM, llama.cpp, or any OpenAI-compatible server)",
+        "prompt": "Custom endpoint base URL",
+        "url": None,
+        "password": False,
+        "category": "provider",
+    },
+    "CUSTOM_API_KEY": {
+        "description": "Custom endpoint API key (optional, only if the endpoint requires auth)",
+        "prompt": "Custom endpoint API key",
+        "url": None,
+        "password": True,
+        "category": "provider",
+    },
     "GLM_API_KEY": {
         "description": "Z.AI / GLM API key (also recognized as ZAI_API_KEY / Z_AI_API_KEY)",
         "prompt": "Z.AI / GLM API key",

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -34,6 +34,7 @@ Substrate facts (verified May 2026):
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+import os
 from typing import Optional
 
 
@@ -82,7 +83,12 @@ def load_picker_context() -> ConfigContext:
     Replaces the inline 17-LOC config-slice that ``web_server.py`` and
     ``tui_gateway/server.py`` (×2 sites) used to do.
     """
-    from hermes_cli.config import get_compatible_custom_providers, load_config
+    from hermes_cli.config import get_compatible_custom_providers, load_config, load_env
+
+    # The desktop model picker is long-lived; refresh its process environment
+    # from .env before provider discovery so newly saved API-key settings are
+    # immediately visible without restarting the server.
+    os.environ.update(load_env())
 
     cfg = load_config()
     model_cfg = cfg.get("model", {})

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1683,6 +1683,30 @@ def list_authenticated_providers(
             live = [current_model]
         curated["lmstudio"] = live
 
+    # Custom endpoint (Ollama, vLLM, llama.cpp, etc.) — probe /v1/models
+    # when CUSTOM_BASE_URL is set.
+    if "custom" not in curated and (
+        os.environ.get("CUSTOM_BASE_URL") or current_provider.strip().lower() == "custom"
+    ):
+        from hermes_cli.models import probe_openai_compatible_models
+        custom_base = (
+            os.environ.get("CUSTOM_BASE_URL")
+            or (current_base_url if current_provider.strip().lower() == "custom" and current_base_url else None)
+            or ""
+        )
+        if custom_base:
+            try:
+                live = probe_openai_compatible_models(
+                    api_key=os.environ.get("CUSTOM_API_KEY", ""),
+                    base_url=custom_base,
+                    timeout=1.5,
+                )
+            except Exception:
+                live = []
+            if not live and current_provider.strip().lower() == "custom" and current_model:
+                live = [current_model]
+            curated["custom"] = live or []
+
     # --- 1. Check Hermes-mapped providers ---
     from hermes_cli.models import _AGGREGATOR_PROVIDERS as _AGG_PROVIDERS
     from hermes_cli.providers import ALIASES as _PROVIDER_ALIAS_TABLE
@@ -2009,9 +2033,14 @@ def list_authenticated_providers(
         if not _cp_has_creds:
             continue
 
+        # Custom endpoints are discovered above from their configured
+        # OpenAI-compatible /v1/models URL. Never run their model ID through
+        # the generic models.dev cache: it can return unrelated public models.
+        if _cp.slug == "custom":
+            _cp_model_ids = curated.get("custom", [])
         # For bedrock, use live discovery so the list reflects the active
         # region (eu.*, us.*, ap.*) instead of the hardcoded us.* static list.
-        if _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
+        elif _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
             try:
                 _ids = cached_provider_model_ids(_cp.slug)
                 _cp_model_ids = _ids if _ids else curated.get(_cp.slug, [])

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1056,6 +1056,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("moa",            "Mixture of Agents",        "Mixture of Agents (named presets; aggregator acts after reference models)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (Local desktop app with built-in model server)"),
+    ProviderEntry("custom",         "Custom Endpoint",           "Custom Endpoint (Ollama, vLLM, llama.cpp, or any OpenAI-compatible server)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models via API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)"),
     ProviderEntry("openai-api",     "OpenAI API",               "OpenAI API (api.openai.com, API key)"),
@@ -3203,6 +3204,41 @@ def fetch_lmstudio_models(
     """
     models = probe_lmstudio_models(api_key=api_key, base_url=base_url, timeout=timeout)
     return models or []
+
+def probe_openai_compatible_models(
+    api_key: str = "",
+    base_url: str = "",
+    timeout: float = 5.0,
+) -> list[str] | None:
+    """Probe an OpenAI-compatible /v1/models endpoint (Ollama, vLLM, etc.)."""
+    import urllib.request
+    url = base_url.strip().rstrip("/")
+    if not url:
+        return None
+    if url.endswith("/v1"):
+        url = url + "/models"
+    elif not url.endswith("/models"):
+        url = url + "/v1/models"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except Exception:
+        return None
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return None
+    keys: list[str] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("id") or "").strip()
+        if key and key not in keys:
+            keys.append(key)
+    return keys
 
 
 def ensure_lmstudio_model_loaded(

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1139,6 +1139,7 @@ def _resolve_openrouter_runtime(
         api_key_candidates = [
             explicit_api_key,
             (cfg_api_key if use_config_base_url else ""),
+            (_getenv("CUSTOM_API_KEY")     if requested_norm == "custom"          else ""),
             (_getenv("OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
             (_getenv("OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),
             (_getenv("OPENROUTER_API_KEY") if _is_openrouter_url                   else ""),


### PR DESCRIPTION
## What

Add a first-class `custom` provider for Ollama, vLLM, llama.cpp, or any OpenAI-compatible server. Users configure `CUSTOM_BASE_URL` and optionally `CUSTOM_API_KEY` in the GUI's API Keys page; the model picker auto-discovers available models via `/v1/models` — the same UX as LM Studio.

## Why

The upstream "Local / custom endpoint" card opened an onboarding overlay that saved a `custom_providers:` entry to `config.yaml`. This PR replaces that with a simpler env-var-driven flow: two fields in API Keys → models appear in the picker. No onboarding wizard, no config.yaml pollution.

## Changes

| File | Change |
|------|--------|
| `constants.ts` | Add `CUSTOM_` prefix to `PROVIDER_GROUPS` — renders the "自定义端点" card in API Keys page |
| `providers-settings.tsx` | Remove upstream `LocalEndpointRow` + `startManualLocalEndpoint` import (replaced by `CUSTOM_` card) |
| `auth.py` | Register `custom` in `PROVIDER_REGISTRY` with `CUSTOM_BASE_URL` / `CUSTOM_API_KEY` |
| `config.py` | Add both vars to `OPTIONAL_ENV_VARS` with descriptions |
| `inventory.py` | Refresh `os.environ` from `.env` on each picker context load — newly saved keys visible without server restart |
| `model_switch.py` | Live-probe custom endpoint `/v1/models`; skip `cached_provider_model_ids` for custom (prevents unrelated public models leaking in) |
| `models.py` | Add `custom` to `CANONICAL_PROVIDERS` + new `probe_openai_compatible_models()` function |
| `runtime_provider.py` | Include `CUSTOM_API_KEY` in runtime API key resolution |

## How it works

1. User sets `CUSTOM_BASE_URL` (e.g. `http://localhost:11434/v1`) and optionally `CUSTOM_API_KEY` in Settings → Providers → API Keys
2. Model picker auto-discovers models via `/v1/models` (1.5s timeout for picker, no blocking)
3. Models appear under "Custom Endpoint" in the model dropdown
4. Config persists in `.env` — survives restarts

## Supersedes

Closes #66320 (that PR was based on a temporary version; this is the final implementation with all issues resolved).