### PR TITLE
fix(feishu): log admission-rejected inbound events at INFO with message id

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2539,7 +2539,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
         reason = self._admit(sender, message)
         if reason is not None:
-            logger.debug("[Feishu] dropping inbound event: %s", reason)
+            # INFO, not DEBUG: _is_duplicate() above already persisted this id to the
+            # seen-store, so a silent drop here is indistinguishable from a dead
+            # dispatch loop when observed from outside the process (#66997).
+            logger.info("[Feishu] Dropped inbound event (%s): id=%s", reason, message_id)
             return
 
         chat_type = getattr(message, "chat_type", "p2p")

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -778,6 +778,31 @@ def test_handle_message_event_data_drops_bot_sender_by_default():
     assert processed == []
 
 
+def test_handle_message_event_data_logs_admission_rejection_at_info(caplog):
+    import asyncio
+    import logging
+
+    adapter = make_adapter_skeleton()
+    install_dedup_state(adapter)
+
+    data = SimpleNamespace(
+        event=SimpleNamespace(
+            sender=make_sender(sender_type="bot", open_id="ou_peer"),
+            message=make_message(message_id="om_bot_rejected", chat_type="p2p"),
+        )
+    )
+
+    with caplog.at_level(logging.INFO, logger="plugins.platforms.feishu.adapter"):
+        asyncio.run(adapter._handle_message_event_data(data))
+
+    dropped = [r for r in caplog.records if "Dropped inbound event" in r.getMessage()]
+    assert dropped, "admission rejection must be visible at INFO level"
+    message = dropped[0].getMessage()
+    assert dropped[0].levelno == logging.INFO
+    assert "bots_disabled" in message
+    assert "om_bot_rejected" in message
+
+
 def test_handle_message_event_data_forwards_sender_when_admitted():
     import asyncio
 


### PR DESCRIPTION
Fixes #66997

## Problem

`_handle_message_event_data` marks an inbound message as seen — persisting `feishu_seen_message_ids.json` inside `_is_duplicate()` — **before** admission filtering, but logs an admission rejection only at DEBUG:

```python
reason = self._admit(sender, message)
if reason is not None:
    logger.debug("[Feishu] dropping inbound event: %s", reason)
    return
```

At the default INFO level, a rejected message (`bot_not_mentioned`, `group_policy_rejected`, `bots_disabled`, `self_echo`, …) leaves no trace at all while the seen-store still advances. Two costs (detail in #66997):

1. **Triage**: "the bot ignored my message" can't be diagnosed without restarting at DEBUG and reproducing — there's no way to distinguish *filtered by policy* from *never arrived* from *dispatch broken*.
2. **External liveness monitoring**: "seen-store advancing with no log output" is the natural external signature of the dead-dispatch half-open case (#53477). Filtered traffic produces exactly that signature, so watchdogs false-positive. In our 16-agent production fleet, unmentioned chatter in a `require_mention` group auto-restarted a healthy agent 4× in two days.

## Change

One line in `plugins/platforms/feishu/adapter.py`: log the rejection at INFO with the reject reason and message id —

```
[Feishu] Dropped inbound event (bot_not_mentioned): id=om_…
```

Volume is bounded to one short line per event the bot already receives. The invariant "every received message leaves an INFO-level trace" is restored: a genuine dead dispatch loop still writes nothing, so half-open detection keeps working while filtered traffic stops looking like it.

## Testing

- New handler-level test `test_handle_message_event_data_logs_admission_rejection_at_info` (mirrors the adjacent event-dispatch tests, uses `caplog`): asserts record level INFO, reject reason, and message id. Verified it **fails** against the previous DEBUG-only behavior.
- Full `tests/gateway/test_feishu_bot_admission.py` suite: **64 passed**.
- The same one-line change has been running in production across our 16-agent fleet (applied as an image patch) since 2026-07-18: monitoring false positives stopped; no regression in real half-open detection.