### PR TITLE
fix(cli): scope TUI npm-install check to the ui-tui workspace closure (#66978)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1656,6 +1656,71 @@ def _termux_workspace_install_context(
     return ws_root, tuple(workspace_args)
 
 
+def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
+    """Package-map keys reachable from workspace ``start`` via npm resolution.
+
+    Returns ``None`` when ``start`` is absent from *packages* so callers fall
+    back to the full-lockfile comparison.
+
+    The launch install is scoped with ``npm install --workspace ui-tui`` (see
+    ``_make_tui_argv``), so only the ui-tui workspace's dependency closure is
+    written to the hidden ``.package-lock.json``.  The shared root
+    ``package-lock.json`` additionally lists every *other* workspace's deps
+    (``apps/desktop``, ``web``, …); comparing the two in full reports those
+    unrelated packages as "missing" and reinstalls on every launch (#66978).
+
+    Keys follow npm's v3 ``packages`` map (``""`` root, ``ui-tui`` /
+    ``apps/desktop`` workspace members, ``node_modules/<name>`` hoisted deps,
+    ``<dir>/node_modules/<name>`` nested deps).  Dependency names resolve to a
+    key by walking up ``node_modules`` ancestors, mirroring node resolution, and
+    workspace symlinks (``link: true``) are followed to their real entry so a
+    linked workspace's own deps join the closure.
+    """
+    if start not in packages:
+        return None
+
+    def resolve(from_key: str, dep: str) -> Optional[str]:
+        base = from_key
+        while True:
+            prefix = f"{base}/" if base else ""
+            candidate = f"{prefix}node_modules/{dep}"
+            if candidate in packages:
+                return candidate
+            if not base:
+                return None
+            base = base.rsplit("/", 1)[0] if "/" in base else ""
+
+    seen: set = set()
+    stack = [start]
+    while stack:
+        key = stack.pop()
+        if key in seen:
+            continue
+        seen.add(key)
+        entry = packages.get(key)
+        if not isinstance(entry, dict):
+            continue
+        # Workspace symlink (e.g. node_modules/@hermes/ink → ui-tui/packages/…):
+        # follow to the real package entry so its dependencies join the closure.
+        resolved = entry.get("resolved")
+        if entry.get("link") and isinstance(resolved, str) and resolved in packages:
+            stack.append(resolved)
+        # devDependencies are installed for the workspace being scoped (ui-tui's
+        # build toolchain), but not for transitive deps.
+        fields = ["dependencies", "optionalDependencies", "peerDependencies"]
+        if key == start:
+            fields.append("devDependencies")
+        for field in fields:
+            deps = entry.get(field)
+            if not isinstance(deps, dict):
+                continue
+            for dep in deps:
+                target = resolve(key, dep)
+                if target is not None:
+                    stack.append(target)
+    return seen
+
+
 def _tui_need_npm_install(root: Path) -> bool:
     """True when @hermes/ink is missing or node_modules is behind package-lock.json.
 
@@ -1717,8 +1782,26 @@ def _tui_need_npm_install(root: Path) -> bool:
     def comparable(pkg: dict) -> dict:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
+    # In a shared workspace checkout the launch install is scoped to the ui-tui
+    # workspace, so only its dependency closure lands in the hidden lock.  Limit
+    # the comparison to that closure so unrelated workspace deps (apps/desktop,
+    # web, …) don't force a reinstall every launch (#66978).  Standalone /
+    # own-lockfile layouts (ws_root == root) do a full install, so keep the full
+    # comparison; a missing/unlocatable workspace falls back to it too.
+    closure: Optional[set] = None
+    if ws_root != root:
+        try:
+            workspace_key = root.relative_to(ws_root).as_posix()
+        except ValueError:
+            workspace_key = ""
+        if workspace_key:
+            closure = _npm_lock_workspace_closure(wanted, workspace_key)
+
     for name, pkg in wanted.items():
         if not name:
+            continue
+
+        if closure is not None and name not in closure:
             continue
 
         if not isinstance(pkg, dict):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1656,18 +1656,24 @@ def _termux_workspace_install_context(
     return ws_root, tuple(workspace_args)
 
 
-def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
-    """Package-map keys reachable from workspace ``start`` via npm resolution.
+def _npm_lock_workspace_closure(packages: dict, starts) -> Optional[set]:
+    """Package-map keys reachable from the selected workspaces via npm resolution.
 
-    Returns ``None`` when ``start`` is absent from *packages* so callers fall
-    back to the full-lockfile comparison.
+    *starts* is the set of workspace keys the launch install explicitly scopes
+    to (a single str is accepted for convenience).  ``devDependencies`` are
+    followed for **each** of those workspaces, since ``npm install`` installs
+    the dev toolchain for every workspace it selects.  Returns ``None`` when
+    none of *starts* are present in *packages* so callers fall back to the
+    full-lockfile comparison.
 
     The launch install is scoped with ``npm install --workspace ui-tui`` (see
     ``_make_tui_argv``), so only the ui-tui workspace's dependency closure is
-    written to the hidden ``.package-lock.json``.  The shared root
-    ``package-lock.json`` additionally lists every *other* workspace's deps
-    (``apps/desktop``, ``web``, …); comparing the two in full reports those
-    unrelated packages as "missing" and reinstalls on every launch (#66978).
+    written to the hidden ``.package-lock.json``.  On Termux it additionally
+    selects ui-tui's child ``packages/*`` workspaces, so their devDependencies
+    join the closure too.  The shared root ``package-lock.json`` additionally
+    lists every *other* workspace's deps (``apps/desktop``, ``web``, …);
+    comparing the two in full reports those unrelated packages as "missing" and
+    reinstalls on every launch (#66978).
 
     Keys follow npm's v3 ``packages`` map (``""`` root, ``ui-tui`` /
     ``apps/desktop`` workspace members, ``node_modules/<name>`` hoisted deps,
@@ -1676,7 +1682,9 @@ def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
     workspace symlinks (``link: true``) are followed to their real entry so a
     linked workspace's own deps join the closure.
     """
-    if start not in packages:
+    start_set = {starts} if isinstance(starts, str) else {s for s in starts if s}
+    present = [s for s in start_set if s in packages]
+    if not present:
         return None
 
     def resolve(from_key: str, dep: str) -> Optional[str]:
@@ -1691,7 +1699,7 @@ def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
             base = base.rsplit("/", 1)[0] if "/" in base else ""
 
     seen: set = set()
-    stack = [start]
+    stack = list(present)
     while stack:
         key = stack.pop()
         if key in seen:
@@ -1705,10 +1713,10 @@ def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
         resolved = entry.get("resolved")
         if entry.get("link") and isinstance(resolved, str) and resolved in packages:
             stack.append(resolved)
-        # devDependencies are installed for the workspace being scoped (ui-tui's
-        # build toolchain), but not for transitive deps.
+        # devDependencies are installed for each explicitly-selected workspace
+        # (its build toolchain), but not for transitive deps.
         fields = ["dependencies", "optionalDependencies", "peerDependencies"]
-        if key == start:
+        if key in start_set:
             fields.append("devDependencies")
         for field in fields:
             deps = entry.get(field)
@@ -1719,6 +1727,35 @@ def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
                 if target is not None:
                     stack.append(target)
     return seen
+
+
+def _tui_selected_workspace_keys(tui_dir: Path, ws_root: Path) -> set:
+    """Lock-map keys for the workspaces the launch install scopes to.
+
+    Mirrors ``_make_tui_argv``: always the ui-tui workspace, plus its child
+    ``packages/*`` workspaces on Termux (where ``include_child_workspaces=True``
+    in ``_termux_workspace_install_context``).  ``npm install`` installs the
+    devDependencies of every workspace it selects, so the freshness closure must
+    treat each as a dev-included root — otherwise a devDependency unique to a
+    selected child is dropped from the closure and a genuine missing package
+    slips past the check.  Returns an empty set when ui-tui can't be located
+    under *ws_root*, so the caller falls back to the full comparison.
+    """
+    try:
+        primary = tui_dir.relative_to(ws_root).as_posix()
+    except ValueError:
+        return set()
+    keys = {primary}
+    if _is_termux_startup_environment():
+        packages_dir = tui_dir / "packages"
+        if packages_dir.is_dir():
+            for child in sorted(packages_dir.iterdir()):
+                if child.is_dir() and (child / "package.json").is_file():
+                    try:
+                        keys.add(child.relative_to(ws_root).as_posix())
+                    except ValueError:
+                        continue
+    return keys
 
 
 def _tui_need_npm_install(root: Path) -> bool:
@@ -1783,19 +1820,17 @@ def _tui_need_npm_install(root: Path) -> bool:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
     # In a shared workspace checkout the launch install is scoped to the ui-tui
-    # workspace, so only its dependency closure lands in the hidden lock.  Limit
-    # the comparison to that closure so unrelated workspace deps (apps/desktop,
+    # workspace (plus its child packages/* workspaces on Termux), so only that
+    # dependency closure lands in the hidden lock.  Limit the comparison to the
+    # same selected-workspace closure so unrelated workspace deps (apps/desktop,
     # web, …) don't force a reinstall every launch (#66978).  Standalone /
     # own-lockfile layouts (ws_root == root) do a full install, so keep the full
     # comparison; a missing/unlocatable workspace falls back to it too.
     closure: Optional[set] = None
     if ws_root != root:
-        try:
-            workspace_key = root.relative_to(ws_root).as_posix()
-        except ValueError:
-            workspace_key = ""
-        if workspace_key:
-            closure = _npm_lock_workspace_closure(wanted, workspace_key)
+        selected = _tui_selected_workspace_keys(root, ws_root)
+        if selected:
+            closure = _npm_lock_workspace_closure(wanted, selected)
 
     for name, pkg in wanted.items():
         if not name:

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -224,6 +224,62 @@ def test_workspace_closure_returns_none_when_start_absent(main_mod) -> None:
     assert main_mod._npm_lock_workspace_closure({"node_modules/foo": {}}, "ui-tui") is None
 
 
+def test_workspace_closure_includes_dev_deps_of_selected_child_workspace(main_mod) -> None:
+    """On Termux the install also scopes to ui-tui's child packages/* workspaces,
+    so each selected child's devDependencies join the closure — a dev dep unique
+    to a child is NOT dropped (regression for the child-scope false-negative)."""
+    packages = {
+        "ui-tui": {"dependencies": {"@hermes/ink": "*"}},
+        "node_modules/@hermes/ink": {
+            "link": True,
+            "resolved": "ui-tui/packages/hermes-ink",
+        },
+        "ui-tui/packages/hermes-ink": {"devDependencies": {"child-dev-only": "1"}},
+        "node_modules/child-dev-only": {},
+    }
+    # Only ui-tui selected (desktop): the child's dev dep is not installed.
+    desktop = main_mod._npm_lock_workspace_closure(packages, {"ui-tui"})
+    assert "node_modules/child-dev-only" not in desktop
+    # ui-tui + child selected (Termux): the child's dev dep is in the closure.
+    termux = main_mod._npm_lock_workspace_closure(
+        packages, {"ui-tui", "ui-tui/packages/hermes-ink"}
+    )
+    assert "node_modules/child-dev-only" in termux
+
+
+def test_termux_install_catches_missing_child_workspace_dev_dep(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """On Termux the launch install selects ui-tui/packages/* too, installing
+    each child's devDependencies.  A child dev dep missing from the hidden lock
+    must trigger a reinstall — off Termux (child not selected) it must not."""
+    ws_lock = (
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"@hermes/ink":"*"}},'
+        '"node_modules/@hermes/ink":{"link":true,"resolved":"ui-tui/packages/hermes-ink"},'
+        '"ui-tui/packages/hermes-ink":{"devDependencies":{"child-dev-only":"1.0.0"}},'
+        '"node_modules/child-dev-only":{"version":"1.0.0"}'
+        "}}"
+    )
+    hidden_lock = (
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"@hermes/ink":"*"}},'
+        '"node_modules/@hermes/ink":{"link":true,"resolved":"ui-tui/packages/hermes-ink"},'
+        '"ui-tui/packages/hermes-ink":{"devDependencies":{"child-dev-only":"1.0.0"}}'
+        "}}"
+    )
+    tui_dir = _write_ws(tmp_path, ws_lock, hidden_lock)
+    child = tui_dir / "packages" / "hermes-ink"
+    child.mkdir(parents=True, exist_ok=True)
+    (child / "package.json").write_text('{"name":"@hermes/ink"}')
+
+    monkeypatch.setattr(main_mod, "_is_termux_startup_environment", lambda: False)
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+    monkeypatch.setattr(main_mod, "_is_termux_startup_environment", lambda: True)
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
 def test_no_install_prebuilt_bundle_mode(tmp_path: Path, main_mod) -> None:
     """dist/entry.js present and no package-lock.json → prebuilt bundle, skip npm install."""
     _touch_tui_entry(tmp_path)

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -57,6 +57,415 @@ def test_make_tui_argv_uses_bundled_tui_when_workspace_missing(
     runnable bundled TUI on disk. The bundled shortcut must succeed without
     ever touching the (missing) ui-tui workspace or git.
     """
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{'
+        '"node_modules/foo":{"version":"1.0.0","dev":true,"peer":true,"resolved":"https://x/foo.tgz"}'
+        '}}'
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{'
+        '"node_modules/foo":{"version":"1.0.0","dev":true,"resolved":"https://x/foo.tgz"}'
+        '}}'
+    )
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_install_when_version_differs_even_with_peer_drop(tmp_path: Path, main_mod) -> None:
+    """The peer-drop tolerance must not mask a real version skew."""
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{"node_modules/foo":{"version":"2.0.0","dev":true,"peer":true}}}'
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{"node_modules/foo":{"version":"1.0.0","dev":true}}}'
+    )
+    assert main_mod._tui_need_npm_install(tmp_path) is True
+
+
+def test_no_install_when_lock_older_than_marker(tmp_path: Path, main_mod) -> None:
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text("{}")
+    (tmp_path / "node_modules" / ".package-lock.json").write_text("{}")
+    os.utime(tmp_path / "package-lock.json", (100, 100))
+    os.utime(tmp_path / "node_modules" / ".package-lock.json", (200, 200))
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_need_install_when_marker_missing(tmp_path: Path, main_mod) -> None:
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text("{}")
+    assert main_mod._tui_need_npm_install(tmp_path) is True
+
+
+def test_no_install_without_lockfile_when_ink_present(tmp_path: Path, main_mod) -> None:
+    _touch_ink(tmp_path)
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+# ── workspace-scoped comparison (#66978) ────────────────────────────
+#
+# In a shared workspace checkout the launch install is scoped to the ui-tui
+# workspace, so only its dependency closure lands in the hidden lock while the
+# root lock lists every other workspace's deps too. The comparison must ignore
+# those unrelated packages instead of reinstalling on every launch.
+
+
+def _write_ws(root: Path, ws_lock: str, hidden_lock: str) -> Path:
+    """Lay out a workspace root + ui-tui member and return the ui-tui dir.
+
+    ``@hermes/ink`` and the marker live at the workspace root (hoisted);
+    ``ui-tui/`` has no lockfile of its own so ``_workspace_root`` treats the
+    parent as the workspace root and the launch scopes to ``--workspace ui-tui``.
+    """
+    (root / "package-lock.json").write_text(ws_lock)
+    _touch_ink(root)
+    (root / "node_modules" / ".package-lock.json").write_text(hidden_lock)
+    tui_dir = root / "ui-tui"
+    tui_dir.mkdir(parents=True, exist_ok=True)
+    # package.json (and no own lockfile) is what makes _workspace_root treat the
+    # parent as the workspace root and the launch scope to --workspace ui-tui.
+    (tui_dir / "package.json").write_text('{"name":"hermes-tui"}')
+    return tui_dir
+
+
+def test_no_install_when_only_other_workspace_deps_missing(tmp_path: Path, main_mod) -> None:
+    """Deps that belong to apps/desktop / web (never installed by the ui-tui
+    scoped install) must not trigger a reinstall on every launch (#66978)."""
+    tui_dir = _write_ws(
+        tmp_path,
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"1.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"},'
+        '"apps/desktop":{"dependencies":{"desktop-only":"1.0.0"}},'
+        '"node_modules/desktop-only":{"version":"1.0.0"},'
+        '"apps/desktop/node_modules/nested":{"version":"1.0.0"}'
+        "}}",
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"1.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"}'
+        "}}",
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_need_install_when_ui_tui_dep_missing_in_workspace_layout(tmp_path: Path, main_mod) -> None:
+    """A genuinely missing ui-tui dependency is still caught after scoping."""
+    tui_dir = _write_ws(
+        tmp_path,
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"1.0.0","bar":"1.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"},'
+        '"node_modules/bar":{"version":"1.0.0"}'
+        "}}",
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"1.0.0","bar":"1.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"}'
+        "}}",
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_need_install_when_linked_workspace_dep_missing(tmp_path: Path, main_mod) -> None:
+    """The closure follows workspace symlinks (@hermes/ink → ui-tui/packages/…)
+    so a linked workspace's own missing dep triggers a reinstall."""
+    tui_dir = _write_ws(
+        tmp_path,
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"@hermes/ink":"*"}},'
+        '"node_modules/@hermes/ink":{"link":true,"resolved":"ui-tui/packages/hermes-ink"},'
+        '"ui-tui/packages/hermes-ink":{"dependencies":{"inkdep":"1.0.0"}},'
+        '"node_modules/inkdep":{"version":"1.0.0"}'
+        "}}",
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"@hermes/ink":"*"}},'
+        '"node_modules/@hermes/ink":{"link":true,"resolved":"ui-tui/packages/hermes-ink"},'
+        '"ui-tui/packages/hermes-ink":{"dependencies":{"inkdep":"1.0.0"}}'
+        "}}",
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_need_install_when_closure_package_version_drifts(tmp_path: Path, main_mod) -> None:
+    """Version drift on an in-closure package still forces a reinstall."""
+    tui_dir = _write_ws(
+        tmp_path,
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"2.0.0"}},'
+        '"node_modules/foo":{"version":"2.0.0"}'
+        "}}",
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"2.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"}'
+        "}}",
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_workspace_closure_includes_dev_deps_of_scoped_workspace(main_mod) -> None:
+    """ui-tui's devDependencies (esbuild/typescript build toolchain) are part of
+    the closure; a transitive package's devDependencies are not."""
+    packages = {
+        "ui-tui": {
+            "dependencies": {"foo": "1"},
+            "devDependencies": {"esbuild": "1"},
+        },
+        "node_modules/foo": {"devDependencies": {"foo-dev-only": "1"}},
+        "node_modules/esbuild": {},
+        "node_modules/foo-dev-only": {},
+    }
+    closure = main_mod._npm_lock_workspace_closure(packages, "ui-tui")
+    assert "node_modules/esbuild" in closure
+    assert "node_modules/foo-dev-only" not in closure
+
+
+def test_workspace_closure_returns_none_when_start_absent(main_mod) -> None:
+    """Missing workspace key → None so the caller falls back to full compare."""
+    assert main_mod._npm_lock_workspace_closure({"node_modules/foo": {}}, "ui-tui") is None
+
+
+def test_no_install_prebuilt_bundle_mode(tmp_path: Path, main_mod) -> None:
+    """dist/entry.js present and no package-lock.json → prebuilt bundle, skip npm install."""
+    _touch_tui_entry(tmp_path)
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_need_rebuild_when_tui_bundle_missing(tmp_path: Path, main_mod) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "entry.tsx").write_text("console.log('src')")
+
+    assert main_mod._tui_need_rebuild(tmp_path) is True
+
+
+def test_no_rebuild_when_tui_bundle_newer_than_inputs(tmp_path: Path, main_mod) -> None:
+    _touch_tui_entry(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "entry.tsx").write_text("console.log('src')")
+    os.utime(src / "entry.tsx", (100, 100))
+    os.utime(tmp_path / "dist" / "entry.js", (200, 200))
+
+    assert main_mod._tui_need_rebuild(tmp_path) is False
+
+
+def test_rebuild_when_tui_source_newer_than_bundle(tmp_path: Path, main_mod) -> None:
+    _touch_tui_entry(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "entry.tsx").write_text("console.log('src')")
+    os.utime(tmp_path / "dist" / "entry.js", (100, 100))
+    os.utime(src / "entry.tsx", (200, 200))
+
+    assert main_mod._tui_need_rebuild(tmp_path) is True
+
+
+def test_make_tui_argv_skips_build_only_on_termux_when_fresh(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_tui_entry(tmp_path)
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("fresh Termux TUI launch must not rebuild")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fail_run)
+
+    argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
+    assert cwd == tmp_path
+
+
+def test_make_tui_argv_skips_install_on_termux_when_bundle_fresh(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_tui_entry(tmp_path)
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("fresh Termux TUI launch must not run npm")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fail_run)
+
+    argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
+    assert cwd == tmp_path
+
+
+def test_make_tui_argv_scopes_npm_install_on_termux_workspace(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    ink_dir = tui_dir / "packages" / "hermes-ink"
+    ink_dir.mkdir(parents=True)
+    (ink_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    install_cmd = calls[0][0][0]
+    assert install_cmd[:7] == [
+        "/bin/npm",
+        "install",
+        "--workspace",
+        "ui-tui",
+        "--workspace",
+        "ui-tui/packages/hermes-ink",
+        "--include-workspace-root=false",
+    ]
+    assert calls[0][1]["cwd"] == str(tmp_path)
+    _assert_utf8_replace_capture(calls[0][1])
+    _assert_utf8_replace_capture(calls[1][1])
+
+
+def test_make_tui_argv_keeps_desktop_workspace_install_behaviour(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert calls[0][0][0] == [
+        "/bin/npm",
+        "install",
+        "--workspace",
+        "ui-tui",
+        "--include=dev",
+        "--silent",
+        "--no-fund",
+        "--no-audit",
+        "--progress=false",
+    ]
+    assert calls[0][1]["cwd"] == str(tmp_path)
+    _assert_utf8_replace_capture(calls[0][1])
+    _assert_utf8_replace_capture(calls[1][1])
+
+
+def test_make_tui_argv_npm_install_forces_include_dev(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """The TUI-launch npm install must force --include=dev: ui-tui's build
+    toolchain (esbuild, typescript) lives in devDependencies, and an inherited
+    NODE_ENV=production (container shells; a parent TUI sets it on its own
+    subprocess env) or an npm `omit=dev` config would silently skip them,
+    breaking the TUI build with `tsc`/`esbuild: command not found."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setenv("NODE_ENV", "production")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    install_cmd = calls[0][0][0]
+    assert install_cmd[:2] == ["/bin/npm", "install"]
+    assert "--include=dev" in install_cmd
+
+
+def test_make_tui_argv_keeps_desktop_always_build_behaviour(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_tui_entry(tmp_path)
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert calls
+    assert calls[0][0][0] == ["/bin/npm", "run", "build"]
+    _assert_utf8_replace_capture(calls[0][1])
+
+
+def test_make_tui_argv_decodes_dev_prebuild_with_utf8_replace(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    ink_dir = tmp_path / "packages" / "hermes-ink"
+    ink_dir.mkdir(parents=True)
+    tsx = tmp_path / "node_modules" / ".bin" / "tsx"
+    tsx.parent.mkdir(parents=True)
+    tsx.write_text("")
+
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=True)
+
+    assert argv == [str(tsx), "src/entry.tsx"]
+    assert cwd == tmp_path
+    assert calls[0][0][0] == ["/bin/npm", "run", "build"]
+    assert calls[0][1]["cwd"] == str(ink_dir)
+    _assert_utf8_replace_capture(calls[0][1])
+
+
+def test_make_tui_argv_exits_with_recovery_hint_when_workspace_unrecoverable(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    """Missing ui-tui + no git checkout → clean error, never touches node/npm."""
     monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
     monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
 


### PR DESCRIPTION
## What does this PR do?

`_tui_need_npm_install()` printed **"Installing TUI dependencies…"** and ran `npm install --workspace ui-tui` on *every* TUI launch, even when nothing had changed.

The check compares the shared root `package-lock.json` against npm's hidden `node_modules/.package-lock.json`. But in a workspace checkout the launch install is scoped with `npm install --workspace ui-tui` (see `_make_tui_argv`), so the hidden lock only ever contains the **ui-tui dependency closure**. The root lock additionally lists every *other* workspace's deps (`apps/desktop`, `web`, `tests-js`, …). Iterating the full root lock, those unrelated packages are always "missing" from the hidden lock, so the check returns `True` and reinstalls each time. npm itself no-ops quickly, but the message and the wasted invocation print on every launch (#66978).

The fix restricts the comparison to the ui-tui workspace's dependency closure, computed from the root lock's `packages` map — mirroring npm's nearest-`node_modules` resolution and following workspace symlinks (`@hermes/ink` → `ui-tui/packages/…`). Standalone / own-lockfile layouts (curl install, where a full `npm install` runs) keep the full comparison, and any case where the workspace can't be located falls back to it too — so drift on a genuine ui-tui dependency is still caught and the change never *under*-installs.

## Related Issue

Fixes #66978

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: new `_npm_lock_workspace_closure(packages, start)` helper — returns the set of lockfile package keys reachable from a workspace via npm dependency resolution (walks `node_modules` ancestors, follows `link: true` workspace entries, includes the scoped workspace's `devDependencies`), or `None` when the workspace key is absent.
- `hermes_cli/main.py`: `_tui_need_npm_install()` now computes that closure in a shared-workspace layout (`ws_root != root`) and skips lock entries outside it; standalone layouts and unlocatable-workspace cases fall back to the existing full comparison.
- `tests/hermes_cli/test_tui_npm_install.py`: 6 new tests (other-workspace deps ignored; genuine missing ui-tui dep still installs; symlinked-workspace dep closure; in-closure version drift installs; devDependency scoping; `None` fallback when the workspace is absent).

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py -q` → **36 passed**.
2. Regression proof: `test_no_install_when_only_other_workspace_deps_missing` models a root lock carrying an `apps/desktop`-only dep absent from the hidden lock; it asserts `_tui_need_npm_install()` is `False` (before this change it returned `True` — the spurious reinstall).
3. Repro in a real checkout: run `hermes` (TUI) twice — the second launch no longer prints "Installing TUI dependencies…".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (affected suite: `tests/hermes_cli/test_tui_npm_install.py`, plus `test_tui_resume_flow.py` / `test_tui_prebuilt_bundle.py`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring updated; no user-facing docs affected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure path/string logic, uses `PurePosixPath`-style `as_posix()` keys that match npm's lock format on all platforms)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (every launch):
```
$ hermes
Installing TUI dependencies…
```
After: silent on subsequent launches once deps are installed.
