### PR TITLE
fix(acp): surface durable sessions when live history is empty (#66881)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -284,12 +284,21 @@ class SessionManager:
 
         # Collect in-memory sessions first.
         with self._lock:
-            seen_ids = set(self._sessions.keys())
+            # Only record live IDs whose in-memory history is non-empty. Earlier
+            # versions seeded ``seen_ids`` from ``self._sessions.keys()`` before
+            # the history-length check, which meant a live session whose
+            # transcript lived entirely in ``SessionDB`` (the ACP runtime path
+            # where the agent persists the transcript through its own database
+            # handle) was treated as "already seen" and skipped by the durable
+            # fallback below -- hiding it from ``session/list`` even though its
+            # persisted row had messages (issue #66881).
+            seen_ids = set()
             results = []
             for s in self._sessions.values():
                 history_len = len(s.history)
                 if history_len <= 0:
                     continue
+                seen_ids.add(s.session_id)
                 if normalized_cwd and _normalize_cwd_for_compare(s.cwd) != normalized_cwd:
                     continue
                 persisted = persisted_rows.get(s.session_id, {})

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -564,6 +564,71 @@ class TestPersistence:
         assert listing[0]["updated_at"]
         assert listing[1]["updated_at"]
 
+    def test_list_sessions_includes_durable_rows_when_live_history_empty(self, tmp_path):
+        """Regression for #66881: a live session whose in-memory history is empty
+        (because the ACP agent persists the transcript through its own DB handle
+        and never populates ``state.history``) must still surface in
+        ``list_sessions`` via its durable SessionDB rows.
+
+        Earlier versions seeded ``seen_ids`` from ``self._sessions.keys()`` before
+        the history-length check, which caused the durable fallback to skip the
+        live-but-empty session — hiding it from ``session/list`` even though its
+        persisted row had messages.
+        """
+        db = SessionDB(tmp_path / "state.db")
+
+        def factory():
+            # Mimic a live ACP agent that owns persistence to this same db.
+            return SimpleNamespace(
+                model="test-model",
+                _session_db=db,
+                _session_db_created=True,
+            )
+
+        manager = SessionManager(agent_factory=factory, db=db)
+        state = manager.create_session(cwd="/durable")
+
+        # Simulate the ACP runtime path: the agent persisted the turn directly
+        # through SessionDB and never touched ``state.history``.
+        db.append_message(
+            session_id=state.session_id, role="user", content="durable needle"
+        )
+        db.append_message(
+            session_id=state.session_id, role="assistant", content="durable reply"
+        )
+        assert state.history == []  # in-memory mirror untouched
+
+        listing = manager.list_sessions()
+        ids = {item["session_id"] for item in listing}
+        assert state.session_id in ids
+        match = next(item for item in listing if item["session_id"] == state.session_id)
+        assert match["history_len"] == 2
+        assert match["cwd"] == "/durable"
+
+    def test_list_sessions_durable_fallback_respects_cwd_filter(self, tmp_path):
+        """The durable fallback for live-but-empty sessions must honor the
+        ``cwd`` filter the same way the in-memory path does (issue #66881)."""
+        db = SessionDB(tmp_path / "state.db")
+
+        def factory():
+            return SimpleNamespace(
+                model="test-model",
+                _session_db=db,
+                _session_db_created=True,
+            )
+
+        manager = SessionManager(agent_factory=factory, db=db)
+        keep = manager.create_session(cwd="/keep")
+        drop = manager.create_session(cwd="/drop")
+        for s in (keep, drop):
+            db.append_message(session_id=s.session_id, role="user", content="x")
+            assert s.history == []
+
+        listing = manager.list_sessions(cwd="/keep")
+        ids = {item["session_id"] for item in listing}
+        assert keep.session_id in ids
+        assert drop.session_id not in ids
+
     def test_fork_restores_source_from_db(self, manager):
         """Forking a session that is only in DB should work."""
         original = manager.create_session()


### PR DESCRIPTION
## Summary

`SessionManager.list_sessions()` hid durable ACP sessions when the live `SessionState.history` was empty, even though `SessionDB` already contained messages for the same session ID. This breaks clients that use `session/list` to verify a completed turn before resuming the session — the ACP runtime path where the agent persists the transcript through its own database handle (and never populates `state.history`) consistently hit this.

Fixes #66881.

## Root cause

`list_sessions()` initialized `seen_ids` from `self._sessions.keys()` *before* filtering out live sessions whose in-memory history was empty:

```python
seen_ids = set(self._sessions.keys())  # every live ID marked "seen"
results = []
for s in self._sessions.values():
    history_len = len(s.history)
    if history_len <= 0:
        continue                              # silently dropped from results
    ...
```

The later persisted-row pass then skipped those IDs because they were already in `seen_ids`:

```python
for sid, row in persisted_rows.items():
    if sid in seen_ids:
        continue                              # durable fallback skipped
    ...
```

So a live-but-empty session whose transcript lived entirely in `SessionDB` was treated as "already seen" and skipped both paths — hidden from `session/list` even though its persisted row had messages.

## Change

Initialize `seen_ids` empty. For each live session, add its ID only after confirming its in-memory history is non-empty, and add it **before** applying the optional cwd filter so non-empty live metadata stays authoritative for cwd while empty live mirrors fall back to durable storage. This matches the proposed semantics in the issue.

```diff
-            seen_ids = set(self._sessions.keys())
+            seen_ids = set()
             results = []
             for s in self._sessions.values():
                 history_len = len(s.history)
                 if history_len <= 0:
                     continue
+                seen_ids.add(s.session_id)
                 if normalized_cwd and _normalize_cwd_for_compare(s.cwd) != normalized_cwd:
                     continue
```

## Tests

Two regression tests added in `tests/acp/test_session.py`:

- `test_list_sessions_includes_durable_rows_when_live_history_empty` — reproduces the ACP runtime path directly: live session + empty in-memory history + durable `SessionDB` rows. Asserts the session surfaces with `history_len == 2` and the correct `cwd`. Fails on `main`, passes with the fix.
- `test_list_sessions_durable_fallback_respects_cwd_filter` — verifies the durable fallback for live-but-empty sessions still honours the `cwd` filter the same way the in-memory path does.

Both tests fail on `main`; both pass with this fix. The existing 47-test `tests/acp/test_session.py` suite continues to pass with no regressions.

## Verification

- `pytest tests/acp/test_session.py` — 47 → 49 passing, 0 regressions
- `pytest tests/acp/test_approval_isolation.py` — 8/8 passing (verified unaffected by this change; an unrelated pre-existing test-order interaction exists in `tests/acp/` that surfaces only when the full directory runs and is not addressed here)

## Scope

Single-file production change (`acp_adapter/session.py`, +10/-1 lines) + targeted regression tests. No public API change, no new dependencies.