### PR TITLE
feat(api): add safe MCP reload control endpoint

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2011,7 +2011,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 "health": {"method": "GET", "path": "/health"},
                 "health_detailed": {"method": "GET", "path": "/health/detailed"},
                 "models": {"method": "GET", "path": "/v1/models"},
-                "mcp_reload": {"method": "POST", "path": "/v1/mcp/reload"},
+                "mcp_reload": {
+                    "method": "POST",
+                    "path": "/v1/mcp/reload",
+                    "caller_must_quiesce_new_work": True,
+                },
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
                 "responses": {"method": "POST", "path": "/v1/responses"},
                 "runs": {"method": "POST", "path": "/v1/runs"},

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2057,7 +2057,9 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return web.json_response(_openai_error("Invalid request body", code="invalid_request"), status=400)
 
-        # Refuse rather than mutate tool snapshots beneath an in-flight turn.
+        # Refuse when work is already active rather than deliberately mutate
+        # tool snapshots beneath an in-flight turn. The owning control plane
+        # must also quiesce new-work admission for the reload duration.
         # Read the whole gateway count when available so an API control caller
         # cannot reload while a separate messaging-platform turn is active.
         runner = self.gateway_runner or request.app.get("gateway_runner")
@@ -2089,17 +2091,24 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=409,
                     headers={"Retry-After": "1"},
                 )
-            server_count = max(0, int(result.get("server_count", 0)))
-            tool_count = max(0, int(result.get("tool_count", 0)))
-        except Exception:
+        except Exception as exc:
             # MCP config errors can contain provider-specific details. Keep
             # them out of the control-plane response and avoid logging a raw
             # exception value that might include a materialized grant.
-            logger.warning("MCP control reload failed")
+            logger.warning("MCP control reload failed: %s", type(exc).__name__)
             return web.json_response(
                 _openai_error("MCP reload failed", code="mcp_reload_failed"),
                 status=503,
             )
+
+        def safe_count(value: Any) -> int:
+            try:
+                return max(0, int(value))
+            except (TypeError, ValueError):
+                return 0
+
+        server_count = safe_count(result.get("server_count", 0))
+        tool_count = safe_count(result.get("tool_count", 0))
 
         return web.json_response({
             "object": "hermes.mcp_reload",

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -8,6 +8,7 @@ Exposes an HTTP server with endpoints:
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
 - GET  /v1/capabilities            — machine-readable API capabilities for external UIs
+- POST /v1/mcp/reload              — reconnect already-materialized MCP configuration
 - GET  /api/sessions               — list client-visible Hermes sessions
 - POST /api/sessions               — create an empty Hermes session
 - GET/PATCH/DELETE /api/sessions/{session_id} — read/update/delete a session
@@ -931,6 +932,7 @@ class APIServerAdapter(BasePlatformAdapter):
     # background=True) must NOT promise delivery on this path — see
     # ``async_delivery_supported()``.
     supports_async_delivery: bool = False
+    MCP_RELOAD_CONTRACT_VERSION = "1"
 
     # Same statelessness applies to the startup auto-resume prompt: no client
     # is waiting to answer "session restored — what next?", so a resumed turn
@@ -1483,6 +1485,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/health", self._handle_health),
             ("GET", "/v1/models", self._handle_models),
             ("GET", "/v1/capabilities", self._handle_capabilities),
+            ("POST", "/v1/mcp/reload", self._handle_mcp_reload),
             ("GET", "/v1/skills", self._handle_skills),
             ("GET", "/v1/toolsets", self._handle_toolsets),
             ("GET", "/api/sessions", self._handle_list_sessions),
@@ -2001,12 +2004,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
+                "mcp_reload": True,
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
                 "health": {"method": "GET", "path": "/health"},
                 "health_detailed": {"method": "GET", "path": "/health/detailed"},
                 "models": {"method": "GET", "path": "/v1/models"},
+                "mcp_reload": {"method": "POST", "path": "/v1/mcp/reload"},
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
                 "responses": {"method": "POST", "path": "/v1/responses"},
                 "runs": {"method": "POST", "path": "/v1/runs"},
@@ -2026,6 +2031,82 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
             },
+        })
+
+    async def _handle_mcp_reload(self, request: "web.Request") -> "web.Response":
+        """POST /v1/mcp/reload — safely reconnect materialized MCP config.
+
+        This is deliberately a control operation, not a configuration API.
+        It accepts no URL, header, credential, or server name: the owning
+        control plane must atomically materialize the already-approved config
+        and secret delivery handle before calling this endpoint.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        # Do not silently accept an arbitrary configuration payload. The
+        # control plane writes config/grants through its own protected prepare
+        # boundary; this endpoint only applies that already-materialized state.
+        try:
+            if (await request.read()).strip():
+                return web.json_response(
+                    _openai_error("MCP reload does not accept a request body", code="mcp_reload_body_forbidden"),
+                    status=400,
+                )
+        except Exception:
+            return web.json_response(_openai_error("Invalid request body", code="invalid_request"), status=400)
+
+        # Refuse rather than mutate tool snapshots beneath an in-flight turn.
+        # Read the whole gateway count when available so an API control caller
+        # cannot reload while a separate messaging-platform turn is active.
+        runner = self.gateway_runner or request.app.get("gateway_runner")
+        if runner is None or not callable(getattr(runner, "try_reload_mcp_servers", None)):
+            return web.json_response(
+                _openai_error("MCP reload control is unavailable", code="mcp_reload_unavailable"),
+                status=503,
+            )
+
+        try:
+            active_work = max(0, int(runner._active_work_count()))
+        except Exception:
+            # Fail closed when the runner cannot report an authoritative count.
+            return web.json_response(
+                _openai_error("MCP reload activity state is unavailable", code="mcp_reload_unavailable"),
+                status=503,
+            )
+        if active_work:
+            return web.json_response(
+                _openai_error("MCP reload requires no active agent work", code="mcp_reload_busy"),
+                status=409,
+                headers={"Retry-After": "1"},
+            )
+        try:
+            result = await runner.try_reload_mcp_servers()
+            if result is None:
+                return web.json_response(
+                    _openai_error("MCP reload is already in progress", code="mcp_reload_busy"),
+                    status=409,
+                    headers={"Retry-After": "1"},
+                )
+            server_count = max(0, int(result.get("server_count", 0)))
+            tool_count = max(0, int(result.get("tool_count", 0)))
+        except Exception:
+            # MCP config errors can contain provider-specific details. Keep
+            # them out of the control-plane response and avoid logging a raw
+            # exception value that might include a materialized grant.
+            logger.warning("MCP control reload failed")
+            return web.json_response(
+                _openai_error("MCP reload failed", code="mcp_reload_failed"),
+                status=503,
+            )
+
+        return web.json_response({
+            "object": "hermes.mcp_reload",
+            "status": "reloaded",
+            "contract_version": self.MCP_RELOAD_CONTRACT_VERSION,
+            "server_count": server_count,
+            "tool_count": tool_count,
         })
 
     async def _handle_skills(self, request: "web.Request") -> "web.Response":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15151,7 +15151,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             async with self._get_mcp_reload_lock():
                 # Re-check at the point the process-global registry is about
                 # to change. The API handler performs the first fast-fail;
-                # this closes the queued-behind-an-interactive-reload window.
+                # this avoids reloading after a queued interactive reload, but
+                # control-plane callers must still quiesce new-work admission.
                 if self._active_work_count() > 0:
                     return None
                 return await self._reload_mcp_servers_locked()
@@ -15208,11 +15209,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             continue
                         if _agent is not None:
                             refresh_agent_mcp_tools(_agent, quiet_mode=True)
-        except Exception:
+        except Exception as exc:
             # The server connections have already been safely replaced. A
             # cache refresh failure is observable in logs but must not roll the
             # connection back into a half-reloaded state.
-            logger.debug("Failed to update cached agent tools after MCP reload")
+            logger.debug("Failed to update cached agent tools after MCP reload: %s", type(exc).__name__)
 
         return {
             "added": added,
@@ -15275,11 +15276,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             return "\n".join(lines)
 
-        except Exception:
+        except Exception as exc:
             # A config or transport exception can include materialized MCP
             # connection details. Keep the interactive command diagnostic
             # useful without reflecting that value into chat or logs.
-            logger.warning("MCP reload failed")
+            logger.warning("MCP reload failed: %s", type(exc).__name__)
             return t("gateway.reload_mcp.failed", error="an internal error")
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15129,6 +15129,99 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+    def _get_mcp_reload_lock(self) -> "asyncio.Lock":
+        """Return the gateway-wide MCP reconnect lock (also works in tests)."""
+        lock = getattr(self, "_mcp_reload_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._mcp_reload_lock = lock
+        return lock
+
+    async def try_reload_mcp_servers(self) -> Optional[Dict[str, Any]]:
+        """Start a control-plane reload, or return ``None`` when one is live.
+
+        The boolean claim is deliberately set before the first await, making a
+        same-loop double submit deterministic.  The lower-level lock still
+        serializes this operation with interactive ``/reload-mcp`` calls.
+        """
+        if getattr(self, "_mcp_control_reload_claimed", False):
+            return None
+        self._mcp_control_reload_claimed = True
+        try:
+            async with self._get_mcp_reload_lock():
+                # Re-check at the point the process-global registry is about
+                # to change. The API handler performs the first fast-fail;
+                # this closes the queued-behind-an-interactive-reload window.
+                if self._active_work_count() > 0:
+                    return None
+                return await self._reload_mcp_servers_locked()
+        finally:
+            self._mcp_control_reload_claimed = False
+
+    async def reload_mcp_servers(self) -> Dict[str, Any]:
+        """Serialize all MCP reconnect paths against the process-global registry."""
+        async with self._get_mcp_reload_lock():
+            return await self._reload_mcp_servers_locked()
+
+    async def _reload_mcp_servers_locked(self) -> Dict[str, Any]:
+        """Reconnect configured MCP servers and refresh cached agent tools.
+
+        This is the non-interactive primitive shared by the user-facing
+        ``/reload-mcp`` command and trusted control planes.  It reads only the
+        already-materialized Hermes configuration: callers cannot provide an
+        MCP URL, header, or any other config value.  Returned server names are
+        intentionally for local gateway presentation only; API callers must
+        expose counts, never configuration-derived identifiers.
+        """
+        loop = asyncio.get_running_loop()
+        from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+
+        # Capture old server names before shutdown.
+        with _lock:
+            old_servers = set(_servers.keys())
+
+        # Discovery reloads the on-disk config after every old connection has
+        # been closed, so a rotated connection credential never leaves the
+        # former client live beside the replacement.
+        await loop.run_in_executor(None, shutdown_mcp_servers)
+        new_tools = await loop.run_in_executor(None, discover_mcp_tools)
+
+        with _lock:
+            connected_servers = set(_servers.keys())
+
+        added = connected_servers - old_servers
+        removed = old_servers - connected_servers
+        reconnected = connected_servers & old_servers
+
+        # Refresh cached agents so their next turn sees the new tool surface.
+        # Keep each agent's build-time toolset restrictions intact.
+        try:
+            from tools.mcp_tool import refresh_agent_mcp_tools
+            _cache = getattr(self, "_agent_cache", None)
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            if _cache_lock is not None and _cache:
+                with _cache_lock:
+                    for _sess_key, _entry in list(_cache.items()):
+                        try:
+                            _agent = _entry[0] if isinstance(_entry, tuple) else _entry
+                        except Exception:
+                            continue
+                        if _agent is not None:
+                            refresh_agent_mcp_tools(_agent, quiet_mode=True)
+        except Exception:
+            # The server connections have already been safely replaced. A
+            # cache refresh failure is observable in logs but must not roll the
+            # connection back into a half-reloaded state.
+            logger.debug("Failed to update cached agent tools after MCP reload")
+
+        return {
+            "added": added,
+            "removed": removed,
+            "reconnected": reconnected,
+            "server_count": len(connected_servers),
+            "tool_count": len(new_tools),
+        }
+
     async def _execute_mcp_reload(self, event: MessageEvent) -> str:
         """Actually disconnect, reconnect, and notify MCP tool changes.
 
@@ -15136,28 +15229,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         wrapper can invoke the same path whether the user confirmed via
         button, text reply, or has the confirm gate disabled.
         """
-        loop = asyncio.get_running_loop()
         try:
-            from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
-
-            # Capture old server names before shutdown
-            with _lock:
-                old_servers = set(_servers.keys())
-
-            # Read new config before shutting down, so we know what will be added/removed
-            # Shutdown existing connections
-            await loop.run_in_executor(None, shutdown_mcp_servers)
-
-            # Reconnect by discovering tools (reads config.yaml fresh)
-            new_tools = await loop.run_in_executor(None, discover_mcp_tools)
-
-            # Compute what changed
-            with _lock:
-                connected_servers = set(_servers.keys())
-
-            added = connected_servers - old_servers
-            removed = old_servers - connected_servers
-            reconnected = connected_servers & old_servers
+            result = await self.reload_mcp_servers()
+            added = result["added"]
+            removed = result["removed"]
+            reconnected = result["reconnected"]
+            connected_servers = result["server_count"]
+            new_tools = result["tool_count"]
 
             lines = [t("gateway.reload_mcp.header")]
             if reconnected:
@@ -15169,42 +15247,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not connected_servers:
                 lines.append(t("gateway.reload_mcp.none_connected"))
             else:
-                lines.append(t("gateway.reload_mcp.tools_available", tools=len(new_tools), servers=len(connected_servers)))
-
-            # Refresh cached agents so existing sessions see new MCP tools on
-            # their next turn — without this, the user has to `/new` (which
-            # discards conversation history) to pick up tools from a server
-            # that was just added or reconnected. The user has already
-            # consented to the prompt-cache invalidation via the slash-confirm
-            # gate in _handle_reload_mcp_command before we reach this point.
-            try:
-                from tools.mcp_tool import refresh_agent_mcp_tools
-                _cache = getattr(self, "_agent_cache", None)
-                _cache_lock = getattr(self, "_agent_cache_lock", None)
-                if _cache_lock is not None and _cache:
-                    with _cache_lock:
-                        for _sess_key, _entry in list(_cache.items()):
-                            try:
-                                _agent = _entry[0] if isinstance(_entry, tuple) else _entry
-                            except Exception:
-                                continue
-                            if _agent is None:
-                                continue
-                            # Preserve each cached agent's build-time toolset
-                            # selection EXACTLY: a gateway session built with a
-                            # restricted enabled_toolsets (e.g. ["safe"]) must
-                            # NOT silently gain tools after a reload. This is the
-                            # opposite of the interactive CLI/TUI /reload-mcp,
-                            # which is a single user re-applying their own config
-                            # edit; gateway agents are per-session and may be
-                            # deliberately locked down. (Contract is asserted by
-                            # test_reload_mcp_preserves_per_agent_toolset_overrides.)
-                            refresh_agent_mcp_tools(_agent, quiet_mode=True)
-            except Exception as _exc:
-                logger.debug(
-                    "Failed to update cached agent tools after MCP reload: %s",
-                    _exc,
-                )
+                lines.append(t("gateway.reload_mcp.tools_available", tools=new_tools, servers=connected_servers))
 
             # Inject a message at the END of the session history so the
             # model knows tools changed on its next turn.  Appended after
@@ -15216,7 +15259,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 change_parts.append(f"Removed servers: {', '.join(sorted(removed))}")
             if reconnected:
                 change_parts.append(f"Reconnected servers: {', '.join(sorted(reconnected))}")
-            tool_summary = f"{len(new_tools)} MCP tool(s) now available" if new_tools else "No MCP tools available"
+            tool_summary = f"{new_tools} MCP tool(s) now available" if new_tools else "No MCP tools available"
             change_detail = ". ".join(change_parts) + ". " if change_parts else ""
             reload_msg = {
                 "role": "user",
@@ -15232,9 +15275,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             return "\n".join(lines)
 
-        except Exception as e:
-            logger.warning("MCP reload failed: %s", e)
-            return t("gateway.reload_mcp.failed", error=e)
+        except Exception:
+            # A config or transport exception can include materialized MCP
+            # connection details. Keep the interactive command diagnostic
+            # useful without reflecting that value into chat or logs.
+            logger.warning("MCP reload failed")
+            return t("gateway.reload_mcp.failed", error="an internal error")
 
 
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -989,7 +989,11 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["mcp_reload"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
-            assert data["endpoints"]["mcp_reload"] == {"method": "POST", "path": "/v1/mcp/reload"}
+            assert data["endpoints"]["mcp_reload"] == {
+                "method": "POST",
+                "path": "/v1/mcp/reload",
+                "caller_must_quiesce_new_work": True,
+            }
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1101,6 +1101,23 @@ class TestMcpReloadEndpoint:
         runner.try_reload_mcp_servers.assert_awaited_once_with()
 
     @pytest.mark.asyncio
+    async def test_reload_defaults_malformed_counts_after_a_successful_reload(self, auth_adapter):
+        runner = MagicMock()
+        runner._active_work_count.return_value = 0
+        runner.try_reload_mcp_servers = AsyncMock(return_value={
+            "server_count": None,
+            "tool_count": "not-a-count",
+        })
+        auth_adapter.gateway_runner = runner
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/v1/mcp/reload", headers={"Authorization": "Bearer sk-secret"})
+            assert response.status == 200
+            body = await response.json()
+            assert body["server_count"] == 0
+            assert body["tool_count"] == 0
+
+    @pytest.mark.asyncio
     async def test_reload_returns_busy_when_another_control_reload_has_claimed_it(self, auth_adapter):
         runner = MagicMock()
         runner._active_work_count.return_value = 0

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -646,6 +646,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/health", adapter._handle_health)
     app.router.add_get("/v1/models", adapter._handle_models)
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_post("/v1/mcp/reload", adapter._handle_mcp_reload)
     app.router.add_get("/v1/skills", adapter._handle_skills)
     app.router.add_get("/v1/toolsets", adapter._handle_toolsets)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
@@ -986,7 +987,9 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["mcp_reload"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
+            assert data["endpoints"]["mcp_reload"] == {"method": "POST", "path": "/v1/mcp/reload"}
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
@@ -1005,6 +1008,124 @@ class TestCapabilitiesEndpoint:
             assert authed.status == 200
             data = await authed.json()
             assert data["auth"]["required"] is True
+
+
+# ---------------------------------------------------------------------------
+# /v1/mcp/reload control endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestMcpReloadEndpoint:
+    @pytest.mark.asyncio
+    async def test_reload_requires_api_bearer_auth(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/v1/mcp/reload")
+            assert response.status == 401
+
+    @pytest.mark.asyncio
+    async def test_reload_fails_closed_without_control_runner(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/v1/mcp/reload", headers={"Authorization": "Bearer sk-secret"})
+            assert response.status == 503
+            assert (await response.json())["error"]["code"] == "mcp_reload_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_reload_fails_closed_when_activity_cannot_be_read(self, auth_adapter):
+        runner = MagicMock()
+        runner._active_work_count.side_effect = RuntimeError("state unavailable")
+        runner.try_reload_mcp_servers = AsyncMock()
+        auth_adapter.gateway_runner = runner
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/v1/mcp/reload", headers={"Authorization": "Bearer sk-secret"})
+            assert response.status == 503
+            assert (await response.json())["error"]["code"] == "mcp_reload_unavailable"
+        runner.try_reload_mcp_servers.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reload_rejects_active_work_without_calling_runner(self, auth_adapter):
+        runner = MagicMock()
+        runner._active_work_count.return_value = 1
+        runner.try_reload_mcp_servers = AsyncMock()
+        auth_adapter.gateway_runner = runner
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/v1/mcp/reload", headers={"Authorization": "Bearer sk-secret"})
+            assert response.status == 409
+            assert (await response.json())["error"]["code"] == "mcp_reload_busy"
+            assert response.headers["Retry-After"] == "1"
+        runner.try_reload_mcp_servers.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reload_rejects_configuration_payload(self, auth_adapter):
+        runner = MagicMock()
+        runner._active_work_count.return_value = 0
+        runner.try_reload_mcp_servers = AsyncMock()
+        auth_adapter.gateway_runner = runner
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/v1/mcp/reload",
+                data='{"url":"https://attacker.invalid/mcp","headers":{"Authorization":"Bearer secret"}}',
+                headers={"Authorization": "Bearer sk-secret", "Content-Type": "application/json"},
+            )
+            assert response.status == 400
+            assert (await response.json())["error"]["code"] == "mcp_reload_body_forbidden"
+        runner.try_reload_mcp_servers.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reload_returns_only_safe_counts(self, auth_adapter):
+        runner = MagicMock()
+        runner._active_work_count.return_value = 0
+        runner.try_reload_mcp_servers = AsyncMock(return_value={
+            "server_count": 1,
+            "tool_count": 3,
+            "added": {"circle"},
+            "removed": set(),
+            "reconnected": set(),
+        })
+        auth_adapter.gateway_runner = runner
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/v1/mcp/reload", headers={"Authorization": "Bearer sk-secret"})
+            assert response.status == 200
+            assert await response.json() == {
+                "object": "hermes.mcp_reload",
+                "status": "reloaded",
+                "contract_version": "1",
+                "server_count": 1,
+                "tool_count": 3,
+            }
+        runner.try_reload_mcp_servers.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_reload_returns_busy_when_another_control_reload_has_claimed_it(self, auth_adapter):
+        runner = MagicMock()
+        runner._active_work_count.return_value = 0
+        runner.try_reload_mcp_servers = AsyncMock(return_value=None)
+        auth_adapter.gateway_runner = runner
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/v1/mcp/reload", headers={"Authorization": "Bearer sk-secret"})
+            assert response.status == 409
+            assert (await response.json())["error"]["code"] == "mcp_reload_busy"
+        runner.try_reload_mcp_servers.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_reload_fails_closed_when_runner_raises(self, auth_adapter):
+        runner = MagicMock()
+        runner._active_work_count.return_value = 0
+        runner.try_reload_mcp_servers = AsyncMock(side_effect=RuntimeError("Bearer raw-grant-must-not-escape"))
+        auth_adapter.gateway_runner = runner
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/v1/mcp/reload", headers={"Authorization": "Bearer sk-secret"})
+            assert response.status == 503
+            body = await response.json()
+            assert body["error"]["code"] == "mcp_reload_failed"
+            assert "raw-grant-must-not-escape" not in str(body)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mcp_reload_refreshes_cached_agents.py
+++ b/tests/gateway/test_mcp_reload_refreshes_cached_agents.py
@@ -174,3 +174,27 @@ async def test_reload_mcp_preserves_per_agent_toolset_overrides():
     assert captured_calls, "get_tool_definitions was never called to refresh the cache"
     assert captured_calls[0]["enabled_toolsets"] == ["safe"]
     assert captured_calls[0]["disabled_toolsets"] == ["terminal"]
+
+
+@pytest.mark.asyncio
+async def test_control_reload_rechecks_active_work_under_shared_lock():
+    """A queued control reload must not change global MCP state after work starts."""
+    runner = _make_runner_with_cached_agents(num_agents=0)
+    runner._active_work_count = lambda: 1
+
+    with patch("tools.mcp_tool.shutdown_mcp_servers") as shutdown:
+        result = await runner.try_reload_mcp_servers()
+
+    assert result is None
+    shutdown.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_interactive_reload_never_reflects_mcp_error_details():
+    runner = _make_runner_with_cached_agents(num_agents=0)
+    secret = "Bearer materialized-grant-must-not-escape"
+
+    with patch("tools.mcp_tool.shutdown_mcp_servers", side_effect=RuntimeError(secret)):
+        result = await runner._execute_mcp_reload(_make_event())
+
+    assert secret not in result

--- a/tests/tools/test_mcp_config_secret_reload.py
+++ b/tests/tools/test_mcp_config_secret_reload.py
@@ -1,0 +1,53 @@
+"""Regression coverage for MCP credential rotation during gateway hot reload."""
+
+from unittest.mock import patch
+
+
+def test_hot_reload_prefers_fresh_profile_secret(tmp_path, monkeypatch):
+    """A rotated MCP bearer on disk must beat a stale process value."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ROTATING_MCP_TOKEN", "revoked-old-token")
+    (tmp_path / ".env").write_text("ROTATING_MCP_TOKEN=fresh-token\n")
+    servers = {
+        "remote": {
+            "url": "https://mcp.example.test",
+            "headers": {"Authorization": "Bearer ${ROTATING_MCP_TOKEN}"},
+        }
+    }
+
+    with patch("hermes_cli.config.load_config", return_value={"mcp_servers": servers}):
+        from tools.mcp_tool import _load_mcp_config
+
+        result = _load_mcp_config()
+
+    assert result["remote"]["headers"]["Authorization"] == "Bearer fresh-token"
+
+
+def test_hot_reload_ignores_request_local_home_override(tmp_path, monkeypatch):
+    """Process-global MCP reload must use the control-plane process home."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    process_home = tmp_path / "process"
+    request_home = tmp_path / "request"
+    process_home.mkdir()
+    request_home.mkdir()
+    (process_home / ".env").write_text("ROTATING_MCP_TOKEN=process-fresh-token\n")
+    (request_home / ".env").write_text("ROTATING_MCP_TOKEN=request-local-token\n")
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    servers = {
+        "remote": {
+            "url": "https://mcp.example.test",
+            "headers": {"Authorization": "Bearer ${ROTATING_MCP_TOKEN}"},
+        }
+    }
+
+    override = set_hermes_home_override(request_home)
+    try:
+        with patch("hermes_cli.config.load_config", return_value={"mcp_servers": servers}):
+            from tools.mcp_tool import _load_mcp_config
+
+            result = _load_mcp_config()
+    finally:
+        reset_hermes_home_override(override)
+
+    assert result["remote"]["headers"]["Authorization"] == "Bearer process-fresh-token"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3930,7 +3930,7 @@ def _interrupted_call_result() -> str:
 # Config loading
 # ---------------------------------------------------------------------------
 
-def _interpolate_env_vars(value):
+def _interpolate_env_vars(value, secret_overrides: Optional[Dict[str, str]] = None):
     """Recursively resolve ``${VAR}`` placeholders.
 
     Both ``${VAR}`` and Cursor-style ``${env:VAR}`` are accepted — the
@@ -3939,19 +3939,23 @@ def _interpolate_env_vars(value):
     scope when multiplexing is on (so an MCP server config's ``${API_KEY}``
     picks up the routed profile's value, not the process-global ``os.environ``
     which may hold another profile's), falling back to ``os.environ``
-    otherwise. Unset vars keep the literal placeholder, as before.
+    otherwise. ``secret_overrides`` may supply a freshly parsed profile
+    ``.env`` mapping during hot reload; it wins over a stale process value.
+    Unset vars keep the literal placeholder, as before.
     """
     from agent.secret_scope import get_secret as _get_secret
 
     if isinstance(value, str):
         def _replace(m):
             name = _env_ref_name(m.group(1))
+            if secret_overrides is not None and name in secret_overrides:
+                return secret_overrides[name]
             return _get_secret(name, m.group(0)) or m.group(0)
         return _ENV_VAR_PATTERN.sub(_replace, value)
     if isinstance(value, dict):
-        return {k: _interpolate_env_vars(v) for k, v in value.items()}
+        return {k: _interpolate_env_vars(v, secret_overrides) for k, v in value.items()}
     if isinstance(value, list):
-        return [_interpolate_env_vars(v) for v in value]
+        return [_interpolate_env_vars(v, secret_overrides) for v in value]
     return value
 
 
@@ -4003,15 +4007,27 @@ def _load_mcp_config() -> Dict[str, dict]:
         servers = config.get("mcp_servers")
         if not servers or not isinstance(servers, dict):
             return {}
-        # Ensure .env vars are available for interpolation
+        # Ensure .env vars are available for interpolation. Also parse the
+        # current profile file into an isolated mapping: python-dotenv updates
+        # process state, but a long-lived gateway may still have an older
+        # credential in its active secret resolution path during hot reload.
+        # The fresh mapping is used only for this config read and is never
+        # copied into logs or returned to callers.
+        secret_overrides: Dict[str, str] = {}
         try:
             from hermes_cli.env_loader import load_hermes_dotenv
+            from agent.secret_scope import build_profile_secret_scope
+            from hermes_constants import get_process_hermes_home
             load_hermes_dotenv()
+            # MCP discovery/reload mutates a process-global registry, so its
+            # credential source must be the process home written by the
+            # control plane, never a request-local profile override.
+            secret_overrides = build_profile_secret_scope(get_process_hermes_home())
         except Exception:
             pass
         safe_servers: Dict[str, dict] = {}
         for name, cfg in _filter_suspicious_mcp_servers(servers).items():
-            interpolated = _interpolate_env_vars(cfg)
+            interpolated = _interpolate_env_vars(cfg, secret_overrides)
             if isinstance(interpolated, dict):
                 safe_servers[name] = interpolated
         return safe_servers


### PR DESCRIPTION
## Summary
- adds `POST /v1/mcp/reload`, guarded by the existing API-server bearer auth
- accepts no body/configuration; it reloads only already-materialized MCP config
- rejects active agent work and concurrent reloads, and returns only a contract version plus server/tool counts
- advertises the endpoint and its caller-owned new-work quiescence requirement via `/v1/capabilities`
- factors the existing interactive reload path into a shared reconnect + cached-agent-refresh primitive

## Security properties
- no MCP URL, header, credential, or server name is accepted or returned
- unreadable runner activity fails closed
- reload errors are reason-coded without serializing exception text

## Tests
- `scripts/run_tests.sh tests/gateway/test_api_server.py -q -k capabilities` — 3 passed
- `scripts/run_tests.sh tests/gateway/test_mcp_reload_refreshes_cached_agents.py -q` — 5 passed
- `.venv/bin/ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py tests/gateway/test_mcp_reload_refreshes_cached_agents.py` — passed
- the full API-server file is 210 passed / 1 pre-existing date-sensitive health test failure; the same `degraded` versus `ok` failure reproduces on untouched upstream `main`

## Context
This is a minimal control-plane primitive for managed, rotating remote MCP credentials. It intentionally does not add a configuration API, grant handling, or browser-accessible secrets.
