### PR TITLE
fix(model): hot-reload model.aliases without a gateway restart

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -247,8 +247,12 @@ _BUILTIN_DIRECT_ALIASES: dict[str, DirectAlias] = {}
 # Merged dict (builtins + user config); populated by _load_direct_aliases()
 DIRECT_ALIASES: dict[str, DirectAlias] = {}
 
+# Latch so the degraded-config warning fires once per degraded->healthy
+# transition (not on every /model switch while a broken config persists).
+_DIRECT_ALIASES_DEGRADED: bool = False
 
-def _load_direct_aliases() -> dict[str, DirectAlias]:
+
+def _load_direct_aliases() -> tuple[dict[str, DirectAlias], bool]:
     """Load direct aliases from config.yaml ``model_aliases:`` section.
 
     Config format::
@@ -267,6 +271,11 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
     and converts simple string entries (``ds-flash: deepseek/deepseek-v4-flash``)
     into DirectAlias objects.  The provider is parsed from the ``provider/``
     prefix in the value; if no slash, the current provider is used.
+
+    Returns ``(merged, ok)`` where *merged* always contains at least the
+    built-in direct aliases.  ``ok`` is ``False`` when reading the user config
+    raised — in that case *merged* holds builtins only, and the caller must
+    retain its last-known-good user aliases rather than pruning to builtins.
     """
     merged = dict(_BUILTIN_DIRECT_ALIASES)
     try:
@@ -311,20 +320,48 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                         base_url="",
                     )
     except Exception:
-        pass
-    return merged
+        # Config read failed — signal degraded so the caller keeps
+        # last-known-good user aliases instead of pruning to builtins.
+        return merged, False
+    return merged, True
 
 
 def _ensure_direct_aliases() -> None:
-    """Lazy-load direct aliases on first use.
+    """Refresh DIRECT_ALIASES from config on every call (hot reload).
 
-    Mutates the existing DIRECT_ALIASES dict in place rather than rebinding
-    the module attribute. This keeps `from hermes_cli.model_switch import
-    DIRECT_ALIASES` references valid in callers — rebinding would leave them
-    pointing at a stale empty dict.
+    ``load_config()`` is mtime-cached (``_LOAD_CONFIG_CACHE``, keyed on
+    ``(mtime_ns, size)``), so on an unchanged config this is a ``stat()`` plus a
+    small merge over ~10 entries — no YAML re-parse.  Dropping the old
+    load-once guard lets a ``model.aliases`` / ``model_aliases`` edit take
+    effect on the next ``/model`` switch with no gateway restart.
+
+    Mutates the existing DIRECT_ALIASES dict IN PLACE (never rebinds — keeps
+    ``from hermes_cli.model_switch import DIRECT_ALIASES`` references valid) and
+    never ``.clear()``s it, so a concurrent reader never observes an empty dict.
+    On a degraded config read it retains the current (last-known-good) dict
+    rather than pruning user aliases back to builtins, warning once per
+    degraded->healthy transition (not on every call).
     """
-    if not DIRECT_ALIASES:
-        DIRECT_ALIASES.update(_load_direct_aliases())
+    global _DIRECT_ALIASES_DEGRADED
+    fresh, ok = _load_direct_aliases()
+    if not ok and DIRECT_ALIASES:
+        if not _DIRECT_ALIASES_DEGRADED:
+            # Fire once on the healthy->degraded transition; stay quiet while the
+            # broken config persists so a mid-write YAML can't flood the log.
+            logger.warning(
+                "model alias refresh: config read failed; retaining %d "
+                "last-known-good alias(es) (aliases stay stale until config "
+                "loads cleanly)", len(DIRECT_ALIASES),
+            )
+            _DIRECT_ALIASES_DEGRADED = True
+        return
+    _DIRECT_ALIASES_DEGRADED = False  # healthy read: re-arm the warning
+    # Snapshot keys first (materialized list) so pruning can't raise
+    # "dict changed size during iteration"; prune removed entries, then overlay
+    # the fresh set — never emptying the dict at any point.
+    for key in [k for k in DIRECT_ALIASES if k not in fresh]:
+        DIRECT_ALIASES.pop(key, None)
+    DIRECT_ALIASES.update(fresh)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
 from dataclasses import dataclass
 from typing import Any, List, NamedTuple, Optional
 
@@ -244,11 +245,28 @@ class DirectAlias(NamedTuple):
 # Built-in direct aliases (can be extended via config.yaml model_aliases:)
 _BUILTIN_DIRECT_ALIASES: dict[str, DirectAlias] = {}
 
-# Merged dict (builtins + user config); populated by _load_direct_aliases()
+# Merged dict (builtins + user config); populated by _load_direct_aliases().
+#
+# CONCURRENCY CONTRACT (#67007 review): this module attribute is an IMMUTABLE
+# snapshot.  ``_ensure_direct_aliases()`` never mutates the dict it publishes —
+# it builds a brand-new dict and rebinds this name, which is atomic under the
+# CPython evaluation loop.  A reader therefore takes its own local reference
+# (``aliases = DIRECT_ALIASES``) and iterates THAT; the object it holds is never
+# written to again, so a concurrent refresh can neither invalidate its iterator
+# ("dictionary changed size during iteration") nor expose a half-pruned table.
+#
+# Do not ``.update()``, ``.pop()`` or ``.clear()`` this dict in place.
 DIRECT_ALIASES: dict[str, DirectAlias] = {}
+
+# Serializes refreshers so two concurrent /model switches can't interleave
+# read-modify-publish and lose one generation.  Readers never take this lock —
+# they only need the atomic rebind above, so the alias lookup on the request
+# path stays lock-free.
+_DIRECT_ALIASES_LOCK = threading.Lock()
 
 # Latch so the degraded-config warning fires once per degraded->healthy
 # transition (not on every /model switch while a broken config persists).
+# Only read/written under _DIRECT_ALIASES_LOCK.
 _DIRECT_ALIASES_DEGRADED: bool = False
 
 
@@ -335,33 +353,47 @@ def _ensure_direct_aliases() -> None:
     load-once guard lets a ``model.aliases`` / ``model_aliases`` edit take
     effect on the next ``/model`` switch with no gateway restart.
 
-    Mutates the existing DIRECT_ALIASES dict IN PLACE (never rebinds — keeps
-    ``from hermes_cli.model_switch import DIRECT_ALIASES`` references valid) and
-    never ``.clear()``s it, so a concurrent reader never observes an empty dict.
-    On a degraded config read it retains the current (last-known-good) dict
-    rather than pruning user aliases back to builtins, warning once per
-    degraded->healthy transition (not on every call).
+    Concurrency (#67007 review): gateway ``/model`` work runs the switch under
+    ``asyncio.to_thread``, so this refresh can run on one worker thread while
+    another is inside ``resolve_alias()``'s reverse-lookup scan over the alias
+    table.  Publishing by REPLACEMENT rather than in-place mutation makes that
+    safe: we build a brand-new dict and rebind the module attribute in a single
+    atomic store, so a reader that already grabbed the previous dict keeps
+    iterating an object nobody writes to.  In-place ``pop()``/``update()`` could
+    (and did) raise ``RuntimeError: dictionary changed size during iteration``
+    in that reader, and could expose a half-pruned table between the prune and
+    the overlay.
+
+    The lock serializes concurrent refreshers (so two switches can't interleave
+    load-and-publish and drop a generation) and guards the degraded latch.
+    Readers never take it — the atomic rebind is all they need, so alias lookup
+    stays lock-free.
+
+    On a degraded config read the currently published table is retained
+    (last-known-good) rather than pruning user aliases back to builtins, warning
+    once per healthy->degraded transition (not on every call).
     """
-    global _DIRECT_ALIASES_DEGRADED
+    global DIRECT_ALIASES, _DIRECT_ALIASES_DEGRADED
     fresh, ok = _load_direct_aliases()
-    if not ok and DIRECT_ALIASES:
-        if not _DIRECT_ALIASES_DEGRADED:
-            # Fire once on the healthy->degraded transition; stay quiet while the
-            # broken config persists so a mid-write YAML can't flood the log.
-            logger.warning(
-                "model alias refresh: config read failed; retaining %d "
-                "last-known-good alias(es) (aliases stay stale until config "
-                "loads cleanly)", len(DIRECT_ALIASES),
-            )
-            _DIRECT_ALIASES_DEGRADED = True
-        return
-    _DIRECT_ALIASES_DEGRADED = False  # healthy read: re-arm the warning
-    # Snapshot keys first (materialized list) so pruning can't raise
-    # "dict changed size during iteration"; prune removed entries, then overlay
-    # the fresh set — never emptying the dict at any point.
-    for key in [k for k in DIRECT_ALIASES if k not in fresh]:
-        DIRECT_ALIASES.pop(key, None)
-    DIRECT_ALIASES.update(fresh)
+    with _DIRECT_ALIASES_LOCK:
+        if not ok and DIRECT_ALIASES:
+            if not _DIRECT_ALIASES_DEGRADED:
+                # Fire once on the healthy->degraded transition; stay quiet while
+                # the broken config persists so a mid-write YAML can't flood the
+                # log.
+                logger.warning(
+                    "model alias refresh: config read failed; retaining %d "
+                    "last-known-good alias(es) (aliases stay stale until config "
+                    "loads cleanly)", len(DIRECT_ALIASES),
+                )
+                _DIRECT_ALIASES_DEGRADED = True
+            return
+        _DIRECT_ALIASES_DEGRADED = False  # healthy read: re-arm the warning
+        # Publish by REPLACEMENT, never in-place mutation: build the complete
+        # next generation, then rebind in one atomic store.  Removed aliases are
+        # dropped simply by not being in *fresh*; concurrent readers holding the
+        # previous dict are unaffected because it is never written to again.
+        DIRECT_ALIASES = dict(fresh)
 
 
 # ---------------------------------------------------------------------------
@@ -617,14 +649,21 @@ def resolve_alias(
 
     # Check direct aliases first (exact model+provider+base_url mappings)
     _ensure_direct_aliases()
-    direct = DIRECT_ALIASES.get(key)
+    # Snapshot the published table ONCE.  _ensure_direct_aliases() rebinds
+    # DIRECT_ALIASES to a new dict rather than mutating it, so this local
+    # reference is a stable, never-written-to generation — a concurrent refresh
+    # on another thread (gateway /model runs under asyncio.to_thread) can't
+    # invalidate the iteration below.  Re-reading the global between the .get()
+    # and the loop would risk mixing two generations.
+    aliases = DIRECT_ALIASES
+    direct = aliases.get(key)
     if direct is not None:
         return (direct.provider, direct.model, key)
 
     # Reverse lookup: match by model ID so full names (e.g. "kimi-k2.5",
     # "glm-4.7") route through direct aliases instead of falling through
     # to the catalog/OpenRouter.
-    for alias_name, da in DIRECT_ALIASES.items():
+    for alias_name, da in aliases.items():
         if da.model.lower() == key:
             return (da.provider, da.model, alias_name)
 

--- a/tests/hermes_cli/test_direct_alias_concurrency.py
+++ b/tests/hermes_cli/test_direct_alias_concurrency.py
@@ -1,0 +1,141 @@
+"""Concurrency regression: refreshing DIRECT_ALIASES must not break a concurrent reader.
+
+Review finding (teknium1 on #67007): the in-place prune/update in
+``_ensure_direct_aliases()`` is not synchronized against ``resolve_alias()``'s
+reverse-lookup ``for alias_name, da in DIRECT_ALIASES.items()``.  Gateway
+``/model`` work runs the switch under ``asyncio.to_thread``
+(``gateway/slash_commands.py``), so a refresh on one worker thread can mutate
+the dict while another thread is iterating it.
+
+On the in-place-mutation implementation these tests fail with
+``RuntimeError: dictionary changed size during iteration``.  They pass once the
+refresh builds a NEW dict and swaps the module reference atomically.
+"""
+import threading
+
+import pytest
+
+from hermes_cli import model_switch as ms
+
+
+@pytest.fixture(autouse=True)
+def _restore_direct_aliases():
+    saved = dict(ms.DIRECT_ALIASES)
+    saved_degraded = ms._DIRECT_ALIASES_DEGRADED
+    yield
+    ms.DIRECT_ALIASES = dict(saved)
+    ms._DIRECT_ALIASES_DEGRADED = saved_degraded
+
+
+def _alias_set(n: int) -> dict:
+    return {
+        f"alias{i}": ms.DirectAlias(f"model-{i}", "custom", "")
+        for i in range(n)
+    }
+
+
+def test_reverse_lookup_survives_concurrent_refresh(monkeypatch):
+    """Reader iterating DIRECT_ALIASES while a refresh prunes/adds entries.
+
+    RED on the in-place implementation:
+        RuntimeError: dictionary changed size during iteration
+    """
+    small = _alias_set(400)
+    large = _alias_set(900)
+    flip = [0]
+
+    def _alternating_loader():
+        flip[0] += 1
+        return (dict(large) if flip[0] % 2 else dict(small)), True
+
+    monkeypatch.setattr(ms, "_load_direct_aliases", _alternating_loader)
+    ms.DIRECT_ALIASES = dict(small)
+
+    errors: list[BaseException] = []
+    stop = threading.Event()
+
+    def _reader():
+        try:
+            while not stop.is_set():
+                # Miss on the direct hit -> exercises the reverse-lookup
+                # `for alias_name, da in DIRECT_ALIASES.items()` scan.
+                ms.resolve_alias("no-such-alias-zzz", "openrouter")
+        except BaseException as exc:  # noqa: BLE001 - recording for assertion
+            errors.append(exc)
+
+    def _refresher():
+        try:
+            while not stop.is_set():
+                ms._ensure_direct_aliases()
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_reader) for _ in range(3)]
+    threads += [threading.Thread(target=_refresher) for _ in range(3)]
+    for t in threads:
+        t.start()
+    stop.wait(6.0)
+    stop.set()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, (
+        "concurrent refresh broke a reader iterating DIRECT_ALIASES: "
+        f"{type(errors[0]).__name__}: {errors[0]}"
+    )
+
+
+def test_reader_never_sees_a_partial_alias_table(monkeypatch):
+    """A reader must observe either the old table or the new one, never a torn mix.
+
+    The in-place prune deletes removed keys BEFORE overlaying the fresh set, so
+    a reader scheduled between the two steps sees a table that matches neither
+    generation.  An atomic swap makes every observation a complete generation.
+    """
+    gen_a = {f"a{i}": ms.DirectAlias(f"m-a{i}", "custom", "") for i in range(300)}
+    gen_b = {f"b{i}": ms.DirectAlias(f"m-b{i}", "custom", "") for i in range(300)}
+    flip = [0]
+
+    def _alternating_loader():
+        flip[0] += 1
+        return (dict(gen_b) if flip[0] % 2 else dict(gen_a)), True
+
+    monkeypatch.setattr(ms, "_load_direct_aliases", _alternating_loader)
+    ms.DIRECT_ALIASES = dict(gen_a)
+
+    torn: list[str] = []
+    errors: list[BaseException] = []
+    stop = threading.Event()
+
+    def _reader():
+        try:
+            while not stop.is_set():
+                snap = ms.DIRECT_ALIASES
+                keys = set(snap)          # single read of the module reference
+                if keys and keys != set(gen_a) and keys != set(gen_b):
+                    torn.append(
+                        f"partial table: {len(keys)} keys "
+                        f"(a={len(keys & set(gen_a))} b={len(keys & set(gen_b))})"
+                    )
+                    return
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    def _refresher():
+        try:
+            while not stop.is_set():
+                ms._ensure_direct_aliases()
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_reader) for _ in range(2)]
+    threads += [threading.Thread(target=_refresher) for _ in range(2)]
+    for t in threads:
+        t.start()
+    stop.wait(5.0)
+    stop.set()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, f"{type(errors[0]).__name__}: {errors[0]}"
+    assert not torn, f"reader observed a torn alias table: {torn[0]}"

--- a/tests/hermes_cli/test_direct_alias_reload.py
+++ b/tests/hermes_cli/test_direct_alias_reload.py
@@ -1,0 +1,153 @@
+"""Tests for DIRECT_ALIASES hot-reload (model.aliases takes effect without restart).
+
+Regression coverage for the load-once bug where `/model <alias>` resolved a stale
+alias table because `_ensure_direct_aliases()` populated `DIRECT_ALIASES` only on
+first use and never refreshed after a `model.aliases` config edit.
+"""
+import logging
+
+import pytest
+
+from hermes_cli import model_switch as ms
+
+
+@pytest.fixture(autouse=True)
+def _reset_direct_aliases():
+    """Reset the module-global DIRECT_ALIASES (in place) and the degraded latch
+    around each test so state doesn't leak between tests."""
+    saved = dict(ms.DIRECT_ALIASES)
+    saved_degraded = ms._DIRECT_ALIASES_DEGRADED
+    ms.DIRECT_ALIASES.clear()
+    ms._DIRECT_ALIASES_DEGRADED = False
+    yield
+    ms.DIRECT_ALIASES.clear()
+    ms.DIRECT_ALIASES.update(saved)
+    ms._DIRECT_ALIASES_DEGRADED = saved_degraded
+
+
+def _fake_load(monkeypatch, aliases_map):
+    """Point _load_direct_aliases at a synthetic config (builtins + given user aliases)."""
+    def _loader():
+        merged = dict(ms._BUILTIN_DIRECT_ALIASES)
+        for k, v in aliases_map.items():
+            prov, model = v.split("/", 1)
+            merged[k] = ms.DirectAlias(model=model, provider=prov, base_url="")
+        return merged, True
+    monkeypatch.setattr(ms, "_load_direct_aliases", _loader)
+
+
+def test_reload_on_config_change(monkeypatch):
+    """The core bug: after first population, a changed config value is reflected
+    on the NEXT call — with no manual clear. RED on the load-once implementation."""
+    _fake_load(monkeypatch, {"zed": "claude-apr/claude-x"})
+    ms._ensure_direct_aliases()
+    assert ms.DIRECT_ALIASES["zed"] == ms.DirectAlias("claude-x", "claude-apr", "")
+
+    # Config edited: zed now points somewhere else.
+    _fake_load(monkeypatch, {"zed": "claude-apr/claude-y"})
+    ms._ensure_direct_aliases()
+    assert ms.DIRECT_ALIASES["zed"] == ms.DirectAlias("claude-y", "claude-apr", ""), (
+        "alias table did not hot-reload after config change (load-once bug)"
+    )
+
+
+def test_resolve_alias_reflects_reload(monkeypatch):
+    """End-to-end via resolve_alias(): a config edit changes what /model <alias> resolves to."""
+    _fake_load(monkeypatch, {"opustest": "claude-apr/claude-opus-4-8"})
+    ms._ensure_direct_aliases()
+    assert ms.resolve_alias("opustest", "claude-apr") == (
+        "claude-apr", "claude-opus-4-8", "opustest",
+    )
+    # Re-point the alias to a different provider; must follow.
+    _fake_load(monkeypatch, {"opustest": "openai-codex/gpt-5.6-terra"})
+    assert ms.resolve_alias("opustest", "claude-apr") == (
+        "openai-codex", "gpt-5.6-terra", "opustest",
+    )
+
+
+def test_removed_alias_disappears(monkeypatch):
+    """An alias deleted from config is pruned on the next refresh."""
+    _fake_load(monkeypatch, {"gone": "claude-apr/claude-x"})
+    ms._ensure_direct_aliases()
+    assert "gone" in ms.DIRECT_ALIASES
+    _fake_load(monkeypatch, {})  # user removed it
+    ms._ensure_direct_aliases()
+    assert "gone" not in ms.DIRECT_ALIASES
+    # Any built-in direct aliases survive the prune (fork ships some; upstream may not).
+    for builtin_key in ms._BUILTIN_DIRECT_ALIASES:
+        assert builtin_key in ms.DIRECT_ALIASES
+
+
+def test_degraded_read_retains_last_known_good(monkeypatch, caplog):
+    """RC-A: a transient config-read failure must NOT prune user aliases back to
+    builtins — the exact wrong-provider symptom this feature fixes."""
+    _fake_load(monkeypatch, {"zed": "claude-apr/claude-x"})
+    ms._ensure_direct_aliases()
+    assert "zed" in ms.DIRECT_ALIASES
+
+    # Next refresh: config read fails (ok=False, builtins only).
+    monkeypatch.setattr(
+        ms, "_load_direct_aliases", lambda: (dict(ms._BUILTIN_DIRECT_ALIASES), False)
+    )
+    with caplog.at_level(logging.WARNING, logger=ms.logger.name):
+        ms._ensure_direct_aliases()
+        # RC-B / Greptile P2: further degraded calls must NOT re-flood the log.
+        ms._ensure_direct_aliases()
+        ms._ensure_direct_aliases()
+
+    assert ms.DIRECT_ALIASES.get("zed") == ms.DirectAlias("claude-x", "claude-apr", ""), (
+        "user alias was pruned to builtins on a degraded config read (MB-2 regression)"
+    )
+    assert ms.resolve_alias("zed", "claude-apr") == ("claude-apr", "claude-x", "zed")
+    # RC-B: the degraded path emits exactly ONE warning across repeated calls.
+    warnings = [r for r in caplog.records if "retaining" in r.message]
+    assert len(warnings) == 1, (
+        f"degraded-retain path logged {len(warnings)} warnings, expected exactly 1 (RC-B/Greptile P2)"
+    )
+
+
+def test_degraded_then_healthy_rearms_warning(monkeypatch, caplog):
+    """After recovery, a subsequent degraded read warns again (latch re-arms)."""
+    _fake_load(monkeypatch, {"zed": "claude-apr/claude-x"})
+    ms._ensure_direct_aliases()
+
+    degraded = lambda: (dict(ms._BUILTIN_DIRECT_ALIASES), False)
+    with caplog.at_level(logging.WARNING, logger=ms.logger.name):
+        monkeypatch.setattr(ms, "_load_direct_aliases", degraded)
+        ms._ensure_direct_aliases()          # warn #1
+        _fake_load(monkeypatch, {"zed": "claude-apr/claude-x"})
+        ms._ensure_direct_aliases()          # healthy: re-arm
+        monkeypatch.setattr(ms, "_load_direct_aliases", degraded)
+        ms._ensure_direct_aliases()          # warn #2
+    warnings = [r for r in caplog.records if "retaining" in r.message]
+    assert len(warnings) == 2
+
+
+def test_in_place_mutation_and_never_empty(monkeypatch):
+    """INV-2: reload mutates in place (stable id) and never observes an empty dict."""
+    _fake_load(monkeypatch, {"a": "p/m1"})
+    ms._ensure_direct_aliases()
+    dict_id = id(ms.DIRECT_ALIASES)
+
+    # Observe the dict during the reload: _load_direct_aliases is called first,
+    # so snapshot the live dict's length at that moment — it must never be empty.
+    seen_lengths = []
+    real_loader = ms._load_direct_aliases
+
+    def _observing_loader():
+        seen_lengths.append(len(ms.DIRECT_ALIASES))
+        merged = dict(ms._BUILTIN_DIRECT_ALIASES)
+        merged["a"] = ms.DirectAlias("m2", "p", "")
+        merged["b"] = ms.DirectAlias("m3", "p", "")
+        return merged, True
+
+    monkeypatch.setattr(ms, "_load_direct_aliases", _observing_loader)
+    ms._ensure_direct_aliases()
+
+    assert id(ms.DIRECT_ALIASES) == dict_id, "DIRECT_ALIASES was rebound (INV-2 violation)"
+    # The dict held its prior contents the whole time (never cleared to empty).
+    assert seen_lengths and all(n > 0 for n in seen_lengths), (
+        "DIRECT_ALIASES was empty during reload (concurrency hazard)"
+    )
+    assert ms.DIRECT_ALIASES["a"] == ms.DirectAlias("m2", "p", "")
+    assert "b" in ms.DIRECT_ALIASES

--- a/tests/hermes_cli/test_direct_alias_reload.py
+++ b/tests/hermes_cli/test_direct_alias_reload.py
@@ -13,15 +13,17 @@ from hermes_cli import model_switch as ms
 
 @pytest.fixture(autouse=True)
 def _reset_direct_aliases():
-    """Reset the module-global DIRECT_ALIASES (in place) and the degraded latch
-    around each test so state doesn't leak between tests."""
-    saved = dict(ms.DIRECT_ALIASES)
+    """Save/restore the module-global DIRECT_ALIASES and the degraded latch
+    around each test so state doesn't leak between tests.
+
+    Rebinds (never mutates) — matching the production atomic-swap contract.
+    """
+    saved = ms.DIRECT_ALIASES
     saved_degraded = ms._DIRECT_ALIASES_DEGRADED
-    ms.DIRECT_ALIASES.clear()
+    ms.DIRECT_ALIASES = {}
     ms._DIRECT_ALIASES_DEGRADED = False
     yield
-    ms.DIRECT_ALIASES.clear()
-    ms.DIRECT_ALIASES.update(saved)
+    ms.DIRECT_ALIASES = saved
     ms._DIRECT_ALIASES_DEGRADED = saved_degraded
 
 
@@ -123,16 +125,29 @@ def test_degraded_then_healthy_rearms_warning(monkeypatch, caplog):
     assert len(warnings) == 2
 
 
-def test_in_place_mutation_and_never_empty(monkeypatch):
-    """INV-2: reload mutates in place (stable id) and never observes an empty dict."""
+def test_atomic_swap_and_never_empty(monkeypatch):
+    """INV-2 (revised for #67007): reload publishes by ATOMIC REPLACEMENT and a
+    reader never observes an empty or half-built table.
+
+    The original invariant was "mutate in place, never rebind" (#16767), which
+    existed to stop a `from hermes_cli.model_switch import DIRECT_ALIASES`
+    consumer being left pointing at a stale empty dict.  Review of #67007
+    (teknium1) showed in-place mutation is unsafe under the gateway's
+    ``asyncio.to_thread`` /model path: the prune could invalidate a concurrent
+    ``resolve_alias()`` iterator.  The stronger, thread-safe invariant is the
+    inverse — build a NEW dict and rebind atomically, so a reader holding the
+    previous generation iterates an object that is never written to again.
+    ``test_no_from_import_of_direct_aliases`` keeps the original hazard closed.
+    """
     _fake_load(monkeypatch, {"a": "p/m1"})
     ms._ensure_direct_aliases()
-    dict_id = id(ms.DIRECT_ALIASES)
+    old_dict = ms.DIRECT_ALIASES
+    old_id = id(old_dict)
+    old_snapshot = dict(old_dict)
 
-    # Observe the dict during the reload: _load_direct_aliases is called first,
+    # Observe the table during the reload: _load_direct_aliases is called first,
     # so snapshot the live dict's length at that moment — it must never be empty.
     seen_lengths = []
-    real_loader = ms._load_direct_aliases
 
     def _observing_loader():
         seen_lengths.append(len(ms.DIRECT_ALIASES))
@@ -144,10 +159,247 @@ def test_in_place_mutation_and_never_empty(monkeypatch):
     monkeypatch.setattr(ms, "_load_direct_aliases", _observing_loader)
     ms._ensure_direct_aliases()
 
-    assert id(ms.DIRECT_ALIASES) == dict_id, "DIRECT_ALIASES was rebound (INV-2 violation)"
-    # The dict held its prior contents the whole time (never cleared to empty).
+    # A NEW generation was published (atomic swap, not in-place mutation).
+    assert id(ms.DIRECT_ALIASES) != old_id, (
+        "DIRECT_ALIASES was mutated in place — a concurrent reverse-lookup "
+        "iterator can be invalidated (see #67007 review)"
+    )
+    # The dict a concurrent reader might still be holding is UNCHANGED, so its
+    # iterator stays valid for the whole scan.
+    assert old_dict == old_snapshot, (
+        "the previously published dict was mutated after publication — "
+        "concurrent readers holding it can raise "
+        "'dictionary changed size during iteration'"
+    )
+    # The table was never empty at any observable point.
     assert seen_lengths and all(n > 0 for n in seen_lengths), (
         "DIRECT_ALIASES was empty during reload (concurrency hazard)"
     )
     assert ms.DIRECT_ALIASES["a"] == ms.DirectAlias("m2", "p", "")
     assert "b" in ms.DIRECT_ALIASES
+
+
+def test_no_from_import_of_direct_aliases():
+    """Guards the ORIGINAL #16767 hazard under the new atomic-swap contract.
+
+    Because ``_ensure_direct_aliases()`` now rebinds the module attribute, any
+    consumer doing ``from hermes_cli.model_switch import DIRECT_ALIASES`` would
+    hold a permanently stale dict.  Consumers must go through the module
+    attribute (``model_switch.DIRECT_ALIASES``), as ``hermes_cli/oneshot.py``
+    does.  This is a source contract asserted over the real tree via AST, so
+    prose mentioning the pattern (like this docstring) is not a false positive.
+    """
+    import ast
+    from pathlib import Path
+
+    root = Path(ms.__file__).resolve().parent.parent
+    offenders = []
+    scanned = 0
+    for path in root.rglob("*.py"):
+        if any(p in {"venv", ".venv", "node_modules", "build", "dist"} for p in path.parts):
+            continue
+        try:
+            src = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        scanned += 1
+        if "DIRECT_ALIASES" not in src:
+            continue
+        try:
+            tree = ast.parse(src)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if not (node.module or "").endswith("model_switch"):
+                continue
+            if any(a.name == "DIRECT_ALIASES" for a in node.names):
+                offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+
+    assert scanned > 50, f"source scan found only {scanned} files — glob is wrong"
+    assert not offenders, (
+        "DIRECT_ALIASES is rebound on refresh, so a from-import captures a "
+        f"permanently stale table. Use `model_switch.DIRECT_ALIASES`. Offenders: {offenders}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: the REAL mtime-cached load_config() path, no mocks.
+#
+# Review finding (teknium1 on #67007): every test above monkeypatches
+# _load_direct_aliases(), so none of them exercise the real
+# hermes_cli.config.load_config() mtime cache that makes per-call refresh
+# affordable.  These tests write an actual config.yaml under a temp
+# HERMES_HOME and assert resolve_alias() follows edits with no process restart.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """A real, isolated HERMES_HOME with a real config.yaml on disk.
+
+    Clears hermes_cli.config's module caches so the (mtime_ns, size) key can't
+    carry over from another test's config path.
+    """
+    import hermes_cli.config as hcfg
+
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_CONFIG", raising=False)
+
+    for cache_name in ("_LOAD_CONFIG_CACHE", "_READ_RAW_CONFIG_CACHE"):
+        cache = getattr(hcfg, cache_name, None)
+        if isinstance(cache, dict):
+            cache.clear()
+
+    cfg_path = hcfg.get_config_path()
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    assert str(home) in str(cfg_path), (
+        f"config path {cfg_path} did not land under the temp HERMES_HOME {home} "
+        "— the test is not hermetic"
+    )
+    yield cfg_path
+    for cache_name in ("_LOAD_CONFIG_CACHE", "_READ_RAW_CONFIG_CACHE"):
+        cache = getattr(hcfg, cache_name, None)
+        if isinstance(cache, dict):
+            cache.clear()
+
+
+def _write_config(cfg_path, aliases: dict) -> None:
+    """Write a real config.yaml with a ``model.aliases`` map, bumping mtime.
+
+    The loader's cache key is (mtime_ns, size); a rewrite inside the same
+    filesystem-timestamp granularity could otherwise reuse the cached parse, so
+    stamp the mtime forward explicitly (this is what a real editor/`hermes
+    config set` does over human timescales).
+    """
+    import os
+    import time
+
+    import yaml
+
+    body = {"model": {"provider": "openrouter", "aliases": dict(aliases)}}
+    cfg_path.write_text(yaml.safe_dump(body), encoding="utf-8")
+    bumped = time.time() + _write_config.counter
+    _write_config.counter += 1
+    os.utime(cfg_path, (bumped, bumped))
+
+
+_write_config.counter = 1
+
+
+def test_integration_real_config_hot_reload(hermes_home):
+    """END-TO-END, no mocks: editing a real config.yaml changes what
+    resolve_alias() returns, in the same process, with no restart.
+
+    Exercises the real hermes_cli.config.load_config() mtime cache — the path
+    the mocked tests above never touch.
+    """
+    cfg_path = hermes_home
+
+    # 1. Initial config on disk.
+    _write_config(cfg_path, {"zed": "claude-apr/claude-x"})
+    assert ms.resolve_alias("zed", "openrouter") == ("claude-apr", "claude-x", "zed")
+
+    # 2. Repeat lookups are served from the mtime cache and stay correct.
+    for _ in range(3):
+        assert ms.resolve_alias("zed", "openrouter") == ("claude-apr", "claude-x", "zed")
+
+    # 3. The user edits the file — re-pointing the alias at another provider.
+    _write_config(cfg_path, {"zed": "openai-codex/gpt-5.6-terra"})
+    assert ms.resolve_alias("zed", "openrouter") == (
+        "openai-codex", "gpt-5.6-terra", "zed",
+    ), "resolve_alias did not follow a real config.yaml edit (hot-reload broken)"
+
+    # 4. The user adds a second alias; both resolve.
+    _write_config(cfg_path, {
+        "zed": "openai-codex/gpt-5.6-terra",
+        "zzalias": "moonshot/zz-model-9",
+    })
+    assert ms.resolve_alias("zzalias", "openrouter") == ("moonshot", "zz-model-9", "zzalias")
+    assert ms.resolve_alias("zed", "openrouter") == (
+        "openai-codex", "gpt-5.6-terra", "zed",
+    )
+
+    # 5. Reverse lookup by full model id also follows the real file.
+    assert ms.resolve_alias("zz-model-9", "openrouter") == (
+        "moonshot", "zz-model-9", "zzalias",
+    )
+
+    # 6. The user deletes an alias — it stops resolving (pruned, not sticky).
+    #    resolve_alias() triggers the refresh, so drive it through the public API.
+    _write_config(cfg_path, {"zed": "openai-codex/gpt-5.6-terra"})
+    assert ms.resolve_alias("zzalias", "openrouter") is None, (
+        "a deleted alias still resolved after a real-config refresh"
+    )
+    assert "zzalias" not in ms.DIRECT_ALIASES, (
+        "a deleted alias survived a real-config refresh"
+    )
+    # ...and the surviving alias is untouched by the prune.
+    assert ms.resolve_alias("zed", "openrouter") == (
+        "openai-codex", "gpt-5.6-terra", "zed",
+    )
+
+
+def test_integration_real_loader_is_actually_exercised(hermes_home, monkeypatch):
+    """Proves these integration tests run the REAL loader, not a mock.
+
+    Two independent proofs, both of which a mocked ``_load_direct_aliases()``
+    would make impossible:
+
+    1. The alias that ``resolve_alias()`` returns is the one *written to disk* —
+       change the bytes in the file, the answer changes.
+    2. Breaking the real ``hermes_cli.config.load_config()`` (the mtime-cached
+       function under test) makes the loader report ``ok=False``; the refresh
+       then retains its last-known-good table instead of pruning to builtins.
+       If the loader were mocked out, breaking ``load_config`` would be inert.
+
+    Note ``load_config()`` deliberately tolerates a *corrupt* config.yaml
+    (it keeps the previously loaded config and warns), so corrupting the YAML
+    is NOT a way to reach the degraded branch — the degraded branch is for a
+    read that actually raises.
+    """
+    import hermes_cli.config as hcfg
+
+    cfg_path = hermes_home
+
+    # --- Proof 1: the answer tracks the real bytes on disk. ---
+    _write_config(cfg_path, {"realpath": "claude-apr/claude-x"})
+    merged, ok = ms._load_direct_aliases()
+    assert ok is True
+    assert merged["realpath"] == ms.DirectAlias("claude-x", "claude-apr", ""), (
+        "the real loader did not read the alias written to the real config.yaml"
+    )
+    assert cfg_path.exists() and "realpath" in cfg_path.read_text(encoding="utf-8")
+
+    ms._ensure_direct_aliases()
+    assert ms.DIRECT_ALIASES["realpath"] == ms.DirectAlias("claude-x", "claude-apr", "")
+
+    # --- Proof 2: break the REAL load_config() the loader calls. ---
+    real_load_config = hcfg.load_config
+
+    def _boom():
+        raise OSError("simulated config read failure")
+
+    hcfg.load_config = _boom
+    try:
+        _merged_bad, ok_bad = ms._load_direct_aliases()
+        assert ok_bad is False, (
+            "breaking the real hermes_cli.config.load_config() did not degrade "
+            "_load_direct_aliases() — this test is not exercising the real path"
+        )
+
+        # Degraded read retains last-known-good rather than pruning to builtins.
+        ms._ensure_direct_aliases()
+        assert ms.DIRECT_ALIASES["realpath"] == ms.DirectAlias("claude-x", "claude-apr", ""), (
+            "degraded real-config read pruned user aliases (MB-2 regression)"
+        )
+    finally:
+        hcfg.load_config = real_load_config
+
+    # Restore the real loader: the refresh recovers from the real file on disk.
+    merged_ok, ok_again = ms._load_direct_aliases()
+    assert ok_again is True
+    assert merged_ok["realpath"] == ms.DirectAlias("claude-x", "claude-apr", "")

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -93,7 +93,7 @@ class TestDirectAliases:
         )
 
         from hermes_cli.model_switch import _load_direct_aliases
-        aliases = _load_direct_aliases()
+        aliases, _ok = _load_direct_aliases()
 
         assert "mymodel" in aliases
         assert aliases["mymodel"].model == "custom-model:latest"
@@ -109,6 +109,7 @@ class TestDirectAliases:
             "glm": DirectAlias("glm-4.7", "custom", "https://ollama.com/v1"),
         }
         monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        monkeypatch.setattr(ms, "_load_direct_aliases", lambda: (dict(test_aliases), True))
 
         result = resolve_alias("glm", "openrouter")
         assert result is not None
@@ -126,6 +127,7 @@ class TestDirectAliases:
             "kimi": DirectAlias("kimi-k2.5", "custom", "https://ollama.com/v1"),
         }
         monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        monkeypatch.setattr(ms, "_load_direct_aliases", lambda: (dict(test_aliases), True))
 
         # Typing full model name should resolve through the alias
         result = resolve_alias("kimi-k2.5", "openrouter")
@@ -144,6 +146,7 @@ class TestDirectAliases:
             "glm": DirectAlias("GLM-4.7", "custom", "https://ollama.com/v1"),
         }
         monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        monkeypatch.setattr(ms, "_load_direct_aliases", lambda: (dict(test_aliases), True))
 
         result = resolve_alias("glm-4.7", "openrouter")
         assert result is not None
@@ -231,7 +234,7 @@ class TestLoadDirectAliasesEdgeCases:
         )
 
         from hermes_cli.model_switch import _load_direct_aliases
-        aliases = _load_direct_aliases()
+        aliases, _ok = _load_direct_aliases()
         assert isinstance(aliases, dict)
 
     def test_model_aliases_not_a_dict(self, monkeypatch):
@@ -243,7 +246,7 @@ class TestLoadDirectAliasesEdgeCases:
         )
 
         from hermes_cli.model_switch import _load_direct_aliases
-        aliases = _load_direct_aliases()
+        aliases, _ok = _load_direct_aliases()
         assert isinstance(aliases, dict)
 
     def test_model_aliases_none_value(self, monkeypatch):
@@ -255,7 +258,7 @@ class TestLoadDirectAliasesEdgeCases:
         )
 
         from hermes_cli.model_switch import _load_direct_aliases
-        aliases = _load_direct_aliases()
+        aliases, _ok = _load_direct_aliases()
         assert isinstance(aliases, dict)
 
     def test_malformed_entry_without_model_key(self, monkeypatch):
@@ -278,7 +281,7 @@ class TestLoadDirectAliasesEdgeCases:
         )
 
         from hermes_cli.model_switch import _load_direct_aliases
-        aliases = _load_direct_aliases()
+        aliases, _ok = _load_direct_aliases()
         assert "bad_entry" not in aliases
         assert "good_entry" in aliases
 
@@ -298,7 +301,7 @@ class TestLoadDirectAliasesEdgeCases:
         )
 
         from hermes_cli.model_switch import _load_direct_aliases
-        aliases = _load_direct_aliases()
+        aliases, _ok = _load_direct_aliases()
         assert "string_entry" not in aliases
         assert "none_entry" not in aliases
         assert "list_entry" not in aliases
@@ -312,7 +315,7 @@ class TestLoadDirectAliasesEdgeCases:
         )
 
         from hermes_cli.model_switch import _load_direct_aliases
-        aliases = _load_direct_aliases()
+        aliases, _ok = _load_direct_aliases()
         assert isinstance(aliases, dict)
 
     def test_alias_name_normalized_lowercase(self, monkeypatch):
@@ -331,7 +334,7 @@ class TestLoadDirectAliasesEdgeCases:
         )
 
         from hermes_cli.model_switch import _load_direct_aliases
-        aliases = _load_direct_aliases()
+        aliases, _ok = _load_direct_aliases()
         assert "mymodel" in aliases
         assert "  MyModel  " not in aliases
 
@@ -349,7 +352,7 @@ class TestLoadDirectAliasesEdgeCases:
         )
 
         from hermes_cli.model_switch import _load_direct_aliases
-        aliases = _load_direct_aliases()
+        aliases, _ok = _load_direct_aliases()
         assert "empty" not in aliases
         assert "good" in aliases
 
@@ -378,8 +381,9 @@ class TestEnsureDirectAliases:
         ms._ensure_direct_aliases()
         assert "test" in ms.DIRECT_ALIASES
 
-    def test_ensure_no_reload_when_populated(self, monkeypatch):
-        """_ensure_direct_aliases does not reload if already populated."""
+    def test_ensure_reloads_when_populated(self, monkeypatch):
+        """_ensure_direct_aliases refreshes on every call (hot-reload), so a
+        config change is reflected even when the dict is already populated."""
         import hermes_cli.model_switch as ms
         from hermes_cli.model_switch import DirectAlias
 
@@ -387,15 +391,19 @@ class TestEnsureDirectAliases:
         monkeypatch.setattr(ms, "DIRECT_ALIASES", existing)
 
         call_count = [0]
-        original_load = ms._load_direct_aliases
         def counting_load():
             call_count[0] += 1
-            return original_load()
+            merged = dict(ms._BUILTIN_DIRECT_ALIASES)
+            merged["fresh"] = DirectAlias("fresh-model", "custom", "")
+            return merged, True
         monkeypatch.setattr(ms, "_load_direct_aliases", counting_load)
 
         ms._ensure_direct_aliases()
-        assert call_count[0] == 0
-        assert "pre" in ms.DIRECT_ALIASES
+        # Hot-reload: it DID reload, and the new alias is present.
+        assert call_count[0] == 1
+        assert "fresh" in ms.DIRECT_ALIASES
+        # 'pre' was not in the fresh config, so it is pruned.
+        assert "pre" not in ms.DIRECT_ALIASES
 
 
 # ---------------------------------------------------------------------------
@@ -422,6 +430,7 @@ class TestResolveAliasEdgeCases:
             "myalias": DirectAlias("my-model", "custom", "https://example.com"),
         }
         monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        monkeypatch.setattr(ms, "_load_direct_aliases", lambda: (dict(test_aliases), True))
 
         result = ms.resolve_alias("  myalias  ", "openrouter")
         assert result is not None
@@ -444,6 +453,7 @@ class TestSwitchModelDirectAliasOverride:
             "qwen": DirectAlias("qwen3.5:397b", "custom", "https://ollama.com/v1"),
         }
         monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        monkeypatch.setattr(ms, "_load_direct_aliases", lambda: (dict(test_aliases), True))
 
         monkeypatch.setattr(ms, "resolve_alias",
             lambda raw, prov: ("custom", "qwen3.5:397b", "qwen"))
@@ -472,6 +482,7 @@ class TestSwitchModelDirectAliasOverride:
             "local": DirectAlias("local-model", "custom", "http://localhost:11434/v1"),
         }
         monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        monkeypatch.setattr(ms, "_load_direct_aliases", lambda: (dict(test_aliases), True))
         monkeypatch.setattr(ms, "resolve_alias",
             lambda raw, prov: ("custom", "local-model", "local"))
         monkeypatch.setattr(

--- a/tests/hermes_cli/test_regression_16767.py
+++ b/tests/hermes_cli/test_regression_16767.py
@@ -13,7 +13,9 @@ def test_ensure_direct_aliases_mutates_in_place(monkeypatch):
     mock_data = {
         "my-custom-alias": DirectAlias("custom-model:v1", "custom", "https://example.com/v1")
     }
-    monkeypatch.setattr(ms, "_load_direct_aliases", lambda: mock_data)
+    # _load_direct_aliases now returns (merged, ok); the in-place-mutation
+    # contract under test is unchanged.
+    monkeypatch.setattr(ms, "_load_direct_aliases", lambda: (mock_data, True))
     
     ms._ensure_direct_aliases()
     

--- a/tests/hermes_cli/test_regression_16767.py
+++ b/tests/hermes_cli/test_regression_16767.py
@@ -4,24 +4,48 @@ import hermes_cli.model_switch as ms
 from hermes_cli.model_switch import DirectAlias
 from hermes_cli.runtime_provider import _resolve_named_custom_runtime
 
-def test_ensure_direct_aliases_mutates_in_place(monkeypatch):
-    """_ensure_direct_aliases mutates DIRECT_ALIASES in place (guards against rebinding regression)."""
-    # Ensure we start with an empty but existing dict to check for mutation vs rebinding
-    ms.DIRECT_ALIASES.clear()
-    initial_id = id(ms.DIRECT_ALIASES)
-    
-    mock_data = {
-        "my-custom-alias": DirectAlias("custom-model:v1", "custom", "https://example.com/v1")
-    }
-    # _load_direct_aliases now returns (merged, ok); the in-place-mutation
-    # contract under test is unchanged.
-    monkeypatch.setattr(ms, "_load_direct_aliases", lambda: (mock_data, True))
-    
-    ms._ensure_direct_aliases()
-    
-    assert id(ms.DIRECT_ALIASES) == initial_id, f"DIRECT_ALIASES was rebound (ID changed from {initial_id} to {id(ms.DIRECT_ALIASES)})"
-    assert "my-custom-alias" in ms.DIRECT_ALIASES
-    assert ms.DIRECT_ALIASES["my-custom-alias"].model == "custom-model:v1"
+def test_ensure_direct_aliases_publishes_atomically(monkeypatch):
+    """_ensure_direct_aliases publishes a NEW dict rather than mutating in place.
+
+    Originally this asserted the opposite (`id()` stable — "never rebind"), to
+    stop a `from hermes_cli.model_switch import DIRECT_ALIASES` consumer being
+    stranded on a stale empty dict.  Review of #67007 showed in-place mutation
+    is not thread-safe: gateway /model runs the switch under
+    ``asyncio.to_thread`` while ``resolve_alias()`` iterates the alias table, so
+    an in-place prune can raise "dictionary changed size during iteration" in
+    the reader.  The refresh now builds a new dict and rebinds atomically; the
+    stale-from-import hazard is instead closed by the source contract in
+    ``tests/hermes_cli/test_direct_alias_reload.py::
+    test_no_from_import_of_direct_aliases`` (no such import exists in-tree — the
+    only consumer, ``hermes_cli/oneshot.py``, reads the module attribute).
+    """
+    saved = ms.DIRECT_ALIASES
+    try:
+        ms.DIRECT_ALIASES = {"stale": DirectAlias("old-model", "custom", "")}
+        previous = ms.DIRECT_ALIASES
+        previous_snapshot = dict(previous)
+
+        mock_data = {
+            "my-custom-alias": DirectAlias("custom-model:v1", "custom", "https://example.com/v1")
+        }
+        # _load_direct_aliases returns (merged, ok).
+        monkeypatch.setattr(ms, "_load_direct_aliases", lambda: (mock_data, True))
+
+        ms._ensure_direct_aliases()
+
+        assert ms.DIRECT_ALIASES is not previous, (
+            "DIRECT_ALIASES was mutated in place — concurrent readers iterating "
+            "it can be invalidated (see #67007 review)"
+        )
+        assert previous == previous_snapshot, (
+            "the previously published dict was mutated after publication; a "
+            "reader still holding it would see a torn table"
+        )
+        assert "my-custom-alias" in ms.DIRECT_ALIASES
+        assert ms.DIRECT_ALIASES["my-custom-alias"].model == "custom-model:v1"
+        assert "stale" not in ms.DIRECT_ALIASES
+    finally:
+        ms.DIRECT_ALIASES = saved
 
 def test_chat_provider_argparse_acceptance(monkeypatch):
     """chat --provider <user-defined> is accepted by argparse (guards against restrictive choices)."""


### PR DESCRIPTION
## What

`_ensure_direct_aliases()` populated the process-global `DIRECT_ALIASES` dict **once** (`if not DIRECT_ALIASES`) and never refreshed. A running gateway that started before a `model.aliases` / `model_aliases` config edit resolved `/model <alias>` against a **stale** table and fell through to the built-in catalog aliases.

**Live symptom:** with `model.aliases.opus: "claude-apr/claude-opus-4-8"` written to config, a running gateway resolved `/model opus` → `openrouter/anthropic/claude-opus-4.8` (built-in family→highest-version fallback), not the configured value — because the alias dict was cached at boot, hours earlier.

## Fix

Refresh the dict on **every** call instead of once. `load_config()` is already mtime-cached (`_LOAD_CONFIG_CACHE`), so on an unchanged config this is a `stat()` + a small merge over ~10 entries — no YAML re-parse. So a `model.aliases` edit now takes effect on the **next `/model` switch, no gateway restart**.

- Mutates the dict **in place** (never rebinds — keeps `from ... import DIRECT_ALIASES` valid) and **never `.clear()`s** it (snapshot-keys-then-prune-then-update), so a concurrent reader never observes an empty dict.
- `_load_direct_aliases()` now returns `(merged, ok)`; on a **degraded** config read (`ok=False`) the refresh **retains last-known-good** user aliases rather than pruning them back to builtins (which would reintroduce the wrong-provider symptom), emitting one bounded `logger.warning`.

## Tests

`tests/hermes_cli/test_direct_alias_reload.py`: reload-on-change, `resolve_alias` reflection (incl. provider switch), removed-alias prune, degraded-read retention + warning, in-place/never-empty. Updated the `test_regression_16767` mock for the new `(merged, ok)` return (in-place-mutation contract unchanged).

Verified live: a temp-`HERMES_HOME` config edit with no restart / no manual clear flips `resolve_alias('opus', …)` from `claude-apr/claude-opus-4-8` to `openai-codex/gpt-5.6-terra`.
