### PR TITLE
fix(acp): preserve full terminal command titles

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -95,8 +95,6 @@ def build_tool_title(tool_name: str, args: Dict[str, Any]) -> str:
     """Build a human-readable title for a tool call."""
     if tool_name == "terminal":
         cmd = args.get("command", "")
-        if len(cmd) > 80:
-            cmd = cmd[:77] + "..."
         return f"terminal: {cmd}"
     if tool_name == "read_file":
         return f"read: {args.get('path', '?')}"

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -94,11 +94,10 @@ class TestBuildToolTitle:
         title = build_tool_title("terminal", {"command": "ls -la /tmp"})
         assert "ls -la /tmp" in title
 
-    def test_terminal_title_truncates_long_command(self):
+    def test_terminal_title_preserves_long_command(self):
         long_cmd = "x" * 200
         title = build_tool_title("terminal", {"command": long_cmd})
-        assert len(title) < 120
-        assert "..." in title
+        assert title == f"terminal: {long_cmd}"
 
     def test_read_file_title(self):
         title = build_tool_title("read_file", {"path": "/etc/hosts"})


### PR DESCRIPTION
## Summary

- stop truncating terminal tool-call titles at 80 characters
- leave presentation and ellipsizing decisions to ACP clients
- update the regression test to require the complete command

Fixes #63949

## Test plan

- `scripts/run_tests.sh tests/acp/test_tools.py -q` (76 passed)
- `uv run --frozen ruff check acp_adapter/tools.py tests/acp/test_tools.py`
- `git diff --check`
- `gitleaks protect --staged --redact`