### PR TITLE
fix: add PID-scoped run-once sentinel to _apply_profile_override (#66907)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -354,6 +354,17 @@ sys.path.insert(0, str(PROJECT_ROOT))
 # ---------------------------------------------------------------------------
 def _apply_profile_override() -> None:
     """Pre-parse --profile/-p and set HERMES_HOME before imports."""
+    # PID-scoped run-once sentinel: under `python -m hermes_cli.main` the
+    # module executes twice (once as __main__, once as import).  The first
+    # pass strips --profile from sys.argv; the second pass would then fall
+    # through to active_profile and silently rebind HERMES_HOME to a
+    # different profile.  This guard prevents the second pass.
+    # See issue #66907.
+    _sentinel_key = "_HERMES_PROFILE_OVERRIDE_APPLIED"
+    if os.environ.get(_sentinel_key) == str(os.getpid()):
+        return
+    os.environ[_sentinel_key] = str(os.getpid())
+
     argv = sys.argv[1:]
     profile_name = None
     consume = 0

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -44,6 +44,11 @@ def _run_apply_profile_override(
 
     monkeypatch.setattr(sys, "argv", argv or ["hermes", "gateway", "start"])
 
+    # Clear the PID-scoped run-once sentinel from issue #66907 so that
+    # _apply_profile_override actually executes inside this test process
+    # (previous test functions in the same pytest process may have set it).
+    os.environ.pop("_HERMES_PROFILE_OVERRIDE_APPLIED", None)
+
     from hermes_cli.main import _apply_profile_override
     _apply_profile_override()
 
@@ -105,6 +110,7 @@ class TestApplyProfileOverrideHermesHomeGuard:
         monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "start"])
 
         from hermes_cli.main import _apply_profile_override
+        os.environ.pop("_HERMES_PROFILE_OVERRIDE_APPLIED", None)
         _apply_profile_override()
 
         assert os.environ.get("HERMES_HOME") == str(profile_dir), (
@@ -144,6 +150,7 @@ class TestApplyProfileOverrideHermesHomeGuard:
         monkeypatch.setattr(pwd, "getpwnam", lambda name: SimpleNamespace(pw_dir=str(user_home)))
 
         from hermes_cli.main import _apply_profile_override
+        os.environ.pop("_HERMES_PROFILE_OVERRIDE_APPLIED", None)
         _apply_profile_override()
 
         assert os.environ.get("HERMES_HOME") == str(profile_dir)
@@ -160,6 +167,7 @@ class TestApplyProfileOverrideHermesHomeGuard:
         (hermes_root / "active_profile").write_text("default")
 
         from hermes_cli.main import _apply_profile_override
+        os.environ.pop("_HERMES_PROFILE_OVERRIDE_APPLIED", None)
         _apply_profile_override()
 
         assert os.environ.get("HERMES_HOME") is None
@@ -194,6 +202,7 @@ class TestApplyProfileOverrideHermesHomeGuard:
         monkeypatch.setattr(sys, "argv", list(argv))
 
         from hermes_cli.main import _apply_profile_override
+        os.environ.pop("_HERMES_PROFILE_OVERRIDE_APPLIED", None)
         _apply_profile_override()
 
         assert os.environ.get("HERMES_HOME") is None
@@ -278,6 +287,7 @@ class TestSupervisedChildIgnoresStickyProfile:
         monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "run"])
 
         from hermes_cli.main import _apply_profile_override
+        os.environ.pop("_HERMES_PROFILE_OVERRIDE_APPLIED", None)
         _apply_profile_override()
 
         assert os.environ.get("HERMES_HOME") == str(hermes_root), (
@@ -317,6 +327,7 @@ class TestSupervisedChildIgnoresStickyProfile:
         monkeypatch.setattr(sys, "argv", ["hermes", "-p", "coder", "gateway", "run"])
 
         from hermes_cli.main import _apply_profile_override
+        os.environ.pop("_HERMES_PROFILE_OVERRIDE_APPLIED", None)
         _apply_profile_override()
 
         result = os.environ.get("HERMES_HOME")


### PR DESCRIPTION
## Summary

Under `python -m hermes_cli.main --profile default gateway run`, the module executes twice: once as `__main__`, and again when any code later does `import hermes_cli.main`. The first pass parses `--profile default`, sets `HERMES_HOME`, and **strips the flag from `sys.argv`**. The second pass then sees no `--profile` flag and falls through to the sticky `active_profile` file — silently rebinding `HERMES_HOME` to a different profile mid-startup.

## Fix

Add a PID-scoped run-once sentinel at the top of `_apply_profile_override()`:

```python
_sentinel_key = "_HERMES_PROFILE_OVERRIDE_APPLIED"
if os.environ.get(_sentinel_key) == str(os.getpid()):
    return
os.environ[_sentinel_key] = str(os.getpid())
```

PID-scoping keeps spawned children resolving their own profile fresh (they inherit the env var but have a different PID).

## Changes

- **`hermes_cli/main.py`**: Add PID-scoped sentinel guard at the top of `_apply_profile_override()`
- **`tests/hermes_cli/test_apply_profile_override.py`**: Clear the sentinel before each call to `_apply_profile_override()` so tests aren't affected by the PID guard in same-process pytest runs

## Verification

All 12 existing tests in `test_apply_profile_override.py` pass with the sentinel in place.

Fixes #66907