### PR TITLE
fix(gateway): transcribe voice replies before clarify

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9685,6 +9685,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 
+    async def _clarify_reply_text(self, event: MessageEvent) -> str:
+        """Return text for a pending clarify reply, transcribing voice input first."""
+        raw_text = (event.text or "").strip()
+        if raw_text:
+            return raw_text
+
+        if event.message_type != MessageType.VOICE:
+            return ""
+
+        media_urls = list(getattr(event, "media_urls", None) or [])
+        audio_paths = [
+            path
+            for index, path in enumerate(media_urls)
+            if _event_media_is_audio(event, index)
+        ]
+        if not audio_paths:
+            return ""
+
+        _, transcripts = await self._enrich_message_with_transcription("", audio_paths)
+        reply_text = "\n".join(
+            transcript.strip()
+            for transcript in transcripts
+            if isinstance(transcript, str) and transcript.strip()
+        )
+        if not reply_text:
+            return ""
+
+        if self._should_echo_stt_transcripts():
+            adapter = self._adapter_for_source(event.source)
+            metadata = self._thread_metadata_for_source(
+                event.source,
+                self._reply_anchor_for_event(event),
+            )
+            if adapter:
+                try:
+                    await adapter.send(
+                        event.source.chat_id,
+                        f'🎙️ "{reply_text}"',
+                        metadata=metadata,
+                    )
+                except Exception as exc:
+                    logger.debug("Clarify transcript echo failed (non-fatal): %s", exc)
+
+        return reply_text
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -9922,7 +9967,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             _pending_clarify = None
         if _pending_clarify is not None and _clarify_mod is not None:
-            _raw_clarify_reply = (event.text or "").strip()
+            _raw_clarify_reply = await self._clarify_reply_text(event)
             # Skip slash commands — the user clearly wanted to issue a
             # command, not answer the clarify.  Leave the clarify pending
             # so the user can retry; if it times out, the agent unblocks

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -54,6 +54,24 @@ def _make_event(text="hello", chat_id="123", platform_val="telegram"):
     return evt
 
 
+def _make_voice_event(chat_id="123"):
+    """Build a cached Telegram voice event before gateway STT enrichment."""
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="dm",
+        user_id="user1",
+    )
+    return MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        message_id="voice-msg1",
+        media_urls=["/tmp/clarify-answer.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+
 def _make_runner():
     """Build a minimal GatewayRunner-like object for testing."""
     from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
@@ -69,6 +87,7 @@ def _make_runner():
     runner.config = MagicMock()
     runner.config.group_sessions_per_user = True
     runner.config.thread_sessions_per_user = False
+    runner.config.multiplex_profiles = False
     runner.session_store = None
     runner.hooks = MagicMock()
     runner.hooks.emit = AsyncMock()
@@ -121,6 +140,36 @@ class TestBusySessionAck:
         assert adapter._pending_messages[sk] is event
         assert sk not in runner._pending_messages
         running_agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pending_clarify_accepts_transcribed_voice_response(self):
+        """A voice reply must unblock clarify instead of remaining empty/queued."""
+        from gateway.run import GatewayRunner
+        from tools import clarify_gateway as clarify
+
+        runner, _sentinel = _make_runner()
+        event = _make_voice_event()
+        session_key = build_session_key(event.source)
+        clarify.register("voice-clarify", session_key, "Your answer?", None)
+
+        runner._enrich_message_with_transcription = AsyncMock(
+            return_value=('"My spoken answer"', ["My spoken answer"])
+        )
+        runner._should_echo_stt_transcripts = MagicMock(return_value=False)
+
+        try:
+            result = await GatewayRunner._handle_message(runner, event)
+
+            assert result == ""
+            pending = clarify.get_pending_for_session(session_key)
+            assert pending is not None
+            assert pending.response == "My spoken answer"
+            assert pending.event.is_set()
+            runner._enrich_message_with_transcription.assert_awaited_once_with(
+                "", ["/tmp/clarify-answer.ogg"]
+            )
+        finally:
+            clarify.clear_session(session_key)
 
     @pytest.mark.asyncio
     async def test_telegram_grace_followups_respect_queue_fifo(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Transcribe cached Telegram voice messages before resolving a pending gateway clarification.
- Preserve existing typed-reply behavior and configurable transcript echo.
- Add a regression test proving a spoken answer unblocks the waiting clarification request.

## Root cause
The active-session adapter correctly routed voice replies around the busy queue when a clarification was pending, but the gateway clarification interceptor read only `event.text`. STT enrichment normally ran later in the standard message pipeline, so the interceptor saw an empty answer and left the agent blocked waiting for the response that had already arrived.

## Verification
- `pytest tests/gateway/test_busy_session_ack.py tests/gateway/test_active_session_text_merge.py tests/tools/test_clarify_gateway.py -q -n 0` — 60 passed.
- `python -m py_compile gateway/run.py tests/gateway/test_busy_session_ack.py` — passed.
- `git diff origin/main...HEAD --check` — passed.
- Reproduced and verified end-to-end with Telegram voice replies to clarification prompts.
