### PR TITLE
fix(discord): deliver MEDIA video attachments instead of silent drop

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5212,6 +5212,12 @@ class BasePlatformAdapter(ABC):
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
+                if _non_image_media:
+                    logger.info(
+                        "[%s] Delivering %d non-image MEDIA attachment(s)",
+                        self.name,
+                        len(_non_image_media),
+                    )
                 for media_path, is_voice in _non_image_media:
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
@@ -5224,6 +5230,12 @@ class BasePlatformAdapter(ABC):
                                 metadata=_final_thread_metadata,
                             )
                         elif ext in _VIDEO_EXTS:
+                            logger.info(
+                                "[%s] Sending video attachment (%s) to %s",
+                                self.name,
+                                ext,
+                                event.source.chat_id,
+                            )
                             media_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=media_path,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3527,6 +3527,45 @@ class BasePlatformAdapter(ABC):
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
 
+    async def _notify_media_delivery_failure(
+        self,
+        chat_id: str,
+        media_path: str,
+        *,
+        is_voice: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Send a user-visible notice when a MEDIA attachment could not be delivered.
+
+        The non-streaming dispatch loop strips ``MEDIA:`` tags before sending
+        attachments. When the subsequent upload returns ``success=False`` (for
+        example Discord accepted the message but attached nothing), the user
+        must see a failure notice instead of a silent drop (#66797).
+        """
+        ext = Path(media_path).suffix.lower()
+        _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
+        if is_voice or should_send_media_as_audio(self.platform, ext, is_voice=is_voice):
+            text = "⚠️ Couldn't deliver the audio attachment."
+        elif ext in _VIDEO_EXTS:
+            text = "⚠️ Couldn't deliver the video attachment."
+        else:
+            file_name = os.path.basename(media_path)
+            text = f"⚠️ Couldn't deliver the file attachment ({file_name})."
+        try:
+            notice = await self.send(chat_id=chat_id, content=text, metadata=metadata)
+            if not notice.success:
+                logger.debug(
+                    "[%s] Could not send media-delivery-failure notice: %s",
+                    self.name,
+                    notice.error,
+                )
+        except Exception as notify_err:
+            logger.debug(
+                "[%s] Could not send media-delivery-failure notice: %s",
+                self.name,
+                notify_err,
+            )
+
     async def send_image_file(
         self,
         chat_id: str,
@@ -5250,6 +5289,12 @@ class BasePlatformAdapter(ABC):
 
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
+                            await self._notify_media_delivery_failure(
+                                event.source.chat_id,
+                                media_path,
+                                is_voice=is_voice,
+                                metadata=_final_thread_metadata,
+                            )
                     except Exception as media_err:
                         logger.warning("[%s] Error sending media: %s", self.name, media_err)
 
@@ -5260,15 +5305,27 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(file_path).suffix.lower()
                         if ext in _VIDEO_EXTS:
-                            await self.send_video(
+                            file_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
                         else:
-                            await self.send_document(
+                            file_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
+                                metadata=_final_thread_metadata,
+                            )
+                        if not file_result.success:
+                            logger.warning(
+                                "[%s] Failed to send local file (%s): %s",
+                                self.name,
+                                ext,
+                                file_result.error,
+                            )
+                            await self._notify_media_delivery_failure(
+                                event.source.chat_id,
+                                file_path,
                                 metadata=_final_thread_metadata,
                             )
                     except Exception as file_err:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2376,6 +2376,30 @@ class DiscordAdapter(BasePlatformAdapter):
         starter_msg = getattr(thread, "message", None)
         message_id = str(getattr(starter_msg, "id", thread_id)) if starter_msg else thread_id
 
+        if file is not None or files:
+            attachments = getattr(starter_msg, "attachments", None) or []
+            if not attachments:
+                filename = ""
+                if file is not None:
+                    filename = getattr(file, "filename", "") or ""
+                elif files:
+                    filename = getattr(files[0], "filename", "") or ""
+                logger.warning(
+                    "[%s] Forum thread %s starter has no attachments for %s",
+                    self.name,
+                    thread_id,
+                    filename or "file",
+                )
+                return SendResult(
+                    success=False,
+                    error=(
+                        "Discord created the forum thread but attached no files"
+                        + (f" ({filename})" if filename else "")
+                    ),
+                    message_id=message_id or None,
+                    raw_response={"thread_id": thread_id},
+                )
+
         return SendResult(
             success=True,
             message_id=message_id,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2601,9 +2601,19 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Forum channels (type 15) get a new thread whose starter message
         carries the file — they reject direct POST /messages.
+
+        Uses a path-based ``discord.File`` (same pattern as
+        ``send_multiple_images``) rather than an open file handle. The
+        handle form can race with Discord's multipart encoder after an
+        earlier image batch on the same channel and produce a successful
+        message with zero attachments — a silent drop for video/document
+        MEDIA tags (#66797).
         """
         if not self._client:
             return SendResult(success=False, error="Not connected")
+
+        if not os.path.isfile(file_path):
+            return SendResult(success=False, error=f"File not found: {file_path}")
 
         channel = self._client.get_channel(int(chat_id))
         if not channel:
@@ -2612,15 +2622,45 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=f"Channel {chat_id} not found")
 
         filename = file_name or os.path.basename(file_path)
-        with open(file_path, "rb") as fh:
-            file = discord.File(fh, filename=filename)
-            if self._is_forum_parent(channel):
-                return await self._forum_post_file(
-                    channel,
-                    content=(caption or "").strip(),
-                    file=file,
-                )
-            msg = await channel.send(content=caption if caption else None, file=file)
+        logger.info(
+            "[%s] Sending file attachment %s (%s) to %s",
+            self.name,
+            filename,
+            os.path.splitext(filename)[1].lower() or "no-ext",
+            chat_id,
+        )
+        # Path-based File: discord.py owns open/close for the upload, matching
+        # the working image-batch path. Prefer ``files=[...]`` over deprecated
+        # singular ``file=`` for the same reason.
+        discord_file = discord.File(file_path, filename=filename)
+        if self._is_forum_parent(channel):
+            result = await self._forum_post_file(
+                channel,
+                content=(caption or "").strip(),
+                files=[discord_file],
+            )
+            return result
+        msg = await channel.send(
+            content=caption if caption else None,
+            files=[discord_file],
+        )
+        attachments = getattr(msg, "attachments", None) or []
+        if not attachments:
+            # Discord accepted the message but attached nothing — the failure
+            # mode reported in #66797 (MEDIA video stripped from text, no
+            # attachment, no prior log line). Fail loud so the dispatch loop
+            # surfaces a warning instead of a silent drop.
+            logger.warning(
+                "[%s] Discord returned message %s with no attachments for %s",
+                self.name,
+                getattr(msg, "id", "?"),
+                filename,
+            )
+            return SendResult(
+                success=False,
+                error=f"Discord accepted the message but attached no files ({filename})",
+                message_id=str(getattr(msg, "id", "") or "") or None,
+            )
         return SendResult(success=True, message_id=str(msg.id))
 
     async def send_multiple_images(

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -326,7 +326,14 @@ async def test_forum_post_file_creates_thread_with_attachment():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
 
     thread_ch = SimpleNamespace(id=777, send=AsyncMock())
-    thread = SimpleNamespace(id=777, message=SimpleNamespace(id=800), thread=thread_ch)
+    thread = SimpleNamespace(
+        id=777,
+        message=SimpleNamespace(
+            id=800,
+            attachments=[SimpleNamespace(filename="photo.png")],
+        ),
+        thread=thread_ch,
+    )
     forum_channel = _discord_mod.ForumChannel()
     forum_channel.id = 999
     forum_channel.name = "ideas"
@@ -356,7 +363,14 @@ async def test_forum_post_file_uses_filename_when_no_content():
     """Thread name falls back to file.filename when no content is provided."""
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
 
-    thread = SimpleNamespace(id=1, message=SimpleNamespace(id=2), thread=SimpleNamespace(id=1, send=AsyncMock()))
+    thread = SimpleNamespace(
+        id=1,
+        message=SimpleNamespace(
+            id=2,
+            attachments=[SimpleNamespace(filename="voice-message.ogg")],
+        ),
+        thread=SimpleNamespace(id=1, send=AsyncMock()),
+    )
     forum_channel = _discord_mod.ForumChannel()
     forum_channel.id = 10
     forum_channel.name = "forum"
@@ -388,6 +402,32 @@ async def test_forum_post_file_creation_failure():
 
     assert result.success is False
     assert "missing perms" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_forum_post_file_fails_when_starter_has_no_attachments():
+    """Forum create_thread can succeed yet return an attachmentless starter (#66797)."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    thread = SimpleNamespace(
+        id=7,
+        message=SimpleNamespace(id=8, attachments=[]),
+        thread=SimpleNamespace(id=7, send=AsyncMock()),
+    )
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(return_value=thread)
+
+    fake_file = SimpleNamespace(filename="clip.mp4")
+    result = await adapter._forum_post_file(
+        forum_channel,
+        content="video clip",
+        files=[fake_file],
+    )
+
+    assert result.success is False
+    assert "no files" in (result.error or "").lower()
+    forum_channel.create_thread.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -622,7 +662,10 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     created_thread = SimpleNamespace(
         id=7,
-        message=SimpleNamespace(id=8),
+        message=SimpleNamespace(
+            id=8,
+            attachments=[SimpleNamespace(filename="clip.mp4")],
+        ),
     )
     forum_channel = SimpleNamespace(
         id=7,
@@ -641,3 +684,39 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     thread_kwargs = forum_channel.create_thread.await_args.kwargs
     assert thread_kwargs.get("file") is None
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_forum_send_video_fails_loud_when_starter_has_no_attachments(tmp_path, monkeypatch):
+    """Forum-parent send_video must fail loud when the starter message drops attachments."""
+    import plugins.platforms.discord.adapter as discord_platform
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake-mp4")
+
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "File",
+        lambda fp, filename=None, **kwargs: SimpleNamespace(fp=fp, filename=filename),
+    )
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    created_thread = SimpleNamespace(
+        id=7,
+        message=SimpleNamespace(id=8, attachments=[]),
+    )
+    forum_channel = SimpleNamespace(
+        id=7,
+        create_thread=AsyncMock(return_value=created_thread),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(adapter, "_is_forum_parent", lambda _ch: True)
+
+    result = await adapter.send_video("555", str(video))
+
+    assert result.success is False
+    assert "no files" in (result.error or "").lower()
+    forum_channel.create_thread.assert_awaited_once()

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -1,7 +1,8 @@
 import asyncio
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
-import sys
 
 import pytest
 
@@ -445,3 +446,198 @@ async def test_typing_stop_cleans_up():
 
     await adapter.stop_typing("12345")
     assert "12345" not in adapter._typing_tasks
+
+
+# ---------------------------------------------------------------------------
+# #66797 — outbound MEDIA video must reach channel.send as a real attachment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_video_uses_path_based_files_kwarg(tmp_path, monkeypatch):
+    """Regression for #66797: video MEDIA delivery must use path-based
+    ``discord.File`` via ``files=[...]`` (same pattern as image batching).
+
+    The previous open-handle + singular ``file=`` form could return a successful
+    message with zero attachments after an earlier image batch on the same
+    channel — silent drop from the user's perspective.
+    """
+    import plugins.platforms.discord.adapter as discord_platform
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"\x00\x00\x00\x18ftypmp42fake")
+
+    captured = {}
+
+    class _FakeFile:
+        def __init__(self, fp, filename=None, **kwargs):
+            captured["fp"] = fp
+            captured["filename"] = filename
+
+    monkeypatch.setattr(discord_platform.discord, "File", _FakeFile)
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent_msg = SimpleNamespace(
+        id=4242,
+        attachments=[SimpleNamespace(filename="clip.mp4", url="https://cdn.example/clip.mp4")],
+    )
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=sent_msg),
+        type=0,
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(adapter, "_is_forum_parent", lambda _ch: False)
+
+    result = await adapter.send_video("555", str(video))
+
+    assert result.success is True
+    assert result.message_id == "4242"
+    assert captured["fp"] == str(video)
+    assert captured["filename"] == "clip.mp4"
+    channel.send.assert_awaited_once()
+    send_kwargs = channel.send.await_args.kwargs
+    assert send_kwargs.get("file") is None
+    assert isinstance(send_kwargs.get("files"), list) and len(send_kwargs["files"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_send_video_fails_loud_when_message_has_no_attachments(tmp_path, monkeypatch):
+    """If Discord accepts the message but attaches nothing, fail loud (#66797)."""
+    import plugins.platforms.discord.adapter as discord_platform
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake-mp4")
+
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "File",
+        lambda fp, filename=None, **kwargs: SimpleNamespace(fp=fp, filename=filename),
+    )
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    # Message id present, but no attachments — the silent-drop failure mode.
+    sent_msg = SimpleNamespace(id=99, attachments=[])
+    channel = SimpleNamespace(send=AsyncMock(return_value=sent_msg), type=0)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(adapter, "_is_forum_parent", lambda _ch: False)
+
+    result = await adapter.send_video("555", str(video))
+
+    assert result.success is False
+    assert "no files" in (result.error or "").lower()
+    channel.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_deliver_media_from_response_routes_mp4_to_send_video(tmp_path, monkeypatch):
+    """Streaming/post-stream dispatch must call send_video for MEDIA:.mp4."""
+    from gateway.platforms.base import BasePlatformAdapter, SendResult
+    from gateway.run import GatewayRunner
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake-mp4")
+    image = tmp_path / "figure.png"
+    image.write_bytes(b"fake-png")
+
+    # Allow delivery from tmp_path in non-strict mode (default).
+    monkeypatch.chdir(tmp_path)
+
+    adapter = SimpleNamespace(
+        name="Discord",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="v")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="d")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="i")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="vid")),
+        send_multiple_images=AsyncMock(),
+    )
+    event = SimpleNamespace(
+        source=SimpleNamespace(
+            platform="discord",
+            chat_id="chat-1",
+            thread_id=None,
+        )
+    )
+    runner = SimpleNamespace(
+        _thread_metadata_for_source=lambda source, anchor=None: {},
+        _reply_anchor_for_event=lambda event: None,
+    )
+    response = (
+        f"Here is the figure:\n\nMEDIA:{image}\n\n"
+        f"And the clip:\n\nMEDIA:{video}\n"
+    )
+
+    await GatewayRunner._deliver_media_from_response(runner, response, event, adapter)
+
+    adapter.send_video.assert_awaited_once()
+    sent_path = adapter.send_video.await_args.kwargs["video_path"]
+    assert Path(sent_path).resolve() == video.resolve()
+    adapter.send_multiple_images.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_video_missing_file_fails_fast_without_touching_channel():
+    """A missing MEDIA path must fail loud before any Discord I/O (#66797).
+
+    The pre-flight ``os.path.isfile`` guard turns a would-be crash inside
+    ``discord.File`` into an actionable ``File not found`` result, and must
+    short-circuit before the channel is ever resolved.
+    """
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("channel must not be resolved for a missing file")
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = SimpleNamespace(get_channel=_boom, fetch_channel=AsyncMock(side_effect=_boom))
+
+    result = await adapter.send_video("555", "/no/such/clip.mp4")
+
+    assert result.success is False
+    assert "not found" in (result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch):
+    """Forum-parent delivery must also route the path-based file through the
+    plural ``files=[...]`` kwarg (#66797), so the create_thread starter message
+    carries the attachment rather than silently dropping it."""
+    import plugins.platforms.discord.adapter as discord_platform
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake-mp4")
+
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "File",
+        lambda fp, filename=None, **kwargs: SimpleNamespace(fp=fp, filename=filename),
+    )
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    created_thread = SimpleNamespace(
+        id=7,
+        message=SimpleNamespace(id=8),
+    )
+    forum_channel = SimpleNamespace(
+        id=7,
+        create_thread=AsyncMock(return_value=created_thread),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(adapter, "_is_forum_parent", lambda _ch: True)
+
+    result = await adapter.send_video("555", str(video))
+
+    assert result.success is True
+    forum_channel.create_thread.assert_awaited_once()
+    thread_kwargs = forum_channel.create_thread.await_args.kwargs
+    assert thread_kwargs.get("file") is None
+    assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -261,3 +261,91 @@ async def test_streaming_delivery_blocks_media_path_outside_allowed_roots(tmp_pa
 
     adapter.send_document.assert_not_awaited()
     adapter.send_voice.assert_not_awaited()
+
+
+class _DiscordMediaFailureAdapter(BasePlatformAdapter):
+    """Minimal adapter to exercise non-streaming MEDIA failure notification."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.DISCORD)
+        self.notices: list[str] = []
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content=None, **kwargs):
+        self.notices.append(content or "")
+        return SendResult(success=True, message_id="notice")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_media_failure_notifies_user(tmp_path, monkeypatch):
+    """Attachmentless send_video results must surface a user-visible notice (#66797)."""
+    adapter = _DiscordMediaFailureAdapter()
+    event = _event()
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "clip.mp4")
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{media_file}")
+    adapter.send_video = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            error="Discord accepted the message but attached no files (clip.mp4)",
+        )
+    )
+    adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc"))
+    adapter.send_voice = AsyncMock(return_value=SendResult(success=True, message_id="voice"))
+    adapter.send_multiple_images = AsyncMock()
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.send_video.assert_awaited_once()
+    assert adapter.notices == ["⚠️ Couldn't deliver the video attachment."]
+
+
+class _DiscordMediaFailureAdapter(BasePlatformAdapter):
+    """Minimal adapter to exercise non-streaming MEDIA failure notification."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.DISCORD)
+        self.notices: list[str] = []
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content=None, **kwargs):
+        self.notices.append(content or "")
+        return SendResult(success=True, message_id="notice")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_media_failure_notifies_user(tmp_path, monkeypatch):
+    """Attachmentless send_video results must surface a user-visible notice (#66797)."""
+    adapter = _DiscordMediaFailureAdapter()
+    event = _event()
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "clip.mp4")
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{media_file}")
+    adapter.send_video = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            error="Discord accepted the message but attached no files (clip.mp4)",
+        )
+    )
+    adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc"))
+    adapter.send_voice = AsyncMock(return_value=SendResult(success=True, message_id="voice"))
+    adapter.send_multiple_images = AsyncMock()
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.send_video.assert_awaited_once()
+    assert adapter.notices == ["⚠️ Couldn't deliver the video attachment."]


### PR DESCRIPTION
## Problem

On Discord's non-streaming path, a `MEDIA:/abs/path/video.mp4` directive is extracted (stripped from the visible text) but the video never arrives: no attachment, no user-visible error, and previously no media-dispatch log line. Image attachments in the same response deliver normally. See #66797.

The shared Discord attachment helper (`_send_file_attachment`, used by `send_video` / `send_document` / `send_image_file`) opened a file handle and passed it via the singular `file=` kwarg. The working image-batch path uses a path-based `discord.File` via `files=[...]`. After an earlier image batch on the same channel, the handle form can race Discord's multipart encoder and produce a successful message with zero attachments — a silent drop.

## Approach

1. **Path-based upload**: `_send_file_attachment` now builds `discord.File(path)` and sends via the plural `files=[...]` kwarg (direct sends and the forum-parent `create_thread` starter message alike), matching the working `send_multiple_images` path.
2. **Fail loud**: if Discord returns a message with no attachments, return `SendResult(success=False, ...)` so the dispatch loop logs a warning instead of treating it as success.
3. **Pre-flight**: `os.path.isfile` guard returns a clear `File not found` result instead of raising deep inside `discord.File`.
4. **Observability**: INFO logs when delivering non-image MEDIA and when sending a video / file attachment, so this class of drop cannot vanish from gateway logs again.

Default Discord text/image behavior is unchanged. Rebased on current `main`. Overlaps in spirit with open #67040 (size preflight on the same helper) but addresses a distinct upload/attachment-result mechanism and does not depend on it.

## Test plan

Regression tests in `tests/gateway/test_discord_send.py`:

- [x] path-based `files=[...]` kwarg used, singular `file=` left unset
- [x] fail-loud when the returned message carries no attachments
- [x] missing file fails fast without resolving the channel
- [x] forum-parent delivery routes through `create_thread` with `files=[...]`
- [x] end-to-end image+video response routes the `.mp4` to `send_video` while images still batch

```
python -m pytest tests/gateway/test_discord_send.py \
  tests/gateway/test_tts_media_routing.py \
  tests/gateway/test_discord_media_metadata.py -q
# 31 passed
ruff check plugins/platforms/discord/adapter.py gateway/platforms/base.py tests/gateway/test_discord_send.py
# All checks passed!
```

Manual verification (unchanged from the report):

- [ ] On a Discord DM with `streaming: false`, emit a response containing both `MEDIA:...png` and `MEDIA:...mp4`; confirm both attachments arrive and gateway logs show the video send line
- [ ] Confirm a missing video path still fails with a clear error (no silent strip)

Fixes #66797
