### PR TITLE
fix(discord): preflight attachment size before upload (#50846)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -85,6 +85,10 @@ _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
 _DISCORD_MAX_APP_COMMANDS = 100
 _DISCORD_SELECT_FIELD_LIMIT = 100
 _DISCORD_BUTTON_LABEL_LIMIT = 80
+# Default Discord attachment cap for DMs / channels without a guild boost
+# context. Guild channels expose the effective limit via
+# ``guild.filesize_limit`` (boost tier may raise it). See issue #50846.
+_DISCORD_DEFAULT_UPLOAD_LIMIT_BYTES = 25 * 1024 * 1024
 _DISCORD_ELLIPSIS = "\u2026"
 _DISCORD_NONCONVERSATIONAL_METADATA_KEYS = frozenset({
     "non_conversational",
@@ -3543,6 +3547,20 @@ class DiscordAdapter(BasePlatformAdapter):
             continuation_message_ids=tuple(continuation_ids),
         )
 
+    @staticmethod
+    def _discord_upload_limit_bytes(channel: Any) -> int:
+        """Return the effective Discord attachment size limit for *channel*.
+
+        Prefer the guild's boost-aware ``filesize_limit`` when present; fall
+        back to the platform default for DMs / group DMs without a guild.
+        """
+        guild = getattr(channel, "guild", None)
+        if guild is not None:
+            limit = getattr(guild, "filesize_limit", None)
+            if isinstance(limit, int) and limit > 0:
+                return limit
+        return _DISCORD_DEFAULT_UPLOAD_LIMIT_BYTES
+
     async def _send_file_attachment(
         self,
         chat_id: str,
@@ -3554,6 +3572,10 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Forum channels (type 15) get a new thread whose starter message
         carries the file — they reject direct POST /messages.
+
+        Oversized files are rejected *before* upload (issue #50846) so we
+        never burn a doomed ``413 Payload Too Large`` round-trip and the
+        user gets an explicit notice instead of a silent/ambiguous failure.
 
         Uses a path-based ``discord.File`` (same pattern as
         ``send_multiple_images``) rather than an open file handle. The
@@ -3575,6 +3597,39 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=f"Channel {chat_id} not found")
 
         filename = file_name or os.path.basename(file_path)
+
+        try:
+            file_size = os.path.getsize(file_path)
+        except OSError as exc:
+            return SendResult(success=False, error=f"Cannot stat file {filename}: {exc}")
+
+        limit = self._discord_upload_limit_bytes(channel)
+        if file_size > limit:
+            size_mb = file_size / (1024 * 1024)
+            limit_mb = limit / (1024 * 1024)
+            error = (
+                f"File too large for Discord upload: {filename} is "
+                f"{size_mb:.1f} MB (limit {limit_mb:.0f} MB)"
+            )
+            logger.warning("[%s] %s", self.name, error)
+            # Best-effort user-facing notice so delivery failure is not silent.
+            notice = (
+                f"⚠️ Could not attach `{filename}` — {size_mb:.1f} MB exceeds "
+                f"Discord's {limit_mb:.0f} MB upload limit for this channel. "
+                f"Compress the file or share a link instead."
+            )
+            try:
+                if not self._is_forum_parent(channel):
+                    await channel.send(content=notice)
+            except Exception:
+                logger.debug(
+                    "[%s] Failed to send oversized-file notice for %s",
+                    self.name,
+                    filename,
+                    exc_info=True,
+                )
+            return SendResult(success=False, error=error)
+
         logger.info(
             "[%s] Sending file attachment %s (%s) to %s",
             self.name,

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -418,3 +419,143 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
 
 
+
+
+
+# ---------------------------------------------------------------------------
+# Upload-size preflight (#50846 / #52698)
+# ---------------------------------------------------------------------------
+
+
+def test_discord_upload_limit_uses_guild_filesize_limit():
+    from plugins.platforms.discord.adapter import (
+        DiscordAdapter,
+        _DISCORD_DEFAULT_UPLOAD_LIMIT_BYTES,
+    )
+
+    guild_channel = SimpleNamespace(guild=SimpleNamespace(filesize_limit=50 * 1024 * 1024))
+    dm_channel = SimpleNamespace(guild=None)
+    no_limit_guild = SimpleNamespace(guild=SimpleNamespace(filesize_limit=0))
+
+    assert DiscordAdapter._discord_upload_limit_bytes(guild_channel) == 50 * 1024 * 1024
+    assert DiscordAdapter._discord_upload_limit_bytes(dm_channel) == _DISCORD_DEFAULT_UPLOAD_LIMIT_BYTES
+    assert DiscordAdapter._discord_upload_limit_bytes(no_limit_guild) == _DISCORD_DEFAULT_UPLOAD_LIMIT_BYTES
+
+
+@pytest.mark.asyncio
+async def test_send_file_attachment_rejects_oversized_before_upload(tmp_path):
+    """Oversized local files must not call channel.send(file=...) — issue #50846."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._is_forum_parent = lambda _ch: False  # type: ignore[method-assign]
+
+    from plugins.platforms.discord.adapter import _DISCORD_DEFAULT_UPLOAD_LIMIT_BYTES
+
+    big = tmp_path / "clip.mp4"
+    big.write_bytes(b"x")
+
+    send = AsyncMock(return_value=SimpleNamespace(id=999))
+    channel = SimpleNamespace(id=555, guild=None, send=send)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _cid: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    original = os.path.getsize
+
+    def fake_getsize(path):
+        if str(path) == str(big):
+            return _DISCORD_DEFAULT_UPLOAD_LIMIT_BYTES + 1
+        return original(path)
+
+    os.path.getsize = fake_getsize
+    try:
+        result = await adapter._send_file_attachment("555", str(big))
+    finally:
+        os.path.getsize = original
+
+    assert result.success is False
+    assert "too large" in (result.error or "").lower()
+    assert "clip.mp4" in (result.error or "")
+    assert send.await_count == 1
+    assert send.await_args is not None
+    kwargs = send.await_args.kwargs
+    assert "file" not in kwargs and "files" not in kwargs
+    assert "Could not attach" in (kwargs.get("content") or "")
+
+
+@pytest.mark.asyncio
+async def test_send_video_respects_guild_filesize_limit(tmp_path):
+    """Guild boost limit is honored; files under the higher cap still upload."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._is_forum_parent = lambda _ch: False  # type: ignore[method-assign]
+
+    video = tmp_path / "ok.mp4"
+    video.write_bytes(b"fake-video-bytes")
+
+    sent_msg = SimpleNamespace(
+        id=42,
+        attachments=[SimpleNamespace(filename="ok.mp4", url="https://cdn.example/ok.mp4")],
+    )
+    send = AsyncMock(return_value=sent_msg)
+    channel = SimpleNamespace(
+        id=777,
+        guild=SimpleNamespace(filesize_limit=50 * 1024 * 1024),
+        send=send,
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _cid: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send_video("777", str(video))
+    assert result.success is True
+    assert result.message_id == "42"
+    assert send.await_count == 1
+    assert send.await_args is not None
+    kwargs = send.await_args.kwargs
+    assert kwargs.get("file") is not None or kwargs.get("files")
+
+
+@pytest.mark.asyncio
+async def test_send_video_oversized_skips_base_fallback(tmp_path, monkeypatch):
+    """Oversized send_video returns failure without falling back to base adapter."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._is_forum_parent = lambda _ch: False  # type: ignore[method-assign]
+
+    from plugins.platforms.discord.adapter import _DISCORD_DEFAULT_UPLOAD_LIMIT_BYTES
+
+    video = tmp_path / "huge.mp4"
+    video.write_bytes(b"x")
+
+    send = AsyncMock(return_value=SimpleNamespace(id=1))
+    channel = SimpleNamespace(id=1, guild=None, send=send)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _cid: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    monkeypatch.setattr(
+        os.path,
+        "getsize",
+        lambda path: (
+            _DISCORD_DEFAULT_UPLOAD_LIMIT_BYTES + 10
+            if str(path) == str(video)
+            else 0
+        ),
+    )
+
+    base_called = {"yes": False}
+
+    async def boom(*_a, **_k):
+        base_called["yes"] = True
+        raise AssertionError("base send_video must not run for preflight reject")
+
+    monkeypatch.setattr(
+        "gateway.platforms.base.BasePlatformAdapter.send_video",
+        boom,
+    )
+
+    result = await adapter.send_video("1", str(video))
+    assert result.success is False
+    assert "too large" in (result.error or "").lower()
+    assert base_called["yes"] is False


### PR DESCRIPTION
## Summary

Fixes #50846 (also addresses the preflight half of #52698).

Discord local video/document uploads currently discover size limits only after a doomed `channel.send(file=...)` call, which fails with `413 Payload Too Large (40005)`. The adapter then falls back ambiguously and the user often sees no useful recovery.

This PR adds an **upload-size preflight** on the shared Discord attachment path (`_send_file_attachment`, used by `send_video` / `send_document` / image-file sends):

1. Resolve the effective limit from `channel.guild.filesize_limit` when present (boost-aware), else **25 MiB** default for DMs.
2. If `os.path.getsize(path) > limit`, **do not upload**.
3. Return `SendResult(success=False, error=...)` with a clear size message.
4. Best-effort user-facing notice in-channel so failure is not silent.

### Changes
- `plugins/platforms/discord/adapter.py`: `_discord_upload_limit_bytes()` + preflight in `_send_file_attachment`
- `tests/gateway/test_discord_send.py`: 4 new tests (limit resolution, oversized reject, under-limit success, no base fallback)

### Test plan
- [x] `bash scripts/run_tests.sh tests/gateway/test_discord_send.py` — 22 passed
- [x] Oversized path never calls `channel.send(file=...)`
- [x] Under-limit video still uploads
- [x] Author email uses `ID+username@users.noreply.github.com`

### Out of scope
External object-storage / link fallback (`media_delivery.external_upload`) — that was explored in closed #52697 and remains a separate optional feature.
