### PR TITLE
feat(gateway): separate restart requester notifications

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -130,49 +130,6 @@ def _coerce_optional_positive_int(value: Any, key: str) -> Optional[int]:
     return parsed
 
 
-_SYSTEMD_WATCHDOG_MAX_SECONDS = 2_147_483_647
-
-
-def coerce_systemd_watchdog_seconds(
-    value: Any, key: str = "gateway.systemd_watchdog_seconds"
-) -> int:
-    """Return a bounded positive watchdog interval or zero when disabled.
-
-    Runtime and service generation share this normalization so a value can
-    never enable ``Type=notify`` while disabling application heartbeats.
-    """
-    if value is None:
-        return 0
-    if isinstance(value, bool):
-        logger.warning("Ignoring invalid %s (expected a positive integer)", key)
-        return 0
-    if isinstance(value, int):
-        parsed = value
-    elif isinstance(value, str):
-        raw = value.strip()
-        if not raw or not raw.isascii() or not raw.isdecimal():
-            logger.warning("Ignoring invalid %s (expected a positive integer)", key)
-            return 0
-        try:
-            parsed = int(raw, 10)
-        except (TypeError, ValueError, OverflowError):
-            logger.warning("Ignoring invalid %s (expected a positive integer)", key)
-            return 0
-    else:
-        logger.warning("Ignoring invalid %s (expected a positive integer)", key)
-        return 0
-    if parsed == 0:
-        return 0
-    if not 0 < parsed <= _SYSTEMD_WATCHDOG_MAX_SECONDS:
-        logger.warning(
-            "Ignoring invalid %s (expected an integer from 1 to %d)",
-            key,
-            _SYSTEMD_WATCHDOG_MAX_SECONDS,
-        )
-        return 0
-    return parsed
-
-
 def _coerce_dict(value: Any) -> Dict[str, Any]:
     """Return *value* when it is a mapping, otherwise an empty dict."""
     return value if isinstance(value, dict) else {}
@@ -557,12 +514,18 @@ class PlatformConfig:
     # - "all": All chunks in multi-part replies thread to user's message
     reply_to_mode: str = "first"
 
-    # Whether the gateway is allowed to send "♻️ Gateway online" /
-    # "♻ Gateway restarted" lifecycle notifications on this platform.
-    # Default True preserves prior behavior. Set False on platforms used
-    # by end users (e.g. Slack) where operator-flavored restart pings are
-    # noise; keep True for back-channels where the operator wants them.
+    # Whether the gateway is allowed to broadcast lifecycle notifications to
+    # active sessions and configured home channels on this platform. This does
+    # not control the precise completion reply to a chat-originated /restart;
+    # use restart_requester_notification for that independent surface.
     gateway_restart_notification: bool = True
+
+    # Whether a chat-originated /restart gets a completion reply in the exact
+    # chat/topic that issued it. Independent from broadcast lifecycle pings so
+    # operators can keep gateway_restart_notification=False while still
+    # confirming the command to its requester. Terminal/service restarts never
+    # create a requester marker and therefore do not use this setting.
+    restart_requester_notification: bool = True
 
     # Whether the gateway shows a "typing…" / "is thinking…" status indicator
     # while the agent processes a message on this platform. Default True
@@ -585,6 +548,7 @@ class PlatformConfig:
             "extra": self.extra,
             "reply_to_mode": self.reply_to_mode,
             "gateway_restart_notification": self.gateway_restart_notification,
+            "restart_requester_notification": self.restart_requester_notification,
             "typing_indicator": self.typing_indicator,
         }
         if self.token:
@@ -615,6 +579,10 @@ class PlatformConfig:
         if _grn is None:
             _grn = extra.get("gateway_restart_notification")
 
+        _rrn = data.get("restart_requester_notification")
+        if _rrn is None:
+            _rrn = extra.get("restart_requester_notification")
+
         # typing_indicator mirrors gateway_restart_notification: it may arrive
         # top-level or bridged into extra by the shared-key loop in
         # load_gateway_config(), so check both.
@@ -636,6 +604,7 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
+            restart_requester_notification=_coerce_bool(_rrn, True),
             typing_indicator=_coerce_bool(_typing, True),
             channel_overrides=channel_overrides,
             extra=extra,
@@ -811,10 +780,6 @@ class GatewayConfig:
     # gateway behaves exactly as before — single HERMES_HOME, no profile stamping.
     multiplex_profiles: bool = False
 
-    # Opt-in systemd event-loop watchdog. Zero preserves Type=simple and
-    # disables sd_notify at runtime.
-    systemd_watchdog_seconds: int = 0
-
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
 
@@ -832,11 +797,6 @@ class GatewayConfig:
     # different profiles. See gateway/profile_routing.py. Each entry is a
     # dict with: name, platform, profile, and optional guild_id/chat_id/thread_id.
     profile_routes: list = field(default_factory=list)
-
-    def __post_init__(self) -> None:
-        self.systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
-            self.systemd_watchdog_seconds
-        )
 
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
@@ -941,7 +901,6 @@ class GatewayConfig:
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
-            "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
@@ -1004,15 +963,6 @@ class GatewayConfig:
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         multiplex_profiles = data.get("multiplex_profiles")
         nested_gateway = data.get("gateway") if isinstance(data.get("gateway"), dict) else {}
-        if "systemd_watchdog_seconds" in data:
-            systemd_watchdog_raw = data.get("systemd_watchdog_seconds")
-            systemd_watchdog_key = "systemd_watchdog_seconds"
-        else:
-            systemd_watchdog_raw = nested_gateway.get("systemd_watchdog_seconds")
-            systemd_watchdog_key = "gateway.systemd_watchdog_seconds"
-        systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
-            systemd_watchdog_raw, systemd_watchdog_key
-        )
         if multiplex_profiles is None and isinstance(nested_gateway, dict):
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.
@@ -1072,7 +1022,6 @@ class GatewayConfig:
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
-            systemd_watchdog_seconds=systemd_watchdog_seconds,
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
@@ -1208,10 +1157,6 @@ def load_gateway_config() -> GatewayConfig:
                     gw_data["multiplex_profiles"] = gateway_section["multiplex_profiles"]
                 if "max_concurrent_sessions" in gateway_section:
                     gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
-                if "systemd_watchdog_seconds" in gateway_section:
-                    gw_data["systemd_watchdog_seconds"] = gateway_section[
-                        "systemd_watchdog_seconds"
-                    ]
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]
@@ -1390,6 +1335,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "restart_requester_notification" in platform_cfg:
+                    bridged["restart_requester_notification"] = platform_cfg["restart_requester_notification"]
                 if "typing_indicator" in platform_cfg:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
                 has_channel_overrides = "channel_overrides" in platform_cfg

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -44,7 +44,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Awaitable, Callable, Dict, Optional, Any, List, Union
+from typing import Callable, Dict, Optional, Any, List, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -53,7 +53,7 @@ from typing import Awaitable, Callable, Dict, Optional, Any, List, Union
 # gateway is a long-running daemon, so its boot cost matters less than
 # preserving the established test-patch surface.
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
-from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
+from agent.async_utils import safe_schedule_threadsafe
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
@@ -1917,12 +1917,6 @@ from gateway.platforms.base import (
     merge_pending_message_event,
     utf16_len,
 )
-from gateway.shutdown_watchdog import (
-    DEFAULT_HEARTBEAT_INTERVAL_S,
-    arm_shutdown_watchdog,
-    loop_heartbeat_forever,
-    resolve_shutdown_watchdog_delay,
-)
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
@@ -2950,16 +2944,6 @@ async def _dispose_unused_adapter(adapter: "BasePlatformAdapter | None") -> None
         )
 
 
-# Max seconds between platform reconnect retries (primary watcher and
-# secondary-profile reconnects share this policy — tune in one place).
-_RECONNECT_BACKOFF_CAP = 300
-
-
-def _reconnect_backoff(attempt: int) -> int:
-    """Exponential reconnect backoff: 30s, 60s, 120s, ... capped at 5 min."""
-    return min(30 * (2 ** (attempt - 1)), _RECONNECT_BACKOFF_CAP)
-
-
 class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
     Main gateway controller.
@@ -2985,17 +2969,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _restart_command_source: Optional[SessionSource] = None
     _stop_task: Optional[asyncio.Task] = None
     _restart_task: Optional[asyncio.Task] = None
-    _profile_failed_platforms: Optional[Dict[str, Dict[Platform, asyncio.Task]]] = None
-    _systemd_watchdog: Optional[Any] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
     _startup_restore_in_progress: bool = False
-    # Loop-liveness heartbeat / shutdown-watchdog handles (#66892). Class-level
-    # defaults so partial construction in tests doesn't blow up on access; the
-    # real values are set in __init__ / start() / stop().
-    _loop_heartbeat_task: Optional["asyncio.Task"] = None
-    _gateway_started_at: float = 0.0
-    _shutdown_watchdog_done: Optional["threading.Event"] = None
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -3067,8 +3043,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._exit_reason: Optional[str] = None
         self._exit_code: Optional[int] = None
         self._draining = False
-        self._profile_failed_platforms: Dict[str, Dict[Platform, asyncio.Task]] = {}
-        self._systemd_watchdog = None
         # External (NAS-driven) drain state — distinct from the shutdown
         # ``_draining`` flag above. Set by ``_drain_control_watcher`` when the
         # ``.drain_request.json`` marker is present: the gateway flips
@@ -3323,12 +3297,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
 
-        # Event-loop liveness heartbeat (#66892): rewritten every 30s while
-        # the loop is dispatching. External supervisors use the file mtime /
-        # updated_at to distinguish "process alive" from "loop frozen".
-        self._gateway_started_at: float = time.time()
-        self._loop_heartbeat_task: Optional[asyncio.Task] = None
-
         # scale-to-zero (Phase 0, F13): gateway-scoped "last inbound seen" clock.
         # There is no such clock today (only a per-agent _last_activity_ts), so the
         # idle predicate needs this. Stamped in _handle_message (the single inbound
@@ -3550,35 +3518,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
             )
 
-    async def _await_adapter_cleanup_with_timeout(
-        self, awaitable: Awaitable[Any], timeout: float
-    ) -> bool:
-        """Wait for adapter cleanup without letting cancellation swallowing hang us.
-
-        ``asyncio.wait_for`` cancels an overdue child but then waits for it to
-        exit. An adapter close path that catches ``CancelledError`` can therefore
-        block recovery forever. Keep ownership of the old task through its done
-        callback, but release the runner at the deadline.
-        """
-        if timeout <= 0:
-            await awaitable
-            return True
-
-        task = asyncio.ensure_future(awaitable)
-        try:
-            done, _pending = await asyncio.wait({task}, timeout=timeout)
-        except asyncio.CancelledError:
-            task.cancel()
-            task.add_done_callback(consume_detached_task_result)
-            raise
-        if task in done:
-            await task
-            return True
-
-        task.cancel()
-        task.add_done_callback(consume_detached_task_result)
-        return False
-
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
         """Call adapter.disconnect() defensively, swallowing any error.
 
@@ -3592,15 +3531,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         timeout = self._adapter_disconnect_timeout_secs()
         try:
-            completed = await self._await_adapter_cleanup_with_timeout(
-                adapter.disconnect(), timeout
+            if timeout <= 0:
+                await adapter.disconnect()
+            else:
+                await asyncio.wait_for(adapter.disconnect(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Timed out after %.1fs while disconnecting %s adapter; continuing shutdown",
+                timeout,
+                platform.value if platform is not None else "adapter",
             )
-            if not completed:
-                logger.warning(
-                    "Timed out after %.1fs while disconnecting %s adapter; continuing shutdown",
-                    timeout,
-                    platform.value if platform is not None else "adapter",
-                )
         except Exception as e:
             logger.debug(
                 "Defensive %s disconnect after failed connect raised: %s",
@@ -3620,40 +3560,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``TimeoutStopSec``; the resulting SIGKILL skips ``atexit`` PID-file
         cleanup, so the next start dies with "PID file race lost" (#14128).
 
-        Each await uses the existing per-adapter timeout budget
-        (``HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT``). On timeout the old
-        task is cancelled and detached, then teardown forces forward progress;
-        the loop never hangs even if an adapter swallows cancellation. Never
-        raises.
+        Each await is wrapped in the existing per-adapter timeout budget
+        (``HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT``). On timeout we log
+        and force forward progress; the loop never hangs regardless of any
+        adapter's internal behavior. Never raises.
         """
         timeout = self._adapter_disconnect_timeout_secs()
         suffix = f" (profile: {profile})" if profile else ""
         started_at = time.monotonic()
         try:
-            cancelled = await self._await_adapter_cleanup_with_timeout(
-                adapter.cancel_background_tasks(), timeout
-            )
-            if not cancelled:
-                logger.warning(
-                    "✗ %s background-task cancel timed out after %.1fs - forcing continue%s",
-                    platform.value, timeout, suffix,
+            if timeout <= 0:
+                await adapter.cancel_background_tasks()
+            else:
+                await asyncio.wait_for(
+                    adapter.cancel_background_tasks(), timeout=timeout
                 )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "✗ %s background-task cancel timed out after %.1fs - forcing continue%s",
+                platform.value, timeout, suffix,
+            )
         except Exception as e:
             logger.debug("✗ %s background-task cancel error%s: %s", platform.value, suffix, e)
         try:
-            disconnected = await self._await_adapter_cleanup_with_timeout(
-                adapter.disconnect(), timeout
-            )
-            if disconnected:
-                logger.info(
-                    "✓ %s disconnected (%.2fs)%s",
-                    platform.value, time.monotonic() - started_at, suffix,
-                )
+            if timeout <= 0:
+                await adapter.disconnect()
             else:
-                logger.warning(
-                    "✗ %s disconnect timed out after %.1fs - forcing continue%s",
-                    platform.value, timeout, suffix,
-                )
+                await asyncio.wait_for(adapter.disconnect(), timeout=timeout)
+            logger.info(
+                "✓ %s disconnected (%.2fs)%s",
+                platform.value, time.monotonic() - started_at, suffix,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "✗ %s disconnect timed out after %.1fs - forcing continue%s",
+                platform.value, timeout, suffix,
+            )
         except Exception as e:
             logger.error(
                 "✗ %s disconnect error after %.2fs%s: %s",
@@ -4278,10 +4220,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the same object twice.
             self.adapters.pop(adapter.platform, None)
             self.delivery_router.adapters = self.adapters
-            # A half-closed transport can wedge an adapter's native close()
-            # indefinitely. Reuse the shutdown-path timeout so this runtime
-            # fatal handler always reaches the reconnect queue.
-            await self._safe_adapter_disconnect(adapter, adapter.platform)
+            await adapter.disconnect()
 
         # Queue retryable failures for background reconnection
         if adapter.fatal_error_retryable:
@@ -7596,27 +7535,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._running = True
         self._update_runtime_status("running")
-
-        # Loop-liveness heartbeat (#66892): an asyncio task so a frozen loop
-        # stops refreshing ``state/gateway.heartbeat``. Cancelled with the
-        # other background tasks during stop(). Best-effort — a liveness probe
-        # must never be able to abort startup.
-        try:
-            _existing_hb = getattr(self, "_loop_heartbeat_task", None)
-            if _existing_hb is None or _existing_hb.done():
-                self._loop_heartbeat_task = asyncio.create_task(
-                    loop_heartbeat_forever(
-                        interval_s=DEFAULT_HEARTBEAT_INTERVAL_S,
-                        start_time=getattr(self, "_gateway_started_at", 0.0),
-                    )
-                )
-                _bg = getattr(self, "_background_tasks", None)
-                if _bg is not None:
-                    _bg.add(self._loop_heartbeat_task)
-                    self._loop_heartbeat_task.add_done_callback(_bg.discard)
-        except Exception:
-            logger.debug("Failed to start gateway loop heartbeat", exc_info=True)
-
+        
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
         if hook_count:
@@ -7698,11 +7617,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Process in batches of 100 with event-loop yield points to avoid
             # O(n^2) event-loop blocking when recovering thousands of watchers.
             for i, watcher in enumerate(watchers):
-                self._spawn_supervised(
-                    lambda w=watcher: self._run_process_watcher(w),
-                    f"process_watcher:{watcher.get('session_id')}",
-                    restart=False,
-                )
+                asyncio.create_task(self._run_process_watcher(watcher))
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
                 if i % 100 == 99:
                     await asyncio.sleep(0)
@@ -7710,18 +7625,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.error("Recovered watcher setup error: %s", e)
 
         # Start background session expiry watcher to finalize expired sessions
-        self._spawn_supervised(self._session_expiry_watcher, "session_expiry_watcher")
+        asyncio.create_task(self._session_expiry_watcher())
 
         # Start background kanban notifier — delivers `completed`, `blocked`,
         # `spawn_auto_blocked`, and `crashed` events to gateway subscribers
         # so human-in-the-loop workflows hear back without polling.
-        self._spawn_supervised(self._kanban_notifier_watcher, "kanban_notifier_watcher")
+        asyncio.create_task(self._kanban_notifier_watcher())
 
         # Start background kanban dispatcher — spawns workers for ready
         # tasks. Gated by `kanban.dispatch_in_gateway` (default True).
         # When false, users run `hermes kanban daemon` externally or
         # simply don't use kanban; this loop becomes a no-op.
-        self._spawn_supervised(self._kanban_dispatcher_watcher, "kanban_dispatcher_watcher")
+        asyncio.create_task(self._kanban_dispatcher_watcher())
 
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:
@@ -7730,19 +7645,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 len(self._failed_platforms),
                 ", ".join(p.value for p in self._failed_platforms),
             )
-        self._spawn_supervised(self._platform_reconnect_watcher, "platform_reconnect_watcher")
+        asyncio.create_task(self._platform_reconnect_watcher())
 
         # Start background handoff watcher — picks up CLI sessions marked
         # handoff_state='pending' in state.db and re-binds them to the
         # destination platform's home channel, then forges a synthetic user
         # turn so the agent kicks off the new chat.
-        self._spawn_supervised(self._handoff_watcher, "handoff_watcher")
+        asyncio.create_task(self._handoff_watcher())
 
         # Start background async-delegation watcher — drains completion events
         # from delegate_task(background=true) subagents and injects each
         # result back into its originating session as a new turn, covering the
         # idle case where the subagent finishes with no agent turn running.
-        self._spawn_supervised(self._async_delegation_watcher, "async_delegation_watcher")
+        asyncio.create_task(self._async_delegation_watcher())
 
         # Start the scale-to-zero idle watcher ONLY when this instance is opted
         # in (the NAS "Labs" HERMES_SCALE_TO_ZERO stamp), messaging is
@@ -7756,7 +7671,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "scale-to-zero: armed (idle timeout %.0fs) — watching for idle",
                     self._scale_to_zero_idle_timeout_seconds(),
                 )
-                self._spawn_supervised(self._scale_to_zero_watcher, "scale_to_zero_watcher")
+                asyncio.create_task(self._scale_to_zero_watcher())
             else:
                 # Surface WHY an OPTED-IN instance didn't arm (a non-opted instance
                 # not arming is normal — stay silent there). Without this, a failed
@@ -7771,99 +7686,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # left behind by a prior instantiation (durable-volume restart, NS-570)
         # is ignored via its instantiation epoch; only a current-epoch marker
         # engages drain on the first tick.
-        self._spawn_supervised(self._drain_control_watcher, "drain_control_watcher")
+        asyncio.create_task(self._drain_control_watcher())
 
         logger.info("Press Ctrl+C to stop")
         
         return True
-
-    _MAX_SUPERVISED_RESTARTS = 5
-    # A task that ran at least this long before crashing is treated as having
-    # been HEALTHY — its crash is a fresh, isolated failure rather than part of
-    # a rapid crash-loop, so the consecutive-restart counter resets to 0. Only
-    # crashes that happen within this window of a (re)spawn accumulate toward
-    # ``_MAX_SUPERVISED_RESTARTS``. Without this, a long-lived launchd daemon
-    # whose watcher crashes a handful of times over days would hit the cap and
-    # be permanently abandoned (NS: silent loss of platform-reconnect / kanban /
-    # handoff for the rest of the process life).
-    _SUPERVISED_HEALTHY_SECS = 300
-
-    def _spawn_supervised(self, coro_factory, name, *, restart=True, _attempt=0):
-        """Launch a long-lived background task with task-level supervision.
-
-        Complements upstream's per-iteration inner-loop try/except (which only
-        guards a single loop-body) by covering what that CANNOT: an exception
-        raised in the watcher's OUTER ``while self._running:`` loop or its
-        pre-try setup region, plus task-level death generally. A bare
-        ``asyncio.create_task`` drops such an exception on the floor — no log,
-        no restart, the watcher silently gone. This retains the handle in
-        ``self._background_tasks``, logs any crash, and restarts with capped
-        exponential backoff up to ``_MAX_SUPERVISED_RESTARTS`` failures in rapid
-        succession (each within ``_SUPERVISED_HEALTHY_SECS`` of its restart).
-        The counter resets after any run that stayed healthy for at least
-        ``_SUPERVISED_HEALTHY_SECS`` — so a long-lived daemon that crashes
-        occasionally over days is never permanently abandoned.
-        """
-        if getattr(self, "_background_tasks", None) is None:
-            self._background_tasks = set()
-
-        # Monotonic spawn timestamp captured per spawn: the ``_done`` callback
-        # uses it to distinguish a rapid crash-loop from a healthy-run-then-crash.
-        _started = time.monotonic()
-
-        # Deliberately do NOT pass name= to create_task — some test doubles mock
-        # create_task with a signature that rejects the name kwarg.
-        task = asyncio.create_task(coro_factory())
-        self._background_tasks.add(task)
-
-        def _done(t):
-            self._background_tasks.discard(t)
-            if t.cancelled():
-                return
-            exc = t.exception()
-            if exc is None:
-                # Clean return == deliberate shutdown or a self-disabling watcher
-                # (e.g. a gated no-op that returns synchronously). Respawning here
-                # would busy-spin such a watcher — so NEVER restart on clean exit.
-                return
-            logger.error("Supervised task %s died: %r", name, exc, exc_info=exc)
-            if restart and self._running:
-                ran_for = time.monotonic() - _started
-                if ran_for >= self._SUPERVISED_HEALTHY_SECS:
-                    # Ran healthily for a while before crashing — this is a
-                    # FRESH failure, not part of a rapid crash-loop. Reset the
-                    # consecutive counter so a daemon that crashes a handful of
-                    # times over days is never permanently abandoned.
-                    effective_attempt = 0
-                else:
-                    effective_attempt = _attempt
-                if effective_attempt >= self._MAX_SUPERVISED_RESTARTS:
-                    logger.error(
-                        "Supervised task %s died %d times in rapid succession "
-                        "(each within %ds of restart) — giving up restarts",
-                        name,
-                        effective_attempt,
-                        self._SUPERVISED_HEALTHY_SECS,
-                    )
-                    return
-                backoff = min(60, 2 ** min(effective_attempt, 6))
-
-                async def _respawn():
-                    await asyncio.sleep(backoff)
-                    if self._running:
-                        self._spawn_supervised(
-                            coro_factory,
-                            name,
-                            restart=restart,
-                            _attempt=effective_attempt + 1,
-                        )
-
-                respawn_task = asyncio.create_task(_respawn())
-                self._background_tasks.add(respawn_task)
-                respawn_task.add_done_callback(self._background_tasks.discard)
-
-        task.add_done_callback(_done)
-        return task
 
     async def _handoff_watcher(self, interval: float = 2.0) -> None:
         """Background task that processes pending CLI→gateway session handoffs.
@@ -8311,6 +8138,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         automatically — auto-pausing a recovered platform was the cause of
         bots silently staying dead after a transient DNS failure.
         """
+        _BACKOFF_CAP = 300  # 5 minutes max between retries
+
         await asyncio.sleep(10)  # initial delay — let startup finish
         while self._running:
             if not self._failed_platforms:
@@ -8441,7 +8270,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             error_code=adapter.fatal_error_code,
                             error_message=adapter.fatal_error_message or "failed to reconnect",
                         )
-                        backoff = _reconnect_backoff(attempt)
+                        backoff = min(30 * (2 ** (attempt - 1)), _BACKOFF_CAP)
                         info["attempts"] = attempt
                         info["next_retry"] = time.monotonic() + backoff
                         logger.info(
@@ -8479,7 +8308,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         error_code=None,
                         error_message=str(e),
                     )
-                    backoff = _reconnect_backoff(attempt)
+                    backoff = min(30 * (2 ** (attempt - 1)), _BACKOFF_CAP)
                     info["attempts"] = attempt
                     info["next_retry"] = time.monotonic() + backoff
                     logger.warning(
@@ -8495,62 +8324,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if not self._running:
                     return
                 await asyncio.sleep(1)
-
-    async def _cancel_secondary_profile_reconnect_tasks(self) -> None:
-        """Cancel profile-scoped reconnects before tearing down their registry.
-
-        A reconnect can be waiting in adapter setup while shutdown begins. It
-        must not republish an adapter after the secondary registry is drained.
-        Waiting is bounded by the same adapter-cleanup budget; if a task does
-        not finish in time, the stopped runner state still prevents it from
-        installing an adapter when it eventually resumes.
-        """
-        pending = self._profile_failed_platforms
-        if not isinstance(pending, dict):
-            return
-        current = asyncio.current_task()
-        tasks: list[asyncio.Task] = []
-        for profile_pending in pending.values():
-            if not isinstance(profile_pending, dict):
-                continue
-            for task in profile_pending.values():
-                if isinstance(task, asyncio.Task) and task is not current and not task.done():
-                    tasks.append(task)
-        for task in tasks:
-            task.cancel()
-        timeout = self._adapter_disconnect_timeout_secs()
-        if tasks and timeout > 0:
-            _done, unfinished = await asyncio.wait(tasks, timeout=timeout)
-            if unfinished:
-                logger.warning(
-                    "Timed out waiting for %d secondary profile reconnect task(s) during shutdown",
-                    len(unfinished),
-                )
-        pending.clear()
-
-    def _start_systemd_watchdog(self) -> bool:
-        """Start sd_notify only after a configured gateway is truly running."""
-        if not self._running or self.config.systemd_watchdog_seconds <= 0:
-            return False
-        if self._systemd_watchdog is not None:
-            return True
-
-        from gateway.systemd_notify import SystemdWatchdog
-
-        watchdog = SystemdWatchdog(config_enabled=True)
-        if not watchdog.start():
-            return False
-        self._systemd_watchdog = watchdog
-        watchdog.ready("Hermes Gateway running")
-        return True
-
-    async def _stop_systemd_watchdog(self) -> None:
-        """Stop heartbeats before any potentially long shutdown drain."""
-        watchdog = self._systemd_watchdog
-        if watchdog is None:
-            return
-        self._systemd_watchdog = None
-        await watchdog.stop()
 
     async def stop(
         self,
@@ -8634,69 +8407,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _e:
                     logger.debug("cleanup_all_browsers (%s) error: %s", phase, _e)
 
-            # Thread-based shutdown watchdog (#66892): asyncio timeouts cannot
-            # recover a frozen loop. Arm a plain OS thread at the start of
-            # stop(); if teardown never finishes within drain+grace it dumps
-            # faulthandler stacks and os._exit so KeepAlive/systemd can revive.
-            # Skip under pytest so stop()-driving unit tests don't get a
-            # delayed hard-exit in the worker.
-            _watchdog_done = threading.Event()
-            self._shutdown_watchdog_done = _watchdog_done
-            _stop_started_at_box: dict[str, float] = {}
-
-            def _shutdown_watchdog_snapshot() -> dict:
-                started = _stop_started_at_box.get("t")
-                return {
-                    "restart_requested": bool(self._restart_requested),
-                    "draining": bool(self._draining),
-                    "running": bool(self._running),
-                    "active_agents": self._running_agent_count(),
-                    "active_cron_jobs": self._active_cron_job_count(),
-                    "active_api_runs": self._active_api_run_count(),
-                    "restart_drain_timeout": self._restart_drain_timeout,
-                    "watchdog_delay_s": resolve_shutdown_watchdog_delay(
-                        self._restart_drain_timeout
-                    ),
-                    "phase_elapsed_s": (
-                        time.monotonic() - started if started is not None else None
-                    ),
-                }
-
-            if not os.environ.get("PYTEST_CURRENT_TEST"):
-                arm_shutdown_watchdog(
-                    resolve_shutdown_watchdog_delay(self._restart_drain_timeout),
-                    done_event=_watchdog_done,
-                    snapshot_fn=_shutdown_watchdog_snapshot,
-                    exit_code=1,
-                )
-
-            try:
-                await _stop_impl_body(
-                    _kill_tool_subprocesses,
-                    _stop_started_at_box,
-                )
-            finally:
-                _watchdog_done.set()
-
-        async def _stop_impl_body(_kill_tool_subprocesses, _stop_started_at_box) -> None:
             logger.info(
                 "Stopping gateway%s...",
                 " for restart" if self._restart_requested else "",
             )
             _stop_started_at = time.monotonic()
-            _stop_started_at_box["t"] = _stop_started_at
 
             def _phase_elapsed() -> float:
                 return time.monotonic() - _stop_started_at
 
             self._running = False
             self._draining = True
-
-            stop_watchdog = getattr(self, "_stop_systemd_watchdog", None)
-            if callable(stop_watchdog):
-                await stop_watchdog()
-
-            await self._cancel_secondary_profile_reconnect_tasks()
 
             # Notify all chats with active agents BEFORE draining.
             # Adapters are still connected here, so messages can be sent.
@@ -9210,7 +8931,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
                 claimed[(platform, fp)] = profile_name
 
-            self._configure_profile_adapter(adapter, profile_name, platform)
+            # Stamp every inbound event from this adapter with its profile so
+            # the agent turn (and session key) resolve to the right home.
+            adapter.set_message_handler(
+                self._make_profile_message_handler(profile_name)
+            )
+            adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+            adapter.set_session_store(self.session_store)
+            adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+            adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
+            adapter.set_authorization_check(
+                self._make_adapter_auth_check(adapter.platform, profile_name=profile_name)
+            )
+            adapter._busy_text_mode = self._busy_text_mode
 
             try:
                 with _profile_runtime_scope(profile_home):
@@ -9226,192 +8959,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.error("✗ %s error (profile: %s): %s", platform.value, profile_name, e)
                 await self._safe_adapter_disconnect(adapter, platform)
         return connected
-
-    def _configure_profile_adapter(
-        self,
-        adapter: BasePlatformAdapter,
-        profile_name: str,
-        platform: Platform,
-    ) -> None:
-        """Install the profile-scoped handlers shared by startup and reconnect."""
-        adapter.set_message_handler(self._make_profile_message_handler(profile_name))
-        adapter.set_fatal_error_handler(
-            self._make_profile_fatal_error_handler(profile_name, platform)
-        )
-        adapter.set_session_store(self.session_store)
-        adapter.set_busy_session_handler(self._handle_active_session_busy_message)
-        adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
-        adapter.set_authorization_check(
-            self._make_adapter_auth_check(platform, profile_name=profile_name)
-        )
-        adapter._busy_text_mode = self._busy_text_mode
-
-    async def _run_secondary_profile_reconnect(
-        self, profile_name: str, platform: Platform
-    ) -> None:
-        """Reconnect a retryable secondary adapter under its own profile scope."""
-        attempts = 0
-        current_task = asyncio.current_task()
-        try:
-            while self._running:
-                adapter = None
-                try:
-                    from hermes_cli.profiles import get_profile_dir
-                    from gateway.config import load_gateway_config
-
-                    profile_home = get_profile_dir(profile_name)
-                    with _profile_runtime_scope(profile_home):
-                        profile_config = load_gateway_config().platforms.get(platform)
-                        if profile_config is None or not profile_config.enabled:
-                            return
-                        adapter = self._create_adapter(platform, profile_config)
-                        if adapter is None:
-                            logger.warning(
-                                "Secondary %s reconnect skipped: adapter unavailable (profile: %s)",
-                                platform.value,
-                                profile_name,
-                            )
-                            return
-                        self._configure_profile_adapter(
-                            adapter, profile_name, platform
-                        )
-                        success = await self._connect_adapter_with_timeout(
-                            adapter, platform, is_reconnect=True
-                        )
-
-                    if success and self._running:
-                        profile_map = self._profile_adapters.setdefault(profile_name, {})
-                        if platform not in profile_map:
-                            profile_map[platform] = adapter
-                            self._sync_voice_mode_state_to_adapter(adapter)
-                            logger.info(
-                                "✓ %s reconnected (profile: %s)",
-                                platform.value,
-                                profile_name,
-                            )
-                            return
-                        # A newer reconnect already won the slot while this
-                        # attempt was awaiting connect; do not replace it.
-                        await self._safe_adapter_disconnect(adapter, platform)
-                        return
-
-                    # Shutdown can begin while connect() is in flight. Do not
-                    # republish a newly connected adapter after the registry has
-                    # been drained; release its partial resources instead.
-                    if success:
-                        await self._safe_adapter_disconnect(adapter, platform)
-                        return
-
-                    await self._safe_adapter_disconnect(adapter, platform)
-                    if (
-                        getattr(adapter, "has_fatal_error", False)
-                        and not getattr(adapter, "fatal_error_retryable", True)
-                    ):
-                        return
-                except asyncio.CancelledError:
-                    if adapter is not None:
-                        await self._safe_adapter_disconnect(adapter, platform)
-                    raise
-                except Exception:
-                    if adapter is not None:
-                        await self._safe_adapter_disconnect(adapter, platform)
-                    logger.debug(
-                        "Secondary %s reconnect attempt failed (profile: %s)",
-                        platform.value,
-                        profile_name,
-                        exc_info=True,
-                    )
-
-                if not self._running:
-                    return
-                attempts += 1
-                backoff = _reconnect_backoff(attempts)
-                logger.info(
-                    "Secondary %s reconnect retry in %ds (profile: %s)",
-                    platform.value,
-                    backoff,
-                    profile_name,
-                )
-                await asyncio.sleep(backoff)
-        finally:
-            pending = self._profile_failed_platforms
-            if isinstance(pending, dict):
-                profile_pending = pending.get(profile_name)
-                task = profile_pending.get(platform) if isinstance(profile_pending, dict) else None
-                if not isinstance(task, asyncio.Task) or task is current_task:
-                    if isinstance(profile_pending, dict):
-                        profile_pending.pop(platform, None)
-                        if not profile_pending:
-                            pending.pop(profile_name, None)
-
-    def _schedule_secondary_profile_reconnect(
-        self, profile_name: str, platform: Platform, adapter: BasePlatformAdapter
-    ) -> None:
-        """Schedule one runner-owned reconnect without sharing primary secrets."""
-        if not self._running or not adapter.fatal_error_retryable:
-            return
-        pending = self._profile_failed_platforms
-        if not isinstance(pending, dict):
-            pending = {}
-            self._profile_failed_platforms = pending
-        profile_pending = pending.setdefault(profile_name, {})
-        if platform in profile_pending:
-            return
-        task = asyncio.create_task(
-            self._run_secondary_profile_reconnect(profile_name, platform),
-            name=f"secondary-reconnect:{profile_name}:{platform.value}",
-        )
-        profile_pending[platform] = task
-        background_tasks = getattr(self, "_background_tasks", None)
-        if not isinstance(background_tasks, set):
-            background_tasks = set()
-            self._background_tasks = background_tasks
-        background_tasks.add(task)
-        task.add_done_callback(background_tasks.discard)
-
-    def _make_profile_fatal_error_handler(
-        self, profile_name: str, platform: Platform
-    ) -> Callable[[BasePlatformAdapter], Awaitable[None]]:
-        """Route a secondary-profile fatal error to that profile's reconnect slot."""
-        async def _handler(adapter: BasePlatformAdapter) -> None:
-            await self._handle_profile_adapter_fatal_error(profile_name, platform, adapter)
-
-        return _handler
-
-    async def _handle_profile_adapter_fatal_error(
-        self,
-        profile_name: str,
-        platform: Platform,
-        adapter: BasePlatformAdapter,
-    ) -> None:
-        """Remove a failed multiplexed adapter without touching the primary slot.
-
-        Secondary adapters are owned by ``_profile_adapters`` rather than
-        ``self.adapters``. The primary-only fatal handler intentionally ignores
-        them; without this route, a fatal secondary Discord client stayed live
-        forever after its liveness sampler stopped.
-        """
-        profile_map = getattr(self, "_profile_adapters", {}).get(profile_name)
-        if not isinstance(profile_map, dict) or profile_map.get(platform) is not adapter:
-            logger.debug(
-                "Ignoring stale fatal error from secondary %s adapter (profile: %s)",
-                platform.value,
-                profile_name,
-            )
-            return
-        profile_map.pop(platform, None)
-        await self._safe_adapter_disconnect(adapter, platform)
-        if not self._running:
-            return
-        self._schedule_secondary_profile_reconnect(profile_name, platform, adapter)
-        logger.error(
-            "Fatal %s adapter error for multiplexed profile %s (%s)",
-            platform.value,
-            profile_name,
-            adapter.fatal_error_code or "unknown",
-        )
-        # Reconnect is scoped to the profile's own config and secret mapping;
-        # never rebuild a secondary adapter with the default profile's credentials.
 
     def _make_profile_message_handler(self, profile_name: str):
         """Return a message handler that stamps source.profile then delegates.
@@ -10732,8 +10279,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
-        if canonical == "topup":
-            return await self._handle_topup_command(event)
+        if canonical == "credits":
+            return await self._handle_credits_command(event)
 
         if canonical == "insights":
             return await self._handle_insights_command(event)
@@ -11293,13 +10840,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if image_paths:
                 # Decide routing: native (attach pixels) vs text (vision_analyze
                 # pre-run + prepend description).  See agent/image_routing.py.
-                # Offload to a worker thread: the decision does blocking network
-                # I/O — a models.dev fetch on cache miss, and the Ollama
-                # ``/api/show`` capability probe for local servers — whose
-                # request timeout would otherwise stall the whole gateway event
-                # loop (every session) while a single image is routed.
-                _img_mode = await asyncio.to_thread(
-                    self._decide_image_input_mode,
+                _img_mode = self._decide_image_input_mode(
                     source=source,
                     session_key=session_key,
                 )
@@ -15869,9 +15410,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return None
 
             platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+            if (
+                platform_cfg is not None
+                and not platform_cfg.restart_requester_notification
+            ):
                 logger.info(
-                    "Restart notification suppressed: %s has gateway_restart_notification=false",
+                    "Restart requester notification suppressed: %s has "
+                    "restart_requester_notification=false",
                     platform_str,
                 )
                 return None
@@ -22114,7 +21659,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if runner.exit_code is not None:
             raise SystemExit(runner.exit_code)
         return True
-
+    
     # Start the background cron scheduler via the resolved provider so
     # scheduled jobs fire automatically. The built-in provider is the
     # historical in-process 60s ticker; an external provider (e.g. chronos)
@@ -22151,14 +21696,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="gateway-housekeeping",
     )
     housekeeping_thread.start()
-
-    # READY is emitted only after adapters, cron, and housekeeping have all
-    # reached their running boundary. Missing config/systemd runtime state
-    # leaves the watchdog disabled without changing gateway behavior.
-    start_watchdog = getattr(runner, "_start_systemd_watchdog", None)
-    if callable(start_watchdog):
-        start_watchdog()
-
+    
     # Wait for shutdown
     await runner.wait_for_shutdown()
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -4,8 +4,6 @@ import logging
 import os
 from unittest.mock import patch
 
-import pytest
-
 from agent.secret_scope import reset_secret_scope, set_secret_scope
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway.config import (
@@ -75,6 +73,19 @@ class TestPlatformConfigRoundtrip:
     def test_gateway_restart_notification_coerces_quoted_false(self):
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
+
+    def test_restart_requester_notification_defaults_true(self):
+        assert PlatformConfig().restart_requester_notification is True
+        assert PlatformConfig.from_dict({}).restart_requester_notification is True
+
+    def test_restart_requester_notification_roundtrip_false(self):
+        pc = PlatformConfig(enabled=True, restart_requester_notification=False)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.restart_requester_notification is False
+
+    def test_restart_requester_notification_coerces_quoted_false(self):
+        restored = PlatformConfig.from_dict({"restart_requester_notification": "false"})
+        assert restored.restart_requester_notification is False
 
     def test_typing_indicator_defaults_true(self):
         assert PlatformConfig().typing_indicator is True
@@ -306,7 +317,6 @@ class TestGatewayConfigRoundtrip:
             quick_commands={"limits": {"type": "exec", "command": "echo ok"}},
             group_sessions_per_user=False,
             thread_sessions_per_user=True,
-            systemd_watchdog_seconds=120,
         )
         d = config.to_dict()
         restored = GatewayConfig.from_dict(d)
@@ -317,33 +327,6 @@ class TestGatewayConfigRoundtrip:
         assert restored.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
         assert restored.group_sessions_per_user is False
         assert restored.thread_sessions_per_user is True
-        assert restored.systemd_watchdog_seconds == 120
-
-    def test_systemd_watchdog_from_dict_disables_invalid_values(self):
-        invalid_values = [
-            None,
-            0,
-            -1,
-            True,
-            1.5,
-            float("nan"),
-            float("inf"),
-            "120.0",
-            "1e3",
-            "bad",
-            2_147_483_648,
-        ]
-
-        for raw in invalid_values:
-            config = GatewayConfig.from_dict({"systemd_watchdog_seconds": raw})
-            assert config.systemd_watchdog_seconds == 0
-
-    def test_systemd_watchdog_from_dict_accepts_nested_positive_integer(self):
-        config = GatewayConfig.from_dict(
-            {"gateway": {"systemd_watchdog_seconds": "45"}}
-        )
-
-        assert config.systemd_watchdog_seconds == 45
 
     def test_max_concurrent_sessions_from_dict_normalizes_disabled_values(self):
         assert GatewayConfig.from_dict({}).max_concurrent_sessions is None
@@ -482,6 +465,26 @@ class TestLoadGatewayConfig:
 
         assert config.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
 
+    def test_bridges_restart_requester_notification_from_platform_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "telegram:\n"
+            "  enabled: true\n"
+            "  gateway_restart_notification: false\n"
+            "  restart_requester_notification: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+        telegram = config.platforms[Platform.TELEGRAM]
+
+        assert telegram.gateway_restart_notification is False
+        assert telegram.restart_requester_notification is True
+
     def test_multiplex_profiles_from_nested_gateway_section(self, tmp_path, monkeypatch):
         """``gateway.multiplex_profiles: true`` (the nested form written by
         ``hermes config set gateway.multiplex_profiles true``) must enable
@@ -507,32 +510,6 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.multiplex_profiles is True
-
-    def test_discord_websocket_health_settings_seed_platform_extra(self, tmp_path, monkeypatch):
-        hermes_home = tmp_path / ".hermes"
-        hermes_home.mkdir()
-        (hermes_home / "config.yaml").write_text(
-            "discord:\n"
-            "  websocket_liveness_interval_seconds: 17\n"
-            "  websocket_liveness_failure_threshold: 4\n"
-            "  websocket_heartbeat_ack_max_age_seconds: 75\n"
-            "  websocket_max_latency_seconds: 30\n",
-            encoding="utf-8",
-        )
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        for key in (
-            "HERMES_DISCORD_LIVENESS_INTERVAL_SECONDS",
-            "HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD",
-        ):
-            monkeypatch.delenv(key, raising=False)
-
-        config = load_gateway_config()
-
-        extra = config.platforms[Platform.DISCORD].extra
-        assert extra["websocket_liveness_interval_seconds"] == 17
-        assert extra["websocket_liveness_failure_threshold"] == 4
-        assert extra["websocket_heartbeat_ack_max_age_seconds"] == 75
-        assert extra["websocket_max_latency_seconds"] == 30
 
     def test_relay_platform_enabled_from_env_url(self, tmp_path, monkeypatch):
         """GATEWAY_RELAY_URL must enable Platform.RELAY in config.platforms so

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -584,15 +584,10 @@ async def test_send_home_channel_startup_notification_default_flag_true(
 
 
 @pytest.mark.asyncio
-async def test_send_restart_notification_skipped_when_flag_disabled(
+async def test_send_restart_notification_uses_requester_flag_independently(
     tmp_path, monkeypatch
 ):
-    """The /restart originator's notification also honors the per-platform flag.
-
-    Slack used by end users → flag off → no "Gateway restarted" message even
-    when an end user accidentally triggers /restart. The marker file is still
-    cleaned up so the notification doesn't leak into the next boot.
-    """
+    """Broadcast opt-out must not suppress the exact /restart requester."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
     notify_path = tmp_path / ".restart_notify.json"
@@ -603,6 +598,32 @@ async def test_send_restart_notification_skipped_when_flag_disabled(
 
     runner, adapter = make_restart_runner()
     runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    runner.config.platforms[Platform.TELEGRAM].restart_requester_notification = True
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m-1"))
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "42", None)
+    adapter.send.assert_awaited_once()
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_skipped_when_requester_flag_disabled(
+    tmp_path, monkeypatch
+):
+    """The dedicated requester flag can silence chat-originated completion pings."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = True
+    runner.config.platforms[Platform.TELEGRAM].restart_requester_notification = False
     adapter.send = AsyncMock()
 
     delivered_target = await runner._send_restart_notification()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1699,6 +1699,26 @@ For separate natural mid-turn assistant updates without progressive token editin
 The master `streaming.enabled` switch is `false` by default — nothing streams until you flip it. Once enabled, streaming is decided **per platform**: Telegram ships with `display.platforms.telegram.streaming: true` (streams) and Discord with `display.platforms.discord.streaming: false` (does not). So after enabling streaming, Telegram streams out of the box and Discord stays on whole-message replies until you change its toggle. You can adjust these per-platform switches from the dashboard's **Channels** toggles or directly in `~/.hermes/config.yaml`.
 :::
 
+## Gateway Restart Notifications
+
+Restart notifications have two independent per-platform controls:
+
+```yaml
+telegram:
+  # Broadcast lifecycle messages to active sessions and the configured home
+  # channel. This includes startup messages after terminal/service restarts.
+  gateway_restart_notification: false
+
+  # Reply only to the exact chat/topic that issued /restart after the gateway
+  # comes back. Terminal/service restarts have no requester and send nothing.
+  restart_requester_notification: true
+```
+
+This combination is useful when operators want `/restart` to confirm success
+to its requester without broadcasting restart messages to other users. Set
+`restart_requester_notification: false` as well to make chat-originated
+restarts completely silent after startup.
+
 ## Group Chat Session Isolation
 
 Limit how many chat sessions can actively be open across CLI, TUI/dashboard,


### PR DESCRIPTION
## Summary
- add a per-platform `restart_requester_notification` setting
- decouple the exact chat-originated `/restart` completion reply from broadcast lifecycle notifications
- keep terminal/service restarts silent when `gateway_restart_notification: false`
- document the two independent controls

## Motivation
Today `gateway_restart_notification: false` suppresses both broad home/active-session lifecycle pings and the precise completion reply to the chat that issued `/restart`. That makes it impossible to confirm the command only to its requester without notifying everyone else.

## Test plan
- configuration default, round-trip, quoted boolean, and YAML bridge tests
- requester delivery remains enabled while broadcasts are disabled
- dedicated requester opt-out suppresses and cleans up the marker
- existing home-channel broadcast opt-out remains covered