### PR TITLE
fix(whatsapp): recognize replies from device JIDs

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -140,9 +140,11 @@ class WhatsAppBehaviorMixin:
         if not value:
             return ""
         normalized = str(value).strip()
-        if ":" in normalized and "@" in normalized:
-            normalized = normalized.replace(":", "@", 1)
-        return normalized
+        # Baileys socket identities may include a device component, e.g.
+        # ``number:42@s.whatsapp.net``. Quotes name the same account without
+        # it, so canonicalize both to ``number@s.whatsapp.net`` before the
+        # reply-to-bot identity comparison.
+        return re.sub(r":[^@]+(?=@)", "", normalized, count=1)
 
     @staticmethod
     def _is_broadcast_chat(chat_id: str) -> bool:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -41,6 +41,7 @@ import {
   extractBridgeEvent,
   inferMediaType,
   mediaPayloadForFile,
+  normalizeWhatsAppId,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
@@ -192,11 +193,6 @@ function rememberSentMessage(sent, payload) {
 
 function trackSentMessageId(sent) {
   rememberSentId(sent?.key?.id);
-}
-
-function normalizeWhatsAppId(value) {
-  if (!value) return '';
-  return String(value).replace(':', '@');
 }
 
 function redactWhatsAppId(value) {

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -19,9 +19,31 @@ import {
   appendMediaFailureNote,
   extractBridgeEvent,
   mediaPayloadForFile,
+  normalizeWhatsAppId,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- WhatsApp identity canonicalization -----------------------------------
+{
+  assert.equal(
+    normalizeWhatsAppId('15559998888:42@s.whatsapp.net'),
+    '15559998888@s.whatsapp.net',
+  );
+  assert.equal(
+    normalizeWhatsAppId('15559998888@s.whatsapp.net'),
+    '15559998888@s.whatsapp.net',
+  );
+  assert.equal(
+    normalizeWhatsAppId('267383306489914:9@lid'),
+    '267383306489914@lid',
+  );
+  assert.equal(
+    normalizeWhatsAppId('120363001234567890@g.us'),
+    '120363001234567890@g.us',
+  );
+  console.log('  ✓ device-suffixed JIDs match quote metadata account JIDs');
+}
 
 // -- quoted outbound text -------------------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -15,7 +15,10 @@ export const MIME_MAP = {
 
 export function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  // Baileys may represent an account as `number:device@jid`, while quote
+  // metadata uses `number@jid`. Drop the device suffix rather than turning it
+  // into a second `@`, so both forms compare as the same WhatsApp account.
+  return String(value).replace(/:[^@]+(?=@)/, '');
 }
 
 export function getMessageContent(msg) {

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -90,6 +90,27 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter._should_process_message(_group_message("/status")) is True
 
 
+def test_group_reply_to_bot_accepts_device_suffixed_bot_jid():
+    """Baileys may report our socket identity as ``number:device@jid``."""
+    adapter = _make_adapter(require_mention=True, group_policy="open")
+
+    assert adapter._should_process_message(
+        _group_message(
+            "replying without an @mention",
+            quotedParticipant="15551230000@s.whatsapp.net",
+            botIds=["15551230000:42@s.whatsapp.net"],
+        )
+    ) is True
+    # The device suffix must not turn a reply to a human into a bot reply.
+    assert adapter._should_process_message(
+        _group_message(
+            "replying to a human without an @mention",
+            quotedParticipant="15559990000@s.whatsapp.net",
+            botIds=["15551230000:42@s.whatsapp.net"],
+        )
+    ) is False
+
+
 def test_regex_mention_patterns_allow_custom_wake_words():
     adapter = _make_adapter(
         require_mention=True,


### PR DESCRIPTION
## Problem

With `require_mention: true`, a group reply should be accepted only when its quoted message was authored by the bot. Baileys can expose those two references in equivalent but differently shaped forms:

```text
socket identity:  account:device@jid
quote metadata:   account@jid
```

The previous normalizer replaced `:` with `@`, producing `account@device@jid` instead of the account JID. The reply-to-bot comparison then failed, so an otherwise valid reply-only trigger was ignored.

## Fix

- Canonicalize device-suffixed WhatsApp JIDs by removing the device segment before identity comparison.
- Reuse the bridge helper from `bridge.js` so bridge and gateway normalization cannot drift.
- Add regressions at both boundaries:
  - gateway group gate accepts a reply whose bot ID includes a device suffix;
  - pure bridge helper canonicalizes device-suffixed and ordinary account JIDs.

## Compatibility

This only changes equivalent representations of the same WhatsApp account. It preserves the mention gate: replies to a non-bot quoted participant remain ignored unless they contain another valid trigger.

## Validation

| Check | Result |
| --- | --- |
| `PYTHONPATH=. python3 -m pytest -o addopts='' tests/gateway/test_whatsapp_group_gating.py -q` | 31 passed |
| `node scripts/whatsapp-bridge/bridge.native.test.mjs` | all helper tests passed |
| `node --check scripts/whatsapp-bridge/bridge.js` | passed |
| `python3 -m compileall -q gateway/platforms/whatsapp_common.py` | passed |

The repository wrapper `scripts/run_tests.sh` could not run in this clean worktree because it has no project virtual environment; the targeted suite above was run directly with the available test environment.
