### PR TITLE
fix: gate Kanban auto-decomposition by board

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 import os
+import re
 import sqlite3
 import time
 from pathlib import Path
@@ -78,6 +78,8 @@ def _resolve_auto_decompose_board_allowlist(
     if not isinstance(kcfg, dict) or "auto_decompose_allowed_boards" not in kcfg:
         return None
     raw = kcfg.get("auto_decompose_allowed_boards")
+    if raw is None:
+        return None
     if not isinstance(raw, list):
         return frozenset()
     allowed: set[str] = set()

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -26,6 +26,86 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+def _run_auto_decompose_tick(
+    kanban_db: Any,
+    decomposer: Any,
+    auto_decompose_per_tick: int,
+    allowed_boards: "Optional[frozenset[str]]" = None,
+) -> int:
+    """Run one board-gated auto-decompose pass with injected collaborators."""
+    try:
+        boards = kanban_db.list_boards(include_archived=False)
+    except Exception:
+        boards = [kanban_db.read_board_metadata(kanban_db.DEFAULT_BOARD)]
+    attempted = 0
+    successes = 0
+    for board in boards:
+        slug = board.get("slug") or kanban_db.DEFAULT_BOARD
+        if not _auto_decompose_board_allowed(slug, allowed_boards):
+            logger.debug(
+                "kanban auto-decompose [%s]: skipped by board allowlist",
+                slug,
+            )
+            continue
+        if attempted >= auto_decompose_per_tick:
+            break
+        prev_env = os.environ.get("HERMES_KANBAN_BOARD")
+        try:
+            os.environ["HERMES_KANBAN_BOARD"] = slug
+            try:
+                triage_ids = decomposer.list_triage_ids()
+            except Exception as exc:
+                logger.debug(
+                    "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
+                    slug,
+                    exc,
+                )
+                triage_ids = []
+            for task_id in triage_ids:
+                if attempted >= auto_decompose_per_tick:
+                    break
+                attempted += 1
+                try:
+                    outcome = decomposer.decompose_task(
+                        task_id,
+                        author="auto-decomposer",
+                    )
+                except Exception:
+                    logger.exception(
+                        "kanban auto-decompose: decompose_task crashed on %s",
+                        task_id,
+                    )
+                    continue
+                if outcome.ok:
+                    successes += 1
+                    if outcome.fanout and outcome.child_ids:
+                        logger.info(
+                            "kanban auto-decompose [%s]: %s → %d children",
+                            slug,
+                            task_id,
+                            len(outcome.child_ids),
+                        )
+                    else:
+                        logger.info(
+                            "kanban auto-decompose [%s]: %s → single task (no fanout)",
+                            slug,
+                            task_id,
+                        )
+                else:
+                    logger.debug(
+                        "kanban auto-decompose [%s]: %s skipped: %s",
+                        slug,
+                        task_id,
+                        outcome.reason,
+                    )
+        finally:
+            if prev_env is None:
+                os.environ.pop("HERMES_KANBAN_BOARD", None)
+            else:
+                os.environ["HERMES_KANBAN_BOARD"] = prev_env
+    return successes
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -804,10 +884,11 @@ class GatewayKanbanWatchersMixin:
         in-flight ``to_thread`` returns on its own after the current
         ``dispatch_once`` call finishes (typically <1ms on an idle board).
         """
-        # Read config once at boot. If the user flips the flag later, they
-        # restart the gateway; same pattern as every other background
-        # watcher here. Honours HERMES_KANBAN_DISPATCH_IN_GATEWAY env var
-        # as an escape hatch (false-y value disables without editing YAML).
+        # Read the dispatcher enablement once at boot. The separate
+        # ``kanban.auto_decompose`` safety toggle is re-read on every tick
+        # below so disabling auto-decomposition does not require a restart.
+        # Honours HERMES_KANBAN_DISPATCH_IN_GATEWAY env var as an escape hatch
+        # (false-y value disables without editing YAML).
         try:
             from hermes_cli.config import load_config as _load_config
         except Exception:
@@ -1180,10 +1261,7 @@ class GatewayKanbanWatchersMixin:
             auto_decompose_per_tick: int,
             allowed_boards: "Optional[frozenset[str]]" = None,
         ) -> int:
-            """Run the auto-decomposer for up to N triage tasks across all
-            boards. Returns the number of triage tasks that were
-            successfully decomposed or specified this tick.
-            """
+            """Run the board-gated auto-decomposer for one dispatcher tick."""
             try:
                 from hermes_cli import kanban_decompose as _decomp
             except Exception as exc:  # pragma: no cover
@@ -1191,76 +1269,12 @@ class GatewayKanbanWatchersMixin:
                     "kanban auto-decompose: import failed (%s); skipping", exc,
                 )
                 return 0
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
-            attempted = 0
-            successes = 0
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
-                if not _auto_decompose_board_allowed(slug, allowed_boards):
-                    logger.debug(
-                        "kanban auto-decompose [%s]: skipped by board allowlist",
-                        slug,
-                    )
-                    continue
-                if attempted >= auto_decompose_per_tick:
-                    break
-                # Pin this board for the duration of the call — same
-                # pattern as the dashboard specify endpoint. The
-                # decomposer module connects with no board kwarg and
-                # relies on the env var.
-                prev_env = os.environ.get("HERMES_KANBAN_BOARD")
-                try:
-                    os.environ["HERMES_KANBAN_BOARD"] = slug
-                    try:
-                        triage_ids = _decomp.list_triage_ids()
-                    except Exception as exc:
-                        logger.debug(
-                            "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
-                            slug, exc,
-                        )
-                        triage_ids = []
-                    for tid in triage_ids:
-                        if attempted >= auto_decompose_per_tick:
-                            break
-                        attempted += 1
-                        try:
-                            outcome = _decomp.decompose_task(
-                                tid, author="auto-decomposer",
-                            )
-                        except Exception:
-                            logger.exception(
-                                "kanban auto-decompose: decompose_task crashed on %s",
-                                tid,
-                            )
-                            continue
-                        if outcome.ok:
-                            successes += 1
-                            if outcome.fanout and outcome.child_ids:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → %d children",
-                                    slug, tid, len(outcome.child_ids),
-                                )
-                            else:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → single task (no fanout)",
-                                    slug, tid,
-                                )
-                        else:
-                            # Common no-op reasons (no aux client configured) shouldn't
-                            # spam logs every tick. Log at debug.
-                            logger.debug(
-                                "kanban auto-decompose [%s]: %s skipped: %s",
-                                slug, tid, outcome.reason,
-                            )
-                finally:
-                    if prev_env is None:
-                        os.environ.pop("HERMES_KANBAN_BOARD", None)
-                    else:
-                        os.environ["HERMES_KANBAN_BOARD"] = prev_env
-            return successes
+            return _run_auto_decompose_tick(
+                _kb,
+                _decomp,
+                auto_decompose_per_tick,
+                allowed_boards,
+            )
 
         logger.info(
             "kanban dispatcher: embedded in gateway (interval=%.1fs)", interval

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import os
 import sqlite3
 import time
@@ -55,6 +56,48 @@ def _resolve_auto_decompose_settings(
     if per_tick < 1:
         per_tick = 1
     return enabled, per_tick
+
+
+def _resolve_auto_decompose_board_allowlist(
+    load_config: Callable[[], Any],
+) -> "Optional[frozenset[str]]":
+    """Resolve the optional board allowlist for auto-decomposition.
+
+    ``None`` preserves the historical default: every board may be considered.
+    An explicitly configured list is an allowlist, not a denylist.  Malformed
+    or unreadable explicit configuration fails closed to an empty allowlist so
+    a config mistake cannot re-enable fan-out on an unintended board.
+    """
+    try:
+        cfg = load_config()
+    except Exception:
+        return frozenset()
+    if not isinstance(cfg, dict):
+        return frozenset()
+    kcfg = cfg.get("kanban", {})
+    if not isinstance(kcfg, dict) or "auto_decompose_allowed_boards" not in kcfg:
+        return None
+    raw = kcfg.get("auto_decompose_allowed_boards")
+    if not isinstance(raw, list):
+        return frozenset()
+    allowed: set[str] = set()
+    for item in raw:
+        if not isinstance(item, str):
+            return frozenset()
+        slug = item.strip().lower()
+        if re.fullmatch(r"[a-z0-9][a-z0-9-]{0,63}", slug):
+            allowed.add(slug)
+        else:
+            return frozenset()
+    return frozenset(allowed)
+
+
+def _auto_decompose_board_allowed(
+    board: str,
+    allowed_boards: "Optional[frozenset[str]]",
+) -> bool:
+    """Return whether a board may enter the auto-decompose path."""
+    return allowed_boards is None or board.strip().lower() in allowed_boards
 
 
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
@@ -1131,7 +1174,10 @@ class GatewayKanbanWatchersMixin:
             """Re-resolve (enabled, per_tick) from current config each tick."""
             return _resolve_auto_decompose_settings(_load_config)
 
-        def _auto_decompose_tick(auto_decompose_per_tick: int) -> int:
+        def _auto_decompose_tick(
+            auto_decompose_per_tick: int,
+            allowed_boards: "Optional[frozenset[str]]" = None,
+        ) -> int:
             """Run the auto-decomposer for up to N triage tasks across all
             boards. Returns the number of triage tasks that were
             successfully decomposed or specified this tick.
@@ -1151,6 +1197,12 @@ class GatewayKanbanWatchersMixin:
             successes = 0
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                if not _auto_decompose_board_allowed(slug, allowed_boards):
+                    logger.debug(
+                        "kanban auto-decompose [%s]: skipped by board allowlist",
+                        slug,
+                    )
+                    continue
                 if attempted >= auto_decompose_per_tick:
                     break
                 # Pin this board for the duration of the call — same
@@ -1230,8 +1282,15 @@ class GatewayKanbanWatchersMixin:
                 # flipping kanban.auto_decompose=false to STOP runaway fan-out
                 # takes effect on the next tick, not on gateway restart (#49638).
                 _ad_enabled, _ad_per_tick = _read_auto_decompose_settings()
+                _ad_allowed_boards = _resolve_auto_decompose_board_allowlist(
+                    _load_config
+                )
                 if _ad_enabled:
-                    await asyncio.to_thread(_auto_decompose_tick, _ad_per_tick)
+                    await asyncio.to_thread(
+                        _auto_decompose_tick,
+                        _ad_per_tick,
+                        _ad_allowed_boards,
+                    )
                 results = await asyncio.to_thread(_tick_once)
                 any_spawned = False
                 for slug, res in (results or []):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2843,6 +2843,11 @@ DEFAULT_CONFIG = {
         # decomposition is manual via `hermes kanban decompose <id>` or
         # the dashboard's Decompose button.
         "auto_decompose": True,
+        # Optional board allowlist for auto-decompose. ``None`` preserves the
+        # historical all-board behavior; an explicit list is fail-closed for
+        # boards not named in the list. This is resolved live by the gateway
+        # dispatcher so a board can be contained without a global code fork.
+        "auto_decompose_allowed_boards": None,
         # Max triage tasks to decompose per dispatcher tick. Prevents a
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.

--- a/tests/gateway/test_kanban_auto_decompose_live.py
+++ b/tests/gateway/test_kanban_auto_decompose_live.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 
 import pytest
 
-from gateway.kanban_watchers import _resolve_auto_decompose_settings
+from gateway.kanban_watchers import (
+    _auto_decompose_board_allowed,
+    _resolve_auto_decompose_board_allowlist,
+    _resolve_auto_decompose_settings,
+)
 
 
 def test_enabled_by_default_when_key_absent():
@@ -81,3 +85,42 @@ def test_live_toggle_takes_effect_between_calls():
     # User edits config.yaml mid-run.
     state["kanban"]["auto_decompose"] = False
     assert _resolve_auto_decompose_settings(lambda: state)[0] is False
+
+
+def test_board_allowlist_is_unrestricted_when_key_absent():
+    assert _resolve_auto_decompose_board_allowlist(lambda: {"kanban": {}}) is None
+    assert _auto_decompose_board_allowed("household-control-plane-pilot", None)
+
+
+def test_board_allowlist_is_explicit_and_normalized():
+    state = {
+        "kanban": {
+            "auto_decompose_allowed_boards": [
+                " default ",
+                "HOUSEHOLD-CONTROL-PLANE-PILOT",
+            ]
+        }
+    }
+    allowed = _resolve_auto_decompose_board_allowlist(lambda: state)
+    assert allowed == frozenset({"default", "household-control-plane-pilot"})
+    assert _auto_decompose_board_allowed("default", allowed)
+    assert _auto_decompose_board_allowed(" DEFAULT ", allowed)
+    assert not _auto_decompose_board_allowed("other-board", allowed)
+
+
+def test_malformed_or_unreadable_board_allowlist_fails_closed():
+    assert _resolve_auto_decompose_board_allowlist(
+        lambda: {"kanban": {"auto_decompose_allowed_boards": "default"}}
+    ) == frozenset()
+    assert _resolve_auto_decompose_board_allowlist(
+        lambda: {"kanban": {"auto_decompose_allowed_boards": ["default", 42]}}
+    ) == frozenset()
+    assert _resolve_auto_decompose_board_allowlist(
+        lambda: {"kanban": {"auto_decompose_allowed_boards": ["default", "bad/slug"]}}
+    ) == frozenset()
+    assert _resolve_auto_decompose_board_allowlist(lambda: None) == frozenset()
+
+    def _boom():
+        raise RuntimeError("config read failed")
+
+    assert _resolve_auto_decompose_board_allowlist(_boom) == frozenset()

--- a/tests/gateway/test_kanban_auto_decompose_live.py
+++ b/tests/gateway/test_kanban_auto_decompose_live.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 
+from hermes_cli.config import DEFAULT_CONFIG
 from gateway.kanban_watchers import (
     _auto_decompose_board_allowed,
     _resolve_auto_decompose_board_allowlist,
@@ -89,6 +90,11 @@ def test_live_toggle_takes_effect_between_calls():
 
 def test_board_allowlist_is_unrestricted_when_key_absent():
     assert _resolve_auto_decompose_board_allowlist(lambda: {"kanban": {}}) is None
+    assert _auto_decompose_board_allowed("household-control-plane-pilot", None)
+
+
+def test_default_config_keeps_auto_decompose_unrestricted():
+    assert _resolve_auto_decompose_board_allowlist(lambda: DEFAULT_CONFIG) is None
     assert _auto_decompose_board_allowed("household-control-plane-pilot", None)
 
 

--- a/tests/gateway/test_kanban_auto_decompose_live.py
+++ b/tests/gateway/test_kanban_auto_decompose_live.py
@@ -9,11 +9,15 @@ called every tick, reading the current config.
 
 from __future__ import annotations
 
+import os
+from types import SimpleNamespace
+
 import pytest
 
 from hermes_cli.config import DEFAULT_CONFIG
 from gateway.kanban_watchers import (
     _auto_decompose_board_allowed,
+    _run_auto_decompose_tick,
     _resolve_auto_decompose_board_allowlist,
     _resolve_auto_decompose_settings,
 )
@@ -130,3 +134,48 @@ def test_malformed_or_unreadable_board_allowlist_fails_closed():
         raise RuntimeError("config read failed")
 
     assert _resolve_auto_decompose_board_allowlist(_boom) == frozenset()
+
+
+def test_dispatcher_tick_skips_disallowed_boards_before_decomposer(monkeypatch):
+    triage_calls = []
+    decompose_calls = []
+
+    class FakeKanbanDb:
+        DEFAULT_BOARD = "default"
+
+        @staticmethod
+        def list_boards(include_archived=False):
+            assert include_archived is False
+            return [
+                {"slug": "default"},
+                {"slug": "household-control-plane-pilot"},
+            ]
+
+        @staticmethod
+        def read_board_metadata(slug):
+            return {"slug": slug}
+
+    class FakeDecomposer:
+        @staticmethod
+        def list_triage_ids():
+            board = os.environ["HERMES_KANBAN_BOARD"]
+            triage_calls.append(board)
+            return [f"{board}-task"]
+
+        @staticmethod
+        def decompose_task(task_id, *, author):
+            decompose_calls.append((os.environ["HERMES_KANBAN_BOARD"], task_id, author))
+            return SimpleNamespace(ok=True, fanout=False, child_ids=[], reason="")
+
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    result = _run_auto_decompose_tick(
+        FakeKanbanDb,
+        FakeDecomposer,
+        auto_decompose_per_tick=3,
+        allowed_boards=frozenset({"default"}),
+    )
+
+    assert result == 1
+    assert triage_calls == ["default"]
+    assert decompose_calls == [("default", "default-task", "auto-decomposer")]
+    assert "HERMES_KANBAN_BOARD" not in os.environ


### PR DESCRIPTION
## Summary

- preserve legacy default-board auto-decompose behavior;
- enforce the configured board allowlist in the actual auto-decompose tick path;
- extract the tick runner for deterministic integration coverage;
- verify that `household-control-plane-pilot` is skipped while `default` remains executable.

## Verification

- targeted Kanban suite — 33 passed
- `git diff --check origin/main..HEAD` — PASS
- branch was created from the local `origin/main` tracking `NousResearch/hermes-agent`; no upstream sync or history rewrite was performed.

No production rollout or gateway restart was performed.