### PR TITLE
fix: share compression budget with context engines

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1891,6 +1891,10 @@ def init_agent(
         )
     except Exception:
         pass
+    # Retain the host policy for an explicitly budget-aware external engine.
+    # Existing engines continue to own their thresholds because they decline
+    # the optional handoff below.
+    agent._compression_threshold_percent = compression_threshold
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
@@ -2012,6 +2016,11 @@ def init_agent(
                 compression_threshold_tokens = None
         except (TypeError, ValueError):
             compression_threshold_tokens = None
+    # Retain the complete host policy for budget-aware external engines. These
+    # mirrors let runtime context changes reproduce ContextCompressor's
+    # override/cap calculation without taking ownership of legacy engines.
+    agent._compression_model_thresholds = compression_model_thresholds
+    agent._compression_threshold_tokens_cap = compression_threshold_tokens
     # In-place compaction: when True, compress_context() rewrites the message
     # list + rebuilds the system prompt WITHOUT rotating the session id (no
     # parent_session_id chain, no `name #N` renumber). See #38763 and
@@ -2471,6 +2480,17 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
         )
+        from agent.conversation_compression import apply_context_engine_compression_budget
+
+        if not apply_context_engine_compression_budget(
+            agent,
+            _plugin_ctx_len,
+            threshold_percent=compression_threshold,
+            reason="model_init",
+        ):
+            # Legacy engines retain #44439 behavior: their policy is private,
+            # so a host-side Codex threshold notice would be misleading.
+            agent._compression_threshold_autoraised = None
         if not agent.quiet_mode:
             _ra().logger.info("Using context engine: %s", _selected_engine.name)
     else:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1807,15 +1807,13 @@ def _compressor_max_tokens(agent):
 
 
 def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_context_length, session_db):
+    agent._compression_threshold_percent = cs.threshold
+    agent._compression_model_thresholds = cs.model_thresholds
+    agent._compression_threshold_tokens_cap = cs.threshold_tokens
+    agent._compression_max_tokens = _compressor_max_tokens(agent)
     _selected_engine = _select_context_engine(_agent_cfg)
     if _selected_engine is not None:
         agent.context_compressor = _selected_engine
-        # External engines own compaction policy — the host threshold (and its Codex
-        # autoraise) never reaches the plugin, so drop the notice.
-        agent._compression_threshold_autoraised = None
-        # External engines own compaction policy: the host compression threshold (including the Codex
-        # gpt-5.5 autoraise above) only configures the built-in ContextCompressor and never reaches the
-        # plugin, so the autoraise notice would announce a change that does not apply. (#44439)
         from agent.model_metadata import get_model_context_length
         _plugin_ctx_len = get_model_context_length(
             agent.model, base_url=agent.base_url, api_key=getattr(agent, "api_key", ""),
@@ -1830,6 +1828,14 @@ def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_c
             model=agent.model, context_length=_plugin_ctx_len, base_url=agent.base_url,
             api_key=getattr(agent, "api_key", ""), provider=agent.provider, api_mode=agent.api_mode,
         )
+        from agent.conversation_compression import apply_context_engine_compression_budget
+
+        if not apply_context_engine_compression_budget(
+            agent, _plugin_ctx_len, threshold_percent=cs.threshold, reason="model_init"
+        ):
+            # Legacy engines retain their private policy, so a host threshold
+            # notice would be misleading.
+            agent._compression_threshold_autoraised = None
         if not agent.quiet_mode:
             _ra().logger.info("Using context engine: %s", _selected_engine.name)
     else:
@@ -1840,7 +1846,7 @@ def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_c
             api_key=getattr(agent, "api_key", ""), config_context_length=_effective_context_length,
             provider=agent.provider, api_mode=agent.api_mode,
             abort_on_summary_failure=cs.abort_on_summary_failure,
-            max_tokens=_compressor_max_tokens(agent), model_thresholds=cs.model_thresholds,
+            max_tokens=agent._compression_max_tokens, model_thresholds=cs.model_thresholds,
             threshold_tokens_cap=cs.threshold_tokens,
             proactive_prune_tokens=cs.proactive_prune_tokens,
             proactive_prune_min_result_chars=cs.proactive_prune_min_chars,
@@ -2027,9 +2033,12 @@ def _configure_ollama_num_ctx(agent, _model_cfg, _config_context_length):
             "Compressor window clamped to Ollama num_ctx: %d -> %d",
             _cc_window, agent._ollama_num_ctx,
         )
-        agent.context_compressor.update_model(
-            model=agent.model, context_length=agent._ollama_num_ctx, base_url=agent.base_url,
-            api_key=getattr(agent, "api_key", ""), provider=agent.provider, api_mode=agent.api_mode,
+        from agent.conversation_compression import update_runtime_context_compressor
+
+        update_runtime_context_compressor(
+            agent, agent._ollama_num_ctx, reason="ollama_num_ctx", model=agent.model,
+            base_url=agent.base_url, api_key=getattr(agent, "api_key", ""),
+            provider=agent.provider, api_mode=agent.api_mode,
         )
 
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1587,6 +1587,13 @@ def restore_primary_runtime(agent) -> bool:
             provider=rt["compressor_provider"],
             api_mode=rt.get("compressor_api_mode", ""),
         )
+        from agent.conversation_compression import apply_context_engine_compression_budget
+
+        apply_context_engine_compression_budget(
+            agent,
+            rt["compressor_context_length"],
+            reason="primary_runtime_restore",
+        )
 
         # ── Rebind and re-select the primary credential pool ──
         # A cross-provider fallback attaches the fallback provider's pool. The
@@ -2684,6 +2691,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             api_key=agent.api_key,  # context_compressor forwards to call_llm; callable preserved
             provider=agent.provider,
             api_mode=agent.api_mode,
+        )
+        from agent.conversation_compression import apply_context_engine_compression_budget
+
+        apply_context_engine_compression_budget(
+            agent, new_context_length, reason="model_switch"
         )
 
     # ── Re-resolve reasoning_config from per-model override ──

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1162,10 +1162,13 @@ def restore_primary_runtime(agent) -> bool:
             agent._use_prompt_caching = False
             agent._use_native_cache_layout = False
         _rebuild_primary_client(agent, rt, reason="restore_primary")
-        agent.context_compressor.update_model(
-            model=rt["compressor_model"], context_length=rt["compressor_context_length"],
-            base_url=rt["compressor_base_url"], api_key=rt["compressor_api_key"],
-            provider=rt["compressor_provider"], api_mode=rt.get("compressor_api_mode", ""),
+        from agent.conversation_compression import update_runtime_context_compressor
+
+        update_runtime_context_compressor(
+            agent, rt["compressor_context_length"], reason="primary_runtime_restore",
+            model=rt["compressor_model"], base_url=rt["compressor_base_url"],
+            api_key=rt["compressor_api_key"], provider=rt["compressor_provider"],
+            api_mode=rt.get("compressor_api_mode", ""),
         )
         _rebind_primary_credential_pool(
             agent, primary_provider, _matches_primary, _load_primary_pool, prefetched_pool, prefetched
@@ -2051,13 +2054,12 @@ def _update_switch_compressor(agent, custom_providers, effective_context_length,
             agent.model, base_url=agent.base_url, api_key=ctx_api_key, provider=agent.provider,
             config_context_length=effective_context_length, custom_providers=custom_providers,
         )
-        agent.context_compressor.update_model(
-            model=agent.model,
-            context_length=new_context_length,
-            base_url=agent.base_url,
-            api_key=agent.api_key,  # context_compressor forwards to call_llm; callable preserved
-            provider=agent.provider,
-            api_mode=agent.api_mode,
+        from agent.conversation_compression import update_runtime_context_compressor
+
+        update_runtime_context_compressor(
+            agent, new_context_length, reason="model_switch", model=agent.model,
+            base_url=agent.base_url, api_key=agent.api_key,
+            provider=agent.provider, api_mode=agent.api_mode,
         )
     except Exception:
         _restore_switch_snapshot(agent, snapshot)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2022,6 +2022,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 provider=agent.provider,
                 api_mode=agent.api_mode,
             )
+            from agent.conversation_compression import apply_context_engine_compression_budget
+
+            apply_context_engine_compression_budget(
+                agent, fb_context_length, reason="fallback_model"
+            )
 
         # Re-resolve reasoning_config for the new fallback model (Closes #21256).
         # Shared chokepoint: per-model override > global reasoning_effort

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1770,9 +1770,12 @@ def _update_fallback_context_compressor(agent) -> None:
         config_context_length=getattr(agent, "_config_context_length", None),
         custom_providers=getattr(agent, "_custom_providers", None),
     )
-    compressor.update_model(  # callable api_key preserved → call_llm
-        model=agent.model, context_length=fb_context_length, base_url=agent.base_url,
-        api_key=getattr(agent, "api_key", ""), provider=agent.provider, api_mode=agent.api_mode,
+    from agent.conversation_compression import update_runtime_context_compressor
+
+    update_runtime_context_compressor(
+        agent, fb_context_length, reason="fallback_model", model=agent.model,
+        base_url=agent.base_url, api_key=getattr(agent, "api_key", ""),
+        provider=agent.provider, api_mode=agent.api_mode,
     )
 
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -128,6 +128,11 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
             context_window = getattr(turn, "model_context_window", None)
             if isinstance(context_window, int) and context_window > 0:
                 compressor.context_length = context_window
+                from agent.conversation_compression import apply_context_engine_compression_budget
+
+                apply_context_engine_compression_budget(
+                    agent, context_window, reason="codex_runtime_context"
+                )
         except Exception:
             logger.debug("codex app-server usage update failed", exc_info=True)
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -121,6 +121,11 @@ def _record_codex_app_server_usage(agent, turn, messages=None) -> dict[str, Any]
             context_window = getattr(turn, "model_context_window", None)
             if isinstance(context_window, int) and context_window > 0:
                 compressor.context_length = context_window
+                from agent.conversation_compression import apply_context_engine_compression_budget
+
+                apply_context_engine_compression_budget(
+                    agent, context_window, reason="codex_runtime_context"
+                )
         except Exception:
             logger.debug("codex app-server usage update failed", exc_info=True)
     if isinstance(messages, list):

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2249,6 +2249,24 @@ class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngin
             if _effective_cap < self.threshold_tokens:
                 self.threshold_tokens = _effective_cap
 
+    @classmethod
+    def compression_budget(
+        cls, context_length: int, threshold_percent: float, max_tokens: Any = None,
+        threshold_tokens_cap: Any = None,
+    ) -> tuple[int, int]:
+        """Return the effective input capacity and compaction trigger."""
+        max_tokens = cls._coerce_max_tokens(max_tokens)
+        context_capacity = context_length - (max_tokens or 0)
+        if context_capacity <= 0:
+            context_capacity = context_length
+        trigger_tokens = cls._compute_threshold_tokens(
+            context_length, cls._effective_threshold_percent(context_length, threshold_percent), max_tokens
+        )
+        threshold_cap = cls._coerce_threshold_tokens_cap(threshold_tokens_cap)
+        if threshold_cap is not None:
+            trigger_tokens = min(trigger_tokens, min(threshold_cap, context_length))
+        return context_capacity, trigger_tokens
+
     @staticmethod
     def _effective_threshold_percent(context_length: int, threshold_percent: float) -> float:
         """Raise-only small-context threshold floor: models under 512K trigger at >= 75%."""

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -382,6 +382,24 @@ class ContextEngine(ABC):
         """
         return True
 
+    # -- Optional: host-owned compression budget ----------------------------
+
+    def set_compression_budget(
+        self,
+        context_capacity: int,
+        trigger_tokens: int,
+        *,
+        reason: str = "",
+    ) -> bool:
+        """Accept Hermes' effective input capacity and compression trigger.
+
+        Engines can override this opt-in hook to synchronize private context
+        management with a model or runtime transition.  The default deliberately
+        declines the handoff, preserving the policy of existing third-party
+        engines.
+        """
+        return False
+
     # -- Optional: session lifecycle ---------------------------------------
 
     def on_session_start(self, session_id: str, **kwargs) -> None:

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -177,6 +177,23 @@ class ContextEngine(ABC):
         compress yet" without an LLM call (e.g. transcript entirely protected)."""
         return True
 
+    # -- Optional: host-owned compression budget ----------------------------
+
+    def set_compression_budget(
+        self,
+        context_capacity: int,
+        trigger_tokens: int,
+        *,
+        reason: str = "",
+    ) -> bool:
+        """Accept Hermes' effective input capacity and compression trigger.
+
+        Engines can override this opt-in hook to synchronize private context
+        management with a model or runtime transition. The default deliberately
+        declines the handoff, preserving existing third-party engine policy.
+        """
+        return False
+
     def on_session_start(self, session_id: str, **kwargs) -> None:
         """Session begins: load persisted state. kwargs may include hermes_home, platform, model."""
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -76,6 +76,94 @@ from agent.session_activity import ActivityProvenance, normalize_activity_proven
 
 logger = logging.getLogger(__name__)
 
+
+def _set_context_engine_compression_budget(
+    compressor: Any,
+    context_capacity: int,
+    trigger_tokens: int,
+    *,
+    reason: str,
+) -> bool:
+    """Apply a host budget only when an engine explicitly accepts it."""
+    setter = getattr(compressor, "set_compression_budget", None)
+    if not callable(setter):
+        return False
+    try:
+        return setter(context_capacity, trigger_tokens, reason=reason) is True
+    except Exception:
+        logger.warning("Context engine rejected host compression budget", exc_info=True)
+        return False
+
+
+def _canonical_context_engine_compression_budget(
+    agent: Any,
+    compressor: Any,
+    context_length: int,
+    threshold_percent: float | None = None,
+) -> tuple[int, int]:
+    """Compute the same usable capacity and trigger as ContextCompressor."""
+    from agent.context_compressor import ContextCompressor
+
+    configured_threshold = threshold_percent
+    if configured_threshold is None:
+        configured_threshold = getattr(agent, "_compression_threshold_percent", None)
+    if not isinstance(configured_threshold, (int, float)):
+        configured_threshold = getattr(compressor, "threshold_percent", None)
+
+    max_tokens = ContextCompressor._coerce_max_tokens(getattr(agent, "max_tokens", None))
+    context_capacity = context_length - (max_tokens or 0)
+    if context_capacity <= 0:
+        context_capacity = context_length
+
+    if not isinstance(configured_threshold, (int, float)):
+        return context_capacity, getattr(compressor, "threshold_tokens", context_length)
+    # Match ContextCompressor construction/update_model exactly: resolve the
+    # longest per-model override against the host's configured base before
+    # applying the small-window floor.
+    from agent.context_compressor import resolve_model_threshold
+
+    model_thresholds = getattr(agent, "_compression_model_thresholds", None)
+    if not isinstance(model_thresholds, dict):
+        model_thresholds = getattr(compressor, "model_thresholds", None)
+    base_threshold = resolve_model_threshold(
+        str(getattr(agent, "model", "")), model_thresholds, float(configured_threshold)
+    )
+    trigger_tokens = ContextCompressor._compute_threshold_tokens(
+        context_length,
+        ContextCompressor._effective_threshold_percent(context_length, base_threshold),
+        max_tokens,
+    )
+    # compression.threshold_tokens is an absolute cap applied after all ratio
+    # adjustments and is clamped to the raw model window, just as
+    # ContextCompressor._apply_threshold_tokens_cap does.
+    if hasattr(agent, "_compression_threshold_tokens_cap"):
+        threshold_cap = agent._compression_threshold_tokens_cap
+    else:
+        threshold_cap = getattr(compressor, "threshold_tokens_cap", None)
+    threshold_cap = ContextCompressor._coerce_threshold_tokens_cap(threshold_cap)
+    if threshold_cap is not None:
+        trigger_tokens = min(trigger_tokens, min(threshold_cap, context_length))
+    return context_capacity, trigger_tokens
+
+
+def apply_context_engine_compression_budget(
+    agent: Any,
+    context_length: int,
+    *,
+    threshold_percent: float | None = None,
+    reason: str,
+) -> bool:
+    """Deliver Hermes' runtime budget to an opt-in external context engine."""
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None or not isinstance(context_length, int) or context_length <= 0:
+        return False
+    context_capacity, trigger_tokens = _canonical_context_engine_compression_budget(
+        agent, compressor, context_length, threshold_percent
+    )
+    return _set_context_engine_compression_budget(
+        compressor, context_capacity, trigger_tokens, reason=reason
+    )
+
 # Terminal compression outcomes published by host/hygiene timeout or cooldown
 # writers. Detached heartbeat workers must not clobber these back to
 # agent.compression after cancel (otherwise timeout is unobservable). Observing

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -37,6 +37,122 @@ from agent.usage_anchor import set_usage_anchor
 logger = logging.getLogger(__name__)
 
 
+def _runtime_compressor_max_tokens(agent: Any) -> int:
+    """Return the active runtime's output reservation (zero clears an old one)."""
+    configured = getattr(agent, "max_tokens", None)
+    if configured is not None:
+        return configured
+    try:
+        from agent.gemini_native_adapter import (
+            GEMINI_DEFAULT_MAX_OUTPUT_TOKENS, is_native_gemini_base_url,
+        )
+        provider = str(getattr(agent, "provider", "") or "").strip().lower()
+        if provider in {"gemini", "google", "google-gemini", "google-ai-studio"} or is_native_gemini_base_url(
+            getattr(agent, "base_url", "")
+        ):
+            return GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
+    except Exception:
+        pass
+    return 0
+
+
+def update_runtime_context_compressor(
+    agent: Any, context_length: int, *, reason: str, **runtime: Any,
+) -> None:
+    """Update a runtime compressor before sharing its resulting budget with an opt-in engine."""
+    from agent.context_compressor import ContextCompressor
+
+    compressor = agent.context_compressor
+    if isinstance(compressor, ContextCompressor):
+        max_tokens = _runtime_compressor_max_tokens(agent)
+        compressor.update_model(context_length=context_length, max_tokens=max_tokens, **runtime)
+        agent._compression_max_tokens = compressor.max_tokens
+    else:
+        compressor.update_model(context_length=context_length, **runtime)
+    apply_context_engine_compression_budget(agent, context_length, reason=reason)
+
+
+def _set_context_engine_compression_budget(
+    compressor: Any,
+    context_capacity: int,
+    trigger_tokens: int,
+    *,
+    reason: str,
+) -> bool:
+    """Apply a host budget only when an engine explicitly accepts it."""
+    setter = getattr(compressor, "set_compression_budget", None)
+    if not callable(setter):
+        return False
+    try:
+        return setter(context_capacity, trigger_tokens, reason=reason) is True
+    except Exception:
+        logger.warning("Context engine rejected host compression budget", exc_info=True)
+        return False
+
+
+def _canonical_context_engine_compression_budget(
+    agent: Any, compressor: Any, context_length: int, threshold_percent: float | None = None,
+) -> tuple[int, int]:
+    """Read the configured compressor policy through its canonical calculation."""
+    from agent.context_compressor import ContextCompressor, resolve_model_threshold
+
+    if isinstance(compressor, ContextCompressor):
+        return ContextCompressor.compression_budget(
+            context_length, compressor.threshold_percent, compressor.max_tokens,
+            compressor.threshold_tokens_cap,
+        )
+
+    configured_threshold = threshold_percent
+    if configured_threshold is None:
+        configured_threshold = getattr(agent, "_compression_threshold_percent", None)
+    if not isinstance(configured_threshold, (int, float)):
+        configured_threshold = getattr(compressor, "threshold_percent", None)
+    if not isinstance(configured_threshold, (int, float)):
+        return context_length, getattr(compressor, "threshold_tokens", context_length)
+    model_thresholds = getattr(agent, "_compression_model_thresholds", None)
+    if not isinstance(model_thresholds, dict):
+        model_thresholds = getattr(compressor, "model_thresholds", None)
+    threshold_percent = resolve_model_threshold(
+        str(getattr(agent, "model", "")), model_thresholds, float(configured_threshold)
+    )
+    max_tokens = getattr(agent, "max_tokens", None)
+    if max_tokens is None:
+        try:
+            from agent.gemini_native_adapter import (
+                GEMINI_DEFAULT_MAX_OUTPUT_TOKENS, is_native_gemini_base_url,
+            )
+            provider = str(getattr(agent, "provider", "") or "").strip().lower()
+            if provider in {"gemini", "google", "google-gemini", "google-ai-studio"} or is_native_gemini_base_url(
+                getattr(agent, "base_url", "")
+            ):
+                max_tokens = GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
+        except Exception:
+            pass
+    return ContextCompressor.compression_budget(
+        context_length, threshold_percent, max_tokens,
+        getattr(agent, "_compression_threshold_tokens_cap", None),
+    )
+
+
+def apply_context_engine_compression_budget(
+    agent: Any,
+    context_length: int,
+    *,
+    threshold_percent: float | None = None,
+    reason: str,
+) -> bool:
+    """Deliver Hermes' runtime budget to an opt-in external context engine."""
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None or not isinstance(context_length, int) or context_length <= 0:
+        return False
+    context_capacity, trigger_tokens = _canonical_context_engine_compression_budget(
+        agent, compressor, context_length, threshold_percent
+    )
+    return _set_context_engine_compression_budget(
+        compressor, context_capacity, trigger_tokens, reason=reason
+    )
+
+
 @contextlib.contextmanager
 def _swallow(message: str, *, exc_info: bool = False):
     """Run a best-effort block; on Exception log ``message`` at DEBUG and continue."""

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4347,6 +4347,15 @@ def run_conversation(
                             provider=agent.provider,
                             api_mode=agent.api_mode,
                         )
+                        from agent.conversation_compression import (
+                            apply_context_engine_compression_budget,
+                        )
+
+                        apply_context_engine_compression_budget(
+                            agent,
+                            _reduced_ctx,
+                            reason="long_context_tier",
+                        )
                         # Context probing flags — only set on built-in
                         # compressor (plugin engines manage their own).
                         if hasattr(compressor, "_context_probed"):
@@ -4882,6 +4891,13 @@ def run_conversation(
                         # confirmed. Keep the probe flags as a best-effort
                         # post-success retry if this write cannot complete.
                         save_context_length(agent.model, agent.base_url, new_ctx)
+                        from agent.conversation_compression import (
+                            apply_context_engine_compression_budget,
+                        )
+
+                        apply_context_engine_compression_budget(
+                            agent, new_ctx, reason="provider_context_limit"
+                        )
                         # Context probing flags — only set on built-in
                         # compressor (plugin engines manage their own).  This
                         # value came from the provider, so it is safe to cache.

--- a/agent/turn_context_compaction.py
+++ b/agent/turn_context_compaction.py
@@ -94,6 +94,9 @@ def _apply_grown_window(agent: Any, compressor: Any, grown: int) -> None:
         provider=getattr(agent, "provider", "") or "",
         api_mode=getattr(agent, "api_mode", "") or "",
     )
+    from agent.conversation_compression import apply_context_engine_compression_budget
+
+    apply_context_engine_compression_budget(agent, grown, reason="local_window_growth")
     agent._buffer_status(
         f"📈 Context window grown to {grown // 1024}K "
         f"(local model; conversation continues uncompressed)"

--- a/agent/turn_overflow.py
+++ b/agent/turn_overflow.py
@@ -330,6 +330,11 @@ def _adopt_provider_context_limit(st: _Recovery, error_msg: str, old_ctx: int) -
         # missing usage, or restart must not lose confirmed metadata. Probe flags
         # remain a fallback if this write fails.
         save_context_length(agent.model, agent.base_url, new_ctx)
+        from agent.conversation_compression import apply_context_engine_compression_budget
+
+        apply_context_engine_compression_budget(
+            agent, new_ctx, reason="provider_context_limit"
+        )
         # Probe flags only on the built-in compressor (plugin engines manage their
         # own); provider-sourced value, so safe to cache.
         if hasattr(compressor, "_context_probed"):

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -1255,6 +1255,11 @@ def _cap_long_context_tier(agent: Any) -> int:
             f"requires extra usage — reducing context: "
             f"{old_ctx:,} → {_LONG_CONTEXT_TIER_CAP:,} tokens"
         )
+        from agent.conversation_compression import apply_context_engine_compression_budget
+
+        apply_context_engine_compression_budget(
+            agent, compressor.context_length, reason="long_context_tier"
+        )
     return old_ctx
 
 

--- a/tests/agent/test_context_engine_compression_budget.py
+++ b/tests/agent/test_context_engine_compression_budget.py
@@ -1,0 +1,116 @@
+"""Regression coverage for host-owned context-engine compression budgets."""
+
+from types import SimpleNamespace
+
+from agent.conversation_compression import apply_context_engine_compression_budget
+
+
+class BudgetAwareEngine:
+    """Minimal external engine explicitly accepting the host budget contract."""
+
+    def __init__(self, *, threshold_percent: float = 0.50) -> None:
+        self.threshold_percent = threshold_percent
+        self.threshold_tokens = 321_000
+        self.budgets: list[tuple[int, int, str]] = []
+
+    def set_compression_budget(
+        self, context_capacity: int, trigger_tokens: int, *, reason: str
+    ) -> bool:
+        self.budgets.append((context_capacity, trigger_tokens, reason))
+        self.threshold_tokens = trigger_tokens
+        return True
+
+
+class LegacyEngine:
+    """An existing engine with no host-budget hook keeps its policy."""
+
+    def __init__(self) -> None:
+        self.threshold_percent = 0.75
+        self.threshold_tokens = 321_000
+
+
+def _agent(
+    engine,
+    *,
+    max_tokens: int | None = None,
+    model: str = "test-model",
+    model_thresholds: dict[str, float] | None = None,
+    threshold_tokens_cap: int | None = None,
+):
+    return SimpleNamespace(
+        context_compressor=engine,
+        max_tokens=max_tokens,
+        model=model,
+        _compression_threshold_percent=0.50,
+        _compression_model_thresholds=model_thresholds or {},
+        _compression_threshold_tokens_cap=threshold_tokens_cap,
+    )
+
+
+def test_budget_aware_engine_receives_builtin_capacity_and_trigger():
+    """Budget handoff preserves ContextCompressor output-reservation semantics."""
+    engine = BudgetAwareEngine()
+
+    assert apply_context_engine_compression_budget(
+        _agent(engine, max_tokens=200_000), 1_000_000, reason="model_init"
+    )
+
+    assert engine.budgets == [(800_000, 400_000, "model_init")]
+
+
+def test_budget_aware_engine_matches_model_override_and_absolute_cap():
+    """The handoff applies the same override, reservation, and cap ordering."""
+    engine = BudgetAwareEngine()
+
+    assert apply_context_engine_compression_budget(
+        _agent(
+            engine,
+            max_tokens=200_000,
+            model="vendor/special-model",
+            model_thresholds={"model": 0.90},
+            threshold_tokens_cap=300_000,
+        ),
+        1_000_000,
+        reason="model_switch",
+    )
+
+    # 90% of the reserved 800K input budget is 720K; the host cap wins.
+    assert engine.budgets == [(800_000, 300_000, "model_switch")]
+
+
+def test_host_uses_no_plugin_cap_when_its_cap_is_unset():
+    """An opted-in engine cannot replace an unset host cap with its own."""
+    engine = BudgetAwareEngine()
+    engine.threshold_tokens_cap = 250_000
+
+    assert apply_context_engine_compression_budget(
+        _agent(engine, max_tokens=200_000), 1_000_000, reason="model_init"
+    )
+
+    assert engine.budgets == [(800_000, 400_000, "model_init")]
+
+
+def test_legacy_engine_without_hook_keeps_its_policy():
+    """Pre-contract engines remain unaffected by the optional extension point."""
+    engine = LegacyEngine()
+
+    assert not apply_context_engine_compression_budget(
+        _agent(engine, max_tokens=200_000), 1_000_000, reason="model_init"
+    )
+    assert engine.threshold_tokens == 321_000
+    assert engine.threshold_percent == 0.75
+
+
+def test_budget_hook_must_explicitly_accept_the_handoff():
+    """An engine that returns False is not treated as budget-aware."""
+
+    class RejectingEngine(BudgetAwareEngine):
+        def set_compression_budget(self, *args, **kwargs) -> bool:
+            return False
+
+    engine = RejectingEngine()
+
+    assert not apply_context_engine_compression_budget(
+        _agent(engine), 1_000_000, reason="model_init"
+    )
+    assert engine.threshold_tokens == 321_000

--- a/tests/agent/test_context_engine_compression_budget.py
+++ b/tests/agent/test_context_engine_compression_budget.py
@@ -1,0 +1,208 @@
+"""Regression coverage for host-owned context-engine compression budgets."""
+
+from types import SimpleNamespace
+
+from agent.conversation_compression import apply_context_engine_compression_budget
+
+
+class BudgetAwareEngine:
+    """Minimal external engine explicitly accepting the host budget contract."""
+
+    def __init__(self, *, threshold_percent: float = 0.50) -> None:
+        self.threshold_percent = threshold_percent
+        self.threshold_tokens = 321_000
+        self.budgets: list[tuple[int, int, str]] = []
+
+    def set_compression_budget(
+        self, context_capacity: int, trigger_tokens: int, *, reason: str
+    ) -> bool:
+        self.budgets.append((context_capacity, trigger_tokens, reason))
+        self.threshold_tokens = trigger_tokens
+        return True
+
+
+class LegacyEngine:
+    """An existing engine with no host-budget hook keeps its policy."""
+
+    def __init__(self) -> None:
+        self.threshold_percent = 0.75
+        self.threshold_tokens = 321_000
+
+
+def _agent(
+    engine,
+    *,
+    max_tokens: int | None = None,
+    model: str = "test-model",
+    model_thresholds: dict[str, float] | None = None,
+    threshold_tokens_cap: int | None = None,
+    compression_max_tokens: int | None = None,
+):
+    return SimpleNamespace(
+        context_compressor=engine,
+        max_tokens=max_tokens,
+        model=model,
+        _compression_threshold_percent=0.50,
+        _compression_model_thresholds=model_thresholds or {},
+        _compression_threshold_tokens_cap=threshold_tokens_cap,
+        _compression_max_tokens=compression_max_tokens,
+    )
+
+
+def test_budget_aware_engine_receives_builtin_capacity_and_trigger():
+    """Budget handoff preserves ContextCompressor output-reservation semantics."""
+    engine = BudgetAwareEngine()
+
+    assert apply_context_engine_compression_budget(
+        _agent(engine, max_tokens=200_000), 1_000_000, reason="model_init"
+    )
+
+    assert engine.budgets == [(800_000, 400_000, "model_init")]
+
+
+def test_provider_transitions_recompute_the_unset_native_gemini_reserve():
+    """Budget handoffs follow the active provider instead of an init-time cache."""
+    engine = BudgetAwareEngine()
+    agent = _agent(engine)
+    agent.provider = "openai"
+    agent.base_url = "https://api.openai.com/v1"
+
+    assert apply_context_engine_compression_budget(agent, 1_000_000, reason="model_switch")
+    agent.provider = "gemini"
+    agent.base_url = "https://generativelanguage.googleapis.com/v1beta"
+    assert apply_context_engine_compression_budget(agent, 1_000_000, reason="model_switch")
+    agent.provider = "openai"
+    agent.base_url = "https://api.openai.com/v1"
+    assert apply_context_engine_compression_budget(agent, 1_000_000, reason="model_switch")
+
+    assert engine.budgets == [
+        (1_000_000, 500_000, "model_switch"),
+        (934_465, 467_232, "model_switch"),
+        (1_000_000, 500_000, "model_switch"),
+    ]
+
+    from agent.agent_init import _compressor_max_tokens
+
+    reverse_engine = BudgetAwareEngine()
+    reverse_agent = _agent(reverse_engine)
+    reverse_agent.provider = "gemini"
+    reverse_agent.base_url = "https://generativelanguage.googleapis.com/v1beta"
+    reverse_agent._compression_max_tokens = _compressor_max_tokens(reverse_agent)
+    reverse_agent.provider = "openai"
+    reverse_agent.base_url = "https://api.openai.com/v1"
+
+    assert apply_context_engine_compression_budget(reverse_agent, 1_000_000, reason="model_switch")
+    assert reverse_engine.budgets == [(1_000_000, 500_000, "model_switch")]
+
+
+def test_budget_aware_engine_matches_model_override_and_absolute_cap():
+    """The handoff applies the same override, reservation, and cap ordering."""
+    engine = BudgetAwareEngine()
+
+    assert apply_context_engine_compression_budget(
+        _agent(
+            engine,
+            max_tokens=200_000,
+            model="vendor/special-model",
+            model_thresholds={"model": 0.90},
+            threshold_tokens_cap=300_000,
+        ),
+        1_000_000,
+        reason="model_switch",
+    )
+
+    assert engine.budgets == [(800_000, 300_000, "model_switch")]
+
+
+def test_host_uses_no_plugin_cap_when_its_cap_is_unset():
+    """An opted-in engine cannot replace an unset host cap with its own."""
+    engine = BudgetAwareEngine()
+    engine.threshold_tokens_cap = 250_000
+
+    assert apply_context_engine_compression_budget(
+        _agent(engine, max_tokens=200_000), 1_000_000, reason="model_init"
+    )
+
+    assert engine.budgets == [(800_000, 400_000, "model_init")]
+
+
+def test_legacy_engine_without_hook_keeps_its_policy():
+    """Pre-contract engines remain unaffected by the optional extension point."""
+    engine = LegacyEngine()
+
+    assert not apply_context_engine_compression_budget(
+        _agent(engine, max_tokens=200_000), 1_000_000, reason="model_init"
+    )
+    assert engine.threshold_tokens == 321_000
+    assert engine.threshold_percent == 0.75
+
+
+def test_budget_hook_must_explicitly_accept_the_handoff():
+    """An engine that returns False is not treated as budget-aware."""
+
+    class RejectingEngine(BudgetAwareEngine):
+        def set_compression_budget(self, *args, **kwargs) -> bool:
+            return False
+
+    engine = RejectingEngine()
+
+    assert not apply_context_engine_compression_budget(
+        _agent(engine), 1_000_000, reason="model_init"
+    )
+    assert engine.threshold_tokens == 321_000
+
+
+def test_ollama_post_init_clamp_resyncs_opted_in_engine():
+    """Ollama's served num_ctx replaces the initial model-window budget."""
+    from agent.agent_init import _configure_ollama_num_ctx
+
+    engine = BudgetAwareEngine()
+    engine.context_length = 131_072
+    engine.update_model = lambda model, context_length, **kwargs: setattr(engine, "context_length", context_length)
+    agent = _agent(engine)
+    agent.base_url = "http://127.0.0.1:11434/v1"
+    agent.api_key = ""
+    agent.provider = "ollama"
+    agent.api_mode = "chat_completions"
+    agent.quiet_mode = True
+
+    _configure_ollama_num_ctx(agent, {"ollama_num_ctx": 65_536}, None)
+
+    assert engine.budgets == [(65_536, 55_705, "ollama_num_ctx")]
+
+
+def test_local_window_growth_resyncs_opted_in_engine():
+    """A managed local expansion immediately gives the engine the larger budget."""
+    from agent.turn_context_compaction import _apply_grown_window
+
+    engine = BudgetAwareEngine()
+    engine.update_model = lambda model, context_length, **kwargs: setattr(engine, "context_length", context_length)
+    agent = _agent(engine)
+    agent.base_url = "http://127.0.0.1:8080/v1"
+    agent.api_key = ""
+    agent.provider = "llamacpp"
+    agent.api_mode = "chat_completions"
+    agent._buffer_status = lambda message: None
+
+    _apply_grown_window(agent, engine, 131_072)
+
+    assert engine.budgets == [(131_072, 98_304, "local_window_growth")]
+
+
+def test_long_context_recovery_advertises_only_the_effective_capacity():
+    """Tier recovery hands off the clamped compressor window, never a presumed one."""
+    from agent.turn_recovery import _cap_long_context_tier
+
+    engine = BudgetAwareEngine()
+    engine.context_length = 300_000
+    engine.update_model = lambda model, context_length, **kwargs: setattr(engine, "context_length", context_length)
+    agent = _agent(engine)
+    agent.base_url = ""
+    agent.api_key = ""
+    agent.provider = "anthropic"
+    agent.api_mode = "anthropic_messages"
+    agent._buffer_vprint = lambda message: None
+
+    _cap_long_context_tier(agent)
+
+    assert engine.budgets == [(200_000, 150_000, "long_context_tier")]

--- a/tests/run_agent/test_compressor_fallback_update.py
+++ b/tests/run_agent/test_compressor_fallback_update.py
@@ -72,3 +72,37 @@ def test_compressor_updated_on_fallback(mock_ctx_len, mock_resolve):
     assert c.threshold_tokens == int(128_000 * c.threshold_percent)
 
 
+@patch("agent.auxiliary_client.resolve_provider_client")
+@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
+def test_native_gemini_fallback_releases_builtin_output_reserve(mock_ctx_len, mock_resolve):
+    """A non-Gemini fallback clears Gemini's default output reservation everywhere."""
+    agent = _make_agent_with_compressor()
+    agent.model = "gemini-2.5-pro"
+    agent.provider = "gemini"
+    agent.base_url = "https://generativelanguage.googleapis.com/v1beta"
+    agent.max_tokens = None
+    agent.context_compressor.update_model(
+        agent.model, 1_000_000, base_url=agent.base_url, provider=agent.provider,
+        max_tokens=65_535,
+    )
+    budget_calls = []
+    agent.context_compressor.set_compression_budget = lambda *args, **kwargs: (
+        budget_calls.append((args, kwargs)) or True
+    )
+
+    fb_client = MagicMock()
+    fb_client.base_url = "https://api.openai.com/v1"
+    fb_client.api_key = "sk-fallback"
+    mock_resolve.return_value = (fb_client, None)
+    agent._is_direct_openai_url = lambda url: "api.openai.com" in url
+    agent._emit_status = lambda msg: None
+
+    assert agent._try_activate_fallback() is True
+
+    c = agent.context_compressor
+    assert c.max_tokens is None
+    assert c.context_length == 1_000_000
+    assert c.threshold_tokens == 500_000
+    assert budget_calls == [((1_000_000, 500_000), {"reason": "fallback_model"})]
+
+

--- a/tests/run_agent/test_overflow_overhead_aware_tokens.py
+++ b/tests/run_agent/test_overflow_overhead_aware_tokens.py
@@ -402,3 +402,29 @@ class TestLongContextTierOverheadAwareTokens:
             "during long-context-tier recovery. All calls: "
             + str([c["tools"] for c in estimate_calls])
         )
+
+    def test_long_context_tier_refreshes_an_opted_in_engine_budget(self, agent):
+        """A 1M-to-200K tier downgrade re-hands the calibrated host budget."""
+        err = self._make_long_context_tier_error()
+        ok_resp = _mock_response(content="Recovered", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err, ok_resp]
+        budget_hook = MagicMock(return_value=True)
+        agent.context_compressor.set_compression_budget = budget_hook
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "compressed"}],
+                "compressed prompt",
+            )
+            agent.run_conversation("hello", conversation_history=_prefill())
+
+        # 200K is below the small-window cutoff, so the built-in 75% floor
+        # produces a 150K trigger when no output reservation is configured.
+        budget_hook.assert_called_once_with(
+            200_000, 150_000, reason="long_context_tier"
+        )

--- a/tests/run_agent/test_overflow_overhead_aware_tokens.py
+++ b/tests/run_agent/test_overflow_overhead_aware_tokens.py
@@ -403,3 +403,29 @@ class TestLongContextTierOverheadAwareTokens:
             "during long-context-tier recovery. All calls: "
             + str([c["tools"] for c in estimate_calls])
         )
+
+    def test_long_context_tier_refreshes_an_opted_in_engine_budget(self, agent):
+        """A 1M-to-200K tier downgrade re-hands the calibrated host budget."""
+        err = self._make_long_context_tier_error()
+        ok_resp = _mock_response(content="Recovered", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err, ok_resp]
+        budget_hook = MagicMock(return_value=True)
+        agent.context_compressor.set_compression_budget = budget_hook
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "compressed"}],
+                "compressed prompt",
+            )
+            agent.run_conversation("hello", conversation_history=_prefill())
+
+        # 200K is below the small-window cutoff, so the built-in 75% floor
+        # produces a 150K trigger when no output reservation is configured.
+        budget_hook.assert_called_once_with(
+            200_000, 150_000, reason="long_context_tier"
+        )

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -37,6 +37,18 @@ class _ToolEngine(_StubEngine):
         ]
 
 
+class _BudgetAwareEngine(_StubEngine):
+    def __init__(self):
+        super().__init__()
+        self.compression_budgets = []
+
+    def set_compression_budget(
+        self, context_capacity, trigger_tokens, *, reason=""
+    ):
+        self.compression_budgets.append((context_capacity, trigger_tokens, reason))
+        return True
+
+
 def test_plugin_engine_gets_context_length_on_init():
     """Plugin context engine should have context_length set during AIAgent init."""
     engine = _StubEngine()
@@ -65,6 +77,34 @@ def test_plugin_engine_gets_context_length_on_init():
     assert agent.context_compressor is engine
     assert engine.context_length == 204_800
     assert engine.threshold_tokens == int(204_800 * engine.threshold_percent)
+
+
+def test_budget_aware_plugin_receives_host_budget_on_init():
+    """An opt-in plugin sees the host's reservation-aware initial budget."""
+    engine = _BudgetAwareEngine()
+    cfg = {"context": {"engine": "stub"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg), patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor is engine
+    # ContextCompressor applies its 75% floor below a 512K context window.
+    assert engine.compression_budgets == [(204_800, 153_600, "model_init")]
 
 
 def test_active_context_engine_tools_survive_explicit_platform_toolsets():


### PR DESCRIPTION
This closes the gap where external context engines could make compression decisions with a different token budget than Hermes itself.

## What changed

- Context engines can opt in to receive Hermes’ effective compression capacity and trigger.
- The budget comes from the configured `ContextCompressor`, so output reservations, model overrides, and threshold caps stay consistent.
- It is refreshed when the runtime changes: startup, model switches, fallback and primary restore, Codex context updates, provider limits, Ollama clamps, local-window growth, and long-context recovery.
- Engines that do not opt in keep their existing threshold and policy.

This gives the Nachos context engine the same runtime budget Hermes is actually using without changing the existing auxiliary-compressor policy.

## Validation

- Context-engine, fallback/restore, overflow, and runtime-transition coverage: 68 passed.
- Includes native Gemini ↔ non-Gemini reserve transitions, explicit and cleared reservations, effective runtime clamps, and legacy-engine compatibility.
- Ruff and whitespace checks pass.

Rebased on current `main` and squashed to one commit.
