### PR TITLE
fix(codex): harden webSearch provenance and MCP elicitation trust

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -28,6 +28,36 @@ from agent.stream_single_writer import claim_stream_writer, stream_writer_is_cur
 logger = logging.getLogger(__name__)
 
 
+def _configured_mcp_elicitation_servers(
+    config: dict[str, Any] | None = None,
+) -> frozenset[str]:
+    """Return explicitly trusted MCP names, failing closed on malformed config."""
+    if config is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly() or {}
+        except Exception:
+            logger.debug(
+                "codex app-server: MCP elicitation policy lookup failed",
+                exc_info=True,
+            )
+            return frozenset()
+    if not isinstance(config, dict):
+        return frozenset()
+    codex = config.get("codex") or {}
+    elicitation = codex.get("mcp_elicitation") if isinstance(codex, dict) else {}
+    if not isinstance(elicitation, dict):
+        return frozenset()
+    raw = elicitation.get("auto_accept_servers")
+    if not isinstance(raw, list):
+        return frozenset()
+    return frozenset(
+        name.strip() for name in raw
+        if isinstance(name, str) and name.strip()
+    )
+
+
 def _coerce_usage_int(value: Any) -> int:
     if isinstance(value, bool):
         return 0
@@ -325,7 +355,7 @@ def _codex_item_to_tool_name(item: dict) -> str:
     if item_type == "dynamicToolCall":
         return item.get("tool") or "dynamic"
     if item_type == "webSearch":
-        return "web_search"
+        return "codex_web_search"
     return item_type or "unknown"
 
 
@@ -347,7 +377,12 @@ def _codex_item_to_args(item: dict) -> dict:
         args = item.get("arguments") or {}
         return args if isinstance(args, dict) else {"arguments": args}
     if item_type == "webSearch":
-        return {"query": item.get("query") or ""}
+        action = item.get("action") or {}
+        return {
+            "query": item.get("query") or (
+                action.get("query") if isinstance(action, dict) else ""
+            ) or ""
+        }
     return {}
 
 
@@ -376,7 +411,10 @@ def _codex_item_to_preview(item: dict) -> Any:
         except (TypeError, ValueError):
             return None
     if item_type == "webSearch":
-        query = item.get("query") or ""
+        action = item.get("action") or {}
+        query = item.get("query") or (
+            action.get("query") if isinstance(action, dict) else ""
+        ) or ""
         return query[:120] if query else None
     return None
 
@@ -422,6 +460,16 @@ def _codex_item_completion_payload(item: dict) -> tuple[str, bool]:
             )
         success = item.get("success", True)
         return f"success={success}", not bool(success)
+    if item_type == "webSearch":
+        status = item.get("status") or "unknown"
+        return (
+            json.dumps(
+                {"provider": "codex", "status": status},
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
+            status in {"failed", "error", "cancelled"},
+        )
     return "", False
 
 
@@ -683,6 +731,9 @@ def run_codex_app_server_turn(
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,
                 auto_approve_apply_patch=auto_approve_requests,
+                auto_accept_mcp_elicitation_servers=(
+                    _configured_mcp_elicitation_servers()
+                ),
             ),
             on_event=make_codex_app_server_event_bridge(agent),
         )

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -187,6 +187,17 @@ class _ServerRequestRouting:
 
     auto_approve_exec: bool = False
     auto_approve_apply_patch: bool = False
+    auto_accept_mcp_elicitation_servers: frozenset[str] = frozenset()
+
+
+def _is_safe_confirmation_elicitation(params: dict) -> bool:
+    """Return True only when no user-provided form fields are requested."""
+    if params.get("mode") != "form":
+        return False
+    schema = params.get("requestedSchema")
+    if not isinstance(schema, dict):
+        return False
+    return schema.get("properties") == {} and schema.get("required") in (None, [])
 
 
 class CodexAppServerSession:
@@ -849,12 +860,15 @@ class CodexAppServerSession:
             # behalf of an MCP server (e.g. tool-call confirmation,
             # OAuth, form data). For our own hermes-tools callback we
             # auto-accept — the user already approved Hermes' tools
-            # by enabling the runtime, and we never expose anything
-            # codex's built-in shell can't already do. For other MCP
-            # servers we decline so the user explicitly opts in via
-            # codex's own auth flow.
+            # For explicitly configured third-party servers, only an empty
+            # confirmation form is accepted; URL and data-entry elicitations
+            # remain fail-closed.
             server_name = params.get("serverName") or ""
-            if server_name == "hermes-tools":
+            configured_safe_confirmation = (
+                server_name in self._routing.auto_accept_mcp_elicitation_servers
+                and _is_safe_confirmation_elicitation(params)
+            )
+            if server_name == "hermes-tools" or configured_safe_confirmation:
                 self._client.respond(
                     rid,
                     {"action": "accept", "content": None, "_meta": None},

--- a/agent/transports/codex_event_projector.py
+++ b/agent/transports/codex_event_projector.py
@@ -106,6 +106,8 @@ class CodexEventProjector:
             return self._project_mcp_tool_call(item, item_id)
         if item_type == "dynamicToolCall":
             return self._project_dynamic_tool_call(item, item_id)
+        if item_type == "webSearch":
+            return self._project_web_search(item, item_id)
         if item_type == "userMessage":
             return self._project_user_message(item)
 
@@ -292,6 +294,48 @@ class CodexEventProjector:
             "role": "tool",
             "tool_call_id": call_id,
             "content": content,
+        }
+        return ProjectionResult(
+            messages=[assistant_msg, tool_msg], is_tool_iteration=True
+        )
+
+    def _project_web_search(self, item: dict, item_id: str) -> ProjectionResult:
+        """Persist Codex-native search without impersonating Hermes web_search."""
+        call_id = _deterministic_call_id("codex_web_search", item_id)
+        action = item.get("action") or {}
+        query = item.get("query") or (
+            action.get("query") if isinstance(action, dict) else ""
+        ) or ""
+        assistant_msg: dict[str, Any] = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": "codex_web_search",
+                        "arguments": _format_tool_args(
+                            {"provider": "codex", "query": query}
+                        ),
+                    },
+                }
+            ],
+        }
+        if self._pending_reasoning:
+            assistant_msg["reasoning"] = "\n".join(self._pending_reasoning)
+            self._pending_reasoning = []
+        tool_msg = {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "content": json.dumps(
+                {
+                    "provider": "codex",
+                    "status": item.get("status") or "unknown",
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
         }
         return ProjectionResult(
             messages=[assistant_msg, tool_msg], is_tool_iteration=True

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -46,7 +46,18 @@ model:
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
 
-  # Azure Foundry keyless auth example:
+  # Codex-native runtime (optional)
+  # openai_runtime: "codex_app_server"
+  #
+  # MCP elicitation auto-accept is disabled for third-party servers by default.
+  # Only empty confirmation forms from names listed in the top-level `codex`
+  # block are auto-accepted; OAuth URLs and forms requesting fields still
+  # require explicit user handling.
+  #
+  # Add this at the top level (not under `model`):
+  # codex:
+  #   mcp_elicitation:
+  #     auto_accept_servers: ["obsidian", "deep_research"]
   # provider: "azure-foundry"
   # base_url: "https://<resource>.openai.azure.com/openai/v1"
   # auth_mode: "entra_id"      # DefaultAzureCredential: az login, managed identity, workload identity, etc.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1196,6 +1196,19 @@ DEFAULT_CONFIG = {
         "reasoning_overrides": {},
     },
 
+    "codex": {
+        "mcp_elicitation": {
+            # Third-party MCP server names that codex app-server may
+            # auto-accept EMPTY confirmation-form elicitations from (no
+            # requested fields, no OAuth/URL flow — those are always
+            # declined regardless of this list). Empty by default: fails
+            # closed for every server except the separately-trusted
+            # upstream `hermes-tools` callback. See
+            # agent.codex_runtime._configured_mcp_elicitation_servers.
+            "auto_accept_servers": [],
+        },
+    },
+
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -91,9 +91,12 @@ class TestCodexItemToToolName:
             {"type": "mcpToolCall", "server": "hermes-tools", "tool": "browser_navigate"}
         ) == "browser_navigate"
 
-    def test_web_search_builtin_maps_to_web_search(self):
-        """Codex's built-in webSearch tool gets a bubble too (#26541)."""
-        assert _codex_item_to_tool_name({"type": "webSearch"}) == "web_search"
+    def test_web_search_builtin_has_codex_provenance(self):
+        """Codex's built-in search is distinct from Hermes web_search."""
+        assert (
+            _codex_item_to_tool_name({"type": "webSearch"})
+            == "codex_web_search"
+        )
 
     def test_unknown_type_returns_type_string(self):
         assert _codex_item_to_tool_name(
@@ -398,12 +401,18 @@ class TestToolProgressDispatch:
             "type": "webSearch",
             "id": "ws-1",
             "query": "hermes agent docs",
+            "status": "completed",
         }))
         calls = agent.tool_progress_callback.call_args_list
         assert [c.args[0] for c in calls] == ["tool.started", "tool.completed"]
-        assert calls[0].args[1] == "web_search"
+        assert calls[0].args[1] == "codex_web_search"
         assert calls[0].args[2] == "hermes agent docs"
         assert calls[0].args[3] == {"query": "hermes agent docs"}
+        assert json.loads(calls[1].kwargs["result"]) == {
+            "provider": "codex",
+            "status": "completed",
+        }
+        assert calls[1].kwargs["is_error"] is False
 
     def test_duration_falls_back_to_wall_time_when_codex_missing_ms(self):
         agent = _make_stub_agent()

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -739,6 +739,67 @@ class TestServerRequestRouting:
         s.run_turn("hi", turn_timeout=1.0)
         assert ("elic-2", {"action": "decline", "content": None, "_meta": None}) in client.responses
 
+    def test_configured_mcp_confirmation_auto_accepts(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "mcpServer/elicitation/request", request_id="elic-safe",
+            threadId="t", turnId="tu1", serverName="obsidian",
+            mode="form", message="confirm",
+            requestedSchema={"type": "object", "properties": {}},
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        routing = _ServerRequestRouting(
+            auto_accept_mcp_elicitation_servers=frozenset({"obsidian"})
+        )
+        make_session(client, request_routing=routing).run_turn("hi", turn_timeout=1.0)
+        assert ("elic-safe", {
+            "action": "accept", "content": None, "_meta": None
+        }) in client.responses
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {
+                "serverName": "obsidian",
+                "mode": "url",
+                "url": "https://example.com/oauth",
+            },
+            {
+                "serverName": "obsidian",
+                "mode": "form",
+                "requestedSchema": {
+                    "type": "object",
+                    "properties": {"secret": {"type": "string"}},
+                },
+            },
+            {
+                "serverName": "not-configured",
+                "mode": "form",
+                "requestedSchema": {"type": "object", "properties": {}},
+            },
+        ],
+    )
+    def test_mcp_auto_accept_policy_declines_unsafe_or_unknown_requests(self, params):
+        client = FakeClient()
+        client.queue_server_request(
+            "mcpServer/elicitation/request", request_id="elic-decline",
+            threadId="t", turnId="tu1", **params,
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        routing = _ServerRequestRouting(
+            auto_accept_mcp_elicitation_servers=frozenset({"obsidian"})
+        )
+        make_session(client, request_routing=routing).run_turn("hi", turn_timeout=1.0)
+        assert ("elic-decline", {
+            "action": "decline", "content": None, "_meta": None
+        }) in client.responses
+
     def test_routing_auto_approve_bypass(self):
         client = FakeClient()
         client.queue_server_request("item/commandExecution/requestApproval", request_id="r1",

--- a/tests/agent/transports/test_codex_event_projector.py
+++ b/tests/agent/transports/test_codex_event_projector.py
@@ -225,6 +225,59 @@ class TestMcpToolCallProjection:
         assert "error" in msgs[1]["content"]
 
 
+class TestWebSearchProjection:
+    def test_web_search_has_explicit_codex_provenance(self) -> None:
+        item = {
+            "type": "webSearch",
+            "id": "ws-1",
+            "query": "Hermes Agent documentation",
+            "status": "completed",
+        }
+        result = CodexEventProjector().project(
+            {"method": "item/completed", "params": {"item": item}}
+        )
+
+        assert result.is_tool_iteration is True
+        assistant, tool = result.messages
+        call = assistant["tool_calls"][0]
+        assert call["function"]["name"] == "codex_web_search"
+        assert json.loads(call["function"]["arguments"]) == {
+            "provider": "codex",
+            "query": "Hermes Agent documentation",
+        }
+        assert json.loads(tool["content"]) == {
+            "provider": "codex",
+            "status": "completed",
+        }
+        assert tool["tool_call_id"] == call["id"]
+
+    def test_web_search_reads_nested_action_query_and_failed_status(self) -> None:
+        item = {
+            "type": "webSearch",
+            "id": "ws-2",
+            "action": {"query": "fallback query"},
+            "status": "failed",
+        }
+        assistant, tool = CodexEventProjector().project(
+            {"method": "item/completed", "params": {"item": item}}
+        ).messages
+
+        args = json.loads(assistant["tool_calls"][0]["function"]["arguments"])
+        assert args["query"] == "fallback query"
+        assert json.loads(tool["content"])["status"] == "failed"
+
+    def test_web_search_call_id_is_stable_across_replay(self) -> None:
+        notification = {
+            "method": "item/completed",
+            "params": {"item": {
+                "type": "webSearch", "id": "ws-stable", "query": "q"
+            }},
+        }
+        first = CodexEventProjector().project(notification).messages[0]
+        second = CodexEventProjector().project(notification).messages[0]
+        assert first["tool_calls"][0]["id"] == second["tool_calls"][0]["id"]
+
+
 class TestUserAndOpaqueProjection:
     def test_user_message_text_fragments_only(self) -> None:
         item = {
@@ -290,6 +343,8 @@ class TestRoleAlternationInvariant:
             {"type": "dynamicToolCall", "id": "d1", "tool": "x",
              "arguments": {}, "status": "completed",
              "contentItems": [], "success": True},
+            {"type": "webSearch", "id": "w1", "query": "x",
+             "status": "completed"},
         ],
     )
     def test_tool_items_emit_assistant_then_tool(self, item) -> None:

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -94,6 +94,40 @@ class TestConfiguredMcpElicitationServers:
         assert _configured_mcp_elicitation_servers(config) == frozenset()
 
 
+class TestConfiguredMcpElicitationServersLoaderDefaults:
+    """Loader-level coverage: DEFAULT_CONFIG's empty ``codex`` policy default
+    (and an explicit user override) actually reach
+    ``_configured_mcp_elicitation_servers`` through the real config merge,
+    not just via a hand-built dict."""
+
+    def test_default_config_has_no_trusted_servers(self, monkeypatch, tmp_path):
+        # No config.yaml at all — load_config() must fall back to
+        # DEFAULT_CONFIG's "codex.mcp_elicitation.auto_accept_servers": [].
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        assert config["codex"]["mcp_elicitation"]["auto_accept_servers"] == []
+        assert _configured_mcp_elicitation_servers(config) == frozenset()
+
+    def test_explicit_user_policy_flows_through_loader(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "codex:\n"
+            "  mcp_elicitation:\n"
+            "    auto_accept_servers:\n"
+            "      - obsidian\n"
+            "      - deep_research\n",
+            encoding="utf-8",
+        )
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        assert _configured_mcp_elicitation_servers(config) == frozenset(
+            {"obsidian", "deep_research"}
+        )
+
+
 class TestRunConversationCodexPath:
     def test_codex_app_server_policy_is_passed_to_session(self, fake_session, monkeypatch):
         monkeypatch.setattr(

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import run_agent
+from agent.codex_runtime import _configured_mcp_elicitation_servers
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
 
 
@@ -72,7 +73,40 @@ class TestApiModeAccepted:
         assert agent.api_mode == "codex_app_server"
 
 
+class TestConfiguredMcpElicitationServers:
+    def test_reads_explicit_codex_policy_and_filters_invalid_entries(self):
+        config = {
+            "codex": {
+                "mcp_elicitation": {
+                    "auto_accept_servers": ["obsidian", "", 42, " deep_research "],
+                }
+            }
+        }
+        assert _configured_mcp_elicitation_servers(config) == frozenset(
+            {"obsidian", "deep_research"}
+        )
+
+    @pytest.mark.parametrize("raw", ["obsidian", {"obsidian": True}, 7, None])
+    def test_malformed_policy_fails_closed(self, raw):
+        config = {
+            "codex": {"mcp_elicitation": {"auto_accept_servers": raw}}
+        }
+        assert _configured_mcp_elicitation_servers(config) == frozenset()
+
+
 class TestRunConversationCodexPath:
+    def test_codex_app_server_policy_is_passed_to_session(self, fake_session, monkeypatch):
+        monkeypatch.setattr(
+            "agent.codex_runtime._configured_mcp_elicitation_servers",
+            lambda: frozenset({"obsidian"}),
+        )
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+        assert agent._codex_session._routing.auto_accept_mcp_elicitation_servers == frozenset(
+            {"obsidian"}
+        )
+
     def test_run_conversation_returns_codex_shape(self, fake_session):
         agent = _make_codex_agent()
         # No background review fork during tests


### PR DESCRIPTION
## Summary

Harden Codex app-server web-search history projection and MCP elicitation trust.

## Changes

### Native Codex webSearch

- Keep upstream live `webSearch` tool bubbles, but persist native Codex search as `codex_web_search` so it cannot be confused with Hermes' own `web_search` tool.
- Persist explicit `provider: codex` and search status.
- Support both top-level and nested Codex query shapes.
- Preserve deterministic replay-safe tool-call IDs.
- Include the same provider/status payload in live completion telemetry.

### MCP elicitation

- Remove the hard-coded third-party server allowlist.
- Add an explicit top-level configuration policy:

```yaml
codex:
  mcp_elicitation:
    auto_accept_servers:
      - obsidian
      - deep_research
```

- Preserve upstream `hermes-tools` behavior.
- For configured third-party servers, auto-accept only empty confirmation forms.
- Continue declining URL/OAuth elicitations, forms requesting fields, unknown servers, and malformed configuration.
- Keep the policy frozen into the Codex session routing object rather than rereading configuration for every request.

## Validation

- 177 relevant Codex projector, event bridge, session, and integration tests passed.
- Ruff passed.
- `git diff --check` passed.
- Static security scan found no hard-coded secrets, shell injection, eval/exec, or unsafe deserialization patterns.
- Live VPS smoke checks passed after deployment.
- `hermes-serve.service`, `hermes-desktop.service`, and `hermes-gateway.service` are active.

## Related work

- Complements merged #66282, which handles live Codex web-search display bubbles.
- Complements open #66360/#66402, which cover serve WebSocket event delivery.
- Keeps the separate upstream `hermes-tools` trust behavior from #56534 while making third-party trust explicit and narrow.

The VPS deployment includes reversible backups and an updated patch-guard bundle.
