### PR TITLE
fix(memory): normalize terminal delimiter

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -782,6 +782,20 @@ class TestExternalDriftGuard:
         result = store.replace("memory", "Entry two", "Entry two replaced.")
         assert result["success"] is True
 
+    def test_replace_normalizes_one_terminal_delimiter(self, store):
+        """A legacy trailing separator carries no content and is safe to normalize."""
+        store.add("memory", "Entry one.")
+        store.add("memory", "Entry two.")
+        path = store._path_for("memory")
+        canonical = path.read_text(encoding="utf-8")
+        path.write_text(canonical + "\n§\n", encoding="utf-8")
+
+        result = store.replace("memory", "Entry two", "Entry two replaced.")
+
+        assert result["success"] is True
+        assert "drift_backup" not in result
+        assert path.read_text(encoding="utf-8") == "Entry one.\n§\nEntry two replaced."
+
     def test_error_message_points_at_remediation(self, store):
         """The error string must reference the backup AND remediation steps."""
         store.add("memory", "Initial.")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -741,7 +741,17 @@ class MemoryStore:
         char_limit = self._char_limit(target)
         max_entry_len = max((len(e) for e in parsed), default=0)
 
-        drift_detected = (raw.strip() != roundtrip) or (max_entry_len > char_limit)
+        # Older/manual writers sometimes leave exactly one terminal delimiter.
+        # It represents no entry content and is safe to normalize away on the
+        # next atomic tool write. Treating that one byte pattern as external
+        # drift blocks otherwise-safe compaction and creates needless backups.
+        # Do not broaden this exception: arbitrary trailing text/whitespace
+        # still needs the fail-closed drift guard below.
+        terminal_delimiter_only = raw == roundtrip + ENTRY_DELIMITER
+        drift_detected = (
+            (raw.strip() != roundtrip and not terminal_delimiter_only)
+            or max_entry_len > char_limit
+        )
         if not drift_detected:
             return None
 


### PR DESCRIPTION
## Summary
- Accept exactly one terminal `§` delimiter as a content-free legacy representation and normalize it during the next memory-tool write.
- Preserve the fail-closed drift guard for all other mismatches and over-limit entries.

## Validation

- `python -m pytest tests/tools/test_memory_tool.py -q -o 'addopts='` — 86 passed

Closes #67032