### PR TITLE
fix(codex): make post-tool watchdog liveness-aware

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -575,11 +575,15 @@ class CodexAppServerSession:
                 # tool-shaped item completes.
                 last_tool_completion_at = time.monotonic()
             else:
-                # Any non-tool projected activity (assistant message,
-                # status update, etc.) means codex is still producing
-                # output — clear the quiet timer so we don't fast-fail.
-                if projection.messages or projection.final_text is not None:
-                    last_tool_completion_at = None
+                # We only get here after take_notification returned a real
+                # notification (None already `continue`d above), so codex is
+                # still alive — clear the quiet timer unconditionally. Empty
+                # projections (item/started for the next tool, *outputDelta,
+                # reasoning items) are liveness too, matching the watchdog's
+                # documented "goes quiet without emitting another item" intent.
+                # Gating this on messages/final_text let a long second tool or
+                # reasoning phase trip the watchdog and kill a live turn.
+                last_tool_completion_at = None
             if projection.final_text is not None:
                 # Codex can emit multiple agentMessage items in one turn
                 # (e.g. partial then final). Take the last one as canonical.

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -475,24 +475,6 @@ class CodexAppServerSession:
                 result.should_retire = True
                 break
 
-            # Post-tool watchdog: if a tool completion was the most recent
-            # signal and codex has been silent past the quiet timeout, give
-            # up on this turn instead of waiting for the outer deadline.
-            if (
-                last_tool_completion_at is not None
-                and (time.monotonic() - last_tool_completion_at)
-                    > post_tool_quiet_timeout
-            ):
-                self._issue_interrupt(result.turn_id)
-                result.interrupted = True
-                result.error = (
-                    f"codex went silent for "
-                    f"{post_tool_quiet_timeout:.0f}s after a tool result; "
-                    f"retiring app-server session."
-                )
-                result.should_retire = True
-                break
-
             # Drain any server-initiated requests (approvals) before
             # reading notifications, so the codex side isn't blocked.
             sreq = self._client.take_server_request(timeout=0)
@@ -547,6 +529,24 @@ class CodexAppServerSession:
                 timeout=notification_poll_timeout
             )
             if note is None:
+                # Only declare the turn quiet after checking both inbound
+                # queues. A notification or approval request may already be
+                # waiting when the threshold is crossed; checking the clock
+                # first would interrupt a live turn at that boundary.
+                if (
+                    last_tool_completion_at is not None
+                    and (time.monotonic() - last_tool_completion_at)
+                        > post_tool_quiet_timeout
+                ):
+                    self._issue_interrupt(result.turn_id)
+                    result.interrupted = True
+                    result.error = (
+                        f"codex went silent for "
+                        f"{post_tool_quiet_timeout:.0f}s after a tool result; "
+                        f"retiring app-server session."
+                    )
+                    result.should_retire = True
+                    break
                 continue
 
             method = note.get("method", "")

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -1026,6 +1026,58 @@ class TestSessionRetirement:
         assert r.should_retire is False
         assert r.interrupted is False
 
+    def test_post_tool_watchdog_reset_on_empty_projection_activity(self):
+        """A tool completion followed by a notification that projects to
+        nothing (a reasoning item, the next tool's item/started, an
+        outputDelta) still means codex is alive and must reset the quiet
+        watchdog. Regression: a long second tool or reasoning phase used to
+        trip the watchdog and kill a live turn."""
+        clock = [1000.0]
+
+        class BumpingClient(FakeClient):
+            def take_notification(self, timeout: float = 0.0):
+                note = super().take_notification(timeout)
+                if note is not None and note.get("method") == "item/completed":
+                    item = (note.get("params") or {}).get("item") or {}
+                    if item.get("type") == "reasoning":
+                        # >post_tool_quiet_timeout passes while codex is still
+                        # streaming reasoning, but well under the turn deadline.
+                        clock[0] += 0.5
+                return note
+
+        client = BumpingClient()
+        client.queue_notification(
+            "item/completed",
+            item={
+                "type": "commandExecution", "id": "ex1",
+                "command": "echo hi", "cwd": "/tmp",
+                "status": "completed", "aggregatedOutput": "hi",
+                "exitCode": 0, "commandActions": [],
+            },
+            threadId="t", turnId="tu1",
+        )
+        # Empty-projection activity (reasoning) after the tool — still alive.
+        client.queue_notification(
+            "item/completed",
+            item={"type": "reasoning", "id": "r1", "content": ["thinking..."]},
+            threadId="t", turnId="tu1",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        s = make_session(client)
+        with patch.object(
+            session_mod.time, "monotonic", side_effect=lambda: clock[0]
+        ):
+            r = s.run_turn(
+                "tool then reasoning then done", turn_timeout=30.0,
+                notification_poll_timeout=0.0,
+                post_tool_quiet_timeout=0.15,
+            )
+        assert r.interrupted is False
+        assert r.should_retire is False
+
     def test_turn_aborted_marker_in_text_is_terminal(self):
         """If codex emits `<turn_aborted>` in agent text and never sends
         turn/completed, we still exit promptly instead of burning the

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -1078,6 +1078,55 @@ class TestSessionRetirement:
         assert r.interrupted is False
         assert r.should_retire is False
 
+    def test_post_tool_watchdog_drains_queued_activity_at_timeout_boundary(self):
+        """A queued liveness event wins over the quiet-timeout boundary.
+
+        Regression: the watchdog checked elapsed time before polling the
+        notification queue, so it could interrupt even though reasoning or
+        another item was already waiting to be consumed.
+        """
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            item={
+                "type": "commandExecution", "id": "ex1",
+                "command": "echo hi", "cwd": "/tmp",
+                "status": "completed", "aggregatedOutput": "hi",
+                "exitCode": 0, "commandActions": [],
+            },
+            threadId="t", turnId="tu1",
+        )
+        client.queue_notification(
+            "item/completed",
+            item={"type": "reasoning", "id": "r1", "content": ["thinking..."]},
+            threadId="t", turnId="tu1",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        # Advance past the quiet timeout exactly as the loop starts its next
+        # iteration. The reasoning event is already queued and must be read
+        # before the watchdog decides the turn is silent.
+        clock_values = iter([1000.0, 1000.0, 1000.0, 1000.2])
+
+        def monotonic():
+            return next(clock_values, 1000.2)
+
+        s = make_session(client)
+        with patch.object(session_mod.time, "monotonic", side_effect=monotonic):
+            r = s.run_turn(
+                "tool then queued reasoning then done",
+                turn_timeout=30.0,
+                notification_poll_timeout=0.0,
+                post_tool_quiet_timeout=0.15,
+            )
+        assert r.interrupted is False
+        assert r.should_retire is False
+        assert not any(
+            method == "turn/interrupt" for (method, _) in client.requests
+        )
+
     def test_turn_aborted_marker_in_text_is_terminal(self):
         """If codex emits `<turn_aborted>` in agent text and never sends
         turn/completed, we still exit promptly instead of burning the


### PR DESCRIPTION
## What does this PR do?

Prevents the Codex app-server post-tool watchdog from interrupting a turn that is still alive.

This builds directly on #63006. Andrew Chen's commit is retained in this branch under its original authorship, and this PR adds the timeout-boundary protection that the original patch does not cover.

## Root cause

After a tool-shaped item completed, Hermes armed a 90-second quiet timer. Two behaviors could then produce a false positive:

1. The timer was cleared only when the event projector produced `messages` or `final_text`. Real Codex activity such as reasoning items, `item/started`, and output deltas can intentionally project to nothing.
2. On every loop iteration, Hermes checked the elapsed timer before polling the server-request and notification queues. If the threshold was crossed while a liveness event was already queued, Hermes interrupted the turn without reading that event.

We observed this in a real Switchboard Hermes/Codex session: a Codex reasoning event was recorded, then the turn was aborted 5 ms later. That is consistent with the queue-boundary race rather than a dead Codex process.

## Changes

- Treat every real non-tool notification as Codex liveness, including empty projections.
- Drain pending approval requests and notifications before declaring post-tool silence.
- Preserve genuine-silence behavior: when both queues are empty beyond the threshold, Hermes still interrupts and retires the app-server session.
- Add regressions for both empty-projection activity and already-queued activity at the timeout boundary.

## Tests

- `scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py -q`
  - 67 passed
- `scripts/run_tests.sh tests/agent/test_codex_app_server_event_bridge.py tests/agent/test_codex_runtime_live_events.py -q`
  - 52 passed
- `uv run ruff check agent/transports/codex_app_server_session.py tests/agent/transports/test_codex_app_server_session.py`
  - passed

Additional integration check: `tests/run_agent/test_codex_app_server_integration.py` reports 28 passed and one approval-routing failure. The same failure reproduces on untouched upstream `main` at `581e92e42c`, so it is unrelated to this watchdog change.

## Attribution

The first commit is the implementation from #63006 by @chuenchen309, preserved with the original author metadata. The second commit adds the queue-ordering fix and boundary regression.
