### PR TITLE
fix(desktop): remove forced Arial font-family from tooltips to fix CJK text corruption

### DIFF
--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -90,7 +90,7 @@ function TooltipContent({
             this inline decoration's geometry, so Radix measures a zero-size chip
             and parks an empty rectangle in the corner (#62022). Force any direct
             child inline-flex so every call site stays safe. */}
-        <span className="box-decoration-clone inline bg-foreground px-1.5 py-1 text-[11px] font-bold leading-normal text-background [font-family:Arial,sans-serif] [&>*]:!inline-flex">
+        <span className="box-decoration-clone inline bg-foreground px-1.5 py-1 text-[11px] font-bold leading-normal text-background [&>*]:!inline-flex">
           {children}
         </span>
       </TooltipPrimitive.Content>


### PR DESCRIPTION
## Summary

Fixes CJK (Chinese/Japanese/Korean) text corruption in all tooltips across Hermes Desktop.

## Problem

When using Hermes Desktop with Chinese (简体中文/繁體中文) UI language, all tooltip/hover popups display garbled CJK characters — valid Unicode but the WRONG characters semantically. This affects every tooltip in the app (status bar, top bar, sidebar, etc.).

**Example:** The correct tooltip `"Hermes Desktop v0.18.2 · 提交 5988fe6 · 分支 main"` displays as `"Hermes Desktop v0.18.2 · 插亢 5988fe6 · 刃壤"`.

## Root Cause

The tooltip `<span>` forces `font-family: Arial, sans-serif` via a Tailwind arbitrary property `[font-family:Arial,sans-serif]`. Arial's CJK glyph mapping interacts poorly with `box-decoration-break: clone` and Radix UI Portal rendering in Electron/Chromium, causing CJK text to render as different (but valid) CJK characters.

## Fix

Removes the forced `[font-family:Arial,sans-serif]` from the tooltip span's className in `apps/desktop/src/components/ui/tooltip.tsx`. The system's default sans-serif font stack handles CJK text correctly (PingFang on macOS, Microsoft YaHei on Windows, Noto Sans CJK on Linux).

**Change:** One line — 1 insertion, 1 deletion.

## Testing

- ✅ All 3 existing tooltip tests pass
- ✅ Verified on macOS arm64 with both zh (Simplified) and zh-hant (Traditional) locales  
- ✅ Full build + package confirmed functional
- ✅ Tooltip visual appearance unchanged for non-CJK text

Closes #67042