### PR TITLE
feat(dashboard): browser.headed schema toggle (#25653 salvage)

### DIFF
--- a/contributors/emails/ayoub@gmail.com
+++ b/contributors/emails/ayoub@gmail.com
@@ -1,0 +1,1 @@
+Black0Fox0

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -746,6 +746,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
             "not writable."
         ),
     },
+    "browser.headed": {
+        "type": "boolean",
+        "description": "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout.",
+    },
 }
 
 # Categories with fewer fields get merged into "general" to avoid tab sprawl.


### PR DESCRIPTION
## Summary

The dashboard now renders `browser.headed` as a labeled boolean toggle — salvages the surviving piece of PR #25653 by @Black0Fox0.

The other two thirds of #25653 (the `browser.headed` DEFAULT_CONFIG key and the headed-mode wiring in `browser_tool.py`) already landed via PR #67018, which went further than the env-var bridge #25653 proposed (`--headed` CLI flag + per-turn cleanup skip). This PR carries the one piece #67018 didn't cover: the `_SCHEMA_OVERRIDES` entry in `hermes_cli/web_server.py` so the dashboard shows a proper toggle with a description instead of a bare untyped key.

## Changes

- `hermes_cli/web_server.py`: `browser.headed` schema override (boolean type + description). Description updated from the original to reflect the merged behavior (window persists between turns, idle reaper still applies).
- `contributors/emails/ayoub@gmail.com`: contributor mapping for @Black0Fox0.

## Validation

| Check | Result |
|---|---|
| ruff | clean |
| Schema entry keys match existing `_SCHEMA_OVERRIDES` shape (`type`, `description`) | verified against neighboring entries |

Contributor authorship preserved (`--author="Ayoub <ayoub@gmail.com>"`, rebase-merge).

## Infographic

![browser.headed dashboard toggle](https://v3b.fal.media/files/b/0aa2c609/8X6UDaDHb1b7PUeU-cIln_v7gEps6Z.png)
