### PR TITLE
fix(checkpoints): ignore excluded paths in size guard

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -542,6 +542,27 @@ class TestDirFileCount:
 
         assert _dir_file_count(work_dir) == 2
 
+    def test_skips_nested_default_excluded_directories(self, work_dir):
+        build_dir = Path(work_dir) / "src" / "build"
+        build_dir.mkdir(parents=True)
+        for idx in range(10):
+            (build_dir / f"generated-{idx}.txt").write_text("generated")
+
+        assert _dir_file_count(work_dir) == 2
+
+    def test_counts_directory_symlink_without_following_target(
+        self, work_dir, tmp_path
+    ):
+        target = tmp_path / "external-output"
+        target.mkdir()
+        for idx in range(10):
+            (target / f"generated-{idx}.txt").write_text("generated")
+        (Path(work_dir) / "linked-output").symlink_to(
+            target, target_is_directory=True
+        )
+
+        assert _dir_file_count(work_dir) == 3
+
     def test_nonexistent_dir(self, tmp_path):
         assert _dir_file_count(str(tmp_path / "nonexistent")) == 0
 

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -532,8 +532,41 @@ class TestDirFileCount:
     def test_counts_files(self, work_dir):
         assert _dir_file_count(str(work_dir)) >= 2
 
+    def test_skips_default_excludes(self, work_dir):
+        build_dir = Path(work_dir) / "build"
+        build_dir.mkdir()
+        for idx in range(10):
+            (build_dir / f"generated-{idx}.o").write_text("generated")
+        (Path(work_dir) / ".DS_Store").write_text("metadata")
+        (Path(work_dir) / "generated.pyc").write_text("bytecode")
+
+        assert _dir_file_count(work_dir) == 2
+
     def test_nonexistent_dir(self, tmp_path):
         assert _dir_file_count(str(tmp_path / "nonexistent")) == 0
+
+    def test_checkpoint_guard_ignores_default_excluded_trees(
+        self, mgr, work_dir, monkeypatch
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager._MAX_FILES", 5)
+        build_dir = Path(work_dir) / "build"
+        build_dir.mkdir()
+        for idx in range(10):
+            (build_dir / f"generated-{idx}.o").write_text("generated")
+
+        assert mgr.ensure_checkpoint(work_dir, "before_edit") is True
+
+    def test_checkpoint_guard_counts_retained_files_and_stops_at_limit(
+        self, mgr, work_dir, monkeypatch
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager._MAX_FILES", 5)
+        source_dir = Path(work_dir) / "src"
+        source_dir.mkdir()
+        for idx in range(10):
+            (source_dir / f"module-{idx}.py").write_text("pass\n")
+
+        assert _dir_file_count(work_dir) == 6
+        assert mgr.ensure_checkpoint(work_dir, "before_edit") is False
 
 
 # =========================================================================

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -557,9 +557,12 @@ class TestDirFileCount:
         target.mkdir()
         for idx in range(10):
             (target / f"generated-{idx}.txt").write_text("generated")
-        (Path(work_dir) / "linked-output").symlink_to(
-            target, target_is_directory=True
-        )
+        try:
+            (Path(work_dir) / "linked-output").symlink_to(
+                target, target_is_directory=True
+            )
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
 
         assert _dir_file_count(work_dir) == 3
 

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -561,7 +561,9 @@ def _dir_file_count(path: str) -> int:
             pattern for pattern in DEFAULT_EXCLUDES if not pattern.endswith("/")
         )
 
-        for current_dir, directory_names, file_names in os.walk(root):
+        for current_dir, directory_names, file_names in os.walk(
+            root, followlinks=False
+        ):
             retained_directories = []
             for name in directory_names:
                 candidate = Path(current_dir) / name

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -48,6 +48,7 @@ reclaim object storage.  A size-cap pass drops the oldest checkpoints per
 project until total store size is under ``max_total_size_mb``.
 """
 
+import fnmatch
 import hashlib
 import json
 import logging
@@ -546,14 +547,42 @@ def _list_projects(store: Path) -> List[Dict]:
 
 
 def _dir_file_count(path: str) -> int:
-    """Quick file count estimate (stops early if over _MAX_FILES)."""
+    """Count checkpoint candidates, pruning the default excludes."""
     count = 0
     try:
-        for _ in Path(path).rglob("*"):
-            count += 1
-            if count > _MAX_FILES:
-                return count
-    except (PermissionError, OSError):
+        root = _normalize_path(path)
+        if not root.is_dir():
+            return 0
+
+        directory_patterns = tuple(
+            pattern[:-1] for pattern in DEFAULT_EXCLUDES if pattern.endswith("/")
+        )
+        file_patterns = tuple(
+            pattern for pattern in DEFAULT_EXCLUDES if not pattern.endswith("/")
+        )
+
+        for current_dir, directory_names, file_names in os.walk(root):
+            retained_directories = []
+            for name in directory_names:
+                candidate = Path(current_dir) / name
+                if candidate.is_symlink():
+                    if not any(fnmatch.fnmatchcase(name, p) for p in file_patterns):
+                        count += 1
+                elif not any(
+                    fnmatch.fnmatchcase(name, p) for p in directory_patterns
+                ):
+                    retained_directories.append(name)
+                if count > _MAX_FILES:
+                    return count
+            directory_names[:] = retained_directories
+
+            for name in file_names:
+                if any(fnmatch.fnmatchcase(name, p) for p in file_patterns):
+                    continue
+                count += 1
+                if count > _MAX_FILES:
+                    return count
+    except OSError:
         pass
     return count
 


### PR DESCRIPTION
## Problem

Checkpoint creation has a 50,000-path preflight guard, but the guard walks every filesystem entry with `Path.rglob("*")` before Git applies the checkpoint store's `DEFAULT_EXCLUDES`.

A large generated tree such as `build/`, `node_modules/`, a virtual environment, or nested VCS data can therefore disable checkpoints even though those paths would never be staged. In the repository that exposed this, the raw guard stopped at 50,001 paths while the staged candidate set contained 1,396 files. The checkpoint metadata was touched, but no recoverable checkpoint commit was created.

### Expected behavior

Paths excluded by the checkpoint manager's built-in defaults do not count toward the snapshot-size guard.

### Actual behavior

Default-excluded directories and files count toward the limit, so `ensure_checkpoint()` returns `False` before staging can apply those exclusions.

## Root cause

`_dir_file_count()` uses an unfiltered recursive path walk. It also counts directories even though Git does not snapshot directory entries.

## Fix

- Walk with `os.walk()` so excluded directories can be pruned before traversal.
- Apply the existing `DEFAULT_EXCLUDES` directory and file patterns during the guard.
- Count retained directory symlinks once without traversing their targets.
- Preserve the bounded `_MAX_FILES + 1` early exit for genuinely large retained trees.
- Leave staging and checkpoint storage behavior unchanged.

This intentionally aligns the preflight guard with Hermes' built-in excludes. Project-specific `.gitignore` rules remain outside this narrowly scoped fix.

## Risk

The change is limited to the preflight estimate. Checkpoint staging, refs, storage, and rollback behavior are unchanged. The principal compatibility change is that built-in excluded paths no longer consume the guard budget, which matches what staging already retains.

## Regression coverage

- Default-excluded directories and files are omitted from the count.
- Nested excluded directories are pruned at any depth.
- Excluded trees over the configured limit no longer block checkpoint creation.
- Directory symlinks count once and are not traversed.
- Retained files still trip the guard.
- Enumeration still stops at `_MAX_FILES + 1`.

## Verification

- `tests/tools/test_checkpoint_manager.py`: **82 passed**
- Ruff on both changed files: **passed**
- `git diff --check`: **passed**
- Final independent focused review: **no findings**
