### PR TITLE
fix(desktop): skip focus-steal on macOS lid-open wake via sleep-resume cooldown

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4655,7 +4655,15 @@ function sendClosePreviewRequested() {
 // Tell the renderer the machine just woke. Sleep silently drops the
 // renderer's WebSocket to the local backend; the renderer reconnects on this
 // signal so the chat composer doesn't stay stuck on "Starting Hermes...".
+// Guard against macOS firing app.on('activate') on lid-open wake.
+// powerMonitor.on('resume') fires first; we set this timestamp so the
+// activate handler can skip focusWindow and avoid stealing the foreground
+// from the app the user was using before sleep.
+let _sleepResumeAt = 0
+
 function sendPowerResume() {
+  _sleepResumeAt = Date.now()
+
   if (!mainWindow || mainWindow.isDestroyed()) {
     return
   }
@@ -9443,12 +9451,12 @@ app.whenReady().then(() => {
   }
 
   app.on('activate', () => {
-    // Recreate the primary window if it's gone. Guard on mainWindow directly
-    // (not just total window count) so a dock click still restores the main
-    // window when only secondary session windows remain open.
+    // macOS fires activate on lid-open wake too, not just dock clicks.
+    // Skip focusWindow right after sleep-resume so we don't steal the
+    // foreground from whatever the user was doing before sleep.
     if (!mainWindow || mainWindow.isDestroyed()) {
       createWindow()
-    } else {
+    } else if (Date.now() - _sleepResumeAt > 2000) {
       focusWindow(mainWindow)
     }
   })


### PR DESCRIPTION
## Problem

Issue #67001 — On macOS, Hermes Desktop steals focus when the MacBook wakes from lid-open sleep, even when another app was foregrounded before sleep.

## Root Cause

On macOS, `app.on('activate')` fires not only for dock clicks but also when the MacBook wakes from sleep (via `NSApplicationDidBecomeActiveNotification`). The existing handler unconditionally calls `focusWindow(mainWindow)`, which restores, shows, and focuses the window — stealing the foreground from whatever app the user was using before sleep.

## Fix

Track the last sleep-resume timestamp in `sendPowerResume()` (which fires from `powerMonitor.on('resume')` before the `activate` event). In the `activate` handler, skip `focusWindow` for 2 seconds after a sleep resume.

- `powerMonitor.on('resume')` fires first → `_sleepResumeAt = Date.now()`
- `app.on('activate')` fires next → checks `Date.now() - _sleepResumeAt > 2000` → skips `focusWindow` on wake
- Normal dock clicks (no recent sleep resume) work as before

## Verification

This change cannot be tested on this Linux environment (electron + macOS required). The fix is purely a guard conditional — no existing behavior is modified for Windows/Linux or for normal macOS dock clicks. A conservative 2-second cooldown prevents false positives: if the user clicks the dock within 2 seconds of wake (unlikely), the window activates on the second click.

Fixes #67001