### PR TITLE
fix: bedrock_converse falls through to OpenAI client in handle_max_iterations()

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2049,6 +2049,26 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 summary_response = agent._anthropic_messages_create(_ant_kw)
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_summary_result.content or "").strip()
+            elif agent.api_mode == "bedrock_converse":
+                # Bedrock has no OpenAI-style client (agent.client is None) —
+                # route the summary call through the same boto3 dispatch path
+                # the main loop uses instead of falling through to the
+                # OpenAI-client branch below, which raises a connection
+                # error with no api_key/base_url configured. See #90-iter
+                # "couldn't summarize" report.
+                _btsum = agent._get_transport()
+                _bregion = getattr(agent, "_bedrock_region", None) or "us-east-1"
+                _bguardrail = getattr(agent, "_bedrock_guardrail_config", None)
+                _bedrock_kwargs = _btsum.build_kwargs(
+                    model=agent.model, messages=api_messages, tools=None,
+                    max_tokens=agent.max_tokens or 4096, region=_bregion,
+                    guardrail_config=_bguardrail,
+                )
+                summary_response = _dispatch_nonstreaming_api_request(
+                    agent, _bedrock_kwargs, make_client=lambda reason: None,
+                )
+                _summary_result = _btsum.normalize_response(summary_response)
+                final_response = (_summary_result.content or "").strip()
             else:
                 summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)
                 _summary_result = agent._get_transport().normalize_response(summary_response)
@@ -2078,6 +2098,22 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                                 preserve_dots=agent._anthropic_preserve_dots())
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)
+                final_response = (_retry_result.content or "").strip()
+            elif agent.api_mode == "bedrock_converse":
+                # Same fix as the primary attempt above — no OpenAI client
+                # exists for Bedrock agents, route through the transport.
+                _btretry = agent._get_transport()
+                _bregion2 = getattr(agent, "_bedrock_region", None) or "us-east-1"
+                _bguardrail2 = getattr(agent, "_bedrock_guardrail_config", None)
+                _bedrock_kwargs2 = _btretry.build_kwargs(
+                    model=agent.model, messages=api_messages, tools=None,
+                    max_tokens=agent.max_tokens or 4096, region=_bregion2,
+                    guardrail_config=_bguardrail2,
+                )
+                retry_response = _dispatch_nonstreaming_api_request(
+                    agent, _bedrock_kwargs2, make_client=lambda reason: None,
+                )
+                _retry_result = _btretry.normalize_response(retry_response)
                 final_response = (_retry_result.content or "").strip()
             else:
                 summary_kwargs = {

--- a/tests/agent/test_bedrock_iteration_limit_summary.py
+++ b/tests/agent/test_bedrock_iteration_limit_summary.py
@@ -1,0 +1,111 @@
+"""Regression test: Bedrock agents must not fall through to the OpenAI
+client branch in handle_max_iterations() (Eddie bot report — "Reached the
+maximum iteration of 90 but couldn't summarize. Error: connection error.").
+
+Bedrock agents have agent.client is None / no api_key/base_url configured
+(they talk to AWS directly via boto3), so the generic fallback branch that
+calls agent._ensure_primary_openai_client().chat.completions.create(...)
+always raised a connection error for api_mode == "bedrock_converse". The
+fix adds an explicit bedrock_converse branch that routes through the same
+transport + boto3 dispatch path the main loop uses.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.chat_completion_helpers import handle_max_iterations
+
+
+class _FakeTransport:
+    def __init__(self, response_content="final summary text"):
+        self.build_kwargs_calls = []
+        self._response_content = response_content
+
+    def build_kwargs(self, **kwargs):
+        self.build_kwargs_calls.append(kwargs)
+        return {"model": kwargs["model"], "messages": kwargs["messages"], "__fake__": True}
+
+    def normalize_response(self, response, **_kwargs):
+        return SimpleNamespace(content=self._response_content)
+
+
+def _make_bedrock_agent(transport, dispatch_response):
+    agent = MagicMock()
+    agent.api_mode = "bedrock_converse"
+    agent.max_iterations = 90
+    agent.model = "us.anthropic.claude-sonnet-5"
+    agent.base_url = ""
+    agent.provider = "bedrock"
+    agent.max_tokens = 4096
+    agent.reasoning_config = None
+    agent.request_overrides = {}
+    agent.prefill_messages = []
+    agent.ephemeral_system_prompt = None
+    agent._cached_system_prompt = ""
+    agent._bedrock_region = "us-east-1"
+    agent._bedrock_guardrail_config = None
+    agent.openrouter_min_coding_score = None
+    agent._base_url_lower = ""
+    agent._should_sanitize_tool_calls.return_value = False
+    agent._copy_reasoning_content_for_api.side_effect = lambda msg, api_msg: None
+    agent._sanitize_api_messages.side_effect = lambda msgs: msgs
+    agent._drop_thinking_only_and_merge_users.side_effect = lambda msgs: msgs
+    agent._supports_reasoning_extra_body.return_value = False
+    agent._get_transport.return_value = transport
+    # If the buggy fallback branch is ever hit again, this raises instead
+    # of silently succeeding, so the test fails loudly.
+    agent._ensure_primary_openai_client.side_effect = AssertionError(
+        "must not build an OpenAI client for bedrock_converse agents"
+    )
+    return agent
+
+
+def test_bedrock_agent_does_not_use_openai_client_on_iteration_limit(monkeypatch):
+    transport = _FakeTransport(response_content="Did X, Y, Z before hitting the cap.")
+
+    dispatch_mock = MagicMock(return_value="RAW_BEDROCK_RESPONSE")
+    monkeypatch.setattr(
+        "agent.chat_completion_helpers._dispatch_nonstreaming_api_request",
+        dispatch_mock,
+    )
+
+    agent = _make_bedrock_agent(transport, dispatch_mock.return_value)
+    messages = [{"role": "user", "content": "do the task"}]
+
+    result = handle_max_iterations(agent, messages, api_call_count=90)
+
+    assert result == "Did X, Y, Z before hitting the cap."
+    assert "connection error" not in result.lower()
+    agent._ensure_primary_openai_client.assert_not_called()
+    dispatch_mock.assert_called_once()
+    # transport.build_kwargs was called with the bedrock region/guardrail
+    assert transport.build_kwargs_calls[0]["region"] == "us-east-1"
+
+
+def test_bedrock_agent_retry_path_also_avoids_openai_client(monkeypatch):
+    # First call returns empty content to force the retry branch.
+    transport = _FakeTransport(response_content="")
+    call_count = {"n": 0}
+
+    def fake_normalize(response, **_kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return SimpleNamespace(content="")
+        return SimpleNamespace(content="Retry summary succeeded.")
+
+    transport.normalize_response = fake_normalize
+
+    dispatch_mock = MagicMock(return_value="RAW_BEDROCK_RESPONSE")
+    monkeypatch.setattr(
+        "agent.chat_completion_helpers._dispatch_nonstreaming_api_request",
+        dispatch_mock,
+    )
+
+    agent = _make_bedrock_agent(transport, dispatch_mock.return_value)
+    messages = [{"role": "user", "content": "do the task"}]
+
+    result = handle_max_iterations(agent, messages, api_call_count=90)
+
+    assert result == "Retry summary succeeded."
+    agent._ensure_primary_openai_client.assert_not_called()
+    assert dispatch_mock.call_count == 2


### PR DESCRIPTION
## Problem

Bedrock-mode agents (`api_mode == "bedrock_converse"`) hit a connection error when a session reaches the iteration cap (default 90) and the agent tries to produce a final summary.

Repro (observed in production): a long-running Bedrock agent hits `max_turns`, and instead of a clean summary the user sees:

> Reached the maximum iterations (90) but couldn't summarize. Error: connection error.

## Root cause

`handle_max_iterations()` in `agent/chat_completion_helpers.py` has explicit branches for `anthropic_messages` and `codex_responses` API modes, but no branch for `bedrock_converse`. It falls through to a generic `else` that calls:

```python
agent._ensure_primary_openai_client().chat.completions.create(...)
```

For Bedrock-mode agents, `agent.client` is intentionally `None` and `agent._client_kwargs = {}` (set in `agent/agent_init.py`, since Bedrock talks to AWS directly via boto3 and never uses an OpenAI-style client). Calling `.chat.completions.create(...)` on that client has no valid `api_key`/`base_url` and fails immediately, producing the "connection error" text seen by the user.

Impact: not data loss — every tool call up to the iteration cap completes and logs normally. Only the final "summarize what happened" step is broken, and it's broken for every Bedrock-mode agent that reaches its iteration cap.

## Fix

Add explicit `bedrock_converse` branches to `handle_max_iterations()` (primary attempt + the empty-response retry path), mirroring the existing `anthropic_messages` branch: route through `agent._get_transport()` + `_dispatch_nonstreaming_api_request(...)` instead of the OpenAI-client fallback.

## Testing

- New regression test: `tests/agent/test_bedrock_iteration_limit_summary.py` — asserts the OpenAI-client fallback path is never invoked for `bedrock_converse` agents, and that the transport-based path is used and produces a normal summary instead of a connection error.
- Ran full existing Bedrock test suite (`test_bedrock_integration.py`, `test_bedrock_transport.py`, `test_bedrock_interrupt_post_worker.py`, `test_bedrock_adapter.py`) — 217 tests, all pass.
- Ran broader `chat_completion_helpers`-adjacent test files — 346 tests, all pass.
- No changes to `agent/bedrock_adapter.py` (left untouched; unrelated in-progress work in that file was not disturbed).