### PR TITLE
fix(agent): expand file/folder/git context refs off the event loop

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -223,17 +223,36 @@ async def _expand_reference(
     allowed_root: Path | None = None,
 ) -> tuple[str | None, str | None]:
     try:
+        # These expanders are synchronous and do real blocking work: disk reads
+        # and a ``git`` subprocess that may run to its 30s timeout. Called
+        # inline they hold whatever loop runs this coroutine — on the gateway
+        # path (``preprocess_context_references_async`` from gateway/run.py)
+        # that is the shared loop serving every other platform. It also defeats
+        # the ``asyncio.gather`` above: blocking calls cannot interleave, so N
+        # refs cost the SUM of their runtimes instead of the max. Hop to a
+        # worker thread so the gather delivers the concurrency it documents.
         if ref.kind == "file":
-            return _expand_file_reference(ref, cwd, allowed_root=allowed_root)
+            return await asyncio.to_thread(
+                _expand_file_reference, ref, cwd, allowed_root=allowed_root
+            )
         if ref.kind == "folder":
-            return _expand_folder_reference(ref, cwd, allowed_root=allowed_root)
+            return await asyncio.to_thread(
+                _expand_folder_reference, ref, cwd, allowed_root=allowed_root
+            )
         if ref.kind == "diff":
-            return _expand_git_reference(ref, cwd, ["diff"], "git diff")
+            return await asyncio.to_thread(
+                _expand_git_reference, ref, cwd, ["diff"], "git diff"
+            )
         if ref.kind == "staged":
-            return _expand_git_reference(ref, cwd, ["diff", "--staged"], "git diff --staged")
+            return await asyncio.to_thread(
+                _expand_git_reference, ref, cwd, ["diff", "--staged"], "git diff --staged"
+            )
         if ref.kind == "git":
             count = max(1, min(int(ref.target or "1"), 10))
-            return _expand_git_reference(ref, cwd, ["log", f"-{count}", "-p"], f"git log -{count} -p")
+            return await asyncio.to_thread(
+                _expand_git_reference,
+                ref, cwd, ["log", f"-{count}", "-p"], f"git log -{count} -p",
+            )
         if ref.kind == "url":
             content = await _fetch_url_content(ref.target, url_fetcher=url_fetcher)
             if not content:

--- a/tests/agent/test_context_refs_concurrent.py
+++ b/tests/agent/test_context_refs_concurrent.py
@@ -51,3 +51,66 @@ async def test_concurrent_preserves_output_contract(tmp_path):
     assert "CONTENT[https://two.example/q]" in res.message
     assert res.message.index("one.example") < res.message.index("two.example")
     assert res.injected_tokens > 0
+
+
+@pytest.mark.asyncio
+async def test_git_ref_expands_off_the_event_loop(tmp_path, monkeypatch):
+    """The git expander must not run on the caller's event loop.
+
+    ``_expand_git_reference`` shells out to ``git`` with a 30s timeout. Called
+    inline it holds whatever loop runs the coroutine — on the gateway path
+    (``preprocess_context_references_async`` from gateway/run.py) that is the
+    shared loop serving every other platform, so one ``@diff`` from one user
+    stalls the whole gateway.
+    """
+    import threading
+
+    from agent import context_references as cr
+
+    main_thread = threading.current_thread()
+    seen: dict = {}
+
+    def _fake_git(ref, cwd, args, label):
+        seen["thread"] = threading.current_thread()
+        return None, f"GIT[{label}]"
+
+    monkeypatch.setattr(cr, "_expand_git_reference", _fake_git)
+
+    res = await preprocess_context_references_async(
+        "look at @diff please", cwd=tmp_path, context_length=100_000,
+    )
+
+    assert "GIT[git diff]" in res.message
+    assert seen.get("thread") is not None, "git expander never ran"
+    assert seen["thread"] is not main_thread, (
+        "git expansion ran on the event-loop thread; it must be dispatched via "
+        "asyncio.to_thread so a 30s git subprocess can't stall the gateway loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_refs_expand_concurrently(tmp_path, monkeypatch):
+    """The gather must deliver real concurrency for the *sync* ref kinds too.
+
+    The existing concurrency coverage uses ``@url:`` refs, which are natively
+    awaitable — so it passed even while file/folder/git refs ran inline and
+    serialised. Blocking calls cannot interleave, so N such refs cost the SUM
+    of their runtimes rather than the max.
+    """
+    from agent import context_references as cr
+
+    def _slow_file(ref, cwd, *, allowed_root=None):
+        time.sleep(0.2)
+        return None, f"FILE[{ref.target}]"
+
+    monkeypatch.setattr(cr, "_expand_file_reference", _slow_file)
+
+    msg = "@file:a.txt @file:b.txt @file:c.txt"
+    t0 = time.perf_counter()
+    res = await preprocess_context_references_async(
+        msg, cwd=tmp_path, context_length=100_000,
+    )
+    elapsed = time.perf_counter() - t0
+
+    assert "FILE[a.txt]" in res.message
+    assert elapsed < 0.4, f"expected concurrent (~0.2s), got {elapsed:.2f}s (serial?)"


### PR DESCRIPTION
## What

`_expand_reference` is a coroutine, but the **file**, **folder** and **git** expanders it dispatches to are synchronous and do real blocking work — disk reads and a `git` subprocess that can run to its **30s timeout**.

The gateway reaches this via `preprocess_context_references_async` (`gateway/run.py`), so one inbound message containing `@diff`, `@staged`, `@git:N`, `@file:` or `@folder:` holds the shared gateway loop for the whole expansion — no other platform's messages, heartbeats or sessions are serviced meanwhile.

It also silently defeats the `asyncio.gather` these coroutines run under. That gather exists so N refs cost one round-trip instead of N:

```python
# Expand all references concurrently. Each _expand_reference is independent
# ... would otherwise pay one full web_extract round-trip per ref in series.
```

Blocking calls can't interleave, so N file/git refs still cost the **sum** of their runtimes. The existing concurrency coverage only used `@url:` refs (natively awaitable), so it stayed green while the sync kinds serialised.

## Fix

Dispatch the three synchronous expanders via `asyncio.to_thread`. Arguments, behaviour and return shape are unchanged.

## Tests

Two new tests in `tests/agent/test_context_refs_concurrent.py`, both failing before the fix and passing after:

- `test_git_ref_expands_off_the_event_loop` — the git expander executes on a worker thread, not the loop thread.
- `test_sync_refs_expand_concurrently` — three `@file:` refs complete in ~0.2s (concurrent) rather than ~0.6s (serial), proving the gather's documented concurrency now holds for sync ref kinds too.

Suite: `1 failed, 39 passed` on clean `main` → `1 failed, 41 passed` with this change (+2 new tests). The single failure (`test_blocks_sensitive_home_and_hermes_paths`) is pre-existing and unrelated.