### PR TITLE
fix(cron): repair non-numeric interval minutes instead of disabling (#67028)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -683,6 +683,32 @@ def _recoverable_oneshot_run_at(
     return None
 
 
+def _coerce_interval_minutes(value: Any) -> Optional[float]:
+    """Return ``schedule["minutes"]`` as a number, or ``None`` when unusable.
+
+    ``minutes`` arrives straight from ``jobs.json``, which is routinely
+    hand-edited — the id / schedule / next_run_at / last_run_at repair passes in
+    ``_get_due_jobs_locked`` exist for exactly that. A quoted number
+    (``"minutes": "60"``) is the common shape and is unambiguous, so coerce it
+    rather than discarding the schedule: every consumer otherwise raises
+    ``TypeError`` on the arithmetic (``timedelta(minutes=str)`` /
+    ``str * 60``), which silently disables the job forever.
+
+    ``bool`` is rejected explicitly — it is an ``int`` subclass, and
+    ``"minutes": true`` is corruption, not a one-minute interval.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
 def _compute_grace_seconds(schedule: dict) -> int:
     """Compute how late a job can be and still catch up instead of fast-forwarding.
 
@@ -696,9 +722,12 @@ def _compute_grace_seconds(schedule: dict) -> int:
     kind = schedule.get("kind")
 
     if kind == "interval":
-        period_seconds = schedule.get("minutes", 1) * 60
+        _minutes = _coerce_interval_minutes(schedule.get("minutes", 1))
+        if _minutes is None:
+            return MIN_GRACE
+        period_seconds = _minutes * 60
         grace = period_seconds // 2
-        return max(MIN_GRACE, min(grace, MAX_GRACE))
+        return int(max(MIN_GRACE, min(grace, MAX_GRACE)))
 
     if kind == "cron" and HAS_CRONITER:
         expr = schedule.get("expr")
@@ -735,7 +764,11 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         return _recoverable_oneshot_run_at(schedule, now, last_run_at=last_run_at)
 
     elif kind == "interval":
-        minutes = schedule.get("minutes")
+        # Coerce before any arithmetic: a hand-edited jobs.json can carry
+        # ``"minutes": "60"``. Previously that raised TypeError here — and the
+        # ``except`` below could not help, because its fallback re-evaluates the
+        # same ``timedelta(minutes=minutes)`` that just failed.
+        minutes = _coerce_interval_minutes(schedule.get("minutes"))
         if minutes is None:
             return None
         if last_run_at:
@@ -1916,6 +1949,27 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 datetime.fromisoformat(lr)
             except Exception:
                 rj.pop("last_run_at", None)
+                needs_save = True
+
+    # Same treatment for a non-numeric interval "minutes" (a hand-edited
+    # jobs.json commonly quotes it: ``"minutes": "60"``). Every consumer does
+    # arithmetic on it — ``timedelta(minutes=...)`` in compute_next_run,
+    # ``* 60`` in _compute_grace_seconds — so a string raises TypeError. In the
+    # due scan the per-job guard swallows that and the job is skipped EVERY
+    # tick: silently disabled forever, exactly the failure mode the id /
+    # schedule repairs above exist to prevent. Coerce a numeric string back to
+    # a number and persist, so the job self-heals instead of vanishing.
+    for _list in (jobs, raw_jobs):
+        for j in _list:
+            sched = j.get("schedule")
+            if not isinstance(sched, dict) or sched.get("kind") != "interval":
+                continue
+            raw_minutes = sched.get("minutes")
+            if raw_minutes is None or isinstance(raw_minutes, (int, float)) and not isinstance(raw_minutes, bool):
+                continue
+            coerced = _coerce_interval_minutes(raw_minutes)
+            if coerced is not None:
+                sched["minutes"] = int(coerced) if float(coerced).is_integer() else coerced
                 needs_save = True
 
     # Resolve the one-shot running-claim stale-recovery TTL once per scan

--- a/tests/cron/test_interval_minutes_coercion.py
+++ b/tests/cron/test_interval_minutes_coercion.py
@@ -1,0 +1,96 @@
+"""Regression tests for a non-numeric interval ``minutes``.
+
+``schedule["minutes"]`` comes straight from ``jobs.json``, which is routinely
+hand-edited — the id / schedule / next_run_at / last_run_at repair passes in
+``_get_due_jobs_locked`` exist for exactly that. A quoted number
+(``"minutes": "60"``) made every consumer raise ``TypeError`` on the arithmetic:
+
+* ``compute_next_run`` — ``timedelta(minutes="60")``; its ``except`` fallback
+  could not help because it re-evaluates the same failing expression.
+* ``_compute_grace_seconds`` — ``"60" * 60`` then ``// 2``.
+
+In the due scan the per-job structural guard swallowed that, so the job was
+skipped on EVERY tick — silently disabled forever, the failure mode the sibling
+repair passes exist to prevent. ``advance_next_run`` / ``mark_job_run`` have no
+such guard and raised outright.
+"""
+from datetime import datetime, timedelta, timezone
+
+from cron.jobs import (
+    _coerce_interval_minutes,
+    _compute_grace_seconds,
+    compute_next_run,
+)
+
+
+def _past(minutes: int = 5) -> str:
+    return (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
+
+
+class TestCoerceIntervalMinutes:
+    def test_numbers_pass_through(self):
+        assert _coerce_interval_minutes(60) == 60.0
+        assert _coerce_interval_minutes(1.5) == 1.5
+
+    def test_quoted_number_is_coerced(self):
+        assert _coerce_interval_minutes("60") == 60.0
+        assert _coerce_interval_minutes(" 60 ") == 60.0
+
+    def test_bool_is_rejected(self):
+        # bool is an int subclass; "minutes": true is corruption, not 1 minute.
+        assert _coerce_interval_minutes(True) is None
+
+    def test_garbage_is_rejected(self):
+        for bad in ("", "later", {}, [], None, object()):
+            assert _coerce_interval_minutes(bad) is None
+
+
+class TestComputeNextRunWithStringMinutes:
+    def test_quoted_minutes_still_schedules(self):
+        got = compute_next_run({"kind": "interval", "minutes": "60"}, _past())
+        assert got is not None
+        assert datetime.fromisoformat(got) > datetime.now(timezone.utc)
+
+    def test_quoted_minutes_without_last_run(self):
+        assert compute_next_run({"kind": "interval", "minutes": "30"}) is not None
+
+    def test_garbage_minutes_returns_none_instead_of_raising(self):
+        for bad in ("", "soon", {}, True):
+            assert compute_next_run({"kind": "interval", "minutes": bad}, _past()) is None
+
+
+class TestGraceSecondsWithStringMinutes:
+    def test_quoted_minutes_grace_matches_numeric(self):
+        assert (
+            _compute_grace_seconds({"kind": "interval", "minutes": "60"})
+            == _compute_grace_seconds({"kind": "interval", "minutes": 60})
+        )
+
+    def test_garbage_minutes_falls_back_to_min_grace(self):
+        assert _compute_grace_seconds({"kind": "interval", "minutes": {}}) == 120
+
+
+class TestDueScanSelfHeals:
+    def test_job_with_quoted_minutes_becomes_due_and_is_repaired(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+
+        import cron.jobs as jobs_mod
+
+        importlib.reload(jobs_mod)
+        jobs_mod.save_jobs([{
+            "id": "j1", "name": "nightly", "enabled": True,
+            "schedule": {"kind": "interval", "minutes": "60"},
+            "next_run_at": _past(), "prompt": "hi",
+        }])
+
+        due = jobs_mod.get_due_jobs()
+        assert [d["id"] for d in due] == ["j1"], "job was silently skipped"
+
+        # Repaired and persisted, so it never degrades again.
+        healed = jobs_mod.load_jobs()[0]["schedule"]["minutes"]
+        assert healed == 60 and isinstance(healed, int)
+
+        # The paths that previously raised now succeed.
+        assert jobs_mod.advance_next_run("j1") is True
+        jobs_mod.mark_job_run("j1", True)


### PR DESCRIPTION
Closes #67028

When a cron interval has a non-numeric value, coerce it to a default instead of disabling the entire job.

+153/-3 across cron/jobs.py and tests.