### PR TITLE
fix(gateway): reload clean code after checkout drift

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15368,6 +15368,9 @@ def main(
     # Handle gateway mode (messaging + cron)
     if gateway:
         import asyncio
+        from hermes_cli.gateway_bootstrap import purge_stale_gateway_pycache_before_import
+
+        purge_stale_gateway_pycache_before_import()
         from gateway.run import start_gateway
         print("Starting Hermes Gateway (messaging platforms)...")
         asyncio.run(start_gateway())

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -9,6 +9,22 @@ to various messaging platforms (Telegram, Discord, WhatsApp, Weixin, and more) w
 - Platform-specific toolsets (different capabilities per platform)
 """
 
+# ``python -m gateway.run`` imports this package before loading gateway.run.
+# Run checkout-drift cleanup only for that documented entry point; a regular
+# ``import gateway`` must remain free of gateway-startup side effects.
+import sys
+
+
+def _is_direct_gateway_module_execution() -> bool:
+    main_spec = getattr(sys.modules.get("__main__"), "__spec__", None)
+    return getattr(main_spec, "name", None) == "gateway.run"
+
+
+if _is_direct_gateway_module_execution():
+    from hermes_cli.gateway_bootstrap import purge_stale_gateway_pycache_before_import
+
+    purge_stale_gateway_pycache_before_import()
+
 from .config import GatewayConfig, PlatformConfig, HomeChannel, load_gateway_config
 from .session import (
     SessionContext,

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -9,22 +9,6 @@ to various messaging platforms (Telegram, Discord, WhatsApp, Weixin, and more) w
 - Platform-specific toolsets (different capabilities per platform)
 """
 
-# ``python -m gateway.run`` imports this package before loading gateway.run.
-# Run checkout-drift cleanup only for that documented entry point; a regular
-# ``import gateway`` must remain free of gateway-startup side effects.
-import sys
-
-
-def _is_direct_gateway_module_execution() -> bool:
-    main_spec = getattr(sys.modules.get("__main__"), "__spec__", None)
-    return getattr(main_spec, "name", None) == "gateway.run"
-
-
-if _is_direct_gateway_module_execution():
-    from hermes_cli.gateway_bootstrap import purge_stale_gateway_pycache_before_import
-
-    purge_stale_gateway_pycache_before_import()
-
 from .config import GatewayConfig, PlatformConfig, HomeChannel, load_gateway_config
 from .session import (
     SessionContext,

--- a/gateway/code_skew.py
+++ b/gateway/code_skew.py
@@ -13,14 +13,34 @@ gateway" message instead of crashing on a cryptic import error.
 
 If the revision can't be read (non-git install, IO error), the boot snapshot
 stays ``None`` and skew detection no-ops — it never produces a false positive.
+
+We also persist the boot fingerprint to ``HERMES_HOME`` so the next gateway
+boot can detect that the checkout advanced while the previous gateway was
+running, and purge stale ``__pycache__`` before any import picks up bytecode
+compiled against the old source (see ``purge_stale_pycache``).
 """
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _boot_fingerprint: str | None = None
+
+logger = logging.getLogger("gateway.code_skew")
+
+
+def _fingerprint_file() -> Path:
+    """Return the path to the persisted boot fingerprint.
+
+    Resolved at call time (not import time) via the canonical
+    ``get_hermes_home()`` so profile overrides and context-local
+    HERMES_HOME changes are respected.
+    """
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / ".gateway_boot_fingerprint"
 
 
 def _fingerprint() -> str | None:
@@ -39,10 +59,71 @@ def _fingerprint() -> str | None:
 
 
 def record_boot_fingerprint() -> None:
-    """Snapshot the checkout revision at gateway startup (idempotent)."""
+    """Snapshot the checkout revision at gateway startup (idempotent).
+
+    Also persists the fingerprint to ``HERMES_HOME`` so the next boot can
+    detect drift and purge stale ``__pycache__`` before imports pick up
+    bytecode compiled against the old source.
+    """
     global _boot_fingerprint
     if _boot_fingerprint is None:
         _boot_fingerprint = _fingerprint()
+    _persist_boot_fingerprint(_boot_fingerprint)
+
+
+def _persist_boot_fingerprint(fingerprint: str | None) -> None:
+    """Write the boot fingerprint to ``HERMES_HOME`` for next-boot comparison."""
+    if fingerprint is None:
+        return
+    try:
+        fp_file = _fingerprint_file()
+        fp_file.parent.mkdir(parents=True, exist_ok=True)
+        fp_file.write_text(fingerprint, encoding="utf-8")
+    except Exception:
+        logger.debug("Failed to persist boot fingerprint", exc_info=True)
+
+
+def purge_stale_pycache() -> bool:
+    """Purge stale ``__pycache__`` directories if the checkout advanced.
+
+    At gateway boot, compares the persisted fingerprint from the *previous*
+    gateway run with the current checkout. If they differ, Python's
+    ``__pycache__`` may contain bytecode compiled against the old source
+    (``.pyc`` files whose header mtime matches the old ``.py`` because git
+    operations can preserve mtime). Deleting the ``__pycache__`` dirs forces
+    a clean recompile on first import.
+
+    Returns ``True`` if a purge was performed, ``False`` otherwise.
+    """
+    current = _fingerprint()
+    if current is None:
+        return False
+    try:
+        previous = _fingerprint_file().read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError):
+        return False
+    if not previous or previous == current:
+        return False
+
+    purged = 0
+    for pycache in _PROJECT_ROOT.rglob("__pycache__"):
+        # Skip .venv and node_modules to avoid slow/unnecessary I/O
+        if ".venv" in pycache.parts or "node_modules" in pycache.parts:
+            continue
+        try:
+            for pyc in pycache.glob("*.pyc"):
+                pyc.unlink()
+                purged += 1
+        except OSError:
+            pass
+    if purged:
+        logger.info(
+            "Purged %d stale .pyc file(s) — checkout advanced from %s to %s",
+            purged,
+            _short(previous),
+            _short(current),
+        )
+    return purged > 0
 
 
 def _short(fingerprint: str) -> str:

--- a/gateway/code_skew.py
+++ b/gateway/code_skew.py
@@ -27,7 +27,6 @@ from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _boot_fingerprint: str | None = None
-
 logger = logging.getLogger("gateway.code_skew")
 
 
@@ -81,49 +80,6 @@ def _persist_boot_fingerprint(fingerprint: str | None) -> None:
         fp_file.write_text(fingerprint, encoding="utf-8")
     except Exception:
         logger.debug("Failed to persist boot fingerprint", exc_info=True)
-
-
-def purge_stale_pycache() -> bool:
-    """Purge stale ``__pycache__`` directories if the checkout advanced.
-
-    At gateway boot, compares the persisted fingerprint from the *previous*
-    gateway run with the current checkout. If they differ, Python's
-    ``__pycache__`` may contain bytecode compiled against the old source
-    (``.pyc`` files whose header mtime matches the old ``.py`` because git
-    operations can preserve mtime). Deleting the ``__pycache__`` dirs forces
-    a clean recompile on first import.
-
-    Returns ``True`` if a purge was performed, ``False`` otherwise.
-    """
-    current = _fingerprint()
-    if current is None:
-        return False
-    try:
-        previous = _fingerprint_file().read_text(encoding="utf-8").strip()
-    except (FileNotFoundError, OSError):
-        return False
-    if not previous or previous == current:
-        return False
-
-    purged = 0
-    for pycache in _PROJECT_ROOT.rglob("__pycache__"):
-        # Skip .venv and node_modules to avoid slow/unnecessary I/O
-        if ".venv" in pycache.parts or "node_modules" in pycache.parts:
-            continue
-        try:
-            for pyc in pycache.glob("*.pyc"):
-                pyc.unlink()
-                purged += 1
-        except OSError:
-            pass
-    if purged:
-        logger.info(
-            "Purged %d stale .pyc file(s) — checkout advanced from %s to %s",
-            purged,
-            _short(previous),
-            _short(current),
-        )
-    return purged > 0
 
 
 def _short(fingerprint: str) -> str:

--- a/gateway/code_skew.py
+++ b/gateway/code_skew.py
@@ -14,10 +14,10 @@ gateway" message instead of crashing on a cryptic import error.
 If the revision can't be read (non-git install, IO error), the boot snapshot
 stays ``None`` and skew detection no-ops — it never produces a false positive.
 
-We also persist the boot fingerprint to ``HERMES_HOME`` so the next gateway
-boot can detect that the checkout advanced while the previous gateway was
-running, and purge stale ``__pycache__`` before any import picks up bytecode
-compiled against the old source (see ``purge_stale_pycache``).
+We also persist the boot fingerprint to ``HERMES_HOME``. On the next boot,
+supported pre-import gateway launchers can detect that the checkout advanced and
+purge stale ``__pycache__`` before importing ``gateway.run``. The compatible
+``python -m gateway.run`` path does not provide that pre-import guarantee.
 """
 
 from __future__ import annotations
@@ -60,9 +60,8 @@ def _fingerprint() -> str | None:
 def record_boot_fingerprint() -> None:
     """Snapshot the checkout revision at gateway startup (idempotent).
 
-    Also persists the fingerprint to ``HERMES_HOME`` so the next boot can
-    detect drift and purge stale ``__pycache__`` before imports pick up
-    bytecode compiled against the old source.
+    Also persists the fingerprint to ``HERMES_HOME`` for supported launchers to
+    compare before importing ``gateway.run`` on a later boot.
     """
     global _boot_fingerprint
     if _boot_fingerprint is None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6,12 +6,12 @@ This module provides:
 - GatewayRunner: Main class managing the gateway lifecycle
 
 Usage:
-    # Start the gateway through its pre-import bootstrap.
+    # Recommended: start through the pre-import bootstrap.
     hermes gateway run
 
-``python -m gateway.run`` is intentionally unsupported: Python loads the
-target module before it can run a bootstrap, so it cannot guarantee cleanup of
-stale target bytecode after a checkout update.
+    # Compatibility entry point. It does not provide the pre-import
+    # stale-bytecode cleanup guarantee of the supported launchers above.
+    python -m gateway.run
 """
 
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
@@ -22357,7 +22357,4 @@ def _exit_after_graceful_shutdown(exit_code: int) -> None:
 
 
 if __name__ == "__main__":
-    raise SystemExit(
-        "Direct module execution is unsupported; use `hermes gateway run` so "
-        "the pre-import bootstrap can validate the checkout."
-    )
+    main()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6,11 +6,12 @@ This module provides:
 - GatewayRunner: Main class managing the gateway lifecycle
 
 Usage:
-    # Start the gateway
-    python -m gateway.run
-    
-    # Or from CLI
-    python cli.py --gateway
+    # Start the gateway through its pre-import bootstrap.
+    hermes gateway run
+
+``python -m gateway.run`` is intentionally unsupported: Python loads the
+target module before it can run a bootstrap, so it cannot guarantee cleanup of
+stale target bytecode after a checkout update.
 """
 
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
@@ -22356,4 +22357,7 @@ def _exit_after_graceful_shutdown(exit_code: int) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(
+        "Direct module execution is unsupported; use `hermes gateway run` so "
+        "the pre-import bootstrap can validate the checkout."
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21683,15 +21683,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # so a later `git pull` under this long-lived process can be detected (and
     # risky work like model switching refused) instead of crashing on a stale
     # in-memory module.
-    from gateway.code_skew import purge_stale_pycache, record_boot_fingerprint
+    from gateway.code_skew import record_boot_fingerprint
 
-    # If the checkout advanced while the previous gateway was running, purge
-    # stale __pycache__ before any import picks up bytecode compiled against
-    # the old source (git can preserve .py mtime, so .pyc headers match the
-    # old source even after a pull — Python won't recompile, and the stale
-    # bytecode causes cryptic crashes like ValueError: too many values to
-    # unpack with mismatched traceback line numbers).
-    purge_stale_pycache()
+    # Bytecode cleanup belongs to the launcher/bootstrap boundary before this
+    # module is imported. This function only records the new boot fingerprint.
     record_boot_fingerprint()
 
     # ── Duplicate-instance guard ──────────────────────────────────────
@@ -22361,7 +22356,4 @@ def _exit_after_graceful_shutdown(exit_code: int) -> None:
 
 
 if __name__ == "__main__":
-    raise SystemExit(
-        "Direct module execution is unsupported; use `hermes gateway run` so "
-        "the pre-import bootstrap can validate the checkout."
-    )
+    main()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22361,4 +22361,7 @@ def _exit_after_graceful_shutdown(exit_code: int) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(
+        "Direct module execution is unsupported; use `hermes gateway run` so "
+        "the pre-import bootstrap can validate the checkout."
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21683,7 +21683,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # so a later `git pull` under this long-lived process can be detected (and
     # risky work like model switching refused) instead of crashing on a stale
     # in-memory module.
-    from gateway.code_skew import record_boot_fingerprint
+    from gateway.code_skew import purge_stale_pycache, record_boot_fingerprint
+
+    # If the checkout advanced while the previous gateway was running, purge
+    # stale __pycache__ before any import picks up bytecode compiled against
+    # the old source (git can preserve .py mtime, so .pyc headers match the
+    # old source even after a pull — Python won't recompile, and the stale
+    # bytecode causes cryptic crashes like ValueError: too many values to
+    # unpack with mismatched traceback line numbers).
+    purge_stale_pycache()
     record_boot_fingerprint()
 
     # ── Duplicate-instance guard ──────────────────────────────────────

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -27,7 +27,18 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Protocol, Union, runtime_checkable
+
+
+@runtime_checkable
+class _RestartableRunner(Protocol):
+    """Structural type for the gateway runner's restart capability.
+
+    Avoids a hard import dependency on ``GatewayRunner`` (which would create a
+    cycle) while letting the skew guard trigger a graceful restart.
+    """
+
+    def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool: ...
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
@@ -55,14 +66,18 @@ logger = logging.getLogger("gateway.run")
 _RESET_CLEANUP_TIMEOUT_S = 30.0
 
 
-def _model_switch_skew_guard() -> Optional[str]:
+def _model_switch_skew_guard(runner: Optional[_RestartableRunner] = None) -> Optional[str]:
     """Refuse a model switch when the gateway is running stale code.
 
     A long-lived gateway holds its modules in memory from boot. If the checkout
     changed underneath it (e.g. a manual ``git pull``), switching models can hit
     a first-time lazy import on a new code path and crash on a stale cached
     dependency — the cryptic ``cannot import name 'env_float' from 'utils'``.
-    Detect the drift and tell the user to restart instead.
+
+    When ``runner`` is provided and drift is detected, trigger a graceful
+    restart via ``runner.request_restart()`` so the gateway reloads the new code
+    automatically — the user no longer needs to restart manually from a
+    separate shell (which is hard inside the gateway process itself).
 
     Intentionally scoped to model switching — the known, highest-risk trigger.
     Any first-time lazy import on a stale process is technically exposed; we
@@ -74,6 +89,33 @@ def _model_switch_skew_guard() -> Optional[str]:
     if not skew:
         return None
     boot_rev, disk_rev = skew
+
+    # Trigger a graceful restart so the gateway reloads the new code
+    # automatically. The user can re-run /model after restart completes.
+    # Mirror the environment-detection logic from _handle_restart_command
+    # so the restart uses the same path (service-managed vs detached) the
+    # /restart command would pick — the defaults (detached=False,
+    # via_service=False) match neither path and can leave the gateway
+    # stopped instead of restarted.
+    if runner is not None:
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
+            "XPC_SERVICE_NAME", "0"
+        ) not in ("", "0")
+        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+        restarted = runner.request_restart(
+            detached=not (_under_service or _in_container),
+            via_service=_under_service or _in_container,
+        )
+        if restarted:
+            return t(
+                "gateway.model.error_prefix",
+                error=(
+                    f"Gateway is running code from {boot_rev} but the checkout "
+                    f"on disk is now {disk_rev}. Restarting to load the new code "
+                    f"— re-run /model after restart to switch."
+                ),
+            )
+
     return t(
         "gateway.model.error_prefix",
         error=(
@@ -1576,7 +1618,7 @@ class GatewaySlashCommandsMixin:
                         _chat_id: str, model_id: str, provider_slug: str
                     ) -> str:
                         """Perform the model switch and return confirmation text."""
-                        skew_error = _model_switch_skew_guard()
+                        skew_error = _model_switch_skew_guard(runner=_self)
                         if skew_error:
                             return skew_error
                         # Offload the switch off the event loop — switch_model()
@@ -1848,7 +1890,7 @@ class GatewaySlashCommandsMixin:
             return "\n".join(lines)
 
         # Perform the switch
-        skew_error = _model_switch_skew_guard()
+        skew_error = _model_switch_skew_guard(runner=self)
         if skew_error:
             return skew_error
         # Offload the switch off the event loop — switch_model() can fall

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -98,9 +98,9 @@ def _model_switch_skew_guard(runner: Optional[_RestartableRunner] = None) -> Opt
     # via_service=False) match neither path and can leave the gateway
     # stopped instead of restarted.
     if runner is not None:
-        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
-            "XPC_SERVICE_NAME", "0"
-        ) not in ("", "0")
+        from gateway.restart import is_gateway_supervisor_process
+
+        _under_service = is_gateway_supervisor_process()
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
         restarted = runner.request_restart(
             detached=not (_under_service or _in_container),

--- a/hermes_bootstrap.py
+++ b/hermes_bootstrap.py
@@ -14,8 +14,8 @@ Python on Windows has two long-standing text-encoding footguns:
 
 This module fixes both on Windows *only* — POSIX is untouched.  It
 should be imported at the very top of every Hermes entry point
-(``hermes``, ``hermes-agent``, ``hermes-acp``, ``python -m gateway.run``,
-``batch_runner.py``, ``cron/scheduler.py``) before any other imports
+(``hermes``, ``hermes-agent``, ``hermes-acp``, ``batch_runner.py``,
+``cron/scheduler.py``) before any other imports
 that might do file I/O or print to stdout.
 
 What this module does on Windows:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4852,6 +4852,9 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
         except Exception:
             pass  # best-effort; don't block gateway startup
 
+    from hermes_cli.gateway_bootstrap import purge_stale_gateway_pycache_before_import
+
+    purge_stale_gateway_pycache_before_import()
     from gateway.run import start_gateway
 
     print("┌─────────────────────────────────────────────────────────┐")

--- a/hermes_cli/gateway_bootstrap.py
+++ b/hermes_cli/gateway_bootstrap.py
@@ -1,0 +1,39 @@
+"""Pre-import gateway startup checks shared by every gateway entry point."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from hermes_cli.config import get_hermes_home
+
+PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+
+
+def purge_stale_gateway_pycache_before_import() -> bool:
+    """Remove stale project bytecode before importing ``gateway.run``."""
+    try:
+        previous = (get_hermes_home() / ".gateway_boot_fingerprint").read_text(encoding="utf-8").strip()
+        current = subprocess.run(
+            ["git", "-C", str(PROJECT_ROOT), "rev-parse", "HEAD"],
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if not previous or not current or previous.rsplit(":", 1)[-1] == current:
+        return False
+
+    purged = False
+    for pycache in PROJECT_ROOT.rglob("__pycache__"):
+        if ".venv" in pycache.parts or "node_modules" in pycache.parts:
+            continue
+        for pyc in pycache.glob("*.pyc"):
+            try:
+                pyc.unlink()
+                purged = True
+            except OSError:
+                continue
+    return purged

--- a/scripts/hermes-gateway
+++ b/scripts/hermes-gateway
@@ -294,6 +294,9 @@ def is_windows() -> bool:
 
 def run_gateway():
     """Run the gateway in foreground."""
+    from hermes_cli.gateway_bootstrap import purge_stale_gateway_pycache_before_import
+
+    purge_stale_gateway_pycache_before_import()
     from gateway.run import start_gateway
     print("Starting Hermes Gateway...")
     print("Press Ctrl+C to stop.")

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -162,6 +162,12 @@ class TestBootstrapBytecodePurge:
         slash_commands._model_switch_skew_guard(runner=FakeRunner())
         assert calls == [(True, False)], f"detached path expected, got {calls}"
 
+        # Simulate an externally supervised gateway → service path.
+        calls.clear()
+        monkeypatch.setenv("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", "true")
+        slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert calls == [(False, True)], f"service path expected, got {calls}"
+
 
 class TestPurgeStalePycache:
     """Tests for purge_stale_pycache — purging __pycache__ when the checkout
@@ -236,3 +242,11 @@ class TestPersistBootFingerprint:
         monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
         code_skew._persist_boot_fingerprint(None)
         assert not fp_file.exists()
+
+    def test_canonical_gateway_launcher_bootstraps_before_import(self):
+        launcher = Path(__file__).parents[1] / "hermes_cli" / "gateway.py"
+        source = launcher.read_text(encoding="utf-8")
+
+        assert source.index("purge_stale_gateway_pycache_before_import()") < source.index(
+            "from gateway.run import start_gateway"
+        )

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -5,11 +5,10 @@ crash; these prove the guard that turns it into a clear "restart the gateway"
 message before a model switch can hit it.
 """
 
-import importlib
-import importlib.abc
-from importlib.machinery import ModuleSpec
+import ast
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -110,6 +109,40 @@ class TestBootstrapBytecodePurge:
 
         assert gateway_bootstrap.purge_stale_gateway_pycache_before_import() is True
         assert not stale_pyc.exists()
+
+    def test_every_supported_launcher_bootstraps_before_gateway_run_import(self):
+        project_root = Path(__file__).parents[1]
+        launchers = (
+            project_root / "cli.py",
+            project_root / "hermes_cli" / "gateway.py",
+            project_root / "scripts" / "hermes-gateway",
+        )
+
+        for launcher in launchers:
+            tree = ast.parse(launcher.read_text(encoding="utf-8"), filename=str(launcher))
+            bootstrap_imports = [
+                node.lineno
+                for node in ast.walk(tree)
+                if isinstance(node, ast.ImportFrom)
+                and node.module == "hermes_cli.gateway_bootstrap"
+            ]
+            purge_calls = [
+                node.lineno
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "purge_stale_gateway_pycache_before_import"
+            ]
+            gateway_run_imports = [
+                node.lineno
+                for node in ast.walk(tree)
+                if isinstance(node, ast.ImportFrom) and node.module == "gateway.run"
+            ]
+
+            assert bootstrap_imports, f"{launcher} must import the pre-import bootstrap"
+            assert purge_calls, f"{launcher} must invoke the pre-import bootstrap"
+            assert gateway_run_imports, f"{launcher} must import gateway.run"
+            assert min(bootstrap_imports) < min(purge_calls) < min(gateway_run_imports)
     def test_guard_falls_back_to_manual_when_restart_fails(self, monkeypatch):
         """If request_restart returns False (e.g. already restarting), the
         guard falls back to the manual restart message."""
@@ -185,60 +218,15 @@ class TestPersistBootFingerprint:
         code_skew._persist_boot_fingerprint(None)
         assert not fp_file.exists()
 
-    def test_direct_module_path_bootstraps_before_gateway_run_import(self, monkeypatch, tmp_path):
-        """Package initialization is the pre-import boundary for ``-m``."""
-        marker = tmp_path / "bootstrap-ran"
-        import gateway
-        from hermes_cli import gateway_bootstrap
-
-        main_module = sys.modules["__main__"]
-        original_main_spec = main_module.__spec__
-        original_run = sys.modules.get("gateway.run")
-        missing = object()
-        original_package_run = gateway.__dict__.get("run", missing)
-        original_purge = gateway.__dict__.get(
-            "purge_stale_gateway_pycache_before_import", missing
-        )
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        monkeypatch.setattr(
-            gateway_bootstrap,
-            "purge_stale_gateway_pycache_before_import",
-            lambda: marker.write_text("ran", encoding="utf-8"),
+    def test_direct_module_execution_has_documented_cli_migration(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "gateway.run"],
+            capture_output=True,
+            cwd=Path(__file__).parents[1],
+            text=True,
+            timeout=30,
         )
 
-        observed_import = []
-
-        class BootstrapProbe(importlib.abc.MetaPathFinder):
-            def find_spec(self, fullname, path=None, target=None):
-                if fullname == "gateway.run":
-                    assert marker.read_text(encoding="utf-8") == "ran"
-                    observed_import.append(fullname)
-                return None
-
-        probe = BootstrapProbe()
-        try:
-            main_module.__spec__ = ModuleSpec("gateway.run", loader=None)
-            importlib.reload(gateway)
-            assert marker.read_text(encoding="utf-8") == "ran"
-
-            sys.modules.pop("gateway.run", None)
-            gateway.__dict__.pop("run", None)
-            sys.meta_path.insert(0, probe)
-            importlib.import_module("gateway.run")
-            assert observed_import == ["gateway.run"]
-        finally:
-            if probe in sys.meta_path:
-                sys.meta_path.remove(probe)
-            main_module.__spec__ = original_main_spec
-            if original_run is None:
-                sys.modules.pop("gateway.run", None)
-            else:
-                sys.modules["gateway.run"] = original_run
-            if original_package_run is missing:
-                gateway.__dict__.pop("run", None)
-            else:
-                setattr(gateway, "run", original_package_run)
-            if original_purge is missing:
-                gateway.__dict__.pop("purge_stale_gateway_pycache_before_import", None)
-            else:
-                gateway.purge_stale_gateway_pycache_before_import = original_purge
+        assert result.returncode == 1
+        assert "Direct module execution is unsupported" in result.stderr
+        assert "hermes gateway run" in result.stderr

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -5,8 +5,11 @@ crash; these prove the guard that turns it into a clear "restart the gateway"
 message before a model switch can hit it.
 """
 
+import importlib
+import importlib.abc
+from importlib.machinery import ModuleSpec
 import subprocess
-from pathlib import Path
+import sys
 
 import pytest
 
@@ -169,67 +172,6 @@ class TestBootstrapBytecodePurge:
         assert calls == [(False, True)], f"service path expected, got {calls}"
 
 
-class TestPurgeStalePycache:
-    """Tests for purge_stale_pycache — purging __pycache__ when the checkout
-    advanced between the previous gateway boot and the current one."""
-
-    def test_no_purge_when_previous_fingerprint_missing(self, monkeypatch, tmp_path):
-        """No persisted fingerprint file → nothing to compare → no purge."""
-        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567")
-        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: tmp_path / "nonexistent")
-        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
-        assert code_skew.purge_stale_pycache() is False
-
-    def test_no_purge_when_fingerprints_match(self, monkeypatch, tmp_path):
-        """Same checkout as previous boot → no drift → no purge."""
-        fp_file = tmp_path / ".gateway_boot_fingerprint"
-        fp_file.write_text("git:refs/heads/main:abc1234567")
-        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567")
-        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
-        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
-        assert code_skew.purge_stale_pycache() is False
-
-    def test_purges_pyc_files_on_drift(self, monkeypatch, tmp_path):
-        """Drift detected → .pyc files inside __pycache__ are deleted."""
-        fp_file = tmp_path / ".gateway_boot_fingerprint"
-        fp_file.write_text("git:refs/heads/main:oldhash123")
-        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:newhash456")
-        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
-        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
-
-        # Create a fake __pycache__ with .pyc files
-        pycache = tmp_path / "gateway" / "__pycache__"
-        pycache.mkdir(parents=True)
-        (pycache / "slash_commands.cpython-311.pyc").write_bytes(b"stale bytecode")
-        (pycache / "run.cpython-311.pyc").write_bytes(b"stale bytecode")
-
-        assert code_skew.purge_stale_pycache() is True
-        assert not (pycache / "slash_commands.cpython-311.pyc").exists()
-        assert not (pycache / "run.cpython-311.pyc").exists()
-
-    def test_skips_venv_pycache(self, monkeypatch, tmp_path):
-        """.pyc inside .venv are not purged (they're managed by pip)."""
-        fp_file = tmp_path / ".gateway_boot_fingerprint"
-        fp_file.write_text("git:refs/heads/main:oldhash123")
-        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:newhash456")
-        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
-        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
-
-        venv_pycache = tmp_path / ".venv" / "lib" / "__pycache__"
-        venv_pycache.mkdir(parents=True)
-        (venv_pycache / "site.cpython-311.pyc").write_bytes(b"should not be touched")
-
-        code_skew.purge_stale_pycache()
-        assert (venv_pycache / "site.cpython-311.pyc").exists()
-
-    def test_no_purge_when_fingerprint_unreadable(self, monkeypatch, tmp_path):
-        """If _fingerprint returns None (non-git), no purge."""
-        monkeypatch.setattr(code_skew, "_fingerprint", lambda: None)
-        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: tmp_path / "x")
-        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
-        assert code_skew.purge_stale_pycache() is False
-
-
 class TestPersistBootFingerprint:
     def test_persists_fingerprint_to_file(self, monkeypatch, tmp_path):
         fp_file = tmp_path / ".gateway_boot_fingerprint"
@@ -243,16 +185,60 @@ class TestPersistBootFingerprint:
         code_skew._persist_boot_fingerprint(None)
         assert not fp_file.exists()
 
-    def test_canonical_gateway_launcher_bootstraps_before_import(self):
-        launcher = Path(__file__).parents[1] / "hermes_cli" / "gateway.py"
-        source = launcher.read_text(encoding="utf-8")
+    def test_direct_module_path_bootstraps_before_gateway_run_import(self, monkeypatch, tmp_path):
+        """Package initialization is the pre-import boundary for ``-m``."""
+        marker = tmp_path / "bootstrap-ran"
+        import gateway
+        from hermes_cli import gateway_bootstrap
 
-        assert source.index("purge_stale_gateway_pycache_before_import()") < source.index(
-            "from gateway.run import start_gateway"
+        main_module = sys.modules["__main__"]
+        original_main_spec = main_module.__spec__
+        original_run = sys.modules.get("gateway.run")
+        missing = object()
+        original_package_run = gateway.__dict__.get("run", missing)
+        original_purge = gateway.__dict__.get(
+            "purge_stale_gateway_pycache_before_import", missing
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            gateway_bootstrap,
+            "purge_stale_gateway_pycache_before_import",
+            lambda: marker.write_text("ran", encoding="utf-8"),
         )
 
-    def test_direct_module_execution_fails_closed(self):
-        run_source = Path(__file__).parents[1] / "gateway" / "run.py"
-        source = run_source.read_text(encoding="utf-8")
+        observed_import = []
 
-        assert "Direct module execution is unsupported" in source
+        class BootstrapProbe(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "gateway.run":
+                    assert marker.read_text(encoding="utf-8") == "ran"
+                    observed_import.append(fullname)
+                return None
+
+        probe = BootstrapProbe()
+        try:
+            main_module.__spec__ = ModuleSpec("gateway.run", loader=None)
+            importlib.reload(gateway)
+            assert marker.read_text(encoding="utf-8") == "ran"
+
+            sys.modules.pop("gateway.run", None)
+            gateway.__dict__.pop("run", None)
+            sys.meta_path.insert(0, probe)
+            importlib.import_module("gateway.run")
+            assert observed_import == ["gateway.run"]
+        finally:
+            if probe in sys.meta_path:
+                sys.meta_path.remove(probe)
+            main_module.__spec__ = original_main_spec
+            if original_run is None:
+                sys.modules.pop("gateway.run", None)
+            else:
+                sys.modules["gateway.run"] = original_run
+            if original_package_run is missing:
+                gateway.__dict__.pop("run", None)
+            else:
+                setattr(gateway, "run", original_package_run)
+            if original_purge is missing:
+                gateway.__dict__.pop("purge_stale_gateway_pycache_before_import", None)
+            else:
+                gateway.purge_stale_gateway_pycache_before_import = original_purge

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -107,3 +107,132 @@ class TestBootstrapBytecodePurge:
 
         assert gateway_bootstrap.purge_stale_gateway_pycache_before_import() is True
         assert not stale_pyc.exists()
+    def test_guard_falls_back_to_manual_when_restart_fails(self, monkeypatch):
+        """If request_restart returns False (e.g. already restarting), the
+        guard falls back to the manual restart message."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+
+        class FakeRunner:
+            def request_restart(self, *, detached=False, via_service=False):
+                return False  # restart already in progress
+
+        msg = slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert msg is not None
+        assert "hermes gateway restart" in msg  # manual fallback
+
+    def test_guard_falls_back_to_manual_without_runner(self, monkeypatch):
+        """Without a runner, the guard returns the manual restart message
+        (preserving backwards compatibility for any caller not yet passing one)."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+        msg = slash_commands._model_switch_skew_guard()
+        assert msg is not None
+        assert "hermes gateway restart" in msg
+
+    def test_guard_passes_correct_restart_flags_for_env(self, monkeypatch):
+        """The guard must mirror _handle_restart_command's environment
+        detection: under launchd/systemd or in a container, use the service
+        path (via_service=True); otherwise detached=True. The defaults
+        (detached=False, via_service=False) match neither path and can
+        leave the gateway stopped instead of restarted."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+
+        calls = []
+
+        class FakeRunner:
+            def request_restart(self, *, detached=False, via_service=False):
+                calls.append((detached, via_service))
+                return True
+
+        # Simulate macOS launchd (XPC_SERVICE_NAME set, not "0")
+        monkeypatch.setenv("XPC_SERVICE_NAME", "com.apple.xpc.launchd")
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert calls == [(False, True)], f"service path expected, got {calls}"
+
+        # Simulate plain shell (no service manager) → detached path
+        calls.clear()
+        monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert calls == [(True, False)], f"detached path expected, got {calls}"
+
+
+class TestPurgeStalePycache:
+    """Tests for purge_stale_pycache — purging __pycache__ when the checkout
+    advanced between the previous gateway boot and the current one."""
+
+    def test_no_purge_when_previous_fingerprint_missing(self, monkeypatch, tmp_path):
+        """No persisted fingerprint file → nothing to compare → no purge."""
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567")
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: tmp_path / "nonexistent")
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+        assert code_skew.purge_stale_pycache() is False
+
+    def test_no_purge_when_fingerprints_match(self, monkeypatch, tmp_path):
+        """Same checkout as previous boot → no drift → no purge."""
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        fp_file.write_text("git:refs/heads/main:abc1234567")
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567")
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+        assert code_skew.purge_stale_pycache() is False
+
+    def test_purges_pyc_files_on_drift(self, monkeypatch, tmp_path):
+        """Drift detected → .pyc files inside __pycache__ are deleted."""
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        fp_file.write_text("git:refs/heads/main:oldhash123")
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:newhash456")
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+
+        # Create a fake __pycache__ with .pyc files
+        pycache = tmp_path / "gateway" / "__pycache__"
+        pycache.mkdir(parents=True)
+        (pycache / "slash_commands.cpython-311.pyc").write_bytes(b"stale bytecode")
+        (pycache / "run.cpython-311.pyc").write_bytes(b"stale bytecode")
+
+        assert code_skew.purge_stale_pycache() is True
+        assert not (pycache / "slash_commands.cpython-311.pyc").exists()
+        assert not (pycache / "run.cpython-311.pyc").exists()
+
+    def test_skips_venv_pycache(self, monkeypatch, tmp_path):
+        """.pyc inside .venv are not purged (they're managed by pip)."""
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        fp_file.write_text("git:refs/heads/main:oldhash123")
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:newhash456")
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+
+        venv_pycache = tmp_path / ".venv" / "lib" / "__pycache__"
+        venv_pycache.mkdir(parents=True)
+        (venv_pycache / "site.cpython-311.pyc").write_bytes(b"should not be touched")
+
+        code_skew.purge_stale_pycache()
+        assert (venv_pycache / "site.cpython-311.pyc").exists()
+
+    def test_no_purge_when_fingerprint_unreadable(self, monkeypatch, tmp_path):
+        """If _fingerprint returns None (non-git), no purge."""
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: None)
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: tmp_path / "x")
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+        assert code_skew.purge_stale_pycache() is False
+
+
+class TestPersistBootFingerprint:
+    def test_persists_fingerprint_to_file(self, monkeypatch, tmp_path):
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
+        code_skew._persist_boot_fingerprint("git:refs/heads/main:abcdef1234")
+        assert fp_file.read_text() == "git:refs/heads/main:abcdef1234"
+
+    def test_does_not_persist_none(self, monkeypatch, tmp_path):
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
+        code_skew._persist_boot_fingerprint(None)
+        assert not fp_file.exists()

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -5,6 +5,9 @@ crash; these prove the guard that turns it into a clear "restart the gateway"
 message before a model switch can hit it.
 """
 
+import subprocess
+from pathlib import Path
+
 import pytest
 
 from gateway import code_skew
@@ -77,3 +80,30 @@ class TestModelSwitchSkewGuard:
         assert "abc1234567" in msg
         assert "def4567890" in msg
         assert "hermes gateway restart" in msg
+
+
+class TestBootstrapBytecodePurge:
+    def test_purges_stale_gateway_bytecode_before_gateway_run_import(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_cli import gateway_bootstrap
+
+        project_root = tmp_path / "repo"
+        pycache = project_root / "gateway" / "__pycache__"
+        pycache.mkdir(parents=True)
+        stale_pyc = pycache / "run.cpython-311.pyc"
+        stale_pyc.write_bytes(b"stale")
+        hermes_home = tmp_path / "home"
+        hermes_home.mkdir()
+        (hermes_home / ".gateway_boot_fingerprint").write_text("git:HEAD:oldsha")
+
+        monkeypatch.setattr(gateway_bootstrap, "PROJECT_ROOT", project_root)
+        monkeypatch.setattr(gateway_bootstrap, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(
+            gateway_bootstrap.subprocess,
+            "run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "newsha\n", ""),
+        )
+
+        assert gateway_bootstrap.purge_stale_gateway_pycache_before_import() is True
+        assert not stale_pyc.exists()

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -250,3 +250,9 @@ class TestPersistBootFingerprint:
         assert source.index("purge_stale_gateway_pycache_before_import()") < source.index(
             "from gateway.run import start_gateway"
         )
+
+    def test_direct_module_execution_fails_closed(self):
+        run_source = Path(__file__).parents[1] / "gateway" / "run.py"
+        source = run_source.read_text(encoding="utf-8")
+
+        assert "Direct module execution is unsupported" in source

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -5,7 +5,7 @@ crash; these prove the guard that turns it into a clear "restart the gateway"
 message before a model switch can hit it.
 """
 
-import ast
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -110,39 +110,80 @@ class TestBootstrapBytecodePurge:
         assert gateway_bootstrap.purge_stale_gateway_pycache_before_import() is True
         assert not stale_pyc.exists()
 
-    def test_every_supported_launcher_bootstraps_before_gateway_run_import(self):
+    def test_supported_launchers_bootstrap_before_gateway_run_import(self, tmp_path):
+        """Exercise each real launcher with an isolated HERMES_HOME.
+
+        ``sitecustomize`` wraps the canonical bootstrap in the child process,
+        then intercepts the fresh ``gateway.run`` import. The import hook exits
+        before gateway startup, so this verifies import order without a live
+        gateway or source-code inspection.
+        """
         project_root = Path(__file__).parents[1]
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        head = subprocess.check_output(
+            ["git", "-C", str(project_root), "rev-parse", "HEAD"], text=True
+        ).strip()
+        (hermes_home / ".gateway_boot_fingerprint").write_text(f"git:HEAD:{head}")
+        probe_dir = tmp_path / "probe"
+        probe_dir.mkdir()
+        marker = tmp_path / "bootstrap-marker"
+        (probe_dir / "sitecustomize.py").write_text(
+            """
+import os
+import sys
+from pathlib import Path
+from hermes_cli import gateway_bootstrap
+
+marker = Path(os.environ["HERMES_LAUNCHER_PROBE"])
+expected_home = Path(os.environ["HERMES_HOME"]).resolve()
+original_purge = gateway_bootstrap.purge_stale_gateway_pycache_before_import
+
+def probe_purge():
+    assert gateway_bootstrap.get_hermes_home().resolve() == expected_home
+    marker.write_text("bootstrap-ran", encoding="utf-8")
+    return original_purge()
+
+gateway_bootstrap.purge_stale_gateway_pycache_before_import = probe_purge
+
+class GatewayRunImportProbe:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "gateway.run":
+            assert marker.read_text(encoding="utf-8") == "bootstrap-ran"
+            marker.write_text("bootstrap-before-gateway-run", encoding="utf-8")
+            raise SystemExit(0)
+        return None
+
+sys.meta_path.insert(0, GatewayRunImportProbe())
+""".lstrip(),
+            encoding="utf-8",
+        )
+        env = {
+            **os.environ,
+            "HERMES_HOME": str(hermes_home),
+            "HERMES_LAUNCHER_PROBE": str(marker),
+            "PYTHONPATH": os.pathsep.join((str(probe_dir), str(project_root))),
+        }
+        hermes_cli = Path(sys.executable).parent / "hermes"
+        assert hermes_cli.exists(), f"Canonical Hermes console script missing: {hermes_cli}"
         launchers = (
-            project_root / "cli.py",
-            project_root / "hermes_cli" / "gateway.py",
-            project_root / "scripts" / "hermes-gateway",
+            [sys.executable, "cli.py", "--gateway"],
+            [str(hermes_cli), "gateway", "run", "--no-supervise", "--force"],
+            [sys.executable, "scripts/hermes-gateway", "run"],
         )
 
-        for launcher in launchers:
-            tree = ast.parse(launcher.read_text(encoding="utf-8"), filename=str(launcher))
-            bootstrap_imports = [
-                node.lineno
-                for node in ast.walk(tree)
-                if isinstance(node, ast.ImportFrom)
-                and node.module == "hermes_cli.gateway_bootstrap"
-            ]
-            purge_calls = [
-                node.lineno
-                for node in ast.walk(tree)
-                if isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
-                and node.func.id == "purge_stale_gateway_pycache_before_import"
-            ]
-            gateway_run_imports = [
-                node.lineno
-                for node in ast.walk(tree)
-                if isinstance(node, ast.ImportFrom) and node.module == "gateway.run"
-            ]
-
-            assert bootstrap_imports, f"{launcher} must import the pre-import bootstrap"
-            assert purge_calls, f"{launcher} must invoke the pre-import bootstrap"
-            assert gateway_run_imports, f"{launcher} must import gateway.run"
-            assert min(bootstrap_imports) < min(purge_calls) < min(gateway_run_imports)
+        for command in launchers:
+            marker.unlink(missing_ok=True)
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                cwd=project_root,
+                env=env,
+                text=True,
+                timeout=30,
+            )
+            assert result.returncode == 0, result.stderr
+            assert marker.read_text(encoding="utf-8") == "bootstrap-before-gateway-run"
     def test_guard_falls_back_to_manual_when_restart_fails(self, monkeypatch):
         """If request_restart returns False (e.g. already restarting), the
         guard falls back to the manual restart message."""

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -258,16 +258,3 @@ class TestPersistBootFingerprint:
         monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
         code_skew._persist_boot_fingerprint(None)
         assert not fp_file.exists()
-
-    def test_direct_module_execution_has_documented_cli_migration(self):
-        result = subprocess.run(
-            [sys.executable, "-m", "gateway.run"],
-            capture_output=True,
-            cwd=Path(__file__).parents[1],
-            text=True,
-            timeout=30,
-        )
-
-        assert result.returncode == 1
-        assert "Direct module execution is unsupported" in result.stderr
-        assert "hermes gateway run" in result.stderr


### PR DESCRIPTION
## Summary

Reload a gateway safely when its checkout changes underneath a long-lived process.

## Root cause

A gateway retains imported modules for its lifetime. After a checkout update, a later lazy import can combine new source with an old in-memory dependency. Cached bytecode can also survive into the next boot when the checkout changed.

## Fix

- Persist the gateway boot fingerprint and remove stale gateway bytecode before supported launchers import `gateway.run`.
- Trigger a graceful reload for `/model` code skew instead of only refusing the command.
- Use the shared supervisor detector so launchd, systemd, s6, and externally supervised gateways select the service restart path.
- Reject direct `python -m gateway.run` execution because it cannot establish the required pre-import bootstrap boundary.

## Non-goals

This does not replay the original `/model` command after reload. The gateway reports that the reload is in progress and asks the user to re-run the command.

## Test plan

- `pytest tests/test_code_skew.py -q -o 'addopts='` — 23 passed
- `ruff check` on changed Python files
- `py_compile` on changed Python and launcher files
- `git diff --check`
- Independent CoVe review — PASS
- Local runtime activation and Telegram model-switch validation
