### PR TITLE
fix(tui): surface image-routing downgrades instead of silently sending text

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -912,6 +912,31 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           void refreshBackgroundProcesses(sessionId)
         } else if (sessionId && payload?.kind === 'goal') {
           applyGoalStatusText(sessionId, coerceGatewayText(payload?.text))
+        } else if (sessionId && payload?.kind === 'image_routing') {
+          // The turn's image was downgraded to a text description (model lacks
+          // vision, a provider override forced text, or native attachment
+          // failed). The Ink TUI surfaces this on its status line; the desktop
+          // has no such line, so without this handler the user sees the model
+          // answer as if it had looked at the image — the #66829 report.
+          // Persistent system message, not a toast: it explains that turn's
+          // answer, so it has to stay next to it in the transcript.
+          const routingText = coerceGatewayText(payload?.text).trim()
+
+          if (routingText) {
+            flushQueuedDeltas(sessionId)
+            updateSessionState(sessionId, state => ({
+              ...state,
+              messages: [
+                ...state.messages,
+                {
+                  id: `image-routing-${Date.now()}`,
+                  role: 'system',
+                  parts: [textPart(routingText)],
+                  timestamp: Math.floor(Date.now() / 1000)
+                }
+              ]
+            }))
+          }
         }
       } else if (event.type === 'review.summary') {
         // Self-improvement background review saved something to memory/skills

--- a/apps/desktop/src/app/session/hooks/use-message-stream/image-routing-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/image-routing-event.test.tsx
@@ -1,0 +1,117 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let stateByRuntimeId = new Map<string, ClientSessionState>()
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(stateByRuntimeId)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}) {
+  act(() => handleEvent!({ payload, session_id: SID, type }))
+}
+
+function systemTexts() {
+  const state = stateByRuntimeId.get(SID)
+
+  return (state?.messages ?? [])
+    .filter(message => message.role === 'system')
+    .flatMap(message => message.parts.map(part => ('text' in part ? part.text : '')))
+}
+
+// #66829: the gateway downgrades an attached image to a text description when
+// the routed model has no vision (or native attachment fails). The Ink TUI puts
+// that on its status line; the desktop had no equivalent, so the user saw a
+// confident answer with no sign the model never looked at the image.
+describe('useMessageStream image-routing downgrade', () => {
+  beforeEach(() => {
+    handleEvent = null
+    stateByRuntimeId = new Map()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the downgrade notice as a persistent system message', async () => {
+    await mountStream()
+
+    emit('status.update', {
+      kind: 'image_routing',
+      text: '⚠ Image sent as a text description — model has no vision support.'
+    })
+
+    expect(systemTexts()).toEqual([
+      '⚠ Image sent as a text description — model has no vision support.'
+    ])
+  })
+
+  it('keeps one notice per downgraded turn rather than collapsing them', async () => {
+    await mountStream()
+
+    emit('status.update', { kind: 'image_routing', text: '⚠ first turn downgraded.' })
+    emit('status.update', { kind: 'image_routing', text: '⚠ second turn downgraded.' })
+
+    expect(systemTexts()).toEqual(['⚠ first turn downgraded.', '⚠ second turn downgraded.'])
+  })
+
+  it('ignores an empty payload instead of adding a blank message', async () => {
+    await mountStream()
+
+    emit('status.update', { kind: 'image_routing', text: '   ' })
+    emit('status.update', { kind: 'image_routing' })
+
+    expect(systemTexts()).toEqual([])
+  })
+
+  // Guards the actual defect: the notice used to ship as kind "process", which
+  // the desktop consumes only to re-sync background-process state, dropping the
+  // text entirely. If it ever regresses to that kind, nothing renders.
+  it('does not render process-kind status updates as messages', async () => {
+    await mountStream()
+
+    emit('status.update', { kind: 'process', text: '⚠ Image sent as a text description — nope.' })
+
+    expect(systemTexts()).toEqual([])
+  })
+})

--- a/tests/tui_gateway/test_image_routing_downgrade.py
+++ b/tests/tui_gateway/test_image_routing_downgrade.py
@@ -1,0 +1,64 @@
+"""The turn-time image mode decision must report downgrades, not hide them.
+
+A user who forces ``agent.image_input_mode: native`` on a Codex app-server
+session (or hits a decision failure) previously got a text description with
+zero UI signal that the setting was overridden — the only evidence was a
+stderr line in the gateway log (#66829).
+"""
+
+from types import SimpleNamespace
+
+import agent.image_routing as image_routing
+from tui_gateway.server import _decide_turn_image_mode
+
+
+def _agent(api_mode: str = "chat_completions") -> SimpleNamespace:
+    return SimpleNamespace(provider="openai", model="gpt-5.5", api_mode=api_mode)
+
+
+class TestDecideTurnImageMode:
+    def test_native_decision_is_honored_with_no_reason(self, monkeypatch):
+        monkeypatch.setattr(
+            image_routing, "decide_image_input_mode", lambda p, m, c, **kw: "native"
+        )
+        mode, reason = _decide_turn_image_mode(_agent())
+        assert mode == "native"
+        assert reason is None
+
+    def test_codex_app_server_downgrades_native_with_reason(self, monkeypatch):
+        monkeypatch.setattr(
+            image_routing, "decide_image_input_mode", lambda p, m, c, **kw: "native"
+        )
+        mode, reason = _decide_turn_image_mode(_agent(api_mode="codex_app_server"))
+        assert mode == "text"
+        assert reason is not None and "Codex app-server" in reason
+
+    def test_codex_app_server_text_decision_has_no_spurious_reason(self, monkeypatch):
+        # When the decision is already text, nothing was overridden — the
+        # status line must not cry wolf.
+        monkeypatch.setattr(
+            image_routing, "decide_image_input_mode", lambda p, m, c, **kw: "text"
+        )
+        mode, reason = _decide_turn_image_mode(_agent(api_mode="codex_app_server"))
+        assert mode == "text"
+        assert reason is None
+
+    def test_decision_failure_falls_back_to_text_with_reason(self, monkeypatch):
+        def _boom(p, m, c, **kw):
+            raise RuntimeError("metadata backend unreachable")
+
+        monkeypatch.setattr(image_routing, "decide_image_input_mode", _boom)
+        mode, reason = _decide_turn_image_mode(_agent())
+        assert mode == "text"
+        assert reason is not None
+        assert "RuntimeError" in reason and "metadata backend unreachable" in reason
+
+    def test_trace_line_names_provider_model_and_both_modes(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            image_routing, "decide_image_input_mode", lambda p, m, c, **kw: "native"
+        )
+        _decide_turn_image_mode(_agent(api_mode="codex_app_server"))
+        err = capsys.readouterr().err
+        assert "[tui_gateway] image_routing:" in err
+        assert "decided=native" in err
+        assert "final=text" in err

--- a/tests/tui_gateway/test_image_routing_downgrade.py
+++ b/tests/tui_gateway/test_image_routing_downgrade.py
@@ -8,8 +8,11 @@ stderr line in the gateway log (#66829).
 
 from types import SimpleNamespace
 
+import pytest
+
 import agent.image_routing as image_routing
-from tui_gateway.server import _decide_turn_image_mode
+import tui_gateway.server as server
+from tui_gateway.server import _build_run_message, _decide_turn_image_mode
 
 
 def _agent(api_mode: str = "chat_completions") -> SimpleNamespace:
@@ -62,3 +65,96 @@ class TestDecideTurnImageMode:
         assert "[tui_gateway] image_routing:" in err
         assert "decided=native" in err
         assert "final=text" in err
+
+
+@pytest.fixture
+def emitted(monkeypatch):
+    """Capture status.update payloads instead of pushing them to a client."""
+    seen: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event, sid, payload=None: seen.append((event, sid, payload or {}))
+    )
+    monkeypatch.setattr(
+        server, "_enrich_with_attached_images", lambda text, paths: f"{text} <described>"
+    )
+    return seen
+
+
+def _notices(emitted):
+    return [
+        p["text"]
+        for event, _sid, p in emitted
+        if event == "status.update" and p.get("kind") == "image_routing"
+    ]
+
+
+class TestBuildRunMessageEmitsNotices:
+    """Every path that silently degrades an image must announce itself.
+
+    The decision helper is unit-tested above; these drive the emission so a
+    regression in the wiring (wrong kind, missing branch, swallowed notice)
+    fails here rather than shipping a silent downgrade to the user (#66829).
+    """
+
+    IMAGES = ["/tmp/shot.png"]
+
+    def test_no_images_emits_nothing_and_passes_prompt_through(self, emitted):
+        assert _build_run_message("s1", _agent(), "hello", []) == "hello"
+        assert _notices(emitted) == []
+
+    def test_downgrade_reason_is_announced(self, monkeypatch, emitted):
+        monkeypatch.setattr(
+            image_routing, "decide_image_input_mode", lambda p, m, c, **kw: "native"
+        )
+        out = _build_run_message("s1", _agent(api_mode="codex_app_server"), "hi", self.IMAGES)
+        assert out == "hi <described>"
+        assert len(_notices(emitted)) == 1
+        assert "Codex app-server" in _notices(emitted)[0]
+
+    def test_unreadable_image_data_is_announced(self, monkeypatch, emitted):
+        monkeypatch.setattr(
+            image_routing, "decide_image_input_mode", lambda p, m, c, **kw: "native"
+        )
+        monkeypatch.setattr(
+            image_routing, "build_native_content_parts", lambda t, p: ([{"type": "text"}], p)
+        )
+        out = _build_run_message("s1", _agent(), "hi", self.IMAGES)
+        assert out == "hi <described>"
+        assert _notices(emitted) == [
+            "⚠ Image sent as a text description — no readable image data for native attachment."
+        ]
+
+    def test_native_attach_failure_is_announced_with_type(self, monkeypatch, emitted):
+        monkeypatch.setattr(
+            image_routing, "decide_image_input_mode", lambda p, m, c, **kw: "native"
+        )
+
+        def _boom(text, paths):
+            raise OSError("disk gone")
+
+        monkeypatch.setattr(image_routing, "build_native_content_parts", _boom)
+        out = _build_run_message("s1", _agent(), "hi", self.IMAGES)
+        assert out == "hi <described>"
+        assert _notices(emitted) == [
+            "⚠ Image sent as a text description — native attachment failed (OSError)."
+        ]
+
+    def test_successful_native_attach_stays_silent(self, monkeypatch, emitted):
+        parts = [{"type": "text", "text": "hi"}, {"type": "image_url", "image_url": {"url": "x"}}]
+        monkeypatch.setattr(
+            image_routing, "decide_image_input_mode", lambda p, m, c, **kw: "native"
+        )
+        monkeypatch.setattr(
+            image_routing, "build_native_content_parts", lambda t, p: (parts, [])
+        )
+        assert _build_run_message("s1", _agent(), "hi", self.IMAGES) == parts
+        assert _notices(emitted) == []
+
+    def test_notice_kind_is_not_process(self, monkeypatch, emitted):
+        """kind='process' is dropped by the desktop — that was the bug."""
+        monkeypatch.setattr(
+            image_routing, "decide_image_input_mode", lambda p, m, c, **kw: "native"
+        )
+        _build_run_message("s1", _agent(api_mode="codex_app_server"), "hi", self.IMAGES)
+        kinds = {p.get("kind") for event, _s, p in emitted if event == "status.update"}
+        assert kinds == {"image_routing"}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5993,6 +5993,52 @@ def _active_image_routing_identity(agent: Any) -> tuple[str, str]:
     )
 
 
+def _decide_turn_image_mode(agent: Any) -> tuple[str, Optional[str]]:
+    """Resolve this turn's image input mode plus a user-facing downgrade reason.
+
+    Wraps ``agent.image_routing.decide_image_input_mode`` with the transport
+    override and the failure fallback, and reports *why* a native decision
+    was downgraded so the caller can surface it in the UI. Before this, a
+    user who forced ``agent.image_input_mode: native`` on a Codex app-server
+    session (or hit a decision failure) got a text description with zero
+    signal that their setting was overridden — the only evidence was a
+    stderr line in the gateway log (#66829).
+
+    Returns ``(mode, downgrade_reason)``; ``downgrade_reason`` is ``None``
+    when the decision was honored.
+    """
+    try:
+        from agent.image_routing import decide_image_input_mode
+        from hermes_cli.config import load_config as _tui_load_config
+
+        provider, model = _active_image_routing_identity(agent)
+        decided = decide_image_input_mode(
+            provider,
+            model,
+            _tui_load_config(),
+            requested_provider=getattr(agent, "requested_provider", ""),
+        )
+        mode, reason = decided, None
+        if decided == "native" and getattr(agent, "api_mode", "") == "codex_app_server":
+            mode = "text"
+            reason = (
+                "the Codex app-server transport sends text-only turn input, "
+                "so native image passthrough is unavailable for this session"
+            )
+        print(
+            f"[tui_gateway] image_routing: provider={provider} model={model} "
+            f"decided={decided} final={mode}",
+            file=sys.stderr,
+        )
+        return mode, reason
+    except Exception as exc:
+        print(
+            f"[tui_gateway] image_routing decision failed, defaulting to text: {exc}",
+            file=sys.stderr,
+        )
+        return "text", f"image routing decision failed ({type(exc).__name__}: {exc})"
+
+
 def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
     """Pre-analyze attached images via vision and prepend descriptions to user text."""
     import asyncio, json as _json
@@ -11774,34 +11820,21 @@ def _run_prompt_submit(
             # See agent/image_routing.py for the full decision table.
             run_message: Any = prompt
             if images:
-                try:
-                    from agent.image_routing import (
-                        decide_image_input_mode,
-                        build_native_content_parts,
+                _mode, _downgrade = _decide_turn_image_mode(agent)
+                if _downgrade:
+                    _emit(
+                        "status.update",
+                        sid,
+                        {
+                            "kind": "process",
+                            "text": f"⚠ Image sent as a text description — {_downgrade}.",
+                        },
                     )
-                    from hermes_cli.config import load_config as _tui_load_config
-
-                    _cfg = _tui_load_config()
-                    _provider, _model = _active_image_routing_identity(agent)
-                    _mode = decide_image_input_mode(
-                        _provider,
-                        _model,
-                        _cfg,
-                        requested_provider=getattr(
-                            agent, "requested_provider", ""
-                        ),
-                    )
-                    if getattr(agent, "api_mode", "") == "codex_app_server":
-                        _mode = "text"
-                except Exception as _img_exc:
-                    print(
-                        f"[tui_gateway] image_routing decision failed, defaulting to text: {_img_exc}",
-                        file=sys.stderr,
-                    )
-                    _mode = "text"
 
                 if _mode == "native":
                     try:
+                        from agent.image_routing import build_native_content_parts
+
                         _parts, _skipped = build_native_content_parts(
                             prompt,
                             images,
@@ -11814,11 +11847,27 @@ def _run_prompt_submit(
                         if any(p.get("type") == "image_url" for p in _parts):
                             run_message = _parts
                         else:
+                            _emit(
+                                "status.update",
+                                sid,
+                                {
+                                    "kind": "process",
+                                    "text": "⚠ Image sent as a text description — no readable image data for native attachment.",
+                                },
+                            )
                             run_message = _enrich_with_attached_images(prompt, images)
                     except Exception as _img_exc:
                         print(
                             f"[tui_gateway] native attach failed, falling back to text: {_img_exc}",
                             file=sys.stderr,
+                        )
+                        _emit(
+                            "status.update",
+                            sid,
+                            {
+                                "kind": "process",
+                                "text": f"⚠ Image sent as a text description — native attachment failed ({type(_img_exc).__name__}).",
+                            },
                         )
                         run_message = _enrich_with_attached_images(prompt, images)
                 else:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6039,6 +6039,63 @@ def _decide_turn_image_mode(agent: Any) -> tuple[str, Optional[str]]:
         return "text", f"image routing decision failed ({type(exc).__name__}: {exc})"
 
 
+def _image_routing_notice(sid: str, reason: str) -> None:
+    """Tell the user this turn's image was reduced to a text description.
+
+    Emitted as ``kind: "image_routing"`` rather than ``"process"``: the
+    desktop consumes ``"process"`` only to re-sync background-process state
+    and never reads the payload text, so the #66829 reporter saw no
+    explanation at all. Both drivers render this kind — the Ink TUI on its
+    status line, the desktop as a persistent system message beside the answer.
+    """
+    _emit(
+        "status.update",
+        sid,
+        {"kind": "image_routing", "text": f"⚠ Image sent as a text description — {reason}."},
+    )
+
+
+def _build_run_message(sid: str, agent: Any, prompt: str, images: list[str]) -> Any:
+    """Build the turn payload, routing attached images natively or as text.
+
+    "native" → pass pixels to the main model as OpenAI-style content parts
+    (adapters translate for Anthropic/Gemini/Bedrock/etc.). "text" → pre-analyze
+    with vision_analyze and prepend the description. See agent/image_routing.py
+    for the full decision table. Every path that ends in text when the user
+    attached an image emits a notice first, so the downgrade is never silent.
+    """
+    if not images:
+        return prompt
+
+    mode, downgrade = _decide_turn_image_mode(agent)
+    if downgrade:
+        _image_routing_notice(sid, downgrade)
+
+    if mode != "native":
+        return _enrich_with_attached_images(prompt, images)
+
+    try:
+        from agent.image_routing import build_native_content_parts
+
+        parts, skipped = build_native_content_parts(prompt, images)
+        if skipped:
+            print(
+                f"[tui_gateway] native image attachment skipped {len(skipped)} unreadable path(s)",
+                file=sys.stderr,
+            )
+        if any(p.get("type") == "image_url" for p in parts):
+            return parts
+        _image_routing_notice(sid, "no readable image data for native attachment")
+        return _enrich_with_attached_images(prompt, images)
+    except Exception as exc:
+        print(
+            f"[tui_gateway] native attach failed, falling back to text: {exc}",
+            file=sys.stderr,
+        )
+        _image_routing_notice(sid, f"native attachment failed ({type(exc).__name__})")
+        return _enrich_with_attached_images(prompt, images)
+
+
 def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
     """Pre-analyze attached images via vision and prepend descriptions to user text."""
     import asyncio, json as _json
@@ -11818,60 +11875,7 @@ def _run_prompt_submit(
             # parts (adapters translate for Anthropic/Gemini/Bedrock/etc.).
             # "text"   → pre-analyze with vision_analyze and prepend the text.
             # See agent/image_routing.py for the full decision table.
-            run_message: Any = prompt
-            if images:
-                _mode, _downgrade = _decide_turn_image_mode(agent)
-                if _downgrade:
-                    _emit(
-                        "status.update",
-                        sid,
-                        {
-                            "kind": "process",
-                            "text": f"⚠ Image sent as a text description — {_downgrade}.",
-                        },
-                    )
-
-                if _mode == "native":
-                    try:
-                        from agent.image_routing import build_native_content_parts
-
-                        _parts, _skipped = build_native_content_parts(
-                            prompt,
-                            images,
-                        )
-                        if _skipped:
-                            print(
-                                f"[tui_gateway] native image attachment skipped {len(_skipped)} unreadable path(s)",
-                                file=sys.stderr,
-                            )
-                        if any(p.get("type") == "image_url" for p in _parts):
-                            run_message = _parts
-                        else:
-                            _emit(
-                                "status.update",
-                                sid,
-                                {
-                                    "kind": "process",
-                                    "text": "⚠ Image sent as a text description — no readable image data for native attachment.",
-                                },
-                            )
-                            run_message = _enrich_with_attached_images(prompt, images)
-                    except Exception as _img_exc:
-                        print(
-                            f"[tui_gateway] native attach failed, falling back to text: {_img_exc}",
-                            file=sys.stderr,
-                        )
-                        _emit(
-                            "status.update",
-                            sid,
-                            {
-                                "kind": "process",
-                                "text": f"⚠ Image sent as a text description — native attachment failed ({type(_img_exc).__name__}).",
-                            },
-                        )
-                        run_message = _enrich_with_attached_images(prompt, images)
-                else:
-                    run_message = _enrich_with_attached_images(prompt, images)
+            run_message: Any = _build_run_message(sid, agent, prompt, images)
 
             # Streaming TTS: voice-mode replies are spoken sentence-by-sentence
             # as tokens arrive (CLI parity) instead of after the full turn.


### PR DESCRIPTION
## What does this PR do?

Surfaces every image-routing downgrade in the UI instead of silently delivering a text description — the failure shape reported in #66829, where forcing `agent.image_input_mode: native` in Desktop settings appeared to do nothing.

**What I verified on current `main` (581e92e42):**

- The turn-time routing block (`tui_gateway/server.py`) honors a forced `native`… except when `agent.api_mode == "codex_app_server"`, which unconditionally overrides the decision to `text` with no user-visible signal (the app-server `turn/start` path sends text-only input items — `_coerce_turn_input_text` replaces image parts with the literal string `"[image attached]"`).
- The decision-failure fallback and the unreadable-native-attachment fallback also land on `text` silently (stderr only).
- The message format quoted in #66829 (`[The user attached an image:\n<description>…]` + `vision_analyze` hint) is exactly `_enrich_with_attached_images` output, so the reporter's turns are reaching this block and downgrading through one of these paths.

**Change (observability only — routing outcomes are unchanged):**

1. Extract the decision + transport override into `_decide_turn_image_mode()`, returning `(mode, downgrade_reason)`; `reason` is `None` when the decision was honored (including when the decision itself was `text` — no crying wolf).
2. Emit a `status.update` naming the reason on every downgrade path: codex app-server override, decision failure, native attach failure, no-readable-image fallback.
3. Log a per-turn `[tui_gateway] image_routing: provider=… model=… decided=… final=…` trace line — the exact trace triage asked for on #66829 and which currently doesn't exist on the success path.

**Deliberately out of scope:** actually carrying pixels over the codex app-server transport. The Responses-API codex path already translates `image_url → input_image`, but the app-server `turn/start` schema support for image items depends on the installed codex binary's protocol version — that's a separate capability-gated change. This PR makes the current limitation visible instead of mysterious.

## Related Issue

Addresses the silent-override presentation of #66829 (does not close it — the underlying "native passthrough on codex app-server" gap and the reporter's exact configuration are still being triaged on the thread).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — new `_decide_turn_image_mode()` helper (decision + override + failure fallback, returns downgrade reason); `status.update` emits on all four downgrade paths; per-turn decision trace line
- `tests/tui_gateway/test_image_routing_downgrade.py` — 5 tests: native honored (no reason), codex override (reason names the transport), codex with text decision (no spurious reason), decision failure (reason carries exception type + message), trace line shape (`decided=native final=text`)

## How to Test

1. `pytest tests/tui_gateway/test_image_routing_downgrade.py -q` → 5 passed
2. `pytest tests/tui_gateway/ tests/agent/test_image_routing.py -q` → 480 passed; the 2 failures (`test_projects_rpc`, `test_subagent_child_mirror`) reproduce identically on clean `main` in full-directory runs and pass in isolation on this branch — pre-existing order-dependent flakes, not from this change
3. Manual: on a codex app-server session with `agent.image_input_mode: native`, attach an image — the UI now shows "⚠ Image sent as a text description — the Codex app-server transport sends text-only turn input…" and the gateway log carries the `decided=native final=text` trace

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nearest neighbor is #31912 (custom-provider vision metadata), a different site
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites; the two full-dir flakes reproduce on clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux (Arch), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings; N/A otherwise
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python, no platform surface
