### PR TITLE
test(agent): guard anthropic_prompt_cache_policy positional agent param (#67016)

### DIFF
--- a/tests/run_agent/test_anthropic_prompt_cache_policy_signature.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy_signature.py
@@ -1,0 +1,62 @@
+"""Signature guard for ``agent.agent_runtime_helpers.anthropic_prompt_cache_policy``.
+
+The behavioural matrix in ``test_anthropic_prompt_cache_policy.py`` only reaches
+the function through the keyword forwarder
+``AIAgent._anthropic_prompt_cache_policy()``. Several hot call sites instead
+pass the agent **positionally**:
+
+* ``agent/moa_loop.py`` — ``anthropic_prompt_cache_policy(stub, provider=..., ...)``
+* ``agent/agent_runtime_helpers.py`` — the MoA-aggregator recursion re-invokes
+  itself as ``anthropic_prompt_cache_policy(agent, ...)``
+
+If the leading positional ``agent`` parameter were dropped (or turned
+keyword-only), those positional calls would raise ``TypeError`` at runtime while
+the keyword-only behavioural tests kept passing. These tests pin the contract so
+that regression surfaces loudly.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import anthropic_prompt_cache_policy
+
+
+def test_agent_is_first_positional_or_keyword_parameter():
+    params = list(inspect.signature(anthropic_prompt_cache_policy).parameters.values())
+    assert params, "anthropic_prompt_cache_policy must accept at least one parameter"
+    first = params[0]
+    assert first.name == "agent"
+    assert first.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert first.default is inspect.Parameter.empty
+
+
+def test_positional_agent_call_matches_moa_loop_usage():
+    # Mirror agent/moa_loop.py: a stub is passed positionally and every field is
+    # supplied as a keyword so the branch is judged purely on its own runtime.
+    stub = SimpleNamespace(provider="", base_url="", api_mode="", model="")
+    result = anthropic_prompt_cache_policy(
+        stub,
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+        model="anthropic/claude-sonnet-4.6",
+    )
+    should_cache, use_native_layout = result
+    assert isinstance(should_cache, bool)
+    assert isinstance(use_native_layout, bool)
+
+
+def test_positional_agent_supplies_field_fallbacks():
+    # With no keyword overrides the function must read the positional agent's
+    # attributes — proving the positional binding actually reaches ``agent.*``.
+    stub = SimpleNamespace(
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+        model="anthropic/claude-sonnet-4.6",
+    )
+    should_cache, use_native_layout = anthropic_prompt_cache_policy(stub)
+    assert isinstance(should_cache, bool)
+    assert isinstance(use_native_layout, bool)


### PR DESCRIPTION
## What does this PR do?

Adds a **test-only** signature guard for `agent.agent_runtime_helpers.anthropic_prompt_cache_policy`.

The function correctly takes `agent` as its first positional-or-keyword parameter on `main`, but the existing behavioural matrix in `tests/run_agent/test_anthropic_prompt_cache_policy.py` only reaches it through the keyword forwarder `AIAgent._anthropic_prompt_cache_policy()`. Two hot call sites instead pass the agent **positionally**:

- `agent/moa_loop.py` — `anthropic_prompt_cache_policy(stub, provider=..., ...)`
- `agent/agent_runtime_helpers.py` — the MoA-aggregator recursion re-invokes itself as `anthropic_prompt_cache_policy(agent, ...)`

If the leading positional `agent` parameter were dropped or turned keyword-only, those positional calls would raise `TypeError` at runtime while the keyword-only behavioural tests kept passing green. This PR pins the contract so that regression surfaces loudly, as requested in the issue. No production code changes.

## Related Issue

Fixes #67016

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `tests/run_agent/test_anthropic_prompt_cache_policy_signature.py`:
  - asserts via `inspect.signature` that `agent` is the first `POSITIONAL_OR_KEYWORD` parameter with no default
  - exercises a positional call with a `SimpleNamespace` stub mirroring `agent/moa_loop.py` usage
  - exercises a positional call with no keyword overrides, proving the positional binding actually reaches `agent.*` fallbacks

## How to Test

```
scripts/run_tests.sh tests/run_agent/test_anthropic_prompt_cache_policy_signature.py
```

Result: `3 tests passed, 0 failed`. The tests pass against current `main` (they document the intended signature); reverting the leading positional `agent` parameter makes the positional-call tests fail.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests via `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (test-only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure-Python stdlib test)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A