### PR TITLE
fix(cron): harden jobs lock descriptor

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 import json
 import logging
 import shutil
+import stat
 import tempfile
 import threading
 import time
@@ -20,9 +21,10 @@ import re
 import uuid
 
 # Cross-process advisory file locking for jobs.json critical sections.
-# fcntl is Unix-only; on Windows fall back to msvcrt. Either may be absent,
-# in which case _jobs_lock() degrades to in-process locking only (the old
-# behaviour) rather than failing.
+# fcntl is Unix-only; on Windows fall back to msvcrt. Either may be absent.
+# An already-private lock retains the historical in-process fallback, while a
+# legacy lock that still needs hardening fails closed without cross-process
+# exclusion.
 try:
     import fcntl
 except ImportError:  # pragma: no cover - non-Unix
@@ -100,6 +102,10 @@ _jobs_lock_state = threading.local()
 _JOBS_LOCK_TIMEOUT_SECONDS = 30.0
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+
+
+class JobsLockSecurityError(RuntimeError):
+    """Raised when the jobs lock cannot be opened or hardened safely."""
 
 
 @dataclass(frozen=True)
@@ -253,6 +259,123 @@ def _jobs_lock_file() -> Path:
     return _current_cron_store().cron_dir / ".jobs.lock"
 
 
+def _validate_jobs_lock_stat(lock_stat: os.stat_result, path: Path) -> None:
+    """Require an owner-correct, singly-linked regular lock inode."""
+    if not stat.S_ISREG(lock_stat.st_mode):
+        kind = "symlink" if stat.S_ISLNK(lock_stat.st_mode) else "non-regular file"
+        raise JobsLockSecurityError(f"Refusing {kind} cron jobs lock: {path}")
+    get_effective_uid = getattr(os, "geteuid", None)
+    if get_effective_uid is None:
+        raise JobsLockSecurityError(
+            "Cannot verify cron jobs lock ownership on this platform"
+        )
+    if lock_stat.st_uid != get_effective_uid():
+        raise JobsLockSecurityError(
+            f"Refusing cron jobs lock owned by another user: {path}"
+        )
+    if lock_stat.st_nlink != 1:
+        raise JobsLockSecurityError(f"Refusing multiply-linked cron jobs lock: {path}")
+
+
+def _validate_jobs_lock_identity(
+    path: Path,
+    fd: int,
+    expected: Optional[os.stat_result] = None,
+    required_mode: Optional[int] = None,
+) -> os.stat_result:
+    """Match a lock descriptor to a no-follow pathname observation."""
+    try:
+        fd_stat = os.fstat(fd)
+        path_stat = os.lstat(path)
+    except OSError as exc:
+        raise JobsLockSecurityError(
+            f"Cannot revalidate cron jobs lock identity: {path}"
+        ) from exc
+
+    current_observations = [fd_stat, path_stat]
+    for observation in current_observations:
+        _validate_jobs_lock_stat(observation, path)
+        if (
+            required_mode is not None
+            and stat.S_IMODE(observation.st_mode) != required_mode
+        ):
+            raise JobsLockSecurityError(
+                f"Cron jobs lock has unsafe permissions: {path}"
+            )
+
+    observations = list(current_observations)
+    if expected is not None:
+        _validate_jobs_lock_stat(expected, path)
+        observations.insert(0, expected)
+
+    identities = {(item.st_dev, item.st_ino) for item in observations}
+    if len(identities) != 1:
+        raise JobsLockSecurityError(f"Cron jobs lock identity changed: {path}")
+    return fd_stat
+
+
+def _open_jobs_lock_fd() -> Tuple[int, os.stat_result]:
+    """Create or securely open the jobs lock and pin its inode identity."""
+    path = _jobs_lock_file()
+    no_follow = getattr(os, "O_NOFOLLOW", None)
+    if not no_follow:
+        raise JobsLockSecurityError(
+            "Final-component no-follow open is unavailable for the cron jobs lock"
+        )
+    base_flags = os.O_RDWR
+    base_flags |= no_follow
+    base_flags |= getattr(os, "O_CLOEXEC", 0)
+    while True:
+        try:
+            fd = os.open(path, base_flags | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            try:
+                path_stat = os.lstat(path)
+            except FileNotFoundError:
+                continue
+            _validate_jobs_lock_stat(path_stat, path)
+            try:
+                fd = os.open(path, base_flags)
+            except OSError as exc:
+                raise JobsLockSecurityError(
+                    f"Cannot securely open cron jobs lock: {path}"
+                ) from exc
+            try:
+                return fd, _validate_jobs_lock_identity(path, fd, path_stat)
+            except Exception:
+                os.close(fd)
+                raise
+        except OSError as exc:
+            raise JobsLockSecurityError(
+                f"Cannot securely create cron jobs lock: {path}"
+            ) from exc
+        try:
+            return fd, _validate_jobs_lock_identity(path, fd)
+        except Exception:
+            os.close(fd)
+            raise
+
+
+def _harden_jobs_lock_fd(
+    path: Path,
+    fd: int,
+    expected: os.stat_result,
+) -> None:
+    """Harden and revalidate the held descriptor without pathname mutation."""
+    fchmod = getattr(os, "fchmod", None)
+    if fchmod is None:
+        raise JobsLockSecurityError(
+            "Descriptor chmod is unavailable for the cron jobs lock"
+        )
+    try:
+        fchmod(fd, 0o600)
+    except (OSError, NotImplementedError) as exc:
+        raise JobsLockSecurityError(
+            f"Cannot harden cron jobs lock permissions: {path}"
+        ) from exc
+    _validate_jobs_lock_identity(path, fd, expected, required_mode=0o600)
+
+
 @contextlib.contextmanager
 def _jobs_lock():
     """Serialize a load_jobs→modify→save_jobs critical section.
@@ -264,10 +387,11 @@ def _jobs_lock():
     at all — a `cron pause` could be silently clobbered by a concurrent
     gateway write, leaving a "paused" job still firing).
 
-    The flock is blocking, but every critical section that uses it is short
-    (field updates only — no agent execution), so contention resolves in
-    milliseconds. If neither fcntl nor msvcrt is available the manager still
-    provides in-process locking, matching the historical behaviour.
+    Every critical section that uses the lock is short (field updates only —
+    no agent execution), so contention normally resolves in milliseconds. If
+    neither fcntl nor msvcrt is available, an already-private lock retains the
+    historical in-process fallback; a legacy lock that needs hardening fails
+    closed because it cannot be safely chmodded without cross-process exclusion.
 
     Nested calls in the same thread reuse the held lock so legacy callers that
     invoke save_jobs() inside a broader mutation section don't deadlock or try
@@ -285,11 +409,14 @@ def _jobs_lock():
     with _jobs_file_lock:
         _jobs_lock_state.depth = 1
         lock_fd = None
+        lock_needs_hardening = False
+        cross_process_locked = False
         try:
             try:
                 ensure_dirs()
-                lock_fd = open(_jobs_lock_file(), "a+", encoding="utf-8")
-                lock_fd.seek(0)
+                lock_fd, _lock_identity = _open_jobs_lock_fd()
+                lock_needs_hardening = stat.S_IMODE(_lock_identity.st_mode) != 0o600
+                os.lseek(lock_fd, 0, os.SEEK_SET)
                 if fcntl is not None:
                     # Bounded acquisition (#60703): a plain blocking
                     # fcntl.flock(LOCK_EX) here has NO timeout, and it is
@@ -301,19 +428,25 @@ def _jobs_lock():
                     # get_due_jobs() — silently and forever: the heartbeat
                     # file stops updating and all jobs stop firing with no
                     # error logged.  Poll LOCK_NB against a deadline instead;
-                    # on timeout, log loudly and fall through to the same
-                    # in-process-only degraded mode used when locking is
-                    # unavailable.  A briefly-torn cross-process write is
-                    # strictly better than a permanently dead scheduler.
+                    # on timeout, retain the reviewed in-process-only fallback
+                    # for an already-private inode. A legacy inode that still
+                    # needs hardening must fail closed: chmod is forbidden until
+                    # the foreign holder releases the same inode.
                     _deadline = time.monotonic() + _JOBS_LOCK_TIMEOUT_SECONDS
                     while True:
                         try:
                             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                            cross_process_locked = True
                             break
                         except (OSError, IOError):
                             if time.monotonic() >= _deadline:
+                                if lock_needs_hardening:
+                                    raise JobsLockSecurityError(
+                                        "Timed out before the legacy cron jobs "
+                                        "lock could be hardened"
+                                    )
                                 logger.error(
-                                    "Timed out after %.0fs waiting for the cron "
+                                    "Timed out after %.1fs waiting for the cron "
                                     "jobs lock (%s) — another process is holding "
                                     "it. Proceeding with in-process locking only "
                                     "so the scheduler stays alive (#60703).",
@@ -321,33 +454,55 @@ def _jobs_lock():
                                     _jobs_lock_file(),
                                 )
                                 try:
-                                    lock_fd.close()
+                                    os.close(lock_fd)
                                 except OSError:
                                     pass
                                 lock_fd = None
                                 break
                             time.sleep(0.1)
                 elif msvcrt is not None:
-                    getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+                    getattr(msvcrt, "locking")(lock_fd, getattr(msvcrt, "LK_LOCK"), 1)
+                    cross_process_locked = True
+                elif lock_needs_hardening:
+                    raise JobsLockSecurityError(
+                        "Cross-process locking is unavailable for legacy cron "
+                        "jobs lock hardening"
+                    )
+                if cross_process_locked:
+                    _harden_jobs_lock_fd(_jobs_lock_file(), lock_fd, _lock_identity)
+            except JobsLockSecurityError:
+                raise
             except (OSError, IOError) as e:
+                if cross_process_locked or (
+                    lock_fd is not None and lock_needs_hardening
+                ):
+                    raise JobsLockSecurityError(
+                        "Cron jobs lock failed before safe hardening"
+                    ) from e
                 # Never let a locking failure take down cron writes — fall back to
                 # in-process-only protection (still held via _jobs_file_lock).
-                logger.warning("jobs.json cross-process lock unavailable (%s); "
-                               "proceeding with in-process lock only", e)
-            try:
-                yield
-            finally:
-                if lock_fd is not None:
-                    try:
-                        if fcntl is not None:
-                            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                        elif msvcrt is not None:
-                            getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
-                    except (OSError, IOError):
-                        pass
-                    finally:
-                        lock_fd.close()
+                logger.warning(
+                    "jobs.json cross-process lock unavailable (%s); "
+                    "proceeding with in-process lock only",
+                    e,
+                )
+            yield
         finally:
+            if lock_fd is not None:
+                try:
+                    if fcntl is not None and cross_process_locked:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    elif msvcrt is not None and cross_process_locked:
+                        getattr(msvcrt, "locking")(
+                            lock_fd, getattr(msvcrt, "LK_UNLCK"), 1
+                        )
+                except (OSError, IOError):
+                    pass
+                finally:
+                    try:
+                        os.close(lock_fd)
+                    except OSError:
+                        pass
             _jobs_lock_state.depth = 0
 
 # Fields on a cron job that must never change after creation. ``id`` is used

--- a/tests/cron/test_jobs_lock_security.py
+++ b/tests/cron/test_jobs_lock_security.py
@@ -1,0 +1,507 @@
+"""Security contract for the cron jobs advisory lock."""
+
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_jobs(monkeypatch):
+    """Import cron.jobs only after pinning a disposable Hermes home."""
+    with tempfile.TemporaryDirectory(prefix="age3472-") as temp_root:
+        hermes_home = (Path(temp_root) / "hermes-home").resolve()
+        hermes_home.mkdir()
+        default_home = (Path.home() / ".hermes").resolve()
+        assert hermes_home != default_home
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
+        sys.dont_write_bytecode = True
+
+        from cron import jobs
+
+        assert jobs.get_hermes_home().resolve() == hermes_home
+        with jobs.use_cron_store(hermes_home):
+            yield jobs, hermes_home
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics required")
+def test_new_jobs_lock_is_0600_under_umask_022(isolated_jobs):
+    jobs, hermes_home = isolated_jobs
+    previous_umask = os.umask(0o022)
+    try:
+        with jobs._jobs_lock():
+            lock_path = jobs._jobs_lock_file()
+            lock_stat = os.lstat(lock_path)
+    finally:
+        os.umask(previous_umask)
+
+    assert lock_path.parent == hermes_home / "cron"
+    assert stat.S_ISREG(lock_stat.st_mode)
+    assert not lock_path.is_symlink()
+    assert lock_stat.st_uid == os.geteuid()  # windows-footgun: ok
+    assert lock_stat.st_nlink == 1
+    assert stat.S_IMODE(lock_stat.st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics required")
+def test_existing_0644_lock_hardens_in_place(isolated_jobs):
+    jobs, _ = isolated_jobs
+    jobs.ensure_dirs()
+    lock_path = jobs._jobs_lock_file()
+
+    previous_umask = os.umask(0)
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644)
+        os.write(fd, b"lock-sentinel")
+        os.close(fd)
+    finally:
+        os.umask(previous_umask)
+
+    before = os.lstat(lock_path)
+    assert stat.S_IMODE(before.st_mode) == 0o644
+
+    with jobs._jobs_lock():
+        during = os.lstat(lock_path)
+        assert stat.S_IMODE(during.st_mode) == 0o600
+        assert (during.st_dev, during.st_ino) == (before.st_dev, before.st_ino)
+
+    after = os.lstat(lock_path)
+    assert lock_path.read_bytes() == b"lock-sentinel"
+    assert stat.S_IMODE(after.st_mode) == 0o600
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX flock semantics required")
+def test_jobs_lock_descriptor_is_non_inheritable(isolated_jobs, monkeypatch):
+    jobs, _ = isolated_jobs
+    if jobs.fcntl is None:
+        pytest.skip("fcntl.flock unavailable")
+
+    original_flock = jobs.fcntl.flock
+    inheritable_at_lock = []
+
+    def observing_flock(fd, operation):
+        if operation & jobs.fcntl.LOCK_EX:
+            inheritable_at_lock.append(os.get_inheritable(fd))
+        return original_flock(fd, operation)
+
+    monkeypatch.setattr(jobs.fcntl, "flock", observing_flock)
+    with jobs._jobs_lock():
+        pass
+
+    assert inheritable_at_lock == [False]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics required")
+def test_jobs_lock_rejects_symlink_without_touching_target(isolated_jobs):
+    jobs, hermes_home = isolated_jobs
+    jobs.ensure_dirs()
+    target = hermes_home / "lock-target"
+    target.write_bytes(b"unchanged")
+    target.chmod(0o640)
+    before = os.lstat(target)
+    lock_path = jobs._jobs_lock_file()
+    lock_path.symlink_to(target)
+
+    with pytest.raises(jobs.JobsLockSecurityError):
+        with jobs._jobs_lock():
+            pytest.fail("unsafe symlink lock yielded its critical section")
+
+    after = os.lstat(target)
+    assert target.read_bytes() == b"unchanged"
+    assert stat.S_IMODE(after.st_mode) == stat.S_IMODE(before.st_mode)
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+    assert lock_path.is_symlink()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file types required")
+@pytest.mark.parametrize("lock_kind", ["directory", "fifo", "socket"])
+def test_jobs_lock_rejects_non_regular_file(isolated_jobs, lock_kind):
+    jobs, _ = isolated_jobs
+    jobs.ensure_dirs()
+    lock_path = jobs._jobs_lock_file()
+    socket_handle = None
+
+    if lock_kind == "directory":
+        lock_path.mkdir(mode=0o750)
+    elif lock_kind == "fifo":
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFO creation unavailable")
+        os.mkfifo(lock_path, 0o640)
+    else:
+        import socket
+
+        if not hasattr(socket, "AF_UNIX"):
+            pytest.skip("Unix-domain sockets unavailable")
+        socket_handle = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        socket_handle.bind(str(lock_path))
+
+    before = os.lstat(lock_path)
+    try:
+        with pytest.raises(jobs.JobsLockSecurityError):
+            with jobs._jobs_lock():
+                pytest.fail(f"unsafe {lock_kind} lock yielded its critical section")
+    finally:
+        if socket_handle is not None:
+            socket_handle.close()
+
+    after = os.lstat(lock_path)
+    assert stat.S_IFMT(after.st_mode) == stat.S_IFMT(before.st_mode)
+    assert stat.S_IMODE(after.st_mode) == stat.S_IMODE(before.st_mode)
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+
+
+@pytest.mark.skipif(not hasattr(os, "geteuid"), reason="effective UID unavailable")
+def test_jobs_lock_rejects_wrong_owner_without_chmod(isolated_jobs, monkeypatch):
+    jobs, _ = isolated_jobs
+    jobs.ensure_dirs()
+    lock_path = jobs._jobs_lock_file()
+    previous_umask = os.umask(0)
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644)
+        os.close(fd)
+    finally:
+        os.umask(previous_umask)
+
+    before = os.lstat(lock_path)
+    monkeypatch.setattr(jobs.os, "geteuid", lambda: before.st_uid + 1)
+
+    with pytest.raises(jobs.JobsLockSecurityError):
+        with jobs._jobs_lock():
+            pytest.fail("wrong-owner lock yielded its critical section")
+
+    after = os.lstat(lock_path)
+    assert stat.S_IMODE(after.st_mode) == 0o644
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX hard-link semantics required")
+def test_jobs_lock_rejects_unexpected_link_count(isolated_jobs):
+    jobs, _ = isolated_jobs
+    jobs.ensure_dirs()
+    lock_path = jobs._jobs_lock_file()
+    alias_path = lock_path.with_name(".jobs.lock.alias")
+    previous_umask = os.umask(0)
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644)
+        os.close(fd)
+    finally:
+        os.umask(previous_umask)
+    os.link(lock_path, alias_path)
+
+    before = os.lstat(lock_path)
+    assert before.st_nlink == 2
+
+    with pytest.raises(jobs.JobsLockSecurityError):
+        with jobs._jobs_lock():
+            pytest.fail("multiply-linked lock yielded its critical section")
+
+    after = os.lstat(lock_path)
+    alias = os.lstat(alias_path)
+    assert after.st_nlink == alias.st_nlink == 2
+    assert stat.S_IMODE(after.st_mode) == stat.S_IMODE(alias.st_mode) == 0o644
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+    assert (alias.st_dev, alias.st_ino) == (before.st_dev, before.st_ino)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX inode semantics required")
+@pytest.mark.parametrize("drift_point", ["before_open", "after_open"])
+def test_jobs_lock_rejects_identity_drift(isolated_jobs, monkeypatch, drift_point):
+    jobs, _ = isolated_jobs
+    jobs.ensure_dirs()
+    lock_path = jobs._jobs_lock_file()
+    displaced_path = lock_path.with_name(f".jobs.lock.{drift_point}")
+    previous_umask = os.umask(0)
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644)
+        os.close(fd)
+    finally:
+        os.umask(previous_umask)
+
+    original_open = jobs.os.open
+    drifted = False
+
+    def replacement_file():
+        replacement_fd = original_open(
+            lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644
+        )
+        os.close(replacement_fd)
+
+    def drifting_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal drifted
+        is_existing_lock_open = (
+            Path(path) == lock_path and not flags & os.O_CREAT and not drifted
+        )
+        if not is_existing_lock_open:
+            if dir_fd is None:
+                return original_open(path, flags, mode)
+            return original_open(path, flags, mode, dir_fd=dir_fd)
+
+        drifted = True
+        if drift_point == "before_open":
+            lock_path.rename(displaced_path)
+            replacement_file()
+            return original_open(path, flags, mode)
+
+        opened_fd = original_open(path, flags, mode)
+        lock_path.rename(displaced_path)
+        replacement_file()
+        return opened_fd
+
+    monkeypatch.setattr(jobs.os, "open", drifting_open)
+
+    with pytest.raises(jobs.JobsLockSecurityError):
+        with jobs._jobs_lock():
+            pytest.fail(f"{drift_point} identity drift yielded its critical section")
+
+    assert drifted
+    assert os.path.samestat(os.lstat(lock_path), os.lstat(displaced_path)) is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX descriptor chmod required")
+@pytest.mark.parametrize("failure_kind", ["error", "no_op", "path_swap"])
+def test_jobs_lock_fails_closed_when_hardening_is_unverified(
+    isolated_jobs, monkeypatch, failure_kind
+):
+    jobs, _ = isolated_jobs
+    jobs.ensure_dirs()
+    lock_path = jobs._jobs_lock_file()
+    displaced_path = lock_path.with_name(".jobs.lock.displaced")
+    previous_umask = os.umask(0)
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644)
+        os.close(fd)
+    finally:
+        os.umask(previous_umask)
+
+    original_fchmod = jobs.os.fchmod
+    original_open = jobs.os.open
+
+    def failing_fchmod(fd, mode):
+        if failure_kind == "error":
+            raise OSError("simulated descriptor chmod failure")
+        if failure_kind == "no_op":
+            return None
+
+        original_fchmod(fd, mode)
+        lock_path.rename(displaced_path)
+        replacement_fd = original_open(
+            lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600
+        )
+        os.close(replacement_fd)
+        return None
+
+    monkeypatch.setattr(jobs.os, "fchmod", failing_fchmod)
+
+    with pytest.raises(jobs.JobsLockSecurityError):
+        with jobs._jobs_lock():
+            pytest.fail(
+                f"unverified {failure_kind} hardening yielded its critical section"
+            )
+
+    if failure_kind in {"error", "no_op"}:
+        assert stat.S_IMODE(os.lstat(lock_path).st_mode) == 0o644
+    else:
+        assert displaced_path.exists()
+        assert not os.path.samestat(os.lstat(lock_path), os.lstat(displaced_path))
+
+
+@pytest.mark.parametrize("missing_capability", ["O_NOFOLLOW", "fchmod", "geteuid"])
+def test_jobs_lock_fails_closed_without_security_capability(
+    isolated_jobs, monkeypatch, missing_capability
+):
+    jobs, _ = isolated_jobs
+    monkeypatch.delattr(jobs.os, missing_capability, raising=False)
+
+    with pytest.raises(jobs.JobsLockSecurityError):
+        with jobs._jobs_lock():
+            pytest.fail(
+                f"lock yielded without required {missing_capability} capability"
+            )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics required")
+def test_legacy_lock_fails_closed_without_cross_process_backend(
+    isolated_jobs, monkeypatch
+):
+    jobs, _ = isolated_jobs
+    jobs.ensure_dirs()
+    lock_path = jobs._jobs_lock_file()
+    previous_umask = os.umask(0)
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644)
+        os.close(fd)
+    finally:
+        os.umask(previous_umask)
+    before = os.lstat(lock_path)
+
+    monkeypatch.setattr(jobs, "fcntl", None)
+    monkeypatch.setattr(jobs, "msvcrt", None)
+    with pytest.raises(jobs.JobsLockSecurityError):
+        with jobs._jobs_lock():
+            pytest.fail("legacy lock yielded without cross-process exclusion")
+
+    after = os.lstat(lock_path)
+    assert stat.S_IMODE(after.st_mode) == 0o644
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics required")
+def test_legacy_lock_fails_closed_when_cross_process_backend_errors(
+    isolated_jobs, monkeypatch
+):
+    jobs, _ = isolated_jobs
+    jobs.ensure_dirs()
+    lock_path = jobs._jobs_lock_file()
+    previous_umask = os.umask(0)
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644)
+        os.close(fd)
+    finally:
+        os.umask(previous_umask)
+    before = os.lstat(lock_path)
+
+    class FailingLockBackend:
+        LK_LOCK = 1
+        LK_UNLCK = 2
+
+        @staticmethod
+        def locking(fd, operation, length):
+            raise OSError("simulated cross-process lock failure")
+
+    monkeypatch.setattr(jobs, "fcntl", None)
+    monkeypatch.setattr(jobs, "msvcrt", FailingLockBackend)
+    entered = False
+    with pytest.raises(jobs.JobsLockSecurityError):
+        with jobs._jobs_lock():
+            entered = True
+
+    after = os.lstat(lock_path)
+    assert not entered
+    assert stat.S_IMODE(after.st_mode) == 0o644
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics required")
+def test_private_lock_keeps_process_local_fallback_without_backend(
+    isolated_jobs, monkeypatch
+):
+    jobs, _ = isolated_jobs
+    with jobs._jobs_lock():
+        pass
+    lock_path = jobs._jobs_lock_file()
+    before = os.lstat(lock_path)
+    assert stat.S_IMODE(before.st_mode) == 0o600
+
+    monkeypatch.setattr(jobs, "fcntl", None)
+    monkeypatch.setattr(jobs, "msvcrt", None)
+    entered = False
+    with jobs._jobs_lock():
+        entered = True
+
+    after = os.lstat(lock_path)
+    assert entered
+    assert stat.S_IMODE(after.st_mode) == 0o600
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX flock semantics required")
+def test_contended_legacy_lock_times_out_without_chmod_then_hardens(
+    isolated_jobs, monkeypatch
+):
+    jobs, hermes_home = isolated_jobs
+    if jobs.fcntl is None:
+        pytest.skip("fcntl.flock unavailable")
+
+    jobs.ensure_dirs()
+    lock_path = jobs._jobs_lock_file()
+    previous_umask = os.umask(0)
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644)
+        os.close(fd)
+    finally:
+        os.umask(previous_umask)
+    before = os.lstat(lock_path)
+
+    ready = hermes_home / "holder-ready"
+    release = hermes_home / "holder-release"
+    holder_code = """
+import fcntl
+import os
+import pathlib
+import sys
+import time
+
+hermes_home = pathlib.Path(sys.argv[1]).resolve()
+lock_path = pathlib.Path(sys.argv[2])
+ready = pathlib.Path(sys.argv[3])
+release = pathlib.Path(sys.argv[4])
+os.environ["HERMES_HOME"] = str(hermes_home)
+os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
+assert hermes_home != (pathlib.Path.home() / ".hermes").resolve()
+fd = os.open(lock_path, os.O_RDWR | os.O_NOFOLLOW | os.O_CLOEXEC)
+try:
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    ready.write_text("ready", encoding="utf-8")
+    deadline = time.monotonic() + 15
+    while not release.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+finally:
+    fcntl.flock(fd, fcntl.LOCK_UN)
+    os.close(fd)
+"""
+    child_env = os.environ.copy()
+    child_env["HERMES_HOME"] = str(hermes_home)
+    child_env["PYTHONDONTWRITEBYTECODE"] = "1"
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            holder_code,
+            str(hermes_home),
+            str(lock_path),
+            str(ready),
+            str(release),
+        ],
+        env=child_env,
+    )
+
+    try:
+        deadline = time.monotonic() + 10
+        while not ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ready.exists(), "holder process never acquired the legacy lock"
+
+        monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.2)
+        entered = False
+        with pytest.raises(jobs.JobsLockSecurityError):
+            with jobs._jobs_lock():
+                entered = True
+        assert not entered
+
+        after_timeout = os.lstat(lock_path)
+        assert stat.S_IMODE(after_timeout.st_mode) == 0o644
+        assert (after_timeout.st_dev, after_timeout.st_ino) == (
+            before.st_dev,
+            before.st_ino,
+        )
+    finally:
+        release.write_text("release", encoding="utf-8")
+        holder.wait(timeout=15)
+        assert holder.returncode == 0
+
+    with jobs._jobs_lock():
+        during = os.lstat(lock_path)
+        assert stat.S_IMODE(during.st_mode) == 0o600
+        assert (during.st_dev, during.st_ino) == (before.st_dev, before.st_ino)
+
+    after = os.lstat(lock_path)
+    assert stat.S_IMODE(after.st_mode) == 0o600
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)

--- a/tests/cron/test_ticker_stall_60703.py
+++ b/tests/cron/test_ticker_stall_60703.py
@@ -3,9 +3,10 @@
 Three fixes under test:
 
 1. ``_jobs_lock()`` bounds its cross-process flock: when another process holds
-   ``.jobs.lock`` indefinitely, acquisition times out, logs at ERROR, and falls
-   through to in-process-only locking — instead of blocking the calling thread
-   (and, transitively, the cron ticker heartbeat) forever.
+   an already-private ``.jobs.lock`` indefinitely, acquisition times out, logs
+   at ERROR, and falls through to in-process-only locking — instead of blocking
+   the calling thread (and, transitively, the cron ticker heartbeat) forever.
+   Legacy locks that still need permission hardening fail closed instead.
 
 2. Claim freshness checks are bounded on both sides (``0 <= age < ttl``): a
    ``fire_claim``/``run_claim`` stamped in the FUTURE (clock/TZ skew across a
@@ -65,11 +66,11 @@ def _hold_jobs_flock(path: Path, release: threading.Event, held: threading.Event
 
 
 class TestBoundedJobsLock:
-    def test_lock_acquisition_times_out_and_degrades(self, monkeypatch, caplog):
-        """A foreign holder of .jobs.lock must NOT block _jobs_lock forever."""
-        jobs_mod.ensure_dirs()
+    def test_private_lock_acquisition_times_out_and_degrades(self, monkeypatch, caplog):
+        """A foreign holder of a private lock must not block forever."""
+        with _jobs_lock():
+            pass
         lock_path = jobs_mod._jobs_lock_file()
-        lock_path.touch()
 
         monkeypatch.setattr(jobs_mod, "_JOBS_LOCK_TIMEOUT_SECONDS", 1.0)
 


### PR DESCRIPTION
## What does this PR do?

Hardens the cron jobs advisory lock against permissive creation modes, final-component symlinks, unsafe file types/ownership/link counts, inode swaps, and unverifiable permission changes.

New locks are created through a raw descriptor at `0600`. Existing owner-correct legacy locks are opened without following the final component, identity-checked before and after open, exclusively locked using the existing scheduler protocol, and hardened in place with descriptor-based `fchmod`. Security validation and hardening failures fail closed; the reviewed process-local fallback remains only for an already-private lock.

## Related Issue

Internal security diagnosis; no public issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/jobs.py`: add descriptor-only secure create/open/validate/harden helpers and fail-closed legacy-lock behavior.
- `tests/cron/test_jobs_lock_security.py`: cover `0600` creation, same-inode hardening, symlink/type/owner/link-count rejection, identity drift, capability failures, contention timeout, and backend errors.
- `tests/cron/test_ticker_stall_60703.py`: retain the bounded process-local fallback test for an already-private lock.

## How to Test

1. `scripts/run_tests.sh tests/cron/test_jobs_lock_security.py tests/cron/test_file_permissions.py tests/cron/test_jobs_crossprocess_lock.py tests/cron/test_ticker_stall_60703.py -q --file-retries 0` — 39 passed.
2. `scripts/run_tests.sh tests/cron/ -q --file-retries 0` — 750 passed.
3. `python scripts/check-windows-footguns.py --diff canonical/main` — clean.
4. Full Ubuntu/Python 3.11 repository CI — pending on this draft PR.

Every local run used a disposable `HOME` and `HERMES_HOME` established before interpreter startup. No live scheduler lock or job registry was opened for write or modified.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run the full repository test suite and all tests pass (upstream Linux CI pending)
- [x] I've added tests for my changes
- [x] I've tested on macOS with disposable state; Linux CI is pending

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior and security invariants are documented in code/tests
- [x] `cli-config.yaml.example` update — N/A; no config changes
- [x] `CONTRIBUTING.md` or `AGENTS.md` update — N/A; no workflow/architecture changes
- [x] Cross-platform impact considered; platforms without the required no-follow/descriptor-hardening guarantees fail closed
- [x] Tool descriptions/schemas update — N/A; no model tool surface changed

## AI provenance and safety boundary

This implementation was produced by an AI engineering runtime under Andrew Noble's direction. Exact-head independent AI security/runtime review is required before any readiness decision. This PR intentionally remains draft; it does not authorize merge, installation, runtime switching/restart, deployment, live permission changes, scheduler mutation, or any trading action.
