### PR TITLE
fix(gateway): recover watchdog after transient loop stalls

### DIFF
--- a/gateway/systemd_notify.py
+++ b/gateway/systemd_notify.py
@@ -60,6 +60,8 @@ def watchdog_interval_seconds() -> Optional[float]:
 class SystemdWatchdog:
     """Feed systemd while the asyncio event loop continues to make progress."""
 
+    _RECOVERY_TICKS = 2
+
     def __init__(
         self,
         *,
@@ -71,6 +73,7 @@ class SystemdWatchdog:
         self._lag_tolerance_seconds = lag_tolerance_seconds
         self._task: Optional[asyncio.Task[None]] = None
         self._unhealthy = False
+        self._timely_ticks = 0
         self._stopping = False
         self._stopping_notified = False
 
@@ -111,6 +114,7 @@ class SystemdWatchdog:
             return False
         self._stopping = False
         self._unhealthy = False
+        self._timely_ticks = 0
         self._stopping_notified = False
         self._task = asyncio.create_task(self._run(), name="hermes-systemd-watchdog")
         return True
@@ -123,8 +127,14 @@ class SystemdWatchdog:
         return notify(f"READY=1\nSTATUS={safe_status}")
 
     def record_tick(self, *, scheduled_at: float, now: float) -> bool:
-        """Feed systemd only when the event loop woke within its lag budget."""
-        if not self.enabled or self._stopping or self._unhealthy:
+        """Feed systemd whenever the event loop is making progress again.
+
+        A late wake-up is evidence of starvation, but the fact that this method
+        is running means the loop recovered before systemd killed the process.
+        Keep feeding the external watchdog while reporting a degraded status;
+        otherwise one transient delay permanently guarantees a later restart.
+        """
+        if not self.enabled or self._stopping:
             return False
         try:
             lag = float(now) - float(scheduled_at)
@@ -132,8 +142,20 @@ class SystemdWatchdog:
             lag = float("inf")
         if not math.isfinite(lag) or lag > self._lag_tolerance():
             self._unhealthy = True
-            notify("STATUS=watchdog unhealthy: event loop progress is late")
-            return False
+            self._timely_ticks = 0
+            notify("WATCHDOG=1\nSTATUS=watchdog degraded: event loop progress was late")
+            return True
+
+        if self._unhealthy:
+            self._timely_ticks += 1
+            if self._timely_ticks >= self._RECOVERY_TICKS:
+                self._unhealthy = False
+                self._timely_ticks = 0
+                notify(
+                    "WATCHDOG=1\nSTATUS=watchdog healthy: event loop progress recovered"
+                )
+                return True
+
         notify("WATCHDOG=1")
         return True
 
@@ -145,7 +167,7 @@ class SystemdWatchdog:
         loop = asyncio.get_running_loop()
         scheduled_at = loop.time() + cadence
         try:
-            while not self._stopping and not self._unhealthy:
+            while not self._stopping:
                 await asyncio.sleep(max(0.0, scheduled_at - loop.time()))
                 now = loop.time()
                 if not self.record_tick(scheduled_at=scheduled_at, now=now):

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import time
 
 import pytest
 
@@ -92,7 +93,7 @@ def test_watchdog_interval_is_disabled_for_missing_invalid_or_nonpositive_values
     assert watchdog_interval_seconds() is None
 
 
-def test_watchdog_latches_when_loop_progress_is_late(monkeypatch):
+def test_watchdog_recovers_after_loop_progress_is_late(monkeypatch):
     calls: list[str] = []
     monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
     monkeypatch.setenv("WATCHDOG_USEC", "1000000")
@@ -106,10 +107,54 @@ def test_watchdog_latches_when_loop_progress_is_late(monkeypatch):
 
     assert watchdog.record_tick(scheduled_at=10.0, now=10.05) is True
     assert calls == ["WATCHDOG=1"]
-    assert watchdog.record_tick(scheduled_at=10.0, now=10.2) is False
+    assert watchdog.record_tick(scheduled_at=10.0, now=10.2) is True
     assert watchdog.unhealthy is True
-    assert calls[-1].startswith("STATUS=watchdog unhealthy")
-    assert watchdog.record_tick(scheduled_at=10.0, now=10.3) is False
+    assert "WATCHDOG=1" in calls[-1]
+    assert "STATUS=watchdog degraded" in calls[-1]
+
+    # A recovered event loop must keep feeding systemd.  Require two timely
+    # samples before clearing the degraded status so one lucky wake-up does not
+    # hide recurring starvation.
+    assert watchdog.record_tick(scheduled_at=10.3, now=10.35) is True
+    assert watchdog.unhealthy is True
+    assert watchdog.record_tick(scheduled_at=10.4, now=10.45) is True
+    assert watchdog.unhealthy is False
+    assert "STATUS=watchdog healthy" in calls[-1]
+
+
+@pytest.mark.asyncio
+async def test_watchdog_task_survives_a_transient_event_loop_stall(monkeypatch):
+    calls: list[str] = []
+    degraded = asyncio.Event()
+    healthy = asyncio.Event()
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "100000")
+
+    import gateway.systemd_notify as notify_mod
+
+    def _capture(message: str) -> bool:
+        calls.append(message)
+        if "STATUS=watchdog degraded" in message:
+            degraded.set()
+        if "STATUS=watchdog healthy" in message:
+            healthy.set()
+        return True
+
+    monkeypatch.setattr(notify_mod, "notify", _capture)
+    watchdog = notify_mod.SystemdWatchdog(lag_tolerance_seconds=0.01)
+
+    assert watchdog.start() is True
+    try:
+        await asyncio.sleep(0)  # Let the watchdog establish its first deadline.
+        time.sleep(0.08)  # Fault injection: delay the loop, but not past WatchdogSec.
+
+        await asyncio.wait_for(degraded.wait(), timeout=2.0)
+        await asyncio.wait_for(healthy.wait(), timeout=2.0)
+        assert watchdog.task is not None
+        assert not watchdog.task.done()
+        assert calls.count("WATCHDOG=1") >= 1
+    finally:
+        await watchdog.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import time
 
 import pytest
 
@@ -55,6 +56,70 @@ def test_notify_uses_nonblocking_datagram_send(monkeypatch):
     assert calls[0] == ("setblocking", False)
 
 
+def test_watchdog_recovers_after_loop_progress_is_late(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog(lag_tolerance_seconds=0.1)
+
+    assert watchdog.record_tick(scheduled_at=10.0, now=10.05) is True
+    assert calls == ["WATCHDOG=1"]
+    assert watchdog.record_tick(scheduled_at=10.0, now=10.2) is True
+    assert watchdog.unhealthy is True
+    assert "WATCHDOG=1" in calls[-1]
+    assert "STATUS=watchdog degraded" in calls[-1]
+
+    # A recovered event loop must keep feeding systemd.  Require two timely
+    # samples before clearing the degraded status so one lucky wake-up does not
+    # hide recurring starvation.
+    assert watchdog.record_tick(scheduled_at=10.3, now=10.35) is True
+    assert watchdog.unhealthy is True
+    assert watchdog.record_tick(scheduled_at=10.4, now=10.45) is True
+    assert watchdog.unhealthy is False
+    assert "STATUS=watchdog healthy" in calls[-1]
+
+
+@pytest.mark.asyncio
+async def test_watchdog_task_survives_a_transient_event_loop_stall(monkeypatch):
+    calls: list[str] = []
+    degraded = asyncio.Event()
+    healthy = asyncio.Event()
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "100000")
+
+    import gateway.systemd_notify as notify_mod
+
+    def _capture(message: str) -> bool:
+        calls.append(message)
+        if "STATUS=watchdog degraded" in message:
+            degraded.set()
+        if "STATUS=watchdog healthy" in message:
+            healthy.set()
+        return True
+
+    monkeypatch.setattr(notify_mod, "notify", _capture)
+    watchdog = notify_mod.SystemdWatchdog(lag_tolerance_seconds=0.01)
+
+    assert watchdog.start() is True
+    try:
+        await asyncio.sleep(0)  # Let the watchdog establish its first deadline.
+        time.sleep(0.08)  # Fault injection: delay the loop, but not past WatchdogSec.
+
+        await asyncio.wait_for(degraded.wait(), timeout=2.0)
+        await asyncio.wait_for(healthy.wait(), timeout=2.0)
+        assert watchdog.task is not None
+        assert not watchdog.task.done()
+        assert calls.count("WATCHDOG=1") >= 1
+    finally:
+        await watchdog.stop()
+
+
 @pytest.mark.asyncio
 async def test_watchdog_sends_ready_heartbeat_and_stopping(monkeypatch):
     calls: list[str] = []
@@ -77,5 +142,3 @@ async def test_watchdog_sends_ready_heartbeat_and_stopping(monkeypatch):
     assert "WATCHDOG=1" in calls
     assert calls[-1] == "STOPPING=1"
     assert watchdog.unhealthy is False
-
-

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -172,11 +172,14 @@ hermes gateway install --force
 ```
 
 A positive value makes the generated unit use `Type=notify`,
-`NotifyAccess=main`, and the matching `WatchdogSec`. Hermes sends heartbeats
-only while its event loop is making timely progress; systemd restarts the
-process when they stop. The default `0` keeps the existing `Type=simple`
-behavior. This setting is Linux/systemd-only and does not treat an ordinary
-platform network disconnect as an event-loop failure.
+`NotifyAccess=main`, and the matching `WatchdogSec`. Hermes normally sends
+heartbeats while its event loop makes timely progress. A late callback shows
+that the loop has resumed, so Hermes renews the watchdog lease with a degraded
+status and reports healthy again after two consecutive timely samples. A full
+stall prevents the callback from running, so no heartbeat is sent and systemd
+restarts the process when `WatchdogSec` expires. The default `0` keeps the
+existing `Type=simple` behavior. This setting is Linux/systemd-only and does
+not treat an ordinary platform network disconnect as an event-loop failure.
 
 ## Chat Commands (Inside Messaging)
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -180,11 +180,14 @@ hermes gateway install --force
 ```
 
 A positive value makes the generated unit use `Type=notify`,
-`NotifyAccess=main`, and the matching `WatchdogSec`. Hermes sends heartbeats
-only while its event loop is making timely progress; systemd restarts the
-process when they stop. The default `0` keeps the existing `Type=simple`
-behavior. This setting is Linux/systemd-only and does not treat an ordinary
-platform network disconnect as an event-loop failure.
+`NotifyAccess=main`, and the matching `WatchdogSec`. Hermes normally sends
+heartbeats while its event loop makes timely progress. A late callback shows
+that the loop has resumed, so Hermes renews the watchdog lease with a degraded
+status and reports healthy again after two consecutive timely samples. A full
+stall prevents the callback from running, so no heartbeat is sent and systemd
+restarts the process when `WatchdogSec` expires. The default `0` keeps the
+existing `Type=simple` behavior. This setting is Linux/systemd-only and does
+not treat an ordinary platform network disconnect as an event-loop failure.
 
 ## Chat Commands (Inside Messaging)
 


### PR DESCRIPTION
## Summary

This fixes a residual failure mode in the opt-in systemd event-loop watchdog introduced by #66946:

- a transient late asyncio tick reports `degraded` and keeps renewing the watchdog lease;
- two consecutive timely ticks are required before the service reports `healthy` again;
- a fully stalled loop still emits no heartbeat, so `WatchdogSec` remains the hard-stop restart path.

The PR has been rebased as one signed commit onto current `main` (`c896c09c42910c584c4c7d2325b58c14713ea42c`). The rebase conflict came from main's later test-pruning pass; the resolution preserves that pruning and retains only the two behavior tests specific to this fix.

## Reproduction and root cause

With `gateway.systemd_watchdog_seconds > 0`:

1. let the watchdog task schedule its next sample;
2. block the asyncio loop longer than the internal lag tolerance but shorter than `WatchdogSec`;
3. allow the loop to run again.

Before this PR, the late callback permanently set `_unhealthy`, returned without `WATCHDOG=1`, and caused `_run()` to exit. The event loop could recover in the same process, but the notifier never restarted, so systemd later restarted an otherwise progressing gateway.

The classification was too coarse: a callback that runs late proves the loop resumed; it is different from a callback that never runs.

## Behavioral contract

| Condition | Notification | State | Supervisor outcome |
|---|---|---|---|
| Timely tick while healthy | `WATCHDOG=1` | healthy | lease renewed |
| Late callback while alive | `WATCHDOG=1` + `STATUS=degraded` | degraded; timely streak reset | lease renewed |
| First timely recovery tick | `WATCHDOG=1` | degraded; streak = 1 | lease renewed |
| Second timely recovery tick | `WATCHDOG=1` + `STATUS=healthy` | healthy | normal operation restored |
| Callback cannot run before `WatchdogSec` | nothing | no in-process transition | systemd restarts the gateway |

## Implementation

- [`gateway/systemd_notify.py`](https://github.com/NousResearch/hermes-agent/blob/365134f66990e2ac5f70bbb826247bbc271036f1/gateway/systemd_notify.py): adds the two-tick recovery state and keeps the notifier alive after a late callback.
- [`tests/gateway/test_systemd_notify.py`](https://github.com/NousResearch/hermes-agent/blob/365134f66990e2ac5f70bbb826247bbc271036f1/tests/gateway/test_systemd_notify.py): verifies the state transitions and injects a real transient loop stall.
- [`website/docs/user-guide/messaging/index.md`](https://github.com/NousResearch/hermes-agent/blob/365134f66990e2ac5f70bbb826247bbc271036f1/website/docs/user-guide/messaging/index.md): distinguishes late-but-resumed progress from a full no-callback stall.

No new task, cadence, configuration key, dependency, public API, or persistence surface is added.

## Validation

- [x] Focused recovery, real transient-stall, existing heartbeat/lifecycle, and generated-unit tests via `scripts/run_tests.sh`: passed, 0 failed.
- [x] `ruff check` on both changed Python files: passed.
- [x] `ruff format --check` on both changed Python files: passed.
- [x] Python compile smoke test: passed.
- [x] `git diff --check origin/main...HEAD`: passed.
- [x] One signed commit; no merge commits in `origin/main..HEAD`.
- [ ] New GitHub CI for rebased head `365134f66990e2ac5f70bbb826247bbc271036f1`: running after force-with-lease push.

Local macOS note: the full `tests/gateway/test_systemd_notify.py` file still contains main's pre-existing Linux abstract-socket test, whose skip condition accepts macOS `AF_UNIX` even though macOS does not support Linux abstract socket addresses. Validation therefore selected the watchdog behavior tests directly; Linux CI runs the full file.

## Compatibility and risk

- Default-disabled watchdog installations are unchanged.
- Non-systemd platforms remain no-ops through the existing `NOTIFY_SOCKET` / AF_UNIX gates.
- Recurring but bounded lateness keeps the process alive in `degraded`; restart remains reserved for loss of progress through the full `WatchdogSec` window.
- Notifications remain local Unix datagrams and contain no user or session data.

## Scope and non-goals

- does not change Discord WebSocket liveness or reconnect policy;
- does not recover interrupted agent sessions or retry external side effects;
- does not add a configurable recovery threshold;
- does not claim exactly-once delivery.

Crash-safe in-flight session continuation remains separate in #67078.

## Rollout and rollback

No migration is needed. Rollback is a single revert of signed commit `365134f66990e2ac5f70bbb826247bbc271036f1`; there is no persisted state to clean up.

## Head integrity

- PR head: `StellarisW:codex/gateway-watchdog-recovery`
- Signed commit: `365134f66990e2ac5f70bbb826247bbc271036f1`
- Base used for the rebase: `c896c09c42910c584c4c7d2325b58c14713ea42c`
- History: one feature commit, no merge commits

## Infographic

![Control-flow diagram contrasting a late callback that renews the systemd watchdog lease with a missing callback that triggers WatchdogSec, plus the two-sample degraded-to-healthy recovery state machine](https://raw.githubusercontent.com/StellarisW/hermes-agent/ee92ad4de05dc3342f708ced3c84566c8469f4d5/pr/67051/watchdog-recovery-v4.png)

A callback that runs renews the lease; only callback absence leaves systemd to expire it. Two consecutive timely callbacks are required before degraded state returns to healthy.
