### PR TITLE
feat(desktop): support Ctrl/Cmd + mouse wheel zoom (#40295)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4984,6 +4984,18 @@ function installZoomShortcuts(window) {
       setAndPersistZoomLevel(window, window.webContents.getZoomLevel() - ZOOM_STEP)
     }
   })
+
+  // Ctrl/Cmd + mouse wheel — the standard desktop/browser zoom gesture
+  // (#40295). Chromium surfaces it as the main-process 'zoom-changed' event
+  // (wheel events are DOM-side, so before-input-event never sees them).
+  // Route through the same persist+notify funnel as the keyboard shortcuts
+  // so wheel zoom survives restarts and the settings Scale control stays in
+  // sync, and use the same half step for consistency.
+  window.webContents.on('zoom-changed', (event, zoomDirection) => {
+    event.preventDefault()
+    const delta = zoomDirection === 'in' ? ZOOM_STEP : -ZOOM_STEP
+    setAndPersistZoomLevel(window, window.webContents.getZoomLevel() + delta)
+  })
 }
 
 function installContextMenu(window) {


### PR DESCRIPTION
## Summary

Salvage of #40414 (@liuhao1024) — Ctrl/Cmd + mouse wheel now zooms Hermes Desktop, the standard gesture missing next to the existing keyboard shortcuts and View menu zoom. Closes #40295.

## Approach (ground-truth reapply)

The original branch predates the ts-ify migration and implemented the gesture by injecting a DOM wheel listener via `executeJavaScript` plus a new IPC channel + preload method. Current Electron surfaces modifier+wheel natively as the main-process `webContents` `zoom-changed` event, so the salvage uses that instead — no renderer injection, no new preload/IPC surface, 12 lines instead of ~50.

## Changes

- `apps/desktop/electron/main.ts`: `zoom-changed` handler in `installZoomShortcuts`, routing through `setAndPersistZoomLevel` — the same persist+notify funnel as the keyboard shortcuts. Same 0.1 half-step, persists to `zoom-state.json` across restarts, settings Scale control stays in sync.
- Session windows inherit the gesture via `wireCommonWindowHandlers`; the pet overlay stays opted out via `zoomWiringForWindowKind`.

## Validation

| Check | Result |
|---|---|
| Full desktop electron suite | 433 passed, 1 skipped |
| tsc scoped to changed file | clean |
| prettier | clean |

Credit: @liuhao1024 (#40414), authorship preserved on the commit.

## Infographic

![wheel-zoom](https://v3b.fal.media/files/b/0aa2c50b/Z_-D9BxjqD6_p-HhO1BJF_ESuRL2CX.png)
