### PR TITLE
feat(tools): add named execution targets

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -38,7 +38,6 @@ from agent.message_sanitization import (
     _repair_tool_call_arguments,
 )
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
-from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
@@ -2118,23 +2117,23 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 def cleanup_task_resources(agent, task_id: str) -> None:
     """Clean up VM and browser resources for a given task.
 
-    Skips ``cleanup_vm`` when the active terminal environment is marked
-    persistent (``persistent_filesystem=True``) so that long-lived sandbox
-    containers survive between turns. The idle reaper in
+    Removes each non-persistent target while keeping persistent named sibling
+    environments live so long-lived containers survive between turns. The
+    idle reaper in
     ``terminal_tool._cleanup_inactive_envs`` still tears them down once
     ``terminal.lifetime_seconds`` is exceeded. Non-persistent backends are
     torn down per-turn as before to prevent resource leakage (the original
     intent of this hook for the Morph backend, see commit fbd3a2fd).
     """
     try:
-        if is_persistent_env(task_id):
-            if agent.verbose_logging:
-                logging.debug(
-                    f"Skipping per-turn cleanup_vm for persistent env {task_id}; "
-                    f"idle reaper will handle it."
-                )
-        else:
-            _ra().cleanup_vm(task_id)
+        from tools.terminal_tool import active_environment_turns
+
+        remaining_turns = active_environment_turns(task_id)
+        _ra().cleanup_vm(
+            task_id,
+            preserve_persistent=True,
+            include_collapsed=(remaining_turns == 0),
+        )
     except Exception as e:
         if agent.verbose_logging:
             logger.warning(f"Failed to cleanup VM for task {task_id}: {e}")

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -4,6 +4,7 @@ All functions are stateless. AIAgent._build_system_prompt() calls these to
 assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -935,7 +936,7 @@ _BACKEND_FALLBACK_DESCRIPTIONS: dict[str, str] = {
 # a mid-process backend switch rebuilds the string. Kept in-module (not on
 # disk) because the probe captures live backend state that may change
 # across Hermes restarts.
-_BACKEND_PROBE_CACHE: dict[tuple[str, str], str] = {}
+_BACKEND_PROBE_CACHE: dict[tuple[str, str, str], str] = {}
 
 
 _WINDOWS_BASH_SHELL_HINT = (
@@ -949,7 +950,11 @@ _WINDOWS_BASH_SHELL_HINT = (
 )
 
 
-def _probe_remote_backend(env_type: str) -> str | None:
+def _probe_remote_backend(
+    env_type: str,
+    terminal_config: dict | None = None,
+    target_name: str = "",
+) -> str | None:
     """Run a tiny introspection command inside the active terminal backend.
 
     Returns a pre-formatted multi-line string describing the backend's OS,
@@ -957,8 +962,14 @@ def _probe_remote_backend(env_type: str) -> str | None:
     per process. Used only for non-local backends where the agent's tools
     operate on a different machine than the host Hermes runs on.
     """
-    cwd_hint = os.getenv("TERMINAL_CWD", "")
-    cache_key = (env_type, cwd_hint)
+    if terminal_config is None:
+        config_identity = os.getenv("TERMINAL_CWD", "")
+    else:
+        serialized = json.dumps(
+            terminal_config, sort_keys=True, default=str, ensure_ascii=True,
+        )
+        config_identity = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    cache_key = (env_type, target_name, config_identity)
     cached = _BACKEND_PROBE_CACHE.get(cache_key)
     if cached is not None:
         return cached or None
@@ -973,7 +984,11 @@ def _probe_remote_backend(env_type: str) -> str | None:
         return None
 
     try:
-        config = _get_env_config()
+        config = (
+            _get_env_config(dict(terminal_config))
+            if terminal_config is not None
+            else _get_env_config()
+        )
         # Build the environment the same way tools/terminal_tool.py does for a
         # live command: select the backend image, then assemble ssh/container
         # config from the env-derived dict. (There is no `get_environment`
@@ -1024,7 +1039,12 @@ def _probe_remote_backend(env_type: str) -> str | None:
             timeout=config.get("timeout", 180),
             ssh_config=ssh_config,
             container_config=container_config,
-            task_id="prompt-backend-probe",
+            task_id=(
+                "prompt-backend-probe-"
+                + hashlib.sha256(
+                    f"{env_type}:{target_name}:{config_identity}".encode("utf-8")
+                ).hexdigest()[:12]
+            ),
             host_cwd=config.get("host_cwd"),
         )
         # Single-line POSIX probe — works on any Unixy backend. Wrapped in
@@ -1102,7 +1122,26 @@ def build_environment_hints() -> str:
 
     hints: list[str] = []
 
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    target_inventory = ()
+    default_target = None
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        resolved_targets = list_execution_targets()
+        if resolved_targets and resolved_targets[0].named:
+            target_inventory = resolved_targets
+            default_target = next(
+                (item for item in target_inventory if item.is_default),
+                target_inventory[0],
+            )
+    except Exception as e:
+        logger.debug("Could not resolve named execution targets for prompt: %s", e)
+
+    backend = (
+        default_target.backend
+        if default_target is not None
+        else (os.getenv("TERMINAL_ENV") or "local")
+    ).strip().lower()
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS
 
     if not is_remote_backend:
@@ -1120,8 +1159,15 @@ def build_environment_hints() -> str:
 
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
-            host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
-        except OSError:
+            if default_target is not None:
+                from tools.terminal_tool import _get_env_config
+
+                cwd_hint = _get_env_config(dict(default_target.config)).get("cwd")
+            else:
+                cwd_hint = resolve_agent_cwd()
+            if cwd_hint:
+                host_lines.append(f"Current working directory: {cwd_hint}")
+        except (OSError, TypeError, ValueError):
             pass
 
         if sys.platform == "win32" and not is_wsl():
@@ -1139,11 +1185,32 @@ def build_environment_hints() -> str:
             hints.append(_WINDOWS_BASH_SHELL_HINT)
     else:
         # --- Remote backend block (host info suppressed) ---
-        probe = _probe_remote_backend(backend)
+        probe = (
+            _probe_remote_backend(
+                backend,
+                terminal_config=dict(default_target.config),
+                target_name=(
+                    f"{default_target.profile_scope}:{default_target.target}"
+                    if default_target.profile_scope
+                    else default_target.target
+                ),
+            )
+            if default_target is not None
+            else _probe_remote_backend(backend)
+        )
+        tool_scope = (
+            "Calls to `terminal`, `read_file`, `write_file`, `patch`, "
+            "`search_files`, and `execute_code` that omit an execution-target "
+            "selector operate"
+            if default_target is not None
+            else (
+                "Your `terminal`, `read_file`, `write_file`, `patch`, "
+                "`search_files`, and `execute_code` tools all operate"
+            )
+        )
         if probe:
             hints.append(
-                f"Terminal backend: {backend}. Your `terminal`, `read_file`, "
-                f"`write_file`, `patch`, and `search_files` tools all operate "
+                f"Terminal backend: {backend}. {tool_scope} "
                 f"inside this {backend} environment — NOT on the machine "
                 f"where Hermes itself is running. The host OS, home, and cwd "
                 f"of the Hermes process are irrelevant; only the following "
@@ -1154,8 +1221,7 @@ def build_environment_hints() -> str:
                 backend, f"a {backend} environment (likely Linux)"
             )
             hints.append(
-                f"Terminal backend: {backend}. Your `terminal`, `read_file`, "
-                f"`write_file`, `patch`, and `search_files` tools all operate "
+                f"Terminal backend: {backend}. {tool_scope} "
                 f"inside {description} — NOT on the machine where Hermes "
                 f"itself runs. The backend probe didn't respond at "
                 f"prompt-build time, so the sandbox's current user, $HOME, "
@@ -1163,6 +1229,23 @@ def build_environment_hints() -> str:
                 f"them, probe directly with a terminal call like "
                 f"`uname -a && whoami && pwd`."
             )
+
+    if default_target is not None and default_target.named:
+        target_summary = ", ".join(
+            f"{json.dumps(item.target, ensure_ascii=True)} ({item.backend}"
+            f"{', default' if item.is_default else ''})"
+            for item in target_inventory
+        )
+        hints.append(
+            "Configured execution targets: " + target_summary + ". "
+            "`terminal`, `read_file`, `write_file`, `patch`, and `execute_code` "
+            "select one with `target`; `search_files` uses `execution_target` "
+            "because its existing `target` argument selects content/files mode. "
+            "Omitting the selector uses the default target. Environment facts "
+            "above describe only the default target "
+            f"{json.dumps(default_target.target, ensure_ascii=True)}; "
+            "tool results report the resolved target, backend, and cwd."
+        )
 
     if is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -20,7 +20,7 @@ import os
 import random
 import threading
 import time
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from agent.display import (
     KawaiiSpinner,
@@ -45,6 +45,7 @@ from tools.terminal_tool import (
 )
 from tools.thread_context import propagate_context_to_thread
 from tools.tool_result_storage import (
+    PERSISTED_OUTPUT_TAG,
     maybe_persist_tool_result,
     enforce_turn_budget,
 )
@@ -67,6 +68,195 @@ def _budget_for_agent(agent) -> BudgetConfig:
         return budget_for_context_window(int(ctx)) if ctx else DEFAULT_BUDGET
     except Exception:
         return DEFAULT_BUDGET
+
+
+def _handle_function_call_with_env_usage(
+    effective_task_id: str,
+    function_name: str,
+    function_args: dict,
+    **kwargs,
+):
+    from tools.terminal_tool import environment_turn_usage
+
+    with environment_turn_usage(effective_task_id):
+        return _ra().handle_function_call(
+            function_name, function_args, effective_task_id, **kwargs,
+        )
+
+
+_TARGET_RESULT_TOOLS = {
+    "terminal", "read_file", "write_file", "patch", "search_files",
+    "execute_code", "process",
+}
+
+
+def _resolved_tool_target(tool_name: str, args: dict, result: Any = None) -> str | None:
+    """Resolve the target identity carried by a tool call/result."""
+    if tool_name in _TARGET_RESULT_TOOLS and isinstance(result, str):
+        try:
+            payload = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            payload = None
+        if isinstance(payload, dict) and isinstance(payload.get("target"), str):
+            return payload["target"]
+    if tool_name == "search_files":
+        value = args.get("execution_target")
+    elif tool_name in _TARGET_RESULT_TOOLS:
+        value = args.get("target")
+    else:
+        value = None
+    return value if isinstance(value, str) and value else None
+
+
+def _active_env_for_tool_result(
+    task_id: str, tool_name: str, args: dict, result: Any = None,
+):
+    target = _resolved_tool_target(tool_name, args, result)
+    try:
+        return get_active_env(task_id, target=target)
+    except Exception:
+        # Persistence is best-effort. Preserve the handler's actionable
+        # configuration error instead of raising a second lookup failure.
+        return None
+
+
+def _append_persisted_target_hint(content: str, target: str | None) -> str:
+    if (
+        target
+        and PERSISTED_OUTPUT_TAG in content
+        and "Execution target for this saved output:" not in content
+    ):
+        return (
+            content
+            + "\nExecution target for this saved output: "
+            + json.dumps(target, ensure_ascii=True)
+            + ". Pass that value as `target` to `read_file`."
+        )
+    return content
+
+
+def _tool_target_map(agent) -> dict[str, str]:
+    mapping = getattr(agent, "_execution_target_by_tool_call", None)
+    if not isinstance(mapping, dict):
+        mapping = {}
+        setattr(agent, "_execution_target_by_tool_call", mapping)
+    return mapping
+
+
+def _selected_local_target_cwd(
+    effective_task_id: str,
+    function_name: str,
+    function_args: dict,
+) -> str | None:
+    """Return the selected target's host cwd, or None for remote targets."""
+    selector_name = (
+        "execution_target" if function_name == "search_files" else "target"
+    )
+    target = function_args.get(selector_name)
+    try:
+        from tools.execution_targets import resolve_execution_target
+        from tools.terminal_tool import _get_env_config, get_session_cwd
+
+        resolution = resolve_execution_target(target)
+        if resolution.backend != "local":
+            return None
+        selected = resolution.target if resolution.named else None
+        cwd = get_session_cwd(effective_task_id, target=selected)
+        if not cwd:
+            config = (
+                _get_env_config(dict(resolution.config))
+                if resolution.named
+                else _get_env_config()
+            )
+            cwd = config.get("cwd")
+        if not isinstance(cwd, str) or not cwd:
+            return None
+        return os.path.abspath(os.path.expanduser(cwd))
+    except Exception:
+        return None
+
+
+def _target_subdirectory_hints(
+    agent,
+    task_id: str,
+    tool_name: str,
+    args: dict,
+    target: str | None,
+):
+    """Load local hints from the selected target; never scan host paths for remotes."""
+    try:
+        from agent.subdirectory_hints import SubdirectoryHintTracker
+        from tools.execution_targets import resolve_execution_target
+        from tools.terminal_tool import _get_env_config, get_session_cwd
+
+        resolution = resolve_execution_target(target)
+        if resolution.backend != "local":
+            return None
+        if not resolution.named:
+            return agent._subdirectory_hints.check_tool_call(tool_name, args)
+        selected_target = resolution.target
+        cwd = get_session_cwd(task_id, target=selected_target)
+        if not cwd:
+            cwd = _get_env_config(dict(resolution.config)).get("cwd")
+        if not isinstance(cwd, str) or not cwd.strip():
+            return None
+        cache_key = (resolution.profile_scope, selected_target, cwd)
+        trackers = getattr(agent, "_target_subdirectory_hints", None)
+        if not isinstance(trackers, dict):
+            trackers = {}
+            setattr(agent, "_target_subdirectory_hints", trackers)
+        tracker = trackers.get(cache_key)
+        if tracker is None:
+            tracker = SubdirectoryHintTracker(working_dir=cwd)
+            trackers[cache_key] = tracker
+        return tracker.check_tool_call(tool_name, args)
+    except Exception:
+        # Hints are optional context. Never replace a tool result with hint
+        # discovery/configuration failures.
+        return None
+
+
+def _enforce_target_aware_turn_budget(
+    tool_messages: list[dict], task_id: str, config: BudgetConfig,
+    target_by_tool_call: dict[str, str] | None = None,
+) -> None:
+    """Persist each aggregate-spilled result in its producing target."""
+    if target_by_tool_call is None:
+        target_by_tool_call = {}
+
+    def _resolve_message_env(message: dict):
+        call_id = str(message.get("tool_call_id") or "")
+        if call_id not in target_by_tool_call:
+            return default_env
+        target = target_by_tool_call.get(call_id)
+        if not isinstance(target, str) or not target:
+            return None
+        try:
+            return get_active_env(task_id, target=target)
+        except Exception:
+            return None
+
+    try:
+        default_env = get_active_env(task_id)
+    except Exception:
+        default_env = None
+
+    enforce_turn_budget(
+        tool_messages,
+        env=default_env,
+        env_resolver=_resolve_message_env,
+        config=config,
+    )
+    for message in tool_messages:
+        tool_call_id = str(message.get("tool_call_id") or "")
+        target = target_by_tool_call.get(tool_call_id)
+        content = message.get("content", "")
+        if isinstance(content, str):
+            message["content"] = _append_persisted_target_hint(
+                content, target,
+            )
+        if tool_call_id:
+            target_by_tool_call.pop(tool_call_id, None)
 
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
@@ -602,16 +792,19 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         start = time.time()
         try:
             try:
-                result = agent._invoke_tool(
-                    function_name,
-                    function_args,
-                    effective_task_id,
-                    tool_call.id,
-                    messages=messages,
-                    pre_tool_block_checked=True,
-                    skip_tool_request_middleware=True,
-                    tool_request_middleware_trace=list(middleware_trace),
-                )
+                from tools.terminal_tool import environment_turn_usage
+
+                with environment_turn_usage(effective_task_id):
+                    result = agent._invoke_tool(
+                        function_name,
+                        function_args,
+                        effective_task_id,
+                        tool_call.id,
+                        messages=messages,
+                        pre_tool_block_checked=True,
+                        skip_tool_request_middleware=True,
+                        tool_request_middleware_trace=list(middleware_trace),
+                    )
             except KeyboardInterrupt:
                 try:
                     agent.interrupt("keyboard interrupt")
@@ -949,20 +1142,33 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
+        result_execution_target = _resolved_tool_target(
+            name, args, function_result,
+        )
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=name,
             tool_use_id=tc.id,
-            env=get_active_env(effective_task_id),
+            env=_active_env_for_tool_result(
+                effective_task_id, name, args, function_result,
+            ),
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
+        if isinstance(function_result, str):
+            function_result = _append_persisted_target_hint(
+                function_result, result_execution_target,
+            )
 
-        subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
+        subdir_hints = _target_subdirectory_hints(
+            agent, effective_task_id, name, args, result_execution_target,
+        )
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
                 # Append the hint to the text summary part so the model
                 # still sees it; don't touch the image blocks.
-                _append_subdir_hint_to_multimodal(function_result, subdir_hints)
+                _append_subdir_hint_to_multimodal(
+                    cast(dict[str, Any], function_result), subdir_hints,
+                )
             else:
                 function_result += subdir_hints
 
@@ -981,6 +1187,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             tc.id,
             effect_disposition=effect_disposition,
         )
+        if result_execution_target:
+            _tool_target_map(agent)[str(tc.id)] = result_execution_target
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if (
@@ -1014,7 +1222,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     num_tools = len(parsed_calls)
     if finalize and num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
-        enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id), config=_tool_budget)
+        _enforce_target_aware_turn_budget(
+            turn_tool_msgs, effective_task_id, _tool_budget,
+            _tool_target_map(agent),
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # Append any pending user steer text to the last tool result so the
@@ -1189,8 +1400,17 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         if not _execution_blocked and function_name in {"write_file", "patch"} and agent._checkpoint_mgr.enabled:
             try:
                 file_path = function_args.get("path", "")
-                if file_path:
-                    work_dir = agent._checkpoint_mgr.get_working_dir_for_path(file_path)
+                target_cwd = _selected_local_target_cwd(
+                    effective_task_id, function_name, function_args,
+                )
+                if file_path and target_cwd:
+                    resolved_path = (
+                        file_path if os.path.isabs(file_path)
+                        else os.path.join(target_cwd, file_path)
+                    )
+                    work_dir = agent._checkpoint_mgr.get_working_dir_for_path(
+                        resolved_path,
+                    )
                     agent._checkpoint_mgr.ensure_checkpoint(
                         work_dir, f"before {function_name}"
                     )
@@ -1202,10 +1422,19 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             try:
                 cmd = function_args.get("command", "")
                 if _is_destructive_command(cmd):
-                    cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
-                    agent._checkpoint_mgr.ensure_checkpoint(
-                        cwd, f"before terminal: {cmd[:60]}"
+                    target_cwd = _selected_local_target_cwd(
+                        effective_task_id, function_name, function_args,
                     )
+                    if target_cwd:
+                        requested_cwd = function_args.get("workdir")
+                        cwd = (
+                            requested_cwd
+                            if requested_cwd and os.path.isabs(requested_cwd)
+                            else os.path.join(target_cwd, requested_cwd or "")
+                        )
+                        agent._checkpoint_mgr.ensure_checkpoint(
+                            cwd, f"before terminal: {cmd[:60]}"
+                        )
             except Exception:
                 pass  # never block tool execution
 
@@ -1483,8 +1712,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 spinner.start()
             _spinner_result = None
             try:
-                function_result = _ra().handle_function_call(
-                    function_name, function_args, effective_task_id,
+                function_result = _handle_function_call_with_env_usage(
+                    effective_task_id, function_name, function_args,
                     tool_call_id=tool_call.id,
                     session_id=agent.session_id or "",
                     turn_id=getattr(agent, "_current_turn_id", "") or "",
@@ -1525,8 +1754,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     agent._vprint(f"  {cute_msg}")
         else:
             try:
-                function_result = _ra().handle_function_call(
-                    function_name, function_args, effective_task_id,
+                function_result = _handle_function_call_with_env_usage(
+                    effective_task_id, function_name, function_args,
                     tool_call_id=tool_call.id,
                     session_id=agent.session_id or "",
                     turn_id=getattr(agent, "_current_turn_id", "") or "",
@@ -1645,19 +1874,36 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
+        result_execution_target = _resolved_tool_target(
+            function_name, function_args, function_result,
+        )
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=function_name,
             tool_use_id=tool_call.id,
-            env=get_active_env(effective_task_id),
+            env=_active_env_for_tool_result(
+                effective_task_id, function_name, function_args, function_result,
+            ),
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
+        if isinstance(function_result, str):
+            function_result = _append_persisted_target_hint(
+                function_result, result_execution_target,
+            )
 
         # Discover subdirectory context files from tool arguments
-        subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)
+        subdir_hints = _target_subdirectory_hints(
+            agent,
+            effective_task_id,
+            function_name,
+            function_args,
+            result_execution_target,
+        )
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
-                _append_subdir_hint_to_multimodal(function_result, subdir_hints)
+                _append_subdir_hint_to_multimodal(
+                    cast(dict[str, Any], function_result), subdir_hints,
+                )
             else:
                 function_result += subdir_hints
 
@@ -1665,6 +1911,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
         tool_message = make_tool_result_message(function_name, _tool_content, tool_call.id)
+        if result_execution_target:
+            _tool_target_map(agent)[str(tool_call.id)] = result_execution_target
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if (
@@ -1728,7 +1976,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # ── Per-turn aggregate budget enforcement ─────────────────────────
     num_tools_seq = len(assistant_message.tool_calls)
     if finalize and num_tools_seq > 0:
-        enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id), config=_tool_budget)
+        _enforce_target_aware_turn_budget(
+            messages[-num_tools_seq:], effective_task_id, _tool_budget,
+            _tool_target_map(agent),
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # See _execute_tool_calls_parallel for the rationale. Same hook,
@@ -1786,10 +2037,9 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
     total_tools = len(assistant_message.tool_calls)
     if total_tools > 0:
         _tool_budget = _budget_for_agent(agent)
-        enforce_turn_budget(
-            messages[-total_tools:],
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
+        _enforce_target_aware_turn_budget(
+            messages[-total_tools:], effective_task_id, _tool_budget,
+            _tool_target_map(agent),
         )
         agent._apply_pending_steer_to_tool_results(messages, total_tools)
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -224,6 +224,23 @@ terminal:
   # sudo_password: "hunter2"  # Optional: pipe a sudo password via sudo -S. SECURITY WARNING: plaintext.
   # sudo_password: ""         # Explicit empty password: try empty and never open the interactive sudo prompt.
 
+# Optional: route each tool call to one of several execution environments.
+# Top-level terminal settings (such as timeout and resource limits) are
+# inherited by every target; values inside a target override them. Keep
+# targets absent or empty to retain the single-backend configuration above.
+# terminal:
+#   timeout: 180
+#   default_target: "local"
+#   targets:
+#     local:
+#       backend: "local"
+#       cwd: "/workspace/local"
+#     devbox:
+#       backend: "ssh"
+#       ssh_host: "devbox.example.com"
+#       ssh_user: "bruno"
+#       cwd: "/home/bruno/project"
+
 # -----------------------------------------------------------------------------
 # OPTION 2: SSH remote execution
 # Commands run on a remote server - agent code stays local (sandboxed)

--- a/cli.py
+++ b/cli.py
@@ -569,7 +569,7 @@ def load_cli_config() -> Dict[str, Any]:
             logger.warning("Failed to load cli-config.yaml: %s", e)
 
     # Expand ${ENV_VAR} references in config values before bridging to env vars.
-    from hermes_cli.config import _expand_env_vars
+    from hermes_cli.config import _expand_env_vars, effective_terminal_config
     defaults = _expand_env_vars(defaults)
 
     # Managed scope: overlay administrator-pinned values LAST so they win over
@@ -584,8 +584,19 @@ def load_cli_config() -> Dict[str, Any]:
 
     defaults = managed_scope.apply_managed_overlay(defaults)
 
+    if os.environ.get("_HERMES_GATEWAY") != "1":
+        from tools.execution_targets import set_execution_target_config_source
+
+        set_execution_target_config_source(defaults)
+
     # Apply terminal config to environment variables (so terminal_tool picks them up)
-    terminal_config = defaults.get("terminal", {})
+    raw_terminal_config = defaults.get("terminal", {})
+    named_terminal_mode = (
+        isinstance(raw_terminal_config, dict)
+        and isinstance(raw_terminal_config.get("targets"), dict)
+        and bool(raw_terminal_config.get("targets"))
+    )
+    terminal_config = effective_terminal_config(raw_terminal_config)
     
     # Normalize config key: the new config system (hermes_cli/config.py) and all
     # documentation use "backend", the legacy cli-config.yaml uses "env_type".
@@ -601,9 +612,13 @@ def load_cli_config() -> Dict[str, Any]:
     _CWD_PLACEHOLDERS = (".", "auto", "cwd")
     effective_backend = terminal_config.get("env_type", "local")
 
-    if effective_backend == "local":
+    if effective_backend == "local" and (
+        not named_terminal_mode
+        or terminal_config.get("cwd") in _CWD_PLACEHOLDERS
+    ):
         terminal_config["cwd"] = os.getcwd()
-        defaults["terminal"]["cwd"] = terminal_config["cwd"]
+        if not named_terminal_mode:
+            defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)
     

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1626,6 +1626,12 @@ if _config_path.exists():
         # config.yaml overrides .env for these since it's the documented config path.
         _terminal_cfg = _cfg.get("terminal", {})
         if _terminal_cfg and isinstance(_terminal_cfg, dict):
+            from hermes_cli.config import effective_terminal_config
+
+            # Legacy consumers below still read TERMINAL_* as the one backend
+            # used when a tool call omits target. In named mode that is the
+            # selected default target, not the top-level inheritance mapping.
+            _terminal_cfg = effective_terminal_config(_terminal_cfg)
             _terminal_backend = str(
                 _terminal_cfg.get("backend") or os.environ.get("TERMINAL_ENV") or ""
             ).strip().lower()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1198,6 +1198,10 @@ DEFAULT_CONFIG = {
 
     "terminal": {
         "backend": "local",
+        # Optional named execution targets. Empty preserves the legacy flat
+        # terminal config and environment-variable behavior.
+        "default_target": "",
+        "targets": {},
         "modal_mode": "auto",
         "cwd": ".",  # Use current directory
         "timeout": 180,
@@ -7097,6 +7101,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "modal_mode": "TERMINAL_MODAL_MODE",
     "cwd": "TERMINAL_CWD",
     "timeout": "TERMINAL_TIMEOUT",
+    "home_mode": "TERMINAL_HOME_MODE",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
     "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
@@ -7128,6 +7133,44 @@ def _terminal_env_value(value: Any) -> str:
     if isinstance(value, (list, dict)):
         return json.dumps(value)
     return str(value)
+
+
+def effective_terminal_config(terminal_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the flat settings represented by the configured default target.
+
+    A few older/runtime-adjacent consumers still use ``TERMINAL_*`` variables
+    to describe the one environment selected when a tool call omits ``target``.
+    In named-target mode those variables must mirror ``default_target`` rather
+    than the top-level inheritance defaults, otherwise prompt hints and helper
+    processes can claim the default backend is local while tools route to SSH.
+
+    Invalid target configuration is left for the strict tool resolver to report;
+    this bridge falls back to the top-level mapping so config loading stays
+    fail-open as it did before named targets existed.
+    """
+    if not isinstance(terminal_cfg, dict):
+        return {}
+    targets = terminal_cfg.get("targets")
+    default_target = terminal_cfg.get("default_target")
+    if not isinstance(targets, dict) or not targets:
+        return dict(terminal_cfg)
+    if not isinstance(default_target, str):
+        return {
+            key: value for key, value in terminal_cfg.items()
+            if key not in {"targets", "default_target"}
+        }
+    selected = targets.get(default_target)
+    if not isinstance(selected, dict):
+        return {
+            key: value for key, value in terminal_cfg.items()
+            if key not in {"targets", "default_target"}
+        }
+    effective = {
+        key: value for key, value in terminal_cfg.items()
+        if key not in {"targets", "default_target"}
+    }
+    effective.update(selected)
+    return effective
 
 
 def terminal_config_env_var_for_key(key: str) -> Optional[str]:
@@ -7165,6 +7208,10 @@ def apply_terminal_config_to_env(
     terminal_cfg = cfg.get("terminal", {}) if isinstance(cfg, dict) else {}
     if not isinstance(terminal_cfg, dict):
         return target
+    terminal_cfg = effective_terminal_config(terminal_cfg)
+    terminal_backend = str(
+        terminal_cfg.get("backend") or terminal_cfg.get("env_type") or "local"
+    ).strip().lower()
 
     for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():
         if cfg_key not in terminal_cfg:
@@ -7174,7 +7221,9 @@ def apply_terminal_config_to_env(
             raw_cwd = str(value or "").strip()
             if raw_cwd in {".", "auto", "cwd"}:
                 continue
-            if isinstance(value, str):
+            if isinstance(value, str) and not (
+                terminal_backend == "ssh" and value.strip().startswith("~")
+            ):
                 value = os.path.expanduser(value)
         if should_override or env_var not in target:
             target[env_var] = _terminal_env_value(value)

--- a/model_tools.py
+++ b/model_tools.py
@@ -605,6 +605,7 @@ def _resolve_active_context_length() -> int:
 # so if something slips through, the LLM sees a sensible message.
 _AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
+_TARGET_SELECTOR_TOOLS = {"terminal", "write_file", "patch", "execute_code"}
 
 
 # =========================================================================
@@ -1232,7 +1233,14 @@ def handle_function_call(
         if function_name not in _READ_SEARCH_TOOLS:
             try:
                 from tools.file_tools import notify_other_tool_call
-                notify_other_tool_call(task_id or "default")
+                notify_other_tool_call(
+                    task_id or "default",
+                    (
+                        function_args.get("target")
+                        if function_name in _TARGET_SELECTOR_TOOLS
+                        else None
+                    ),
+                )
             except Exception:
                 pass  # file_tools may not be loaded yet
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1264,7 +1264,9 @@ class TestEnvironmentHints:
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         # Force the probe to fail so we exercise the static fallback path
         # deterministically (the live probe would try to spin up docker).
-        monkeypatch.setattr(_pb, "_probe_remote_backend", lambda _t: None)
+        monkeypatch.setattr(
+            _pb, "_probe_remote_backend", lambda *args, **kwargs: None,
+        )
         _pb._clear_backend_probe_cache()
         result = _pb.build_environment_hints()
         # Host suppression: none of the local-backend lines should appear.
@@ -1274,6 +1276,86 @@ class TestEnvironmentHints:
         # Backend info must appear instead.
         assert "Terminal backend: docker" in result
         assert "inside" in result.lower()
+
+    def test_named_targets_use_default_backend_and_are_listed(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        import tools.execution_targets as targets_mod
+
+        probe_calls = []
+
+        def _capture_probe(backend, terminal_config=None, target_name=""):
+            probe_calls.append((backend, terminal_config, target_name))
+            return None
+
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "_probe_remote_backend", _capture_probe)
+        monkeypatch.setattr(
+            targets_mod,
+            "_load_merged_config",
+            lambda: {
+                "terminal": {
+                    "backend": "local",
+                    "default_target": "devbox",
+                    "targets": {
+                        "local": {"backend": "local", "cwd": "."},
+                        "devbox": {
+                            "backend": "ssh",
+                            "cwd": "/srv/project",
+                            "ssh_host": "devbox.example.com",
+                            "ssh_user": "agent",
+                        },
+                    },
+                },
+            },
+        )
+
+        result = _pb.build_environment_hints()
+
+        assert "Terminal backend: ssh" in result
+        assert "Host:" not in result
+        assert "Configured execution targets:" in result
+        assert "omit an execution-target selector" in result
+        assert '"devbox" (ssh, default)' in result
+        assert '"local" (local)' in result
+        assert "search_files` uses `execution_target" in result
+        assert probe_calls == [(
+            "ssh",
+            {
+                "backend": "ssh",
+                "cwd": "/srv/project",
+                "ssh_host": "devbox.example.com",
+                "ssh_user": "agent",
+            },
+            "devbox",
+        )]
+
+    def test_named_local_default_uses_target_cwd(self, monkeypatch, tmp_path):
+        import agent.prompt_builder as _pb
+        import tools.execution_targets as targets_mod
+
+        target_cwd = tmp_path / "named-target"
+        target_cwd.mkdir()
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(
+            targets_mod,
+            "_load_merged_config",
+            lambda: {
+                "terminal": {
+                    "default_target": "workspace",
+                    "targets": {
+                        "workspace": {
+                            "backend": "local",
+                            "cwd": str(target_cwd),
+                        },
+                    },
+                },
+            },
+        )
+        monkeypatch.chdir(tmp_path)
+
+        result = _pb.build_environment_hints()
+
+        assert f"Current working directory: {target_cwd}" in result
 
     def test_build_environment_hints_uses_terminal_cwd_over_launch_dir(self, monkeypatch, tmp_path):
         """THE BUG: gateway/cron set TERMINAL_CWD but the prompt emitted os.getcwd()

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -144,6 +144,39 @@ class TestTirithAllowDangerous:
         # allow_permanent should be True (no tirith warning)
         assert cb.call_args[1]["allow_permanent"] is True
 
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_named_target_session_approval_does_not_authorize_sibling_target(
+        self, mock_tirith,
+    ):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        command = "rm -rf /tmp/hermes-target-scope"
+
+        approve_local = MagicMock(return_value="session")
+        first = check_all_command_guards(
+            command, "local", approval_callback=approve_local,
+            execution_target="local", execution_backend="local",
+            execution_target_named=True,
+        )
+        assert first["approved"] is True
+
+        local_again = MagicMock(return_value="deny")
+        second = check_all_command_guards(
+            command, "local", approval_callback=local_again,
+            execution_target="local", execution_backend="local",
+            execution_target_named=True,
+        )
+        assert second["approved"] is True
+        local_again.assert_not_called()
+
+        deny_prod = MagicMock(return_value="deny")
+        third = check_all_command_guards(
+            command, "local", approval_callback=deny_prod,
+            execution_target="prod", execution_backend="ssh",
+            execution_target_named=True,
+        )
+        assert third["approved"] is False
+        deny_prod.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # tirith warn + safe command

--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -73,6 +73,23 @@ class TestOverrideCwdSanitizedAtCallSite:
     the (sanitized) config["cwd"] and flowed raw into `docker run -w`.
     """
 
+    def test_explicit_docker_mount_mode_uses_registered_host_workspace(
+        self, tmp_path,
+    ):
+        config = {
+            "env_type": "docker",
+            "cwd": "/workspace",
+            "host_cwd": None,
+            "docker_mount_cwd_to_workspace": True,
+        }
+
+        cwd = tt._apply_task_cwd_override(
+            config, str(tmp_path), str(tmp_path),
+        )
+
+        assert cwd == "/workspace"
+        assert config["host_cwd"] == str(tmp_path)
+
     def _run_and_capture_cwd(self, monkeypatch, override_cwd, config_cwd="/root"):
         """Drive terminal_tool() on the docker backend with a host-path cwd
         override registered, and return the cwd that reached _create_environment

--- a/tests/tools/test_docker_orphan_reaper_integration.py
+++ b/tests/tools/test_docker_orphan_reaper_integration.py
@@ -11,6 +11,7 @@ opt-out would silently do nothing.
 """
 
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import tools.terminal_tool as terminal_tool
@@ -103,6 +104,34 @@ def test_maybe_reap_floors_at_60_seconds(monkeypatch):
     assert captured_args.get("max_age_seconds") == 120, (
         f"expected floored 60 × 2 = 120, got {captured_args.get('max_age_seconds')}"
     )
+
+
+def test_named_targets_use_longest_docker_lifetime(monkeypatch):
+    _reset_reaper_gate()
+    captured_args = {}
+
+    monkeypatch.setattr(
+        "tools.execution_targets.list_execution_targets",
+        lambda: (
+            SimpleNamespace(
+                named=True, backend="docker", config={"lifetime_seconds": 60},
+            ),
+            SimpleNamespace(
+                named=True, backend="docker", config={"lifetime_seconds": 900},
+            ),
+        ),
+    )
+
+    with patch(
+        "tools.environments.docker.reap_orphan_containers",
+        lambda **kwargs: captured_args.update(kwargs) or 0,
+    ):
+        terminal_tool._maybe_reap_docker_orphans({
+            "docker_orphan_reaper": True,
+            "lifetime_seconds": 60,
+        })
+
+    assert captured_args["max_age_seconds"] == 1800
 
 
 def test_maybe_reap_passes_current_profile_as_filter(monkeypatch):

--- a/tests/tools/test_execution_targets.py
+++ b/tests/tools/test_execution_targets.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+from contextvars import Context
+
+import pytest
+
+from tools.execution_targets import (
+    ExecutionTargetError,
+    list_execution_targets,
+    resolve_execution_target,
+    set_execution_target_config_source,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_execution_target_config_source():
+    try:
+        yield
+    finally:
+        set_execution_target_config_source(None)
+
+
+def _root(terminal: dict) -> dict:
+    return {"terminal": terminal}
+
+
+def test_legacy_omitted_and_default_select_the_flat_environment():
+    config = _root({"backend": "ssh", "ssh_host": "host", "ssh_user": "user"})
+
+    omitted = resolve_execution_target(config=config)
+    explicit = resolve_execution_target("default", config=config)
+
+    assert omitted.target == explicit.target == "default"
+    assert omitted.backend == explicit.backend == "ssh"
+    assert omitted.named is explicit.named is False
+    assert omitted.config["ssh_host"] == "host"
+
+
+def test_legacy_backend_metadata_respects_terminal_env_override(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    resolution = resolve_execution_target(
+        config=_root({
+            "backend": "ssh",
+            "ssh_host": "configured-but-overridden",
+            "ssh_user": "agent",
+        }),
+    )
+
+    assert resolution.named is False
+    assert resolution.target == "default"
+    assert resolution.backend == "local"
+
+
+def test_legacy_unknown_target_is_actionable():
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target("devbox", config=_root({"backend": "local"}))
+
+    message = str(excinfo.value)
+    assert "devbox" in message
+    assert "Available targets: 'default'" in message
+
+
+def test_named_default_and_explicit_target_inherit_top_level_and_override():
+    config = _root({
+        "backend": "local",
+        "timeout": 180,
+        "container_memory": 4096,
+        "default_target": "local",
+        "targets": {
+            "local": {"cwd": "/workspace/local"},
+            "devbox": {
+                "backend": "ssh",
+                "ssh_host": "devbox.example.com",
+                "ssh_user": "bruno",
+                "cwd": "/home/bruno/project",
+                "timeout": 45,
+            },
+        },
+    })
+
+    default = resolve_execution_target(config=config)
+    devbox = resolve_execution_target("devbox", config=config)
+
+    assert default.target == "local"
+    assert default.backend == "local"
+    assert default.is_default is True
+    assert default.config["timeout"] == 180
+    assert devbox.target == "devbox"
+    assert devbox.backend == "ssh"
+    assert devbox.is_default is False
+    assert devbox.config["timeout"] == 45
+    assert devbox.config["container_memory"] == 4096
+    assert devbox.config["ssh_host"] == "devbox.example.com"
+    assert "targets" not in devbox.config
+    assert "default_target" not in devbox.config
+
+    inventory = list_execution_targets(config=config)
+    assert [(item.target, item.is_default) for item in inventory] == [
+        ("devbox", False),
+        ("local", True),
+    ]
+
+
+@pytest.mark.parametrize("default_target", [None, "", "missing"])
+def test_named_targets_require_a_valid_default(default_target):
+    terminal = {
+        "backend": "local",
+        "targets": {"zeta": {"backend": "local"}, "alpha": {"backend": "local"}},
+    }
+    if default_target is not None:
+        terminal["default_target"] = default_target
+
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target(config=_root(terminal))
+
+    assert "Available targets: 'alpha', 'zeta'" in str(excinfo.value)
+
+
+def test_unknown_named_target_lists_names_deterministically():
+    config = _root({
+        "default_target": "zeta",
+        "targets": {"zeta": {"backend": "local"}, "alpha": {"backend": "local"}},
+    })
+
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target("other", config=config)
+
+    assert "Available targets: 'alpha', 'zeta'" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("targets", "expected"),
+    [
+        ({"dev": "ssh"}, "must be a mapping"),
+        ({"": {"backend": "local"}}, "non-empty strings"),
+        ({1: {"backend": "local"}}, "non-empty strings"),
+    ],
+)
+def test_malformed_target_entries_are_clear(targets, expected):
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target(config=_root({"default_target": "dev", "targets": targets}))
+
+    assert expected in str(excinfo.value)
+
+
+def test_target_names_are_otherwise_arbitrary_static_strings():
+    resolution = resolve_execution_target(
+        "prod blue/1",
+        config=_root({
+            "default_target": "prod blue/1",
+            "targets": {"prod blue/1": {"backend": "local"}},
+        }),
+    )
+
+    assert resolution.target == "prod blue/1"
+
+
+def test_tool_schemas_use_static_optional_string_target_fields():
+    from tools.code_execution_tool import EXECUTE_CODE_SCHEMA
+    from tools.file_tools import (
+        PATCH_SCHEMA,
+        READ_FILE_SCHEMA,
+        SEARCH_FILES_SCHEMA,
+        WRITE_FILE_SCHEMA,
+    )
+    from tools.terminal_tool import TERMINAL_SCHEMA
+
+    for schema in (
+        TERMINAL_SCHEMA,
+        READ_FILE_SCHEMA,
+        WRITE_FILE_SCHEMA,
+        PATCH_SCHEMA,
+        EXECUTE_CODE_SCHEMA,
+    ):
+        target = schema["parameters"]["properties"]["target"]
+        assert target["type"] == "string"
+        assert "enum" not in target
+        assert "target" not in schema["parameters"].get("required", [])
+
+    search_properties = SEARCH_FILES_SCHEMA["parameters"]["properties"]
+    assert search_properties["target"]["enum"] == ["content", "files"]
+    assert search_properties["execution_target"]["type"] == "string"
+    assert "enum" not in search_properties["execution_target"]
+    assert "compatibility" in SEARCH_FILES_SCHEMA["description"].lower()
+
+
+def test_successful_terminal_result_reports_target_backend_and_cwd(monkeypatch, tmp_path):
+    import tools.execution_targets as targets_mod
+    import tools.terminal_tool as terminal_mod
+
+    config = _root({
+        "default_target": "local",
+        "targets": {"local": {"backend": "local", "cwd": str(tmp_path)}},
+    })
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    monkeypatch.setattr(terminal_mod, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_mod,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(terminal_mod, "_active_environments", {})
+    monkeypatch.setattr(terminal_mod, "_last_activity", {})
+    monkeypatch.setattr(terminal_mod, "_creation_locks", {})
+    monkeypatch.setattr(terminal_mod, "_session_cwd", {})
+
+    result = json.loads(terminal_mod.terminal_tool("pwd", task_id="session"))
+
+    assert result["exit_code"] == 0
+    assert result["target"] == "local"
+    assert result["backend"] == "local"
+    assert result["cwd"] == str(tmp_path)
+
+
+def test_multiplex_profiles_do_not_share_environment_or_session_keys(monkeypatch):
+    import tools.execution_targets as targets_mod
+
+    config = _root({
+        "default_target": "devbox",
+        "targets": {"devbox": {"backend": "ssh"}},
+    })
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "profile-a")
+    profile_a = resolve_execution_target("devbox", config=config)
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "profile-b")
+    profile_b = resolve_execution_target("devbox", config=config)
+
+    assert profile_a.environment_key("default") != profile_b.environment_key("default")
+    assert profile_a.session_key("chat") != profile_b.session_key("chat")
+
+
+def test_classic_cli_config_override_is_context_scoped():
+    ssh_config = _root({
+        "default_target": "devbox",
+        "targets": {"devbox": {"backend": "ssh"}},
+    })
+    local_config = _root({
+        "default_target": "local",
+        "targets": {"local": {"backend": "local"}},
+    })
+
+    def configure_and_resolve(config):
+        set_execution_target_config_source(config)
+        return resolve_execution_target().backend
+
+    assert Context().run(configure_and_resolve, ssh_config) == "ssh"
+    assert Context().run(configure_and_resolve, local_config) == "local"
+
+    import threading
+
+    set_execution_target_config_source(ssh_config)
+    observed = []
+    thread = threading.Thread(
+        target=lambda: observed.append(resolve_execution_target().backend),
+    )
+    thread.start()
+    thread.join(timeout=5)
+    assert observed == ["ssh"]

--- a/tests/tools/test_file_state_registry.py
+++ b/tests/tools/test_file_state_registry.py
@@ -182,6 +182,34 @@ class FileStateRegistryUnitTests(unittest.TestCase):
         self.assertIn(foo, out["child"])
         self.assertNotIn(baz, out["child"])
 
+    def test_delegate_state_aggregates_task_targets_without_cross_target_conflicts(self):
+        path = self._mk()
+        file_state.record_read(("parent", "alpha"), path, namespace="alpha")
+        file_state.record_read(("parent", "beta"), path, namespace="beta")
+        since = time.time()
+        time.sleep(0.01)
+        file_state.note_write(("child", "alpha"), path, namespace="alpha")
+
+        parent_reads = file_state.known_reads("parent")
+
+        self.assertIn(f"alpha\0{path}", parent_reads)
+        self.assertIn(f"beta\0{path}", parent_reads)
+        out = file_state.writes_since("parent", since, [f"alpha\0{path}"])
+        self.assertEqual(out, {"child": [path]})
+
+    def test_writes_since_excludes_all_scopes_of_raw_parent_task(self):
+        path = self._mk()
+        file_state.record_read(("parent", "alpha"), path, namespace="alpha")
+        since = time.time()
+        time.sleep(0.01)
+        file_state.note_write(("parent", "alpha"), path, namespace="alpha")
+
+        out = file_state.writes_since(
+            "parent", since, file_state.known_reads("parent"),
+        )
+
+        self.assertEqual(out, {})
+
     def test_writes_since_excludes_the_target_agent(self):
         p = self._mk()
         file_state.record_read("parent", p)

--- a/tests/tools/test_named_execution_target_routing.py
+++ b/tests/tools/test_named_execution_target_routing.py
@@ -1,0 +1,1143 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import pytest
+
+
+def _named_config(cwds: dict[str, str], default: str = "alpha") -> dict:
+    return {
+        "terminal": {
+            "timeout": 60,
+            "lifetime_seconds": 3600,
+            "default_target": default,
+            "targets": {
+                name: {"backend": "local", "cwd": cwd}
+                for name, cwd in cwds.items()
+            },
+        },
+    }
+
+
+@pytest.fixture
+def isolated_target_state(monkeypatch):
+    import tools.file_tools as file_mod
+    import tools.terminal_tool as terminal_mod
+
+    monkeypatch.setattr(terminal_mod, "_active_environments", {})
+    monkeypatch.setattr(terminal_mod, "_last_activity", {})
+    monkeypatch.setattr(terminal_mod, "_creation_locks", {})
+    monkeypatch.setattr(terminal_mod, "_session_cwd", {})
+    monkeypatch.setattr(terminal_mod, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_mod, "_active_turn_counts", {})
+    monkeypatch.setattr(terminal_mod, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(file_mod, "_file_ops_cache", {})
+    monkeypatch.setattr(file_mod, "_read_tracker", {})
+    monkeypatch.setattr(file_mod, "_patch_failure_tracker", {})
+    monkeypatch.setattr(
+        terminal_mod,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
+    yield terminal_mod, file_mod
+    for env in list(terminal_mod._active_environments.values()):
+        try:
+            env.cleanup()
+        except Exception:
+            pass
+
+
+def test_same_task_reuses_within_target_and_isolates_across_targets(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    first = json.loads(terminal_mod.terminal_tool("pwd", task_id="child-a"))
+    second = json.loads(terminal_mod.terminal_tool("pwd", task_id="child-b", target="alpha"))
+    third = json.loads(terminal_mod.terminal_tool("pwd", task_id="child-a", target="beta"))
+
+    assert first["output"] == second["output"] == str(alpha)
+    assert third["output"] == str(beta)
+    assert set(terminal_mod._active_environments) == {("default", "alpha"), ("default", "beta")}
+
+
+def test_ssh_target_routes_terminal_and_file_adapter_to_same_environment(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "backend": "local",
+            "default_target": "local",
+            "targets": {
+                "local": {"backend": "local", "cwd": "/workspace/local"},
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": "/srv/project",
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    created = []
+
+    class FakeSshEnvironment:
+        def __init__(self, cwd):
+            self.cwd = cwd
+            self.is_persistent = True
+
+        def execute(self, command, cwd="", timeout=None, **kwargs):
+            return {"output": self.cwd + "\n", "returncode": 0}
+
+        def cleanup(self):
+            pass
+
+    def fake_create(**kwargs):
+        created.append(kwargs)
+        return FakeSshEnvironment(kwargs["cwd"])
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    result = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="session", target="devbox",
+    ))
+    file_ops = file_mod._get_file_ops("session", "devbox")
+
+    assert result["target"] == "devbox"
+    assert result["backend"] == "ssh"
+    assert result["output"] == "/srv/project"
+    assert created[0]["env_type"] == "ssh"
+    assert created[0]["ssh_config"]["host"] == "devbox.example.com"
+    assert created[0]["cwd"] == "/srv/project"
+    assert file_ops.env is terminal_mod._active_environments[("default", "devbox")]
+
+
+def test_ssh_paths_stay_remote_relative_and_ignore_host_workspace_override(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "backend": "local",
+            "default_target": "devbox",
+            "targets": {
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": ".",
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+                "container": {"backend": "docker", "cwd": "."},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    terminal_mod.register_task_env_overrides(
+        "session", {"cwd": str(tmp_path)},
+    )
+
+    assert file_mod._authoritative_workspace_root("session", "devbox") == "."
+    assert file_mod._backend_operation_path(
+        "relative.txt", str(tmp_path / "relative.txt"), "session", "devbox",
+    ) == "relative.txt"
+    assert file_mod._backend_operation_path(
+        "~/notes.txt", str(tmp_path / "notes.txt"), "session", "devbox",
+    ) == "~/notes.txt"
+    assert file_mod._authoritative_workspace_root(
+        "session", "container",
+    ) == "/root"
+
+    terminal_mod.record_session_cwd(
+        "session-a", "/srv/a", target="devbox",
+    )
+    terminal_mod.record_session_cwd(
+        "session-b", "/srv/b", target="devbox",
+    )
+    assert file_mod._backend_operation_path(
+        "relative.txt", "/host/wrong", "session-a", "devbox",
+    ) == "/srv/a/relative.txt"
+    assert file_mod._backend_operation_path(
+        "relative.txt", "/host/wrong", "session-b", "devbox",
+    ) == "/srv/b/relative.txt"
+    rewritten = file_mod._backend_v4a_patch(
+        "*** Begin Patch\n*** Update File: relative.txt\n*** End Patch",
+        "session-a",
+        "devbox",
+    )
+    assert "*** Update File: /srv/a/relative.txt" in rewritten
+
+
+def test_legacy_ssh_search_preserves_relative_path(monkeypatch, isolated_target_state):
+    from tools.file_operations import SearchResult
+
+    _, file_mod = isolated_target_state
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_CWD", "~")
+    captured = {}
+
+    class FakeOps:
+        def search(self, **kwargs):
+            captured.update(kwargs)
+            return SearchResult(matches=[], total_count=0)
+
+    monkeypatch.setattr(file_mod, "_get_file_ops", lambda *args, **kwargs: FakeOps())
+
+    result = json.loads(file_mod.search_tool("needle", path="."))
+
+    assert not result.get("error")
+    assert captured["path"] == "."
+
+
+def test_ssh_reads_never_use_host_mtime_dedup(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    _, file_mod = isolated_target_state
+    import tools.execution_targets as targets_mod
+    from tools.file_operations import ReadResult
+
+    host_twin = tmp_path / "same.txt"
+    host_twin.write_text("host\n", encoding="utf-8")
+    config = {
+        "terminal": {
+            "default_target": "devbox",
+            "targets": {
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": str(tmp_path),
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+
+    class FakeOps:
+        calls = 0
+
+        @classmethod
+        def read_file(cls, path, offset, limit):
+            cls.calls += 1
+            return ReadResult(
+                content=f"remote-{cls.calls}", total_lines=1, file_size=8,
+            )
+
+    monkeypatch.setattr(
+        file_mod, "_get_file_ops", lambda task_id, target=None: FakeOps(),
+    )
+
+    first = json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="session", target="devbox",
+    ))
+    second = json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="session", target="devbox",
+    ))
+
+    assert first["content"] != second["content"]
+    assert second.get("status") != "unchanged"
+    assert FakeOps.calls == 2
+
+
+def test_target_specific_cd_does_not_cross_talk_to_terminal_or_file_tools(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha_sub = alpha / "sub"
+    beta_sub = beta / "sub"
+    alpha_sub.mkdir(parents=True)
+    beta_sub.mkdir(parents=True)
+    (alpha_sub / "which.txt").write_text("alpha\n", encoding="utf-8")
+    (beta / "which.txt").write_text("beta-root\n", encoding="utf-8")
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    cd_result = json.loads(terminal_mod.terminal_tool("cd sub", task_id="session", target="alpha"))
+    beta_pwd = json.loads(terminal_mod.terminal_tool("pwd", task_id="session", target="beta"))
+    alpha_read = json.loads(file_mod.read_file_tool("which.txt", task_id="session", target="alpha"))
+    beta_read = json.loads(file_mod.read_file_tool("which.txt", task_id="session", target="beta"))
+
+    assert cd_result["exit_code"] == 0
+    assert beta_pwd["output"] == str(beta)
+    assert "alpha" in alpha_read["content"]
+    assert "beta-root" in beta_read["content"]
+
+
+def test_local_targets_route_write_read_patch_search_and_cache_separately(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    _, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    write_alpha = json.loads(file_mod.write_file_tool(
+        "shared.txt", "alpha-value\n", task_id="session", target="alpha",
+    ))
+    write_beta = json.loads(file_mod.write_file_tool(
+        "shared.txt", "beta-value\n", task_id="session", target="beta",
+    ))
+    patch_alpha = json.loads(file_mod.patch_tool(
+        path="shared.txt", old_string="alpha-value\n", new_string="alpha-patched\n",
+        task_id="session", target="alpha",
+    ))
+    search_alpha = json.loads(file_mod.search_tool(
+        "alpha-patched", path=".", task_id="session", execution_target="alpha",
+    ))
+    search_beta = json.loads(file_mod.search_tool(
+        "beta-value", path=".", task_id="session", execution_target="beta",
+    ))
+
+    assert not write_alpha.get("error") and not write_beta.get("error")
+    assert not patch_alpha.get("error")
+    assert (alpha / "shared.txt").read_text(encoding="utf-8") == "alpha-patched\n"
+    assert (beta / "shared.txt").read_text(encoding="utf-8") == "beta-value\n"
+    assert search_alpha["matches"] and search_beta["matches"]
+    assert write_alpha["target"] == patch_alpha["target"] == "alpha"
+    assert search_beta["target"] == "beta"
+    assert set(file_mod._file_ops_cache) == {("default", "alpha"), ("default", "beta")}
+    assert ("session", "alpha") in file_mod._read_tracker
+    assert ("session", "beta") in file_mod._read_tracker
+
+
+def test_real_config_loader_routes_terminal_and_files_between_two_local_targets(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import yaml
+
+    import tools.file_tools as file_mod
+    import tools.terminal_tool as terminal_mod
+
+    alpha = tmp_path / "configured-alpha"
+    beta = tmp_path / "configured-beta"
+    alpha.mkdir()
+    beta.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "terminal": {
+                "default_target": "alpha",
+                "targets": {
+                    "alpha": {"backend": "local", "cwd": str(alpha)},
+                    "beta": {"backend": "local", "cwd": str(beta)},
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    alpha_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="configured-session", target="alpha",
+    ))
+    beta_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="configured-session", target="beta",
+    ))
+    assert alpha_pwd["output"] == str(alpha)
+    assert beta_pwd["output"] == str(beta)
+
+    assert json.loads(file_mod.write_file_tool(
+        "same.txt", "from alpha\n", task_id="configured-session", target="alpha",
+    ))["target"] == "alpha"
+    assert json.loads(file_mod.write_file_tool(
+        "same.txt", "from beta\n", task_id="configured-session", target="beta",
+    ))["target"] == "beta"
+    assert "from alpha" in json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="configured-session", target="alpha",
+    ))["content"]
+    assert "from beta" in json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="configured-session", target="beta",
+    ))["content"]
+
+
+def test_workspace_override_applies_only_to_default_named_target(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    host_workspace = tmp_path / "host-workspace"
+    alpha.mkdir()
+    beta.mkdir()
+    host_workspace.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    # ACP/TUI/gateway surfaces register the host workspace as a task override.
+    # It should seed the configured default target, not replace an explicit
+    # remote/container target's own cwd.
+    terminal_mod.register_task_env_overrides(
+        "session", {"cwd": str(host_workspace)},
+    )
+
+    alpha_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="session", target="alpha",
+    ))
+    beta_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="session", target="beta",
+    ))
+    beta_write = json.loads(file_mod.write_file_tool(
+        "target-only.txt", "beta\n", task_id="session", target="beta",
+    ))
+
+    assert alpha_pwd["output"] == str(host_workspace)
+    assert beta_pwd["output"] == str(beta)
+    assert beta_write["resolved_path"] == str(beta / "target-only.txt")
+    assert (beta / "target-only.txt").read_text(encoding="utf-8") == "beta\n"
+    assert not (host_workspace / "target-only.txt").exists()
+
+
+def test_unknown_target_errors_are_returned_by_execution_and_file_tools(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha)}),
+    )
+
+    results = [
+        json.loads(terminal_mod.terminal_tool("pwd", target="missing")),
+        json.loads(file_mod.read_file_tool("x.txt", target="missing")),
+        json.loads(file_mod.write_file_tool("x.txt", "x", target="missing")),
+        json.loads(file_mod.search_tool(
+            "x", path=".", execution_target="missing",
+        )),
+        json.loads(code_mod.execute_code("print('x')", target="missing")),
+    ]
+
+    for result in results:
+        assert "missing" in result["error"]
+        assert "Available targets: 'alpha'" in result["error"]
+    assert not (alpha / "x.txt").exists()
+
+
+def test_cleanup_without_target_removes_all_task_scopes_and_explicit_removes_one(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+
+    class FakeEnv:
+        def __init__(self):
+            self.cleaned = 0
+
+        def cleanup(self):
+            self.cleaned += 1
+
+    config = _named_config({"alpha": "/a", "beta": "/b"})
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    alpha = FakeEnv()
+    beta = FakeEnv()
+    terminal_mod._active_environments.update({
+        ("default", "alpha"): alpha,
+        ("default", "beta"): beta,
+    })
+    terminal_mod._last_activity.update({
+        ("default", "alpha"): time.time(),
+        ("default", "beta"): time.time(),
+    })
+
+    # Unregistered delegate ids collapse to the parent's "default" scope for
+    # execution, but closing a delegate must preserve legacy cleanup semantics
+    # and must not tear down the parent's shared environments.
+    terminal_mod.cleanup_vm("child-a")
+    terminal_mod.cleanup_vm("child-a", target="alpha")
+    assert alpha.cleaned == beta.cleaned == 0
+
+    terminal_mod.cleanup_vm("default", target="alpha")
+    assert alpha.cleaned == 1 and beta.cleaned == 0
+    assert set(terminal_mod._active_environments) == {("default", "beta")}
+
+    terminal_mod.cleanup_vm("default")
+    assert beta.cleaned == 1
+    assert terminal_mod._active_environments == {}
+
+
+def test_per_turn_cleanup_preserves_only_persistent_named_siblings(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+
+    class FakeEnv:
+        def __init__(self, persistent):
+            self._persistent = persistent
+            self.cleaned = 0
+
+        def cleanup(self):
+            self.cleaned += 1
+
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: _named_config({"alpha": "/a", "beta": "/b"}),
+    )
+    key_a = ("default", "alpha")
+    key_b = ("default", "beta")
+    persistent = FakeEnv(True)
+    ephemeral = FakeEnv(False)
+    terminal_mod._active_environments.update({
+        key_a: persistent,
+        key_b: ephemeral,
+    })
+    terminal_mod._last_activity.update({key_a: 1.0, key_b: 1.0})
+    persistent_ops = object()
+    ephemeral_ops = object()
+    file_mod._file_ops_cache.update({
+        key_a: persistent_ops,
+        key_b: ephemeral_ops,
+    })
+
+    terminal_mod.register_environment_turn("turn-a")
+    terminal_mod.register_environment_turn("turn-b")
+    assert terminal_mod.release_environment_turn("turn-a") == 1
+    terminal_mod.cleanup_vm(
+        "turn-a", preserve_persistent=True, include_collapsed=False,
+    )
+    assert key_b in terminal_mod._active_environments
+
+    assert terminal_mod.release_environment_turn("turn-b") == 0
+    terminal_mod.cleanup_vm(
+        "turn-b", preserve_persistent=True, include_collapsed=True,
+    )
+
+    assert terminal_mod._active_environments[key_a] is persistent
+    assert key_b not in terminal_mod._active_environments
+    assert persistent.cleaned == 0
+    assert ephemeral.cleaned == 1
+    assert file_mod._file_ops_cache[key_a] is persistent_ops
+    assert key_b not in file_mod._file_ops_cache
+
+    from tools.process_registry import process_registry
+
+    active_env = FakeEnv(False)
+    terminal_mod._active_environments[key_b] = active_env
+    monkeypatch.setattr(
+        process_registry, "has_active_processes", lambda key: key == key_b,
+    )
+    terminal_mod.cleanup_vm(
+        "turn-c", preserve_persistent=True, include_collapsed=True,
+    )
+    assert terminal_mod._active_environments[key_b] is active_env
+    assert active_env.cleaned == 0
+
+
+def test_local_persistent_config_marks_environment(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+
+    class FakeLocal:
+        def __init__(self, cwd, timeout):
+            self.cwd = cwd
+            self.timeout = timeout
+
+    monkeypatch.setattr(terminal_mod, "_LocalEnvironment", FakeLocal)
+    env = terminal_mod._create_environment(
+        "local", "", "/workspace", 30,
+        local_config={"persistent": True},
+    )
+
+    assert terminal_mod._environment_is_persistent(env)
+
+
+def test_process_metadata_survives_status_list_and_checkpoint(monkeypatch, tmp_path):
+    import tools.process_registry as process_mod
+
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(process_mod, "CHECKPOINT_PATH", checkpoint)
+    registry = process_mod.ProcessRegistry()
+    session = process_mod.ProcessSession(
+        id="proc_targeted",
+        command="sleep 30",
+        task_id="default",
+        target="devbox",
+        backend="ssh",
+        timeout_seconds=7,
+        environment_task_key="profile-a:default",
+        pid=4321,
+        host_start_time=99,
+        started_at=time.time(),
+    )
+    registry._running[session.id] = session
+
+    assert registry.has_active_processes(("profile-a:default", "devbox"))
+    assert registry.poll(session.id)["target"] == "devbox"
+    assert registry.list_sessions()[0]["backend"] == "ssh"
+    registry._write_checkpoint()
+    raw = json.loads(checkpoint.read_text(encoding="utf-8"))
+    assert raw[0]["target"] == "devbox"
+    assert raw[0]["timeout_seconds"] == 7
+    assert raw[0]["environment_task_key"] == "profile-a:default"
+    assert raw[0]["backend"] == "ssh"
+
+    recovered = process_mod.ProcessRegistry()
+    monkeypatch.setattr(recovered, "_host_pid_is_ours", lambda pid, started: True)
+    assert recovered.recover_from_checkpoint() == 1
+    recovered_session = recovered.get(session.id)
+    assert recovered_session is not None
+    assert recovered_session.target == "devbox"
+    assert recovered_session.backend == "ssh"
+    assert recovered_session.timeout_seconds == 7
+    assert recovered_session.environment_task_key == "profile-a:default"
+
+    recovered_session.exited = True
+    waited = recovered.wait(session.id, timeout=99)
+    assert "configured limit of 7s" in waited["timeout_note"]
+
+
+def test_execute_code_inherits_target_for_nested_tools_and_preserves_override(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+    source = code_mod.generate_hermes_tools_module(
+        ["write_file", "read_file", "search_files"],
+    )
+    namespace = {}
+    exec(source, namespace)
+    calls = []
+    namespace["_call"] = lambda name, args: calls.append((name, args)) or {}
+
+    namespace["write_file"]("nested.txt", "alpha-default\n")
+    namespace["write_file"]("nested.txt", "beta-explicit\n", target="beta")
+    namespace["search_files"]("needle")
+
+    inherited = [
+        (name, code_mod._inherit_execution_target(name, args, "alpha"))
+        for name, args in calls
+    ]
+    assert inherited[0][1]["target"] == "alpha"
+    assert inherited[1][1]["target"] == "beta"
+    assert inherited[2][1]["execution_target"] == "alpha"
+
+    remote_config = _named_config({"alpha": str(alpha), "beta": str(beta)})
+    remote_config["terminal"]["targets"]["alpha"]["backend"] = "ssh"
+    remote_config["terminal"]["targets"]["alpha"]["ssh_host"] = "example.invalid"
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: remote_config)
+    forwarded = {}
+    monkeypatch.setattr(code_mod, "_get_execution_mode", lambda: "project")
+    monkeypatch.setattr(
+        code_mod, "_execute_remote",
+        lambda code, task_id, enabled_tools, target=None, mode="strict": (
+            forwarded.update(target=target, mode=mode)
+            or json.dumps({"status": "success"})
+        ),
+    )
+
+    result = json.loads(code_mod.execute_code("print('ok')", target="alpha"))
+    assert result["status"] == "success"
+    assert forwarded["target"] == "alpha"
+    assert forwarded["mode"] == "project"
+
+
+def test_execute_code_routes_real_nested_file_call_to_selected_local_target(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    result = json.loads(code_mod.execute_code(
+        "from hermes_tools import write_file\n"
+        "print(write_file('from-code.txt', 'beta-via-rpc\\n'))\n",
+        task_id="execute-target-session",
+        enabled_tools=["write_file"],
+        target="beta",
+    ))
+
+    assert result["status"] == "success"
+    assert result["target"] == "beta"
+    assert result["backend"] == "local"
+    assert (beta / "from-code.txt").read_text(encoding="utf-8") == "beta-via-rpc\n"
+    assert not (alpha / "from-code.txt").exists()
+
+
+def test_remote_project_mode_executes_from_target_session_cwd(
+    monkeypatch, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    config = _named_config({"alpha": "/srv/configured", "beta": "/b"})
+    config["terminal"]["targets"]["alpha"].update({
+        "backend": "ssh",
+        "ssh_host": "example.invalid",
+    })
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    terminal_mod, _ = isolated_target_state
+    terminal_mod.record_session_cwd(
+        "remote-project", "/srv/session-project", target="alpha",
+    )
+
+    calls = []
+
+    class FakeEnv:
+        cwd = "/srv/configured"
+
+        def execute(self, command, cwd=None, timeout=None, stdin_data=None):
+            calls.append((command, cwd))
+            if "command -v python3" in command:
+                return {"output": "OK\n", "returncode": 0}
+            return {"output": "done\n", "returncode": 0}
+
+        def get_temp_dir(self):
+            return "/tmp"
+
+    class DummyThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+    env = FakeEnv()
+    monkeypatch.setattr(
+        code_mod, "_get_or_create_env", lambda task_id, target=None: (env, "ssh"),
+    )
+    monkeypatch.setattr(code_mod, "_ship_file_to_remote", lambda *args, **kwargs: None)
+    monkeypatch.setattr(code_mod.threading, "Thread", DummyThread)
+    monkeypatch.setattr(
+        code_mod, "_load_config", lambda: {"timeout": 30, "max_tool_calls": 5},
+    )
+
+    result = json.loads(code_mod._execute_remote(
+        "print('ok')", "remote-project", [], target="alpha", mode="project",
+    ))
+
+    assert result["status"] == "success"
+    script_calls = [item for item in calls if "python3 /tmp/hermes_exec_" in item[0]]
+    assert script_calls
+    assert script_calls[0][1] == "/srv/session-project"
+
+
+def test_tool_output_persistence_uses_the_result_target(monkeypatch):
+    import agent.tool_executor as executor
+
+    default_env = object()
+    beta_env = object()
+
+    def fake_get_active_env(_task_id, target=None):
+        return beta_env if target == "beta" else default_env
+
+    monkeypatch.setattr(executor, "get_active_env", fake_get_active_env)
+
+    result = json.dumps({"target": "beta", "output": "x"})
+    assert executor._active_env_for_tool_result(
+        "session", "terminal", {}, result,
+    ) is beta_env
+
+    captured = {}
+
+    def fake_enforce(messages, env=None, env_resolver=None, config=None):
+        assert callable(env_resolver)
+        captured["default"] = env
+        captured["selected"] = env_resolver(messages[0])
+
+    monkeypatch.setattr(executor, "enforce_turn_budget", fake_enforce)
+    messages = [{"content": "large", "tool_call_id": "call-beta"}]
+    target_map = {"call-beta": "beta"}
+    executor._enforce_target_aware_turn_budget(
+        messages, "session", executor.DEFAULT_BUDGET, target_map,
+    )
+
+    assert captured == {"default": default_env, "selected": beta_env}
+    assert target_map == {}
+    assert "_execution_target" not in messages[0]
+
+    captured.clear()
+    executor._enforce_target_aware_turn_budget(
+        [{"content": "web result", "tool_call_id": "call-web"}],
+        "session",
+        executor.DEFAULT_BUDGET,
+        {},
+    )
+    assert captured == {"default": default_env, "selected": default_env}
+    persisted = executor._append_persisted_target_hint(
+        f"{executor.PERSISTED_OUTPUT_TAG}\nfull output saved",
+        "beta",
+    )
+    assert 'Execution target for this saved output: "beta"' in persisted
+    assert "`target` to `read_file`" in persisted
+
+    monkeypatch.setattr(
+        executor, "get_active_env",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("bad target config")),
+    )
+    assert executor._active_env_for_tool_result(
+        "session", "terminal", {"target": "broken"},
+    ) is None
+    captured.clear()
+    target_map = {"call-broken": "broken"}
+    executor._enforce_target_aware_turn_budget(
+        [{"content": "error", "tool_call_id": "call-broken"}],
+        "session",
+        executor.DEFAULT_BUDGET,
+        target_map,
+    )
+    assert captured == {"default": None, "selected": None}
+
+
+def test_subdirectory_hints_follow_local_target_and_skip_remote_host(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    from types import SimpleNamespace
+
+    import agent.tool_executor as executor
+    import tools.execution_targets as targets_mod
+
+    local_root = tmp_path / "local-target"
+    subdir = local_root / "src"
+    subdir.mkdir(parents=True)
+    (subdir / "AGENTS.md").write_text("LOCAL TARGET HINT", encoding="utf-8")
+    config = {
+        "terminal": {
+            "default_target": "local",
+            "targets": {
+                "local": {"backend": "local", "cwd": str(local_root)},
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": "/srv/project",
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+
+    class DefaultTracker:
+        def __init__(self):
+            self.calls = 0
+
+        def check_tool_call(self, *args, **kwargs):
+            self.calls += 1
+            return "WRONG HOST HINT"
+
+    default_tracker = DefaultTracker()
+    agent = SimpleNamespace(_subdirectory_hints=default_tracker)
+    local_hint = executor._target_subdirectory_hints(
+        agent, "session", "read_file", {"path": "src/main.py"}, "local",
+    )
+    remote_hint = executor._target_subdirectory_hints(
+        agent, "session", "read_file", {"path": "src/main.py"}, "devbox",
+    )
+    config["terminal"]["default_target"] = "devbox"
+    omitted_remote_hint = executor._target_subdirectory_hints(
+        agent, "session", "read_file", {"path": "src/main.py"}, None,
+    )
+
+    assert isinstance(local_hint, str)
+    assert "LOCAL TARGET HINT" in local_hint
+    assert executor._selected_local_target_cwd(
+        "session", "write_file", {"target": "local"},
+    ) == str(local_root)
+    assert executor._selected_local_target_cwd(
+        "session", "terminal", {"target": "devbox"},
+    ) is None
+    assert remote_hint is None
+    assert omitted_remote_hint is None
+    assert default_tracker.calls == 0
+
+
+def test_targetless_intervening_tool_resets_all_target_read_trackers(
+    monkeypatch, isolated_target_state,
+):
+    import model_tools
+    import tools.execution_targets as targets_mod
+
+    _, file_mod = isolated_target_state
+    assert "memory" not in model_tools._TARGET_SELECTOR_TOOLS
+    assert "terminal" in model_tools._TARGET_SELECTOR_TOOLS
+    for key in ("session", ("session", "alpha"), ("session", "beta")):
+        file_mod._read_tracker[key] = {
+            "last_key": "same",
+            "consecutive": 4,
+            "dedup_hits": {"same": 2},
+        }
+
+    file_mod.notify_other_tool_call("session")
+
+    for data in file_mod._read_tracker.values():
+        assert data["last_key"] is None
+        assert data["consecutive"] == 0
+        assert data["dedup_hits"] == {}
+
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "profile-a")
+    profile_key = ("profile-profile-a:session", "alpha")
+    file_mod._read_tracker[profile_key] = {
+        "dedup": {"region": (1.0, 2, "hash")},
+        "dedup_hits": {"region": 3},
+    }
+    file_mod.reset_file_dedup("session")
+    assert file_mod._read_tracker[profile_key]["dedup"] == {}
+    assert file_mod._read_tracker[profile_key]["dedup_hits"] == {}
+
+
+def test_sudo_cache_and_nopasswd_probe_are_target_scoped(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    terminal_mod._reset_cached_sudo_passwords()
+
+    terminal_mod._set_cached_sudo_password("local-secret", "local", "local")
+    assert terminal_mod._get_cached_sudo_password("local", "local") == "local-secret"
+    assert terminal_mod._get_cached_sudo_password("devbox", "ssh") == ""
+
+    calls = []
+
+    class Probe:
+        returncode = 0
+
+    monkeypatch.setattr(
+        terminal_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or Probe(),
+    )
+    with terminal_mod._scoped_sudo_execution("devbox", "ssh"):
+        assert terminal_mod._sudo_nopasswd_works() is False
+    assert calls == []
+
+    with terminal_mod._scoped_sudo_execution("local", "local"):
+        assert terminal_mod._sudo_nopasswd_works() is True
+    assert len(calls) == 1
+
+    monkeypatch.setenv("SUDO_PASSWORD", "default-secret")
+    with terminal_mod._scoped_sudo_execution(
+        "devbox", "ssh", named=True, sudo_password="target-secret",
+    ):
+        transformed, selected_password = terminal_mod._transform_sudo_command(
+            "sudo id",
+        )
+    assert "target-secret" not in transformed
+    assert "default-secret" not in transformed
+    assert selected_password == "target-secret\n"
+
+    with terminal_mod._scoped_sudo_execution("devbox", "ssh", named=True):
+        terminal_mod._set_cached_sudo_password("cached-target")
+        _, cached_password = terminal_mod._transform_sudo_command("sudo id")
+    assert cached_password == "cached-target\n"
+
+
+def test_requirements_keep_tools_registered_when_any_target_is_usable(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "broken-docker",
+            "targets": {
+                "broken-docker": {"backend": "docker", "cwd": "/workspace"},
+                "local": {"backend": "local", "cwd": "/workspace/local"},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    checked = []
+    monkeypatch.setattr(
+        terminal_mod,
+        "_check_terminal_config_requirements",
+        lambda cfg: checked.append(cfg["env_type"]) or cfg["env_type"] == "local",
+    )
+
+    assert terminal_mod.check_terminal_requirements() is True
+    assert checked == ["local"]
+
+
+def test_local_target_aliases_share_file_state_lock_namespace(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import file_state
+
+    _, file_mod = isolated_target_state
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    path = shared / "same.txt"
+    path.write_text("v1", encoding="utf-8")
+    config = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {"backend": "local", "cwd": str(shared)},
+                "alias": {"backend": "local", "cwd": str(shared)},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    assert file_mod._file_state_namespace("reader", "alpha") is None
+    assert file_mod._file_state_namespace("writer", "alias") is None
+
+    registry = file_state.FileStateRegistry()
+    monkeypatch.setattr(file_state, "_registry", registry)
+    file_state.record_read(("reader", "alpha"), path, namespace=None)
+    file_state.note_write(("writer", "alias"), path, namespace=None)
+    warning = file_state.check_stale(("reader", "alpha"), path, namespace=None)
+    assert warning is not None
+    assert "writer" in warning
+
+
+def test_command_approval_payload_and_observer_include_target_metadata(monkeypatch):
+    from tools import approval as approval_mod
+
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(approval_mod, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(approval_mod, "detect_hardline_command", lambda command: (False, None))
+    monkeypatch.setattr(approval_mod, "_check_sudo_stdin_guard", lambda command: (False, None))
+    monkeypatch.setattr(approval_mod, "_match_user_deny_rule", lambda command: None)
+    monkeypatch.setattr(approval_mod, "_command_matches_permanent_allowlist", lambda command: False)
+    monkeypatch.setattr(
+        approval_mod, "detect_dangerous_command",
+        lambda command: (True, "danger", "dangerous command"),
+    )
+    monkeypatch.setattr("tools.tirith_security.check_command_security", lambda command: {
+        "action": "allow", "findings": [], "summary": "",
+    })
+    session_key = "approval-target-session"
+    token = approval_mod.set_current_session_key(session_key)
+    seen = {}
+    hooks = []
+
+    def notify(data):
+        seen.update(data)
+        with approval_mod._lock:
+            entry = approval_mod._gateway_queues[session_key][-1]
+            entry.result = "deny"
+            entry.event.set()
+
+    monkeypatch.setattr(approval_mod, "_fire_approval_hook", lambda name, **data: hooks.append((name, data)))
+    approval_mod.register_gateway_notify(session_key, notify)
+    try:
+        approval_mod.check_all_command_guards(
+            "danger", "local", execution_target="alpha", execution_backend="local",
+        )
+    finally:
+        approval_mod.unregister_gateway_notify(session_key)
+        approval_mod.reset_current_session_key(token)
+
+    assert seen["target"] == "alpha"
+    assert seen["backend"] == "local"
+    assert "alpha" in seen["description"] and "local" in seen["description"]
+    pre_hook = next(data for name, data in hooks if name == "pre_approval_request")
+    assert pre_hook["target"] == "alpha"
+    assert pre_hook["backend"] == "local"
+
+
+def test_execute_code_approval_payload_includes_target_metadata(monkeypatch):
+    from tools import approval as approval_mod
+
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(approval_mod, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(approval_mod, "is_approved", lambda *args: False)
+    monkeypatch.setattr(approval_mod, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(
+        approval_mod, "is_current_session_yolo_enabled", lambda: False,
+    )
+    seen = {}
+    monkeypatch.setattr(
+        approval_mod, "_await_gateway_decision",
+        lambda session_key, notify_cb, approval_data, surface: (
+            seen.update(approval_data) or {"resolved": True, "choice": "once"}
+        ),
+    )
+    session_token = approval_mod.set_current_session_key("target-approval")
+    try:
+        with approval_mod._lock:
+            approval_mod._gateway_notify_cbs["target-approval"] = lambda data: None
+        result = approval_mod.check_execute_code_guard(
+            "print('ok')", "ssh", execution_target="devbox",
+            execution_backend="ssh",
+        )
+    finally:
+        approval_mod.reset_current_session_key(session_token)
+        with approval_mod._lock:
+            approval_mod._gateway_notify_cbs.pop("target-approval", None)
+
+    assert result["approved"] is True
+    assert seen["target"] == "devbox"
+    assert seen["backend"] == "ssh"
+    assert "devbox" in seen["description"]
+
+
+def test_legacy_flat_config_still_uses_plain_string_keys(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: {"terminal": {"backend": "local", "cwd": str(tmp_path), "timeout": 60}},
+    )
+
+    result = json.loads(terminal_mod.terminal_tool("pwd", task_id="legacy"))
+
+    assert result["exit_code"] == 0
+    assert "default" in terminal_mod._active_environments
+    assert all(not isinstance(key, tuple) for key in terminal_mod._active_environments)

--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -242,3 +242,26 @@ class TestCommandCwdReadsTheRecord:
         assert tt.get_session_cwd("sess-a") == "/project"
         json.loads(tt.terminal_tool(command="pwd", task_id="sess-a"))
         assert fake.last_cwd_arg == "/project"
+
+
+def test_inherit_session_cwds_copies_every_named_target_scope(monkeypatch):
+    monkeypatch.setattr(
+        "tools.execution_targets._load_merged_config",
+        lambda: {
+            "terminal": {
+                "default_target": "alpha",
+                "targets": {
+                    "alpha": {"backend": "local", "cwd": "/alpha"},
+                    "beta": {"backend": "local", "cwd": "/beta"},
+                },
+            },
+        },
+    )
+    tt.record_session_cwd("parent", "/alpha/work", target="alpha")
+    tt.record_session_cwd("parent", "/beta/work", target="beta")
+
+    count = tt.inherit_session_cwds("parent", "child")
+
+    assert count == 2
+    assert tt.get_session_cwd("child", target="alpha") == "/alpha/work"
+    assert tt.get_session_cwd("child", target="beta") == "/beta/work"

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -25,6 +25,10 @@ mirrors the pattern used in tests/hermes_cli/test_config_drift.py.
 
 import ast
 import inspect
+import json
+import os
+import subprocess
+import sys
 
 
 def _extract_dict_values(source: str, dict_name: str) -> set[str]:
@@ -68,6 +72,91 @@ def _extract_dict_keys(source: str, dict_name: str) -> set[str]:
                 out.add(k.value)
         return out
     raise AssertionError(f"Could not find `{dict_name} = {{...}}` literal in source")
+
+
+def test_classic_cli_bridges_named_default_target(tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        "terminal:\n"
+        "  default_target: devbox\n"
+        "  targets:\n"
+        "    devbox:\n"
+        "      backend: ssh\n"
+        "      cwd: ~/project\n"
+        "      ssh_host: example.invalid\n"
+        "      ssh_user: agent\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    for key in (
+        "_HERMES_GATEWAY", "TERMINAL_ENV", "TERMINAL_CWD", "HERMES_PROFILE",
+    ):
+        env.pop(key, None)
+    env.update({
+        "HERMES_HOME": str(tmp_path),
+        "HERMES_IGNORE_USER_CONFIG": "0",
+    })
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, os, cli; "
+                "print(json.dumps([os.environ.get('TERMINAL_ENV'), "
+                "os.environ.get('TERMINAL_CWD')]))"
+            ),
+        ],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    assert json.loads(proc.stdout.strip().splitlines()[-1]) == ["ssh", "~/project"]
+
+    ignored_env = env.copy()
+    ignored_env["HERMES_IGNORE_USER_CONFIG"] = "1"
+    ignored = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, cli; "
+                "from tools.execution_targets import resolve_execution_target; "
+                "r=resolve_execution_target(); "
+                "print(json.dumps([r.named, r.backend]))"
+            ),
+        ],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        env=ignored_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    assert json.loads(ignored.stdout.strip().splitlines()[-1]) == [False, "local"]
+
+    gateway_env = ignored_env.copy()
+    gateway_env["_HERMES_GATEWAY"] = "1"
+    gateway = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, cli; "
+                "from tools.execution_targets import resolve_execution_target; "
+                "r=resolve_execution_target(); "
+                "print(json.dumps([r.named, r.backend]))"
+            ),
+        ],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        env=gateway_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    assert json.loads(gateway.stdout.strip().splitlines()[-1]) == [True, "ssh"]
 
 
 def _cli_env_map_keys() -> set[str]:

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -28,6 +28,9 @@ def _reset_bridge_state(monkeypatch):
     monkeypatch.delenv("TERMINAL_ENV", raising=False)
     monkeypatch.delenv("TERMINAL_CWD", raising=False)
     monkeypatch.delenv("TERMINAL_DOCKER_IMAGE", raising=False)
+    monkeypatch.delenv("TERMINAL_TIMEOUT", raising=False)
+    monkeypatch.delenv("TERMINAL_SSH_HOST", raising=False)
+    monkeypatch.delenv("TERMINAL_SSH_USER", raising=False)
     # The config layer caches by (path, mtime, size); leave it alone — each
     # test writes its own config.yaml which changes the signature.
     yield
@@ -64,6 +67,76 @@ def test_explicit_terminal_env_wins_over_config(monkeypatch):
     config = terminal_tool._get_env_config()
 
     assert config["env_type"] == "local"
+
+
+def test_bridge_mirrors_named_default_target_for_legacy_consumers():
+    _write_config(
+        "terminal:\n"
+        "  backend: local\n"
+        "  timeout: 77\n"
+        "  default_target: devbox\n"
+        "  targets:\n"
+        "    local:\n"
+        "      backend: local\n"
+        "      cwd: /workspace/local\n"
+        "    devbox:\n"
+        "      backend: ssh\n"
+        "      cwd: /srv/project\n"
+        "      ssh_host: devbox.example.com\n"
+        "      ssh_user: agent\n"
+    )
+
+    from hermes_cli.config import apply_terminal_config_to_env, load_config_readonly
+
+    mirrored = apply_terminal_config_to_env(
+        env={}, config=load_config_readonly(), override=True,
+    )
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "ssh"
+    assert config["cwd"] == "/srv/project"
+    assert config["timeout"] == 77
+    assert config["ssh_host"] == "devbox.example.com"
+    assert mirrored["TERMINAL_ENV"] == "ssh"
+    assert mirrored["TERMINAL_CWD"] == "/srv/project"
+    assert mirrored["TERMINAL_TIMEOUT"] == "77"
+    assert mirrored["TERMINAL_SSH_HOST"] == "devbox.example.com"
+
+
+def test_bridge_preserves_remote_tilde_for_named_ssh_default():
+    from hermes_cli.config import apply_terminal_config_to_env
+
+    mirrored = apply_terminal_config_to_env(
+        env={},
+        config={
+            "terminal": {
+                "default_target": "devbox",
+                "targets": {
+                    "devbox": {
+                        "backend": "ssh",
+                        "cwd": "~/project",
+                        "ssh_host": "devbox.example.com",
+                        "ssh_user": "agent",
+                    },
+                },
+            },
+        },
+        override=True,
+    )
+
+    assert mirrored["TERMINAL_ENV"] == "ssh"
+    assert mirrored["TERMINAL_CWD"] == "~/project"
+
+
+def test_invalid_default_target_type_stays_fail_open():
+    from hermes_cli.config import effective_terminal_config
+
+    effective = effective_terminal_config({
+        "backend": "local",
+        "default_target": ["not", "hashable"],
+        "targets": {"local": {"backend": "local"}},
+    })
+    assert effective == {"backend": "local"}
 
 
 def test_preset_terminal_vars_survive_backfill(monkeypatch):

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -519,6 +519,23 @@ class TestEnforceTurnBudget:
         # Should be truncated (no sandbox available)
         assert "Truncated" in msgs[0]["content"] or PERSISTED_OUTPUT_TAG in msgs[0]["content"]
 
+    def test_target_without_env_does_not_spill_into_default_env(self):
+        default_env = MagicMock()
+        default_env.execute.return_value = {"output": "", "returncode": 0}
+        msgs = [
+            {"role": "tool", "tool_call_id": "targeted", "content": "x" * 250_000},
+        ]
+
+        enforce_turn_budget(
+            msgs,
+            env=default_env,
+            env_resolver=lambda _msg: None,
+            config=BudgetConfig(turn_budget=200_000),
+        )
+
+        default_env.execute.assert_not_called()
+        assert "Truncated" in msgs[0]["content"]
+
     def test_returns_same_list(self):
         msgs = [{"role": "tool", "tool_call_id": "t1", "content": "ok"}]
         result = enforce_turn_budget(msgs, env=None, config=BudgetConfig(turn_budget=200_000))

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3074,6 +3074,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
+    execution_target = approval_data.get("target")
+    execution_backend = approval_data.get("backend")
 
     entry = _ApprovalEntry(approval_data)
     with _lock:
@@ -3097,6 +3099,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         pattern_keys=list(all_keys),
         session_key=session_key,
         surface=surface,
+        target=execution_target,
+        backend=execution_backend,
     )
 
     # Notify the user (bridges sync agent thread → async gateway)
@@ -3166,13 +3170,37 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         session_key=session_key,
         surface=surface,
         choice=_outcome,
+        target=execution_target,
+        backend=execution_backend,
     )
     return {"resolved": resolved, "choice": choice, "reason": entry.reason}
 
 
+def _execution_scoped_pattern_key(
+    pattern_key: str, execution_target: str, named: bool,
+) -> str:
+    """Scope persisted approvals to a named target without key collisions."""
+    if not named:
+        return pattern_key
+    target = str(execution_target or "")
+    try:
+        from tools.execution_targets import _active_profile_scope
+
+        profile_scope = _active_profile_scope()
+    except Exception:
+        profile_scope = ""
+    digest = hashlib.sha256(
+        f"{profile_scope}:{target}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"target:{digest}:{pattern_key}"
+
+
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             execution_target: str = "default",
+                             execution_backend: Optional[str] = None,
+                             execution_target_named: bool = False) -> dict:
     """Run all pre-exec security checks and return a single approval decision.
 
     Gathers findings from tirith and dangerous-command detection, then
@@ -3360,12 +3388,17 @@ def check_all_command_guards(command: str, env_type: str,
     if tirith_result["action"] in {"block", "warn"}:
         findings = tirith_result.get("findings") or []
         rule_id = findings[0].get("rule_id", "unknown") if findings else "unknown"
-        tirith_key = f"tirith:{rule_id}"
+        tirith_key = _execution_scoped_pattern_key(
+            f"tirith:{rule_id}", execution_target, execution_target_named,
+        )
         tirith_desc = _format_tirith_description(tirith_result)
         if not is_approved(session_key, tirith_key):
             warnings.append((tirith_key, tirith_desc, True))
 
     if is_dangerous:
+        pattern_key = _execution_scoped_pattern_key(
+            pattern_key, execution_target, execution_target_named,
+        )
         if not is_approved(session_key, pattern_key):
             warnings.append((pattern_key, description, False))
 
@@ -3373,13 +3406,23 @@ def check_all_command_guards(command: str, env_type: str,
     if not warnings:
         return {"approved": True, "message": None}
 
+    execution_backend = execution_backend or env_type
+
+    def _target_description(description: str) -> str:
+        return (
+            f"{description} [execution target: {execution_target!r}; "
+            f"backend: {execution_backend}]"
+        )
+
     # --- Phase 2.5: Smart approval (auxiliary LLM risk assessment) ---
     # When approvals.mode=smart, ask the aux LLM before prompting the user.
     # Inspired by OpenAI Codex's Smart Approvals guardian subagent
     # (openai/codex#13860).
     smart_denied_for_owner = False
     if approval_mode == "smart":
-        combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
+        combined_desc_for_llm = _target_description(
+            "; ".join(desc for _, desc, _ in warnings)
+        )
         observer_payload = _prepare_smart_approval_observer(
             command=command,
             description=combined_desc_for_llm,
@@ -3387,6 +3430,10 @@ def check_all_command_guards(command: str, env_type: str,
             pattern_keys=[key for key, _, _ in warnings],
             session_key=session_key,
         )
+        if isinstance(observer_payload, dict):
+            observer_payload.update(
+                target=execution_target, backend=execution_backend,
+            )
         verdict = _smart_approve(command, combined_desc_for_llm)
         _observe_smart_approval_verdict(observer_payload, verdict)
         if verdict == "approve":
@@ -3413,7 +3460,9 @@ def check_all_command_guards(command: str, env_type: str,
     # --- Phase 3: Approval ---
 
     # Combine descriptions for a single approval prompt
-    combined_desc = "; ".join(desc for _, desc, _ in warnings)
+    combined_desc = _target_description(
+        "; ".join(desc for _, desc, _ in warnings)
+    )
     primary_key = warnings[0][0]
     all_keys = [key for key, _, _ in warnings]
     has_tirith = any(is_t for _, _, is_t in warnings)
@@ -3448,6 +3497,8 @@ def check_all_command_guards(command: str, env_type: str,
                 # Smart DENY overrides are one-operation decisions, so the UI
                 # must not offer a permanent scope.
                 "allow_permanent": not has_tirith and not smart_denied_for_owner,
+                "target": execution_target,
+                "backend": execution_backend,
             }
             if smart_denied_for_owner:
                 approval_data["smart_denied"] = True
@@ -3530,6 +3581,8 @@ def check_all_command_guards(command: str, env_type: str,
             "pattern_key": primary_key,
             "pattern_keys": all_keys,
             "description": _disp_combined_desc,
+            "target": execution_target,
+            "backend": execution_backend,
         }
         if smart_denied_for_owner:
             pending_data.update(smart_denied=True, allow_permanent=False)
@@ -3544,6 +3597,8 @@ def check_all_command_guards(command: str, env_type: str,
             "message": (
                 f"⚠️ {_disp_combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{_disp_command}\n```"
             ),
+            "target": execution_target,
+            "backend": execution_backend,
         }
         if smart_denied_for_owner:
             result.update(smart_denied=True, allow_permanent=False)
@@ -3559,6 +3614,8 @@ def check_all_command_guards(command: str, env_type: str,
         pattern_keys=list(all_keys),
         session_key=session_key,
         surface="cli",
+        target=execution_target,
+        backend=execution_backend,
     )
     choice = prompt_dangerous_approval(
         command,
@@ -3576,6 +3633,8 @@ def check_all_command_guards(command: str, env_type: str,
         session_key=session_key,
         surface="cli",
         choice=choice,
+        target=execution_target,
+        backend=execution_backend,
     )
 
     if choice == "deny":
@@ -3613,7 +3672,10 @@ def check_all_command_guards(command: str, env_type: str,
 
 
 def check_execute_code_guard(code: str, env_type: str,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             execution_target: str = "default",
+                             execution_backend: str | None = None,
+                             execution_target_named: bool = False) -> dict:
     """Approve an execute_code script before its child process is spawned.
 
     execute_code runs arbitrary local Python — the script can call
@@ -3631,11 +3693,18 @@ def check_execute_code_guard(code: str, env_type: str,
     trusted-by-config (set a gateway/ask surface or ``approvals.cron_mode`` to
     require approval).
     """
-    pattern_key = "execute_code"
+    pattern_key = _execution_scoped_pattern_key(
+        "execute_code", execution_target, execution_target_named,
+    )
     description = (
         "execute_code script execution. The script can spawn subprocesses or "
         "mutate files without passing through terminal command approval; "
         "approval is one-shot for this run."
+    )
+    execution_backend = execution_backend or env_type
+    description += (
+        f" [execution target: {execution_target!r}; "
+        f"backend: {execution_backend}]"
     )
 
     # Isolated backends already sandbox the child — matches the container skip
@@ -3706,6 +3775,10 @@ def check_execute_code_guard(code: str, env_type: str,
             pattern_keys=[pattern_key],
             session_key=session_key,
         )
+        if isinstance(observer_payload, dict):
+            observer_payload.update(
+                target=execution_target, backend=execution_backend,
+            )
         verdict = _smart_approve(command, description)
         _observe_smart_approval_verdict(observer_payload, verdict)
         if verdict == "approve":
@@ -3753,6 +3826,8 @@ def check_execute_code_guard(code: str, env_type: str,
             "pattern_key": pattern_key,
             "pattern_keys": [pattern_key],
             "description": display_description,
+            "target": execution_target,
+            "backend": execution_backend,
         }
         if smart_denied_for_owner:
             pending_data.update(smart_denied=True, allow_permanent=False)
@@ -3764,6 +3839,8 @@ def check_execute_code_guard(code: str, env_type: str,
             "approval_pending": True,
             "command": display_command,
             "description": display_description,
+            "target": execution_target,
+            "backend": execution_backend,
             "message": (
                 f"⚠️ {display_description}. Asking the user for approval.\n\n"
                 f"**Code:**\n```python\n{display_code}\n```"
@@ -3779,6 +3856,8 @@ def check_execute_code_guard(code: str, env_type: str,
         "pattern_keys": [pattern_key],
         "description": display_description,
         "allow_permanent": not smart_denied_for_owner,
+        "target": execution_target,
+        "backend": execution_backend,
     }
     if smart_denied_for_owner:
         approval_data["smart_denied"] = True

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -292,33 +292,33 @@ _TOOL_STUBS = {
     ),
     "read_file": (
         "read_file",
-        "path: str, offset: int = 1, limit: int = 500",
+        "path: str, offset: int = 1, limit: int = 500, target: str = None",
         '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines"."""',
-        '{"path": path, "offset": offset, "limit": limit}',
+        '{"path": path, "offset": offset, "limit": limit, "target": target}',
     ),
     "write_file": (
         "write_file",
-        "path: str, content: str, cross_profile: bool = False",
+        "path: str, content: str, cross_profile: bool = False, target: str = None",
         '"""Write content to a file (always overwrites). Returns dict with status. cross_profile=True opts out of the cross-Hermes-profile soft guard."""',
-        '{"path": path, "content": content, "cross_profile": cross_profile}',
+        '{"path": path, "content": content, "cross_profile": cross_profile, "target": target}',
     ),
     "search_files": (
         "search_files",
-        'pattern: str, target: str = "content", path: str = ".", file_glob: str = None, limit: int = 50, offset: int = 0, output_mode: str = "content", context: int = 0',
+        'pattern: str, target: str = "content", path: str = ".", file_glob: str = None, limit: int = 50, offset: int = 0, output_mode: str = "content", context: int = 0, execution_target: str = None',
         '"""Search file contents (target="content") or find files by name (target="files"). Returns dict with "matches"."""',
-        '{"pattern": pattern, "target": target, "path": path, "file_glob": file_glob, "limit": limit, "offset": offset, "output_mode": output_mode, "context": context}',
+        '{"pattern": pattern, "target": target, "path": path, "file_glob": file_glob, "limit": limit, "offset": offset, "output_mode": output_mode, "context": context, "execution_target": execution_target}',
     ),
     "patch": (
         "patch",
-        'path: str = None, old_string: str = None, new_string: str = None, replace_all: bool = False, mode: str = "replace", patch: str = None, cross_profile: bool = False',
+        'path: str = None, old_string: str = None, new_string: str = None, replace_all: bool = False, mode: str = "replace", patch: str = None, cross_profile: bool = False, target: str = None',
         '"""Targeted find-and-replace (mode="replace") or V4A multi-file patches (mode="patch"). Returns dict with status. cross_profile=True opts out of the cross-Hermes-profile soft guard."""',
-        '{"path": path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all, "mode": mode, "patch": patch, "cross_profile": cross_profile}',
+        '{"path": path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all, "mode": mode, "patch": patch, "cross_profile": cross_profile, "target": target}',
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
+        "command: str, timeout: int = None, workdir: str = None, target: str = None",
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "target": target}',
     ),
 }
 
@@ -541,6 +541,24 @@ def _call(tool_name, args):
 _TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
 
 
+def _inherit_execution_target(tool_name: str, tool_args: Any,
+                              execution_target: Optional[str]) -> Any:
+    """Default nested target-aware tool calls to execute_code's target.
+
+    The generated stubs always send their optional selector, often as
+    ``None``. Treat that as omitted while preserving any explicit selector.
+    ``search_files`` keeps its historical ``target`` search-mode argument, so
+    its execution selector is named ``execution_target``.
+    """
+    if not execution_target or not isinstance(tool_args, dict):
+        return tool_args
+    selector = "execution_target" if tool_name == "search_files" else "target"
+    if tool_name in {"terminal", "read_file", "write_file", "patch", "search_files"}:
+        if tool_args.get(selector) is None:
+            tool_args[selector] = execution_target
+    return tool_args
+
+
 def _rpc_server_loop(
     server_sock: socket.socket,
     task_id: str,
@@ -550,6 +568,7 @@ def _rpc_server_loop(
     allowed_tools: frozenset,
     stop_event: threading.Event,
     rpc_token: str,
+    execution_target: Optional[str] = None,
 ):
     """
     Accept one client connection and dispatch tool-call requests until
@@ -607,6 +626,9 @@ def _rpc_server_loop(
 
                 tool_name = request.get("tool", "")
                 tool_args = request.get("args", {})
+                tool_args = _inherit_execution_target(
+                    tool_name, tool_args, execution_target,
+                )
 
                 # Enforce the allow-list
                 if tool_name not in allowed_tools:
@@ -684,7 +706,7 @@ def _rpc_server_loop(
 # Remote execution support (file-based RPC via terminal backend)
 # ---------------------------------------------------------------------------
 
-def _get_or_create_env(task_id: str):
+def _get_or_create_env(task_id: str, target: str = None):
     """Get or create the terminal environment for *task_id*.
 
     Reuses the same environment (container/sandbox/SSH session) that the
@@ -694,17 +716,27 @@ def _get_or_create_env(task_id: str):
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
-        _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id,
+        _creation_locks, _creation_locks_lock, _resolve_container_task_id,
+        resolve_task_overrides, get_session_cwd, _record_environment_lifetime,
+        _apply_task_cwd_override,
     )
+    from tools.execution_targets import resolve_execution_target
 
-    effective_task_id = _resolve_container_task_id(task_id)
+    raw_task_id = task_id or "default"
+    resolution = resolve_execution_target(target)
+    base_task_id = _resolve_container_task_id(raw_task_id)
+    effective_task_id = resolution.environment_key(base_task_id)
+    backend_task_id = resolution.backend_task_id(base_task_id)
+    config = (
+        _get_env_config(dict(resolution.config))
+        if resolution.named else _get_env_config()
+    )
 
     # Fast path: environment already exists
     with _env_lock:
         if effective_task_id in _active_environments:
             _last_activity[effective_task_id] = time.time()
-            return _active_environments[effective_task_id], _get_env_config()["env_type"]
+            return _active_environments[effective_task_id], config["env_type"]
 
     # Slow path: create environment (same pattern as file_tools._get_file_ops)
     with _creation_locks_lock:
@@ -716,11 +748,10 @@ def _get_or_create_env(task_id: str):
         with _env_lock:
             if effective_task_id in _active_environments:
                 _last_activity[effective_task_id] = time.time()
-                return _active_environments[effective_task_id], _get_env_config()["env_type"]
+                return _active_environments[effective_task_id], config["env_type"]
 
-        config = _get_env_config()
         env_type = config["env_type"]
-        overrides = _task_env_overrides.get(effective_task_id, {})
+        overrides = resolve_task_overrides(raw_task_id)
 
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]
@@ -733,7 +764,18 @@ def _get_or_create_env(task_id: str):
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or config["cwd"]
+        cwd_override = (
+            overrides.get("cwd")
+            if (
+                not resolution.named
+                or (resolution.is_default and resolution.backend != "ssh")
+            )
+            else None
+        )
+        cwd = cwd_override or get_session_cwd(
+            raw_task_id, _resolution=resolution,
+        ) or config["cwd"]
+        cwd = _apply_task_cwd_override(config, cwd, cwd_override)
 
         container_config = None
         if env_type in {"docker", "singularity", "modal", "daytona"}:
@@ -742,9 +784,17 @@ def _get_or_create_env(task_id: str):
                 "container_memory": config.get("container_memory", 5120),
                 "container_disk": config.get("container_disk", 51200),
                 "container_persistent": config.get("container_persistent", True),
+                "modal_mode": config.get("modal_mode", "auto"),
                 "docker_volumes": config.get("docker_volumes", []),
+                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                "docker_forward_env": config.get("docker_forward_env", []),
+                "docker_env": config.get("docker_env", {}),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                "docker_extra_args": config.get("docker_extra_args", []),
                 "docker_network": config.get("docker_network", True),
+                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+                "lifetime_seconds": config.get("lifetime_seconds", 300),
             }
 
         ssh_config = None
@@ -764,7 +814,7 @@ def _get_or_create_env(task_id: str):
             }
 
         logger.info("Creating new %s environment for execute_code task %s...",
-                     env_type, effective_task_id[:8])
+                     env_type, str(effective_task_id)[:48])
         env = _create_environment(
             env_type=env_type,
             image=image,
@@ -773,9 +823,10 @@ def _get_or_create_env(task_id: str):
             ssh_config=ssh_config,
             container_config=container_config,
             local_config=local_config,
-            task_id=effective_task_id,
+            task_id=backend_task_id,
             host_cwd=config.get("host_cwd"),
         )
+        _record_environment_lifetime(env, config)
 
         with _env_lock:
             _active_environments[effective_task_id] = env
@@ -783,7 +834,7 @@ def _get_or_create_env(task_id: str):
 
         _start_cleanup_thread()
         logger.info("%s environment ready for execute_code task %s",
-                     env_type, effective_task_id[:8])
+                     env_type, str(effective_task_id)[:48])
         return env, env_type
 
 
@@ -830,6 +881,7 @@ def _rpc_poll_loop(
     allowed_tools: frozenset,
     stop_event: threading.Event,
     rpc_token: str,
+    execution_target: Optional[str] = None,
 ):
     """Poll the remote filesystem for tool call requests and dispatch them.
 
@@ -895,6 +947,9 @@ def _rpc_poll_loop(
 
                 tool_name = request.get("tool", "")
                 tool_args = request.get("args", {})
+                tool_args = _inherit_execution_target(
+                    tool_name, tool_args, execution_target,
+                )
                 seq = request.get("seq", 0)
                 seq_str = f"{seq:06d}"
                 res_file = f"{rpc_dir}/res_{seq_str}"
@@ -977,6 +1032,8 @@ def _execute_remote(
     code: str,
     task_id: Optional[str],
     enabled_tools: Optional[List[str]],
+    target: str = None,
+    mode: str = "strict",
 ) -> str:
     """Run a script on the remote terminal backend via file-based RPC.
 
@@ -994,8 +1051,15 @@ def _execute_remote(
     if not sandbox_tools:
         sandbox_tools = SANDBOX_ALLOWED_TOOLS
 
+    from tools.execution_targets import resolve_execution_target
+
     effective_task_id = task_id or "default"
-    env, env_type = _get_or_create_env(effective_task_id)
+    resolution = resolve_execution_target(target)
+    # Legacy omitted/default selection already routes every nested call to the
+    # one existing environment.  Keep that path byte-for-byte compatible and
+    # only inject/pass the extra selector when named targets are configured.
+    inherited_target = resolution.target if resolution.named else None
+    env, env_type = _get_or_create_env(effective_task_id, inherited_target)
 
     sandbox_id = uuid.uuid4().hex[:12]
     temp_dir = _env_temp_dir(env)
@@ -1016,7 +1080,7 @@ def _execute_remote(
             cwd="/", timeout=15,
         )
         if "OK" not in py_check.get("output", ""):
-            return json.dumps({
+            result = {
                 "status": "error",
                 "error": (
                     f"Python 3 is not available in the {env_type} terminal "
@@ -1025,7 +1089,9 @@ def _execute_remote(
                 ),
                 "tool_calls_made": 0,
                 "duration_seconds": 0,
-            })
+            }
+            result.update(resolution.metadata(cwd=getattr(env, "cwd", None)))
+            return json.dumps(result)
 
         # Create sandbox directory on remote
         env.execute(
@@ -1050,6 +1116,7 @@ def _execute_remote(
                 env, f"{sandbox_dir}/rpc", effective_task_id,
                 tool_call_log, tool_call_counter, max_tool_calls,
                 sandbox_tools, stop_event, rpc_token,
+                inherited_target,
             ),
             daemon=True,
         )
@@ -1059,7 +1126,8 @@ def _execute_remote(
         env_prefix = (
             f"HERMES_RPC_DIR={shlex.quote(f'{sandbox_dir}/rpc')} "
             f"HERMES_RPC_TOKEN={shlex.quote(rpc_token)} "
-            f"PYTHONDONTWRITEBYTECODE=1"
+            f"PYTHONDONTWRITEBYTECODE=1 "
+            f"PYTHONPATH={shlex.quote(sandbox_dir)}:$PYTHONPATH"
         )
         tz = os.getenv("HERMES_TIMEZONE", "").strip()
         if tz:
@@ -1068,8 +1136,25 @@ def _execute_remote(
         # Execute the script on the remote backend
         logger.info("Executing code on %s backend (task %s)...",
                      env_type, effective_task_id[:8])
+        if mode == "project":
+            from tools.terminal_tool import get_session_cwd
+
+            run_cwd = (
+                get_session_cwd(effective_task_id, target=inherited_target)
+                or getattr(env, "cwd", None)
+                or resolution.config.get("cwd")
+                or "/"
+            )
+        else:
+            run_cwd = sandbox_dir
+        script_ref = (
+            shlex.quote(f"{sandbox_dir}/script.py")
+            if mode == "project"
+            else "script.py"
+        )
         script_result = env.execute(
-            f"cd {quoted_sandbox_dir} && {env_prefix} python3 script.py",
+            f"{env_prefix} python3 {script_ref}",
+            cwd=run_cwd,
             timeout=timeout,
         )
 
@@ -1090,12 +1175,14 @@ def _execute_remote(
             duration, tool_call_counter[0], type(exc).__name__, exc,
             exc_info=True,
         )
-        return json.dumps({
+        result = {
             "status": "error",
             "error": str(exc),
             "tool_calls_made": tool_call_counter[0],
             "duration_seconds": duration,
-        }, ensure_ascii=False)
+        }
+        result.update(resolution.metadata(cwd=getattr(env, "cwd", None)))
+        return json.dumps(result, ensure_ascii=False)
 
     finally:
         # Stop the polling thread
@@ -1136,6 +1223,7 @@ def _execute_remote(
         "duration_seconds": duration,
     }
     result.update(stdout_metadata)
+    result.update(resolution.metadata(cwd=getattr(env, "cwd", None)))
 
     if status == "timeout":
         timeout_msg = f"Script timed out after {timeout}s and was killed."
@@ -1169,6 +1257,7 @@ def execute_code(
     code: str,
     task_id: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
+    target: str = None,
 ) -> str:
     """
     Run a Python script in a sandboxed child process with RPC access
@@ -1182,6 +1271,8 @@ def execute_code(
         task_id:       Session task ID for tool isolation (terminal env, etc.).
         enabled_tools: Tool names enabled in the current session. The sandbox
                        gets the intersection with SANDBOX_ALLOWED_TOOLS.
+        target:        Optional named execution target. The configured default
+                       is selected when omitted.
 
     Returns:
         JSON string with execution results.
@@ -1195,9 +1286,23 @@ def execute_code(
     if not code or not code.strip():
         return tool_error("No code provided.")
 
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = resolve_execution_target(target)
+    except Exception as exc:
+        return tool_error(str(exc))
+    # Legacy omitted/default selection already routes every nested call to the
+    # one existing environment. Preserve that call shape and only propagate a
+    # selector when named targets are configured.
+    inherited_target = resolution.target if resolution.named else None
+
     # Dispatch: remote backends use file-based RPC, local uses UDS
     from tools.terminal_tool import _get_env_config, _docker_has_host_access
-    _env_config = _get_env_config()
+    _env_config = (
+        _get_env_config(dict(resolution.config))
+        if resolution.named else _get_env_config()
+    )
     env_type = _env_config["env_type"]
 
     # execute_code runs arbitrary Python (subprocess/os.system/...) that never
@@ -1210,6 +1315,9 @@ def execute_code(
     _guard = check_execute_code_guard(
         code, env_type,
         has_host_access=_docker_has_host_access(_env_config),
+        execution_target=resolution.target,
+        execution_backend=resolution.backend,
+        execution_target_named=resolution.named,
     )
     if not _guard.get("approved", False):
         return json.dumps({
@@ -1230,7 +1338,12 @@ def execute_code(
         clear_current_thread_interrupt()
 
     if env_type != "local":
-        return _execute_remote(code, task_id, enabled_tools)
+        mode = _get_execution_mode()
+        if inherited_target is None:
+            return _execute_remote(code, task_id, enabled_tools, mode=mode)
+        return _execute_remote(
+            code, task_id, enabled_tools, inherited_target, mode=mode,
+        )
 
     # --- Local execution path (UDS) --- below this line is unchanged ---
 
@@ -1325,6 +1438,7 @@ def execute_code(
             args=(
                 server_sock, task_id, tool_call_log,
                 tool_call_counter, max_tool_calls, sandbox_tools, stop_event, rpc_token,
+                inherited_target,
             ),
             daemon=True,
         )
@@ -1392,7 +1506,9 @@ def execute_code(
         # Env scrubbing and tool whitelist apply identically in both modes.
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id or "")
+        _child_cwd = _resolve_child_cwd(
+            _mode, tmpdir, task_id=task_id or "", target=inherited_target,
+        )
         _script_path = os.path.join(tmpdir, "script.py")
 
         proc = subprocess.Popen(
@@ -1560,6 +1676,7 @@ def execute_code(
             "duration_seconds": duration,
         }
         result.update(stdout_metadata)
+        result.update(resolution.metadata(cwd=_child_cwd))
 
         if status == "timeout":
             timeout_msg = f"Script timed out after {timeout}s and was killed."
@@ -1597,12 +1714,14 @@ def execute_code(
             exc,
             exc_info=True,
         )
-        return json.dumps({
+        result = {
             "status": "error",
             "error": str(exc),
             "tool_calls_made": tool_call_counter[0],
             "duration_seconds": duration,
-        }, ensure_ascii=False)
+        }
+        result.update(resolution.metadata())
+        return json.dumps(result, ensure_ascii=False)
 
     finally:
         # Cleanup temp dir and socket
@@ -1792,7 +1911,8 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
+def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "",
+                       target: str = None) -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
@@ -1810,16 +1930,39 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
     """
     if mode != "project":
         return staging_dir
+
+    target_resolution = None
+    target_cwd = ""
+    if target is not None:
+        try:
+            from tools.execution_targets import resolve_execution_target
+
+            target_resolution = resolve_execution_target(target)
+            target_cwd = str(target_resolution.config.get("cwd") or "").strip()
+        except Exception:
+            target_resolution = None
+
     if task_id:
         # 1. The session's cwd record — IS the session's `cd` state.
         try:
             from tools.terminal_tool import get_session_cwd
 
-            recorded = get_session_cwd(task_id)
+            recorded = get_session_cwd(task_id, target=target)
         except Exception:
             recorded = None
         if recorded and os.path.isdir(recorded):
             return recorded
+        # A non-default target owns its configured cwd. The host workspace
+        # override below belongs to the default target and must not replace it.
+        if (
+            target_resolution is not None
+            and target_resolution.named
+            and not target_resolution.is_default
+            and target_cwd
+        ):
+            expanded_target_cwd = os.path.abspath(os.path.expanduser(target_cwd))
+            if os.path.isdir(expanded_target_cwd):
+                return expanded_target_cwd
         # 2. Registered workspace override (session.cwd.set → gateway/TUI/ACP).
         try:
             from tools.file_tools import _registered_task_cwd_override
@@ -1829,7 +1972,9 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
             session_cwd = None
         if session_cwd and os.path.isdir(session_cwd):
             return session_cwd
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    raw = target_cwd
+    if not raw:
+        raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)
         if os.path.isdir(expanded):
@@ -1855,19 +2000,19 @@ _TOOL_DOC_LINES = [
      "    Returns {\"results\": [{\"url\", \"title\", \"content\", \"error\"}, ...]} where content is markdown.\n"
      "    No LLM summarization. Pages over char_limit (default 15000) are head+tail truncated; full text stored on disk (path in the content footer)."),
     ("read_file",
-     "  read_file(path: str, offset: int = 1, limit: int = 500) -> dict\n"
+     "  read_file(path: str, offset: int = 1, limit: int = 500, target: str = None) -> dict\n"
      "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}"),
     ("write_file",
-     "  write_file(path: str, content: str) -> dict\n"
+     "  write_file(path: str, content: str, target: str = None) -> dict\n"
      "    Always overwrites the entire file."),
     ("search_files",
-     "  search_files(pattern: str, target=\"content\", path=\".\", file_glob=None, limit=50) -> dict\n"
-     "    target: \"content\" (search inside files) or \"files\" (find files by name). Returns {\"matches\": [...]}"),
+     "  search_files(pattern: str, target=\"content\", path=\".\", file_glob=None, limit=50, execution_target: str = None) -> dict\n"
+     "    target selects search mode (\"content\" or \"files\"); execution_target selects the configured environment. Returns {\"matches\": [...]}"),
     ("patch",
-     "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False) -> dict\n"
+     "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False, target: str = None) -> dict\n"
      "    Replaces old_string with new_string in the file."),
     ("terminal",
-     "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
+     "  terminal(command: str, timeout=None, workdir=None, target: str = None) -> dict\n"
      "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
@@ -1955,6 +2100,13 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
                         "and print your final result to stdout."
                     ),
                 },
+                "target": {
+                    "type": "string",
+                    "description": (
+                        "Optional named execution target, for example 'local' "
+                        "or 'devbox'. Uses terminal.default_target when omitted."
+                    ),
+                },
             },
             "required": ["code"],
         },
@@ -1976,7 +2128,8 @@ registry.register(
     handler=lambda args, **kw: execute_code(
         code=args.get("code", ""),
         task_id=kw.get("task_id"),
-        enabled_tools=kw.get("enabled_tools")),
+        enabled_tools=kw.get("enabled_tools"),
+        target=args.get("target")),
     check_fn=check_sandbox_requirements,
     emoji="🐍",
     max_result_size_chars=100_000,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1958,9 +1958,10 @@ def _run_single_child(
         # isolated in its own record (a child's cd no longer bleeds back into
         # the parent once readers flip to the record store).
         try:
-            from tools.terminal_tool import get_session_cwd, record_session_cwd
+            from tools.terminal_tool import inherit_session_cwds
 
-            record_session_cwd(child_task_id, get_session_cwd(parent_task_id))
+            if parent_task_id:
+                inherit_session_cwds(parent_task_id, child_task_id)
         except Exception as e:
             logger.debug("Child cwd seed failed: %s", e)
         wall_start = time.time()

--- a/tools/execution_targets.py
+++ b/tools/execution_targets.py
@@ -1,0 +1,240 @@
+"""Resolve static named terminal execution targets.
+
+The resolver is deliberately small and lazy: importing tool schemas never reads
+user configuration, and configured names never enter a schema.  Legacy flat
+terminal configuration stays on the existing environment-variable path.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from contextvars import ContextVar
+from dataclasses import dataclass
+import hashlib
+import os
+import threading
+from typing import Any, Hashable, Iterable, Mapping, Optional
+
+
+class ExecutionTargetError(ValueError):
+    """Raised when terminal target configuration or selection is invalid."""
+
+
+_effective_config_override: ContextVar[dict[str, Any] | None] = ContextVar(
+    "hermes_execution_target_config", default=None,
+)
+_classic_config_lock = threading.RLock()
+_classic_config_override: dict[str, Any] | None = None
+
+
+def set_execution_target_config_source(config: Mapping[str, Any] | None) -> None:
+    """Use an entry point's already-effective config for target resolution.
+
+    The classic CLI has project-fallback and ``--ignore-user-config`` rules
+    that differ from the shared loader. Registering its merged result here
+    keeps tool routing on the same authority boundary.
+    """
+    global _classic_config_override
+    value = deepcopy(dict(config)) if isinstance(config, Mapping) else None
+    _effective_config_override.set(value)
+    with _classic_config_lock:
+        _classic_config_override = deepcopy(value)
+
+
+def _active_profile_scope() -> str:
+    """Return a stable multiplex-profile scope, empty in legacy mode."""
+    try:
+        from agent.secret_scope import is_multiplex_active
+        if not is_multiplex_active():
+            return ""
+        from hermes_constants import get_hermes_home
+
+        home = str(get_hermes_home().resolve())
+        return hashlib.sha256(home.encode("utf-8")).hexdigest()[:12]
+    except Exception:
+        return ""
+
+
+@dataclass(frozen=True)
+class ExecutionTargetResolution:
+    """A resolved execution target and its inherited terminal configuration."""
+
+    target: str
+    backend: str
+    config: Mapping[str, Any]
+    named: bool
+    is_default: bool = True
+    profile_scope: str = ""
+
+    def scope_task_key(self, task_key: Hashable) -> Hashable:
+        if not self.profile_scope:
+            return task_key
+        return f"profile-{self.profile_scope}:{task_key}"
+
+    def environment_key(self, task_key: Hashable) -> Hashable:
+        """Scope an already-collapsed environment key to this target."""
+        scoped = self.scope_task_key(task_key)
+        return (scoped, self.target) if self.named else scoped
+
+    def session_key(self, raw_session_key: Optional[str]) -> Hashable:
+        """Scope per-session state without changing legacy string keys."""
+        key = str(self.scope_task_key(str(raw_session_key or "default")))
+        return (key, self.target) if self.named else key
+
+    def backend_task_id(self, task_key: Hashable) -> str:
+        """Return a backend-safe isolation id without exposing target syntax."""
+        base = str(self.scope_task_key(task_key))
+        if not self.named:
+            return base
+        digest = hashlib.sha256(self.target.encode("utf-8")).hexdigest()[:12]
+        return f"{base}-target-{digest}"
+
+    def metadata(self, *, cwd: Optional[str] = None) -> dict[str, Any]:
+        data: dict[str, Any] = {"target": self.target, "backend": self.backend}
+        if cwd:
+            data["cwd"] = cwd
+        return data
+
+
+def _load_merged_config() -> dict[str, Any]:
+    """Load merged config lazily so importing fixed tool schemas stays cheap."""
+    override = _effective_config_override.get()
+    if override is None:
+        try:
+            from agent.secret_scope import is_multiplex_active
+
+            multiplex = is_multiplex_active()
+        except Exception:
+            multiplex = False
+        if not multiplex:
+            with _classic_config_lock:
+                override = deepcopy(_classic_config_override)
+    if override is not None:
+        return deepcopy(override)
+    from hermes_cli.config import load_config_readonly
+
+    config = load_config_readonly()
+    return config if isinstance(config, dict) else {}
+
+
+def _available(names: Iterable[str]) -> str:
+    return ", ".join(repr(name) for name in sorted(names)) or "(none)"
+
+
+def resolve_execution_target(
+    target: Optional[str] = None,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+) -> ExecutionTargetResolution:
+    """Resolve *target* against merged ``terminal`` configuration.
+
+    With no non-empty ``terminal.targets`` mapping, only omitted target and
+    explicit ``"default"`` are valid and the returned configuration marks the
+    legacy env-driven path.  With named targets, top-level terminal settings
+    are inherited and the selected target mapping overrides them.
+    """
+    if target is not None and (not isinstance(target, str) or not target):
+        raise ExecutionTargetError("Execution target must be a non-empty string.")
+
+    root = config if config is not None else _load_merged_config()
+    profile_scope = _active_profile_scope()
+    if not isinstance(root, Mapping):
+        raise ExecutionTargetError("Terminal configuration must be a mapping.")
+    terminal = root.get("terminal", {})
+    if terminal is None:
+        terminal = {}
+    if not isinstance(terminal, Mapping):
+        raise ExecutionTargetError("terminal must be a mapping.")
+
+    raw_targets = terminal.get("targets")
+    if raw_targets is None or raw_targets == {}:
+        if target not in (None, "default"):
+            raise ExecutionTargetError(
+                f"Unknown execution target {target!r}. Named targets are not configured. "
+                f"Available targets: {_available(['default'])}."
+            )
+        flat = dict(terminal)
+        flat.pop("targets", None)
+        flat.pop("default_target", None)
+        # Legacy flat mode preserves the historical TERMINAL_ENV precedence.
+        # Metadata must describe the backend that will actually execute, not a
+        # stale config.yaml value hidden by an explicit launcher/.env override.
+        backend = str(
+            os.getenv("TERMINAL_ENV")
+            or flat.get("backend")
+            or flat.get("env_type")
+            or "local"
+        ).strip().lower() or "local"
+        return ExecutionTargetResolution(
+            target="default", backend=backend, config=flat, named=False,
+            is_default=True, profile_scope=profile_scope,
+        )
+
+    if not isinstance(raw_targets, Mapping):
+        raise ExecutionTargetError("terminal.targets must be a mapping.")
+
+    invalid_names = [
+        name for name in raw_targets
+        if not isinstance(name, str) or not name
+    ]
+    if invalid_names:
+        raise ExecutionTargetError("terminal.targets names must be non-empty strings.")
+
+    names = sorted(raw_targets)
+    for name in names:
+        if not isinstance(raw_targets[name], Mapping):
+            raise ExecutionTargetError(
+                f"terminal.targets[{name!r}] must be a mapping. "
+                f"Available targets: {_available(names)}."
+            )
+
+    selected = target if target is not None else terminal.get("default_target")
+    if not isinstance(selected, str) or not selected or selected not in raw_targets:
+        if target is not None:
+            prefix = f"Unknown execution target {target!r}."
+        else:
+            prefix = (
+                "terminal.default_target must be a non-empty name present in "
+                "terminal.targets."
+            )
+        raise ExecutionTargetError(
+            f"{prefix} Available targets: {_available(names)}."
+        )
+
+    merged = {
+        key: value
+        for key, value in terminal.items()
+        if key not in {"targets", "default_target"}
+    }
+    merged.update(dict(raw_targets[selected]))
+    backend = str(
+        merged.get("backend") or merged.get("env_type") or "local"
+    ).strip().lower() or "local"
+    return ExecutionTargetResolution(
+        target=selected, backend=backend, config=merged, named=True,
+        is_default=selected == terminal.get("default_target"),
+        profile_scope=profile_scope,
+    )
+
+
+def list_execution_targets(
+    *, config: Optional[Mapping[str, Any]] = None,
+) -> tuple[ExecutionTargetResolution, ...]:
+    """Return configured targets in deterministic order for runtime guidance.
+
+    Tool schemas remain static for prompt-cache stability; callers such as the
+    system-prompt environment hint can use this lightweight runtime inventory
+    to tell the model which fixed-string target values are available.
+    """
+    root = config if config is not None else _load_merged_config()
+    terminal = root.get("terminal", {}) if isinstance(root, Mapping) else {}
+    targets = terminal.get("targets") if isinstance(terminal, Mapping) else None
+    if not isinstance(targets, Mapping) or not targets:
+        return (resolve_execution_target(config=root),)
+    # Resolve the default first so name/default validation uses the same clear
+    # ExecutionTargetError shape as an ordinary omitted-selector tool call.
+    resolve_execution_target(config=root)
+    return tuple(
+        resolve_execution_target(name, config=root)
+        for name in sorted(targets)
+    )

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -38,14 +38,15 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Hashable, Iterable, List, Optional, Tuple
 
 
 # ── Public stamp type ────────────────────────────────────────────────
 # (mtime, read_ts, partial).  partial=True when read_file returned a
 # windowed view (offset > 1 or limit < total_lines) — writes that happen
 # after a partial read should still warn so the model re-reads in full.
-ReadStamp = Tuple[float, float, bool]
+ReadStamp = Tuple[Optional[float], float, bool]
+TaskKey = Hashable
 
 # Number of resolved-path entries retained per agent.  Bounded to keep
 # long sessions from accumulating unbounded state.  On overflow we drop
@@ -56,33 +57,49 @@ _MAX_PATHS_PER_AGENT = 4096
 _MAX_GLOBAL_WRITERS = 4096
 
 
+def _raw_task_id(task_id: TaskKey) -> TaskKey:
+    if isinstance(task_id, tuple) and len(task_id) == 2:
+        return task_id[0]
+    return task_id
+
+
 class FileStateRegistry:
     """Process-wide coordinator for cross-agent file edits."""
 
     def __init__(self) -> None:
-        self._reads: Dict[str, Dict[str, ReadStamp]] = defaultdict(dict)
-        self._last_writer: Dict[str, Tuple[str, float]] = {}
+        self._reads: Dict[TaskKey, Dict[str, ReadStamp]] = defaultdict(dict)
+        self._last_writer: Dict[str, Tuple[TaskKey, float]] = {}
         self._path_locks: Dict[str, threading.Lock] = {}
         self._meta_lock = threading.Lock()  # guards _path_locks
         self._state_lock = threading.Lock()  # guards _reads + _last_writer
 
     # ── Path lock management ────────────────────────────────────────
-    def _lock_for(self, resolved: str) -> threading.Lock:
+    @staticmethod
+    def _state_path(resolved: str, namespace: Optional[str] = None) -> str:
+        return f"{namespace}\0{resolved}" if namespace else resolved
+
+    @staticmethod
+    def _display_path(state_path: str) -> str:
+        return state_path.split("\0", 1)[-1]
+
+    def _lock_for(self, resolved: str,
+                  namespace: Optional[str] = None) -> threading.Lock:
+        state_path = self._state_path(resolved, namespace)
         with self._meta_lock:
-            lock = self._path_locks.get(resolved)
+            lock = self._path_locks.get(state_path)
             if lock is None:
                 lock = threading.Lock()
-                self._path_locks[resolved] = lock
+                self._path_locks[state_path] = lock
             return lock
 
     @contextmanager
-    def lock_path(self, resolved: str):
+    def lock_path(self, resolved: str, namespace: Optional[str] = None):
         """Acquire the per-path lock for a read→modify→write section.
 
         Same process, same filesystem — threads on the same path serialize.
         Different paths proceed in parallel.
         """
-        lock = self._lock_for(resolved)
+        lock = self._lock_for(resolved, namespace)
         lock.acquire()
         try:
             yield
@@ -92,31 +109,39 @@ class FileStateRegistry:
     # ── Read/write accounting ───────────────────────────────────────
     def record_read(
         self,
-        task_id: str,
+        task_id: TaskKey,
         resolved: str,
         *,
         partial: bool = False,
         mtime: Optional[float] = None,
+        namespace: Optional[str] = None,
+        stat_path: bool = True,
     ) -> None:
         if _disabled():
             return
-        if mtime is None:
+        if mtime is None and stat_path:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
                 return
         now = time.time()
+        state_path = self._state_path(resolved, namespace)
         with self._state_lock:
             agent_reads = self._reads[task_id]
-            agent_reads[resolved] = (float(mtime), now, bool(partial))
+            agent_reads[state_path] = (
+                float(mtime) if mtime is not None else None,
+                now,
+                bool(partial),
+            )
             _cap_dict(agent_reads, _MAX_PATHS_PER_AGENT)
 
     def note_write(
         self,
-        task_id: str,
+        task_id: TaskKey,
         resolved: str,
         *,
         mtime: Optional[float] = None,
+        namespace: Optional[str] = None,
     ) -> None:
         """Record a successful write.
 
@@ -132,14 +157,16 @@ class FileStateRegistry:
             except OSError:
                 return
         now = time.time()
+        state_path = self._state_path(resolved, namespace)
         with self._state_lock:
-            self._last_writer[resolved] = (task_id, now)
+            self._last_writer[state_path] = (task_id, now)
             _cap_dict(self._last_writer, _MAX_GLOBAL_WRITERS)
             # Writer's own view is now up-to-date.
-            self._reads[task_id][resolved] = (float(mtime), now, False)
+            self._reads[task_id][state_path] = (float(mtime), now, False)
             _cap_dict(self._reads[task_id], _MAX_PATHS_PER_AGENT)
 
-    def check_stale(self, task_id: str, resolved: str) -> Optional[str]:
+    def check_stale(self, task_id: TaskKey, resolved: str,
+                    namespace: Optional[str] = None) -> Optional[str]:
         """Return a model-facing warning if this write would be stale.
 
         Three staleness classes, in order of severity:
@@ -153,20 +180,15 @@ class FileStateRegistry:
         """
         if _disabled():
             return None
+        state_path = self._state_path(resolved, namespace)
         with self._state_lock:
-            stamp = self._reads.get(task_id, {}).get(resolved)
-            last_writer = self._last_writer.get(resolved)
+            stamp = self._reads.get(task_id, {}).get(state_path)
+            last_writer = self._last_writer.get(state_path)
 
         # Case 3: never read AND we have no write record — net-new file or
         # first touch by this agent.  Let existing _check_sensitive_path
         # and file-exists logic handle it; nothing to warn about here.
         if stamp is None and last_writer is None:
-            return None
-
-        try:
-            current_mtime = os.path.getmtime(resolved)
-        except OSError:
-            # File doesn't exist — write will create it; not stale.
             return None
 
         # Case 1: sibling subagent modified after our last read.
@@ -192,12 +214,18 @@ class FileStateRegistry:
         # Case 2: external / unknown modification (mtime drifted).
         if stamp is not None:
             read_mtime, _read_ts, partial = stamp
-            if current_mtime != read_mtime:
-                return (
-                    f"{resolved} was modified since you last read it "
-                    "on disk (external edit or unrecorded writer). "
-                    "Re-read the file before writing."
-                )
+            if read_mtime is not None:
+                try:
+                    current_mtime = os.path.getmtime(resolved)
+                except OSError:
+                    # File doesn't exist — write will create it; not stale.
+                    return None
+                if current_mtime != read_mtime:
+                    return (
+                        f"{resolved} was modified since you last read it "
+                        "on disk (external edit or unrecorded writer). "
+                        "Re-read the file before writing."
+                    )
             if partial:
                 return (
                     f"{resolved} was last read with offset/limit pagination "
@@ -217,7 +245,7 @@ class FileStateRegistry:
     # ── Reminder helper for delegate_tool ───────────────────────────
     def writes_since(
         self,
-        exclude_task_id: str,
+        exclude_task_id: TaskKey,
         since_ts: float,
         paths: Iterable[str],
     ) -> Dict[str, List[str]]:
@@ -230,23 +258,39 @@ class FileStateRegistry:
         if _disabled():
             return {}
         paths_set = set(paths)
+        exclude_raw = _raw_task_id(exclude_task_id)
         out: Dict[str, List[str]] = defaultdict(list)
         with self._state_lock:
-            for p, (writer_tid, ts) in self._last_writer.items():
-                if writer_tid == exclude_task_id:
+            for state_path, (writer_tid, ts) in self._last_writer.items():
+                writer_raw = _raw_task_id(writer_tid)
+                if writer_raw == exclude_raw:
                     continue
                 if ts < since_ts:
                     continue
-                if p in paths_set:
-                    out[writer_tid].append(p)
+                display_path = self._display_path(state_path)
+                if state_path in paths_set or display_path in paths_set:
+                    out[str(writer_raw)].append(display_path)
         return dict(out)
 
-    def known_reads(self, task_id: str) -> List[str]:
-        """Return the list of resolved paths this agent has read."""
+    def known_reads(self, task_id: TaskKey) -> List[str]:
+        """Return reads for a raw task across all named-target scopes."""
         if _disabled():
             return []
         with self._state_lock:
-            return list(self._reads.get(task_id, {}).keys())
+            reads: list[str] = []
+            seen: set[str] = set()
+            for key, paths in self._reads.items():
+                if key != task_id and _raw_task_id(key) != task_id:
+                    continue
+                for path in paths:
+                    # Preserve the internal target namespace for delegate
+                    # coordination; writes_since strips it before user-facing
+                    # output but uses it to avoid cross-host false conflicts.
+                    read_path = path if "\0" in path else self._display_path(path)
+                    if read_path not in seen:
+                        reads.append(read_path)
+                        seen.add(read_path)
+            return reads
 
     # ── Testing hooks ───────────────────────────────────────────────
     def clear(self) -> None:
@@ -292,32 +336,58 @@ def _cap_dict(d: dict, limit: int) -> None:
 
 
 # ── Convenience wrappers (short names used at call sites) ────────────
-def record_read(task_id: str, resolved_or_path: str | Path, *, partial: bool = False) -> None:
-    _registry.record_read(task_id, str(resolved_or_path), partial=partial)
+def record_read(task_id: TaskKey, resolved_or_path: str | Path, *,
+                partial: bool = False, namespace: Optional[str] = None,
+                stat_path: bool = True) -> None:
+    _registry.record_read(
+        task_id, str(resolved_or_path), partial=partial, namespace=namespace,
+        stat_path=stat_path,
+    )
 
 
-def note_write(task_id: str, resolved_or_path: str | Path) -> None:
-    _registry.note_write(task_id, str(resolved_or_path))
+def note_write(task_id: TaskKey, resolved_or_path: str | Path, *,
+               namespace: Optional[str] = None) -> None:
+    _registry.note_write(task_id, str(resolved_or_path), namespace=namespace)
 
 
-def check_stale(task_id: str, resolved_or_path: str | Path) -> Optional[str]:
-    return _registry.check_stale(task_id, str(resolved_or_path))
+def check_stale(task_id: TaskKey, resolved_or_path: str | Path, *,
+                namespace: Optional[str] = None) -> Optional[str]:
+    return _registry.check_stale(
+        task_id, str(resolved_or_path), namespace=namespace,
+    )
 
 
-def lock_path(resolved_or_path: str | Path):
-    return _registry.lock_path(str(resolved_or_path))
+def lock_path(resolved_or_path: str | Path, *, namespace: Optional[str] = None):
+    return _registry.lock_path(str(resolved_or_path), namespace=namespace)
 
 
 def writes_since(
-    exclude_task_id: str,
+    exclude_task_id: TaskKey,
     since_ts: float,
     paths: Iterable[str | Path],
 ) -> Dict[str, List[str]]:
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        exclude_task_id = resolve_execution_target().scope_task_key(exclude_task_id)
+    except Exception:
+        pass
     return _registry.writes_since(exclude_task_id, since_ts, [str(p) for p in paths])
 
 
-def known_reads(task_id: str) -> List[str]:
-    return _registry.known_reads(task_id)
+def known_reads(task_id: TaskKey) -> List[str]:
+    reads = _registry.known_reads(task_id)
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        scoped = resolve_execution_target().scope_task_key(task_id)
+    except Exception:
+        scoped = task_id
+    if scoped != task_id:
+        for path in _registry.known_reads(scoped):
+            if path not in reads:
+                reads.append(path)
+    return reads
 
 
 __all__ = [

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -148,11 +148,13 @@ _BLOCKED_DEVICE_PATHS = frozenset({
 })
 
 
-def _resolve_path(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
+def _resolve_path(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+) -> Path | PurePosixPath:
     """Resolve a path relative to TERMINAL_CWD (the worktree base directory)
     instead of the main repository root.
     """
-    return _resolve_path_for_task(filepath, task_id)
+    return _resolve_path_for_task(filepath, task_id, execution_target)
 
 
 # Sentinel ``TERMINAL_CWD`` values that mean "not configured", NOT a literal
@@ -167,7 +169,9 @@ _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
 _CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona"})
 
 
-def _terminal_env_type_for_task(task_id: str = "default") -> str:
+def _terminal_env_type_for_task(
+    task_id: str = "default", execution_target: str | None = None,
+) -> str:
     """Best-effort terminal backend type for path-resolution decisions."""
     try:
         from tools.terminal_tool import (
@@ -176,13 +180,19 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
             _get_env_config,
             _resolve_container_task_id,
         )
+        from tools.execution_targets import resolve_execution_target
 
+        resolution = resolve_execution_target(execution_target)
         try:
-            container_key = _resolve_container_task_id(task_id)
+            container_key = resolution.environment_key(
+                _resolve_container_task_id(task_id)
+            )
+            raw_key = resolution.environment_key(task_id)
         except Exception:
             container_key = task_id
+            raw_key = task_id
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(raw_key)
         if env is not None:
             name = env.__class__.__name__.lower()
             if "local" in name:
@@ -197,19 +207,128 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
                 return "modal"
             if "daytona" in name:
                 return "daytona"
-        cfg = _get_env_config()
+        cfg = (
+            _get_env_config(dict(resolution.config))
+            if resolution.named else _get_env_config()
+        )
         return str(cfg.get("env_type") or os.getenv("TERMINAL_ENV") or "local").lower()
     except Exception:
         return str(os.getenv("TERMINAL_ENV") or "local").lower()
 
 
-def _uses_container_paths(task_id: str = "default") -> bool:
+def _uses_container_paths(
+    task_id: str = "default", execution_target: str | None = None,
+) -> bool:
     try:
         from tools.terminal_tool import _CONTAINER_BACKENDS
         container_backends = _CONTAINER_BACKENDS
     except Exception:
         container_backends = _CONTAINER_PATH_BACKENDS_FALLBACK
-    return _terminal_env_type_for_task(task_id) in container_backends
+    return _terminal_env_type_for_task(task_id, execution_target) in container_backends
+
+
+def _file_state_namespace(
+    task_id: str = "default", execution_target: str | None = None,
+) -> str | None:
+    """Namespace remote/container paths, but share locks for local aliases."""
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = resolve_execution_target(execution_target)
+        if resolution.backend == "local":
+            return None
+        if resolution.profile_scope:
+            return f"profile-{resolution.profile_scope}:{resolution.target}"
+        # Preserve the pre-target single-profile legacy state key.
+        return resolution.target if execution_target is not None else None
+    except Exception:
+        # Unknown targets are reported by the tool resolver before state access.
+        return execution_target
+
+
+def _backend_operation_path(
+    original: str,
+    resolved: str | Path | PurePosixPath,
+    task_id: str = "default",
+    execution_target: str | None = None,
+) -> str:
+    """Return the path that should be sent to the selected backend.
+
+    SSH owns relative and ``~`` expansion. Resolving those paths on the Hermes
+    host first creates a host-absolute path that may name a different file (or
+    no file) on the remote machine. Container/local backends retain the existing
+    exact resolved-path contract.
+    """
+    if _terminal_env_type_for_task(task_id, execution_target) == "ssh":
+        original = str(original)
+        if posixpath.isabs(original) or original.startswith("~"):
+            return original
+        try:
+            from tools.terminal_tool import get_session_cwd
+
+            recorded_cwd = get_session_cwd(task_id, target=execution_target)
+        except Exception:
+            recorded_cwd = None
+        if recorded_cwd and posixpath.isabs(str(recorded_cwd)):
+            return posixpath.normpath(posixpath.join(str(recorded_cwd), original))
+        try:
+            from tools.execution_targets import resolve_execution_target
+
+            resolution = resolve_execution_target(execution_target)
+        except Exception:
+            resolution = None
+        # Legacy SSH file operations historically followed the live env cwd.
+        # Only a named target has a stable configured root we can anchor before
+        # a session-specific terminal cwd has been recorded.
+        if resolution is not None and resolution.named:
+            session_cwd = _authoritative_workspace_root(task_id, execution_target)
+            if session_cwd and posixpath.isabs(str(session_cwd)):
+                return posixpath.normpath(posixpath.join(str(session_cwd), original))
+        return original
+    return str(resolved)
+
+
+def _backend_v4a_patch(
+    patch_text: str,
+    task_id: str,
+    execution_target: str | None,
+) -> str:
+    """Anchor relative V4A headers to the calling SSH session's cwd."""
+    if _terminal_env_type_for_task(task_id, execution_target) != "ssh":
+        return patch_text
+    import re
+
+    def _single(match):
+        path = match.group(2).strip()
+        routed = _backend_operation_path(
+            path, path, task_id, execution_target,
+        )
+        return match.group(1) + routed
+
+    rewritten = re.sub(
+        r"^(\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*)(.+)$",
+        _single,
+        patch_text,
+        flags=re.MULTILINE,
+    )
+
+    def _move(match):
+        source = match.group(2).strip()
+        destination = match.group(3).strip()
+        routed_source = _backend_operation_path(
+            source, source, task_id, execution_target,
+        )
+        routed_destination = _backend_operation_path(
+            destination, destination, task_id, execution_target,
+        )
+        return f"{match.group(1)}{routed_source} -> {routed_destination}"
+
+    return re.sub(
+        r"^(\*\*\*\s*Move\s+File:\s*)(.+?)\s*->\s*(.+)$",
+        _move,
+        rewritten,
+        flags=re.MULTILINE,
+    )
 
 
 def _normalize_without_host_deref(path: str | Path | PurePosixPath) -> PurePosixPath:
@@ -269,7 +388,9 @@ def _registered_task_cwd_override(task_id: str = "default") -> str | None:
     return _sentinel_free_abs_cwd(overrides.get("cwd"))
 
 
-def _authoritative_workspace_root(task_id: str = "default") -> str | None:
+def _authoritative_workspace_root(
+    task_id: str = "default", execution_target: str | None = None,
+) -> str | None:
     """Best-effort absolute workspace root for divergence checks.
 
     Resolution:
@@ -279,11 +400,12 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
          registration, keyed by the raw session id. Because the record is
          per-session, one session's ``cd`` can never leak into another
          session's resolution.
-      2. A registered task/session cwd override (TUI/Desktop/ACP sessions
+      2. For an explicit non-default named target, that target's configured
+         cwd. Host workspace overrides must not leak into remote targets.
+      3. A registered task/session cwd override (TUI/Desktop/ACP sessions
          register a raw-keyed cwd before any tool runs). Normally already
-         mirrored into the record at registration; kept as a direct fallback
-         so a cleared/never-written record still resolves the workspace.
-      3. A sentinel-free absolute ``$TERMINAL_CWD`` (the worktree path set by
+         mirrored into the default target's record; kept as a fallback.
+      4. A sentinel-free absolute ``$TERMINAL_CWD`` (the worktree path set by
          ``cli.py``/``main.py`` for ``-w`` sessions).
 
     Returns ``None`` only when there is genuinely no reliable anchor, in which
@@ -292,14 +414,72 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
     try:
         from tools.terminal_tool import get_session_cwd
 
-        recorded = get_session_cwd(task_id)
+        recorded = get_session_cwd(task_id, target=execution_target)
     except Exception:
         recorded = None
     if recorded:
         return recorded
-    registered = _registered_task_cwd_override(task_id)
+
+    target_resolution = None
+    configured_target_cwd = None
+    if execution_target is not None:
+        try:
+            from tools.execution_targets import resolve_execution_target
+            from tools.terminal_tool import _get_env_config
+
+            target_resolution = resolve_execution_target(execution_target)
+            configured = _get_env_config(
+                dict(target_resolution.config)
+            ).get("cwd")
+            if isinstance(configured, str) and configured.strip():
+                if (
+                    target_resolution.backend == "ssh"
+                    and (
+                        configured in {".", "./", "auto", "cwd", "~"}
+                        or configured.startswith("~/")
+                    )
+                ):
+                    # Keep relative/tilde SSH paths on the remote side. Before
+                    # the SSH environment exists there is no truthful absolute
+                    # host-side anchor; actual file operations preserve the raw
+                    # path, and a later terminal call records the resolved remote
+                    # cwd for this session.
+                    configured_target_cwd = configured
+                elif configured in {".", "./", "auto", "cwd"}:
+                    configured_target_cwd = os.getcwd()
+                elif configured == "~" or configured.startswith("~/"):
+                    # SSH expands this remotely; local targets expand here.
+                    configured_target_cwd = (
+                        configured
+                        if target_resolution.backend == "ssh"
+                        else _expand_tilde(configured)
+                    )
+                else:
+                    configured_target_cwd = configured
+        except Exception:
+            target_resolution = None
+
+    if (
+        target_resolution is not None
+        and target_resolution.named
+        and not target_resolution.is_default
+        and configured_target_cwd
+    ):
+        return configured_target_cwd
+
+    registered = (
+        None
+        if (
+            target_resolution is not None
+            and target_resolution.named
+            and target_resolution.backend == "ssh"
+        )
+        else _registered_task_cwd_override(task_id)
+    )
     if registered:
         return registered
+    if configured_target_cwd:
+        return configured_target_cwd
     return _configured_terminal_cwd()
 
 
@@ -307,6 +487,7 @@ def _resolve_base_dir(
     task_id: str = "default",
     *,
     container_paths: bool | None = None,
+    execution_target: str | None = None,
 ) -> Path | PurePosixPath:
     """Return the ABSOLUTE base directory for resolving relative paths.
 
@@ -330,9 +511,16 @@ def _resolve_base_dir(
     outright (rather than anchoring them to the process cwd) and fall through to
     the process cwd only as a last resort, deterministically.
     """
-    root = _authoritative_workspace_root(task_id)
+    root = (
+        _authoritative_workspace_root(task_id, execution_target)
+        if execution_target is not None
+        else _authoritative_workspace_root(task_id)
+    )
     if container_paths is None:
-        container_paths = _uses_container_paths(task_id)
+        container_paths = (
+            _uses_container_paths(task_id, execution_target)
+            if execution_target is not None else _uses_container_paths(task_id)
+        )
     if root:
         base_text = _expand_tilde(root)
     else:
@@ -361,7 +549,9 @@ def _resolve_base_dir(
     return base.resolve()
 
 
-def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
+def _resolve_path_for_task(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+) -> Path | PurePosixPath:
     """Resolve *filepath* against the task's absolute base directory.
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
@@ -371,12 +561,17 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     translated to ``C:\\Users\\...`` before resolution so file tools don't
     treat them as relative ``\\c\\Users\\...`` under the process cwd.
     """
-    container_paths = _uses_container_paths(task_id)
+    container_paths = (
+        _uses_container_paths(task_id, execution_target)
+        if execution_target is not None else _uses_container_paths(task_id)
+    )
     if container_paths:
         expanded = _expand_tilde(filepath)
         if posixpath.isabs(expanded):
             return _normalize_without_host_deref(expanded)
-        resolved = _resolve_base_dir(task_id, container_paths=True) / expanded
+        resolved = _resolve_base_dir(
+            task_id, container_paths=True, execution_target=execution_target,
+        ) / expanded
         return _normalize_without_host_deref(resolved)
 
     # Host paths only — never rewrite Linux paths inside a container/WSL env.
@@ -388,17 +583,24 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
 
         if ntpath.isabs(expanded):
             return Path(ntpath.normpath(expanded))
-        joined = ntpath.join(str(_resolve_base_dir(task_id, container_paths=False)), expanded)
+        joined = ntpath.join(str(_resolve_base_dir(
+            task_id, container_paths=False, execution_target=execution_target,
+        )), expanded)
         return Path(ntpath.normpath(joined))
 
     p = Path(expanded)
     if p.is_absolute():
         return p.resolve()
-    resolved = _resolve_base_dir(task_id, container_paths=False) / p
+    resolved = _resolve_base_dir(
+        task_id, container_paths=False, execution_target=execution_target,
+    ) / p
     return resolved.resolve()
 
 
-def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
+def _path_resolution_warning(
+    filepath: str, resolved: Path, task_id: str = "default",
+    execution_target: str | None = None,
+) -> str | None:
     """Warn when a relative path resolved OUTSIDE the task's workspace root.
 
     Surfaces the worktree-cwd divergence the moment it would matter: if the
@@ -416,10 +618,10 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
     try:
         if Path(_expand_tilde(filepath)).is_absolute():
             return None
-        workspace_root = _authoritative_workspace_root(task_id)
+        workspace_root = _authoritative_workspace_root(task_id, execution_target)
         if not workspace_root:
             return None  # No authoritative workspace root to compare against.
-        if _uses_container_paths(task_id):
+        if _uses_container_paths(task_id, execution_target):
             root = _normalize_without_host_deref(Path(_expand_tilde(workspace_root)))
         else:
             root = Path(_expand_tilde(workspace_root)).resolve()
@@ -515,7 +717,9 @@ def _is_blocked_device(filepath: str, base_dir: str | Path | None = None) -> boo
     return False
 
 
-def _search_result_read_block_error(path: str, task_id: str = "default") -> str | None:
+def _search_result_read_block_error(
+    path: str, task_id: str = "default", execution_target: str | None = None,
+) -> str | None:
     """Return the read-safety error for a search result path.
 
     Search backends may return paths relative to the task cwd, while
@@ -524,20 +728,22 @@ def _search_result_read_block_error(path: str, task_id: str = "default") -> str 
     resolution before applying the shared read guard.
     """
     try:
-        resolved = _resolve_path_for_task(path, task_id)
+        resolved = _resolve_path_for_task(path, task_id, execution_target)
     except (OSError, ValueError, RuntimeError):
         return get_read_block_error(path)
     return get_read_block_error(str(resolved))
 
 
-def _filter_read_blocked_search_results(result, task_id: str = "default") -> int:
+def _filter_read_blocked_search_results(
+    result, task_id: str = "default", execution_target: str | None = None,
+) -> int:
     """Remove credential/cache/env paths from a SearchResult in-place."""
     omitted = 0
 
     if hasattr(result, "matches") and result.matches:
         allowed_matches = []
         for match in result.matches:
-            if _search_result_read_block_error(match.path, task_id):
+            if _search_result_read_block_error(match.path, task_id, execution_target):
                 omitted += 1
                 continue
             allowed_matches.append(match)
@@ -546,7 +752,7 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
     if hasattr(result, "files") and result.files:
         allowed_files = []
         for file_path in result.files:
-            if _search_result_read_block_error(file_path, task_id):
+            if _search_result_read_block_error(file_path, task_id, execution_target):
                 omitted += 1
                 continue
             allowed_files.append(file_path)
@@ -555,7 +761,7 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
     if hasattr(result, "counts") and result.counts:
         allowed_counts = {}
         for file_path, count in result.counts.items():
-            if _search_result_read_block_error(file_path, task_id):
+            if _search_result_read_block_error(file_path, task_id, execution_target):
                 omitted += 1
                 continue
             allowed_counts[file_path] = count
@@ -593,10 +799,12 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
-def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
+def _check_sensitive_path(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(filepath, task_id, execution_target))
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(_expand_tilde(filepath))
@@ -623,7 +831,9 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     return None
 
 
-def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | None:
+def _get_container_mirror_prefix_for_task(
+    task_id: str = "default", execution_target: str | None = None,
+) -> str | None:
     """Return the container-side Hermes mirror prefix for Docker file tools."""
     try:
         from tools.terminal_tool import (
@@ -632,14 +842,17 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
             _get_env_config,
             _resolve_container_task_id,
         )
+        from tools.execution_targets import resolve_execution_target
 
-        container_key = _resolve_container_task_id(task_id)
+        resolution = resolve_execution_target(execution_target)
+        container_key = resolution.environment_key(_resolve_container_task_id(task_id))
+        raw_key = resolution.environment_key(task_id)
     except Exception:
         return None
 
     try:
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(raw_key)
 
         if env is not None:
             if env.__class__.__name__ == "DockerEnvironment" and bool(
@@ -648,7 +861,10 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
                 return "/root/.hermes"
             return None
 
-        config = _get_env_config()
+        config = (
+            _get_env_config(dict(resolution.config))
+            if resolution.named else _get_env_config()
+        )
     except Exception:
         return None
 
@@ -657,7 +873,9 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
     return None
 
 
-def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | None:
+def _check_cross_profile_path(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+) -> str | None:
     """Return a soft-guard warning when ``filepath`` lands in another Hermes
     profile's scoped area, a host-side sandbox-mirror of authoritative profile
     state, or the Docker container's sandbox mirror of Hermes state.
@@ -699,7 +917,7 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     # in a session that cd'd into ``~/.hermes/profiles/other/`` is
     # classified against the right base.
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(filepath, task_id, execution_target))
     except (OSError, ValueError):
         resolved = filepath
 
@@ -711,9 +929,14 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     if warning is not None:
         return warning
 
+    mirror_prefix = (
+        _get_container_mirror_prefix_for_task(task_id)
+        if execution_target is None
+        else _get_container_mirror_prefix_for_task(task_id, execution_target)
+    )
     return get_container_mirror_warning(
         resolved,
-        mirror_prefix=_get_container_mirror_prefix_for_task(task_id),
+        mirror_prefix=mirror_prefix,
     )
 
 
@@ -925,7 +1148,9 @@ def _is_internal_file_tool_content(content: str) -> bool:
     )
 
 
-def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
+def _get_file_ops(
+    task_id: str = "default", target: str = None,
+) -> ShellFileOperations:
     """Get or create ShellFileOperations for a terminal environment.
 
     Respects the TERMINAL_ENV setting -- if the task_id doesn't have an
@@ -946,13 +1171,17 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _creation_locks,
         _creation_locks_lock,
         _resolve_container_task_id,
-        _is_unusable_container_cwd,
-        _CONTAINER_BACKENDS,
+        _record_environment_lifetime,
+        _apply_task_cwd_override,
     )
+    from tools.execution_targets import resolve_execution_target
     import time
 
     raw_task_id = task_id or "default"
-    task_id = _resolve_container_task_id(raw_task_id)
+    resolution = resolve_execution_target(target)
+    base_task_id = _resolve_container_task_id(raw_task_id)
+    task_id = resolution.environment_key(base_task_id)
+    backend_task_id = resolution.backend_task_id(base_task_id)
 
     # Fast path: check cache -- but also verify the underlying environment
     # is still alive (it may have been killed by the cleanup thread).
@@ -973,7 +1202,9 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 if old_cwd:
                     try:
                         from tools.terminal_tool import record_session_cwd
-                        record_session_cwd(raw_task_id, old_cwd)
+                        record_session_cwd(
+                            raw_task_id, old_cwd, _resolution=resolution,
+                        )
                     except Exception:
                         pass
                 with _file_ops_lock:
@@ -998,7 +1229,10 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         if terminal_env is None:
             from tools.terminal_tool import resolve_task_overrides
 
-            config = _get_env_config()
+            config = (
+                _get_env_config(dict(resolution.config))
+                if resolution.named else _get_env_config()
+            )
             env_type = config["env_type"]
             overrides = resolve_task_overrides(raw_task_id)
 
@@ -1015,31 +1249,22 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
 
             try:
                 from tools.terminal_tool import get_session_cwd
-                recorded_cwd = get_session_cwd(raw_task_id)
+                recorded_cwd = get_session_cwd(
+                    raw_task_id, _resolution=resolution,
+                )
             except Exception:
                 recorded_cwd = None
-            cwd = overrides.get("cwd") or recorded_cwd or config["cwd"]
-            # Re-apply the container cwd guard that _get_env_config() already
-            # ran on config["cwd"] (see #50636).  A per-task cwd override
-            # registered by the gateway/TUI/ACP for workspace tracking is a
-            # raw host path (e.g. a Desktop session's /Users/<me>/workspace or
-            # C:\\Users\\<me>). On a container backend that reaches
-            # ``docker run -w <host-path>`` and the container starts in a
-            # directory that doesn't exist inside the sandbox, so search_files
-            # and friends silently return empty results (#54447).  Sanitize it
-            # back to the already-validated config["cwd"] so the override can't
-            # bypass the guard.  Valid in-container override paths (RL/benchmark
-            # sandboxes that set cwd to /workspace, /root, etc.) are absolute
-            # non-host paths and pass through untouched.
-            if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
-                if cwd != config["cwd"]:
-                    logger.info(
-                        "Ignoring host/relative cwd override %r for %s backend "
-                        "(won't exist in sandbox). Using %r instead.",
-                        cwd, env_type, config["cwd"],
-                    )
-                cwd = config["cwd"]
-            logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
+            cwd_override = (
+                overrides.get("cwd")
+                if (
+                    not resolution.named
+                    or (resolution.is_default and resolution.backend != "ssh")
+                )
+                else None
+            )
+            cwd = cwd_override or recorded_cwd or config["cwd"]
+            cwd = _apply_task_cwd_override(config, cwd, cwd_override)
+            logger.info("Creating new %s environment for task %s...", env_type, task_id)
 
             container_config = None
             if env_type in {"docker", "singularity", "modal", "daytona"}:
@@ -1048,11 +1273,17 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "container_memory": config.get("container_memory", 5120),
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
+                    "modal_mode": config.get("modal_mode", "auto"),
                     "docker_volumes": config.get("docker_volumes", []),
                     "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                     "docker_forward_env": config.get("docker_forward_env", []),
+                    "docker_env": config.get("docker_env", {}),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                    "docker_extra_args": config.get("docker_extra_args", []),
                     "docker_network": config.get("docker_network", True),
+                    "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                    "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+                    "lifetime_seconds": config.get("lifetime_seconds", 300),
                 }
 
             ssh_config = None
@@ -1079,16 +1310,17 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 ssh_config=ssh_config,
                 container_config=container_config,
                 local_config=local_config,
-                task_id=task_id,
+                task_id=backend_task_id,
                 host_cwd=config.get("host_cwd"),
             )
+            _record_environment_lifetime(terminal_env, config)
 
             with _env_lock:
                 _active_environments[task_id] = terminal_env
                 _last_activity[task_id] = time.time()
 
             _start_cleanup_thread()
-            logger.info("%s environment ready for task %s", env_type, task_id[:8])
+            logger.info("%s environment ready for task %s", env_type, task_id)
 
     # Build file_ops from the (guaranteed live) environment and cache it
     file_ops = ShellFileOperations(terminal_env)
@@ -1097,7 +1329,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     return file_ops
 
 
-def clear_file_ops_cache(task_id: str = None):
+def clear_file_ops_cache(task_id=None):
     """Clear the file operations cache."""
     with _file_ops_lock:
         if task_id:
@@ -1106,15 +1338,27 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
+def read_file_tool(
+    path: str, offset: int = 1, limit: int = 500,
+    task_id: str = "default", target: str = None,
+) -> str:
     """Read a file with pagination and line numbers."""
     try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = resolve_execution_target(target)
+        selected_target = resolution.target if resolution.named else None
+        host_mtime_tracking = resolution.backend == "local"
+        state_task_id = resolution.session_key(task_id)
+        state_namespace = _file_state_namespace(task_id, selected_target)
         offset, limit = normalize_read_pagination(offset, limit)
 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
         # blocking on input).  Pure path check — no I/O.
-        device_base = None if Path(path).expanduser().is_absolute() else _resolve_base_dir(task_id)
+        device_base = None if Path(path).expanduser().is_absolute() else _resolve_base_dir(
+            task_id, execution_target=selected_target,
+        )
         if _is_blocked_device(path, base_dir=device_base):
             return json.dumps({
                 "error": (
@@ -1123,20 +1367,27 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 ),
             })
 
-        _resolved = _resolve_path_for_task(path, task_id)
+        _resolved = _resolve_path_for_task(path, task_id, selected_target)
 
         # ── Structured-document extraction ────────────────────────────
         # Try before the binary-extension guard so .docx/.xlsx can render as text.
         # Malformed documents fall through to the normal path/binary guard.
         from tools.read_extract import ExtractionError, extract_document_text, is_extractable_document
 
-        if is_extractable_document(str(_resolved)):
+        if (
+            _terminal_env_type_for_task(task_id, selected_target) == "local"
+            and is_extractable_document(str(_resolved))
+        ):
             try:
                 extracted_text = extract_document_text(str(_resolved))
             except ExtractionError:
                 logger.debug("document extraction failed for %s", path, exc_info=True)
             else:
-                file_ops = _get_file_ops(task_id)
+                file_ops = (
+                    _get_file_ops(task_id)
+                    if selected_target is None
+                    else _get_file_ops(task_id, target=selected_target)
+                )
                 lines = extracted_text.splitlines()
                 total_lines = len(lines)
                 end_line = offset + limit - 1
@@ -1182,6 +1433,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                         )
                 if result_dict["content"]:
                     result_dict["content"] = redact_sensitive_text(result_dict["content"], file_read=True)
+                result_dict.update(resolution.metadata(
+                    cwd=_authoritative_workspace_root(task_id, selected_target),
+                ))
                 return json.dumps(result_dict, ensure_ascii=False)
 
         # ── Binary file guard ─────────────────────────────────────────
@@ -1213,7 +1467,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         resolved_str = str(_resolved)
         dedup_key = (resolved_str, offset, limit)
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
+            task_data = _read_tracker.setdefault(state_task_id, {
                 "last_key": None, "consecutive": 0,
                 "read_history": set(), "dedup": {},
                 "dedup_hits": {}, "read_timestamps": {},
@@ -1225,7 +1479,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 task_data["dedup_hits"] = {}
             if "read_timestamps" not in task_data:
                 task_data["read_timestamps"] = {}
-            cached_mtime = task_data.get("dedup", {}).get(dedup_key)
+            cached_mtime = (
+                task_data.get("dedup", {}).get(dedup_key)
+                if host_mtime_tracking
+                else None
+            )
 
         if cached_mtime is not None:
             try:
@@ -1256,20 +1514,32 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                             "already_read": hits + 1,
                         }, ensure_ascii=False)
 
-                    return json.dumps({
+                    unchanged = {
                         "status": "unchanged",
                         "message": _READ_DEDUP_STATUS_MESSAGE,
                         "path": path,
                         "dedup": True,
                         "content_returned": False,
-                    }, ensure_ascii=False)
+                    }
+                    unchanged.update(resolution.metadata(
+                        cwd=_authoritative_workspace_root(task_id, selected_target),
+                    ))
+                    return json.dumps(unchanged, ensure_ascii=False)
             except OSError:
                 pass  # stat failed — fall through to full read
 
         # ── Perform the read ──────────────────────────────────────────
-        file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        file_ops = (
+            _get_file_ops(task_id)
+            if selected_target is None
+            else _get_file_ops(task_id, target=selected_target)
+        )
+        operation_path = _backend_operation_path(
+            path, _resolved, task_id, selected_target,
+        )
+        result = file_ops.read_file(operation_path, offset, limit)
         result_dict = result.to_dict()
+        result_dict.setdefault("resolved_path", operation_path)
 
         # ── Character-count guard ─────────────────────────────────────
         # We're model-agnostic so we can't count tokens; characters are
@@ -1354,12 +1624,13 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             # 1. Dedup: skip identical re-reads of unchanged files.
             # 2. Staleness: warn on write/patch if the file changed since
             #    the agent last read it (external edit, concurrent agent, etc.).
-            try:
-                _mtime_now = os.path.getmtime(resolved_str)
-                task_data["dedup"][dedup_key] = _mtime_now
-                task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
-            except OSError:
-                pass  # Can't stat — skip tracking for this entry
+            if host_mtime_tracking:
+                try:
+                    _mtime_now = os.path.getmtime(resolved_str)
+                    task_data["dedup"][dedup_key] = _mtime_now
+                    task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
+                except OSError:
+                    pass  # Can't stat — skip tracking for this entry
 
             # Bound the per-task containers so a long CLI session doesn't
             # accumulate megabytes of dict/set state.  See _cap_read_tracker_data.
@@ -1374,7 +1645,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # isn't nested under ours.
         try:
             _partial = (offset > 1) or bool(result_dict.get("truncated"))
-            file_state.record_read(task_id, resolved_str, partial=_partial)
+            file_state.record_read(
+                state_task_id, resolved_str, partial=_partial,
+                namespace=state_namespace,
+                stat_path=host_mtime_tracking,
+            )
         except Exception:
             logger.debug("file_state.record_read failed", exc_info=True)
 
@@ -1396,6 +1671,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "If you are stuck in a loop, stop reading and proceed with writing or responding."
             )
 
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
+
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
@@ -1416,8 +1695,25 @@ def reset_file_dedup(task_id: str = None):
     """
     with _read_tracker_lock:
         if task_id:
-            task_data = _read_tracker.get(task_id)
-            if task_data:
+            try:
+                from tools.execution_targets import resolve_execution_target
+
+                scoped_task_id = resolve_execution_target().scope_task_key(task_id)
+            except Exception:
+                scoped_task_id = task_id
+            task_ids = {task_id, scoped_task_id}
+            keys = list(task_ids) + [
+                key for key in _read_tracker
+                if (
+                    isinstance(key, tuple)
+                    and len(key) == 2
+                    and key[0] in task_ids
+                )
+            ]
+            for key in keys:
+                task_data = _read_tracker.get(key)
+                if not task_data:
+                    continue
                 if "dedup" in task_data:
                     task_data["dedup"].clear()
                 if "dedup_hits" in task_data:
@@ -1430,7 +1726,9 @@ def reset_file_dedup(task_id: str = None):
                     task_data["dedup_hits"].clear()
 
 
-def notify_other_tool_call(task_id: str = "default"):
+def notify_other_tool_call(
+    task_id: str = "default", execution_target: str | None = None,
+):
     """Reset consecutive read/search counter for a task.
 
     Called by the tool dispatcher (model_tools.py) whenever a tool OTHER
@@ -1440,8 +1738,34 @@ def notify_other_tool_call(task_id: str = "default"):
     resets and the next read is treated as fresh.
     """
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
-        if task_data:
+        if execution_target is None:
+            try:
+                from tools.execution_targets import resolve_execution_target
+
+                scoped_task_id = resolve_execution_target().scope_task_key(task_id)
+            except Exception:
+                scoped_task_id = task_id
+            keys = [task_id, scoped_task_id] + [
+                key for key in _read_tracker
+                if (
+                    isinstance(key, tuple)
+                    and len(key) == 2
+                    and key[0] in {task_id, scoped_task_id}
+                )
+            ]
+        else:
+            try:
+                from tools.execution_targets import resolve_execution_target
+
+                keys = [
+                    resolve_execution_target(execution_target).session_key(task_id)
+                ]
+            except Exception:
+                keys = [task_id]
+        for key in keys:
+            task_data = _read_tracker.get(key)
+            if not task_data:
+                continue
             task_data["last_key"] = None
             task_data["consecutive"] = 0
             # An intervening non-read tool call breaks any stub-loop in
@@ -1450,7 +1774,9 @@ def notify_other_tool_call(task_id: str = "default"):
                 task_data["dedup_hits"].clear()
 
 
-def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
+def _invalidate_dedup_for_path(
+    filepath: str, task_id: str, execution_target: str | None = None,
+) -> None:
     """Remove all dedup cache entries whose resolved path matches *filepath*.
 
     Called after write_file and patch so that a subsequent read_file on
@@ -1463,12 +1789,16 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
     Must be called with ``_read_tracker_lock`` **not** held — acquires it
     internally.
     """
+    from tools.execution_targets import resolve_execution_target
+    resolution = resolve_execution_target(execution_target)
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.session_key(task_id)
     try:
-        resolved = str(_resolve_path(filepath))
+        resolved = str(_resolve_path_for_task(filepath, task_id, selected_target))
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(state_task_id)
         if task_data is None:
             return
         dedup = task_data.get("dedup")
@@ -1480,7 +1810,9 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
             del dedup[k]
 
 
-def _update_read_timestamp(filepath: str, task_id: str) -> None:
+def _update_read_timestamp(
+    filepath: str, task_id: str, execution_target: str | None = None,
+) -> None:
     """Record the file's current modification time after a successful write.
 
     Called after write_file and patch so that consecutive edits by the
@@ -1491,32 +1823,42 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
     subsequent reads return fresh content (fixes #13144).
     """
     # Invalidate dedup first (before acquiring lock for timestamp update).
-    _invalidate_dedup_for_path(filepath, task_id)
+    from tools.execution_targets import resolve_execution_target
+    resolution = resolve_execution_target(execution_target)
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.session_key(task_id)
+    _invalidate_dedup_for_path(filepath, task_id, selected_target)
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(filepath, task_id, selected_target))
         current_mtime = os.path.getmtime(resolved)
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(state_task_id)
         if task_data is not None:
             task_data.setdefault("read_timestamps", {})[resolved] = current_mtime
             _cap_read_tracker_data(task_data)
 
 
-def _check_file_staleness(filepath: str, task_id: str) -> str | None:
+def _check_file_staleness(
+    filepath: str, task_id: str, execution_target: str | None = None,
+) -> str | None:
     """Check whether a file was modified since the agent last read it.
 
     Returns a warning string if the file is stale (mtime changed since
     the last read_file call for this task), or None if the file is fresh
     or was never read.  Does not block — the write still proceeds.
     """
+    from tools.execution_targets import resolve_execution_target
+    resolution = resolve_execution_target(execution_target)
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.session_key(task_id)
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(filepath, task_id, selected_target))
     except (OSError, ValueError):
         return None
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(state_task_id)
         if not task_data:
             return None
         read_mtime = task_data.get("read_timestamps", {}).get(resolved)
@@ -1539,6 +1881,7 @@ def _mark_verification_stale(
     task_id: str,
     resolved_paths: list[str],
     session_id: str | None = None,
+    execution_target: str | None = None,
 ) -> None:
     """Best-effort note that successful edits made prior verification stale."""
     paths = [p for p in resolved_paths if p]
@@ -1558,7 +1901,7 @@ def _mark_verification_stale(
                 cwd = candidate
                 break
         if cwd is None:
-            cwd = _authoritative_workspace_root(task_id)
+            cwd = _authoritative_workspace_root(task_id, execution_target)
         if cwd is None:
             try:
                 cwd = str(Path(paths[0]).parent)
@@ -1571,7 +1914,8 @@ def _mark_verification_stale(
 
 def write_file_tool(path: str, content: str, task_id: str = "default",
                     cross_profile: bool = False,
-                    session_id: str | None = None) -> str:
+                    session_id: str | None = None,
+                    target: str = None) -> str:
     """Write content to a file.
 
     ``cross_profile`` opts out of the soft cross-Hermes-profile guard. The
@@ -1580,11 +1924,19 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     Pass ``True`` after explicit user direction — same shape as ``force``
     on the terminal tool.
     """
-    sensitive_err = _check_sensitive_path(path, task_id)
+    try:
+        from tools.execution_targets import resolve_execution_target
+        resolution = resolve_execution_target(target)
+    except Exception as exc:
+        return tool_error(str(exc))
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.session_key(task_id)
+    state_namespace = _file_state_namespace(task_id, selected_target)
+    sensitive_err = _check_sensitive_path(path, task_id, selected_target)
     if sensitive_err:
         return tool_error(sensitive_err)
     if not cross_profile:
-        cross_warning = _check_cross_profile_path(path, task_id)
+        cross_warning = _check_cross_profile_path(path, task_id, selected_target)
         if cross_warning:
             return tool_error(cross_warning)
     if _is_internal_file_tool_content(content):
@@ -1598,35 +1950,56 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         # fall back to the legacy path — write proceeds, per-task staleness
         # check below still runs.
         try:
-            _resolved = str(_resolve_path_for_task(path, task_id))
+            _resolved = str(_resolve_path_for_task(path, task_id, selected_target))
         except Exception:
             _resolved = None
 
         if _resolved is None:
-            stale_warning = _check_file_staleness(path, task_id)
-            file_ops = _get_file_ops(task_id)
+            stale_warning = _check_file_staleness(path, task_id, selected_target)
+            file_ops = (
+                _get_file_ops(task_id)
+                if selected_target is None
+                else _get_file_ops(task_id, target=selected_target)
+            )
             result = file_ops.write_file(path, content)
             result_dict = result.to_dict()
             if stale_warning:
                 result_dict["_warning"] = stale_warning
             if not result_dict.get("error"):
-                _mark_verification_stale(task_id, [path], session_id=session_id)
-            _update_read_timestamp(path, task_id)
+                _mark_verification_stale(
+                    task_id, [path], session_id=session_id,
+                    execution_target=selected_target,
+                )
+            _update_read_timestamp(path, task_id, selected_target)
+            result_dict.update(resolution.metadata(
+                cwd=_authoritative_workspace_root(task_id, selected_target),
+            ))
             return json.dumps(result_dict, ensure_ascii=False)
 
         # Serialize the read→modify→write region per-path so concurrent
         # subagents can't interleave on the same file.  Different paths
         # remain fully parallel.
-        with file_state.lock_path(_resolved):
+        with file_state.lock_path(_resolved, namespace=state_namespace):
             # Cross-agent staleness wins over per-task warning when both
             # fire — its message names the sibling subagent.
-            cross_warning = file_state.check_stale(task_id, _resolved)
-            stale_warning = _check_file_staleness(path, task_id)
+            cross_warning = file_state.check_stale(
+                state_task_id, _resolved, namespace=state_namespace,
+            )
+            stale_warning = _check_file_staleness(path, task_id, selected_target)
             # Workspace-divergence warning: relative path resolving outside the
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
-            cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
-            file_ops = _get_file_ops(task_id)
-            result = file_ops.write_file(_resolved, content)
+            cwd_warning = _path_resolution_warning(
+                path, Path(_resolved), task_id, selected_target,
+            )
+            file_ops = (
+                _get_file_ops(task_id)
+                if selected_target is None
+                else _get_file_ops(task_id, target=selected_target)
+            )
+            operation_path = _backend_operation_path(
+                path, _resolved, task_id, selected_target,
+            )
+            result = file_ops.write_file(operation_path, content)
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning
             if effective_warning:
@@ -1634,15 +2007,23 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # Always report the ABSOLUTE path actually written, so a wrong-cwd
             # mismatch is visible in the response instead of silently routing
             # the edit to the wrong checkout.
-            result_dict["resolved_path"] = _resolved
+            result_dict["resolved_path"] = operation_path
             if not result_dict.get("error"):
-                result_dict["files_modified"] = [_resolved]
-                _mark_verification_stale(task_id, [_resolved], session_id=session_id)
+                result_dict["files_modified"] = [operation_path]
+                _mark_verification_stale(
+                    task_id, [operation_path], session_id=session_id,
+                    execution_target=selected_target,
+                )
             # Refresh stamps after the successful write so consecutive
             # writes by this task don't trigger false staleness warnings.
-            _update_read_timestamp(path, task_id)
+            _update_read_timestamp(path, task_id, selected_target)
             if not result_dict.get("error"):
-                file_state.note_write(task_id, _resolved)
+                file_state.note_write(
+                    state_task_id, _resolved, namespace=state_namespace,
+                )
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):
@@ -1655,13 +2036,22 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default", cross_profile: bool = False,
-               session_id: str | None = None) -> str:
+               session_id: str | None = None, target: str = None) -> str:
     """Patch a file using replace mode or V4A patch format.
 
     ``cross_profile`` opts out of the soft cross-Hermes-profile guard for
     targets under another profile's skills/plugins/cron/memories
     directory. Same shape as ``write_file``'s flag.
     """
+    try:
+        from tools.execution_targets import resolve_execution_target
+        resolution = resolve_execution_target(target)
+    except Exception as exc:
+        return tool_error(str(exc))
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.session_key(task_id)
+    state_namespace = _file_state_namespace(task_id, selected_target)
+
     # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
     _paths_to_check = []
     if path:
@@ -1708,11 +2098,11 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     return _err
                 _paths_to_check.append(v4a_path)
     for _p in _paths_to_check:
-        sensitive_err = _check_sensitive_path(_p, task_id)
+        sensitive_err = _check_sensitive_path(_p, task_id, selected_target)
         if sensitive_err:
             return tool_error(sensitive_err)
         if not cross_profile:
-            cross_warning = _check_cross_profile_path(_p, task_id)
+            cross_warning = _check_cross_profile_path(_p, task_id, selected_target)
             if cross_warning:
                 return tool_error(cross_warning)
     try:
@@ -1723,7 +2113,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         _seen: set[str] = set()
         for _p in _paths_to_check:
             try:
-                _r = str(_resolve_path_for_task(_p, task_id))
+                _r = str(_resolve_path_for_task(_p, task_id, selected_target))
             except Exception:
                 _r = None
             if _r and _r not in _seen:
@@ -1737,7 +2127,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         from contextlib import ExitStack
         with ExitStack() as _locks:
             for _r in _resolved_paths:
-                _locks.enter_context(file_state.lock_path(_r))
+                _locks.enter_context(
+                    file_state.lock_path(_r, namespace=state_namespace)
+                )
 
             # Collect warnings — cross-agent registry first (names sibling),
             # then per-task tracker as a fallback.
@@ -1745,20 +2137,28 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             _path_to_resolved: dict[str, str] = {}
             for _p in _paths_to_check:
                 try:
-                    _r = str(_resolve_path_for_task(_p, task_id))
+                    _r = str(_resolve_path_for_task(_p, task_id, selected_target))
                 except Exception:
                     _r = None
                 _path_to_resolved[_p] = _r
-                _cross = file_state.check_stale(task_id, _r) if _r else None
-                _sw = _cross or _check_file_staleness(_p, task_id)
+                _cross = file_state.check_stale(
+                    state_task_id, _r, namespace=state_namespace,
+                ) if _r else None
+                _sw = _cross or _check_file_staleness(_p, task_id, selected_target)
                 if not _sw and _r:
                     # Workspace-divergence warning (worktree-cwd bug): relative
                     # path resolving outside the terminal's cwd.
-                    _sw = _path_resolution_warning(_p, Path(_r), task_id)
+                    _sw = _path_resolution_warning(
+                        _p, Path(_r), task_id, selected_target,
+                    )
                 if _sw:
                     stale_warnings.append(_sw)
 
-            file_ops = _get_file_ops(task_id)
+            file_ops = (
+                _get_file_ops(task_id)
+                if selected_target is None
+                else _get_file_ops(task_id, target=selected_target)
+            )
 
             if mode == "replace":
                 if not path:
@@ -1770,12 +2170,17 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 # shell's own cwd may differ (worktree-cwd bug), and a relative
                 # path would let the two layers disagree about which file is
                 # being edited.
-                _replace_target = _path_to_resolved.get(path) or path
+                _replace_target = _backend_operation_path(
+                    path, _path_to_resolved.get(path) or path,
+                    task_id, selected_target,
+                )
                 result = file_ops.patch_replace(_replace_target, old_string, new_string, replace_all)
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
-                result = file_ops.patch_v4a(patch)
+                result = file_ops.patch_v4a(
+                    _backend_v4a_patch(patch, task_id, selected_target)
+                )
             else:
                 return tool_error(f"Unknown mode: {mode}")
 
@@ -1786,7 +2191,11 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # mismatch (e.g. a worktree session editing the main checkout) is
             # visible in the response instead of silently landing elsewhere.
             _resolved_modified = [
-                _path_to_resolved.get(_p) or _p for _p in _paths_to_check
+                _backend_operation_path(
+                    _p, _path_to_resolved.get(_p) or _p,
+                    task_id, selected_target,
+                )
+                for _p in _paths_to_check
             ]
             # Refresh stored timestamps for all successfully-patched paths so
             # consecutive edits by this task don't trigger false warnings.
@@ -1794,16 +2203,21 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 result_dict["files_modified"] = _resolved_modified
                 if len(_resolved_modified) == 1:
                     result_dict["resolved_path"] = _resolved_modified[0]
-                _mark_verification_stale(task_id, _resolved_modified, session_id=session_id)
+                _mark_verification_stale(
+                    task_id, _resolved_modified, session_id=session_id,
+                    execution_target=selected_target,
+                )
                 for _p in _paths_to_check:
-                    _update_read_timestamp(_p, task_id)
+                    _update_read_timestamp(_p, task_id, selected_target)
                     _r = _path_to_resolved.get(_p)
                     if _r:
-                        file_state.note_write(task_id, _r)
+                        file_state.note_write(
+                            state_task_id, _r, namespace=state_namespace,
+                        )
                 # Successful patch: clear any prior consecutive-failure
                 # counters for the touched paths so a future failure on
                 # the same path starts the escalation cycle fresh.
-                _reset_patch_failures(task_id, [
+                _reset_patch_failures(state_task_id, [
                     _r for _r in (_path_to_resolved.get(_p) for _p in _paths_to_check) if _r
                 ])
         # Hint when old_string not found — saves iterations where the agent
@@ -1818,7 +2232,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             failure_count = 0
             if mode == "replace" and path:
                 resolved = _path_to_resolved.get(path) or path
-                failure_count = _record_patch_failure(task_id, resolved)
+                failure_count = _record_patch_failure(state_task_id, resolved)
 
             if failure_count >= 3:
                 # Escalating hint after multiple consecutive failures on the
@@ -1841,6 +2255,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     "old_string not found. Use read_file to verify the current "
                     "content, or search_files to locate the text."
                 )
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
@@ -1849,9 +2266,14 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
-                task_id: str = "default") -> str:
+                task_id: str = "default", execution_target: str = None) -> str:
     """Search for content or files."""
     try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = resolve_execution_target(execution_target)
+        selected_target = resolution.target if resolution.named else None
+        state_task_id = resolution.session_key(task_id)
         offset, limit = normalize_search_pagination(offset, limit)
 
         # Track searches to detect *consecutive* repeated search loops.
@@ -1867,7 +2289,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             offset,
         )
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
+            task_data = _read_tracker.setdefault(state_task_id, {
                 "last_key": None, "consecutive": 0, "read_history": set(),
             })
             if task_data["last_key"] == search_key:
@@ -1889,19 +2311,29 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             }, ensure_ascii=False)
 
         try:
-            resolved_path = _resolve_path_for_task(path, task_id)
+            resolved_path = _resolve_path_for_task(path, task_id, selected_target)
         except (OSError, ValueError, RuntimeError):
             resolved_path = None
         block_error = get_read_block_error(str(resolved_path) if resolved_path else path)
         if block_error:
             return json.dumps({"error": block_error}, ensure_ascii=False)
 
-        file_ops = _get_file_ops(task_id)
+        file_ops = (
+            _get_file_ops(task_id)
+            if selected_target is None
+            else _get_file_ops(task_id, target=selected_target)
+        )
+        operation_path = _backend_operation_path(
+            path, resolved_path or path, task_id, selected_target,
+        )
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
+            pattern=pattern, path=operation_path, target=target,
+            file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
-        omitted = _filter_read_blocked_search_results(result, task_id)
+        omitted = _filter_read_blocked_search_results(
+            result, task_id, selected_target,
+        )
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
@@ -1919,6 +2351,10 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 f"You have run this exact search {count} times consecutively. "
                 "The results have not changed. Use the information you already have."
             )
+
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
 
         result_json = json.dumps(result_dict, ensure_ascii=False)
         # Hint when results were truncated — explicit next offset is clearer
@@ -1952,7 +2388,8 @@ READ_FILE_SCHEMA = {
         "properties": {
             "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000}
+            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000},
+            "target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. Uses terminal.default_target when omitted."},
         },
         "required": ["path"]
     }
@@ -1966,6 +2403,7 @@ WRITE_FILE_SCHEMA = {
         "properties": {
             "path": {"type": "string", "description": "Path to the file to write (will be created if it doesn't exist, overwritten if it does)"},
             "content": {"type": "string", "description": "Complete content to write to the file"},
+            "target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. Uses terminal.default_target when omitted."},
             "cross_profile": {
                 "type": "boolean",
                 "description": "Opt out of the cross-profile soft guard. Defaults to false. Set true ONLY after explicit user direction to edit another Hermes profile's skills/plugins/cron/memories — by default these writes are blocked with a warning because they affect a different profile than the one this session is running under.",
@@ -2022,6 +2460,7 @@ PATCH_SCHEMA = {
                 "description": "Opt out of the cross-profile soft guard. Defaults to false. Set true ONLY after explicit user direction to edit another Hermes profile's skills/plugins/cron/memories.",
                 "default": False,
             },
+            "target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. Uses terminal.default_target when omitted."},
         },
         "required": ["mode"],
     },
@@ -2029,7 +2468,7 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nCompatibility exception: target still selects search mode ('content' or 'files'); execution_target selects the named terminal execution target.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -2040,7 +2479,8 @@ SEARCH_FILES_SCHEMA = {
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
             "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
-            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
+            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0},
+            "execution_target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. This is separate from target, which selects content/files search mode."},
         },
         "required": ["pattern"]
     }
@@ -2049,7 +2489,10 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""), offset=args.get("offset", 1),
+        limit=args.get("limit", 500), task_id=tid, target=args.get("target"),
+    )
 
 
 def _handle_write_file(args, **kw):
@@ -2076,6 +2519,7 @@ def _handle_write_file(args, **kw):
         path=args["path"], content=args["content"], task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
         session_id=kw.get("session_id"),
+        target=args.get("target"),
     )
 
 
@@ -2087,6 +2531,7 @@ def _handle_patch(args, **kw):
         replace_all=args.get("replace_all", False), patch=args.get("patch"), task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
         session_id=kw.get("session_id"),
+        target=args.get("target"),
     )
 
 
@@ -2098,7 +2543,10 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode", "content"),
+        context=args.get("context", 0), task_id=tid,
+        execution_target=args.get("execution_target"),
+    )
 
 
 registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -137,6 +137,12 @@ class ProcessSession:
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
+    # Trailing fields preserve the positional constructor contract for every
+    # pre-existing ProcessSession field.
+    target: str = ""                           # Named execution target (empty in legacy mode)
+    backend: str = ""                          # Resolved terminal backend
+    timeout_seconds: int = 0                   # Selected target's wait ceiling
+    environment_task_key: str = ""            # Profile-scoped env ownership key
 
 
 class ProcessRegistry:
@@ -212,6 +218,17 @@ class ProcessRegistry:
         # terminal tab. Distinct from kill — the process keeps running; only the
         # UI view is dropped (the user can reopen it from the status stack).
         self.on_close = None
+
+    @staticmethod
+    def _with_execution_metadata(result: dict, session: ProcessSession) -> dict:
+        """Add stable target/backend identity to a process result."""
+        if session.target:
+            result["target"] = session.target
+        if session.backend:
+            result["backend"] = session.backend
+        if session.cwd and "cwd" not in result:
+            result["cwd"] = session.cwd
+        return result
 
     @staticmethod
     def _clean_shell_noise(text: str) -> str:
@@ -325,6 +342,9 @@ class ProcessRegistry:
                     "user_name": session.watcher_user_name,
                     "thread_id": session.watcher_thread_id,
                     "message_id": session.watcher_message_id,
+                    **({"target": session.target} if session.target else {}),
+                    **({"backend": session.backend} if session.backend else {}),
+                    **({"cwd": session.cwd} if session.cwd else {}),
                     "message": (
                         f"Watch patterns disabled for process {session.id} — "
                         f"{WATCH_STRIKE_LIMIT} consecutive rate-limit windows triggered "
@@ -358,6 +378,9 @@ class ProcessRegistry:
             "user_name": session.watcher_user_name,
             "thread_id": session.watcher_thread_id,
             "message_id": session.watcher_message_id,
+            **({"target": session.target} if session.target else {}),
+            **({"backend": session.backend} if session.backend else {}),
+            **({"cwd": session.cwd} if session.cwd else {}),
         })
 
     def _global_watch_admit(self, now: float) -> bool:
@@ -694,6 +717,10 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        target: str = "",
+        backend: str = "",
+        timeout_seconds: int = 0,
+        environment_task_key: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -711,6 +738,10 @@ class ProcessRegistry:
             task_id=task_id,
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
+            target=target,
+            backend=backend or "local",
+            timeout_seconds=timeout_seconds,
+            environment_task_key=environment_task_key,
             started_at=time.time(),
         )
 
@@ -833,6 +864,10 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        target: str = "",
+        backend: str = "",
+        timeout_seconds: int = 0,
+        environment_task_key: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -851,6 +886,10 @@ class ProcessRegistry:
             task_id=task_id,
             session_key=session_key,
             cwd=cwd,
+            target=target,
+            backend=backend,
+            timeout_seconds=timeout_seconds,
+            environment_task_key=environment_task_key,
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
@@ -1102,6 +1141,9 @@ class ProcessRegistry:
                 # a consumer-observed completion timestamp, this does not vary
                 # based on which watcher notices exit first.
                 "started_at": session.started_at,
+                **({"target": session.target} if session.target else {}),
+                **({"backend": session.backend} if session.backend else {}),
+                **({"cwd": session.cwd} if session.cwd else {}),
             })
 
     # ----- Query Methods -----
@@ -1353,6 +1395,7 @@ class ProcessRegistry:
             "uptime_seconds": int(time.time() - session.started_at),
             "output_preview": output_preview,
         }
+        self._with_execution_metadata(result, session)
         if session.exited:
             result["exit_code"] = session.exit_code
             result["completion_reason"] = session.completion_reason
@@ -1406,6 +1449,7 @@ class ProcessRegistry:
             "total_lines": total_lines,
             "showing": f"{len(selected)} lines",
         }
+        self._with_execution_metadata(result, session)
         if session.exited and observed_completion_output:
             self._completion_consumed.add(session_id)
         return result
@@ -1416,7 +1460,7 @@ class ProcessRegistry:
 
         Args:
             session_id: The process to wait for.
-            timeout: Max seconds to block. Falls back to TERMINAL_TIMEOUT config.
+            timeout: Max seconds to block. Falls back to the process target's timeout.
 
         Returns:
             dict with status ("exited", "timeout", "interrupted", "not_found")
@@ -1425,8 +1469,16 @@ class ProcessRegistry:
         from tools.ansi_strip import strip_ansi
         from tools.interrupt import is_interrupted as _is_interrupted
 
+        session = self.get(session_id)
+        if session is None:
+            return {"status": "not_found", "error": f"No process with ID {session_id}"}
+
         try:
-            default_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
+            default_timeout = (
+                int(session.timeout_seconds)
+                if int(session.timeout_seconds) > 0
+                else int(os.getenv("TERMINAL_TIMEOUT", "180"))
+            )
         except (ValueError, TypeError):
             default_timeout = 180
         max_timeout = default_timeout
@@ -1441,10 +1493,6 @@ class ProcessRegistry:
             )
         else:
             effective_timeout = requested_timeout or max_timeout
-
-        session = self.get(session_id)
-        if session is None:
-            return {"status": "not_found", "error": f"No process with ID {session_id}"}
 
         deadline = time.monotonic() + effective_timeout
 
@@ -1466,6 +1514,7 @@ class ProcessRegistry:
                     "termination_source": session.termination_source,
                     "output": strip_ansi(session.output_buffer[-2000:]),
                 }
+                self._with_execution_metadata(result, session)
                 if timeout_note:
                     result["timeout_note"] = timeout_note
                 return result
@@ -1477,6 +1526,7 @@ class ProcessRegistry:
                     "output": strip_ansi(session.output_buffer[-1000:]),
                     "note": "User sent a new message -- wait interrupted",
                 }
+                self._with_execution_metadata(result, session)
                 if timeout_note:
                     result["timeout_note"] = timeout_note
                 return result
@@ -1491,6 +1541,7 @@ class ProcessRegistry:
             "command": session.command,
             "output": strip_ansi(session.output_buffer[-1000:]),
         }
+        self._with_execution_metadata(result, session)
         if timeout_note:
             result["timeout_note"] = timeout_note
         else:
@@ -1527,6 +1578,7 @@ class ProcessRegistry:
                     "termination_source": session.termination_source,
                     "output": strip_ansi(session.output_buffer[-2000:]),
                 }
+            self._with_execution_metadata(result, session)
             # Only suppress the autonomous turn after its output is present in
             # the explicit kill result, matching wait/log consumption.
             if consume_output:
@@ -1562,11 +1614,12 @@ class ProcessRegistry:
                     if consume_output:
                         self._completion_consumed.add(session_id)
                     self._move_to_finished(session)
-                    return {
+                    result = {
                         "status": "already_exited",
                         "exit_code": session.exit_code,
                         "output": output,
                     }
+                    return self._with_execution_metadata(result, session)
                 self._terminate_host_pid(session.pid, session.host_start_time)
             else:
                 return {
@@ -1589,13 +1642,14 @@ class ProcessRegistry:
                 session.termination_source = source
             self._move_to_finished(session)
             self._write_checkpoint()
-            return {
+            result = {
                 "status": "killed",
                 "session_id": session.id,
                 "completion_reason": session.completion_reason,
                 "termination_source": session.termination_source,
                 "output": output,
             }
+            return self._with_execution_metadata(result, session)
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
@@ -1736,6 +1790,7 @@ class ProcessRegistry:
                 "status": "exited" if s.exited else "running",
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
             }
+            self._with_execution_metadata(entry, s)
             # Flag processes surfaced only because they share the gateway
             # session (not the current task) — these are the long-lived
             # background processes a user may have forgotten about (#29177).
@@ -1758,7 +1813,7 @@ class ProcessRegistry:
 
     # ----- Session/Task Queries (for gateway integration) -----
 
-    def has_active_processes(self, task_id: str) -> bool:
+    def has_active_processes(self, task_id: Any) -> bool:
         """Check if there are active (running) processes for a task_id."""
         with self._lock:
             sessions = list(self._running.values())
@@ -1766,11 +1821,16 @@ class ProcessRegistry:
         for session in sessions:
             self._refresh_detached_session(session)
 
-        with self._lock:
-            return any(
-                s.task_id == task_id and not s.exited
-                for s in self._running.values()
+        if isinstance(task_id, tuple) and len(task_id) == 2:
+            base_task_id, target = task_id
+            matches = lambda s: (
+                (s.environment_task_key or s.task_id) == base_task_id
+                and s.target == target
             )
+        else:
+            matches = lambda s: (s.environment_task_key or s.task_id) == task_id
+        with self._lock:
+            return any(matches(s) and not s.exited for s in self._running.values())
 
     def has_active_for_session(
         self, session_key: str, max_active_age: Optional[float] = None,
@@ -1899,6 +1959,10 @@ class ProcessRegistry:
                             "started_at": s.started_at,
                             "task_id": s.task_id,
                             "session_key": s.session_key,
+                            "target": s.target,
+                            "backend": s.backend,
+                            "timeout_seconds": s.timeout_seconds,
+                            "environment_task_key": s.environment_task_key,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
                             "watcher_user_id": s.watcher_user_id,
@@ -1975,6 +2039,10 @@ class ProcessRegistry:
                 host_start_time=recorded_start,
                 pid_scope=pid_scope,
                 cwd=entry.get("cwd"),
+                target=entry.get("target", ""),
+                backend=entry.get("backend", ""),
+                timeout_seconds=int(entry.get("timeout_seconds") or 0),
+                environment_task_key=entry.get("environment_task_key", ""),
                 started_at=entry.get("started_at", time.time()),
                 detached=True,  # Can't read output, but can report status + kill
                 watcher_platform=entry.get("watcher_platform", ""),
@@ -2331,11 +2399,15 @@ def _handle_process(args, **kw):
                 ensure_ascii=False,
             )
         elif action == "write":
-            return json.dumps(process_registry.write_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
+            result = process_registry.write_stdin(session_id, str(args.get("data", "")))
         elif action == "submit":
-            return json.dumps(process_registry.submit_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
+            result = process_registry.submit_stdin(session_id, str(args.get("data", "")))
         elif action == "close":
-            return json.dumps(process_registry.close_stdin(session_id), ensure_ascii=False)
+            result = process_registry.close_stdin(session_id)
+        session = process_registry.get(session_id)
+        if session is not None:
+            process_registry._with_execution_metadata(result, session)
+        return json.dumps(result, ensure_ascii=False)
     return tool_error(f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit, close")
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -42,8 +42,10 @@ import threading
 import atexit
 import shutil
 import subprocess
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Hashable
 
 from utils import env_var_enabled
 
@@ -200,8 +202,35 @@ def set_approval_callback(cb):
     _callback_tls.approval = cb
 
 
-def _get_sudo_password_cache_scope() -> str:
-    """Return the cache scope for interactive sudo passwords."""
+_sudo_execution_context: ContextVar[
+    tuple[str, str, bool, Optional[str]] | None
+] = ContextVar(
+    "hermes_sudo_execution_context", default=None,
+)
+
+
+@contextmanager
+def _scoped_sudo_execution(
+    target: str,
+    backend: str,
+    *,
+    named: bool = False,
+    sudo_password: Optional[str] = None,
+):
+    token = _sudo_execution_context.set(
+        (target, backend, named, sudo_password),
+    )
+    try:
+        yield
+    finally:
+        _sudo_execution_context.reset(token)
+
+
+def _get_sudo_password_cache_scope(
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+) -> str:
+    """Return the session + target scope for interactive sudo passwords."""
     try:
         from gateway.session_context import get_session_env
 
@@ -209,29 +238,49 @@ def _get_sudo_password_cache_scope() -> str:
     except Exception:
         session_key = os.getenv("HERMES_SESSION_KEY", "")
     if session_key:
-        return f"session:{session_key}"
+        base_scope = f"session:{session_key}"
+    else:
+        callback = _get_sudo_password_callback()
+        if callback is not None:
+            owner = getattr(callback, "__self__", None)
+            func = getattr(callback, "__func__", None)
+            if owner is not None and func is not None:
+                base_scope = f"callback-owner:{id(owner)}:{id(func)}"
+            else:
+                base_scope = f"callback:{id(callback)}"
+        else:
+            base_scope = f"thread:{threading.get_ident()}"
 
-    callback = _get_sudo_password_callback()
-    if callback is not None:
-        owner = getattr(callback, "__self__", None)
-        func = getattr(callback, "__func__", None)
-        if owner is not None and func is not None:
-            return f"callback-owner:{id(owner)}:{id(func)}"
-        return f"callback:{id(callback)}"
+    active_context = _sudo_execution_context.get()
+    if execution_target is None and active_context is not None:
+        execution_target = active_context[0]
+    if execution_backend is None and active_context is not None:
+        execution_backend = active_context[1]
+    if execution_target is None and execution_backend is None:
+        return base_scope
+    return (
+        f"{base_scope}|target:{execution_target!r}"
+        f"|backend:{str(execution_backend or '').lower()}"
+    )
 
-    return f"thread:{threading.get_ident()}"
 
-
-def _get_cached_sudo_password() -> str:
-    """Return the cached sudo password for the current scope."""
-    scope = _get_sudo_password_cache_scope()
+def _get_cached_sudo_password(
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+) -> str:
+    """Return the cached sudo password for the current target scope."""
+    scope = _get_sudo_password_cache_scope(execution_target, execution_backend)
     with _sudo_password_cache_lock:
         return _sudo_password_cache.get(scope, "")
 
 
-def _set_cached_sudo_password(password: str) -> None:
-    """Persist a sudo password for the current scope."""
-    scope = _get_sudo_password_cache_scope()
+def _set_cached_sudo_password(
+    password: str,
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+) -> None:
+    """Persist a sudo password for the current target scope."""
+    scope = _get_sudo_password_cache_scope(execution_target, execution_backend)
     with _sudo_password_cache_lock:
         if password:
             _sudo_password_cache[scope] = password
@@ -279,11 +328,17 @@ def _docker_has_host_access(config: Dict[str, Any]) -> bool:
 
 
 def _check_all_guards(command: str, env_type: str,
-                      has_host_access: bool = False) -> dict:
+                      has_host_access: bool = False,
+                      execution_target: str = "default",
+                      execution_backend: Optional[str] = None,
+                      execution_target_named: bool = False) -> dict:
     """Delegate to consolidated guard (tirith + dangerous cmd) with CLI callback."""
     return _check_all_guards_impl(command, env_type,
                                   approval_callback=_get_approval_callback(),
-                                  has_host_access=has_host_access)
+                                  has_host_access=has_host_access,
+                                  execution_target=execution_target,
+                                  execution_backend=execution_backend or env_type,
+                                  execution_target_named=execution_target_named)
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
@@ -359,7 +414,10 @@ def _sudo_wrong_password_failure(output: str) -> bool:
 
 
 def _invalidate_cached_sudo_on_auth_failure(
-    command: str | None, output: str
+    command: str | None,
+    output: str,
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
 ) -> bool:
     """Drop a session-cached sudo password after sudo rejects it.
 
@@ -372,9 +430,9 @@ def _invalidate_cached_sudo_on_auth_failure(
         return False
     if _count_real_sudo_invocations(command or "") == 0:
         return False
-    if not _get_cached_sudo_password():
+    if not _get_cached_sudo_password(execution_target, execution_backend):
         return False
-    _set_cached_sudo_password("")
+    _set_cached_sudo_password("", execution_target, execution_backend)
     return True
 
 
@@ -685,7 +743,11 @@ def _sudo_nopasswd_works() -> bool:
     cache) so an expired sudo timestamp cannot make a later command silently
     block waiting for a password.
     """
-    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    active_context = _sudo_execution_context.get()
+    if active_context is not None:
+        terminal_env = active_context[1].strip().lower() or "local"
+    else:
+        terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
     if terminal_env != "local":
         return False
 
@@ -909,12 +971,24 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     if sudo_count == 0:
         return command, None
 
-    has_configured_password = "SUDO_PASSWORD" in os.environ
-    sudo_password = (
-        os.environ.get("SUDO_PASSWORD", "")
-        if has_configured_password
-        else _get_cached_sudo_password()
-    )
+    active_context = _sudo_execution_context.get()
+    if active_context is not None and active_context[2]:
+        # Named targets are config-isolated: never inherit the default target's
+        # bridged SUDO_PASSWORD into another host/container.
+        configured_password = active_context[3]
+        has_configured_password = configured_password is not None
+        sudo_password = (
+            str(configured_password)
+            if has_configured_password
+            else _get_cached_sudo_password()
+        )
+    else:
+        has_configured_password = "SUDO_PASSWORD" in os.environ
+        sudo_password = (
+            os.environ.get("SUDO_PASSWORD", "")
+            if has_configured_password
+            else _get_cached_sudo_password()
+        )
 
     # Local hosts with sudoers NOPASSWD should not be forced through the
     # interactive Hermes password prompt or the sudo -S password-pipe path.
@@ -955,7 +1029,7 @@ import sys
 
 
 # Tool description for LLM
-TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
+TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on the selected execution target (using bash/Linux shell semantics). Filesystem, current working directory, and exported environment variables persist between calls.
 
 Do NOT use cat/head/tail to read files — use read_file instead.
 Do NOT use grep/rg/find to search — use search_files instead.
@@ -979,10 +1053,10 @@ Do NOT use vim/nano/interactive tools without pty=true — they hang without a p
 """
 
 # Global state for environment lifecycle management
-_active_environments: Dict[str, Any] = {}
-_last_activity: Dict[str, float] = {}
+_active_environments: Dict[Hashable, Any] = {}
+_last_activity: Dict[Hashable, float] = {}
 _env_lock = threading.Lock()
-_creation_locks: Dict[str, threading.Lock] = {}  # Per-task locks for sandbox creation
+_creation_locks: Dict[Hashable, threading.Lock] = {}  # Per-target locks for sandbox creation
 _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
 _cleanup_thread = None
 _cleanup_running = False
@@ -1026,15 +1100,32 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
             return
         _docker_orphan_reaper_ran = True
 
-    # 2 × lifetime_seconds gives sibling Hermes processes a generous grace
-    # window. Floor at 60s so an operator with TERMINAL_LIFETIME_SECONDS=0
-    # doesn't get an instant-reap that races their own setup.
-    # ``container_config`` only carries container_* keys, so read
-    # lifetime_seconds from the env var the rest of the module uses.
+    # 2 × the longest configured Docker-target lifetime gives every named
+    # sibling a conservative grace window. A process-wide reaper runs only
+    # once, so using the first-created target's value could reap a longer-lived
+    # target prematurely.
     try:
-        lifetime = int(os.getenv("TERMINAL_LIFETIME_SECONDS", "300"))
+        lifetime = int(container_config.get(
+            "lifetime_seconds", os.getenv("TERMINAL_LIFETIME_SECONDS", "300"),
+        ))
     except (TypeError, ValueError):
         lifetime = 300
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        targets = list_execution_targets()
+        if targets and targets[0].named:
+            for target in targets:
+                if target.backend != "docker":
+                    continue
+                try:
+                    lifetime = max(
+                        lifetime, int(target.config.get("lifetime_seconds", 300)),
+                    )
+                except (TypeError, ValueError):
+                    continue
+    except Exception:
+        logger.debug("Could not resolve Docker target lifetimes", exc_info=True)
     lifetime = max(60, lifetime)
     max_age = lifetime * 2
 
@@ -1067,8 +1158,10 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
 #
 # This is never exposed to the model -- only infrastructure code calls it.
 # Thread-safe because each task_id is unique per rollout.
-_task_env_overrides: Dict[str, Dict[str, Any]] = {}
-
+_task_env_overrides: Dict[Hashable, Dict[str, Any]] = {}
+_task_env_overrides_lock = threading.Lock()
+_active_turn_counts: Dict[Hashable, int] = {}
+_active_turn_counts_lock = threading.Lock()
 # ── Per-session cwd records (cwd rearchitecture, step 1) ────────────────────
 #
 # The durable source of truth for "which directory is THIS session working
@@ -1083,11 +1176,75 @@ _task_env_overrides: Dict[str, Dict[str, Any]] = {}
 # here. Readers still use the legacy env.cwd ladder. Later steps flip
 # file_tools and _resolve_command_cwd to read this store, then delete the
 # env-side tracking + ownership guards.
-_session_cwd: Dict[str, str] = {}
+_session_cwd: Dict[Hashable, str] = {}
 _session_cwd_lock = threading.Lock()
 
 
-def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
+def _target_resolution(target=None):
+    from tools.execution_targets import resolve_execution_target
+
+    return resolve_execution_target(target)
+
+
+def _environment_scope_key(task_key: Hashable, resolution) -> Hashable:
+    return resolution.environment_key(task_key)
+
+
+def _profile_scoped_task_key(task_key: Hashable) -> Hashable:
+    try:
+        return _target_resolution(None).scope_task_key(task_key)
+    except Exception:
+        return task_key
+
+
+def _turn_scope_key(task_id: Hashable) -> Hashable:
+    collapsed = _resolve_container_task_id(str(task_id))
+    return _profile_scoped_task_key(collapsed)
+
+
+def register_environment_turn(task_id: Hashable) -> None:
+    """Mark one conversation turn as using the shared target environments."""
+    key = _turn_scope_key(task_id)
+    with _active_turn_counts_lock:
+        _active_turn_counts[key] = _active_turn_counts.get(key, 0) + 1
+
+
+def release_environment_turn(task_id: Hashable) -> int:
+    """Release a turn and return the remaining users of its environment scope."""
+    key = _turn_scope_key(task_id)
+    with _active_turn_counts_lock:
+        remaining = max(0, _active_turn_counts.get(key, 0) - 1)
+        if remaining:
+            _active_turn_counts[key] = remaining
+        else:
+            _active_turn_counts.pop(key, None)
+        return remaining
+
+
+def active_environment_turns(task_id: Hashable) -> int:
+    """Return active tool executions sharing this task's environment scope."""
+    key = _turn_scope_key(task_id)
+    with _active_turn_counts_lock:
+        return _active_turn_counts.get(key, 0)
+
+
+@contextmanager
+def environment_turn_usage(task_id: Hashable):
+    """Keep shared environments alive for one in-flight tool execution."""
+    register_environment_turn(task_id)
+    try:
+        yield
+    finally:
+        release_environment_turn(task_id)
+
+
+def record_session_cwd(
+    session_key: Optional[str],
+    cwd: Optional[str],
+    target: Optional[str] = None,
+    *,
+    _resolution=None,
+) -> None:
     """Record *cwd* as the working directory of *session_key*.
 
     Called wherever a session's live cwd becomes known: after a terminal
@@ -1098,28 +1255,66 @@ def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
     """
     if not isinstance(cwd, str) or not cwd.strip():
         return
-    key = str(session_key or "default")
+    resolution = _resolution or _target_resolution(target)
+    key = resolution.session_key(session_key)
     with _session_cwd_lock:
         if _session_cwd.get(key) != cwd:
             _session_cwd[key] = cwd
 
 
-def get_session_cwd(session_key: Optional[str]) -> Optional[str]:
+def get_session_cwd(
+    session_key: Optional[str],
+    target: Optional[str] = None,
+    *,
+    _resolution=None,
+) -> Optional[str]:
     """Return the recorded working directory for *session_key*, if any.
 
     No fallback chain here on purpose: callers decide what an absent record
     means (config default, TERMINAL_CWD seed, process cwd). ``None``/empty
     keys read the ``"default"`` record.
     """
-    key = str(session_key or "default")
+    resolution = _resolution or _target_resolution(target)
+    key = resolution.session_key(session_key)
     with _session_cwd_lock:
         return _session_cwd.get(key)
 
 
-def clear_session_cwd(session_key: str) -> None:
-    """Drop a session's cwd record (session teardown)."""
+def inherit_session_cwds(parent_task_id: str, child_task_id: str) -> int:
+    """Seed a child with every cwd scope currently owned by its parent."""
+    if not parent_task_id or not child_task_id:
+        return 0
+    parent_key = _profile_scoped_task_key(parent_task_id)
+    child_key = _profile_scoped_task_key(child_task_id)
+    inherited: Dict[Hashable, str] = {}
     with _session_cwd_lock:
-        _session_cwd.pop(session_key, None)
+        for key, cwd in _session_cwd.items():
+            if key == parent_key:
+                inherited[child_key] = cwd
+            elif (
+                isinstance(key, tuple)
+                and len(key) == 2
+                and key[0] == parent_key
+            ):
+                inherited[(child_key, key[1])] = cwd
+        _session_cwd.update(inherited)
+    return len(inherited)
+
+
+def clear_session_cwd(session_key: str) -> None:
+    """Drop all legacy and named-target cwd records for a raw session."""
+    raw = str(session_key or "default")
+    scoped = _profile_scoped_task_key(raw)
+    with _session_cwd_lock:
+        _session_cwd.pop(raw, None)
+        _session_cwd.pop(scoped, None)
+        for key in list(_session_cwd):
+            if (
+                isinstance(key, tuple)
+                and len(key) == 2
+                and key[0] in {raw, scoped}
+            ):
+                _session_cwd.pop(key, None)
 
 
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
@@ -1138,7 +1333,7 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         task_id: The rollout's unique task identifier
         overrides: Dict of config keys to override
     """
-    _task_env_overrides[task_id] = overrides
+    _task_env_overrides[_profile_scoped_task_key(task_id)] = overrides
 
     # If a live environment already exists for this task, a freshly registered
     # ``cwd`` override (e.g. the ACP client switching the editor's project root
@@ -1148,8 +1343,23 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     new_cwd = overrides.get("cwd")
     if isinstance(new_cwd, str) and new_cwd.strip():
         # A registered workspace cwd IS the session's working directory until
-        # a `cd` changes it.
-        record_session_cwd(task_id, new_cwd)
+        # a `cd` changes it. With named targets this host/workspace override
+        # belongs to the configured default target only; applying it to every
+        # explicit remote/container target would replace that target's own cwd.
+        try:
+            default_resolution = _target_resolution(None)
+        except Exception:
+            default_resolution = None
+        if (
+            default_resolution is not None
+            and not (
+                default_resolution.named
+                and default_resolution.backend == "ssh"
+            )
+        ):
+            record_session_cwd(
+                task_id, new_cwd, _resolution=default_resolution,
+            )
         # The live env is cached under the raw task_id for per-session surfaces
         # (ACP/gateway/dashboard) and under the collapsed container id for
         # isolation-keyed rollouts. Try the raw id first, then the container id,
@@ -1157,9 +1367,24 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         # updates the originating session's env.
         container_id = _resolve_container_task_id(task_id)
         with _env_lock:
-            env = _active_environments.get(task_id) or _active_environments.get(container_id)
-        if env is not None and getattr(env, "cwd", None) is not None:
-            env.cwd = new_cwd
+            if (
+                default_resolution is not None
+                and default_resolution.named
+                and default_resolution.backend != "ssh"
+            ):
+                candidate_keys = {
+                    default_resolution.environment_key(task_id),
+                    default_resolution.environment_key(container_id),
+                }
+            else:
+                candidate_keys = {task_id, container_id}
+            envs = [
+                env for key, env in _active_environments.items()
+                if key in candidate_keys
+            ]
+        for env in envs:
+            if getattr(env, "cwd", None) is not None:
+                env.cwd = new_cwd
 
 
 def clear_task_env_overrides(task_id: str):
@@ -1168,7 +1393,7 @@ def clear_task_env_overrides(task_id: str):
 
     Called during cleanup to avoid stale entries accumulating.
     """
-    _task_env_overrides.pop(task_id, None)
+    _task_env_overrides.pop(_profile_scoped_task_key(task_id), None)
     clear_session_cwd(task_id)
 
 
@@ -1200,10 +1425,11 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
         "docker_image", "modal_image", "singularity_image",
         "daytona_image", "env_type",
     })
-    if task_id and task_id in _task_env_overrides:
-        overrides = _task_env_overrides[task_id]
+    scoped_task_id = _profile_scoped_task_key(task_id) if task_id else None
+    if scoped_task_id and scoped_task_id in _task_env_overrides:
+        overrides = _task_env_overrides[scoped_task_id]
         if set(overrides.keys()) & _ISOLATION_KEYS:
-            return task_id
+            return str(task_id)
     return "default"
 
 
@@ -1220,9 +1446,11 @@ def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
     source of that lookup so the terminal and file layers can't drift apart.
     """
     raw = task_id or "default"
+    scoped_raw = _profile_scoped_task_key(raw)
+    scoped_collapsed = _profile_scoped_task_key(_resolve_container_task_id(raw))
     return (
-        _task_env_overrides.get(raw)
-        or _task_env_overrides.get(_resolve_container_task_id(raw))
+        _task_env_overrides.get(scoped_raw)
+        or _task_env_overrides.get(scoped_collapsed)
         or {}
     )
 
@@ -1305,6 +1533,40 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
+def _apply_task_cwd_override(
+    config: Dict[str, Any], cwd: str, cwd_override: Optional[str],
+) -> str:
+    """Apply a task workspace cwd without leaking host paths into containers.
+
+    Docker's explicit mount-cwd mode is the exception: a registered host
+    workspace should become the bind source and commands should run in
+    ``/workspace``. Other container backends fall back to the target's already
+    sanitized configured cwd.
+    """
+    env_type = config.get("env_type")
+    if (
+        env_type == "docker"
+        and config.get("docker_mount_cwd_to_workspace")
+        and isinstance(cwd_override, str)
+        and cwd_override.strip()
+    ):
+        candidate = os.path.abspath(os.path.expanduser(cwd_override))
+        is_host_path = (
+            any(candidate.startswith(prefix) for prefix in _HOST_CWD_PREFIXES)
+            or (
+                os.path.isabs(candidate)
+                and os.path.isdir(candidate)
+                and not candidate.startswith(("/workspace", "/root"))
+            )
+        )
+        if is_host_path:
+            config["host_cwd"] = candidate
+            return "/workspace"
+    if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
+        return config["cwd"]
+    return cwd
+
+
 # One-shot guard for the config-fallback bridge below.  Purely an
 # optimization: after the first attempt either TERMINAL_ENV is set (bridge
 # succeeded — merged config always carries terminal.backend) or the import
@@ -1346,14 +1608,50 @@ def _ensure_terminal_env_bridged() -> None:
         logger.debug("terminal config → env fallback bridge failed", exc_info=True)
 
 
-def _get_env_config() -> Dict[str, Any]:
-    """Get terminal environment configuration from environment variables."""
-    # Default image with Python and Node.js for maximum compatibility
+def _get_env_config(terminal_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return canonical terminal config for legacy env vars or a target mapping.
+
+    ``terminal_config is None`` is the historical flat/env-driven path.  A
+    selected named target passes its inherited mapping here directly; values
+    are parsed without mutating ``os.environ`` so concurrent target calls
+    cannot affect each other.
+    """
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    if terminal_config is None:
+        _ensure_terminal_env_bridged()
+
+    def _get(key: str, env_name: str, default: Any) -> Any:
+        if terminal_config is None:
+            return os.getenv(env_name, str(default) if not isinstance(default, (list, dict)) else json.dumps(default))
+        return terminal_config.get(key, default)
+
+    def _coerce(value: Any, converter: Any, label: str, key: str) -> Any:
+        if converter is json.loads and isinstance(value, (list, dict)):
+            return value
+        try:
+            return converter(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            source = (
+                f"terminal target setting {key}"
+                if terminal_config is not None
+                else f"TERMINAL_{key.upper()}"
+            )
+            raise ValueError(f"Invalid value for {source}: {value!r} (expected {label}).")
+
+    def _bool(key: str, env_name: str, default: bool) -> bool:
+        value = _get(key, env_name, default)
+        if isinstance(value, bool):
+            return value
+        return str(value).lower() in {"true", "1", "yes"}
+
+    env_type = str(
+        _get(
+            "backend", "TERMINAL_ENV",
+            terminal_config.get("env_type", "local") if terminal_config else "local",
+        )
+    ).strip().lower() or "local"
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = _bool("docker_mount_cwd_to_workspace", "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", False)
     container_backend = env_type in {"docker", "singularity", "modal", "daytona"}
     docker_backend = env_type == "docker"
 
@@ -1362,19 +1660,19 @@ def _get_env_config() -> Dict[str, Any]:
     # until a backend that can consume them is selected; a stale or invalid
     # Docker value should not make local terminal/execute_code unusable.
     if container_backend:
-        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number")
-        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120")
-        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200")
+        container_cpu = _coerce(_get("container_cpu", "TERMINAL_CONTAINER_CPU", 1), float, "number", "container_cpu")
+        container_memory = _coerce(_get("container_memory", "TERMINAL_CONTAINER_MEMORY", 5120), int, "integer", "container_memory")
+        container_disk = _coerce(_get("container_disk", "TERMINAL_CONTAINER_DISK", 51200), int, "integer", "container_disk")
     else:
         container_cpu = 1.0
         container_memory = 5120
         container_disk = 51200
 
     if docker_backend:
-        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
-        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
-        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
-        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
+        docker_forward_env = _coerce(_get("docker_forward_env", "TERMINAL_DOCKER_FORWARD_ENV", []), json.loads, "valid JSON", "docker_forward_env")
+        docker_volumes = _coerce(_get("docker_volumes", "TERMINAL_DOCKER_VOLUMES", []), json.loads, "valid JSON", "docker_volumes")
+        docker_env = _coerce(_get("docker_env", "TERMINAL_DOCKER_ENV", {}), json.loads, "valid JSON", "docker_env")
+        docker_extra_args = _coerce(_get("docker_extra_args", "TERMINAL_DOCKER_EXTRA_ARGS", []), json.loads, "valid JSON", "docker_extra_args")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1395,12 +1693,18 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = str(_get("cwd", "TERMINAL_CWD", default_cwd) or default_cwd)
+    if env_type == "local" and cwd in {".", "./", "auto", "cwd"}:
+        cwd = _safe_getcwd()
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = (
+            (os.getenv("TERMINAL_CWD") or _safe_getcwd())
+            if terminal_config is None
+            else (cwd or _safe_getcwd())
+        )
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1418,40 +1722,40 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(_get("modal_mode", "TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": str(_get("docker_image", "TERMINAL_DOCKER_IMAGE", default_image)),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
+        "singularity_image": str(_get("singularity_image", "TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}")),
+        "modal_image": str(_get("modal_image", "TERMINAL_MODAL_IMAGE", default_image)),
+        "daytona_image": str(_get("daytona_image", "TERMINAL_DAYTONA_IMAGE", default_image)),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _coerce(_get("timeout", "TERMINAL_TIMEOUT", 180), int, "integer", "timeout"),
+        "lifetime_seconds": _coerce(_get("lifetime_seconds", "TERMINAL_LIFETIME_SECONDS", 300), int, "integer", "lifetime_seconds"),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
-        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_host": str(_get("ssh_host", "TERMINAL_SSH_HOST", "")),
+        "ssh_user": str(_get("ssh_user", "TERMINAL_SSH_USER", "")),
+        "ssh_port": _coerce(_get("ssh_port", "TERMINAL_SSH_PORT", 22), int, "integer", "ssh_port"),
+        "ssh_key": str(_get("ssh_key", "TERMINAL_SSH_KEY", "")),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
-            "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
-        ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "ssh_persistent": _bool(
+            "ssh_persistent", "TERMINAL_SSH_PERSISTENT",
+            _bool("persistent_shell", "TERMINAL_PERSISTENT_SHELL", True),
+        ),
+        "local_persistent": _bool("local_persistent", "TERMINAL_LOCAL_PERSISTENT", False),
         # Container resource config (applies to docker, singularity, modal,
         # daytona -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": _bool("container_persistent", "TERMINAL_CONTAINER_PERSISTENT", True),
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": _bool("docker_run_as_host_user", "TERMINAL_DOCKER_RUN_AS_HOST_USER", False),
+        "docker_network": _bool("docker_network", "TERMINAL_DOCKER_NETWORK", True),
         "docker_extra_args": docker_extra_args,
         # Cross-process container reuse (issue #20561).  The docs claim
         # "ONE long-lived container shared across sessions" — this toggle
@@ -1459,17 +1763,25 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
-            "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
-        ).lower() in {"true", "1", "yes"},
+        "docker_persist_across_processes": _bool(
+            "docker_persist_across_processes", "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", True,
+        ),
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
-            "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
-        ).lower() in {"true", "1", "yes"},
+        "docker_orphan_reaper": _bool(
+            "docker_orphan_reaper", "TERMINAL_DOCKER_ORPHAN_REAPER", True,
+        ),
     }
+
+
+def _record_environment_lifetime(env: Any, config: Dict[str, Any]) -> None:
+    """Attach the resolved target's idle lifetime to its environment."""
+    try:
+        env._hermes_lifetime_seconds = int(config["lifetime_seconds"])
+    except (AttributeError, KeyError, TypeError, ValueError):
+        pass
 
 
 def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
@@ -1515,7 +1827,12 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_network = cc.get("docker_network", True)
 
     if env_type == "local":
-        return _LocalEnvironment(cwd=cwd, timeout=timeout)
+        env = _LocalEnvironment(cwd=cwd, timeout=timeout)
+        setattr(
+            env, "_persistent",
+            bool((local_config or {}).get("persistent", False)),
+        )
+        return env
     
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by
@@ -1655,7 +1972,11 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
 
     with _env_lock:
         for task_id, last_time in list(_last_activity.items()):
-            if current_time - last_time > lifetime_seconds:
+            tracked_env = _active_environments.get(task_id)
+            effective_lifetime = getattr(
+                tracked_env, "_hermes_lifetime_seconds", lifetime_seconds,
+            )
+            if current_time - last_time > effective_lifetime:
                 env = _active_environments.pop(task_id, None)
                 _last_activity.pop(task_id, None)
                 if env is not None:
@@ -1732,14 +2053,23 @@ def _stop_cleanup_thread():
             pass
 
 
-def get_active_env(task_id: str):
+def get_active_env(task_id: str, target: Optional[str] = None):
     """Return the active BaseEnvironment for *task_id*, or None."""
-    lookup = _resolve_container_task_id(task_id)
+    resolution = _target_resolution(target)
+    lookup = _environment_scope_key(_resolve_container_task_id(task_id), resolution)
+    raw_lookup = _environment_scope_key(task_id, resolution)
     with _env_lock:
-        return _active_environments.get(lookup) or _active_environments.get(task_id)
+        return _active_environments.get(lookup) or _active_environments.get(raw_lookup)
 
 
-def is_persistent_env(task_id: str) -> bool:
+def _environment_is_persistent(env: Any) -> bool:
+    return bool(
+        getattr(env, "_persistent", False)
+        or getattr(env, "persistent_filesystem", False)
+    )
+
+
+def is_persistent_env(task_id: str, target: Optional[str] = None) -> bool:
     """Return True if the active environment for task_id is configured for
     cross-turn persistence (``persistent_filesystem=True``).
 
@@ -1750,10 +2080,10 @@ def is_persistent_env(task_id: str) -> bool:
     (``_cleanup_inactive_envs``) handles persistent envs once they exceed
     ``terminal.lifetime_seconds``.
     """
-    env = get_active_env(task_id)
+    env = get_active_env(task_id, target=target)
     if env is None:
         return False
-    return bool(getattr(env, "_persistent", False))
+    return _environment_is_persistent(env)
 
 
 
@@ -1785,11 +2115,20 @@ def cleanup_all_environments():
     return cleaned
 
 
-def cleanup_vm(task_id: str, *, force_remove: bool = False):
+def cleanup_vm(
+    task_id: Hashable,
+    *,
+    force_remove: bool = False,
+    preserve_persistent: bool = False,
+    target: Optional[str] = None,
+    include_collapsed: bool = False,
+):
     """Manually clean up a specific environment by task_id.
 
     *force_remove* (default False) is forwarded to backends that accept it
-    — currently only ``DockerEnvironment``. The default of False matches
+    — currently only ``DockerEnvironment``. ``preserve_persistent`` is used
+    by per-turn cleanup to keep each persistent named sibling live while
+    removing only non-persistent targets. The default of False matches
     session-lifecycle semantics: this function is called from
     ``AIAgent.close()`` (TUI session close, gateway session teardown) and the
     per-turn cleanup branch for non-persistent envs, both of which should
@@ -1806,51 +2145,121 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     via this function), so persist-mode idle envs are similarly no-op'd —
     only the orphan reaper at next startup reclaims them.
     """
-    # Remove from tracking dicts while holding the lock, but defer the
-    # actual (potentially slow) env.cleanup() call to outside the lock
-    # so other tool calls aren't blocked.
-    env = None
+    # Direct tuple keys are used by global/idle cleanup. For a raw task,
+    # omitted target cleans every target scope owned by that exact raw key;
+    # an explicit target cleans exactly that scope. Do not collapse arbitrary
+    # subagent ids to "default" here: legacy cleanup_vm(child_id) never tore
+    # down the parent's shared environment, and doing so in named mode would
+    # let a delegate's close race/disrupt its parent.
+    if isinstance(task_id, tuple):
+        keys = [task_id]
+    elif target is None:
+        try:
+            resolution = _target_resolution(None)
+            scoped_task_id = resolution.scope_task_key(task_id)
+            collapsed_task_id = _resolve_container_task_id(str(task_id))
+            scoped_collapsed_task_id = resolution.scope_task_key(collapsed_task_id)
+        except Exception:
+            scoped_task_id = task_id
+            collapsed_task_id = task_id
+            scoped_collapsed_task_id = task_id
+        matching_task_ids = {task_id, scoped_task_id}
+        if include_collapsed:
+            matching_task_ids.update({
+                collapsed_task_id, scoped_collapsed_task_id,
+            })
+        with _env_lock:
+            keys = [
+                key for key in _active_environments
+                if key in matching_task_ids
+                or (
+                    isinstance(key, tuple) and len(key) == 2
+                    and key[0] in matching_task_ids
+                )
+            ]
+        if not keys:
+            keys = [task_id]
+    else:
+        resolution = _target_resolution(target)
+        if resolution.named:
+            keys = [resolution.environment_key(task_id)]
+        else:
+            keys = [task_id]
+
+    active_process_keys = set()
+    if preserve_persistent:
+        try:
+            from tools.process_registry import process_registry
+
+            active_process_keys = {
+                key for key in keys
+                if process_registry.has_active_processes(key)
+            }
+        except Exception:
+            logger.debug(
+                "Failed to inspect active processes before cleanup",
+                exc_info=True,
+            )
+
+    envs = []
+    removed_keys = []
     with _env_lock:
-        env = _active_environments.pop(task_id, None)
-        _last_activity.pop(task_id, None)
+        for key in keys:
+            existing = _active_environments.get(key)
+            if key in active_process_keys:
+                continue
+            if (
+                preserve_persistent
+                and existing is not None
+                and _environment_is_persistent(existing)
+            ):
+                continue
+            env = _active_environments.pop(key, None)
+            _last_activity.pop(key, None)
+            removed_keys.append(key)
+            if env is not None:
+                envs.append((key, env))
 
     # Clean up per-task creation lock
     with _creation_locks_lock:
-        _creation_locks.pop(task_id, None)
+        for key in removed_keys:
+            _creation_locks.pop(key, None)
 
     # Invalidate stale file_ops cache entry
     try:
         from tools.file_tools import clear_file_ops_cache
-        clear_file_ops_cache(task_id)
+        for key in removed_keys:
+            clear_file_ops_cache(key)
     except ImportError:
         pass
 
-    if env is None:
+    if not envs:
         return
 
-    try:
-        if hasattr(env, 'cleanup'):
-            # Pass force_remove only if the env's cleanup() accepts it
-            # (DockerEnvironment after issue #20561; other backends don't).
-            import inspect
-            sig = inspect.signature(env.cleanup)
-            if "force_remove" in sig.parameters:
-                env.cleanup(force_remove=force_remove)
+    for key, env in envs:
+        try:
+            if hasattr(env, 'cleanup'):
+                # Pass force_remove only if the env's cleanup() accepts it
+                # (DockerEnvironment after issue #20561; other backends don't).
+                import inspect
+                sig = inspect.signature(env.cleanup)
+                if "force_remove" in sig.parameters:
+                    env.cleanup(force_remove=force_remove)
+                else:
+                    env.cleanup()
+            elif hasattr(env, 'stop'):
+                env.stop()
+            elif hasattr(env, 'terminate'):
+                env.terminate()
+
+            logger.info("Manually cleaned up environment for task: %s", key)
+
+        except Exception as e:
+            error_str = str(e)
+            if "404" in error_str or "not found" in error_str.lower():
+                logger.info("Environment for task %s already cleaned up", key)
             else:
-                env.cleanup()
-        elif hasattr(env, 'stop'):
-            env.stop()
-        elif hasattr(env, 'terminate'):
-            env.terminate()
-
-        logger.info("Manually cleaned up environment for task: %s", task_id)
-
-    except Exception as e:
-        error_str = str(e)
-        if "404" in error_str or "not found" in error_str.lower():
-            logger.info("Environment for task %s already cleaned up", task_id)
-        else:
-            logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+                logger.warning("Error cleaning up environment for task %s: %s", key, e)
 
 
 def _atexit_cleanup():
@@ -2082,6 +2491,8 @@ def _resolve_command_cwd(
     workdir: Optional[str],
     default_cwd: str,
     session_key: Optional[str] = None,
+    target: Optional[str] = None,
+    _resolution=None,
 ) -> str:
     """Return the cwd for a command. Explicit ``workdir=`` overrides everything.
 
@@ -2094,7 +2505,9 @@ def _resolve_command_cwd(
     """
     if workdir:
         return workdir
-    return get_session_cwd(session_key) or default_cwd
+    return get_session_cwd(
+        session_key, target=target, _resolution=_resolution,
+    ) or default_cwd
 
 
 def terminal_tool(
@@ -2108,6 +2521,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    target: Optional[str] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2123,6 +2537,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        target: Named execution target. Omit to use the configured default.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2153,15 +2568,33 @@ def terminal_tool(
                 "status": "error",
             }, ensure_ascii=False)
 
-        # Get configuration
-        config = _get_env_config()
+        # Resolve configuration per call. Named targets read merged config
+        # directly; legacy flat config keeps the existing env-driven path.
+        from tools.execution_targets import ExecutionTargetError
+        try:
+            target_resolution = _target_resolution(target)
+        except ExecutionTargetError as exc:
+            return json.dumps({
+                "output": "", "exit_code": -1, "error": str(exc), "status": "error",
+            }, ensure_ascii=False)
+        config = (
+            _get_env_config(dict(target_resolution.config))
+            if target_resolution.named else _get_env_config()
+        )
         env_type = config["env_type"]
 
         # Use task_id for environment isolation. By default all subagent
         # task_ids collapse back to "default" so the top-level agent and
         # every delegate_task child share one container; only task_ids with
         # a registered env override (RL benchmarks) get isolated sandboxes.
-        effective_task_id = _resolve_container_task_id(task_id)
+        effective_base_task_id = _resolve_container_task_id(task_id)
+        effective_task_id = _environment_scope_key(
+            effective_base_task_id, target_resolution,
+        )
+        raw_environment_key = _environment_scope_key(
+            task_id, target_resolution,
+        ) if task_id else None
+        backend_task_id = target_resolution.backend_task_id(effective_base_task_id)
 
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config. ``resolve_task_overrides``
@@ -2183,26 +2616,21 @@ def terminal_tool(
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or get_session_cwd(task_id) or config["cwd"]
-        # A per-task cwd override (registered by the gateway/TUI for workspace
-        # tracking, or by RL/benchmark envs) wins over config["cwd"] — but
-        # config["cwd"] was already sanitized for container backends in
-        # _get_env_config() while the override is raw. On a container backend a
-        # raw host path (e.g. a Windows desktop session's C:\Users\<user>, or a
-        # POSIX /home/<user>) reaches `docker run -w <host-path>` and the
-        # container fails to start (exit 125). Re-apply the same host/relative
-        # path guard to the *resolved* cwd so the override can't bypass it.
-        # Valid in-container override paths (RL/benchmark sandboxes that set
-        # cwd to /workspace, /root, etc.) are absolute non-host paths and pass
-        # through untouched.
-        if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
-            if cwd != config["cwd"]:
-                logger.info(
-                    "Ignoring host/relative cwd override %r for %s backend "
-                    "(won't exist in sandbox). Using %r instead.",
-                    cwd, env_type, config["cwd"],
+        cwd_override = (
+            overrides.get("cwd")
+            if (
+                not target_resolution.named
+                or (
+                    target_resolution.is_default
+                    and target_resolution.backend != "ssh"
                 )
-            cwd = config["cwd"]
+            )
+            else None
+        )
+        cwd = cwd_override or get_session_cwd(
+            task_id, _resolution=target_resolution,
+        ) or config["cwd"]
+        cwd = _apply_task_cwd_override(config, cwd, cwd_override)
         default_timeout = config["timeout"]
         effective_timeout = timeout or default_timeout
 
@@ -2245,7 +2673,7 @@ def terminal_tool(
             # task_id; honor it instead of spawning a duplicate.
             _existing_key = (
                 effective_task_id if effective_task_id in _active_environments
-                else (task_id if task_id and task_id in _active_environments else None)
+                else (raw_environment_key if raw_environment_key in _active_environments else None)
             )
             if _existing_key is not None:
                 _last_activity[_existing_key] = time.time()
@@ -2266,7 +2694,7 @@ def terminal_tool(
                 with _env_lock:
                     _existing_key = (
                         effective_task_id if effective_task_id in _active_environments
-                        else (task_id if task_id and task_id in _active_environments else None)
+                        else (raw_environment_key if raw_environment_key in _active_environments else None)
                     )
                     if _existing_key is not None:
                         _last_activity[_existing_key] = time.time()
@@ -2276,7 +2704,7 @@ def terminal_tool(
                 if needs_creation:
                     if env_type == "singularity":
                         _check_disk_usage_warning()
-                    logger.info("Creating new %s environment for task %s...", env_type, effective_task_id[:8])
+                    logger.info("Creating new %s environment for task %s...", env_type, effective_task_id)
                     try:
                         ssh_config = None
                         if env_type == "ssh":
@@ -2305,6 +2733,7 @@ def terminal_tool(
                                 "docker_network": config.get("docker_network", True),
                                 "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
                                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+                                "lifetime_seconds": config.get("lifetime_seconds", 300),
                             }
 
                         local_config = None
@@ -2321,9 +2750,10 @@ def terminal_tool(
                             ssh_config=ssh_config,
                             container_config=container_config,
                             local_config=local_config,
-                            task_id=effective_task_id,
+                            task_id=backend_task_id,
                             host_cwd=config.get("host_cwd"),
                         )
+                        _record_environment_lifetime(new_env, config)
                     except ImportError as e:
                         return json.dumps({
                             "output": "",
@@ -2336,7 +2766,7 @@ def terminal_tool(
                         _active_environments[effective_task_id] = new_env
                         _last_activity[effective_task_id] = time.time()
                         env = new_env
-                    logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
+                    logger.info("%s environment ready for task %s", env_type, effective_task_id)
 
         if env is None:
             # Unreachable in practice (either the cached branch or the creation
@@ -2383,11 +2813,14 @@ def terminal_tool(
             approval = _check_all_guards(
                 command, env_type,
                 has_host_access=_docker_has_host_access(config),
+                execution_target=target_resolution.target,
+                execution_backend=target_resolution.backend,
+                execution_target_named=target_resolution.named,
             )
             if not approval["approved"]:
                 # Check if this is an approval_required (gateway ask mode)
                 if approval.get("status") == "pending_approval":
-                    return json.dumps({
+                    pending_result = {
                         "output": "",
                         "exit_code": -1,
                         "error": "",
@@ -2398,7 +2831,9 @@ def terminal_tool(
                         "pattern_key": approval.get("pattern_key", ""),
                         "smart_denied": approval.get("smart_denied", False),
                         "allow_permanent": approval.get("allow_permanent", True),
-                    }, ensure_ascii=False)
+                    }
+                    pending_result.update(target_resolution.metadata(cwd=cwd))
+                    return json.dumps(pending_result, ensure_ascii=False)
                 # Command was blocked
                 desc = approval.get("description", "command flagged")
                 fallback_msg = (
@@ -2463,25 +2898,57 @@ def terminal_tool(
                 workdir=workdir,
                 default_cwd=cwd,
                 session_key=session_key,
+                _resolution=target_resolution,
             )
             try:
-                if env_type == "local":
-                    proc_session = process_registry.spawn_local(
-                        command=command,
-                        cwd=effective_cwd,
-                        task_id=effective_task_id,
-                        session_key=session_key,
-                        env_vars=env.env if hasattr(env, 'env') else None,
-                        use_pty=effective_pty,
-                    )
-                else:
-                    proc_session = process_registry.spawn_via_env(
-                        env=env,
-                        command=command,
-                        cwd=effective_cwd,
-                        task_id=effective_task_id,
-                        session_key=session_key,
-                    )
+                spawn_metadata = {}
+                environment_task_key = str(
+                    target_resolution.scope_task_key(effective_base_task_id)
+                )
+                if target_resolution.named:
+                    spawn_metadata = {
+                        "target": target_resolution.target,
+                        "backend": target_resolution.backend,
+                        "timeout_seconds": effective_timeout,
+                        "environment_task_key": environment_task_key,
+                    }
+                with _scoped_sudo_execution(
+                    target_resolution.target,
+                    target_resolution.backend,
+                    named=target_resolution.named,
+                    sudo_password=target_resolution.config.get("sudo_password"),
+                ):
+                    if env_type == "local":
+                        proc_session = process_registry.spawn_local(
+                            command=command,
+                            cwd=effective_cwd,
+                            task_id=effective_base_task_id,
+                            session_key=session_key,
+                            env_vars=env.env if hasattr(env, 'env') else None,
+                            use_pty=effective_pty,
+                            **spawn_metadata,
+                        )
+                    else:
+                        proc_session = process_registry.spawn_via_env(
+                            env=env,
+                            command=command,
+                            cwd=effective_cwd,
+                            task_id=effective_base_task_id,
+                            session_key=session_key,
+                            timeout=effective_timeout,
+                            **spawn_metadata,
+                        )
+
+                # Preserve the exact legacy spawn call signature while still
+                # attaching additive metadata to subsequent process results.
+                if not target_resolution.named:
+                    proc_session.target = target_resolution.target
+                    proc_session.backend = target_resolution.backend
+                    proc_session.timeout_seconds = effective_timeout
+                    proc_session.environment_task_key = environment_task_key
+                    checkpoint = getattr(process_registry, "_write_checkpoint", None)
+                    if callable(checkpoint):
+                        checkpoint()
 
                 result_data = {
                     "output": "Background process started",
@@ -2490,6 +2957,7 @@ def terminal_tool(
                     "exit_code": 0,
                     "error": None,
                 }
+                result_data.update(target_resolution.metadata(cwd=effective_cwd))
                 # Background spawns detached and returns exit_code 0 immediately;
                 # it never inline-polls is_interrupted(), so the stale-bit kill
                 # cannot occur here and this note never co-occurs with rc=130.
@@ -2724,6 +3192,7 @@ def terminal_tool(
                         workdir=workdir,
                         default_cwd=cwd,
                         session_key=session_key,
+                        _resolution=target_resolution,
                     )
                     execute_kwargs = {
                         "timeout": effective_timeout,
@@ -2735,7 +3204,13 @@ def terminal_tool(
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
                     }
-                    result = env.execute(command, **execute_kwargs)
+                    with _scoped_sudo_execution(
+                        target_resolution.target,
+                        target_resolution.backend,
+                        named=target_resolution.named,
+                        sudo_password=target_resolution.config.get("sudo_password"),
+                    ):
+                        result = env.execute(command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
@@ -2771,7 +3246,9 @@ def terminal_tool(
             # session — record it under the session key so the durable record
             # never depends on the shared env surviving or on who drives the
             # env next.
-            record_session_cwd(session_key, getattr(env, "cwd", None))
+            record_session_cwd(
+                session_key, getattr(env, "cwd", None), _resolution=target_resolution,
+            )
 
             # Extract output
             output = result.get("output", "")
@@ -2782,7 +3259,10 @@ def terminal_tool(
 
             sudo_auth_failed = _sudo_wrong_password_failure(output)
             sudo_cache_cleared = _invalidate_cached_sudo_on_auth_failure(
-                command, output
+                command,
+                output,
+                target_resolution.target,
+                target_resolution.backend,
             )
             if sudo_cache_cleared:
                 has_sudo_prompt_callback = _get_sudo_password_callback() is not None
@@ -2800,13 +3280,21 @@ def terminal_tool(
             # The hook is fail-open, and the first valid string return wins.
             try:
                 from hermes_cli.plugins import invoke_hook
+                hook_kwargs = {
+                    "command": command,
+                    "output": output,
+                    "returncode": returncode,
+                    "task_id": effective_base_task_id or "",
+                    "env_type": env_type,
+                }
+                if target_resolution.named:
+                    hook_kwargs.update({
+                        "execution_target": target_resolution.target,
+                        "execution_backend": target_resolution.backend,
+                    })
                 hook_results = invoke_hook(
                     "transform_terminal_output",
-                    command=command,
-                    output=output,
-                    returncode=returncode,
-                    task_id=effective_task_id or "",
-                    env_type=env_type,
+                    **hook_kwargs,
                 )
                 for hook_result in hook_results:
                     if isinstance(hook_result, str):
@@ -2854,25 +3342,31 @@ def terminal_tool(
                 "exit_code": returncode,
                 "error": None,
             }
-            try:
-                from agent.verification_evidence import record_terminal_result
+            result_dict.update(target_resolution.metadata(cwd=command_cwd))
+            if target_resolution.backend == "local":
+                try:
+                    from agent.verification_evidence import record_terminal_result
 
-                evidence = record_terminal_result(
-                    command=command,
-                    cwd=command_cwd,
-                    session_id=session_id or task_id or effective_task_id or "default",
-                    exit_code=returncode,
-                    output=output,
-                )
-                if evidence:
-                    result_dict["verification_evidence"] = {
-                        "status": evidence.get("status"),
-                        "kind": evidence.get("kind"),
-                        "scope": evidence.get("scope"),
-                        "canonical_command": evidence.get("canonical_command"),
-                    }
-            except Exception:
-                logger.debug("verification evidence recording failed", exc_info=True)
+                    evidence = record_terminal_result(
+                        command=command,
+                        cwd=command_cwd,
+                        session_id=(
+                            session_id or task_id or backend_task_id or "default"
+                        ),
+                        exit_code=returncode,
+                        output=output,
+                    )
+                    if evidence:
+                        result_dict["verification_evidence"] = {
+                            "status": evidence.get("status"),
+                            "kind": evidence.get("kind"),
+                            "scope": evidence.get("scope"),
+                            "canonical_command": evidence.get("canonical_command"),
+                        }
+                except Exception:
+                    logger.debug(
+                        "verification evidence recording failed", exc_info=True,
+                    )
             if approval_note:
                 # Treat rc=130 as an interrupt only when the executor's marker is
                 # present.  A command can legitimately exit 130 on its own
@@ -2909,10 +3403,9 @@ def terminal_tool(
         }, ensure_ascii=False)
 
 
-def check_terminal_requirements() -> bool:
-    """Check if all requirements for the terminal tool are met."""
+def _check_terminal_config_requirements(config: Dict[str, Any]) -> bool:
+    """Check one already-resolved backend configuration."""
     try:
-        config = _get_env_config()
         env_type = config["env_type"]
 
         if env_type == "local":
@@ -3019,6 +3512,46 @@ def check_terminal_requirements() -> bool:
         return False
 
 
+def check_terminal_requirements() -> bool:
+    """Keep tools available when any configured execution target is usable."""
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        inventory = list_execution_targets()
+    except Exception as exc:
+        # In named-target mode, malformed config should remain model-visible via
+        # the normal tool error instead of removing every execution/file tool.
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            terminal_cfg = load_config_readonly().get("terminal", {})
+            if isinstance(terminal_cfg, dict) and terminal_cfg.get("targets"):
+                logger.error("Invalid named execution target config: %s", exc)
+                return True
+        except Exception:
+            pass
+        return _check_terminal_config_requirements(_get_env_config())
+
+    if inventory and inventory[0].named:
+        # Cheap/always-available local targets first, so an unavailable Docker
+        # daemon or cloud credential on another target does not emit a scary
+        # startup error when at least one target is healthy.
+        ordered = sorted(
+            inventory,
+            key=lambda item: (item.backend != "local", not item.is_default, item.target),
+        )
+        for resolution in ordered:
+            try:
+                config = _get_env_config(dict(resolution.config))
+            except Exception:
+                continue
+            if _check_terminal_config_requirements(config):
+                return True
+        return False
+
+    return _check_terminal_config_requirements(_get_env_config())
+
+
 if __name__ == "__main__":
     # Simple test when run directly
     print("Terminal Tool Module")
@@ -3095,6 +3628,10 @@ TERMINAL_SCHEMA = {
                 "type": "string",
                 "description": "Working directory for this command (absolute path). Defaults to the session working directory."
             },
+            "target": {
+                "type": "string",
+                "description": "Named execution target from terminal.targets (for example 'local' or 'devbox'). Omit to use terminal.default_target; legacy flat config accepts only 'default'.",
+            },
             "pty": {
                 "type": "boolean",
                 "description": "Run in pseudo-terminal (PTY) mode for interactive CLI tools like Codex, Claude Code, or Python REPL. Only works with local and SSH backends. Default: false.",
@@ -3127,6 +3664,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        target=args.get("target"),
     )
 
 

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -203,6 +203,7 @@ def maybe_persist_tool_result(
 def enforce_turn_budget(
     tool_messages: list[dict],
     env=None,
+    env_resolver=None,
     config: BudgetConfig = DEFAULT_BUDGET,
 ) -> list[dict]:
     """Layer 3: enforce aggregate budget across all tool results in a turn.
@@ -211,7 +212,9 @@ def enforce_turn_budget(
     first (via sandbox write) until under budget. Already-persisted results
     are skipped.
 
-    Mutates the list in-place and returns it.
+    ``env_resolver`` may return the producing environment for each message;
+    this keeps saved outputs on the same named execution target as the tool
+    call. Mutates the list in-place and returns it.
     """
     candidates = []
     total_size = 0
@@ -234,11 +237,12 @@ def enforce_turn_budget(
         content = msg["content"]
         tool_use_id = msg.get("tool_call_id", f"budget_{idx}")
 
+        message_env = env_resolver(msg) if callable(env_resolver) else env
         replacement = maybe_persist_tool_result(
             content=content,
             tool_name=_BUDGET_TOOL_NAME,
             tool_use_id=tool_use_id,
-            env=env,
+            env=message_env if callable(env_resolver) else env,
             config=config,
             threshold=0,
         )

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -90,6 +90,19 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 | `search_files` | Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. Content search (target='content'): Regex search inside files. Output modes: full matches with line… | — |
 | `write_file` | Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. | — |
 
+### File execution targets
+
+`read_file`, `write_file`, and `patch` accept an optional static string `target` selecting a configured `terminal.targets` entry. `search_files` preserves its existing `target="content"|"files"` argument and uses `execution_target` for environment selection:
+
+```text
+read_file(path="README.md", target="local")
+write_file(path="build.txt", content="ready\n", target="devbox")
+patch(mode="replace", path="app.py", old_string="old", new_string="new", target="devbox")
+search_files(pattern="TODO", target="content", execution_target="devbox")
+```
+
+Relative paths use the selected target's own session working directory and FileOperations adapter. Results include resolved `target` and `backend` metadata, plus `cwd` when available. See [Named Execution Targets](/user-guide/configuration#named-execution-targets) for configuration, default, and legacy behavior.
+
 ## `homeassistant` toolset
 
 | Tool | Description | Requires environment |
@@ -167,8 +180,23 @@ Tools for driving desktop [Projects](../user-guide/cli.md) — named, multi-fold
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `process` | Manage background processes started with terminal(background=true). Actions: 'list' (show all), 'poll' (check status + new output), 'log' (full output with pagination), 'wait' (block until done or timeout), 'kill' (terminate), 'write' (sen… | — |
-| `terminal` | Execute shell commands on a Linux environment. Filesystem persists between calls. Set `background=true` for long-running servers. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
+| `terminal` | Execute shell commands on the selected execution target (using bash/Linux shell semantics). Filesystem persists between calls. Set `background=true` for long-running servers. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
 | `read_terminal` | Read what's currently shown in the in-app terminal pane of the Hermes desktop GUI (the embedded shell beside this chat). Desktop-app only. | — |
+
+### Terminal and code-execution targets
+
+`terminal` and `execute_code` accept an optional static string `target`, for example:
+
+```text
+terminal(command="git status", target="devbox")
+execute_code(code="print('hello')", target="devbox")
+```
+
+Omitting the selector uses `terminal.default_target` when named targets exist. Without named targets, omission and `target="default"` preserve the legacy environment; other names fail. Successful results and approval prompts identify the resolved `target` and `backend`. Background process follow-ups need only their `session_id`; process results retain the spawn target/backend across poll, list, log, wait, kill, and checkpoint recovery.
+
+Inside `execute_code`, nested `hermes_tools` calls default to the script's selected target. An explicit nested `target` overrides it; nested `search_files` uses `execution_target` for that override. Python itself runs on the selected environment, and project mode resolves its cwd from that target's session/config state.
+
+See [Named Execution Targets](/user-guide/configuration#named-execution-targets) for the complete config shape and inheritance rules.
 
 ## `todo` toolset
 
@@ -265,5 +293,4 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -130,6 +130,47 @@ terminal:
 
 For cloud sandboxes such as Modal and Daytona, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
 
+### Named Execution Targets
+
+A single Hermes process can route terminal, file, and Python execution calls to several configured environments. Top-level backend settings under `terminal` are inherited by every target, and each target overrides the values it declares. Keep process-wide policy such as shell initialization and environment-passthrough settings at the top level:
+
+```yaml
+terminal:
+  timeout: 180
+  container_memory: 5120
+  default_target: local
+  targets:
+    local:
+      backend: local
+      cwd: /workspace/local
+    devbox:
+      backend: ssh
+      ssh_host: devbox.example.com
+      ssh_user: bruno
+      cwd: /home/bruno/project
+```
+
+When `targets` is non-empty, a tool call with no selector uses `default_target`. The default must name an entry; invalid defaults and unknown explicit names fail with an error listing the available names. Target names are arbitrary non-empty strings.
+
+The tools use fixed string parameters so changing config does not change the model tool schema:
+
+```text
+terminal(command="git status", target="devbox")
+read_file(path="README.md", target="local")
+write_file(path="notes.txt", content="...", target="devbox")
+patch(mode="replace", path="app.py", old_string="old", new_string="new", target="devbox")
+execute_code(code="print('hello')", target="devbox")
+search_files(pattern="TODO", target="content", execution_target="devbox")
+```
+
+`search_files` is the compatibility exception: its existing `target` argument still selects `content` or `files` search mode, while `execution_target` selects the named environment. A target's terminal and file operations share the same environment and per-session working directory. A `cd` on one target does not change another target; an explicit `workdir` on a terminal call still wins.
+
+Background process follow-up actions remain keyed only by `session_id`. Process start, list, poll, log, wait, kill, and recovered checkpoint results expose the selected `target` and `backend`. Successful terminal/file/code-execution results expose the same metadata (and `cwd` when available). The system prompt lists configured names and marks the default without changing tool schemas.
+
+Command and execute-code approval prompts identify the resolved target/backend. Session and UI-created permanent pattern approvals are scoped to a named target, so approving a command on `local` does not silently authorize the same pattern on `prod`. Explicit entries an operator writes in the global `approvals.command_allowlist` remain global by design.
+
+If `targets` is absent or empty, Hermes preserves the existing flat config and environment-variable behavior exactly. In that legacy mode, omitted `target` and `target="default"` select the existing environment; every other explicit name is an error. Environment variables remain the legacy single-backend interface and do not select named targets. In named mode Hermes mirrors the resolved default target into `TERMINAL_*` for older internal consumers, but explicit tool selection still comes only from `target` / `execution_target`. Start a new Hermes process after changing a target's backend/host settings; already-created environments and background sessions remain bound to the settings with which they were spawned.
+
 ### Backend Overview
 
 | Backend | Where commands run | Isolation | Best for |
@@ -289,7 +330,7 @@ Parallel subagents spawned via `delegate_task(tasks=[...])` share this one conta
 
 #### Environment variable overrides
 
-Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_UPPERCASE>`. The most useful ones for the Docker backend:
+Legacy single-backend terminal settings have `TERMINAL_*` environment-variable overrides. Named `default_target` / `targets` selection is config-only; environment variables do not switch targets. The most useful Docker overrides are:
 
 | Env var | Maps to | Notes |
 |---|---|---|


### PR DESCRIPTION
## Summary

- add fixed-schema named execution targets under `terminal.default_target` / `terminal.targets`
- route `terminal`, `read_file`, `write_file`, `patch`, `search_files`, and `execute_code` through the selected target while preserving the flat legacy config when targets are absent
- isolate environments, cwd, file state, background-process metadata, approvals, output persistence, and profile-multiplex state by target
- inherit the parent target inside `execute_code` RPC calls and preserve per-target cwd for delegated agents
- document configuration, selector names, result metadata, and SSH/local examples

`search_files` keeps its existing `target=content|files` selector for compatibility and uses `execution_target` for the execution target. Other target-aware tools use `target`.

Closes #1855.

## Configuration example

```yaml
terminal:
  default_target: local
  targets:
    local:
      backend: local
      cwd: /home/me/project
    devbox:
      backend: ssh
      ssh_host: devbox.example.com
      ssh_user: agent
      cwd: ~/project
```

```python
terminal(command="pytest -q", target="devbox")
write_file(path="notes.txt", content="remote\n", target="devbox")
search_files(pattern="TODO", execution_target="devbox")
execute_code(code="...", target="devbox")
```

## Compatibility and safety

- no `targets` block: existing flat terminal config and omitted selectors behave as before (`target="default"` is also accepted)
- target names remain ordinary string fields rather than dynamic schema enums, so tool schemas stay cache-stable
- approval prompts and session/permanent approvals are target-scoped
- local target aliases share physical-path locking; remote/container targets retain isolated file-state namespaces
- persistent and active-process environments survive per-turn cleanup, while non-persistent idle targets are reclaimed safely
- multiplexed Hermes profiles receive profile-scoped environment, cwd, process, file-state, sudo, and approval keys

## Validation

Post-rebase focused suites:

- `881 passed` across target routing, config/env bridge, process registry, prompt builder, tool budgeting, and run-agent suites
- `589 passed` across execute-code, target routing, file-state, Docker reaper, and tool-batch/run-agent suites after the final review fixes
- `ruff check` on every changed Python file: pass
- `py_compile` on changed runtime modules: pass
- `git diff --check`: pass

Broader `tests/tools` run:

- `8,342 passed`
- 3 environment/baseline failures (`sort` leading-dash payload and two voice-mode audio assertions), reproduced unchanged on `origin/main`

The final diff went through repeated read-only Codex review passes; all reported target-routing, profile-isolation, cwd, approval, persistence, and cleanup findings were addressed and re-tested.
