### PR TITLE
fix(honcho): return created conclusion ID

### DIFF
--- a/optional-skills/autonomous-ai-agents/honcho/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/honcho/SKILL.md
@@ -251,7 +251,7 @@ The agent has 5 bidirectional Honcho tools (hidden in `context` recall mode):
 | `honcho_search` | No | low | Fetch specific past facts to reason over yourself — raw excerpts, no synthesis |
 | `honcho_context` | No | low | Full session context snapshot: summary, representation, card, recent messages |
 | `honcho_reasoning` | Yes | medium–high | Natural language question synthesized by Honcho's dialectic engine |
-| `honcho_conclude` | No | minimal | Write or delete a persistent fact; pass `peer: "ai"` for AI self-knowledge |
+| `honcho_conclude` | No | minimal | Create, list/search, or delete persistent conclusions; creation returns an ID for immediate deletion |
 
 ### `honcho_profile`
 Read or update a peer card — curated key facts (name, role, preferences, communication style). Pass `card: [...]` to update; omit to read. No LLM call.
@@ -266,7 +266,7 @@ Full session context snapshot from Honcho — session summary, peer representati
 Natural language question answered by Honcho's dialectic reasoning engine (LLM call on Honcho's backend). Higher cost, higher quality. Pass `reasoning_level` to control depth: `minimal` (fast/cheap) → `low` → `medium` → `high` → `max` (thorough). Omit to use the configured default (`low`). Use for synthesized understanding of the user's patterns, goals, or current state.
 
 ### `honcho_conclude`
-Write or delete a persistent conclusion about a peer. Pass `conclusion: "..."` to create. Pass `delete_id: "..."` to remove a conclusion (for PII removal — Honcho self-heals incorrect conclusions over time, so deletion is only needed for PII). You MUST pass exactly one of the two.
+Create, list/search, or delete a persistent conclusion about a peer. You MUST pass exactly one of `conclusion: "..."`, `list: true`, or `delete_id: "..."`. A successful creation returns `conclusion_id`; pass it directly as `delete_id` for immediate deletion. To find an older conclusion, use `list: true` and optionally `query: "..."`, then pass a returned `id` as `delete_id`. Deletion is for PII removal — Honcho self-heals incorrect conclusions over time, so write a corrected conclusion instead for non-PII corrections.
 
 ### Bidirectional peer targeting
 
@@ -281,9 +281,10 @@ honcho_profile                        # read user's card
 honcho_profile peer="ai"              # read AI peer's card
 honcho_reasoning query="What does this user care about most?"
 honcho_reasoning query="What are my interaction patterns?" peer="ai" reasoning_level="medium"
-honcho_conclude conclusion="Prefers terse answers"
+honcho_conclude conclusion="Prefers terse answers"  # response includes conclusion_id
 honcho_conclude conclusion="I tend to over-explain code" peer="ai"
-honcho_conclude delete_id="abc123"    # PII removal
+honcho_conclude list=true query="terse answers"  # returns older conclusions with ids
+honcho_conclude delete_id="abc123"  # use an id from creation or list; PII removal only
 ```
 
 ## Agent Usage Patterns

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -129,7 +129,7 @@ Five bidirectional tools. All accept an optional `peer` parameter (`"user"` or `
 | `honcho_search` | No | Cross-session message search (hybrid semantic + keyword, ranked excerpts; 800 tok default, 2000 max) |
 | `honcho_context` | No | Full session context: summary, representation, card, messages |
 | `honcho_reasoning` | Yes | LLM-synthesized answer via dialectic `.chat()` |
-| `honcho_conclude` | No | Write, list/search, or delete persistent conclusions (list surfaces the ids delete needs) |
+| `honcho_conclude` | No | Write, list/search, or delete persistent conclusions (creation returns an ID immediately; list surfaces IDs for older conclusions) |
 
 Tool visibility depends on `recallMode`: hidden in `context` mode, always present in `tools` and `hybrid`.
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -208,7 +208,12 @@ CONCLUDE_SCHEMA = {
             },
             "delete_id": {
                 "type": "string",
-                "description": "Conclusion ID to delete for PII removal. Provide this when deleting a conclusion. Do not send it together with conclusion or list. Get this id from a prior `list` call — never guess it.",
+                "description": (
+                    "Conclusion ID to delete for PII removal. Provide this when deleting a "
+                    "conclusion. Do not send it together with conclusion or list. Use the "
+                    "`conclusion_id` from a successful creation response or an ID returned "
+                    "by `list=true`; never guess an ID."
+                ),
             },
             "list": {
                 "type": "boolean",

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -190,8 +190,9 @@ CONCLUDE_SCHEMA = {
         "correction, a standing constraint) so future sessions carry it forward. "
         "You MUST pass exactly one of `conclusion` (to create), `delete_id` (to "
         "delete), or `list` (to list/search); any other combination is an error. "
-        "A deletion ID is an opaque server-generated string: first call with `list=true` "
-        "and optionally `query`, then pass the returned ID as `delete_id`. "
+        "Creation returns the opaque server-generated conclusion ID for immediate deletion. "
+        "To delete an older conclusion, first call with `list=true` and optionally `query`, "
+        "then pass the returned ID as `delete_id`. "
         "Deletion exists only for "
         "PII removal — for merely wrong facts, write a corrected conclusion instead; "
         "Honcho self-heals contradictions over time. This is a WRITE tool: to read "
@@ -1525,9 +1526,15 @@ class HonchoMemoryProvider(MemoryProvider):
                     if ok:
                         return json.dumps({"result": f"Conclusion {delete_id} deleted."})
                     return tool_error(f"Failed to delete conclusion {delete_id}.")
-                ok = self._manager.create_conclusion(self._session_key, conclusion, peer=peer)
-                if ok:
-                    return json.dumps({"result": f"Conclusion saved for {peer}: {conclusion}"})
+                conclusion_id = self._manager.create_conclusion(
+                    self._session_key, conclusion, peer=peer
+                )
+                if conclusion_id:
+                    return json.dumps({
+                        "result": f"Conclusion saved for {peer}: {conclusion}",
+                        "conclusion_id": conclusion_id,
+                        "peer": peer,
+                    })
                 return tool_error("Failed to save conclusion.")
 
             return tool_error(f"Unknown tool: {tool_name}")

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1219,7 +1219,7 @@ class HonchoSessionManager:
             target_peer = self._get_or_create_peer(target_peer_id)
             return target_peer.conclusions_of(target_peer_id)
 
-    def create_conclusion(self, session_key: str, content: str, peer: str = "user") -> bool:
+    def create_conclusion(self, session_key: str, content: str, peer: str = "user") -> str | None:
         """Write a conclusion about a target peer back to Honcho.
 
         Conclusions are facts a peer observes about another peer or itself —
@@ -1232,32 +1232,36 @@ class HonchoSessionManager:
             peer: Peer alias or explicit peer ID. "user" is the default alias.
 
         Returns:
-            True on success, False on failure.
+            The server-generated conclusion ID on success, otherwise None.
         """
         if not content or not content.strip():
-            return False
+            return None
 
         session = self._cache.get(session_key)
         if not session:
             logger.warning("No session cached for '%s', skipping conclusion", session_key)
-            return False
+            return None
 
         try:
             target_peer_id = self._resolve_peer_id(session, peer)
             if target_peer_id is None:
                 logger.warning("Could not resolve conclusion peer '%s' for session '%s'", peer, session_key)
-                return False
+                return None
 
             conclusions_scope = self._conclusions_scope(session, target_peer_id)
-            conclusions_scope.create([{
+            created = conclusions_scope.create([{
                 "content": content.strip(),
                 "session_id": session.honcho_session_id,
             }])
-            logger.info("Created conclusion about %s for %s: %s", target_peer_id, session_key, content[:80])
-            return True
+            if not created or not getattr(created[0], "id", None):
+                logger.error("Honcho created a conclusion without returning its ID")
+                return None
+            conclusion_id = str(created[0].id)
+            logger.info("Created conclusion %s about %s for %s: %s", conclusion_id, target_peer_id, session_key, content[:80])
+            return conclusion_id
         except Exception as e:
             logger.error("Failed to create conclusion: %s", e)
-            return False
+            return None
 
     def delete_conclusion(self, session_key: str, conclusion_id: str, peer: str = "user") -> bool:
         """Delete a conclusion by ID. Use only for PII removal.

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
@@ -426,12 +428,13 @@ class TestPeerLookupHelpers:
         mgr, session = self._make_cached_manager()
         assistant_peer = MagicMock()
         scope = MagicMock()
+        scope.create.return_value = [SimpleNamespace(id="conc-user")]
         assistant_peer.conclusions_of.return_value = scope
         mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
 
-        ok = mgr.create_conclusion(session.key, "User prefers dark mode")
+        conclusion_id = mgr.create_conclusion(session.key, "User prefers dark mode")
 
-        assert ok is True
+        assert conclusion_id == "conc-user"
         assistant_peer.conclusions_of.assert_called_once_with(session.user_peer_id)
         scope.create.assert_called_once_with([{
             "content": "User prefers dark mode",
@@ -442,12 +445,13 @@ class TestPeerLookupHelpers:
         mgr, session = self._make_cached_manager()
         assistant_peer = MagicMock()
         scope = MagicMock()
+        scope.create.return_value = [SimpleNamespace(id="conc-ai")]
         assistant_peer.conclusions_of.return_value = scope
         mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
 
-        ok = mgr.create_conclusion(session.key, "Assistant prefers terse summaries", peer="ai")
+        conclusion_id = mgr.create_conclusion(session.key, "Assistant prefers terse summaries", peer="ai")
 
-        assert ok is True
+        assert conclusion_id == "conc-ai"
         assistant_peer.conclusions_of.assert_called_once_with(session.assistant_peer_id)
         scope.create.assert_called_once_with([{
             "content": "Assistant prefers terse summaries",
@@ -458,17 +462,42 @@ class TestPeerLookupHelpers:
         mgr, session = self._make_cached_manager()
         assistant_peer = MagicMock()
         scope = MagicMock()
+        scope.create.return_value = [SimpleNamespace(id="conc-robert")]
         assistant_peer.conclusions_of.return_value = scope
         mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
 
-        ok = mgr.create_conclusion(session.key, "Robert prefers vinyl", peer=session.user_peer_id)
+        conclusion_id = mgr.create_conclusion(session.key, "Robert prefers vinyl", peer=session.user_peer_id)
 
-        assert ok is True
+        assert conclusion_id == "conc-robert"
         assistant_peer.conclusions_of.assert_called_once_with(session.user_peer_id)
         scope.create.assert_called_once_with([{
             "content": "Robert prefers vinyl",
             "session_id": session.honcho_session_id,
         }])
+
+    @pytest.mark.parametrize(
+        "created",
+        [[], [SimpleNamespace(id=None)]],
+    )
+    def test_create_conclusion_returns_none_without_created_id(self, created):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        scope = MagicMock()
+        scope.create.return_value = created
+        assistant_peer.conclusions_of.return_value = scope
+        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+
+        assert mgr.create_conclusion(session.key, "User prefers dark mode") is None
+
+    def test_create_conclusion_returns_none_on_sdk_exception(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        scope = MagicMock()
+        scope.create.side_effect = RuntimeError("boom")
+        assistant_peer.conclusions_of.return_value = scope
+        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+
+        assert mgr.create_conclusion(session.key, "User prefers dark mode") is None
 
     def test_list_conclusions_uses_query_when_query_given(self):
         mgr, session = self._make_cached_manager()
@@ -536,7 +565,7 @@ class TestConcludeToolDispatch:
         provider._session_initialized = True
         provider._session_key = "telegram:123"
         provider._manager = MagicMock()
-        provider._manager.create_conclusion.return_value = True
+        provider._manager.create_conclusion.return_value = "conc-123"
 
         result = provider.handle_tool_call(
             "honcho_conclude",
@@ -550,12 +579,38 @@ class TestConcludeToolDispatch:
             peer="user",
         )
 
+    def test_honcho_conclude_returns_id_for_immediate_deletion(self):
+        import json
+
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.create_conclusion.return_value = "conc-123"
+        provider._manager.delete_conclusion.return_value = True
+
+        created = json.loads(provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "Temporary health check"},
+        ))
+        deleted = json.loads(provider.handle_tool_call(
+            "honcho_conclude",
+            {"delete_id": created["conclusion_id"]},
+        ))
+
+        assert created["conclusion_id"] == "conc-123"
+        assert created["peer"] == "user"
+        assert deleted == {"result": "Conclusion conc-123 deleted."}
+        provider._manager.delete_conclusion.assert_called_once_with(
+            "telegram:123", "conc-123", peer="user"
+        )
+
     def test_honcho_conclude_can_target_ai_peer(self):
         provider = HonchoMemoryProvider()
         provider._session_initialized = True
         provider._session_key = "telegram:123"
         provider._manager = MagicMock()
-        provider._manager.create_conclusion.return_value = True
+        provider._manager.create_conclusion.return_value = "conc-123"
 
         result = provider.handle_tool_call(
             "honcho_conclude",

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -226,7 +226,9 @@ When Honcho is active as the memory provider, five tools become available:
 | `honcho_search` | Semantic search over context — raw excerpts, no LLM synthesis |
 | `honcho_context` | Full session context — summary, representation, card, recent messages |
 | `honcho_reasoning` | Synthesized answer from Honcho's LLM — pass `reasoning_level` (minimal/low/medium/high/max) to control depth |
-| `honcho_conclude` | Create or delete conclusions — pass `conclusion` to create, `delete_id` to remove (PII only) |
+| `honcho_conclude` | Create, list/search, or delete conclusions; creation returns an ID for immediate deletion |
+
+A successful `honcho_conclude` create returns `conclusion_id`, which can be passed directly as `delete_id`. For an older conclusion, call `honcho_conclude` with `list=true` and optionally `query`, then use a returned `id`. Deletion remains intended for PII removal; for a non-PII correction, write a corrected conclusion and let Honcho reconcile the contradiction.
 
 ## CLI Commands
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -51,7 +51,7 @@ AI-native cross-session user modeling with dialectic reasoning, session-scoped c
 | **Data storage** | Honcho Cloud or self-hosted |
 | **Cost** | Honcho pricing (cloud) / free (self-hosted) |
 
-**Tools (5):** `honcho_profile` (read/update peer card), `honcho_search` (semantic search), `honcho_context` (session context — summary, representation, card, messages), `honcho_reasoning` (LLM-synthesized), `honcho_conclude` (create/delete conclusions)
+**Tools (5):** `honcho_profile` (read/update peer card), `honcho_search` (semantic search), `honcho_context` (session context — summary, representation, card, messages), `honcho_reasoning` (LLM-synthesized), `honcho_conclude` (create/list-search/delete conclusions; creation returns an ID for immediate deletion)
 
 **Architecture:** Two-layer context injection — a base layer (session summary + representation + peer card, refreshed on `contextCadence`) plus a dialectic supplement (LLM reasoning, refreshed on `dialecticCadence`). The dialectic automatically selects cold-start prompts (general user facts) vs. warm prompts (session-scoped context) based on whether base context exists.
 

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
@@ -266,7 +266,7 @@ The agent has 5 bidirectional Honcho tools (hidden in `context` recall mode):
 | `honcho_search` | No | low | Fetch specific past facts to reason over yourself — raw excerpts, no synthesis |
 | `honcho_context` | No | low | Full session context snapshot: summary, representation, card, recent messages |
 | `honcho_reasoning` | Yes | medium–high | Natural language question synthesized by Honcho's dialectic engine |
-| `honcho_conclude` | No | minimal | Write or delete a persistent fact; pass `peer: "ai"` for AI self-knowledge |
+| `honcho_conclude` | No | minimal | Create, list/search, or delete persistent conclusions; creation returns an ID for immediate deletion |
 
 ### `honcho_profile`
 Read or update a peer card — curated key facts (name, role, preferences, communication style). Pass `card: [...]` to update; omit to read. No LLM call.
@@ -281,7 +281,7 @@ Full session context snapshot from Honcho — session summary, peer representati
 Natural language question answered by Honcho's dialectic reasoning engine (LLM call on Honcho's backend). Higher cost, higher quality. Pass `reasoning_level` to control depth: `minimal` (fast/cheap) → `low` → `medium` → `high` → `max` (thorough). Omit to use the configured default (`low`). Use for synthesized understanding of the user's patterns, goals, or current state.
 
 ### `honcho_conclude`
-Write or delete a persistent conclusion about a peer. Pass `conclusion: "..."` to create. Pass `delete_id: "..."` to remove a conclusion (for PII removal — Honcho self-heals incorrect conclusions over time, so deletion is only needed for PII). You MUST pass exactly one of the two.
+Create, list/search, or delete a persistent conclusion about a peer. You MUST pass exactly one of `conclusion: "..."`, `list: true`, or `delete_id: "..."`. A successful creation returns `conclusion_id`; pass it directly as `delete_id` for immediate deletion. To find an older conclusion, use `list: true` and optionally `query: "..."`, then pass a returned `id` as `delete_id`. Deletion is for PII removal — Honcho self-heals incorrect conclusions over time, so write a corrected conclusion instead for non-PII corrections.
 
 ### Bidirectional peer targeting
 
@@ -296,9 +296,10 @@ honcho_profile                        # read user's card
 honcho_profile peer="ai"              # read AI peer's card
 honcho_reasoning query="What does this user care about most?"
 honcho_reasoning query="What are my interaction patterns?" peer="ai" reasoning_level="medium"
-honcho_conclude conclusion="Prefers terse answers"
+honcho_conclude conclusion="Prefers terse answers"  # response includes conclusion_id
 honcho_conclude conclusion="I tend to over-explain code" peer="ai"
-honcho_conclude delete_id="abc123"    # PII removal
+honcho_conclude list=true query="terse answers"  # returns older conclusions with ids
+honcho_conclude delete_id="abc123"  # use an id from creation or list; PII removal only
 ```
 
 ## Agent Usage Patterns


### PR DESCRIPTION
## Summary

- return the server-generated conclusion ID from `HonchoSessionManager.create_conclusion`
- include `conclusion_id` and `peer` in successful `honcho_conclude` creation responses
- enable deterministic create → delete flows without a separate list/search lookup
- preserve `list=true` with optional `query` for locating older conclusions
- normalize creation failure returns to `None`
- align the tool schema, optional Honcho skill, generated skill page, plugin README, and feature docs with the create/list/delete contract

## Why

`honcho_conclude(delete_id=...)` requires an opaque server-generated ID, but creation previously discarded that ID. This made immediate reversible writes—and especially PII-removal workflows—unnecessarily difficult even though Honcho SDK 2.2.0 returns the created `Conclusion` objects.

## Tests

- `./scripts/run_tests.sh tests/honcho_plugin/test_session.py -q` — 145 passed
- `./scripts/run_tests.sh tests/honcho_plugin -q` — 427 passed
- Ruff on the modified Python files — passed
- `git diff --check` — passed
- generated optional-skill source/page parity check — passed
- `cd website && npm run build` — passed for English and Chinese locales (with pre-existing broken-link/anchor warnings outside the changed Honcho pages)

The regression coverage verifies SDK ID extraction, empty/missing-ID and exception failure paths, and provider-level create → delete dispatch using the returned ID.

### Full-suite note

A full repository test run was also attempted on macOS before this review follow-up. It did not pass: 49 failures across 23 unrelated test files, plus 17 files that timed out or failed before collection. None of the failures were in `tests/honcho_plugin`; observed failures included platform-specific executable behavior and subprocess timeouts. The focused Honcho suites above remain clean.