### PR TITLE
fix(dashboard): accept the plugin directory key in plugins.enabled gates

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17191,6 +17191,11 @@ def _discover_dashboard_plugins() -> list:
                     "source": source,
                     "_dir": str(dashboard_dir),
                     "_api_file": safe_api,
+                    # Install-directory key — the identifier
+                    # ``hermes plugins enable`` writes to
+                    # ``plugins.enabled`` (may differ from the manifest
+                    # ``name``, which doubles as the mount prefix).
+                    "_owner_key": child.name,
                 })
             except Exception as exc:
                 _log.warning("Bad dashboard plugin manifest %s: %s", manifest_file, exc)
@@ -17210,6 +17215,15 @@ def _get_dashboard_plugins(force_rescan: bool = False) -> list:
         if any(not Path(p["_dir"]).is_dir() for p in _dashboard_plugins_cache):
             _dashboard_plugins_cache = _discover_dashboard_plugins()
     return _dashboard_plugins_cache
+
+
+def _plugin_gate_ids(plugin: dict) -> set:
+    """Identifiers under which ``plugins.enabled``/``disabled`` may
+    reference a dashboard plugin: its manifest ``name`` and its
+    install-directory key (what ``hermes plugins enable`` writes) —
+    the same "accept both" back-compat lookup the agent loader uses.
+    """
+    return {plugin.get("name", ""), plugin.get("_owner_key", "")} - {""}
 
 
 @app.get("/api/dashboard/plugins")
@@ -17234,13 +17248,14 @@ async def get_dashboard_plugins():
         name = p.get("name", "")
         if name in hidden:
             return False
+        ids = _plugin_gate_ids(p)
         if p.get("source") == "user":
-            if name in disabled_set:
+            if ids & disabled_set:
                 return False
-            if name not in enabled_set:
+            if not (ids & enabled_set):
                 return False
         elif p.get("source") == "bundled":
-            if name in disabled_set:
+            if ids & disabled_set:
                 return False
         return True
 
@@ -17650,23 +17665,28 @@ def _mount_plugin_api_routes():
         # Gate: user plugins must be in plugins.enabled and not in
         # plugins.disabled before we import their Python code.
         # Bundled plugins are trusted (they ship with the release) but
-        # still respect an explicit disable.
+        # still respect an explicit disable.  Membership counts both the
+        # manifest name and the install-directory key, matching the
+        # agent loader's back-compat lookup.  Skips log at INFO: an
+        # enabled-but-unmounted plugin presents as its API 404ing, and
+        # a DEBUG-level skip leaves no trace of why.
+        gate_ids = _plugin_gate_ids(plugin)
         if plugin.get("source") == "user":
-            if plugin_name in disabled_set:
-                _log.debug(
+            if gate_ids & disabled_set:
+                _log.info(
                     "Plugin %s: skipping API mount (explicitly disabled)",
                     plugin_name,
                 )
                 continue
-            if plugin_name not in enabled_set:
-                _log.debug(
+            if not (gate_ids & enabled_set):
+                _log.info(
                     "Plugin %s: skipping API mount (not in plugins.enabled)",
                     plugin_name,
                 )
                 continue
         elif plugin.get("source") == "bundled":
-            if plugin_name in disabled_set:
-                _log.debug(
+            if gate_ids & disabled_set:
+                _log.info(
                     "Plugin %s: skipping API mount (explicitly disabled)",
                     plugin_name,
                 )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -544,14 +544,21 @@ async def _plugin_api_runtime_gate(request: Request, call_next):
                         None,
                     )
                     source = plugin.get("source") if plugin else "user"
+                    # Membership counts both the manifest name and the
+                    # install-directory key, matching the loader's
+                    # back-compat lookup (an unknown plugin keeps the
+                    # URL-derived name only, and blocks).
+                    gate_ids = (
+                        _plugin_gate_ids(plugin) if plugin else {plugin_name}
+                    )
                     if source == "user":
-                        if plugin_name in disabled_set or plugin_name not in enabled_set:
+                        if gate_ids & disabled_set or not (gate_ids & enabled_set):
                             return JSONResponse(
                                 status_code=404,
                                 content={"detail": "Plugin not found"},
                             )
                     elif source == "bundled":
-                        if plugin_name in disabled_set:
+                        if gate_ids & disabled_set:
                             return JSONResponse(
                                 status_code=404,
                                 content={"detail": "Plugin not found"},
@@ -17574,11 +17581,12 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
     except Exception:
         enabled_set = set()
         disabled_set = set()
+    gate_ids = _plugin_gate_ids(plugin)
     if plugin.get("source") == "user":
-        if plugin_name in disabled_set or plugin_name not in enabled_set:
+        if gate_ids & disabled_set or not (gate_ids & enabled_set):
             raise HTTPException(status_code=404, detail="Plugin not found")
     elif plugin.get("source") == "bundled":
-        if plugin_name in disabled_set:
+        if gate_ids & disabled_set:
             raise HTTPException(status_code=404, detail="Plugin not found")
 
     base = Path(plugin["_dir"])

--- a/tests/hermes_cli/test_dashboard_plugin_enable_gate.py
+++ b/tests/hermes_cli/test_dashboard_plugin_enable_gate.py
@@ -41,7 +41,15 @@ def _reset_plugin_cache():
     web_server._dashboard_plugins_cache = None
 
 
-API_SRC = "from fastapi import APIRouter\nrouter = APIRouter()\n"
+API_SRC = (
+    "from fastapi import APIRouter\n"
+    "router = APIRouter()\n"
+    "\n"
+    "\n"
+    '@router.get("/hello")\n'
+    "def hello():\n"
+    '    return {"ok": True}\n'
+)
 
 
 @pytest.fixture
@@ -154,3 +162,92 @@ class TestListingGateAcceptsDirectoryKey:
             web_server._get_dashboard_plugins(force_rescan=True)
             served = asyncio.run(web_server.get_dashboard_plugins())
         assert "mobile" not in {p["name"] for p in served}
+
+
+class TestRequestTimeGatesAcceptDirectoryKey:
+    """End-to-end through the live app: mounting is not enough — the
+    ``_plugin_api_runtime_gate`` middleware re-checks the policy on every
+    authenticated ``/api/plugins/<name>/…`` request, and
+    ``/dashboard-plugins/<name>/…`` re-checks it per asset request.  Both
+    must honor the directory key, or a plugin enabled the documented way
+    mounts fine and then 404s at request time anyway.
+    """
+
+    @pytest.fixture
+    def live_client(self, mobile_plugin, monkeypatch):
+        """Authenticated TestClient against the real app with the
+        mismatched-key plugin mounted (mirrors the route snapshot /
+        reorder / restore dance of ``_install_example_plugin`` in
+        ``test_web_server.py``)."""
+        from starlette.testclient import TestClient
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(
+            hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"
+        )
+        app = web_server.app
+        # Earlier suites in a full run can leak global app state that has
+        # nothing to do with the plugin gates: an OAuth/password-login
+        # suite leaves ``app.state.auth_required = True`` (engaging the
+        # cookie auth gate, so the legacy session-token header 401s) and
+        # a server-bind suite leaves ``app.state.bound_host`` set (the
+        # DNS-rebinding host check then 400s TestClient's ``testserver``
+        # host).  Neutralize both so these tests are order-independent;
+        # monkeypatch restores the prior values on teardown.
+        monkeypatch.setattr(app.state, "auth_required", False, raising=False)
+        monkeypatch.setattr(app.state, "bound_host", None, raising=False)
+        original_routes = list(app.router.routes)
+        with gate_config(enabled={"hermes-mobile"}):
+            web_server._get_dashboard_plugins(force_rescan=True)
+            web_server._mount_plugin_api_routes()
+        # Mid-flight mounts append after the SPA catch-all; move them to
+        # the front so they win the match-order race (as the app does
+        # when mounting at import time).
+        new_routes = [r for r in app.router.routes if r not in original_routes]
+        for route in new_routes:
+            app.router.routes.remove(route)
+        for offset, route in enumerate(new_routes):
+            app.router.routes.insert(offset, route)
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        try:
+            yield client
+        finally:
+            app.router.routes[:] = original_routes
+            web_server._dashboard_plugins_cache = None
+
+    def test_api_request_allowed_when_enabled_by_directory_key(self, live_client):
+        """The field regression's second half: enabled as
+        ``hermes plugins enable hermes-mobile``, an authenticated request
+        to the mounted route must reach the handler."""
+        with gate_config(enabled={"hermes-mobile"}):
+            resp = live_client.get("/api/plugins/mobile/hello")
+        assert resp.status_code == 200, resp.text
+
+    def test_api_request_blocked_when_disabled_by_directory_key(self, live_client):
+        """Runtime disable under either identifier wins immediately."""
+        with gate_config(
+            enabled={"hermes-mobile", "mobile"}, disabled={"hermes-mobile"}
+        ):
+            resp = live_client.get("/api/plugins/mobile/hello")
+        assert resp.status_code == 404
+
+    def test_api_request_blocked_when_not_enabled(self, live_client):
+        """#46435 invariant at request time: no enable spelling → 404,
+        even though the router is still mounted."""
+        with gate_config(enabled=set()):
+            resp = live_client.get("/api/plugins/mobile/hello")
+        assert resp.status_code == 404
+
+    def test_asset_served_when_enabled_by_directory_key(self, live_client):
+        with gate_config(enabled={"hermes-mobile"}):
+            resp = live_client.get("/dashboard-plugins/mobile/manifest.json")
+        assert resp.status_code == 200, resp.text
+
+    def test_asset_blocked_when_not_enabled(self, live_client):
+        with gate_config(enabled=set()):
+            resp = live_client.get("/dashboard-plugins/mobile/manifest.json")
+        assert resp.status_code == 404

--- a/tests/hermes_cli/test_dashboard_plugin_enable_gate.py
+++ b/tests/hermes_cli/test_dashboard_plugin_enable_gate.py
@@ -1,0 +1,156 @@
+"""Regression coverage for the ``plugins.enabled`` gate on dashboard
+plugins whose manifest ``name`` differs from their install-directory key.
+
+``hermes plugins enable <key>`` writes the *path-derived registry key*
+(the plugin's directory name, e.g. ``hermes-mobile``) into
+``plugins.enabled``, and the agent loader explicitly accepts both that
+key and the manifest name ("Accept both the path-derived key and the
+legacy bare name so existing configs keep working").  The two dashboard
+gates added for #46435 (GHSA-mcfc-hp25-cjv7) compared only the
+*dashboard* manifest ``name`` — which doubles as the mount prefix and
+routinely differs from the directory key (a plugin installed at
+``~/.hermes/plugins/hermes-mobile/`` with ``{"name": "mobile"}`` mounts
+at ``/api/plugins/mobile/``).  Such a plugin loaded fine in the agent
+while its backend API and dashboard assets were silently skipped (the
+skip is logged at DEBUG), which presents as "plugin enabled but its
+dashboard API 404s" after an upgrade.
+
+These tests pin the fix: both gates accept *either* the directory key or
+the manifest name, for enable and disable alike, without widening the
+gate (a plugin enabled under neither identifier must still be skipped).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import web_server
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_cache():
+    """Bust the per-process discovery cache before and after each test so
+    the import-time production scan can't bleed in."""
+    web_server._dashboard_plugins_cache = None
+    yield
+    web_server._dashboard_plugins_cache = None
+
+
+API_SRC = "from fastapi import APIRouter\nrouter = APIRouter()\n"
+
+
+@pytest.fixture
+def mobile_plugin(tmp_path, monkeypatch):
+    """A user plugin whose directory key and dashboard name differ.
+
+    Installed at ``<home>/plugins/hermes-mobile/`` (registry key
+    ``hermes-mobile``) with ``dashboard/manifest.json`` declaring
+    ``{"name": "mobile"}`` — the shape that regressed in the field.
+    Bundled plugins are pointed at an empty directory so the only
+    discoverable plugin is this one.
+    """
+    home = tmp_path / "home"
+    (home / "plugins").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+    empty_bundled = tmp_path / "no-bundled-plugins"
+    empty_bundled.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_bundled_plugins_dir", lambda: empty_bundled
+    )
+    dash = home / "plugins" / "hermes-mobile" / "dashboard"
+    dash.mkdir(parents=True)
+    (dash / "manifest.json").write_text(
+        json.dumps({
+            "name": "mobile",
+            "label": "Mobile",
+            "entry": "dist/index.js",
+            "api": "plugin_api.py",
+        })
+    )
+    (dash / "plugin_api.py").write_text(API_SRC)
+    return dash
+
+
+@contextmanager
+def gate_config(enabled, disabled=()):
+    """Pin the ``plugins.enabled`` / ``plugins.disabled`` sets the gates read."""
+    with (
+        patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set(enabled)),
+        patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set(disabled)),
+    ):
+        yield
+
+
+def _mounted_prefixes():
+    """Run the mount routine against a spy app; return mounted prefixes."""
+    with patch.object(web_server.app, "include_router") as inc:
+        web_server._mount_plugin_api_routes()
+    return [c.kwargs.get("prefix") for c in inc.call_args_list]
+
+
+class TestMountGateAcceptsDirectoryKey:
+    def test_enabled_by_directory_key_mounts_api(self, mobile_plugin):
+        """The field regression: enabled via ``hermes plugins enable
+        hermes-mobile`` (directory key), API must mount under the
+        manifest name."""
+        with gate_config(enabled={"hermes-mobile"}):
+            web_server._get_dashboard_plugins(force_rescan=True)
+            prefixes = _mounted_prefixes()
+        assert "/api/plugins/mobile" in prefixes
+
+    def test_enabled_by_manifest_name_still_mounts_api(self, mobile_plugin):
+        """Back-compat: configs that listed the manifest name keep working."""
+        with gate_config(enabled={"mobile"}):
+            web_server._get_dashboard_plugins(force_rescan=True)
+            prefixes = _mounted_prefixes()
+        assert "/api/plugins/mobile" in prefixes
+
+    def test_disabled_by_directory_key_wins(self, mobile_plugin):
+        """An explicit disable under either identifier must block the
+        mount even when the plugin is also enabled."""
+        with gate_config(
+            enabled={"hermes-mobile", "mobile"}, disabled={"hermes-mobile"}
+        ):
+            web_server._get_dashboard_plugins(force_rescan=True)
+            prefixes = _mounted_prefixes()
+        assert prefixes == []
+
+    def test_not_enabled_is_still_skipped(self, mobile_plugin):
+        """#46435 invariant: a user plugin enabled under neither
+        identifier must not have its backend imported or mounted."""
+        with gate_config(enabled=set()):
+            web_server._get_dashboard_plugins(force_rescan=True)
+            prefixes = _mounted_prefixes()
+        assert prefixes == []
+
+
+class TestListingGateAcceptsDirectoryKey:
+    def test_enabled_by_directory_key_served_to_frontend(self, mobile_plugin):
+        """The /api/dashboard/plugins listing applies the same gate: a
+        plugin enabled by its directory key must be served (its JS/CSS
+        entry is what the frontend loads)."""
+        with gate_config(enabled={"hermes-mobile"}):
+            web_server._get_dashboard_plugins(force_rescan=True)
+            served = asyncio.run(web_server.get_dashboard_plugins())
+        assert "mobile" in {p["name"] for p in served}
+
+    def test_internal_fields_not_leaked_to_frontend(self, mobile_plugin):
+        """Whatever the gate records internally must stay internal —
+        underscore-prefixed fields never reach the frontend."""
+        with gate_config(enabled={"hermes-mobile"}):
+            web_server._get_dashboard_plugins(force_rescan=True)
+            served = asyncio.run(web_server.get_dashboard_plugins())
+        assert served, "expected the enabled plugin to be served"
+        assert all(not k.startswith("_") for p in served for k in p)
+
+    def test_not_enabled_not_served(self, mobile_plugin):
+        with gate_config(enabled=set()):
+            web_server._get_dashboard_plugins(force_rescan=True)
+            served = asyncio.run(web_server.get_dashboard_plugins())
+        assert "mobile" not in {p["name"] for p in served}


### PR DESCRIPTION
## Problem

The #46435 gates (GHSA-mcfc-hp25-cjv7) — backend API mounting in `_mount_plugin_api_routes()` and the `/api/dashboard/plugins` listing — compare only the **dashboard manifest `name`** against `plugins.enabled`/`plugins.disabled`.

But `hermes plugins enable <key>` writes the **path-derived registry key** (the plugin's install-directory name) into `plugins.enabled`, and the agent loader explicitly accepts both spellings ("Accept both the path-derived key and the legacy bare name so existing configs keep working").

The dashboard manifest name doubles as the `/api/plugins/<name>/` mount prefix, so it routinely differs from the directory key. A user plugin installed at `~/.hermes/plugins/hermes-mobile/` with `dashboard/manifest.json` `{"name": "mobile"}`, enabled the documented way (`hermes plugins enable hermes-mobile`), loads fine in the agent — auth providers, platforms, hooks all register — while its backend API and dashboard assets are **silently skipped** (DEBUG-level log). After upgrading past #46435 this presents in the field as "plugin enabled but its API 404s", with nothing in the logs to say why. Hit this in production upgrading a deployment from 0.17.0 to 0.18.2.

## Fix

- Discovery records the install-directory key on each dashboard plugin entry (`_owner_key` — internal field, stripped before reaching the frontend like the existing `_dir`/`_api_file`).
- A `_plugin_gate_ids()` helper returns `{manifest name, directory key}`, and **both** gates check enable/disable membership against that set — mirroring the loader's back-compat lookup, for enable and disable alike.
- Skip logs bump DEBUG → INFO so the next operator hitting a gate mismatch finds the reason in the log.

Security posture of #46435 is unchanged: nothing is mounted or served without an explicit enable — the gates simply honor the same two identifiers the loader already does, and an explicit disable under either identifier still wins.

## Test plan

New `tests/hermes_cli/test_dashboard_plugin_enable_gate.py` (7 tests), written red-first against the unpatched gates:

- enable by directory key → API mounts / plugin served (the field regression; failed before the fix)
- enable by manifest name → still works (back-compat pin)
- disable by either identifier → wins over an enable (failed before the fix)
- enabled under neither identifier → still skipped, backend never imported (#46435 invariant)
- `_owner_key` never leaks to the frontend

Verified locally: the new file, `test_project_plugin_rce_bypass.py` (35/35 — GHSA-5qr3-c538-wm9j defences intact), and the full `test_web_server.py` (409/409). A full `tests/hermes_cli/` sweep on this branch and on its base commit produces **byte-identical** failure sets (312 environment-dependent failures on both, none related) — the change introduces no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)