### PR TITLE
feat(discord): add react/unreact actions to the discord tool

### DIFF
--- a/tests/tools/test_discord_react.py
+++ b/tests/tools/test_discord_react.py
@@ -1,0 +1,117 @@
+"""Tests for the discord tool's react / unreact actions."""
+import json
+
+import pytest
+
+import tools.discord_tool as dt
+
+
+@pytest.fixture(autouse=True)
+def _token(monkeypatch):
+    monkeypatch.setattr(dt, "_get_bot_token", lambda: "test-token")
+    # Default: no server_actions allowlist configured (all actions available).
+    monkeypatch.setattr(dt, "_load_allowed_actions_config", lambda: None)
+
+
+def _spy(monkeypatch):
+    calls = []
+
+    def _fake_request(method, path, token, params=None, body=None, timeout=15):
+        calls.append({"method": method, "path": path})
+        return None  # Discord returns 204 for add/remove reaction
+
+    monkeypatch.setattr(dt, "_discord_request", _fake_request)
+    return calls
+
+
+def test_react_issues_put_with_encoded_unicode_emoji(monkeypatch):
+    calls = _spy(monkeypatch)
+    out = json.loads(dt.discord_core(
+        "react", channel_id="C1", message_id="M1", emoji="✅",
+    ))
+    assert out["success"] is True
+    assert calls == [{
+        "method": "PUT",
+        "path": "/channels/C1/messages/M1/reactions/%E2%9C%85/@me",
+    }]
+
+
+def test_react_encodes_custom_emoji_name_id(monkeypatch):
+    calls = _spy(monkeypatch)
+    dt.discord_core("react", channel_id="C1", message_id="M1", emoji="party:123")
+    assert calls[0]["path"] == "/channels/C1/messages/M1/reactions/party%3A123/@me"
+
+
+def test_react_encodes_reserved_delimiter_hash(monkeypatch):
+    """INV-5: a '#'-bearing emoji must be percent-encoded, not corrupt the path."""
+    calls = _spy(monkeypatch)
+    dt.discord_core("react", channel_id="C1", message_id="M1", emoji="#\u20e3")
+    assert calls[0]["path"] == "/channels/C1/messages/M1/reactions/%23%E2%83%A3/@me"
+
+
+def test_unreact_issues_delete(monkeypatch):
+    calls = _spy(monkeypatch)
+    out = json.loads(dt.discord_core(
+        "unreact", channel_id="C1", message_id="M1", emoji="✅",
+    ))
+    assert out["success"] is True
+    assert calls[0]["method"] == "DELETE"
+    assert calls[0]["path"] == "/channels/C1/messages/M1/reactions/%E2%9C%85/@me"
+
+
+def test_react_missing_emoji_returns_error(monkeypatch):
+    _spy(monkeypatch)
+    out = json.loads(dt.discord_core("react", channel_id="C1", message_id="M1", emoji=""))
+    assert "error" in out
+    assert "emoji" in out["error"].lower()
+    assert out.get("success") is not True
+
+
+def test_react_non_403_failure_does_not_fabricate_success(monkeypatch):
+    """B1 fake-green guard: a 404 (message gone) must surface an error, never success:True."""
+    def _raise_404(method, path, token, params=None, body=None, timeout=15):
+        raise dt.DiscordAPIError(404, "Unknown Message")
+
+    monkeypatch.setattr(dt, "_discord_request", _raise_404)
+    out = json.loads(dt.discord_core("react", channel_id="C1", message_id="M1", emoji="✅"))
+    assert out.get("success") is not True
+    assert "error" in out
+
+
+def test_react_403_gives_actionable_hint(monkeypatch):
+    def _raise_403(method, path, token, params=None, body=None, timeout=15):
+        raise dt.DiscordAPIError(403, "Missing Permissions")
+
+    monkeypatch.setattr(dt, "_discord_request", _raise_403)
+    out = json.loads(dt.discord_core("react", channel_id="C1", message_id="M1", emoji="✅"))
+    assert "error" in out
+    assert "ADD_REACTIONS" in out["error"]
+
+
+def test_react_blocked_by_server_actions_allowlist(monkeypatch):
+    _spy(monkeypatch)
+    monkeypatch.setattr(dt, "_load_allowed_actions_config", lambda: ["fetch_messages"])
+    out = json.loads(dt.discord_core("react", channel_id="C1", message_id="M1", emoji="✅"))
+    assert "error" in out
+    assert "disabled by config" in out["error"]
+
+
+def test_react_available_when_server_actions_unset(monkeypatch):
+    """RC-C / D-1: with discord.server_actions unset, react runs (mirrors pin_message)."""
+    calls = _spy(monkeypatch)
+    monkeypatch.setattr(dt, "_load_allowed_actions_config", lambda: None)
+    out = json.loads(dt.discord_core("react", channel_id="C1", message_id="M1", emoji="✅"))
+    assert out["success"] is True
+    assert len(calls) == 1
+
+
+def test_react_unreact_in_core_schema():
+    assert dt._STATIC_CORE_SCHEMA is not None
+    enum = dt._STATIC_CORE_SCHEMA["parameters"]["properties"]["action"]["enum"]
+    assert "react" in enum and "unreact" in enum
+    assert "emoji" in dt._STATIC_CORE_SCHEMA["parameters"]["properties"]
+    # RC1: unreact description states the own-reaction scope.
+    unreact_line = next(
+        (d for n, _s, d in dt._ACTION_MANIFEST if n == "unreact"), "",
+    )
+    assert "OWN" in unreact_line or "own" in unreact_line

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -589,18 +589,20 @@ class TestRegistration:
         assert entry.requires_env == ["DISCORD_BOT_TOKEN"]
 
     def test_core_schema_actions(self):
-        """Core static schema should list only core actions."""
+        """Core static schema should list exactly the core actions."""
         from tools.registry import registry
+        from tools.discord_tool import _CORE_ACTION_NAMES
         entry = registry._tools["discord"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
-        assert actions == {"fetch_messages", "search_members", "create_thread"}
+        assert actions == set(_CORE_ACTION_NAMES)
 
     def test_admin_schema_actions(self):
         """Admin static schema should list only admin actions."""
         from tools.registry import registry
+        from tools.discord_tool import _CORE_ACTION_NAMES
         entry = registry._tools["discord_admin"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
-        expected_admin = set(_ACTIONS.keys()) - {"fetch_messages", "search_members", "create_thread"}
+        expected_admin = set(_ACTIONS.keys()) - set(_CORE_ACTION_NAMES)
         assert actions == expected_admin
 
     def test_all_actions_covered(self):

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -626,6 +626,41 @@ def _remove_role(token: str, guild_id: str, user_id: str, role_id: str, **_kwarg
     return json.dumps({"success": True, "message": f"Role {role_id} removed from user {user_id}."})
 
 
+def _react(
+    token: str, channel_id: str, message_id: str, emoji: str,
+    remove: bool = False, **_kwargs: Any,
+) -> str:
+    """Add (or with ``remove=True`` retract) the bot's OWN emoji reaction on a message.
+
+    ``emoji`` is a Unicode emoji (e.g. ``✅``) or a custom emoji as ``name:id``.
+    Discord returns 204 for both add and remove; ``_discord_request`` raises
+    ``DiscordAPIError`` on any non-2xx, so the success line below is reached
+    only on a genuine success (never fabricated).
+    """
+    if not emoji:
+        return json.dumps({"error": "Missing required parameter for 'react': emoji"})
+    # URL-encode the whole emoji token (encodes ':' -> %3A for custom name:id,
+    # '#' -> %23, and every UTF-8 byte for Unicode emoji) so the reaction path
+    # is never corrupted.
+    enc = urllib.parse.quote(emoji, safe="")
+    method = "DELETE" if remove else "PUT"
+    _discord_request(
+        method, f"/channels/{channel_id}/messages/{message_id}/reactions/{enc}/@me", token,
+    )
+    verb = "Removed" if remove else "Added"
+    return json.dumps({
+        "success": True,
+        "message": f"{verb} reaction {emoji} on message {message_id}.",
+    })
+
+
+def _unreact(
+    token: str, channel_id: str, message_id: str, emoji: str, **_kwargs: Any,
+) -> str:
+    """Remove the bot's OWN emoji reaction from a message."""
+    return _react(token, channel_id, message_id, emoji, remove=True)
+
+
 # ---------------------------------------------------------------------------
 # Action dispatch + metadata
 # ---------------------------------------------------------------------------
@@ -646,9 +681,11 @@ _ACTIONS = {
     "create_thread": _create_thread,
     "add_role": _add_role,
     "remove_role": _remove_role,
+    "react": _react,
+    "unreact": _unreact,
 }
 
-_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
+_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread", "react", "unreact"})
 _ADMIN_ACTION_NAMES = frozenset(_ACTIONS.keys()) - _CORE_ACTION_NAMES
 
 _CORE_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _CORE_ACTION_NAMES}
@@ -671,6 +708,8 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
     ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
+    ("react", "(channel_id, message_id, emoji)", "add an emoji reaction to a message"),
+    ("unreact", "(channel_id, message_id, emoji)", "remove the bot's OWN emoji reaction from a message"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -692,6 +731,8 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
     "create_thread": ["channel_id", "name"],
+    "react": ["channel_id", "message_id", "emoji"],
+    "unreact": ["channel_id", "message_id", "emoji"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
 }
@@ -872,6 +913,13 @@ def _build_schema(
             "enum": [60, 1440, 4320, 10080],
             "description": "Thread archive duration in minutes (create_thread, default 1440).",
         },
+        "emoji": {
+            "type": "string",
+            "description": (
+                "Emoji for react/unreact: a Unicode emoji (e.g. ✅) or a custom "
+                "emoji as 'name:id'."
+            ),
+        },
     }
 
     return {
@@ -932,6 +980,13 @@ _ACTION_403_HINT = {
     ),
     "create_thread": (
         "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it."
+    ),
+    "react": (
+        "Bot needs ADD_REACTIONS and READ_MESSAGE_HISTORY in this channel."
+    ),
+    "unreact": (
+        "Bot needs READ_MESSAGE_HISTORY in this channel (removing its own "
+        "reaction does not require ADD_REACTIONS)."
     ),
     "add_role": (
         "Either the bot lacks MANAGE_ROLES, or the target role sits higher "
@@ -999,6 +1054,7 @@ def _run_discord_action(
     before: str = "",
     after: str = "",
     auto_archive_duration: int = 1440,
+    emoji: str = "",
 ) -> str:
     """Shared handler logic for both discord tools."""
     token = _get_bot_token()
@@ -1032,6 +1088,7 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "emoji": emoji,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
@@ -1054,6 +1111,7 @@ def _run_discord_action(
             before=before,
             after=after,
             auto_archive_duration=auto_archive_duration,
+            emoji=emoji,
         )
     except DiscordAPIError as e:
         logger.warning("Discord API error in %s action '%s': %s", tool_label, action, e)
@@ -1083,6 +1141,7 @@ _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "emoji": "",
 }
 
 


### PR DESCRIPTION
## What

The `discord` REST tool exposed `pin_message` / `unpin_message` / `delete_message` but **no way for an agent to add or remove an emoji reaction**. The only reaction path was the Discord adapter's automatic 👀/✅/❌ processing markers, which are unreachable from a tool call — so an agent could not react to a Discord message at all. (`send_message action="react"` only supports adapters exposing a public `add_reaction(chat_id, emoji, message_id)` coroutine — Signal/iMessage — not Discord.)

## Fix

Add `react` / `unreact` as **core `discord` actions** via pure REST:

```
PUT    /channels/{channel_id}/messages/{message_id}/reactions/{emoji}/@me   (add, 204)
DELETE /channels/{channel_id}/messages/{message_id}/reactions/{emoji}/@me   (remove own, 204)
```

- The emoji is URL-encoded (`urllib.parse.quote(emoji, safe="")`) — Unicode percent-encoded, custom emoji as `name:id` → `name%3Aid`, `#` → `%23` — so `:` / `#` / multibyte sequences never corrupt the path.
- `unreact` removes only the **bot's own** reaction — stated in the action manifest so an agent doesn't read the idempotent 204 as "cleared everyone's reaction."
- Per-action 403 hints: `react` needs `ADD_REACTIONS` + `READ_MESSAGE_HISTORY`; `unreact` needs only `READ_MESSAGE_HISTORY` (removing an own reaction doesn't need `ADD_REACTIONS`), so operators aren't told to over-grant.
- `_discord_request` raises `DiscordAPIError` on every non-2xx, so the success result is emitted **only** on a genuine 204 — a 404/400/429 surfaces an error, never a fabricated success.
- react/unreact inherit the existing `discord.server_actions` allowlist exactly (available by default when unset, same as `pin_message`/`delete_message`; gated when the key is a list).

## Tests

`tests/tools/test_discord_react.py`: encoding (Unicode ✅, custom `name:id`, reserved `#`), PUT vs DELETE, missing-emoji error, **non-403 (404) does not fabricate success**, 403 actionable hint, allowlist gate, default-unset availability, schema/manifest wiring. Updated two core/admin schema-split tests to derive from `_CORE_ACTION_NAMES` instead of a hardcoded literal (behavior-contract, not change-detector). 109 tests pass.

Verified live: added + removed + re-added ✅ on a real Discord message via the runtime handler.
