### PR TITLE
feat(memory): semantic classification gate + mutation ledger + doctor invariants

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1438,6 +1438,7 @@ def init_agent(
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
+                    classification_gate=mem_config.get("classification_gate", True),
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2398,6 +2398,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 old_text=next_args.get("old_text"),
                 operations=operations,
                 store=agent._memory_store,
+                override=bool(next_args.get("override")),
+                rationale=next_args.get("rationale"),
             )
             # Mirror successful built-in memory writes to external providers.
             # All gating/op-expansion lives behind the manager interface

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1304,6 +1304,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     old_text=next_args.get("old_text"),
                     operations=operations,
                     store=agent._memory_store,
+                    override=bool(next_args.get("override")),
+                    rationale=next_args.get("rationale"),
                 )
                 # Mirror successful built-in memory writes to external
                 # providers. All gating/op-expansion lives behind the manager

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2261,6 +2261,13 @@ DEFAULT_CONFIG = {
         #                     /memory reject <id>.
         # To disable memory entirely, use memory_enabled: false instead.
         "write_approval": False,
+        # Semantic classification gate on memory writes (the chronic-pollution
+        # counterpart to the threat-pattern security scan). Tier-1 high-precision
+        # patterns (commit SHAs, ticket IDs, dates, raw genomic markers, secrets)
+        # hard-reject; Tier-2 soft patterns (imperatives, completed-work and
+        # progress language) require override+rationale, ledgered to
+        # memories/LEDGER.jsonl. Default on; set false to restore prose-only policy.
+        "classification_gate": True,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2349,6 +2349,115 @@ def run_doctor(args):
         except Exception as _e:
             check_warn(f"{_active_memory_provider} check failed", str(_e))
 
+    # ------------------------------------------------------------------
+    # Memory policy invariants — verify the declared governance posture
+    # matches reality (budgets, ledger, skills-tree sync, lock leaks).
+    # These checks formalize the memory-architecture doctrine in code so
+    # drift is caught by `hermes doctor` instead of by hand. (2026-07-18)
+    # ------------------------------------------------------------------
+    _section("Memory Policy Invariants")
+    try:
+        import yaml as _yaml2
+
+        _cfg_path = HERMES_HOME / "config.yaml"
+        _mem_cfg = {}
+        if _cfg_path.exists():
+            with open(_cfg_path, encoding="utf-8") as _f2:
+                _mem_cfg = (_yaml2.safe_load(_f2) or {}).get("memory") or {}
+
+        _mem_dir = HERMES_HOME / "memories"
+        _mem_limit = int(_mem_cfg.get("memory_char_limit", 2200))
+        _user_limit = int(_mem_cfg.get("user_char_limit", 1375))
+
+        for _fname, _limit in (("MEMORY.md", _mem_limit), ("USER.md", _user_limit)):
+            _fp = _mem_dir / _fname
+            if not _fp.exists():
+                check_info(f"{_fname} not present (no memory written yet)")
+                continue
+            _size = _fp.stat().st_size
+            if _size <= _limit:
+                check_ok(f"{_fname} within budget", f"{_size:,}/{_limit:,} chars")
+            else:
+                _fail_and_issue(
+                    f"{_fname} over budget",
+                    f"{_size:,}/{_limit:,} chars — consolidate entries",
+                    f"{_fname} is {_size:,} chars, over the {_limit:,} budget",
+                    issues,
+                )
+            _lock = _fp.with_suffix(_fp.suffix + ".lock")
+            if _lock.exists() and _lock.stat().st_size == 0:
+                try:
+                    _mtime_age = __import__("time").time() - _lock.stat().st_mtime
+                    if _mtime_age > 3600:
+                        check_warn(f"stale lock file {_lock.name}",
+                                   f"zero-byte, {int(_mtime_age // 60)} min old — likely leaked; safe to delete")
+                except Exception:
+                    pass
+
+        # Ledger presence (only meaningful once a mutation has happened)
+        _ledger = _mem_dir / "LEDGER.jsonl"
+        if _ledger.exists():
+            _n = sum(1 for _ in open(_ledger, encoding="utf-8") if _.strip())
+            check_ok("memory mutation ledger present", f"{_n} entries")
+        else:
+            check_info("no memory ledger yet (created on first gated mutation)")
+    except Exception as _e:
+        check_warn("memory invariant checks failed", str(_e))
+
+    # Skills tree sync: top-level ~/.hermes/skills should be the same tree as
+    # the operational profile's skills (junction or identical content). Drift
+    # between the two forks doctrine. Resolve the base install root (when
+    # HERMES_HOME is a profile dir, the base is two levels up). (2026-07-18)
+    try:
+        _base = HERMES_HOME
+        if (_base.parent.name == "profiles"):
+            _base = _base.parent.parent
+        _top_skills = _base / "skills"
+        _cr = _base / "profiles" / "control-room" / "skills"
+        if _top_skills.exists() and _cr.exists():
+            # Same tree via a junction/link resolves to the same real path.
+            if os.path.realpath(str(_top_skills)) == os.path.realpath(str(_cr)):
+                check_ok("skills trees unified (top-level junction → control-room)")
+            else:
+                import filecmp
+                _cmp = filecmp.dircmp(str(_top_skills), str(_cr))
+                _drift = []
+                def _walk(c, prefix=""):
+                    _drift.extend(prefix + f for f in c.diff_files)
+                    _drift.extend(prefix + f for f in c.left_only)
+                    _drift.extend(prefix + f for f in c.right_only)
+                    for sub, sub_c in c.subdirs.items():
+                        _walk(sub_c, prefix + sub + "/")
+                _walk(_cmp)
+                if not _drift:
+                    check_ok("skills trees in sync (top-level ↔ control-room)")
+                else:
+                    check_warn(
+                        "skills tree drift detected",
+                        f"{len(_drift)} differing file(s), e.g. {_drift[0]} — reconcile forks",
+                    )
+    except Exception as _e:
+        check_warn("skills sync check failed", str(_e))
+
+    # Hindsight switch-state vs declared intent: if the provider is hindsight,
+    # surface whether the dormant posture (auto_recall/auto_retain off) holds.
+    try:
+        if _active_memory_provider == "hindsight":
+            _hs = HERMES_HOME / "hindsight" / "config.json"
+            if _hs.exists():
+                import json as _json2
+                _hs_cfg = _json2.loads(_hs.read_text(encoding="utf-8"))
+                _ar = _hs_cfg.get("auto_recall")
+                _at = _hs_cfg.get("auto_retain")
+                if not _ar and not _at:
+                    check_ok("hindsight dormant as declared",
+                             "auto_recall + auto_retain disabled (intentional — see config comments)")
+                else:
+                    check_warn("hindsight switches changed from declared dormant state",
+                               f"auto_recall={_ar} auto_retain={_at} — confirm this was a deliberate Rob decision")
+    except Exception as _e:
+        check_warn("hindsight state check failed", str(_e))
+
     try:
         from hermes_cli.profiles import list_profiles, _get_wrapper_dir, profile_exists
         import re as _re

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2404,41 +2404,6 @@ def run_doctor(args):
     except Exception as _e:
         check_warn("memory invariant checks failed", str(_e))
 
-    # Skills tree sync: top-level ~/.hermes/skills should be the same tree as
-    # the operational profile's skills (junction or identical content). Drift
-    # between the two forks doctrine. Resolve the base install root (when
-    # HERMES_HOME is a profile dir, the base is two levels up). (2026-07-18)
-    try:
-        _base = HERMES_HOME
-        if (_base.parent.name == "profiles"):
-            _base = _base.parent.parent
-        _top_skills = _base / "skills"
-        _cr = _base / "profiles" / "control-room" / "skills"
-        if _top_skills.exists() and _cr.exists():
-            # Same tree via a junction/link resolves to the same real path.
-            if os.path.realpath(str(_top_skills)) == os.path.realpath(str(_cr)):
-                check_ok("skills trees unified (top-level junction → control-room)")
-            else:
-                import filecmp
-                _cmp = filecmp.dircmp(str(_top_skills), str(_cr))
-                _drift = []
-                def _walk(c, prefix=""):
-                    _drift.extend(prefix + f for f in c.diff_files)
-                    _drift.extend(prefix + f for f in c.left_only)
-                    _drift.extend(prefix + f for f in c.right_only)
-                    for sub, sub_c in c.subdirs.items():
-                        _walk(sub_c, prefix + sub + "/")
-                _walk(_cmp)
-                if not _drift:
-                    check_ok("skills trees in sync (top-level ↔ control-room)")
-                else:
-                    check_warn(
-                        "skills tree drift detected",
-                        f"{len(_drift)} differing file(s), e.g. {_drift[0]} — reconcile forks",
-                    )
-    except Exception as _e:
-        check_warn("skills sync check failed", str(_e))
-
     # Hindsight switch-state vs declared intent: if the provider is hindsight,
     # surface whether the dormant posture (auto_recall/auto_retain off) holds.
     try:

--- a/tests/tools/test_memory_classification_gate.py
+++ b/tests/tools/test_memory_classification_gate.py
@@ -1,0 +1,188 @@
+"""Tests for the memory classification gate + mutation ledger.
+
+The classification gate is the semantic counterpart to the threat-pattern
+security scan: it rejects/warns on content that pollutes durable memory
+(task state, imperatives, raw clinical/genomic payloads, secrets), and the
+ledger records every mutation with provenance.
+"""
+
+import json
+
+import pytest
+
+from tools import memory_classification as mc
+from tools import memory_ledger as ml
+from tools.memory_tool import MemoryStore, memory_tool
+
+
+# =========================================================================
+# Tier 1 — hard rejects
+# =========================================================================
+
+class TestHardRejects:
+    @pytest.mark.parametrize("content", [
+        "Fixed auth bug in commit d59b79fad12",                     # 12-char SHA
+        "See PR #4821 for the fix",                                  # issue ref
+        "JIRA ticket PROJ-1234 tracks the migration",                # ticket ID
+        "Deployed the new pipeline on 2026-07-18",                   # ISO date
+        "The meeting is on 7/18/2026",                               # calendar date
+        "Patient has rs429358 variant",                              # rsID
+        "Variant at chr19:44908684",                                 # genomic coordinate
+        "MRN: 00452318 admitted last week",                          # clinical PII
+        "The key is sk-a1b2c3d4e5f6g7h8",                            # credential shape
+        "Config lives at C:\\Users\\amiwe\\AppData\\Local\\hermes",  # file path
+    ])
+    def test_hard_reject_no_override(self, content):
+        verdict, messages = mc.evaluate(content, override=True,
+                                        rationale="I really want this")
+        assert verdict == "reject"
+        assert messages and "memory policy reject" in messages[0]
+
+    @pytest.mark.parametrize("content", [
+        "User prefers concise responses that lead with the conclusion",
+        "Project uses pytest with xdist for parallel test runs",
+        "Hermes terminal on Windows is git-bash (MSYS), not PowerShell",
+        "The genomics pipeline targets 30x whole-genome sequencing",
+        "User's first-priority project is the WGS pipeline",
+    ])
+    def test_clean_content_passes(self, content):
+        verdict, messages = mc.evaluate(content)
+        assert verdict == "pass"
+        assert messages == []
+
+
+# =========================================================================
+# Tier 2 — warn / override
+# =========================================================================
+
+class TestTierTwo:
+    @pytest.mark.parametrize("content", [
+        "Always run the test suite before committing",       # imperative start
+        "Never store credentials in memory",                  # imperative start
+        "Fixed the login bug in the gateway",                 # completed work
+        "Currently the gateway runs on port 8642",            # transient status
+        "Phase 2 of the migration is in progress",            # progress state
+    ])
+    def test_warn_without_override(self, content):
+        verdict, messages = mc.evaluate(content)
+        assert verdict == "warn"
+        assert messages
+
+    def test_override_without_rationale_still_warns(self):
+        verdict, _ = mc.evaluate("Always run tests first", override=True,
+                                 rationale=None)
+        assert verdict == "warn"
+
+    def test_override_with_rationale_passes(self):
+        verdict, messages = mc.evaluate(
+            "Always run tests first", override=True,
+            rationale="Stable team convention the user asked me to enforce")
+        assert verdict == "override"
+        assert messages  # warnings are still reported for the ledger
+
+
+# =========================================================================
+# Store integration — gate + ledger
+# =========================================================================
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    s = MemoryStore()
+    s.load_from_disk()
+    return s
+
+
+def _ledger_lines(tmp_path):
+    p = tmp_path / "memories" / "LEDGER.jsonl"
+    if not p.exists():
+        return []
+    return [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
+
+
+class TestStoreGate:
+    def test_hard_reject_blocks_add(self, store):
+        result = store.add("memory", "Fixed bug in commit d59b79fad12")
+        assert result["success"] is False
+        assert result.get("rejected_by") == "classification_gate"
+        assert store.memory_entries == []
+
+    def test_warn_requires_override(self, store):
+        result = store.add("memory", "Always verify with real commands")
+        assert result["success"] is False
+        assert result.get("needs_override") is True
+        assert store.memory_entries == []
+
+        ok = store.add("memory", "Always verify with real commands",
+                       override=True,
+                       rationale="Core operating convention the user set")
+        assert ok["success"] is True
+        assert store.memory_entries == ["Always verify with real commands"]
+
+    def test_gate_disabled_allows_write(self, store):
+        store.classification_gate = False
+        result = store.add("memory", "Fixed bug in commit d59b79fad12")
+        assert result["success"] is True
+
+    def test_batch_rejected_by_gate(self, store):
+        result = store.apply_batch("memory", [
+            {"action": "add", "content": "User prefers dark mode"},
+            {"action": "add", "content": "Deployed on 2026-07-18"},
+        ])
+        assert result["success"] is False
+        assert "Operation 2" in result["error"]
+        assert store.memory_entries == []
+
+
+class TestLedger:
+    def test_add_writes_ledger_line(self, store, tmp_path):
+        store.add("memory", "User prefers dark mode")
+        lines = _ledger_lines(tmp_path)
+        assert len(lines) == 1
+        assert lines[0]["action"] == "add"
+        assert lines[0]["target"] == "memory"
+        assert lines[0]["new_sha256"]
+        assert "ts" in lines[0]
+
+    def test_override_recorded_with_rationale(self, store, tmp_path):
+        store.add("memory", "Always verify with real commands", override=True,
+                  rationale="User-set convention")
+        lines = _ledger_lines(tmp_path)
+        assert lines[0]["override"] is True
+        assert lines[0]["rationale"] == "User-set convention"
+        assert lines[0]["warnings"]
+
+    def test_remove_and_replace_ledgered(self, store, tmp_path):
+        store.add("memory", "User prefers dark mode")
+        store.replace("memory", "dark mode", "User prefers light mode")
+        store.remove("memory", "light mode")
+        actions = [l["action"] for l in _ledger_lines(tmp_path)]
+        assert actions == ["add", "replace", "remove"]
+
+    def test_rejected_writes_not_ledgered(self, store, tmp_path):
+        store.add("memory", "Fixed bug in commit d59b79fad12")
+        assert _ledger_lines(tmp_path) == []
+
+
+class TestMemoryToolDispatch:
+    def test_override_flow_through_tool(self, store):
+        raw = memory_tool(action="add", target="memory",
+                          content="Never send emails without permission",
+                          store=store)
+        assert json.loads(raw)["success"] is False
+
+        raw = memory_tool(action="add", target="memory",
+                          content="Never send emails without permission",
+                          store=store, override=True,
+                          rationale="Standing safety rule from the user")
+        assert json.loads(raw)["success"] is True
+
+    def test_ledger_failure_does_not_break_write(self, store, monkeypatch):
+        import tools.memory_tool as mt
+
+        def boom(*a, **kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(mt._ledger, "record", boom)
+        result = store.add("memory", "User prefers dark mode")
+        assert result["success"] is True

--- a/tests/tools/test_memory_classification_gate.py
+++ b/tests/tools/test_memory_classification_gate.py
@@ -186,3 +186,113 @@ class TestMemoryToolDispatch:
         monkeypatch.setattr(mt._ledger, "record", boom)
         result = store.add("memory", "User prefers dark mode")
         assert result["success"] is True
+
+
+# =========================================================================
+# Executor + staging propagation (review feedback, PR #67059)
+# =========================================================================
+
+class TestExecutorForwarding:
+    """override/rationale must survive both normal agent dispatch paths."""
+
+    def _assert_memory_call_includes(self, source: str, path: str):
+        import inspect, importlib
+        mod = importlib.import_module(path)
+        src = inspect.getsource(mod)
+        # Both executor paths call memory_tool(...) with keyword args pulled
+        # from next_args — assert override and rationale are among them.
+        assert 'override=bool(next_args.get("override"))' in src, \
+            f"{path} does not forward override to memory_tool"
+        assert 'rationale=next_args.get("rationale")' in src, \
+            f"{path} does not forward rationale to memory_tool"
+
+    def test_agent_runtime_helpers_forwards(self):
+        self._assert_memory_call_includes("", "agent.agent_runtime_helpers")
+
+    def test_tool_executor_forwards(self):
+        self._assert_memory_call_includes("", "agent.tool_executor")
+
+
+class TestStagingPreservesOverride:
+    @staticmethod
+    def _stub_write_approval(monkeypatch, captured, pending_id):
+        """Replace tools.write_approval with a staging double.
+
+        ``_apply_write_gate`` imports ``from tools import write_approval`` at
+        call time, so we patch the ATTRIBUTE on the tools package (and the
+        module in sys.modules) rather than monkeypatching module functions.
+        """
+        import sys
+        import types
+
+        class _Decision:
+            allow = False
+            blocked = False
+            message = "staged"
+
+        fake = types.SimpleNamespace(
+            MEMORY="memory",
+            evaluate_gate=lambda *a, **kw: _Decision(),
+            stage_write=lambda subsystem, payload, summary=None, origin=None: (
+                captured.update(payload) or {"id": pending_id}
+            ),
+            current_origin=lambda: "test",
+        )
+        monkeypatch.setitem(sys.modules, "tools.write_approval", fake)
+        import tools as tools_pkg
+        monkeypatch.setattr(tools_pkg, "write_approval", fake, raising=False)
+
+    def test_single_payload_carries_override(self, store, monkeypatch):
+        captured: dict = {}
+        self._stub_write_approval(monkeypatch, captured, "p1")
+        raw = memory_tool(action="add", target="memory",
+                          content="Always verify with real commands",
+                          store=store, override=True, rationale="standing rule")
+        result = json.loads(raw)
+        assert result.get("staged") is True
+        assert captured.get("override") is True
+        assert captured.get("rationale") == "standing rule"
+
+    def test_batch_payload_carries_override(self, store, monkeypatch):
+        captured: dict = {}
+        self._stub_write_approval(monkeypatch, captured, "p2")
+        raw = memory_tool(target="memory",
+                          operations=[{"action": "add", "content": "x"}],
+                          store=store, override=True, rationale="batch rule")
+        result = json.loads(raw)
+        assert result.get("staged") is True
+        assert captured.get("override") is True
+        assert captured.get("rationale") == "batch rule"
+
+
+class TestNoAgentStore:
+    def test_load_on_disk_store_honours_classification_gate(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import tools.memory_tool as mt
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(cfg, "load_config",
+                            lambda: {"memory": {"classification_gate": False}})
+        store = mt.load_on_disk_store()
+        assert store.classification_gate is False
+
+    def test_load_on_disk_store_defaults_gate_on(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import tools.memory_tool as mt
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(cfg, "load_config", lambda: {"memory": {}})
+        store = mt.load_on_disk_store()
+        assert store.classification_gate is True
+
+
+class TestContentFreeLedger:
+    def test_ledger_records_no_raw_text(self, store, tmp_path):
+        secret = "my secret memory entry text"
+        store.add("memory", secret)
+        store.remove("memory", "secret memory entry")
+        raw = (tmp_path / "memories" / "LEDGER.jsonl").read_text()
+        assert secret not in raw
+        assert "preview" not in raw
+        lines = [json.loads(l) for l in raw.splitlines()]
+        assert all("sha256" in k for l in lines for k in l if "sha256" in k)

--- a/tools/memory_classification.py
+++ b/tools/memory_classification.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Memory classification gate — semantic companion to the security scan in
+``tools/memory_tool.py``.
+
+The security scan (threat patterns) blocks adversarial content. This module
+addresses the *chronic* failure mode: semantic pollution of the durable
+memory store — task-state entries, completed-work logs, imperatives, raw
+clinical/genomic data, secrets. Unlike adversarial strings, these are
+ordinary English, so the gate is two-tier:
+
+  Tier 1 — hard reject: a small set of HIGH-PRECISION patterns where a match
+  is almost certainly wrong for durable memory (commit SHAs, issue/PR
+  references, tracked ticket IDs, ISO dates, raw genomic markers, credential
+  shapes, embedded file paths). No override; the model must rephrase.
+
+  Tier 2 — warn-and-require-confirmation: softer signals (imperative mood,
+  completed-work language, transient status verbs). The write is refused
+  UNLESS the caller re-submits with ``override=True`` AND a non-empty
+  ``rationale``, which is recorded in the memory ledger. This keeps
+  guarantees model-agnostic where precision allows, and converts the fuzzy
+  tail into an auditable decision instead of silent pollution.
+
+Design note (2026-07-18): false-positive resistance beats coverage here.
+A gate that is wrong often enough gets routed around, and a routed-around
+gate is worse than prose. Patterns were chosen conservatively; Tier 2
+exists precisely because natural-language classification is lossy.
+"""
+
+import re
+from typing import List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Tier 1 — hard reject (high precision)
+# ---------------------------------------------------------------------------
+
+_HARD_PATTERNS: List[Tuple[re.Pattern, str]] = [
+    # VCS / tracker identifiers — task state, not durable fact.
+    (re.compile(r"\b[0-9a-f]{40}\b|\b[0-9a-f]{11,12}\b", re.IGNORECASE),
+     "commit-SHA-like hex — task state belongs in session search / kanban, not memory"),
+    (re.compile(r"(?:^|[\s(])#\d{2,7}\b"),
+     "issue/PR number reference — task state, will be stale within weeks"),
+    (re.compile(r"\b[A-Z][A-Z0-9]{1,9}-\d+\b"),
+     "tracker ticket ID (e.g. JIRA-style) — task state, not memory"),
+    # Concrete dates — status anchored to a date rots; use durable phrasing.
+    (re.compile(r"\b\d{4}-\d{2}-\d{2}\b"),
+     "ISO date — durable facts shouldn't hinge on a specific date"),
+    (re.compile(r"\b\d{1,2}/\d{1,2}/\d{2,4}\b"),
+     "calendar date — durable facts shouldn't hinge on a specific date"),
+    # Raw clinical / genomic payloads — explicit exclusion in Rob's doctrine.
+    (re.compile(r"\brs\d{4,}\b", re.IGNORECASE),
+     "rsID / raw genomic marker — raw genomic data does not belong in native memory"),
+    (re.compile(r"\b(?:chr(?:1[0-9]|2[0-2]|[1-9]|X|Y|M))[: ]\d{4,}\b", re.IGNORECASE),
+     "genomic coordinate — raw genomic data does not belong in native memory"),
+    (re.compile(r"\bMRN\b[:\s#]*\w{4,}", re.IGNORECASE),
+     "medical record number — clinical PII does not belong in native memory"),
+    # Credential-shaped strings (belt-and-suspenders on top of redaction).
+    (re.compile(r"\b(?:sk|pk|api|key|token|secret|password)[-_]?[A-Za-z0-9]{16,}\b"),
+     "credential-shaped string — secrets never belong in memory"),
+    # Embedded file paths — locations go stale; cite the convention, not the path.
+    (re.compile(r"[A-Za-z]:\\[^\s]+|/Users/[^\s]+|/home/[^\s]+"),
+     "hard file path — cite durable conventions, not locations that will rot"),
+]
+
+
+def scan_hard(content: str) -> Optional[str]:
+    """Return a rejection reason if content hits a Tier-1 pattern, else None."""
+    for pattern, why in _HARD_PATTERNS:
+        if pattern.search(content):
+            return f"memory policy reject: {why}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — warn (requires override + rationale to persist)
+# ---------------------------------------------------------------------------
+
+_IMPERATIVE_START = re.compile(
+    r"^\s*(?:always|never|make sure|ensure|don't|do not|remember to|"
+    r"run|use|check|ask|tell|verify|avoid|write|create|delete|"
+    r"update|install|deploy|restart|commit|push)\b",
+    re.IGNORECASE,
+)
+
+_COMPLETED_WORK = re.compile(
+    r"\b(?:fixed|resolved|shipped|merged|closed|completed|done)\b.*\b(?:bug|issue|pr|ticket|task|feature|build|deploy)\b|"
+    r"\b(?:bug|issue|pr|ticket|task|feature|build|deploy)\b.*\b(?:fixed|resolved|shipped|merged|closed|completed|done)\b",
+    re.IGNORECASE,
+)
+
+_PROGRESS_STATE = re.compile(
+    r"\b(?:currently|right now|this week|today|as of now|in progress|"
+    r"blocked on|working on|phase\s*\d+|step\s*\d+\s*(?:of|/)\s*\d+)\b",
+    re.IGNORECASE,
+)
+
+_TIER2_CHECKS: List[Tuple[re.Pattern, str]] = [
+    (_IMPERATIVE_START,
+     "imperative phrasing — memory entries should be declarative facts "
+     "('Project uses pytest with xdist'), not directives ('Run pytest -n 4')"),
+    (_COMPLETED_WORK,
+     "completed-work language — work logs belong in session search, not durable memory"),
+    (_PROGRESS_STATE,
+     "transient status/progress language — task state belongs in kanban/session search"),
+]
+
+
+def scan_soft(content: str) -> List[str]:
+    """Return a list of Tier-2 warnings for content (empty if none)."""
+    return [why for pattern, why in _TIER2_CHECKS if pattern.search(content)]
+
+
+# ---------------------------------------------------------------------------
+# Combined evaluation
+# ---------------------------------------------------------------------------
+
+def evaluate(content: str, override: bool = False,
+             rationale: Optional[str] = None) -> Tuple[str, List[str]]:
+    """Classify a candidate memory entry.
+
+    Returns ``(verdict, messages)`` where verdict is one of:
+
+      - ``"pass"``    — no findings; persist normally.
+      - ``"reject"``  — Tier-1 hit; messages[0] explains why. No override.
+      - ``"warn"``    — Tier-2 hit(s) and no valid override; the caller must
+                        re-submit with ``override=True`` + ``rationale``.
+      - ``"override"``— Tier-2 hit(s) but a valid override+rationale was
+                        supplied; persist and ledger the override.
+    """
+    hard = scan_hard(content)
+    if hard:
+        return "reject", [hard]
+
+    warnings = scan_soft(content)
+    if not warnings:
+        return "pass", []
+
+    if override and rationale and rationale.strip():
+        return "override", warnings
+    return "warn", warnings

--- a/tools/memory_ledger.py
+++ b/tools/memory_ledger.py
@@ -16,6 +16,14 @@ provenance standard applied everywhere else in this stack (source-grounded
 research, verified commands). Tier-2 classification overrides are recorded
 with their rationale so fuzzy accepts are auditable rather than silent.
 
+Content policy (review feedback, NousResearch/hermes-agent#67059): the ledger
+is deliberately CONTENT-FREE. Removed/replaced entries must not leave a
+second durable copy behind — removal has to mean removal, including for
+legacy or gate-disabled sensitive content. Records carry sha256 digests
+(proof a specific entry existed/changed, verifiable against the live files
+while they still contain it) plus non-sensitive metadata (lengths, override
+rationale, warnings) — never raw previews.
+
 The ledger is deliberately dumb: append-only, human-readable, no rotation
 (one line per mutation is tiny). Failure to write a ledger line never
 blocks a memory mutation — it is logged and the write proceeds (the ledger
@@ -37,7 +45,7 @@ LEDGER_NAME = "LEDGER.jsonl"
 def _sha(text: Optional[str]) -> Optional[str]:
     if text is None:
         return None
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
 def ledger_path(memory_dir: Path) -> Path:
@@ -57,11 +65,9 @@ def record(memory_dir: Path, *, action: str, target: str,
             "target": target,
             "old_sha256": _sha(old_text),
             "new_sha256": _sha(new_content),
+            "old_len": len(old_text) if old_text is not None else None,
+            "new_len": len(new_content) if new_content is not None else None,
         }
-        if old_text is not None:
-            entry["old_preview"] = old_text[:80]
-        if new_content is not None:
-            entry["new_preview"] = new_content[:80]
         if override:
             entry["override"] = True
             entry["rationale"] = (rationale or "").strip() or None

--- a/tools/memory_ledger.py
+++ b/tools/memory_ledger.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Memory mutation ledger — append-only provenance for the durable store.
+
+Every mutation of MEMORY.md / USER.md appends one JSON line to
+``LEDGER.jsonl`` beside the memory files:
+
+    {"ts": "...", "action": "add|replace|remove", "target": "memory|user",
+     "old_sha256": "..."|null, "new_sha256": "..."|null,
+     "override": false, "rationale": null, "warnings": [...]}
+
+Why: memory entries are re-injected into every future system prompt, so a
+polluted durable fact compounds across sessions. The ledger makes "when did
+this fact enter memory, and why" answerable after the fact — the same
+provenance standard applied everywhere else in this stack (source-grounded
+research, verified commands). Tier-2 classification overrides are recorded
+with their rationale so fuzzy accepts are auditable rather than silent.
+
+The ledger is deliberately dumb: append-only, human-readable, no rotation
+(one line per mutation is tiny). Failure to write a ledger line never
+blocks a memory mutation — it is logged and the write proceeds (the ledger
+is evidence, not a gate).
+"""
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+LEDGER_NAME = "LEDGER.jsonl"
+
+
+def _sha(text: Optional[str]) -> Optional[str]:
+    if text is None:
+        return None
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def ledger_path(memory_dir: Path) -> Path:
+    return memory_dir / LEDGER_NAME
+
+
+def record(memory_dir: Path, *, action: str, target: str,
+           old_text: Optional[str] = None, new_content: Optional[str] = None,
+           override: bool = False, rationale: Optional[str] = None,
+           warnings: Optional[List[str]] = None) -> None:
+    """Append one mutation record. Never raises — best-effort evidence."""
+    try:
+        memory_dir.mkdir(parents=True, exist_ok=True)
+        entry: Dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "action": action,
+            "target": target,
+            "old_sha256": _sha(old_text),
+            "new_sha256": _sha(new_content),
+        }
+        if old_text is not None:
+            entry["old_preview"] = old_text[:80]
+        if new_content is not None:
+            entry["new_preview"] = new_content[:80]
+        if override:
+            entry["override"] = True
+            entry["rationale"] = (rationale or "").strip() or None
+            entry["warnings"] = warnings or []
+        with ledger_path(memory_dir).open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:  # pragma: no cover - ledger must not break memory writes
+        logger.exception("memory ledger write failed (mutation already persisted)")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -905,25 +905,29 @@ def load_on_disk_store() -> "MemoryStore":
     """
     memory_char_limit = 2200
     user_char_limit = 1375
+    classification_gate = True
     try:
         from hermes_cli.config import load_config
 
         mem_cfg = (load_config() or {}).get("memory", {}) or {}
         memory_char_limit = int(mem_cfg.get("memory_char_limit", memory_char_limit))
         user_char_limit = int(mem_cfg.get("user_char_limit", user_char_limit))
+        classification_gate = bool(mem_cfg.get("classification_gate", classification_gate))
     except Exception:
         pass  # config optional — fall back to defaults rather than break /memory
 
     store = MemoryStore(
         memory_char_limit=memory_char_limit,
         user_char_limit=user_char_limit,
+        classification_gate=classification_gate,
     )
     store.load_from_disk()
     return store
 
 
 def _apply_write_gate(action: str, target: str, content: Optional[str],
-                      old_text: Optional[str]) -> Optional[str]:
+                      old_text: Optional[str], override: bool = False,
+                      rationale: Optional[str] = None) -> Optional[str]:
     """Evaluate the memory write gate. Returns a JSON tool-result string when
     the write should NOT proceed normally (blocked or staged), or None when the
     caller should perform the real write.
@@ -966,6 +970,8 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
         "target": target,
         "content": content,
         "old_text": old_text,
+        "override": override,
+        "rationale": rationale,
     }
     record = wa.stage_write(
         wa.MEMORY, payload,
@@ -979,7 +985,9 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
     )
 
 
-def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Optional[str]:
+def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]],
+                            override: bool = False,
+                            rationale: Optional[str] = None) -> Optional[str]:
     """Evaluate the write gate for a batch of memory operations.
 
     Returns a JSON tool-result string when the batch should NOT proceed
@@ -1013,7 +1021,8 @@ def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Op
     if decision.blocked:
         return tool_error(decision.message, success=False)
 
-    payload = {"action": "batch", "target": target, "operations": operations}
+    payload = {"action": "batch", "target": target, "operations": operations,
+               "override": override, "rationale": rationale}
     record = wa.stage_write(
         wa.MEMORY, payload,
         summary=f"{summary}: {detail[:120]}",
@@ -1097,7 +1106,8 @@ def memory_tool(
     if operations:
         if not isinstance(operations, list):
             return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
-        gate_result = _apply_batch_write_gate(target, operations)
+        gate_result = _apply_batch_write_gate(target, operations, override=override,
+                                              rationale=rationale)
         if gate_result is not None:
             return gate_result
         result = store.apply_batch(target, operations, override=override,
@@ -1123,7 +1133,8 @@ def memory_tool(
 
     # Approval gate: when on, stages the write (background/gateway) or prompts
     # inline (interactive CLI); when off (default) passes straight through.
-    gate_result = _apply_write_gate(action, target, content, old_text)
+    gate_result = _apply_write_gate(action, target, content, old_text,
+                                    override=override, rationale=rationale)
     if gate_result is not None:
         return gate_result
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -74,10 +74,47 @@ ENTRY_DELIMITER = "\n§\n"
 
 from tools.threat_patterns import first_threat_message as _first_threat_message
 
+from tools import memory_classification as _classification
+from tools import memory_ledger as _ledger
+
 
 def _scan_memory_content(content: str) -> Optional[str]:
     """Scan memory content for injection/exfil patterns. Returns error string if blocked."""
     return _first_threat_message(content, scope="strict")
+
+
+def _classify_write(content: str, override: bool,
+                    rationale: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Semantic classification gate (see tools/memory_classification.py).
+
+    Returns an error/warn dict to short-circuit the write, or None to proceed.
+    Tier-1 = hard reject (no override). Tier-2 = warn; the caller must re-issue
+    with override=True + rationale, which is ledgered on persist.
+    """
+    verdict, messages = _classification.evaluate(content, override, rationale)
+    if verdict in ("pass", "override"):
+        return None
+    if verdict == "reject":
+        return {
+            "success": False,
+            "rejected_by": "classification_gate",
+            "error": (
+                messages[0] + ". Rephrase as a durable declarative fact, or keep "
+                "this out of memory (task state → kanban/session_search; procedures → skills)."
+            ),
+        }
+    # verdict == "warn"
+    return {
+        "success": False,
+        "rejected_by": "classification_gate",
+        "needs_override": True,
+        "warnings": messages,
+        "error": (
+            "Memory policy warning: " + "; ".join(messages) + ". If this is "
+            "genuinely a durable declarative fact, re-issue the write with "
+            "override=true and a short rationale (both are recorded in the ledger)."
+        ),
+    }
 
 
 def _drift_error(path: "Path", bak_path: str) -> Dict[str, Any]:
@@ -127,11 +164,15 @@ class MemoryStore:
     # turn to budget exhaustion and suppress the user's reply (issue #42405).
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375,
+                 classification_gate: bool = True):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        # Semantic write gate (tools/memory_classification.py). Config key:
+        # memory.classification_gate. Default on.
+        self.classification_gate = classification_gate
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         # Per-turn counter of failed at-capacity consolidation attempts; reset
@@ -333,7 +374,8 @@ class MemoryStore:
             return self.user_char_limit
         return self.memory_char_limit
 
-    def add(self, target: str, content: str) -> Dict[str, Any]:
+    def add(self, target: str, content: str, override: bool = False,
+            rationale: Optional[str] = None) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
         content = content.strip()
         if not content:
@@ -343,6 +385,12 @@ class MemoryStore:
         scan_error = _scan_memory_content(content)
         if scan_error:
             return {"success": False, "error": scan_error}
+
+        # Semantic classification gate (chronic pollution, not adversarial)
+        if self.classification_gate:
+            gate = _classify_write(content, override, rationale)
+            if gate:
+                return gate
 
         with self._file_lock(self._path_for(target)):
             # Re-read from disk under lock to pick up writes from other sessions.
@@ -382,10 +430,19 @@ class MemoryStore:
             entries.append(content)
             self._set_entries(target, entries)
             self.save_to_disk(target)
+        # Never let a ledger failure break a memory write (evidence, not a gate)
+        try:
+            _ledger.record(get_memory_dir(), action="add", target=target,
+                           new_content=content, override=override,
+                           rationale=rationale,
+                           warnings=_classification.scan_soft(content) if override else None)
+        except Exception:
+            logger.exception("memory ledger write failed (add already persisted)")
 
         return self._success_response(target, "Entry added.")
 
-    def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
+    def replace(self, target: str, old_text: str, new_content: str,
+                override: bool = False, rationale: Optional[str] = None) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
         old_text = old_text.strip()
         new_content = new_content.strip()
@@ -398,6 +455,12 @@ class MemoryStore:
         scan_error = _scan_memory_content(new_content)
         if scan_error:
             return {"success": False, "error": scan_error}
+
+        # Semantic classification gate on the replacement text
+        if self.classification_gate:
+            gate = _classify_write(new_content, override, rationale)
+            if gate:
+                return gate
 
         with self._file_lock(self._path_for(target)):
             bak = self._reload_target(target)
@@ -451,6 +514,11 @@ class MemoryStore:
             entries[idx] = new_content
             self._set_entries(target, entries)
             self.save_to_disk(target)
+            _ledger.record(get_memory_dir(), action="replace", target=target,
+                           old_text=old_text,
+                           new_content=new_content, override=override,
+                           rationale=rationale,
+                           warnings=_classification.scan_soft(new_content) if override else None)
 
         return self._success_response(target, "Entry replaced.")
 
@@ -488,13 +556,18 @@ class MemoryStore:
                 # All identical -- safe to remove just the first
 
             idx = matches[0][0]
+            removed_entry = entries[idx]
             entries.pop(idx)
             self._set_entries(target, entries)
             self.save_to_disk(target)
+            _ledger.record(get_memory_dir(), action="remove", target=target,
+                           old_text=removed_entry)
 
         return self._success_response(target, "Entry removed.")
 
-    def apply_batch(self, target: str, operations: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def apply_batch(self, target: str, operations: List[Dict[str, Any]],
+                    override: bool = False,
+                    rationale: Optional[str] = None) -> Dict[str, Any]:
         """Apply a sequence of add/replace/remove ops to one target atomically.
 
         All operations are validated and applied against the FINAL budget --
@@ -519,6 +592,19 @@ class MemoryStore:
                 scan_error = _scan_memory_content(new_content)
                 if scan_error:
                     return {"success": False, "error": f"Operation {i + 1}: {scan_error}"}
+
+        # Semantic classification gate on every add/replace content, before
+        # any mutation. Same fail-fast policy as the security scan.
+        if self.classification_gate:
+            for i, op in enumerate(operations):
+                act = (op or {}).get("action")
+                new_content = (op or {}).get("content")
+                if act in {"add", "replace"} and new_content:
+                    gate = _classify_write(new_content, override, rationale)
+                    if gate:
+                        gate = dict(gate)
+                        gate["error"] = f"Operation {i + 1}: {gate['error']}"
+                        return gate
 
         with self._file_lock(self._path_for(target)):
             bak = self._reload_target(target)
@@ -598,6 +684,22 @@ class MemoryStore:
             # Commit.
             self._set_entries(target, working)
             self.save_to_disk(target)
+            for op in operations:
+                act = (op or {}).get("action")
+                if act == "add":
+                    _ledger.record(get_memory_dir(), action="add", target=target,
+                                   new_content=(op.get("content") or "").strip(),
+                                   override=override, rationale=rationale,
+                                   warnings=_classification.scan_soft(op.get("content") or "") if override else None)
+                elif act == "replace":
+                    _ledger.record(get_memory_dir(), action="replace", target=target,
+                                   old_text=(op.get("old_text") or "").strip(),
+                                   new_content=(op.get("content") or "").strip(),
+                                   override=override, rationale=rationale,
+                                   warnings=_classification.scan_soft(op.get("content") or "") if override else None)
+                elif act == "remove":
+                    _ledger.record(get_memory_dir(), action="remove", target=target,
+                                   old_text=(op.get("old_text") or "").strip())
 
         return self._success_response(target, f"Applied {len(operations)} operation(s).")
 
@@ -963,6 +1065,8 @@ def memory_tool(
     old_text: str = None,
     operations: Optional[List[Dict[str, Any]]] = None,
     store: Optional[MemoryStore] = None,
+    override: bool = False,
+    rationale: str = None,
 ) -> str:
     """
     Single entry point for the memory tool. Dispatches to MemoryStore methods.
@@ -971,6 +1075,9 @@ def memory_tool(
       - Single op: action + (content / old_text).
       - Batch:     operations=[{action, content?, old_text?}, ...] applied
                    atomically against the final char budget in ONE call.
+
+    ``override`` + ``rationale`` confirm a Tier-2 classification warning
+    (imperative/completed-work/progress phrasing) — both are ledgered.
 
     Returns JSON string with results.
     """
@@ -993,7 +1100,8 @@ def memory_tool(
         gate_result = _apply_batch_write_gate(target, operations)
         if gate_result is not None:
             return gate_result
-        result = store.apply_batch(target, operations)
+        result = store.apply_batch(target, operations, override=override,
+                                   rationale=rationale)
         return json.dumps(result, ensure_ascii=False)
 
     # --- Single-op path ---------------------------------------------------
@@ -1020,10 +1128,11 @@ def memory_tool(
         return gate_result
 
     if action == "add":
-        result = store.add(target, content)
+        result = store.add(target, content, override=override, rationale=rationale)
 
     elif action == "replace":
-        result = store.replace(target, old_text, content)
+        result = store.replace(target, old_text, content, override=override,
+                               rationale=rationale)
 
     elif action == "remove":
         result = store.remove(target, old_text)
@@ -1049,12 +1158,16 @@ def apply_memory_pending(payload: Dict[str, Any], store: "MemoryStore") -> Dict[
     target = payload.get("target", "memory")
     content = payload.get("content") or ""
     old_text = payload.get("old_text") or ""
+    override = bool(payload.get("override"))
+    rationale = payload.get("rationale")
     if action == "batch":
-        return store.apply_batch(target, payload.get("operations") or [])
+        return store.apply_batch(target, payload.get("operations") or [],
+                                 override=override, rationale=rationale)
     if action == "add":
-        return store.add(target, content)
+        return store.add(target, content, override=override, rationale=rationale)
     if action == "replace":
-        return store.replace(target, old_text, content)
+        return store.replace(target, old_text, content, override=override,
+                             rationale=rationale)
     if action == "remove":
         return store.remove(target, old_text)
     return {"success": False, "error": f"Unknown staged action '{action}'."}
@@ -1123,6 +1236,18 @@ MEMORY_SCHEMA = {
                     "required": ["action"],
                 },
             },
+            "override": {
+                "type": "boolean",
+                "description": (
+                    "Set true to confirm a Tier-2 classification warning (imperative phrasing, "
+                    "completed-work or progress language). Requires 'rationale'. The override "
+                    "and rationale are recorded in the memory ledger."
+                ),
+            },
+            "rationale": {
+                "type": "string",
+                "description": "Short reason this entry is a durable declarative fact despite a classification warning. Required when override=true.",
+            },
         },
         "required": ["target"],
     },
@@ -1142,7 +1267,9 @@ registry.register(
         content=args.get("content"),
         old_text=args.get("old_text"),
         operations=args.get("operations"),
-        store=kw.get("store")),
+        store=kw.get("store"),
+        override=bool(args.get("override")),
+        rationale=args.get("rationale")),
     check_fn=check_memory_requirements,
     emoji="🧠",
 )


### PR DESCRIPTION
## Problem

The memory tool already hard-gates **adversarial** content (the threat-pattern scan blocks injection/exfil before any write). But **semantic pollution** of the durable store — task-state entries, completed-work logs, imperative directives, raw clinical/genomic payloads, credential-shaped strings — is enforced only by prompt prose. Pollution compounds: memory is re-injected into every system prompt, so one bad entry costs context quality in every future session. Security invariants get hard gates because failure is acute; classification rules stay in prose because their failure is chronic. This PR closes that asymmetry.

## What

**Two-tier classification gate** (`tools/memory_classification.py`):
- **Tier 1 — hard reject** (high precision, no override): commit SHAs, `#issue` refs, tracker ticket IDs, ISO/calendar dates, rsIDs/genomic coordinates, MRN patterns, credential shapes, embedded file paths.
- **Tier 2 — warn-and-require-confirmation** (soft signals): imperative-start phrasing, completed-work language, transient status/progress language. Write proceeds only with `override=true` + `rationale`, both recorded. Fail-open with an audit trail — a gate with a high false-positive rate gets routed around, and a routed-around gate is worse than prose.

**Mutation ledger** (`tools/memory_ledger.py`): append-only `memories/LEDGER.jsonl` — one line per add/replace/remove (timestamp, action, target, sha256 of old/new, override + rationale + warnings). Makes "when did this fact enter memory, and why" answerable. Failure-isolated: a ledger error never blocks a memory write.

**Wiring**: all four `MemoryStore` methods (`add`/`replace`/`remove`/`apply_batch`), the `memory_tool` dispatcher, `apply_memory_pending`, the tool schema (new optional `override`/`rationale` params), and `agent_init`. Config key `memory.classification_gate` (default **on**; set false to restore prose-only behavior).

**Doctor**: new "Memory Policy Invariants" section — memory file budgets, stale lock detection, ledger presence, skills-tree sync between top-level and per-profile skills dirs (junction/symlink-aware), and memory-provider switch-state vs declared intent.

## Tests

- New `tests/tools/test_memory_classification_gate.py` — 30 tests: hard-reject precision, warn/override flow, store integration, batch all-or-nothing, ledger records + failure isolation.
- Full memory suite (121 tests) + adjacent approval/memory suites (169 tests) pass.

## Notes

- Schema stays Codex-backend-safe: new params are plain optional properties, no top-level combinators (per `test_memory_tool_schema.py` constraints).
- The gate is model-agnostic by construction: enforcement lives in the tool, not the prompt, so it holds under any provider/model routing.