### PR TITLE
fix(gateway): isolate named profile env credentials

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1516,11 +1516,11 @@ def _profile_runtime_scope(profile_home: "Path"):
          keys and never the process-global ``os.environ`` (which in a
          multiplexer may hold another profile's values).
 
-    Only used on the multiplexed inbound path. Single-profile gateways never
-    enter this scope, so their behavior is unchanged. Loading the profile's
-    ``.env`` here does NOT mutate ``os.environ`` — ``build_profile_secret_scope``
-    returns an isolated dict — which is what keeps subprocesses (MCP, kanban)
-    from inheriting cross-profile secrets.
+    Used by multiplexed gateways and by a named profile's single-profile
+    startup. The default and custom single-home deployments remain unscoped.
+    Loading the profile's ``.env`` here does NOT mutate ``os.environ`` —
+    ``build_profile_secret_scope`` returns an isolated dict — which is what
+    keeps subprocesses (MCP, kanban) from inheriting cross-profile secrets.
     """
     from hermes_constants import set_hermes_home_override, reset_hermes_home_override
     from agent.secret_scope import (
@@ -1541,8 +1541,10 @@ def _profile_runtime_scope(profile_home: "Path"):
 def load_gateway_config_for_runner() -> "GatewayConfig":
     """Load gateway config for the process-level GatewayRunner.
 
-    When ``gateway.multiplex_profiles`` is off, this is identical to
-    ``load_gateway_config()`` (legacy single-profile path).
+    A named profile always reloads under its own secret scope. This prevents a
+    profile without a ``.env`` from auto-enabling an adapter with credentials
+    inherited through the process environment. The default and custom
+    single-home deployments retain their legacy unscoped behavior.
 
     When multiplexing is on, reload under the default/active profile's
     ``_profile_runtime_scope`` so platform tokens in that profile's ``.env``
@@ -1552,15 +1554,27 @@ def load_gateway_config_for_runner() -> "GatewayConfig":
     ``os.environ``, which often has no ``TELEGRAM_BOT_TOKEN`` once the token
     lives only under ``profiles/<name>/.env`` (#64674).
 
-    Single-profile gateways never set ``multiplex_profiles``, so they keep the
-    unscoped load and are unaffected.
+    A named profile receives the same scoped reload even when multiplexing is
+    off; it must not inherit the default profile's credentials.
     """
     cfg = load_gateway_config()
-    if not getattr(cfg, "multiplex_profiles", False):
-        return cfg
     try:
         home = get_hermes_home()
     except Exception:
+        return cfg
+
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        is_named_profile = get_active_profile_name() not in {"default", "custom"}
+    except Exception:
+        is_named_profile = False
+
+    if is_named_profile:
+        with _profile_runtime_scope(Path(home)):
+            return load_gateway_config()
+
+    if not getattr(cfg, "multiplex_profiles", False):
         return cfg
     try:
         with _profile_runtime_scope(Path(home)):

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -33,6 +33,49 @@ def _reset_multiplex_flag():
 
 
 class TestLoadGatewayConfigForRunner:
+    def test_named_profile_ignores_inherited_platform_credentials(self, tmp_path, monkeypatch):
+        """A bare named profile must not activate Matrix from the root env."""
+        from gateway import run as run_mod
+
+        root_home = tmp_path / ".hermes"
+        profile_home = root_home / "profiles" / "bare"
+        profile_home.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text("", encoding="utf-8")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "root-profile-token")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.test")
+
+        cfg = run_mod.load_gateway_config_for_runner()
+
+        assert Platform.MATRIX not in cfg.platforms
+
+    def test_named_profile_uses_its_own_platform_credentials(self, tmp_path, monkeypatch):
+        """A named profile's .env remains authoritative over the process env."""
+        from gateway import run as run_mod
+
+        root_home = tmp_path / ".hermes"
+        profile_home = root_home / "profiles" / "bare"
+        profile_home.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text("", encoding="utf-8")
+        (profile_home / ".env").write_text(
+            "MATRIX_ACCESS_TOKEN=profile-token\n"
+            "MATRIX_HOMESERVER=https://profile.example.test\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "root-profile-token")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://root.example.test")
+
+        cfg = run_mod.load_gateway_config_for_runner()
+
+        matrix = cfg.platforms[Platform.MATRIX]
+        assert matrix.token == "profile-token"
+        assert matrix.extra["homeserver"] == "https://profile.example.test"
+
     def test_unscoped_when_multiplex_off(self, tmp_path, monkeypatch):
         from gateway import run as run_mod
 


### PR DESCRIPTION
## What does this PR do?

Prevents a named, non-multiplexed profile from auto-enabling gateway adapters with credentials inherited from the default profile's process environment. The gateway now resolves platform credentials from the named profile's own `.env`; an envless profile leaves those adapters disabled.

## Related Issue

Fixes #66930

## Addressing maintainer feedback

- #59441 is the related Matrix configuration-leak report for the service-child environment path. This change fixes the distinct non-multiplex runner configuration path identified in the maintainer note; it does not replace or duplicate #59441.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: reload named single-profile gateway configuration under its authoritative profile secret scope, while preserving legacy behavior for default and custom single-home deployments.
- `tests/gateway/test_64674_multiplex_primary_token_scope.py`: cover both suppressing inherited Matrix credentials for a bare profile and honoring a profile-owned Matrix `.env`.

## How to Test

1. Create a named profile with no `.env` or platform configuration, then start its gateway with `MATRIX_ACCESS_TOKEN` and `MATRIX_HOMESERVER` present only in the inherited environment.
2. Verify Matrix is not enabled for that profile.
3. Add Matrix credentials to the profile's own `.env` and verify the gateway uses those values instead of the inherited ones.
4. Run `PATH="$VIRTUAL_ENV/bin:$PATH" /opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`.

## What platforms tested on

- macOS (darwin-arm64), local shared project venv.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is a gateway configuration isolation fix.

<!-- autocontrib:worker-id=issue-new-0ee47c74 kind=pr-open -->