### PR TITLE
fix(desktop): use native frame on WSL

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -130,6 +130,7 @@ import {
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import { spawnUpdaterProcess } from './updater-process'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
+import { windowTitleBarStyle } from './window-frame-options'
 import {
   computeWindowOptions,
   debounce,
@@ -7247,7 +7248,7 @@ function spawnSecondaryWindow({
     minWidth: SESSION_WINDOW_MIN_WIDTH,
     minHeight: SESSION_WINDOW_MIN_HEIGHT,
     title: 'Hermes',
-    titleBarStyle: 'hidden',
+    titleBarStyle: windowTitleBarStyle(IS_WSL),
     titleBarOverlay: getTitleBarOverlayOptions(),
     trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
     vibrancy: IS_MAC ? 'sidebar' : undefined,
@@ -7458,7 +7459,7 @@ function createWindow() {
     // inside the same band. On Windows/Linux, titleBarOverlay tells Electron
     // to paint native min/max/close in the top-right of the renderer; on
     // macOS it just reserves a content inset alongside the traffic lights.
-    titleBarStyle: 'hidden',
+    titleBarStyle: windowTitleBarStyle(IS_WSL),
     titleBarOverlay: getTitleBarOverlayOptions(),
     trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
     vibrancy: IS_MAC ? 'sidebar' : undefined,

--- a/apps/desktop/electron/window-frame-options.test.ts
+++ b/apps/desktop/electron/window-frame-options.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { windowTitleBarStyle } from './window-frame-options'
+
+test('uses the native title bar on WSL', () => {
+  assert.equal(windowTitleBarStyle(true), 'default')
+})
+
+test('preserves the hidden title bar outside WSL', () => {
+  assert.equal(windowTitleBarStyle(false), 'hidden')
+})

--- a/apps/desktop/electron/window-frame-options.ts
+++ b/apps/desktop/electron/window-frame-options.ts
@@ -1,0 +1,3 @@
+export function windowTitleBarStyle(isWsl: boolean): 'default' | 'hidden' {
+  return isWsl ? 'default' : 'hidden'
+}


### PR DESCRIPTION
## What does this PR do?

Uses Electron's native/default title bar for Hermes Desktop windows on WSL while preserving the existing hidden title bar behavior on macOS, Windows, and non-WSL Linux.

Hermes already disables `titleBarOverlay` on WSL because WSLg paints window controls through the RDP host. Keeping `titleBarStyle: 'hidden'` at the same time can leave the window without visible close/minimize/maximize controls or practical resize borders. Selecting `default` only when `IS_WSL` restores those native controls.

## Related Issue

No linked issue. Reproduced locally on WSL2/WSLg.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `windowTitleBarStyle(isWsl)` as a small pure platform decision helper.
- Use the native/default title bar for primary and secondary Desktop windows on WSL.
- Preserve the existing title bar overlay, theme, vibrancy, and traffic-light behavior on every other platform.
- Add focused tests for WSL and non-WSL title bar selection.

## How to Test

1. Run `../../node_modules/.bin/vitest run --project electron electron/window-frame-options.test.ts` from `apps/desktop`.
2. Run `npm run typecheck` and ESLint on the three touched files.
3. Build Desktop, launch it under WSLg, and verify visible minimize/maximize/close controls plus resize from the native borders.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 with WSL2/WSLg

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior-only platform fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture/workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — non-WSL behavior remains unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool changes

## Screenshots / Logs

Runtime validation on WSLg:

```text
Hermes main window: Map State: IsViewable
Focused Vitest: 2 passed
TypeScript typecheck: passed
ESLint: passed with zero warnings
```

Manual validation confirmed visible native close/minimize/maximize controls and working border resize.
