### PR TITLE
fix(gateway): make in-flight session recovery crash-safe

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -925,6 +925,7 @@ def init_agent(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = None
     agent._persist_user_message_timestamp = None
+    agent._persist_user_message_id = None
 
     # Cache anthropic image-to-text fallbacks per image payload/URL so a
     # single tool loop does not repeatedly re-run auxiliary vision on the

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -676,6 +676,7 @@ def run_conversation(
     persist_user_message: Optional[Any] = None,
     persist_user_timestamp: Optional[float] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    persist_user_message_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -693,6 +694,8 @@ def run_conversation(
             synthetic prefixes.
         persist_user_timestamp: Optional platform event timestamp to store
             as metadata on that persisted user message.
+        persist_user_message_id: Optional platform message id to store on the
+            durable user row before the first model or tool call.
                 or queuing follow-up prefetch work.
 
     Returns:
@@ -735,6 +738,7 @@ def run_conversation(
         stream_callback,
         persist_user_message,
         persist_user_timestamp,
+        persist_user_message_id,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -333,6 +333,7 @@ def build_turn_context(
     stream_callback,
     persist_user_message: Optional[Any],
     persist_user_timestamp: Optional[float] = None,
+    persist_user_message_id: Optional[str] = None,
     *,
     restore_or_build_system_prompt,
     install_safe_stdio,
@@ -424,6 +425,7 @@ def build_turn_context(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+    agent._persist_user_message_id = persist_user_message_id
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -53,6 +53,8 @@ from hermes_constants import get_hermes_home
 logger = logging.getLogger(__name__)
 
 _DB_LOCK = threading.Lock()
+_SCHEMA_LOCK = threading.Lock()
+_SCHEMA_READY_PATHS: set[str] = set()
 
 # Redelivery policy knobs (module constants; deliberately not config — the
 # ledger itself is gated by ``gateway.delivery_ledger`` and these bounds
@@ -95,9 +97,30 @@ def _connect() -> sqlite3.Connection:
             updated_at REAL NOT NULL,
             owner_pid INTEGER,
             owner_started_at INTEGER,
-            last_error TEXT
+            last_error TEXT,
+            run_id TEXT
         )"""
     )
+    schema_key = str(path)
+    if schema_key not in _SCHEMA_READY_PATHS:
+        with _SCHEMA_LOCK:
+            if schema_key not in _SCHEMA_READY_PATHS:
+                columns = {
+                    row[1]
+                    for row in conn.execute("PRAGMA table_info(delivery_obligations)")
+                }
+                if "run_id" not in columns:
+                    try:
+                        conn.execute(
+                            "ALTER TABLE delivery_obligations ADD COLUMN run_id TEXT"
+                        )
+                    except sqlite3.OperationalError as exc:
+                        # Another gateway process may have completed the
+                        # additive migration after our PRAGMA snapshot.
+                        if "duplicate column name" not in str(exc).lower():
+                            raise
+                conn.commit()
+                _SCHEMA_READY_PATHS.add(schema_key)
     return conn
 
 
@@ -162,6 +185,7 @@ def record_obligation(
     chat_id: str,
     thread_id: Optional[str],
     content: str,
+    run_id: Optional[str] = None,
 ) -> None:
     """Record a final response as owed to the platform (state='pending')."""
     now = time.time()
@@ -171,11 +195,11 @@ def record_obligation(
             """INSERT OR REPLACE INTO delivery_obligations
                (obligation_id, session_key, platform, chat_id, thread_id,
                 content, state, attempts, created_at, updated_at,
-                owner_pid, owner_started_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+                owner_pid, owner_started_at, run_id)
+               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?, ?)""",
             (obligation_id, session_key, platform, str(chat_id),
              str(thread_id) if thread_id else None, content, now, now,
-             pid, started),
+             pid, started, str(run_id) if run_id else None),
         )
     _prune()
 
@@ -230,12 +254,12 @@ def sweep_recoverable(
         rows = conn.execute(
             """SELECT obligation_id, session_key, platform, chat_id, thread_id,
                       content, state, attempts, created_at,
-                      owner_pid, owner_started_at
+                      owner_pid, owner_started_at, run_id
                FROM delivery_obligations
                WHERE state IN ('pending', 'attempting', 'failed')"""
         ).fetchall()
         for (oid, session_key, platform, chat_id, thread_id, content, state,
-             attempts, created_at, owner_pid, owner_started_at) in rows:
+             attempts, created_at, owner_pid, owner_started_at, run_id) in rows:
             if _owner_alive(owner_pid, owner_started_at):
                 continue  # a live gateway still owns this row
             if attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:
@@ -271,6 +295,7 @@ def sweep_recoverable(
                     # attempting/failed = ambiguous or rejected, carry marker.
                     "needs_marker": state != "pending",
                     "attempts": attempts + 1,
+                    "run_id": run_id,
                 })
     return claimed
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5318,6 +5318,9 @@ class BasePlatformAdapter(ABC):
                                     chat_id=event.source.chat_id,
                                     thread_id=getattr(event.source, "thread_id", None),
                                     content=text_content,
+                                    run_id=getattr(
+                                        event, "_hermes_active_run_id", None
+                                    ),
                                 )
                                 mark_attempting(_obligation_id)
                         except Exception:

--- a/gateway/recovery.py
+++ b/gateway/recovery.py
@@ -1,0 +1,368 @@
+"""Crash-safe active gateway run journal and startup recovery classification.
+
+The routing index in ``state.db`` is deliberately not used for this marker:
+an active turn changes phase at message frequency, while some installations
+have multi-gigabyte state databases.  This module keeps the hot lifecycle bit
+in one tiny, atomically-replaced sidecar and stores no user message content.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any, Iterable, Literal, Optional
+
+from agent.replay_cleanup import sanitize_replay_history
+from utils import atomic_replace
+
+logger = logging.getLogger(__name__)
+
+ACTIVE_RUN_JOURNAL_NAME = ".active_runs.json"
+ACTIVE_RUN_JOURNAL_VERSION = 1
+RECOVERY_ATTEMPT_LIMIT = 3
+
+PHASE_EXECUTING = "executing"
+PHASE_RESPONSE_READY = "response_ready"
+ActiveRunPhase = Literal["executing", "response_ready"]
+
+RECOVERY_AUTO_RESUME = "auto_resume"
+RECOVERY_WAIT_FOR_PROCESS = "wait_for_process"
+RECOVERY_PAUSE_SIDE_EFFECT = "pause_side_effect_unknown"
+RECOVERY_PAUSE_DELIVERY = "pause_delivery_unknown"
+RECOVERY_PAUSE_INPUT = "pause_input_missing"
+RECOVERY_PAUSE_RETRY_LIMIT = "pause_retry_limit"
+
+
+@dataclass(frozen=True)
+class ActiveRunRecord:
+    """Durable identity and phase for one in-flight gateway turn."""
+
+    session_key: str
+    run_id: str
+    started_at: float
+    trigger_message_id: Optional[str] = None
+    phase: ActiveRunPhase = PHASE_EXECUTING
+    recovery_attempts: int = 0
+    last_recovery_boot_id: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> "ActiveRunRecord":
+        if not isinstance(raw, dict):
+            raise ValueError("active-run record must be an object")
+        phase = str(raw.get("phase") or "")
+        if phase not in {PHASE_EXECUTING, PHASE_RESPONSE_READY}:
+            raise ValueError(f"invalid active-run phase: {phase!r}")
+        session_key = str(raw.get("session_key") or "")
+        run_id = str(raw.get("run_id") or "")
+        if not session_key or not run_id:
+            raise ValueError("active-run record is missing session_key or run_id")
+        trigger = raw.get("trigger_message_id")
+        return cls(
+            session_key=session_key,
+            run_id=run_id,
+            started_at=float(raw.get("started_at") or 0.0),
+            trigger_message_id=str(trigger) if trigger not in {None, ""} else None,
+            phase=phase,
+            recovery_attempts=max(0, int(raw.get("recovery_attempts") or 0)),
+            last_recovery_boot_id=(
+                str(raw["last_recovery_boot_id"])
+                if raw.get("last_recovery_boot_id")
+                else None
+            ),
+        )
+
+
+class ActiveRunStore:
+    """Thread-safe, atomic sidecar store keyed by gateway ``session_key``."""
+
+    def __init__(
+        self, sessions_dir: Path | str, *, filename: str = ACTIVE_RUN_JOURNAL_NAME
+    ):
+        self.path = Path(sessions_dir) / filename
+        self._lock = threading.RLock()
+        self._loaded = False
+        self._runs: dict[str, ActiveRunRecord] = {}
+
+    def _ensure_loaded_locked(self) -> None:
+        if self._loaded:
+            return
+        self._loaded = True
+        if not self.path.exists():
+            return
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+            if not isinstance(raw, dict):
+                raise ValueError("active-run journal root must be an object")
+            if int(raw.get("version") or 0) != ACTIVE_RUN_JOURNAL_VERSION:
+                raise ValueError("unsupported active-run journal version")
+            records = raw.get("runs") or {}
+            if not isinstance(records, dict):
+                raise ValueError("active-run journal runs must be an object")
+            loaded: dict[str, ActiveRunRecord] = {}
+            for key, value in records.items():
+                try:
+                    record = ActiveRunRecord.from_dict(value)
+                except (TypeError, ValueError) as exc:
+                    logger.warning(
+                        "Skipping invalid active-run record %r: %s", key, exc
+                    )
+                    continue
+                if str(key) != record.session_key:
+                    logger.warning(
+                        "Skipping active-run record with mismatched key %r", key
+                    )
+                    continue
+                loaded[record.session_key] = record
+            self._runs = loaded
+        except Exception as exc:
+            # Fail safe: a corrupt optional sidecar must never prevent the
+            # gateway from starting.  The next mutation replaces it atomically
+            # with a valid journal; state.db and transcripts remain untouched.
+            logger.warning("Ignoring corrupt active-run journal %s: %s", self.path, exc)
+            self._runs = {}
+
+    def _save_locked(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": ACTIVE_RUN_JOURNAL_VERSION,
+            "runs": {key: asdict(record) for key, record in sorted(self._runs.items())},
+        }
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.", suffix=".tmp", dir=str(self.path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, ensure_ascii=False, separators=(",", ":"))
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            atomic_replace(tmp_name, self.path)
+            try:
+                dir_fd = os.open(str(self.path.parent), os.O_RDONLY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+            except OSError:
+                pass
+        finally:
+            try:
+                Path(tmp_name).unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def snapshot(self) -> list[ActiveRunRecord]:
+        with self._lock:
+            self._ensure_loaded_locked()
+            return list(self._runs.values())
+
+    def get(self, session_key: str) -> Optional[ActiveRunRecord]:
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._runs.get(session_key)
+
+    def begin(
+        self,
+        session_key: str,
+        *,
+        trigger_message_id: Optional[str] = None,
+        recovery_run_id: Optional[str] = None,
+        started_at: Optional[float] = None,
+    ) -> ActiveRunRecord:
+        """Start a new turn, or reclaim the exact run during startup recovery."""
+        if not session_key:
+            raise ValueError("session_key is required")
+        with self._lock:
+            self._ensure_loaded_locked()
+            current = self._runs.get(session_key)
+            if recovery_run_id and current and current.run_id == recovery_run_id:
+                return current
+            record = ActiveRunRecord(
+                session_key=session_key,
+                run_id=uuid.uuid4().hex,
+                started_at=time.time() if started_at is None else float(started_at),
+                trigger_message_id=(
+                    str(trigger_message_id)
+                    if trigger_message_id not in {None, ""}
+                    else None
+                ),
+            )
+            self._runs[session_key] = record
+            self._save_locked()
+            return record
+
+    def mark_response_ready(self, session_key: str, run_id: str) -> bool:
+        """CAS the matching run from ``executing`` to ``response_ready``."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            current = self._runs.get(session_key)
+            if current is None or current.run_id != run_id:
+                return False
+            if current.phase == PHASE_RESPONSE_READY:
+                return True
+            self._runs[session_key] = replace(current, phase=PHASE_RESPONSE_READY)
+            self._save_locked()
+            return True
+
+    def finish(
+        self, session_key: str, run_id: str, *, require_ready: bool = True
+    ) -> bool:
+        """CAS-delete a delivered run without clearing a newer replacement."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            current = self._runs.get(session_key)
+            if current is None or current.run_id != run_id:
+                return False
+            if require_ready and current.phase != PHASE_RESPONSE_READY:
+                return False
+            del self._runs[session_key]
+            self._save_locked()
+            return True
+
+    def discard(self, session_key: str, *, run_id: Optional[str] = None) -> bool:
+        """Explicitly discard a run for /stop, /new, or stale routing cleanup."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            current = self._runs.get(session_key)
+            if current is None or (run_id is not None and current.run_id != run_id):
+                return False
+            del self._runs[session_key]
+            self._save_locked()
+            return True
+
+    def record_recovery_attempt(
+        self, session_key: str, run_id: str, boot_id: str
+    ) -> Optional[ActiveRunRecord]:
+        """Increment a run's recovery count at most once for this boot."""
+        if not boot_id:
+            raise ValueError("boot_id is required")
+        with self._lock:
+            self._ensure_loaded_locked()
+            current = self._runs.get(session_key)
+            if current is None or current.run_id != run_id:
+                return None
+            if current.last_recovery_boot_id == boot_id:
+                return current
+            updated = replace(
+                current,
+                recovery_attempts=current.recovery_attempts + 1,
+                last_recovery_boot_id=boot_id,
+            )
+            self._runs[session_key] = updated
+            self._save_locked()
+            return updated
+
+
+@dataclass(frozen=True)
+class RecoveryDecision:
+    disposition: str
+    reason: str
+
+
+def _message_timestamp(message: dict[str, Any]) -> Optional[float]:
+    value = message.get("timestamp")
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _find_trigger_index(
+    record: ActiveRunRecord, transcript: list[dict[str, Any]]
+) -> Optional[int]:
+    if record.trigger_message_id:
+        for index in range(len(transcript) - 1, -1, -1):
+            message = transcript[index]
+            if (
+                message.get("role") == "user"
+                and str(message.get("message_id") or "") == record.trigger_message_id
+            ):
+                return index
+        return None
+
+    # Legacy/internal events may not carry a platform message id.  Match the
+    # first durable user row written around or after journal creation.  A small
+    # tolerance covers clocks captured on opposite sides of an async boundary.
+    threshold = record.started_at - 5.0
+    for index in range(len(transcript) - 1, -1, -1):
+        message = transcript[index]
+        if message.get("role") != "user":
+            continue
+        timestamp = _message_timestamp(message)
+        if timestamp is not None and timestamp >= threshold:
+            return index
+    return None
+
+
+def classify_active_run(
+    record: ActiveRunRecord,
+    transcript: Iterable[dict[str, Any]],
+    *,
+    has_active_process: bool = False,
+    attempt_limit: int = RECOVERY_ATTEMPT_LIMIT,
+) -> RecoveryDecision:
+    """Classify whether a crashed turn is safe to continue automatically."""
+    messages = [message for message in transcript if isinstance(message, dict)]
+
+    if record.phase == PHASE_RESPONSE_READY:
+        return RecoveryDecision(
+            RECOVERY_PAUSE_DELIVERY,
+            "assistant response was ready but delivery acknowledgement is missing",
+        )
+    if record.recovery_attempts >= attempt_limit:
+        return RecoveryDecision(
+            RECOVERY_PAUSE_RETRY_LIMIT,
+            f"run was interrupted during {record.recovery_attempts} recovery boots",
+        )
+    if has_active_process:
+        return RecoveryDecision(
+            RECOVERY_WAIT_FOR_PROCESS,
+            "a recovered background process still owns the continuation",
+        )
+
+    trigger_index = _find_trigger_index(record, messages)
+    if trigger_index is None:
+        return RecoveryDecision(
+            RECOVERY_PAUSE_INPUT,
+            "triggering request was not durably persisted",
+        )
+
+    segment = [
+        message
+        for message in messages[trigger_index:]
+        if message.get("role") not in {"session_meta", "system"}
+    ]
+    sanitized = sanitize_replay_history(segment)
+    if any(
+        message.get("role") == "tool" and message.get("effect_disposition") == "unknown"
+        for message in sanitized
+    ):
+        return RecoveryDecision(
+            RECOVERY_PAUSE_SIDE_EFFECT,
+            "a side-effecting tool may have executed without a durable result",
+        )
+
+    # A plain assistant tail means model output reached durable history but the
+    # journal never reached response_ready.  Recomputing or re-sending could
+    # duplicate work, so take the same conservative delivery-unknown path.
+    if sanitized:
+        tail = sanitized[-1]
+        if tail.get("role") == "assistant" and not tail.get("tool_calls"):
+            return RecoveryDecision(
+                RECOVERY_PAUSE_DELIVERY,
+                "assistant output is durable but its delivery state is unknown",
+            )
+
+    return RecoveryDecision(
+        RECOVERY_AUTO_RESUME,
+        "durable request tail contains no uncertain external side effect",
+    )

--- a/gateway/recovery.py
+++ b/gateway/recovery.py
@@ -32,6 +32,12 @@ PHASE_EXECUTING = "executing"
 PHASE_RESPONSE_READY = "response_ready"
 ActiveRunPhase = Literal["executing", "response_ready"]
 
+INTERRUPTION_GATEWAY_SHUTDOWN = "gateway_shutdown"
+INTERRUPTION_GATEWAY_RESTART = "gateway_restart"
+_CONTROLLED_GATEWAY_INTERRUPTION_REASONS = frozenset(
+    {INTERRUPTION_GATEWAY_SHUTDOWN, INTERRUPTION_GATEWAY_RESTART}
+)
+
 RECOVERY_AUTO_RESUME = "auto_resume"
 RECOVERY_WAIT_FOR_PROCESS = "wait_for_process"
 RECOVERY_PAUSE_SIDE_EFFECT = "pause_side_effect_unknown"
@@ -51,6 +57,7 @@ class ActiveRunRecord:
     phase: ActiveRunPhase = PHASE_EXECUTING
     recovery_attempts: int = 0
     last_recovery_boot_id: Optional[str] = None
+    interruption_reason: Optional[str] = None
 
     @classmethod
     def from_dict(cls, raw: Any) -> "ActiveRunRecord":
@@ -74,6 +81,11 @@ class ActiveRunRecord:
             last_recovery_boot_id=(
                 str(raw["last_recovery_boot_id"])
                 if raw.get("last_recovery_boot_id")
+                else None
+            ),
+            interruption_reason=(
+                str(raw["interruption_reason"])
+                if raw.get("interruption_reason")
                 else None
             ),
         )
@@ -207,9 +219,59 @@ class ActiveRunStore:
                 return False
             if current.phase == PHASE_RESPONSE_READY:
                 return True
-            self._runs[session_key] = replace(current, phase=PHASE_RESPONSE_READY)
+            self._runs[session_key] = replace(
+                current,
+                phase=PHASE_RESPONSE_READY,
+                interruption_reason=None,
+            )
             self._save_locked()
             return True
+
+    def mark_interrupted(self, session_key: str, *, reason: str) -> bool:
+        """Durably identify a turn force-interrupted by gateway shutdown.
+
+        This marker is written before the agent is interrupted.  Recovery can
+        then distinguish an intentionally truncated assistant tail from model
+        output whose delivery state is genuinely unknown.
+        """
+        return self.mark_interrupted_many([session_key], reason=reason) == 1
+
+    def mark_interrupted_many(
+        self,
+        session_keys: Iterable[str],
+        *,
+        reason: str,
+    ) -> int:
+        """Mark executing turns in one atomic journal write.
+
+        A high-concurrency drain may interrupt dozens of sessions at once.
+        Persisting the whole set under one fsync keeps the shutdown deadline
+        bounded instead of paying one journal replacement per session.
+        """
+        if reason not in _CONTROLLED_GATEWAY_INTERRUPTION_REASONS:
+            raise ValueError(f"invalid gateway interruption reason: {reason!r}")
+        keys = {key for key in session_keys if key}
+        if not keys:
+            return 0
+        with self._lock:
+            self._ensure_loaded_locked()
+            marked = 0
+            changed = False
+            for session_key in keys:
+                current = self._runs.get(session_key)
+                if current is None or current.phase != PHASE_EXECUTING:
+                    continue
+                marked += 1
+                if current.interruption_reason == reason:
+                    continue
+                self._runs[session_key] = replace(
+                    current,
+                    interruption_reason=reason,
+                )
+                changed = True
+            if changed:
+                self._save_locked()
+            return marked
 
     def finish(
         self, session_key: str, run_id: str, *, require_ready: bool = True
@@ -349,6 +411,16 @@ def classify_active_run(
         return RecoveryDecision(
             RECOVERY_PAUSE_SIDE_EFFECT,
             "a side-effecting tool may have executed without a durable result",
+        )
+
+    # A controlled drain timeout writes this marker before interrupting the
+    # agent.  The resulting plain assistant tail is known to be truncated,
+    # not a completed response with ambiguous delivery, so replay is safe once
+    # uncertain side effects have been ruled out above.
+    if record.interruption_reason in _CONTROLLED_GATEWAY_INTERRUPTION_REASONS:
+        return RecoveryDecision(
+            RECOVERY_AUTO_RESUME,
+            "gateway interrupted the executing turn during controlled shutdown",
         )
 
     # A plain assistant tail means model output reached durable history but the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10748,6 +10748,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+    async def _discard_recovery_paused_inbox_claim(
+        self,
+        event: MessageEvent,
+        reason: str,
+    ) -> bool:
+        """Release a replay claim that a recovery safety guard rejects.
+
+        Durable-inbox replays carry a task-scoped claim.  Returning early from
+        a recovery guard without completing that claim leaves the session FIFO
+        permanently blocked, so later explicit user instructions can never
+        become the session head.  Keep this optional so recovery remains
+        compatible with deployments that do not enable the durable inbox.
+        """
+        marker_reader = getattr(self, "_inbox_marker", None)
+        if not callable(marker_reader):
+            return False
+        marker = marker_reader(event)
+        if not isinstance(marker, dict) or not marker.get("claim_token"):
+            return False
+        discard = getattr(self, "_inbox_cancel_or_complete_stale_event", None)
+        if not callable(discard):
+            return False
+        try:
+            return bool(await discard(event, reason))
+        except Exception:
+            logger.warning(
+                "Failed to release recovery-paused durable inbox claim",
+                exc_info=True,
+            )
+            return False
+
     async def _deliver_platform_notice(self, source, content: str) -> None:
         """Deliver a setup/operational notice using platform-specific privacy rules."""
         adapter = self._adapter_for_source(source)
@@ -11117,6 +11148,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _quick_key,
                 _recovery_reason,
             )
+            await self._discard_recovery_paused_inbox_claim(
+                event,
+                "internal event rejected by recovery pause",
+            )
             return None
         if not is_internal and _recovery_reason in DURABLE_RESUME_REASONS:
             store = getattr(self, "_active_run_store", None)
@@ -11133,6 +11168,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "session %s; a new user event is required",
                     inbound_message_id,
                     _quick_key,
+                )
+                await self._discard_recovery_paused_inbox_claim(
+                    event,
+                    "trigger redelivery rejected by recovery pause",
                 )
                 return None
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2075,6 +2075,8 @@ from gateway.session import (
     neutralize_untrusted_inline_text,
 )
 from gateway.recovery import (
+    INTERRUPTION_GATEWAY_RESTART,
+    INTERRUPTION_GATEWAY_SHUTDOWN,
     RECOVERY_AUTO_RESUME,
     RECOVERY_PAUSE_DELIVERY,
     RECOVERY_PAUSE_INPUT,
@@ -7873,8 +7875,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     row["obligation_id"], send_err,
                 )
                 result = None
+            delivered = result is not None and getattr(result, "success", False)
             try:
-                if result is not None and getattr(result, "success", False):
+                if delivered:
                     mark_delivered(row["obligation_id"])
                     redelivered += 1
                     logger.info(
@@ -7891,18 +7894,66 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 logger.debug("delivery ledger update failed", exc_info=True)
 
-            # The answer reached (or was owed to) this session — don't ALSO
-            # re-run the turn via the resume path.
+            # Only a confirmed send can close the corresponding active run.
+            # A rejected send remains recovery-paused and recoverable on the
+            # next boot instead of being falsely unblocked.
             session_key = row.get("session_key") or ""
-            if session_key:
-                try:
-                    await self.async_session_store.clear_resume_pending(session_key)
-                except Exception:
-                    logger.debug(
-                        "clear_resume_pending failed for %s", session_key,
-                        exc_info=True,
-                    )
+            if delivered and session_key:
+                await self._finish_recovered_delivery(
+                    session_key=session_key,
+                    run_id=row.get("run_id"),
+                )
         return redelivered
+
+    async def _finish_recovered_delivery(
+        self,
+        *,
+        session_key: str,
+        run_id: Optional[str],
+    ) -> bool:
+        """CAS-close recovery state after a ledger reply is delivered."""
+        store = getattr(self, "_active_run_store", None)
+        if store is not None:
+            try:
+                current = await asyncio.to_thread(store.get, session_key)
+                if current is not None:
+                    if not run_id:
+                        # Legacy ledger rows cannot prove that they belong to
+                        # the current run.  Deliver the owed reply, but retain
+                        # the newer recovery state for human reconciliation.
+                        return False
+                    finished = await asyncio.to_thread(
+                        store.finish,
+                        session_key,
+                        str(run_id),
+                        require_ready=False,
+                    )
+                    if not finished:
+                        return False
+                elif run_id:
+                    # The obligation names a run that no longer owns this
+                    # session.  Never clear a potentially newer resume marker.
+                    return False
+            except Exception:
+                logger.warning(
+                    "Failed to reconcile recovered delivery for %s",
+                    session_key,
+                    exc_info=True,
+                )
+                return False
+
+        getattr(self, "_active_recovery_reasons", {}).pop(session_key, None)
+        self._clear_restart_failure_count(session_key)
+        try:
+            await self.async_session_store.clear_resume_pending(session_key)
+        except Exception:
+            logger.debug(
+                "clear_resume_pending failed for %s",
+                session_key,
+                exc_info=True,
+            )
+            return False
+        return True
 
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
@@ -8097,6 +8148,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Let both consumer classes enter their loops before any synthetic
         # session continuation can observe or recreate their work.
         await asyncio.sleep(0)
+        await self._redeliver_pending_obligations()
         self._schedule_resume_pending_sessions()
 
     def _startup_should_abort(self) -> bool:
@@ -8810,7 +8862,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Restore process/delegation consumers before synthesizing session
         # continuations.  The helper also schedules the bounded recoveries.
         await self._start_recovery_consumers()
-        await self._finish_startup_restore()
 
         # Start background session expiry watcher to finalize expired sessions
         self._spawn_supervised(self._session_expiry_watcher, "session_expiry_watcher")
@@ -9882,9 +9933,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _resume_reason = (
                     "restart_timeout" if self._restart_requested else "shutdown_timeout"
                 )
-                for _sk, _agent in list(self._running_agents.items()):
-                    if _agent is _AGENT_PENDING_SENTINEL:
-                        continue
+                _interruption_reason = (
+                    INTERRUPTION_GATEWAY_RESTART
+                    if self._restart_requested
+                    else INTERRUPTION_GATEWAY_SHUTDOWN
+                )
+                _interrupted_session_keys = [
+                    _sk
+                    for _sk, _agent in list(self._running_agents.items())
+                    if _agent is not _AGENT_PENDING_SENTINEL
+                ]
+                _active_store = getattr(self, "_active_run_store", None)
+                if _active_store is not None and _interrupted_session_keys:
+                    try:
+                        await asyncio.to_thread(
+                            _active_store.mark_interrupted_many,
+                            _interrupted_session_keys,
+                            reason=_interruption_reason,
+                        )
+                    except Exception as _e:
+                        logger.debug(
+                            "mark active runs interrupted failed: %s",
+                            _e,
+                        )
+                for _sk in _interrupted_session_keys:
                     try:
                         await self.async_session_store.mark_resume_pending(_sk, _resume_reason)
                     except Exception as _e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14140,6 +14140,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_message_id=(
+                    str(event.message_id) if event.message_id else None
+                ),
             )
 
             # Stop persistent typing indicator now that the agent is done.
@@ -20207,6 +20210,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        persist_user_message_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -20225,6 +20229,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_message_id=persist_user_message_id,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -20236,6 +20241,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_message_id=persist_user_message_id,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -20357,6 +20363,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        persist_user_message_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -22456,6 +22463,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
+                if persist_user_message_id is not None:
+                    _conversation_kwargs["persist_user_message_id"] = persist_user_message_id
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)
@@ -23445,6 +23454,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 next_source = source
                 next_message = pending
                 next_message_id = None
+                next_platform_message_id = None
                 next_channel_prompt = None
                 next_session_key = session_key
                 if pending_event is not None:
@@ -23477,6 +23487,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if next_message is None:
                         return result
                     next_message_id = self._reply_anchor_for_event(pending_event)
+                    next_platform_message_id = getattr(
+                        pending_event, "message_id", None
+                    )
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
 
                 # Restart typing indicator so the user sees activity while
@@ -23518,6 +23531,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     run_generation=run_generation,
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
+                    persist_user_message_id=(
+                        str(next_platform_message_id)
+                        if next_platform_message_id
+                        else None
+                    ),
                     channel_prompt=next_channel_prompt,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7482,15 +7482,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # an untracked replay.  No journal means there is no run identity or
         # phase to recover safely, so treat the marker as delivery cleanup that
         # completed and clear only the stale routing flag.
-        with self.session_store._lock:  # noqa: SLF001 - startup reconciliation
-            self.session_store._ensure_loaded_locked()  # noqa: SLF001
-            stale_durable_keys = [
-                entry.session_key
-                for entry in self.session_store._entries.values()  # noqa: SLF001
-                if entry.resume_pending
-                and entry.resume_reason in DURABLE_RESUME_REASONS
-                and entry.session_key not in exact_keys
-            ]
+        entries = await self.async_session_store.list_sessions()
+        entries_by_key = {entry.session_key: entry for entry in entries}
+        stale_durable_keys = [
+            entry.session_key
+            for entry in entries
+            if entry.resume_pending
+            and entry.resume_reason in DURABLE_RESUME_REASONS
+            and entry.session_key not in exact_keys
+        ]
         for session_key in stale_durable_keys:
             logger.warning(
                 "Clearing stale durable recovery marker for %s: active-run "
@@ -7528,9 +7528,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._recovery_boot_id = boot_id
 
         for original in records:
-            with self.session_store._lock:  # noqa: SLF001 - startup snapshot
-                self.session_store._ensure_loaded_locked()  # noqa: SLF001
-                entry = self.session_store._entries.get(original.session_key)  # noqa: SLF001
+            entry = entries_by_key.get(original.session_key)
             if entry is None or entry.origin is None or entry.suspended:
                 logger.warning(
                     "Discarding orphan active-run record %s: routing entry is "
@@ -7658,16 +7656,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._recovery_pause_notified = notified
         try:
             current_run = self._get_active_run_store().get(entry.session_key)
-            with self.session_store._lock:  # noqa: SLF001 - guarded read
-                self.session_store._ensure_loaded_locked()  # noqa: SLF001
-                current_entry = self.session_store._entries.get(  # noqa: SLF001
-                    entry.session_key
-                )
-                still_paused = bool(
-                    current_entry
-                    and current_entry.resume_pending
-                    and current_entry.resume_reason == reason
-                )
+            current_entry = await self.async_session_store.lookup_by_session_key(
+                entry.session_key
+            )
+            still_paused = bool(
+                current_entry
+                and current_entry.resume_pending
+                and current_entry.resume_reason == reason
+            )
             if (
                 current_run is None
                 or current_run.run_id != run_id
@@ -11093,14 +11089,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
         try:
-            with self.session_store._lock:  # noqa: SLF001 - guarded read
-                self.session_store._ensure_loaded_locked()  # noqa: SLF001
-                _recovery_entry = self.session_store._entries.get(_quick_key)  # noqa: SLF001
-                _recovery_reason = (
-                    _recovery_entry.resume_reason
-                    if _recovery_entry is not None and _recovery_entry.resume_pending
-                    else None
-                )
+            _recovery_entry = await self.async_session_store.lookup_by_session_key(
+                _quick_key
+            )
+            _recovery_reason = (
+                _recovery_entry.resume_reason
+                if _recovery_entry is not None and _recovery_entry.resume_pending
+                else None
+            )
         except Exception:
             _recovery_reason = None
         if is_internal and _recovery_reason in self._RECOVERY_PAUSE_REASONS:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -39,6 +39,7 @@ import signal
 import tempfile
 import threading
 import time
+import uuid
 import sqlite3
 from collections import OrderedDict
 from contextvars import copy_context
@@ -771,6 +772,54 @@ def build_resume_recovery_note(
     silently abandoned behind a "restored" acknowledgement that goes
     nowhere (#57056).
     """
+    if reason in {
+        "side_effect_unknown",
+        "delivery_unknown",
+        "request_not_recorded",
+        "recovery_retry_limit",
+    }:
+        if reason == "side_effect_unknown":
+            incident = (
+                "a prior side-effecting tool may already have changed an external "
+                "system, but its result was lost"
+            )
+        elif reason == "delivery_unknown":
+            incident = (
+                "the prior assistant result was persisted, but its delivery state "
+                "is unknown"
+            )
+        elif reason == "request_not_recorded":
+            incident = "the triggering request was not durably recorded"
+        else:
+            incident = "automatic recovery was interrupted three times"
+        return (
+            f"[System note: Recovery was paused because {incident}. "
+            "The user has now sent a NEW explicit instruction. Address that new "
+            "instruction first, inspect the current external state before acting, "
+            "and do NOT blindly replay, recompute, or resend any old tool call or "
+            "assistant result whose outcome is uncertain.]"
+            + (f"\n\n{message}" if message else "")
+        )
+
+    if reason == "restart_interrupted_exact":
+        return (
+            "[System note: The previous turn was interrupted by a gateway crash. "
+            "The triggering user request and completed tool results are durable, "
+            "and recovery classified the remaining tail as safe. Continue the "
+            "interrupted task from the first unfinished read-only step. Do NOT "
+            "repeat tool calls whose results already appear in the history.]"
+            + (f"\n\n{message}" if message else "")
+        )
+
+    if reason == "waiting_recovered_process":
+        return (
+            "[System note: The gateway recovered a background process that owned "
+            "the interrupted turn. Continue from the current process status, "
+            "watcher event, or the user's NEW instruction. Inspect the process "
+            "state first and do NOT launch the old process or tool call again.]"
+            + (f"\n\n{message}" if message else "")
+        )
+
     reason_phrase = (
         "a gateway restart"
         if reason == "restart_timeout"
@@ -2013,6 +2062,7 @@ from gateway.config import (
 )
 from gateway.session import (
     AsyncSessionStore,
+    DURABLE_RESUME_REASONS,
     SessionEntry,
     SessionStore,
     SessionSource,
@@ -2023,6 +2073,16 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
     neutralize_untrusted_inline_text,
+)
+from gateway.recovery import (
+    RECOVERY_AUTO_RESUME,
+    RECOVERY_PAUSE_DELIVERY,
+    RECOVERY_PAUSE_INPUT,
+    RECOVERY_PAUSE_RETRY_LIMIT,
+    RECOVERY_PAUSE_SIDE_EFFECT,
+    RECOVERY_WAIT_FOR_PROCESS,
+    ActiveRunStore,
+    classify_active_run,
 )
 from gateway.delivery import DeliveryRouter, looks_like_telegram_private_chat_id
 from gateway.turn_lease import SessionTurnLeaseRegistry
@@ -3266,6 +3326,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Sync helpers keep using ``session_store`` directly; async gateway
         # handlers call this facade and await every operation.
         self._async_session_store = AsyncSessionStore(self.session_store)
+        self._active_run_store = ActiveRunStore(self.config.sessions_dir)
+        # A new process UUID is sufficient here: the journal only needs to
+        # deduplicate repeated reconnect/startup passes inside one gateway
+        # process, not identify an OS or machine boot.
+        self._recovery_boot_id = uuid.uuid4().hex
+        self._recovery_semaphore = asyncio.Semaphore(4)
+        self._recovery_pause_notified: set[tuple[str, str, str]] = set()
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False
         self._gateway_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -6878,7 +6945,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
-    def _suspend_stuck_loop_sessions(self) -> int:
+    def _suspend_stuck_loop_sessions(
+        self,
+        exclude_session_keys: Optional[set[str]] = None,
+    ) -> int:
         """Suspend sessions that have been active across too many restarts.
 
         Returns the number of sessions suspended.  Called on gateway startup
@@ -6897,7 +6967,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return 0
 
         suspended = 0
-        stuck_keys = [k for k, v in counts.items() if v >= self._STUCK_LOOP_THRESHOLD]
+        excluded = exclude_session_keys or set()
+        stuck_keys = [
+            k
+            for k, v in counts.items()
+            if v >= self._STUCK_LOOP_THRESHOLD and k not in excluded
+        ]
 
         for session_key in stuck_keys:
             try:
@@ -7215,8 +7290,319 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # .clean_shutdown marker).  All three mean "the agent was mid-turn and
     # we killed it" — eligible for startup auto-resume.
     _AUTO_RESUME_REASONS = frozenset(
-        {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
+        {
+            "restart_timeout",
+            "shutdown_timeout",
+            "restart_interrupted",
+            "restart_interrupted_exact",
+        }
     )
+
+    _RECOVERY_PAUSE_REASONS = frozenset(
+        {
+            "side_effect_unknown",
+            "delivery_unknown",
+            "request_not_recorded",
+            "recovery_retry_limit",
+        }
+    )
+
+    def _get_active_run_store(self) -> ActiveRunStore:
+        store = getattr(self, "_active_run_store", None)
+        if store is None:
+            store = ActiveRunStore(self.config.sessions_dir)
+            self._active_run_store = store
+        return store
+
+    async def _discard_active_run(
+        self,
+        session_key: str,
+        *,
+        run_id: Optional[str] = None,
+    ) -> bool:
+        store = getattr(self, "_active_run_store", None)
+        if not session_key or store is None:
+            return False
+        return await asyncio.to_thread(
+            store.discard,
+            session_key,
+            run_id=run_id,
+        )
+
+    async def _clear_resume_pending_after_explicit_discard(
+        self,
+        session_key: str,
+    ) -> bool:
+        """Best-effort clear for /stop and /new-compatible test stores."""
+        clear_resume_pending = getattr(
+            getattr(self, "session_store", None),
+            "clear_resume_pending",
+            None,
+        )
+        if not session_key or not callable(clear_resume_pending):
+            return False
+        try:
+            return bool(await asyncio.to_thread(clear_resume_pending, session_key))
+        except Exception:
+            logger.debug(
+                "Failed to clear recovery marker after explicit discard for %s",
+                session_key,
+                exc_info=True,
+            )
+            return False
+
+    async def _begin_active_run(
+        self,
+        *,
+        event: MessageEvent,
+        session_key: str,
+    ) -> Optional[str]:
+        """Persist ``executing`` after routing resolves and before agent work."""
+        if not isinstance(session_key, str) or not session_key:
+            return None
+        store = getattr(self, "_active_run_store", None)
+        if store is None:
+            # ``object.__new__(GatewayRunner)`` test scaffolds intentionally
+            # omit lifecycle components.  Real runners always initialize the
+            # store in __init__.
+            return None
+        trigger_message_id = (
+            getattr(event, "message_id", None)
+            or getattr(getattr(event, "source", None), "message_id", None)
+        )
+        recovery_run_id = getattr(event, "_hermes_recovery_run_id", None)
+        try:
+            record = await asyncio.to_thread(
+                store.begin,
+                session_key,
+                trigger_message_id=(
+                    str(trigger_message_id) if trigger_message_id else None
+                ),
+                recovery_run_id=(str(recovery_run_id) if recovery_run_id else None),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to write active-run journal for %s",
+                session_key,
+                exc_info=True,
+            )
+            return None
+        try:
+            setattr(event, "_hermes_active_run_id", record.run_id)
+        except Exception:
+            pass
+        return record.run_id
+
+    async def _mark_active_run_response_ready(
+        self,
+        *,
+        session_key: str,
+        run_id: Optional[str],
+        source: SessionSource,
+        run_generation: int,
+    ) -> bool:
+        """Persist the delivery boundary and register the CAS cleanup hook."""
+        if not session_key or not run_id:
+            return False
+        try:
+            marked = await asyncio.to_thread(
+                self._get_active_run_store().mark_response_ready,
+                session_key,
+                run_id,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to mark active run response-ready for %s",
+                session_key,
+                exc_info=True,
+            )
+            return False
+        if not marked:
+            return False
+
+        adapter = self._adapter_for_source(source)
+        if adapter is None or not hasattr(adapter, "register_post_delivery_callback"):
+            # Keep response_ready durable.  On restart this is classified as
+            # delivery-unknown instead of being recomputed or resent.
+            return True
+
+        async def _finish_delivered_run() -> None:
+            try:
+                finished = await asyncio.to_thread(
+                    self._get_active_run_store().finish,
+                    session_key,
+                    run_id,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to clear delivered active run for %s",
+                    session_key,
+                    exc_info=True,
+                )
+                return
+            if not finished:
+                return
+            self._clear_restart_failure_count(session_key)
+            try:
+                await self.async_session_store.clear_resume_pending(session_key)
+            except Exception:
+                logger.debug(
+                    "clear_resume_pending after delivery failed for %s",
+                    session_key,
+                    exc_info=True,
+                )
+
+        try:
+            adapter.register_post_delivery_callback(
+                session_key,
+                _finish_delivered_run,
+                generation=run_generation,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to register active-run delivery cleanup for %s",
+                session_key,
+                exc_info=True,
+            )
+        return True
+
+    async def _prepare_active_run_recovery(self) -> set[str]:
+        """Classify exact crash-left runs before adapters start dispatching."""
+        store = self._get_active_run_store()
+        # This is a tiny sidecar (one metadata-only row per active session),
+        # not state.db.  Read it directly during single-threaded startup so a
+        # cold executor cannot delay the shutdown/restart race boundary.
+        records = store.snapshot()
+        exact_keys = {record.session_key for record in records}
+        self._exact_active_run_keys = exact_keys
+
+        # ``finish()`` and ``clear_resume_pending()`` live in separate durable
+        # stores.  If SIGKILL lands after the journal CAS-delete but before the
+        # routing flag is cleared, the remaining exact marker must never cause
+        # an untracked replay.  No journal means there is no run identity or
+        # phase to recover safely, so treat the marker as delivery cleanup that
+        # completed and clear only the stale routing flag.
+        with self.session_store._lock:  # noqa: SLF001 - startup reconciliation
+            self.session_store._ensure_loaded_locked()  # noqa: SLF001
+            stale_durable_keys = [
+                entry.session_key
+                for entry in self.session_store._entries.values()  # noqa: SLF001
+                if entry.resume_pending
+                and entry.resume_reason in DURABLE_RESUME_REASONS
+                and entry.session_key not in exact_keys
+            ]
+        for session_key in stale_durable_keys:
+            logger.warning(
+                "Clearing stale durable recovery marker for %s: active-run "
+                "journal record is missing",
+                session_key,
+            )
+            try:
+                await self.async_session_store.clear_resume_pending(session_key)
+            except Exception:
+                logger.warning(
+                    "Failed to clear stale durable recovery marker for %s",
+                    session_key,
+                    exc_info=True,
+                )
+
+        if not records:
+            return exact_keys
+
+        try:
+            from tools.process_registry import process_registry
+        except Exception:
+            process_registry = None
+
+        reason_for_disposition = {
+            RECOVERY_AUTO_RESUME: "restart_interrupted_exact",
+            RECOVERY_WAIT_FOR_PROCESS: "waiting_recovered_process",
+            RECOVERY_PAUSE_SIDE_EFFECT: "side_effect_unknown",
+            RECOVERY_PAUSE_DELIVERY: "delivery_unknown",
+            RECOVERY_PAUSE_INPUT: "request_not_recorded",
+            RECOVERY_PAUSE_RETRY_LIMIT: "recovery_retry_limit",
+        }
+        boot_id = getattr(self, "_recovery_boot_id", None)
+        if not boot_id:
+            boot_id = uuid.uuid4().hex
+            self._recovery_boot_id = boot_id
+
+        for original in records:
+            with self.session_store._lock:  # noqa: SLF001 - startup snapshot
+                self.session_store._ensure_loaded_locked()  # noqa: SLF001
+                entry = self.session_store._entries.get(original.session_key)  # noqa: SLF001
+            if entry is None or entry.origin is None or entry.suspended:
+                logger.warning(
+                    "Discarding orphan active-run record %s: routing entry is "
+                    "missing, unroutable, or explicitly suspended",
+                    original.session_key,
+                )
+                await asyncio.to_thread(
+                    store.discard,
+                    original.session_key,
+                    run_id=original.run_id,
+                )
+                exact_keys.discard(original.session_key)
+                continue
+
+            record = await asyncio.to_thread(
+                store.record_recovery_attempt,
+                original.session_key,
+                original.run_id,
+                boot_id,
+            )
+            if record is None:
+                continue
+            try:
+                transcript = await self.async_session_store.load_transcript(
+                    entry.session_id
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to load transcript for active-run recovery %s: %s",
+                    record.session_key,
+                    exc,
+                )
+                transcript = []
+            has_active_process = False
+            if process_registry is not None:
+                try:
+                    has_active_process = await asyncio.to_thread(
+                        process_registry.has_active_for_session,
+                        record.session_key,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Active-process lookup failed during recovery for %s",
+                        record.session_key,
+                        exc_info=True,
+                    )
+            decision = classify_active_run(
+                record,
+                transcript,
+                has_active_process=has_active_process,
+            )
+            reason = reason_for_disposition[decision.disposition]
+            marked = await self.async_session_store.mark_resume_pending(
+                record.session_key,
+                reason,
+            )
+            if not marked:
+                logger.warning(
+                    "Could not mark exact active run %s for recovery (%s)",
+                    record.session_key,
+                    decision.disposition,
+                )
+                continue
+            logger.info(
+                "Classified active run %s (%s, attempt %d): %s",
+                record.session_key,
+                decision.disposition,
+                record.recovery_attempts,
+                decision.reason,
+            )
+        self._exact_active_run_keys = exact_keys
+        return exact_keys
 
     async def _run_startup_resume_event(
         self,
@@ -7224,87 +7610,178 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         event: MessageEvent,
         session_key: str,
     ) -> None:
-        """Dispatch one synthetic startup resume and wait for its agent turn.
-
-        ``BasePlatformAdapter.handle_message()`` returns after it installs the
-        adapter-level guard and spawns the background processing task.  Startup
-        restore needs a stronger boundary: inbound messages must stay queued
-        until the resumed agent turn itself has finished, otherwise a user
-        message can race the restore turn immediately after ``handle_message``
-        returns.
-        """
+        """Run one synthetic recovery under the fixed concurrency limit."""
+        semaphore = getattr(self, "_recovery_semaphore", None)
+        if semaphore is None:
+            semaphore = asyncio.Semaphore(4)
+            self._recovery_semaphore = semaphore
         try:
-            await adapter.handle_message(event)
-            session_tasks = getattr(adapter, "_session_tasks", {})
-            task = session_tasks.get(session_key) if isinstance(session_tasks, dict) else None
-            if task is not None:
-                await asyncio.shield(task)
+            async with semaphore:
+                # /stop or /new can discard a recovery while it waits for the
+                # semaphore.  Re-check both the preclaim and durable marker.
+                if self._running_agents.get(session_key) is not _AGENT_PENDING_SENTINEL:
+                    return
+                with self.session_store._lock:  # noqa: SLF001 - guarded read
+                    entry = self.session_store._entries.get(session_key)  # noqa: SLF001
+                    eligible = bool(
+                        entry
+                        and entry.resume_pending
+                        and not entry.suspended
+                        and entry.resume_reason in self._AUTO_RESUME_REASONS
+                    )
+                if not eligible:
+                    return
+                await adapter.handle_message(event)
+                session_tasks = getattr(adapter, "_session_tasks", {})
+                task = (
+                    session_tasks.get(session_key)
+                    if isinstance(session_tasks, dict)
+                    else None
+                )
+                if task is not None:
+                    await asyncio.shield(task)
         finally:
-            # _schedule_resume_pending_sessions pre-claims the runner slot
-            # before spawning this task.  If adapter.handle_message raises
-            # before _handle_message takes ownership, release that pre-claim;
-            # otherwise the real run's normal cleanup owns the slot.
             if self._running_agents.get(session_key) is _AGENT_PENDING_SENTINEL:
                 self._release_running_agent_state(session_key)
 
-    def _queue_startup_restore_event(self, event: MessageEvent) -> None:
-        queue = getattr(self, "_startup_restore_queue", None)
-        if queue is None:
-            queue = []
-            self._startup_restore_queue = queue
-        queue.append(event)
+    async def _send_recovery_pause_notification(
+        self,
+        *,
+        entry: Any,
+        run_id: str,
+    ) -> None:
+        reason = str(entry.resume_reason or "")
+        dedupe_key = (entry.session_key, run_id, reason)
+        notified = getattr(self, "_recovery_pause_notified", None)
+        if notified is None:
+            notified = set()
+            self._recovery_pause_notified = notified
         try:
-            source = event.source
-            logger.info(
-                "Queued inbound message during gateway startup restore: platform=%s chat=%s",
-                source.platform.value if source and source.platform else "unknown",
-                source.chat_id if source else "unknown",
-            )
-        except Exception:
-            pass
-
-    async def _drain_startup_restore_queue(self) -> int:
-        """Replay inbound messages queued while startup auto-resume ran."""
-        drained = 0
-        queue = getattr(self, "_startup_restore_queue", None)
-        if queue is None:
-            return 0
-        while queue:
-            event = queue.pop(0)
-            source = getattr(event, "source", None)
-            adapter = self._adapter_for_source(source)
-            if adapter is None:
-                logger.debug(
-                    "Dropping startup-restore queued message: adapter unavailable for %s",
-                    getattr(getattr(source, "platform", None), "value", None),
+            current_run = self._get_active_run_store().get(entry.session_key)
+            with self.session_store._lock:  # noqa: SLF001 - guarded read
+                self.session_store._ensure_loaded_locked()  # noqa: SLF001
+                current_entry = self.session_store._entries.get(  # noqa: SLF001
+                    entry.session_key
                 )
-                continue
-            # Mark this replay so _handle_message does not queue it again while
-            # the restore gate remains closed for any fresh inbound arrivals.
-            try:
-                setattr(event, "_hermes_startup_restore_replay", True)
-            except Exception:
-                pass
-            await adapter.handle_message(event)
-            drained += 1
-        return drained
+                still_paused = bool(
+                    current_entry
+                    and current_entry.resume_pending
+                    and current_entry.resume_reason == reason
+                )
+            if (
+                current_run is None
+                or current_run.run_id != run_id
+                or not still_paused
+                or entry.session_key in getattr(self, "_running_agents", {})
+            ):
+                return
+        except Exception:
+            logger.warning(
+                "Skipping stale recovery pause notification for %s",
+                entry.session_key,
+                exc_info=True,
+            )
+            return
+        source = entry.origin
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return
+        try:
+            if not self._is_user_authorized(source):
+                return
+        except Exception:
+            logger.warning(
+                "Skipping recovery pause notice for %s: authorization failed",
+                entry.session_key,
+            )
+            return
 
-    async def _finish_startup_restore(self) -> None:
-        """Wait for startup auto-resume, then release and drain inbound queue."""
-        tasks = list(getattr(self, "_startup_restore_tasks", []) or [])
-        if tasks:
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            for result in results:
-                if isinstance(result, Exception):
-                    logger.debug(
-                        "startup auto-resume task failed",
-                        exc_info=(type(result), result, result.__traceback__),
-                    )
-        self._startup_restore_tasks = []
-        drained = await self._drain_startup_restore_queue()
-        self._startup_restore_in_progress = False
-        if drained:
-            logger.info("Drained %d inbound message(s) queued during startup restore", drained)
+        notices = {
+            "side_effect_unknown": (
+                "⚠️ Recovery paused: a tool may already have changed an external "
+                "system, but its result was lost when the gateway stopped. I will "
+                "not replay it automatically. Check the external state, then send "
+                "a new explicit instruction."
+            ),
+            "delivery_unknown": (
+                "⚠️ Recovery paused: the prior answer was generated, but Hermes "
+                "cannot prove whether it was delivered. I will not recompute or "
+                "resend it automatically. Send a new instruction when ready."
+            ),
+            "request_not_recorded": (
+                "⚠️ Recovery paused: the triggering request was not durably "
+                "recorded before the gateway stopped. Please resend the request."
+            ),
+            "recovery_retry_limit": (
+                "⚠️ Automatic recovery was interrupted three times, so this "
+                "session is paused to prevent a restart loop. Inspect the current "
+                "state, then send a new explicit instruction."
+            ),
+        }
+        content = notices.get(reason)
+        if not content:
+            return
+        try:
+            result = await adapter.send(
+                source.chat_id,
+                content,
+                metadata=self._thread_metadata_for_source(source),
+            )
+            if result is not None and getattr(result, "success", True) is False:
+                return
+        except Exception:
+            logger.warning(
+                "Recovery pause notification failed for %s",
+                entry.session_key,
+                exc_info=True,
+            )
+            return
+        notified.add(dedupe_key)
+
+    def _schedule_recovery_pause_notifications(self, platform=None) -> int:
+        store = getattr(self, "_active_run_store", None)
+        if store is None:
+            return 0
+        try:
+            records = {record.session_key: record for record in store.snapshot()}
+            with self.session_store._lock:  # noqa: SLF001 - startup snapshot
+                self.session_store._ensure_loaded_locked()  # noqa: SLF001
+                entries = [
+                    entry
+                    for entry in self.session_store._entries.values()  # noqa: SLF001
+                    if entry.resume_pending
+                    and entry.resume_reason in self._RECOVERY_PAUSE_REASONS
+                    and entry.origin is not None
+                    and (platform is None or entry.origin.platform == platform)
+                    and entry.session_key in records
+                ]
+        except Exception as exc:
+            logger.warning("Failed to enumerate paused recovery sessions: %s", exc)
+            return 0
+
+        scheduled = 0
+        for entry in entries:
+            record = records[entry.session_key]
+            dedupe_key = (entry.session_key, record.run_id, entry.resume_reason)
+            if dedupe_key in getattr(self, "_recovery_pause_notified", set()):
+                continue
+            if entry.session_key in getattr(self, "_running_agents", {}):
+                continue
+            if self._adapter_for_source(entry.origin) is None:
+                continue
+            # Claim the boot-local notification before starting I/O so
+            # reconnect/startup passes cannot race duplicate sends.  There is
+            # intentionally no durable outbox or resend promise.
+            self._recovery_pause_notified.add(dedupe_key)
+            task = asyncio.create_task(
+                self._send_recovery_pause_notification(entry=entry, run_id=record.run_id)
+            )
+            background = getattr(self, "_background_tasks", None)
+            if background is not None:
+                background.add(task)
+                task.add_done_callback(background.discard)
+            scheduled += 1
+        return scheduled
 
     async def _redeliver_pending_obligations(self) -> int:
         """Redeliver final responses recorded in the delivery ledger by a
@@ -7435,6 +7912,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent is already running are skipped regardless, so a session
         scheduled at startup is never resumed a second time.
         """
+        self._schedule_recovery_pause_notifications(platform=platform)
         window = _auto_continue_freshness_window()
         try:
             with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
@@ -7461,13 +7939,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # is now in the loop). Defenses 1-2 cover the cron/CLI/terminal paths;
         # this catches every other SIGTERM source (e.g. a raw `terminal(
         # "launchctl kickstart ai.hermes.gateway")`).
-        if candidates:
+        legacy_candidates = [
+            entry
+            for entry in candidates
+            if entry.resume_reason != "restart_interrupted_exact"
+        ]
+        if legacy_candidates:
             try:
                 from gateway import restart_loop_guard as _rlg
 
                 _max_restarts, _window = self._restart_loop_guard_config()
                 if _rlg.check_and_record(_max_restarts, _window):
-                    return 0
+                    candidates = [
+                        entry
+                        for entry in candidates
+                        if entry.resume_reason == "restart_interrupted_exact"
+                    ]
             except Exception as exc:  # noqa: BLE001 — breaker must fail OPEN
                 logger.debug("Restart-loop guard check skipped: %s", exc)
 
@@ -7475,7 +7962,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         scheduled = 0
         for entry in candidates:
             marker = entry.last_resume_marked_at or entry.updated_at
-            if marker is not None and (now - marker).total_seconds() > window:
+            if (
+                entry.resume_reason not in DURABLE_RESUME_REASONS
+                and marker is not None
+                and (now - marker).total_seconds() > window
+            ):
                 continue
 
             # Already being resumed (e.g. scheduled at startup and still
@@ -7514,6 +8005,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 continue
 
+            store = getattr(self, "_active_run_store", None)
+            record = store.get(entry.session_key) if store is not None else None
+            if entry.resume_reason == "restart_interrupted_exact" and record is None:
+                # A durable exact marker without its CAS identity must never
+                # fall back to an untracked synthetic replay.  Startup
+                # reconciliation clears this crash-gap state; a reconnect
+                # pass in the meantime simply leaves it alone.
+                logger.warning(
+                    "Skipping exact auto-resume for %s: active-run journal "
+                    "record is missing",
+                    entry.session_key,
+                )
+                continue
+
             # Claim the session slot *before* spawning the task so that an
             # inbound message arriving between task creation and the task's
             # first await (where _process_message_background sets the real
@@ -7532,17 +8037,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 source=source,
                 internal=True,
             )
+            if record is not None:
+                setattr(event, "_hermes_recovery_run_id", record.run_id)
             task = asyncio.create_task(
                 self._run_startup_resume_event(adapter, event, entry.session_key)
             )
             self._background_tasks.add(task)
             task.add_done_callback(self._background_tasks.discard)
-            if getattr(self, "_startup_restore_in_progress", False):
-                tasks = getattr(self, "_startup_restore_tasks", None)
-                if tasks is None:
-                    tasks = []
-                    self._startup_restore_tasks = tasks
-                tasks.append(task)
+            task.add_done_callback(consume_detached_task_result)
             scheduled += 1
         if scheduled:
             logger.info(
@@ -7550,6 +8052,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 scheduled,
             )
         return scheduled
+
+    async def _start_recovery_consumers(self) -> None:
+        """Start recovered process/delegation watchers before session replay."""
+        try:
+            from tools.process_registry import process_registry
+
+            watchers = process_registry.pending_watchers
+            process_registry.pending_watchers = []
+            for i, watcher in enumerate(watchers):
+                self._spawn_supervised(
+                    lambda w=watcher: self._run_process_watcher(w),
+                    f"process_watcher:{watcher.get('session_id')}",
+                    restart=False,
+                )
+                logger.info(
+                    "Resumed watcher for recovered process %s",
+                    watcher.get("session_id"),
+                )
+                if i % 100 == 99:
+                    await asyncio.sleep(0)
+        except Exception as exc:
+            logger.error("Recovered watcher setup error: %s", exc)
+
+        self._spawn_supervised(
+            self._async_delegation_watcher,
+            "async_delegation_watcher",
+        )
+        # Let both consumer classes enter their loops before any synthetic
+        # session continuation can observe or recreate their work.
+        await asyncio.sleep(0)
+        self._schedule_resume_pending_sessions()
 
     def _startup_should_abort(self) -> bool:
         return (
@@ -7860,6 +8393,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Process checkpoint recovery: %s", e)
 
+        # Exact active-run records are authoritative across clean markers and
+        # age windows.  Classify them after process adoption (so active
+        # background work is visible) and before the legacy 120s heuristic.
+        try:
+            _exact_active_run_keys = await self._prepare_active_run_recovery()
+        except Exception as e:
+            logger.warning("Exact active-run recovery preparation failed: %s", e)
+            # Never fall back to the permissive 120-second heuristic for a
+            # run whose exact safety classification failed.  The preparation
+            # method snapshots these keys before any transcript/process work.
+            _exact_active_run_keys = set(
+                getattr(self, "_exact_active_run_keys", set()) or set()
+            )
+
         # Suspend sessions that were active when the gateway last exited.
         # This prevents stuck sessions from being blindly resumed on restart,
         # which can create an unrecoverable loop (#7536).  Suspended sessions
@@ -7878,7 +8425,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         else:
             try:
-                suspended = await self.async_session_store.suspend_recently_active()
+                suspended = await self.async_session_store.suspend_recently_active(
+                    exclude_session_keys=_exact_active_run_keys,
+                )
                 if suspended:
                     logger.info("Marked %d in-flight session(s) as resumable from previous run", suspended)
             except Exception as e:
@@ -7889,20 +8438,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # history keeps causing the agent to hang).  Auto-suspend it so the
         # user gets a clean slate on the next message.
         try:
-            stuck = self._suspend_stuck_loop_sessions()
+            stuck = self._suspend_stuck_loop_sessions(
+                exclude_session_keys=_exact_active_run_keys,
+            )
             if stuck:
                 logger.warning("Auto-suspended %d stuck-loop session(s)", stuck)
         except Exception as e:
             logger.debug("Stuck-loop detection failed: %s", e)
-
-        # Serialize startup restore against inbound dispatch.  Platform
-        # adapters can begin receiving messages as soon as they connect, but
-        # restart-interrupted sessions are not auto-resumed until all startup
-        # wiring below completes.  Queue inbound messages until the resume
-        # pass runs and every synthetic resume turn has finished.
-        self._startup_restore_in_progress = True
-        self._startup_restore_queue = []
-        self._startup_restore_tasks = []
 
         connected_count = 0
         enabled_platform_count = 0
@@ -8077,7 +8619,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
             self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
             self._request_clean_exit(reason)
-            self._startup_restore_in_progress = False
             return True
         except Exception as e:
             logger.error("Secondary-profile adapter startup failed: %s", e, exc_info=True)
@@ -8116,7 +8657,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pass
                 self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
                 self._request_clean_exit(reason)
-                self._startup_restore_in_progress = False
                 return True
             if enabled_platform_count > 0:
                 if startup_retryable_errors:
@@ -8252,42 +8792,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             finally:
                 _clear_planned_restart_notification()
 
-        # Automatically continue fresh sessions that were interrupted by the
-        # previous gateway restart/shutdown.  The resume_pending flag is cleared
-        # by the normal successful-turn path, so a failed auto-resume remains
-        # visible for manual recovery on the next user message.
-        #
-        # Delivery-obligation redelivery runs FIRST: a session whose final
-        # response was generated but never confirmed-delivered has its answer
-        # in the ledger — redelivering it (and clearing resume_pending for
-        # that session) is strictly cheaper and more correct than re-running
-        # the whole turn.
-        await self._redeliver_pending_obligations()
-        self._schedule_resume_pending_sessions()
+        # Restore process/delegation consumers before synthesizing session
+        # continuations.  The helper also schedules the bounded recoveries.
+        await self._start_recovery_consumers()
         await self._finish_startup_restore()
-
-        # Drain any recovered process watchers (from crash recovery checkpoint)
-        try:
-            from tools.process_registry import process_registry
-            # Detach the current batch atomically: reassigning to a fresh list
-            # takes ownership of exactly the watchers present now, so any watcher
-            # appended concurrently during the yield below isn't silently dropped
-            # by a clear() on the shared list.
-            watchers = process_registry.pending_watchers
-            process_registry.pending_watchers = []
-            # Process in batches of 100 with event-loop yield points to avoid
-            # O(n^2) event-loop blocking when recovering thousands of watchers.
-            for i, watcher in enumerate(watchers):
-                self._spawn_supervised(
-                    lambda w=watcher: self._run_process_watcher(w),
-                    f"process_watcher:{watcher.get('session_id')}",
-                    restart=False,
-                )
-                logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
-                if i % 100 == 99:
-                    await asyncio.sleep(0)
-        except Exception as e:
-            logger.error("Recovered watcher setup error: %s", e)
 
         # Start background session expiry watcher to finalize expired sessions
         self._spawn_supervised(self._session_expiry_watcher, "session_expiry_watcher")
@@ -8317,12 +8825,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # destination platform's home channel, then forges a synthetic user
         # turn so the agent kicks off the new chat.
         self._spawn_supervised(self._handoff_watcher, "handoff_watcher")
-
-        # Start background async-delegation watcher — drains completion events
-        # from delegate_task(background=true) subagents and injects each
-        # result back into its originating session as a new turn, covering the
-        # idle case where the subagent finishes with no agent turn running.
-        self._spawn_supervised(self._async_delegation_watcher, "async_delegation_watcher")
 
         # Start the scale-to-zero idle watcher ONLY when this instance is opted
         # in (the NAS "Labs" HERMES_SCALE_TO_ZERO stamp), messaging is
@@ -10459,7 +10961,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # are system-generated and must skip user authorization.
         is_internal = bool(getattr(event, "internal", False))
 
-        # Ignored-channel guard runs FIRST — before startup-restore queueing,
+        # Ignored-channel guard runs FIRST — before recovery dispatch,
         # plugin hooks, auth, and session setup — so a configured ignored
         # channel can never reach pairing/auth/session state (#51899).
         # getattr: bare test runners construct GatewayRunner via
@@ -10476,14 +10978,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Dropping Slack message from configured ignored channel %s",
                 getattr(source, "chat_id", None),
             )
-            return None
-
-        if (
-            getattr(self, "_startup_restore_in_progress", False)
-            and not is_internal
-            and not getattr(event, "_hermes_startup_restore_replay", False)
-        ):
-            self._queue_startup_restore_event(event)
             return None
 
         # scale-to-zero (Phase 0, 0.B/F13): stamp the gateway-scoped last-inbound
@@ -10598,6 +11092,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
+        try:
+            with self.session_store._lock:  # noqa: SLF001 - guarded read
+                self.session_store._ensure_loaded_locked()  # noqa: SLF001
+                _recovery_entry = self.session_store._entries.get(_quick_key)  # noqa: SLF001
+                _recovery_reason = (
+                    _recovery_entry.resume_reason
+                    if _recovery_entry is not None and _recovery_entry.resume_pending
+                    else None
+                )
+        except Exception:
+            _recovery_reason = None
+        if is_internal and _recovery_reason in self._RECOVERY_PAUSE_REASONS:
+            logger.info(
+                "Ignoring internal event for recovery-paused session %s (%s); "
+                "a new explicit user instruction is required",
+                _quick_key,
+                _recovery_reason,
+            )
+            return None
+        if not is_internal and _recovery_reason in DURABLE_RESUME_REASONS:
+            store = getattr(self, "_active_run_store", None)
+            paused_run = store.get(_quick_key) if store is not None else None
+            inbound_message_id = getattr(event, "message_id", None)
+            if (
+                paused_run is not None
+                and inbound_message_id
+                and paused_run.trigger_message_id
+                and str(inbound_message_id) == paused_run.trigger_message_id
+            ):
+                logger.info(
+                    "Ignoring redelivery of trigger message %s for recovering "
+                    "session %s; a new user event is required",
+                    inbound_message_id,
+                    _quick_key,
+                )
+                return None
+
         _update_prompts = getattr(self, "_update_prompt_pending", {})
         if _update_prompts.get(_quick_key):
             raw = (event.text or "").strip()
@@ -12606,6 +13137,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await asyncio.to_thread(self._record_telegram_topic_binding, source, session_entry)
                 except Exception:
                     logger.debug("Failed to record Telegram topic binding", exc_info=True)
+
+        # The routing decision is now stable.  Persist an exact executing-run
+        # marker before hooks, transcript hygiene, or agent setup can be
+        # interrupted by SIGKILL.
+        active_run_id = await self._begin_active_run(
+            event=event,
+            session_key=session_key,
+        )
         # Capture and immediately consume was_auto_reset so it does not
         # re-fire on subsequent messages — preventing the cleanup from
         # wiping model/reasoning overrides set between turns (Closes #48031).
@@ -13498,6 +14037,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=session_key,
         )
         if message_text is None:
+            # Preprocessing intentionally consumed/refused the event; no agent
+            # response will cross the delivery callback boundary.
+            await self._discard_active_run(session_key, run_id=active_run_id)
             return
 
         # Capture the platform event time as message metadata and keep the
@@ -13666,24 +14208,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # must include the first-turn `session_meta` marker row and the
             # compression session_id swap, both of which happen later.  See
             # the call site after the `update_session(...)` write.
-
-            # Successful turn — clear any stuck-loop counter for this session.
-            # This ensures the counter only accumulates across CONSECUTIVE
-            # restarts where the session was active (never completed).
-            #
-            # Also clear the resume_pending flag (set by drain-timeout
-            # shutdown) — the turn ran to completion, so recovery
-            # succeeded and subsequent messages should no longer receive
-            # the restart-interruption system note.
-            if session_key and _should_clear_resume_pending_after_turn(agent_result):
-                self._clear_restart_failure_count(session_key)
-                try:
-                    await self.async_session_store.clear_resume_pending(session_key)
-                except Exception as _e:
-                    logger.debug(
-                        "clear_resume_pending failed for %s: %s",
-                        session_key, _e,
-                    )
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.
@@ -14121,6 +14645,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key, session_entry.session_id
             )
 
+            # Transcript persistence is complete.  Do not clear the journal
+            # here: the adapter's post-delivery callback owns the CAS delete,
+            # so a SIGKILL in the remaining delivery window leaves an explicit
+            # response_ready record that startup pauses instead of replaying.
+            if not agent_result.get("interrupted"):
+                _active_run_ready = await self._mark_active_run_response_ready(
+                    session_key=session_key,
+                    run_id=active_run_id,
+                    source=source,
+                    run_generation=run_generation,
+                )
+                if (
+                    not _active_run_ready
+                    and session_key
+                    and _should_clear_resume_pending_after_turn(agent_result)
+                ):
+                    # Journal I/O is deliberately fail-safe.  Preserve the
+                    # pre-journal success behavior if the tiny sidecar could
+                    # not be created or transitioned for this turn.
+                    self._clear_restart_failure_count(session_key)
+                    try:
+                        await self.async_session_store.clear_resume_pending(session_key)
+                    except Exception as _e:
+                        logger.debug(
+                            "clear_resume_pending fallback failed for %s: %s",
+                            session_key,
+                            _e,
+                        )
+
             # Intentional silence is a delivery decision, not a transcript
             # mutation.  The agent's [SILENT]/NO_REPLY assistant turn above is
             # still persisted in session history so later turns keep normal
@@ -14202,30 +14755,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # inbound turn itself, so append the user message here once. If the
             # agent already reached its early turn-start persistence, the latest
             # transcript user row will match and we skip the duplicate.
+            _user_turn_persisted = False
             try:
                 if 'message_text' in locals() and message_text is not None and session_entry is not None:
                     _already_persisted = False
+                    _expected_user_content = (
+                        persist_user_message
+                        if persist_user_message is not None
+                        else message_text
+                    )
+                    _expected_message_id = (
+                        str(event.message_id)
+                        if getattr(event, "message_id", None)
+                        else None
+                    )
                     try:
                         _recent_transcript = await self.async_session_store.load_transcript(session_entry.session_id)
                     except Exception:
                         _recent_transcript = []
                     for _msg in reversed(_recent_transcript[-10:]):
                         if _msg.get("role") == "user":
-                            _expected_user_content = (
-                                persist_user_message
-                                if persist_user_message is not None
-                                else message_text
+                            _already_persisted = bool(
+                                _msg.get("content") == _expected_user_content
+                                and (
+                                    _expected_message_id is None
+                                    or str(_msg.get("message_id") or "")
+                                    == _expected_message_id
+                                )
                             )
-                            _already_persisted = (_msg.get("content") == _expected_user_content)
                             break
                     if not _already_persisted:
                         _user_entry = {
                             "role": "user",
-                            "content": (
-                                persist_user_message
-                                if persist_user_message is not None
-                                else message_text
-                            ),
+                            "content": _expected_user_content,
                             "timestamp": (
                                 persist_user_timestamp
                                 if persist_user_timestamp is not None
@@ -14238,8 +14800,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_entry.session_id,
                             _user_entry,
                         )
+                        try:
+                            _recent_transcript = await self.async_session_store.load_transcript(
+                                session_entry.session_id
+                            )
+                        except Exception:
+                            _recent_transcript = []
+                        _already_persisted = any(
+                            _msg.get("role") == "user"
+                            and _msg.get("content") == _expected_user_content
+                            and (
+                                _expected_message_id is None
+                                or str(_msg.get("message_id") or "")
+                                == _expected_message_id
+                            )
+                            for _msg in _recent_transcript[-10:]
+                        )
+                    _user_turn_persisted = _already_persisted
             except Exception:
                 logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
+            if _user_turn_persisted:
+                await self._mark_active_run_response_ready(
+                    session_key=session_key,
+                    run_id=active_run_id,
+                    source=source,
+                    run_generation=run_generation,
+                )
             # Log full details server-side only; never expose raw exception
             # types or messages to end users (info-leakage risk).
             status_hint = ""
@@ -18646,6 +19232,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Interrupt the current run and clear queued session state consistently."""
         if not session_key:
             return
+        await self._discard_active_run(session_key)
+        await self._clear_resume_pending_after_explicit_discard(session_key)
         running_agent = self._running_agents.get(session_key)
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             running_agent.interrupt(interrupt_reason)
@@ -21716,10 +22304,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     getattr(_resume_entry, "last_resume_marked_at", None),
                     window_secs=_freshness_window,
                 )
+            _resume_reason = (
+                getattr(_resume_entry, "resume_reason", None)
+                if _resume_entry is not None
+                else None
+            )
             _is_resume_pending = bool(
                 _resume_entry is not None
                 and getattr(_resume_entry, "resume_pending", False)
-                and (_interruption_is_fresh or _resume_mark_is_fresh)
+                and (
+                    _resume_reason in DURABLE_RESUME_REASONS
+                    or _interruption_is_fresh
+                    or _resume_mark_is_fresh
+                )
             )
             _has_fresh_tool_tail = bool(
                 agent_history
@@ -21728,7 +22325,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
             if _is_resume_pending:
-                _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
+                _reason = _resume_reason or "restart_timeout"
                 _persist_user_message_override = message
                 # The empty-message case is the auto-resume startup turn
                 # synthesized by _schedule_resume_pending_sessions — there is

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3333,6 +3333,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._recovery_boot_id = uuid.uuid4().hex
         self._recovery_semaphore = asyncio.Semaphore(4)
         self._recovery_pause_notified: set[tuple[str, str, str]] = set()
+        # Boot-local fast path for inbound recovery guards.  Durable truth
+        # remains in SessionStore + ActiveRunStore; this avoids an executor
+        # hop before the per-session pending sentinel is claimed.
+        self._active_recovery_reasons: dict[str, str] = {}
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False
         self._gateway_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -7323,11 +7327,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         store = getattr(self, "_active_run_store", None)
         if not session_key or store is None:
             return False
-        return await asyncio.to_thread(
+        discarded = await asyncio.to_thread(
             store.discard,
             session_key,
             run_id=run_id,
         )
+        if discarded:
+            getattr(self, "_active_recovery_reasons", {}).pop(session_key, None)
+        return discarded
 
     async def _clear_resume_pending_after_explicit_discard(
         self,
@@ -7342,7 +7349,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not session_key or not callable(clear_resume_pending):
             return False
         try:
-            return bool(await asyncio.to_thread(clear_resume_pending, session_key))
+            cleared = bool(await asyncio.to_thread(clear_resume_pending, session_key))
+            if cleared:
+                getattr(self, "_active_recovery_reasons", {}).pop(
+                    session_key, None
+                )
+            return cleared
         except Exception:
             logger.debug(
                 "Failed to clear recovery marker after explicit discard for %s",
@@ -7442,6 +7454,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
             if not finished:
                 return
+            getattr(self, "_active_recovery_reasons", {}).pop(session_key, None)
             self._clear_restart_failure_count(session_key)
             try:
                 await self.async_session_store.clear_resume_pending(session_key)
@@ -7475,6 +7488,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         records = store.snapshot()
         exact_keys = {record.session_key for record in records}
         self._exact_active_run_keys = exact_keys
+        # Only exact journal records populate this index.  Legacy recovery
+        # continues to use the existing freshness heuristic and never needs
+        # the side-effect/delivery redelivery guards below.
+        recovery_reasons: dict[str, str] = {}
+        self._active_recovery_reasons = recovery_reasons
 
         # ``finish()`` and ``clear_resume_pending()`` live in separate durable
         # stores.  If SIGKILL lands after the journal CAS-delete but before the
@@ -7581,6 +7599,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 has_active_process=has_active_process,
             )
             reason = reason_for_disposition[decision.disposition]
+            recovery_reasons[record.session_key] = reason
             marked = await self.async_session_store.mark_resume_pending(
                 record.session_key,
                 reason,
@@ -11088,17 +11107,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
-        try:
-            _recovery_entry = await self.async_session_store.lookup_by_session_key(
-                _quick_key
-            )
-            _recovery_reason = (
-                _recovery_entry.resume_reason
-                if _recovery_entry is not None and _recovery_entry.resume_pending
-                else None
-            )
-        except Exception:
-            _recovery_reason = None
+        _recovery_reason = getattr(self, "_active_recovery_reasons", {}).get(
+            _quick_key
+        )
         if is_internal and _recovery_reason in self._RECOVERY_PAUSE_REASONS:
             logger.info(
                 "Ignoring internal event for recovery-paused session %s (%s); "
@@ -12462,6 +12473,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
+            # A genuinely new user turn is the human recovery boundary.  Keep
+            # the durable resume marker until the turn/delivery path clears it,
+            # but stop treating later internal events as belonging to the old
+            # uncertain run inside this boot.
+            if not is_internal and _recovery_reason in DURABLE_RESUME_REASONS:
+                getattr(self, "_active_recovery_reasons", {}).pop(
+                    _quick_key, None
+                )
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2934,6 +2934,14 @@ class SessionStore:
                     return entry
         return None
 
+    def lookup_by_session_key(self, session_key: str) -> Optional[SessionEntry]:
+        """Return the active session entry for a routing key, if any."""
+        if not session_key:
+            return None
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
     def peek_session_id(self, session_key: str) -> Optional[str]:
         """Return the persisted session_id currently bound to a session key.
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -36,6 +36,21 @@ def _now() -> datetime:
 # ``HERMES_AUTO_CONTINUE_FRESHNESS`` at startup.
 _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
 
+# Exact active-run journal markers and safety pauses are durable lifecycle
+# state, not the legacy "recent activity" heuristic.  They must survive the
+# one-hour auto-continue freshness gate until the journal is delivered or the
+# user explicitly resumes/discards the run.
+DURABLE_RESUME_REASONS = frozenset(
+    {
+        "restart_interrupted_exact",
+        "waiting_recovered_process",
+        "side_effect_unknown",
+        "delivery_unknown",
+        "request_not_recorded",
+        "recovery_retry_limit",
+    }
+)
+
 
 def auto_continue_freshness_window() -> float:
     """Return the configured auto-continue freshness window in seconds.
@@ -1919,8 +1934,11 @@ class SessionStore:
         
         Works from the entry alone — no SessionSource needed.
         Used by the background expiry watcher to proactively flush memories.
-        Sessions with active background processes are never considered expired.
+        Sessions with durable recovery state or active background processes
+        are never considered expired.
         """
+        if entry.resume_pending and entry.resume_reason in DURABLE_RESUME_REASONS:
+            return False
         if self._has_active_processes_safe(entry.session_key, context="expiry"):
             logger.debug(
                 "Session %s not expired — active background processes",
@@ -2268,7 +2286,14 @@ class SessionStore:
             if _entry_for_checks.suspended:
                 _reset_reason = "suspended"
             elif _entry_for_checks.resume_pending:
-                _reset_reason = self._should_reset(_entry_for_checks, source)
+                _durable_resume = (
+                    _entry_for_checks.resume_reason in DURABLE_RESUME_REASONS
+                )
+                _reset_reason = (
+                    None
+                    if _durable_resume
+                    else self._should_reset(_entry_for_checks, source)
+                )
                 if not _reset_reason:
                     # Freshness-gate stale resume_pending zombies (#46934) —
                     # but honor an explicit ``session_reset.mode: none``: the
@@ -2280,7 +2305,7 @@ class SessionStore:
                         platform=source.platform,
                         session_type=source.chat_type,
                     )
-                    if _policy.mode != "none":
+                    if _policy.mode != "none" and not _durable_resume:
                         _fw = auto_continue_freshness_window()
                         _ref_time = (
                             _entry_for_checks.last_resume_marked_at
@@ -2615,10 +2640,10 @@ class SessionStore:
 
         Pruning is based on ``updated_at`` (last activity), not ``created_at``.
         A session that's been active within the window is kept regardless of
-        how old it is.  Entries marked ``suspended`` are kept — the user
-        explicitly paused them for later resume.  Entries held by an active
-        process (via has_active_processes_fn) are also kept so long-running
-        background work isn't orphaned.
+        how old it is.  Entries marked ``suspended`` or carrying durable
+        recovery state are kept until the user resolves them.  Entries held
+        by an active process (via has_active_processes_fn) are also kept so
+        long-running background work isn't orphaned.
 
         Pruning is functionally identical to a natural reset-policy expiry:
         the transcript in SQLite stays, but the session_key → session_id
@@ -2638,6 +2663,11 @@ class SessionStore:
             self._ensure_loaded_locked()
             for key, entry in list(self._entries.items()):
                 if entry.suspended:
+                    continue
+                if (
+                    entry.resume_pending
+                    and entry.resume_reason in DURABLE_RESUME_REASONS
+                ):
                     continue
                 # Never prune sessions with an active background process
                 # attached — the user may still be waiting on output.
@@ -2660,7 +2690,11 @@ class SessionStore:
             )
         return len(removed_keys)
 
-    def suspend_recently_active(self, max_age_seconds: int = 120) -> int:
+    def suspend_recently_active(
+        self,
+        max_age_seconds: int = 120,
+        exclude_session_keys: Optional[set[str]] = None,
+    ) -> int:
         """Mark recently-active sessions as resumable after an unexpected exit.
 
         Called on gateway startup after a crash or fast restart to preserve
@@ -2670,21 +2704,24 @@ class SessionStore:
         the next incoming message on the same session_key auto-resumes from
         the existing transcript.
 
-        Entries already flagged ``resume_pending=True`` are skipped.  Entries
-        explicitly ``suspended=True`` (from /stop or stuck-loop escalation)
-        are also skipped.  Terminal escalation for genuinely stuck sessions
-        is still handled by the existing ``.restart_failure_counts`` counter
-        (threshold 3), which runs after this method and sets ``suspended=True``.
+        Entries already flagged ``resume_pending=True``, explicitly suspended,
+        or named in *exclude_session_keys* are skipped.  Exact journal records
+        use that exclusion so this legacy heuristic cannot overwrite their
+        safety classification.  Terminal escalation for genuinely stuck
+        legacy sessions is still handled by ``.restart_failure_counts``.
 
         Returns the number of sessions marked resumable.
         """
         from datetime import timedelta
 
         cutoff = _now() - timedelta(seconds=max_age_seconds)
+        excluded = exclude_session_keys or set()
         count = 0
         with self._lock:
             self._ensure_loaded_locked()
             for entry in self._entries.values():
+                if entry.session_key in excluded:
+                    continue
                 if entry.resume_pending:
                     continue
                 if not entry.suspended and entry.updated_at >= cutoff:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -109,6 +109,7 @@ class GatewaySlashCommandsMixin:
         
         # Get existing session key
         session_key = self._session_key_for_source(source)
+        await self._discard_active_run(session_key)
         self._invalidate_session_run_generation(session_key, reason="session_reset")
         # Evict the running-agent slot now that the generation is bumped. The
         # in-flight run's own guarded release (run_generation=old) will return
@@ -1082,6 +1083,8 @@ class GatewaySlashCommandsMixin:
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        await self._discard_active_run(session_key)
+        await self._clear_resume_pending_after_explicit_discard(session_key)
 
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1912,6 +1912,7 @@ class AIAgent:
         _ov_idx = getattr(self, "_persist_user_message_idx", None)
         _ov_content = getattr(self, "_persist_user_message_override", None)
         _ov_timestamp = getattr(self, "_persist_user_message_timestamp", None)
+        _ov_message_id = getattr(self, "_persist_user_message_id", None)
         try:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:
@@ -2026,6 +2027,9 @@ class AIAgent:
                         content = _ov_content
                     if _ov_timestamp is not None:
                         _row_timestamp = _ov_timestamp
+                    _row_platform_message_id = _ov_message_id
+                else:
+                    _row_platform_message_id = None
                 # Store the sidecar only when it actually differs.
                 if _row_api_content == content:
                     _row_api_content = None
@@ -2083,6 +2087,7 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    platform_message_id=_row_platform_message_id,
                     timestamp=_row_timestamp,
                     api_content=_row_api_content,
                     display_kind=(
@@ -6620,6 +6625,7 @@ class AIAgent:
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        persist_user_message_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.aux_accounting import (
@@ -6661,6 +6667,7 @@ class AIAgent:
                     stream_callback,
                     persist_user_message,
                     persist_user_timestamp=persist_user_timestamp,
+                    persist_user_message_id=persist_user_message_id,
                     moa_config=moa_config,
                 )
             finally:

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -123,6 +123,31 @@ def _assert_user_call_has_skip_db(calls, expected_skip_db: bool):
         )
 
 
+@pytest.mark.asyncio
+async def test_gateway_passes_raw_platform_id_to_turn_start_persistence(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Hello!",
+            "messages": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert runner._run_agent.await_args.kwargs["event_message_id"] is None
+    assert (
+        runner._run_agent.await_args.kwargs["persist_user_message_id"]
+        == "msg-42"
+    )
+
+
 # ── Test 1: agent_failed_early path uses skip_db=True ─────────────────
 
 

--- a/tests/gateway/test_active_run_gateway_lifecycle.py
+++ b/tests/gateway/test_active_run_gateway_lifecycle.py
@@ -1,0 +1,519 @@
+"""Gateway lifecycle integration tests for exact active-run recovery."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.recovery import PHASE_EXECUTING, PHASE_RESPONSE_READY, ActiveRunStore
+from gateway.run import GatewayRunner
+from gateway.session import (
+    AsyncSessionStore,
+    SessionEntry,
+    SessionSource,
+    SessionStore,
+    build_session_key,
+)
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+def _source(chat_id: str = "chat-1") -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        chat_type="dm",
+        user_id="owner",
+        thread_id="thread-1",
+    )
+
+
+def _entry(
+    source: SessionSource, *, updated_at: datetime | None = None
+) -> SessionEntry:
+    now = datetime.now()
+    return SessionEntry(
+        session_key=build_session_key(source),
+        session_id=f"sid-{source.chat_id}",
+        created_at=now - timedelta(hours=3),
+        updated_at=updated_at or now,
+        origin=source,
+        platform=source.platform,
+        chat_type=source.chat_type,
+    )
+
+
+def _minimal_store(tmp_path, entry: SessionEntry) -> SessionStore:
+    config = GatewayConfig(
+        sessions_dir=tmp_path,
+        write_sessions_json=False,
+        default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=1),
+    )
+    store = SessionStore(tmp_path, config)
+    store._db = None
+    store._entries = {entry.session_key: entry}
+    store._loaded = True
+    return store
+
+
+@pytest.mark.asyncio
+async def test_old_exact_run_recovers_even_with_clean_marker_and_idle_policy(
+    tmp_path, monkeypatch
+):
+    source = _source()
+    entry = _entry(source, updated_at=datetime.now() - timedelta(hours=2))
+    store = _minimal_store(tmp_path, entry)
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+    runner._active_run_store = ActiveRunStore(tmp_path)
+    runner._recovery_boot_id = "boot-a"
+    record = runner._active_run_store.begin(
+        entry.session_key,
+        trigger_message_id="message-1",
+        started_at=time.time() - 7200,
+    )
+    # The exact journal is authoritative even if a graceful marker exists.
+    (tmp_path / ".clean_shutdown").write_text("clean", encoding="utf-8")
+
+    facade = MagicMock(spec=AsyncSessionStore)
+    facade._store = store
+    facade.load_transcript = AsyncMock(
+        return_value=[
+            {
+                "role": "user",
+                "content": "long-running request",
+                "message_id": "message-1",
+                "timestamp": time.time() - 7200,
+            }
+        ]
+    )
+
+    async def _mark(session_key, reason):
+        return store.mark_resume_pending(session_key, reason)
+
+    facade.mark_resume_pending = _mark
+    runner._async_session_store = facade
+    monkeypatch.setattr(
+        "tools.process_registry.process_registry.has_active_for_session",
+        lambda _key: False,
+    )
+
+    exact_keys = await runner._prepare_active_run_recovery()
+
+    assert exact_keys == {entry.session_key}
+    recovered = store._entries[entry.session_key]
+    assert recovered.resume_pending is True
+    assert recovered.resume_reason == "restart_interrupted_exact"
+    assert runner._active_run_store.get(entry.session_key).run_id == record.run_id
+    assert runner._active_run_store.get(entry.session_key).recovery_attempts == 1
+    # Durable exact recovery also bypasses the ordinary idle reset policy.
+    assert store._is_session_expired(recovered) is False
+    assert store.get_or_create_session(source).session_id == entry.session_id
+
+
+@pytest.mark.asyncio
+async def test_missing_journal_clears_stale_exact_resume_marker(tmp_path):
+    source = _source()
+    entry = _entry(source)
+    entry.resume_pending = True
+    entry.resume_reason = "restart_interrupted_exact"
+    store = _minimal_store(tmp_path, entry)
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+    runner._async_session_store = AsyncSessionStore(store)
+    runner._active_run_store = ActiveRunStore(tmp_path)
+
+    exact_keys = await runner._prepare_active_run_recovery()
+
+    assert exact_keys == set()
+    assert entry.resume_pending is False
+    assert entry.resume_reason is None
+
+
+def test_durable_pause_is_not_expired_or_pruned(tmp_path):
+    source = _source()
+    entry = _entry(source, updated_at=datetime.now() - timedelta(days=2))
+    entry.resume_pending = True
+    entry.resume_reason = "side_effect_unknown"
+    store = _minimal_store(tmp_path, entry)
+
+    assert store._is_session_expired(entry) is False
+    assert store.prune_old_entries(max_age_days=1) == 0
+    assert store._entries[entry.session_key] is entry
+
+
+@pytest.mark.asyncio
+async def test_explicitly_suspended_session_discards_orphan_journal(tmp_path):
+    source = _source()
+    entry = _entry(source)
+    entry.suspended = True
+    store = _minimal_store(tmp_path, entry)
+    active_store = ActiveRunStore(tmp_path)
+    active_store.begin(entry.session_key, trigger_message_id="message-1")
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+    runner._async_session_store = AsyncSessionStore(store)
+    runner._active_run_store = active_store
+    runner._recovery_boot_id = "boot-a"
+
+    exact_keys = await runner._prepare_active_run_recovery()
+
+    assert exact_keys == set()
+    assert active_store.get(entry.session_key) is None
+
+
+def test_legacy_120_second_heuristic_excludes_exact_journal_keys(tmp_path):
+    source_exact = _source("exact")
+    source_legacy = _source("legacy")
+    exact = _entry(source_exact)
+    legacy = _entry(source_legacy)
+    store = _minimal_store(tmp_path, exact)
+    store._entries[legacy.session_key] = legacy
+
+    count = store.suspend_recently_active(
+        max_age_seconds=120,
+        exclude_session_keys={exact.session_key},
+    )
+
+    assert count == 1
+    assert exact.resume_pending is False
+    assert legacy.resume_reason == "restart_interrupted"
+
+
+class _DeliveryAdapter:
+    def __init__(self):
+        self.callback = None
+        self.generation = None
+
+    def register_post_delivery_callback(
+        self, session_key, callback, *, generation=None
+    ):
+        self.callback = callback
+        self.generation = generation
+
+
+@pytest.mark.asyncio
+async def test_delivery_callback_clears_only_response_ready_run(tmp_path):
+    source = _source()
+    entry = _entry(source)
+    store = _minimal_store(tmp_path, entry)
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+    runner._active_run_store = ActiveRunStore(tmp_path)
+    runner._clear_restart_failure_count = MagicMock()
+    adapter = _DeliveryAdapter()
+    runner._adapter_for_source = lambda _source: adapter
+
+    facade = MagicMock(spec=AsyncSessionStore)
+    facade._store = store
+    facade.clear_resume_pending = AsyncMock(return_value=True)
+    runner._async_session_store = facade
+    event = MessageEvent(
+        text="work",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="message-1",
+    )
+
+    run_id = await runner._begin_active_run(event=event, session_key=entry.session_key)
+    assert runner._active_run_store.get(entry.session_key).phase == PHASE_EXECUTING
+    await runner._mark_active_run_response_ready(
+        session_key=entry.session_key,
+        run_id=run_id,
+        source=source,
+        run_generation=7,
+    )
+    assert runner._active_run_store.get(entry.session_key).phase == PHASE_RESPONSE_READY
+    assert adapter.generation == 7
+
+    await adapter.callback()
+
+    assert runner._active_run_store.get(entry.session_key) is None
+    facade.clear_resume_pending.assert_awaited_once_with(entry.session_key)
+    runner._clear_restart_failure_count.assert_called_once_with(entry.session_key)
+
+
+@pytest.mark.asyncio
+async def test_stale_delivery_callback_cannot_clear_newer_run(tmp_path):
+    source = _source()
+    entry = _entry(source)
+    store = _minimal_store(tmp_path, entry)
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+    runner._active_run_store = ActiveRunStore(tmp_path)
+    runner._clear_restart_failure_count = MagicMock()
+    adapter = _DeliveryAdapter()
+    runner._adapter_for_source = lambda _source: adapter
+    facade = MagicMock(spec=AsyncSessionStore)
+    facade._store = store
+    facade.clear_resume_pending = AsyncMock(return_value=True)
+    runner._async_session_store = facade
+
+    old = runner._active_run_store.begin(
+        entry.session_key,
+        trigger_message_id="message-1",
+    )
+    await runner._mark_active_run_response_ready(
+        session_key=entry.session_key,
+        run_id=old.run_id,
+        source=source,
+        run_generation=7,
+    )
+    newer = runner._active_run_store.begin(
+        entry.session_key,
+        trigger_message_id="message-2",
+    )
+
+    await adapter.callback()
+
+    assert runner._active_run_store.get(entry.session_key) == newer
+    facade.clear_resume_pending.assert_not_awaited()
+    runner._clear_restart_failure_count.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_response_ready_leaves_executing_run(tmp_path):
+    source = _source()
+    entry = _entry(source)
+    store = _minimal_store(tmp_path, entry)
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+    runner._active_run_store = ActiveRunStore(tmp_path)
+    event = MessageEvent(
+        text="work",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="message-1",
+    )
+
+    run_id = await runner._begin_active_run(event=event, session_key=entry.session_key)
+
+    record = runner._active_run_store.get(entry.session_key)
+    assert record.run_id == run_id
+    assert record.phase == PHASE_EXECUTING
+
+
+@pytest.mark.asyncio
+async def test_recovered_watchers_start_before_session_replay(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    order: list[str] = []
+    runner._spawn_supervised = lambda factory, name, **kwargs: order.append(name)
+    runner._schedule_resume_pending_sessions = lambda: order.append("session-replay")
+    monkeypatch.setattr(
+        "tools.process_registry.process_registry.pending_watchers",
+        [{"session_id": "process-1"}],
+    )
+
+    await runner._start_recovery_consumers()
+
+    assert order == [
+        "process_watcher:process-1",
+        "async_delegation_watcher",
+        "session-replay",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_internal_event_cannot_resume_safety_paused_session(tmp_path):
+    source = _source()
+    entry = _entry(source)
+    entry.resume_pending = True
+    entry.resume_reason = "side_effect_unknown"
+    store = _minimal_store(tmp_path, entry)
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+
+    event = MessageEvent(
+        text="background completion",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+    )
+
+    assert await runner._handle_message(event) is None
+    assert entry.resume_pending is True
+
+
+@pytest.mark.asyncio
+async def test_trigger_message_redelivery_cannot_resume_safety_pause(tmp_path):
+    runner, _adapter = make_restart_runner()
+    source = make_restart_source(chat_id="paused-redelivery")
+    session_key = build_session_key(source)
+    entry = SessionEntry(
+        session_key=session_key,
+        session_id="sid-paused-redelivery",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="side_effect_unknown",
+    )
+    runner.session_store._entries = {session_key: entry}
+    runner._active_run_store = ActiveRunStore(tmp_path)
+    runner._active_run_store.begin(
+        session_key,
+        trigger_message_id="original-message",
+    )
+    runner._handle_message_with_agent = AsyncMock(return_value="must not run")
+    event = MessageEvent(
+        text="original request",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="original-message",
+    )
+
+    assert await runner._handle_message(event) is None
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_startup_recovery_concurrency_is_capped_at_four(tmp_path):
+    runner, adapter = make_restart_runner()
+    runner._active_run_store = ActiveRunStore(tmp_path)
+    entries = []
+    for index in range(7):
+        source = make_restart_source(chat_id=f"recover-{index}")
+        session_key = f"agent:main:telegram:dm:recover-{index}"
+        entries.append(
+            SessionEntry(
+                session_key=session_key,
+                session_id=f"sid-{index}",
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                origin=source,
+                platform=Platform.TELEGRAM,
+                chat_type="dm",
+                resume_pending=True,
+                resume_reason="restart_interrupted_exact",
+                last_resume_marked_at=datetime.now(),
+            )
+        )
+        runner._active_run_store.begin(
+            session_key,
+            trigger_message_id=f"message-{index}",
+        )
+    runner.session_store._entries = {entry.session_key: entry for entry in entries}
+    runner._recovery_semaphore = asyncio.Semaphore(4)
+    gate = asyncio.Event()
+    active = 0
+    maximum = 0
+
+    async def _blocked_handle(_event):
+        nonlocal active, maximum
+        active += 1
+        maximum = max(maximum, active)
+        try:
+            await gate.wait()
+        finally:
+            active -= 1
+
+    adapter.handle_message = _blocked_handle
+    assert runner._schedule_resume_pending_sessions() == 7
+    for _ in range(20):
+        if maximum == 4:
+            break
+        await asyncio.sleep(0.01)
+
+    assert maximum == 4
+    gate.set()
+    await asyncio.sleep(0.1)
+    assert active == 0
+
+
+def test_exact_resume_without_journal_is_never_scheduled(tmp_path):
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="missing-journal")
+    entry = SessionEntry(
+        session_key="agent:main:telegram:dm:missing-journal",
+        session_id="sid-missing",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted_exact",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {entry.session_key: entry}
+    runner._active_run_store = ActiveRunStore(tmp_path)
+    adapter.handle_message = AsyncMock()
+
+    assert runner._schedule_resume_pending_sessions() == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pause_notification_is_sent_once_per_boot_to_original_thread(tmp_path):
+    source = _source()
+    entry = _entry(source)
+    entry.resume_pending = True
+    entry.resume_reason = "side_effect_unknown"
+    store = _minimal_store(tmp_path, entry)
+    active_store = ActiveRunStore(tmp_path)
+    active_store.begin(entry.session_key, trigger_message_id="message-1")
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+    runner._active_run_store = active_store
+    runner._recovery_pause_notified = set()
+    runner._background_tasks = set()
+    runner._running_agents = {}
+    adapter = MagicMock()
+    adapter.send = AsyncMock(return_value=None)
+    runner._adapter_for_source = lambda _source: adapter
+    runner._is_user_authorized = lambda _source: True
+    runner._thread_metadata_for_source = lambda _source: {
+        "thread_id": _source.thread_id
+    }
+
+    assert runner._schedule_recovery_pause_notifications() == 1
+    assert runner._schedule_recovery_pause_notifications() == 0
+    await asyncio.gather(*list(runner._background_tasks))
+
+    adapter.send.assert_awaited_once()
+    args, kwargs = adapter.send.await_args
+    assert args[0] == source.chat_id
+    assert "will not replay" in args[1]
+    assert kwargs["metadata"] == {"thread_id": source.thread_id}
+
+
+@pytest.mark.asyncio
+async def test_stale_pause_notification_is_suppressed_after_manual_recovery(tmp_path):
+    source = _source()
+    entry = _entry(source)
+    entry.resume_pending = True
+    entry.resume_reason = "side_effect_unknown"
+    store = _minimal_store(tmp_path, entry)
+    active_store = ActiveRunStore(tmp_path)
+    record = active_store.begin(entry.session_key, trigger_message_id="message-1")
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+    runner._active_run_store = active_store
+    runner._recovery_pause_notified = set()
+    runner._running_agents = {}
+    adapter = MagicMock()
+    adapter.send = AsyncMock(return_value=None)
+    runner._adapter_for_source = lambda _source: adapter
+
+    # A new user turn replaces the paused run before the queued notification
+    # task gets CPU time.
+    active_store.begin(entry.session_key, trigger_message_id="message-2")
+    await runner._send_recovery_pause_notification(entry=entry, run_id=record.run_id)
+
+    adapter.send.assert_not_awaited()

--- a/tests/gateway/test_active_run_gateway_lifecycle.py
+++ b/tests/gateway/test_active_run_gateway_lifecycle.py
@@ -109,6 +109,9 @@ async def test_old_exact_run_recovers_even_with_clean_marker_and_idle_policy(
     recovered = store._entries[entry.session_key]
     assert recovered.resume_pending is True
     assert recovered.resume_reason == "restart_interrupted_exact"
+    assert runner._active_recovery_reasons[entry.session_key] == (
+        "restart_interrupted_exact"
+    )
     assert runner._active_run_store.get(entry.session_key).run_id == record.run_id
     assert runner._active_run_store.get(entry.session_key).recovery_attempts == 1
     # Durable exact recovery also bypasses the ordinary idle reset policy.
@@ -333,6 +336,7 @@ async def test_internal_event_cannot_resume_safety_paused_session(tmp_path):
     runner = object.__new__(GatewayRunner)
     runner.config = store.config
     runner.session_store = store
+    runner._active_recovery_reasons = {entry.session_key: "side_effect_unknown"}
 
     event = MessageEvent(
         text="background completion",
@@ -362,9 +366,7 @@ async def test_trigger_message_redelivery_cannot_resume_safety_pause(tmp_path):
         resume_reason="side_effect_unknown",
     )
     runner.session_store._entries = {session_key: entry}
-    runner._async_session_store = MagicMock()
-    runner._async_session_store._store = runner.session_store
-    runner._async_session_store.lookup_by_session_key = AsyncMock(return_value=entry)
+    runner._active_recovery_reasons = {session_key: "side_effect_unknown"}
     runner._active_run_store = ActiveRunStore(tmp_path)
     runner._active_run_store.begin(
         session_key,

--- a/tests/gateway/test_active_run_gateway_lifecycle.py
+++ b/tests/gateway/test_active_run_gateway_lifecycle.py
@@ -311,6 +311,9 @@ async def test_recovered_watchers_start_before_session_replay(monkeypatch):
     runner = object.__new__(GatewayRunner)
     order: list[str] = []
     runner._spawn_supervised = lambda factory, name, **kwargs: order.append(name)
+    runner._redeliver_pending_obligations = AsyncMock(
+        side_effect=lambda: order.append("delivery-redelivery")
+    )
     runner._schedule_resume_pending_sessions = lambda: order.append("session-replay")
     monkeypatch.setattr(
         "tools.process_registry.process_registry.pending_watchers",
@@ -322,6 +325,7 @@ async def test_recovered_watchers_start_before_session_replay(monkeypatch):
     assert order == [
         "process_watcher:process-1",
         "async_delegation_watcher",
+        "delivery-redelivery",
         "session-replay",
     ]
 

--- a/tests/gateway/test_active_run_gateway_lifecycle.py
+++ b/tests/gateway/test_active_run_gateway_lifecycle.py
@@ -337,6 +337,8 @@ async def test_internal_event_cannot_resume_safety_paused_session(tmp_path):
     runner.config = store.config
     runner.session_store = store
     runner._active_recovery_reasons = {entry.session_key: "side_effect_unknown"}
+    runner._inbox_marker = MagicMock(return_value={"claim_token": "claim-1"})
+    runner._inbox_cancel_or_complete_stale_event = AsyncMock(return_value=True)
 
     event = MessageEvent(
         text="background completion",
@@ -347,6 +349,10 @@ async def test_internal_event_cannot_resume_safety_paused_session(tmp_path):
 
     assert await runner._handle_message(event) is None
     assert entry.resume_pending is True
+    runner._inbox_cancel_or_complete_stale_event.assert_awaited_once_with(
+        event,
+        "internal event rejected by recovery pause",
+    )
 
 
 @pytest.mark.asyncio
@@ -372,6 +378,8 @@ async def test_trigger_message_redelivery_cannot_resume_safety_pause(tmp_path):
         session_key,
         trigger_message_id="original-message",
     )
+    runner._inbox_marker = MagicMock(return_value={"claim_token": "claim-1"})
+    runner._inbox_cancel_or_complete_stale_event = AsyncMock(return_value=True)
     runner._handle_message_with_agent = AsyncMock(return_value="must not run")
     event = MessageEvent(
         text="original request",
@@ -382,6 +390,10 @@ async def test_trigger_message_redelivery_cannot_resume_safety_pause(tmp_path):
 
     assert await runner._handle_message(event) is None
     runner._handle_message_with_agent.assert_not_awaited()
+    runner._inbox_cancel_or_complete_stale_event.assert_awaited_once_with(
+        event,
+        "trigger redelivery rejected by recovery pause",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_active_run_gateway_lifecycle.py
+++ b/tests/gateway/test_active_run_gateway_lifecycle.py
@@ -81,8 +81,7 @@ async def test_old_exact_run_recovers_even_with_clean_marker_and_idle_policy(
     # The exact journal is authoritative even if a graceful marker exists.
     (tmp_path / ".clean_shutdown").write_text("clean", encoding="utf-8")
 
-    facade = MagicMock(spec=AsyncSessionStore)
-    facade._store = store
+    facade = AsyncSessionStore(store)
     facade.load_transcript = AsyncMock(
         return_value=[
             {
@@ -363,6 +362,9 @@ async def test_trigger_message_redelivery_cannot_resume_safety_pause(tmp_path):
         resume_reason="side_effect_unknown",
     )
     runner.session_store._entries = {session_key: entry}
+    runner._async_session_store = MagicMock()
+    runner._async_session_store._store = runner.session_store
+    runner._async_session_store.lookup_by_session_key = AsyncMock(return_value=entry)
     runner._active_run_store = ActiveRunStore(tmp_path)
     runner._active_run_store.begin(
         session_key,

--- a/tests/gateway/test_active_run_recovery.py
+++ b/tests/gateway/test_active_run_recovery.py
@@ -9,10 +9,13 @@ import subprocess
 import sys
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from gateway.recovery import (
+    INTERRUPTION_GATEWAY_RESTART,
+    INTERRUPTION_GATEWAY_SHUTDOWN,
     PHASE_EXECUTING,
     PHASE_RESPONSE_READY,
     RECOVERY_AUTO_RESUME,
@@ -99,6 +102,29 @@ class TestActiveRunStore:
         assert store.get("session-a").phase == PHASE_RESPONSE_READY
         assert store.finish("session-a", second.run_id) is True
         assert store.get("session-a") is None
+
+    def test_controlled_interruption_is_persisted_and_cleared_at_response_ready(
+        self, tmp_path
+    ):
+        store = ActiveRunStore(tmp_path)
+        record = store.begin("session-a", trigger_message_id="m1")
+        other = store.begin("session-b", trigger_message_id="m2")
+
+        with patch.object(store, "_save_locked", wraps=store._save_locked) as save:
+            assert store.mark_interrupted_many(
+                ["session-a", "session-b", "missing"],
+                reason=INTERRUPTION_GATEWAY_RESTART,
+            ) == 2
+        save.assert_called_once()
+        interrupted = ActiveRunStore(tmp_path).get("session-a")
+        assert interrupted.interruption_reason == INTERRUPTION_GATEWAY_RESTART
+        assert store.get("session-b").interruption_reason == INTERRUPTION_GATEWAY_RESTART
+
+        assert store.mark_response_ready("session-a", record.run_id) is True
+        ready = store.get("session-a")
+        assert ready.phase == PHASE_RESPONSE_READY
+        assert ready.interruption_reason is None
+        assert store.get("session-b").run_id == other.run_id
 
     def test_recovery_reclaims_same_run_without_resetting_state(self, tmp_path):
         store = ActiveRunStore(tmp_path)
@@ -212,6 +238,35 @@ class TestActiveRunClassification:
         assert (
             classify_active_run(_record(), transcript).disposition
             == RECOVERY_PAUSE_SIDE_EFFECT
+        )
+
+    def test_controlled_shutdown_with_plain_assistant_tail_auto_resumes(self):
+        record = _record(interruption_reason=INTERRUPTION_GATEWAY_SHUTDOWN)
+        transcript = [_user(), {"role": "assistant", "content": "interrupted"}]
+
+        assert (
+            classify_active_run(record, transcript).disposition
+            == RECOVERY_AUTO_RESUME
+        )
+
+    def test_controlled_shutdown_never_replays_uncertain_side_effect(self):
+        record = _record(interruption_reason=INTERRUPTION_GATEWAY_SHUTDOWN)
+        transcript = [_user(), _tool_call("terminal")]
+
+        assert (
+            classify_active_run(record, transcript).disposition
+            == RECOVERY_PAUSE_SIDE_EFFECT
+        )
+
+    def test_response_ready_wins_over_controlled_interruption(self):
+        record = _record(
+            phase=PHASE_RESPONSE_READY,
+            interruption_reason=INTERRUPTION_GATEWAY_RESTART,
+        )
+
+        assert (
+            classify_active_run(record, [_user()]).disposition
+            == RECOVERY_PAUSE_DELIVERY
         )
 
     @pytest.mark.parametrize(

--- a/tests/gateway/test_active_run_recovery.py
+++ b/tests/gateway/test_active_run_recovery.py
@@ -1,0 +1,244 @@
+"""Behavior tests for crash-safe active gateway run recovery."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+from dataclasses import replace
+
+import pytest
+
+from gateway.recovery import (
+    PHASE_EXECUTING,
+    PHASE_RESPONSE_READY,
+    RECOVERY_AUTO_RESUME,
+    RECOVERY_PAUSE_DELIVERY,
+    RECOVERY_PAUSE_INPUT,
+    RECOVERY_PAUSE_RETRY_LIMIT,
+    RECOVERY_PAUSE_SIDE_EFFECT,
+    RECOVERY_WAIT_FOR_PROCESS,
+    ActiveRunRecord,
+    ActiveRunStore,
+    classify_active_run,
+)
+
+
+def _record(**overrides) -> ActiveRunRecord:
+    values = {
+        "session_key": "agent:main:discord:dm:chat-1",
+        "run_id": "run-1",
+        "started_at": 100.0,
+        "trigger_message_id": "msg-1",
+        "phase": PHASE_EXECUTING,
+        "recovery_attempts": 1,
+    }
+    values.update(overrides)
+    return ActiveRunRecord(**values)
+
+
+def _user(timestamp: float = 101.0) -> dict:
+    return {
+        "role": "user",
+        "content": "do the work",
+        "message_id": "msg-1",
+        "timestamp": timestamp,
+    }
+
+
+def _tool_call(name: str, call_id: str = "call-1") -> dict:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }
+        ],
+    }
+
+
+class TestActiveRunStore:
+    def test_atomic_roundtrip_and_no_message_content(self, tmp_path):
+        store = ActiveRunStore(tmp_path)
+        record = store.begin(
+            "agent:main:discord:dm:chat-1", trigger_message_id="msg-1", started_at=12.5
+        )
+
+        restored = ActiveRunStore(tmp_path).get(record.session_key)
+        assert restored == record
+        payload = json.loads(store.path.read_text(encoding="utf-8"))
+        assert payload["version"] == 1
+        assert "do the work" not in store.path.read_text(encoding="utf-8")
+        assert not list(tmp_path.glob(".*.tmp"))
+
+    def test_corrupt_journal_recovers_on_next_write(self, tmp_path, caplog):
+        path = tmp_path / ".active_runs.json"
+        path.write_text("{not-json", encoding="utf-8")
+        store = ActiveRunStore(tmp_path)
+
+        assert store.snapshot() == []
+        assert "corrupt active-run journal" in caplog.text
+        record = store.begin("session-a", trigger_message_id="m1")
+        assert ActiveRunStore(tmp_path).get("session-a") == record
+
+    def test_run_id_cas_and_phase(self, tmp_path):
+        store = ActiveRunStore(tmp_path)
+        first = store.begin("session-a", trigger_message_id="m1")
+        second = store.begin("session-a", trigger_message_id="m2")
+
+        assert first.run_id != second.run_id
+        assert store.mark_response_ready("session-a", first.run_id) is False
+        assert store.finish("session-a", first.run_id) is False
+        assert store.mark_response_ready("session-a", second.run_id) is True
+        assert store.get("session-a").phase == PHASE_RESPONSE_READY
+        assert store.finish("session-a", second.run_id) is True
+        assert store.get("session-a") is None
+
+    def test_recovery_reclaims_same_run_without_resetting_state(self, tmp_path):
+        store = ActiveRunStore(tmp_path)
+        original = store.begin("session-a", trigger_message_id="m1", started_at=10)
+        attempted = store.record_recovery_attempt(
+            "session-a", original.run_id, "boot-a"
+        )
+
+        reclaimed = store.begin(
+            "session-a",
+            trigger_message_id=None,
+            recovery_run_id=original.run_id,
+            started_at=999,
+        )
+        assert reclaimed == attempted
+        assert reclaimed.started_at == 10
+        assert reclaimed.recovery_attempts == 1
+
+    def test_recovery_attempt_is_deduplicated_per_boot(self, tmp_path):
+        store = ActiveRunStore(tmp_path)
+        record = store.begin("session-a")
+
+        once = store.record_recovery_attempt("session-a", record.run_id, "boot-a")
+        duplicate = store.record_recovery_attempt("session-a", record.run_id, "boot-a")
+        twice = store.record_recovery_attempt("session-a", record.run_id, "boot-b")
+
+        assert once.recovery_attempts == 1
+        assert duplicate == once
+        assert twice.recovery_attempts == 2
+        assert twice.last_recovery_boot_id == "boot-b"
+
+    @pytest.mark.skipif(not hasattr(signal, "SIGKILL"), reason="requires SIGKILL")
+    def test_sigkill_fault_injection_leaves_one_recoverable_run(self, tmp_path):
+        script = """
+import os
+import signal
+import sys
+from gateway.recovery import ActiveRunStore
+store = ActiveRunStore(sys.argv[1])
+store.begin('session-killed', trigger_message_id='message-killed', started_at=42)
+os.kill(os.getpid(), signal.SIGKILL)
+"""
+        child = subprocess.run(
+            [sys.executable, "-c", script, str(tmp_path)],
+            cwd=os.getcwd(),
+            check=False,
+        )
+        assert child.returncode == -signal.SIGKILL
+
+        store = ActiveRunStore(tmp_path)
+        records = store.snapshot()
+        assert len(records) == 1
+        assert records[0].session_key == "session-killed"
+        first = store.record_recovery_attempt(
+            "session-killed", records[0].run_id, "new-boot"
+        )
+        duplicate = store.record_recovery_attempt(
+            "session-killed", records[0].run_id, "new-boot"
+        )
+        assert first.recovery_attempts == 1
+        assert duplicate == first
+
+
+class TestActiveRunClassification:
+    def test_durable_user_tail_auto_resumes(self):
+        decision = classify_active_run(_record(), [_user()])
+        assert decision.disposition == RECOVERY_AUTO_RESUME
+
+    def test_complete_tool_result_auto_resumes(self):
+        transcript = [
+            _user(),
+            _tool_call("web_search"),
+            {"role": "tool", "tool_call_id": "call-1", "content": "done"},
+        ]
+        assert (
+            classify_active_run(_record(), transcript).disposition
+            == RECOVERY_AUTO_RESUME
+        )
+
+    def test_dangling_read_only_tool_auto_resumes(self):
+        transcript = [_user(), _tool_call("web_search")]
+        assert (
+            classify_active_run(_record(), transcript).disposition
+            == RECOVERY_AUTO_RESUME
+        )
+
+    def test_dangling_side_effecting_tool_pauses(self):
+        transcript = [_user(), _tool_call("terminal")]
+        assert (
+            classify_active_run(_record(), transcript).disposition
+            == RECOVERY_PAUSE_SIDE_EFFECT
+        )
+
+    def test_interrupted_side_effecting_tool_pauses(self):
+        transcript = [
+            _user(),
+            _tool_call("terminal"),
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": "[Command interrupted] exit_code: 130",
+            },
+        ]
+        assert (
+            classify_active_run(_record(), transcript).disposition
+            == RECOVERY_PAUSE_SIDE_EFFECT
+        )
+
+    @pytest.mark.parametrize(
+        "record,transcript",
+        [
+            (_record(phase=PHASE_RESPONSE_READY), [_user()]),
+            (_record(), [_user(), {"role": "assistant", "content": "finished"}]),
+        ],
+    )
+    def test_delivery_unknown_pauses(self, record, transcript):
+        assert (
+            classify_active_run(record, transcript).disposition
+            == RECOVERY_PAUSE_DELIVERY
+        )
+
+    def test_missing_trigger_input_pauses(self):
+        transcript = [{"role": "user", "content": "older", "message_id": "other"}]
+        assert (
+            classify_active_run(_record(), transcript).disposition
+            == RECOVERY_PAUSE_INPUT
+        )
+
+    def test_triggerless_run_requires_a_timestamped_current_input(self):
+        record = _record(trigger_message_id=None)
+        transcript = [{"role": "user", "content": "unverifiable legacy input"}]
+        assert (
+            classify_active_run(record, transcript).disposition == RECOVERY_PAUSE_INPUT
+        )
+
+    def test_active_process_waits_for_watcher(self):
+        decision = classify_active_run(_record(), [_user()], has_active_process=True)
+        assert decision.disposition == RECOVERY_WAIT_FOR_PROCESS
+
+    def test_third_recovery_interruption_pauses(self):
+        decision = classify_active_run(
+            replace(_record(), recovery_attempts=3), [_user()]
+        )
+        assert decision.disposition == RECOVERY_PAUSE_RETRY_LIMIT

--- a/tests/gateway/test_active_run_recovery.py
+++ b/tests/gateway/test_active_run_recovery.py
@@ -8,6 +8,7 @@ import signal
 import subprocess
 import sys
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
@@ -135,19 +136,26 @@ class TestActiveRunStore:
 import os
 import signal
 import sys
+from pathlib import Path
 from gateway.recovery import ActiveRunStore
-store = ActiveRunStore(sys.argv[1])
+hermes_home = Path(sys.argv[1])
+os.environ['HERMES_HOME'] = str(hermes_home)
+store = ActiveRunStore(hermes_home / 'sessions')
 store.begin('session-killed', trigger_message_id='message-killed', started_at=42)
 os.kill(os.getpid(), signal.SIGKILL)
 """
+        child_env = dict(os.environ)
+        child_env["HERMES_HOME"] = str(tmp_path)
         child = subprocess.run(
             [sys.executable, "-c", script, str(tmp_path)],
             cwd=os.getcwd(),
+            env=child_env,
             check=False,
         )
         assert child.returncode == -signal.SIGKILL
 
-        store = ActiveRunStore(tmp_path)
+        assert Path(child_env["HERMES_HOME"]) == tmp_path
+        store = ActiveRunStore(tmp_path / "sessions")
         records = store.snapshot()
         assert len(records) == 1
         assert records[0].session_key == "session-killed"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -2463,6 +2463,7 @@ class TestApiServerEnvOverride:
         The fix honors the explicit disable, flagged by ``_enabled_explicit`` in
         the platform's extra (set when the config.yaml pins enabled).
         """
+        valid_api_server_key = "regression-key-1234"
         config = GatewayConfig(
             platforms={
                 Platform.API_SERVER: PlatformConfig(
@@ -2472,10 +2473,17 @@ class TestApiServerEnvOverride:
             },
         )
 
-        with patch.dict(os.environ, {"API_SERVER_KEY": "secret-key"}, clear=True):
+        with patch.dict(
+            os.environ,
+            {"API_SERVER_KEY": valid_api_server_key},
+            clear=True,
+        ):
             _apply_env_overrides(config)
 
         # Explicit disable wins over the env-var presence.
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
-        assert config.platforms[Platform.API_SERVER].extra.get("key") == "secret-key"
+        assert (
+            config.platforms[Platform.API_SERVER].extra.get("key")
+            == valid_api_server_key
+        )

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -9,6 +9,7 @@ id stability, and the startup redelivery sweep's contract:
 - poison rows abandon at the attempts cap / stale cutoff
 """
 
+import sqlite3
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -35,18 +36,20 @@ def _record(oid="ob-1", session_key="agent:main:slack:channel:C1", **kw):
         chat_id=kw.get("chat_id", "C1"),
         thread_id=kw.get("thread_id", "171.001"),
         content=kw.get("content", "the final answer"),
+        run_id=kw.get("run_id"),
     )
 
 
 def _row(oid):
     with dl._connect() as conn:
         r = conn.execute(
-            """SELECT state, attempts, owner_pid, content
+            """SELECT state, attempts, owner_pid, content, run_id
                FROM delivery_obligations WHERE obligation_id=?""",
             (oid,),
         ).fetchone()
     return None if r is None else {
         "state": r[0], "attempts": r[1], "owner_pid": r[2], "content": r[3],
+        "run_id": r[4],
     }
 
 
@@ -64,6 +67,40 @@ class TestStateMachine:
     def test_record_starts_pending(self):
         _record()
         assert _row("ob-1")["state"] == "pending"
+
+    def test_record_persists_active_run_identity(self):
+        _record(run_id="run-1")
+        assert _row("ob-1")["run_id"] == "run-1"
+
+    def test_existing_database_is_migrated_with_nullable_run_id(self):
+        with dl._DB_LOCK:
+            path = dl._db_path()
+            with sqlite3.connect(path) as conn:
+                conn.execute(
+                    """CREATE TABLE delivery_obligations (
+                        obligation_id TEXT PRIMARY KEY,
+                        session_key TEXT NOT NULL,
+                        platform TEXT NOT NULL,
+                        chat_id TEXT NOT NULL,
+                        thread_id TEXT,
+                        content TEXT NOT NULL,
+                        state TEXT NOT NULL,
+                        attempts INTEGER NOT NULL DEFAULT 0,
+                        created_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        owner_pid INTEGER,
+                        owner_started_at INTEGER,
+                        last_error TEXT
+                    )"""
+                )
+
+        with dl._connect() as conn:
+            columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(delivery_obligations)")
+            }
+
+        assert "run_id" in columns
 
     def test_full_happy_path(self):
         _record()
@@ -103,12 +140,13 @@ class TestSweep:
         assert dl.sweep_recoverable() == []
 
     def test_dead_owner_pending_claimed_without_marker(self):
-        _record()
+        _record(run_id="run-1")
         _orphan("ob-1")
         claimed = dl.sweep_recoverable()
         assert len(claimed) == 1
         assert claimed[0]["needs_marker"] is False
         assert claimed[0]["attempts"] == 1
+        assert claimed[0]["run_id"] == "run-1"
         # Claim re-stamps ownership: a second sweep in the same (live)
         # process must not double-claim.
         assert dl.sweep_recoverable() == []
@@ -203,6 +241,9 @@ class TestGatewayRedeliverySweep:
         _store._store = None
         runner.session_store = None
         runner._async_session_store = _store
+        runner._active_run_store = None
+        runner._active_recovery_reasons = {}
+        runner._clear_restart_failure_count = MagicMock()
         return runner
 
     @staticmethod
@@ -255,6 +296,50 @@ class TestGatewayRedeliverySweep:
 
         assert n == 0
         assert _row("ob-1")["state"] == "failed"
+        runner._async_session_store.clear_resume_pending.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_successful_redelivery_finishes_matching_active_run(self, tmp_path):
+        from gateway.recovery import ActiveRunStore
+
+        session_key = "agent:main:slack:channel:C1"
+        active_store = ActiveRunStore(tmp_path)
+        record = active_store.begin(session_key, trigger_message_id="msg-1")
+        assert active_store.mark_response_ready(session_key, record.run_id)
+        _record(session_key=session_key, run_id=record.run_id)
+        _orphan("ob-1")
+        runner = self._runner(self._adapter())
+        runner._active_run_store = active_store
+        runner._active_recovery_reasons = {session_key: "delivery_unknown"}
+
+        assert await runner._redeliver_pending_obligations() == 1
+
+        assert active_store.get(session_key) is None
+        assert session_key not in runner._active_recovery_reasons
+        runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
+            session_key
+        )
+        runner._clear_restart_failure_count.assert_called_once_with(session_key)
+
+    @pytest.mark.asyncio
+    async def test_stale_redelivery_cannot_clear_newer_active_run(self, tmp_path):
+        from gateway.recovery import ActiveRunStore
+
+        session_key = "agent:main:slack:channel:C1"
+        active_store = ActiveRunStore(tmp_path)
+        stale = active_store.begin(session_key, trigger_message_id="msg-old")
+        newer = active_store.begin(session_key, trigger_message_id="msg-new")
+        _record(session_key=session_key, run_id=stale.run_id)
+        _orphan("ob-1")
+        runner = self._runner(self._adapter())
+        runner._active_run_store = active_store
+        runner._active_recovery_reasons = {session_key: "delivery_unknown"}
+
+        assert await runner._redeliver_pending_obligations() == 1
+
+        assert active_store.get(session_key) == newer
+        assert runner._active_recovery_reasons[session_key] == "delivery_unknown"
+        runner._async_session_store.clear_resume_pending.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_missing_adapter_leaves_row_recoverable(self):

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -61,7 +61,7 @@ def _event(text="hello agent"):
 def _rows():
     with dl._connect() as conn:
         return conn.execute(
-            "SELECT obligation_id, state, content FROM delivery_obligations"
+            "SELECT obligation_id, state, content, run_id FROM delivery_obligations"
         ).fetchall()
 
 
@@ -76,13 +76,16 @@ class TestProducerHook:
     @pytest.mark.asyncio
     async def test_normal_turn_records_and_delivers(self):
         adapter = _Adapter()
-        await _run(adapter, _event())
+        event = _event()
+        event._hermes_active_run_id = "run-42"
+        await _run(adapter, event)
 
         assert adapter.sent == ["final answer"]
         rows = _rows()
         assert len(rows) == 1
         assert rows[0][1] == "delivered"
         assert rows[0][2] == "final answer"
+        assert rows[0][3] == "run-42"
 
     @pytest.mark.asyncio
     async def test_send_failure_leaves_failed_row(self):

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -30,6 +30,7 @@ class _CapturingAgent:
         task_id=None,
         persist_user_message=None,
         persist_user_timestamp=None,
+        persist_user_message_id=None,
     ):
         type(self).last_run = {
             "user_message": user_message,
@@ -37,6 +38,7 @@ class _CapturingAgent:
             "task_id": task_id,
             "persist_user_message": persist_user_message,
             "persist_user_timestamp": persist_user_timestamp,
+            "persist_user_message_id": persist_user_message_id,
         }
         return {
             "final_response": "ok",
@@ -253,6 +255,36 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_platform_message_id_for_early_persistence(
+    monkeypatch, tmp_path
+):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "openrouter", "api_mode": "chat_completions"},
+    )
+
+    await runner._run_agent(
+        message="recover me",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        persist_user_message_id="discord-message-123",
+    )
+
+    assert _CapturingAgent.last_run["persist_user_message_id"] == "discord-message-123"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_queued_native_image_session_key.py
+++ b/tests/gateway/test_queued_native_image_session_key.py
@@ -56,7 +56,13 @@ class CaptureQueuedNativeImageAgent:
         self.tools = []
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
 
-    def run_conversation(self, message, conversation_history=None, task_id=None):
+    def run_conversation(
+        self,
+        message,
+        conversation_history=None,
+        task_id=None,
+        persist_user_message_id=None,
+    ):
         type(self).calls.append(message)
         return {
             "final_response": f"done-{len(type(self).calls)}",

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1435,32 +1435,9 @@ async def test_auto_resume_skips_sessions_with_running_agent():
 
 
 @pytest.mark.asyncio
-async def test_startup_restore_gate_queues_real_inbound_messages():
-    """Real inbound messages wait while startup restore is in progress."""
-    runner, _adapter = make_restart_runner()
-    runner._startup_restore_in_progress = True
-    runner._startup_restore_queue = []
-
-    inbound = MessageEvent(
-        text="hello",
-        message_type=MessageType.TEXT,
-        source=make_restart_source(chat_id="restore-chat"),
-    )
-
-    result = await runner._handle_message(inbound)
-
-    assert result is None
-    assert runner._startup_restore_queue == [inbound]
-
-
-@pytest.mark.asyncio
-async def test_startup_restore_waits_for_resume_before_draining_inbound():
-    """Queued inbound turns replay only after startup resume tasks finish."""
+async def test_unrelated_inbound_is_not_blocked_by_startup_recovery():
+    """Only the recovering session is locked; other chats dispatch immediately."""
     runner, adapter = make_restart_runner()
-    runner._startup_restore_in_progress = True
-    runner._startup_restore_queue = []
-    runner._startup_restore_tasks = []
-
     source = make_restart_source(chat_id="restore-chat")
     pending_entry = SessionEntry(
         session_key="agent:main:telegram:dm:restore-chat",
@@ -1477,17 +1454,24 @@ async def test_startup_restore_waits_for_resume_before_draining_inbound():
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
 
     resume_done = asyncio.Event()
-    seen: list[str] = []
 
     async def fake_handle_message(event: MessageEvent) -> None:
-        if event.internal:
-            seen.append("resume-start")
-            task = asyncio.create_task(resume_done.wait())
-            adapter._session_tasks[pending_entry.session_key] = task
-            return
-        seen.append(f"inbound:{event.text}")
+        task = asyncio.create_task(resume_done.wait())
+        adapter._session_tasks[pending_entry.session_key] = task
 
     adapter.handle_message = fake_handle_message
+    runner._claim_active_session_slot = lambda session_key, source: (object(), None)
+    runner._active_session_leases = {}
+    runner._begin_session_run_generation = lambda session_key: 1
+    runner._is_session_run_current = lambda session_key, generation: True
+    runner._post_turn_goal_continuation = AsyncMock()
+    unrelated_runs: list[str] = []
+
+    async def fake_agent(event, source, session_key, run_generation):
+        unrelated_runs.append(session_key)
+        return "UNRELATED OK"
+
+    runner._handle_message_with_agent = fake_agent
 
     scheduled = runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
@@ -1495,23 +1479,54 @@ async def test_startup_restore_waits_for_resume_before_draining_inbound():
     inbound = MessageEvent(
         text="hello",
         message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="other-chat"),
+    )
+    assert await runner._handle_message(inbound) == "UNRELATED OK"
+    assert scheduled == 1
+    assert unrelated_runs == ["agent:main:telegram:dm:other-chat"]
+
+    resume_done.set()
+    await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_inbound_for_recovering_session_queues_behind_preclaim():
+    """A same-session user message waits behind its synthetic recovery turn."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="restore-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:restore-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    resume_done = asyncio.Event()
+
+    async def fake_handle_message(event: MessageEvent) -> None:
+        task = asyncio.create_task(resume_done.wait())
+        adapter._session_tasks[pending_entry.session_key] = task
+
+    adapter.handle_message = fake_handle_message
+    assert runner._schedule_resume_pending_sessions() == 1
+    await asyncio.sleep(0)
+
+    inbound = MessageEvent(
+        text="new instruction",
+        message_type=MessageType.TEXT,
         source=source,
     )
     assert await runner._handle_message(inbound) is None
-    assert scheduled == 1
-    assert seen == ["resume-start"]
-    assert runner._startup_restore_queue == [inbound]
-
-    finish_task = asyncio.create_task(runner._finish_startup_restore())
-    await asyncio.sleep(0)
-    assert seen == ["resume-start"]
+    assert adapter._pending_messages[pending_entry.session_key] is inbound
 
     resume_done.set()
-    await finish_task
-
-    assert seen == ["resume-start", "inbound:hello"]
-    assert runner._startup_restore_queue == []
-    assert runner._startup_restore_in_progress is False
+    await asyncio.sleep(0.05)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -944,6 +944,9 @@ async def test_drain_timeout_marks_resume_pending():
         session_key_one: running_agent,
         session_key_two: MagicMock(),
     }
+    active_store = MagicMock()
+    active_store.mark_interrupted_many = MagicMock(return_value=2)
+    runner._active_run_store = active_store
 
     # Plug a mock session_store that records marks.
     session_store = MagicMock()
@@ -961,6 +964,10 @@ async def test_drain_timeout_marks_resume_pending():
     assert marked == {session_key_one, session_key_two}
     for args in calls:
         assert args[0][1] == "shutdown_timeout"
+    active_store.mark_interrupted_many.assert_called_once_with(
+        [session_key_one, session_key_two],
+        reason="gateway_shutdown",
+    )
 
 
 @pytest.mark.asyncio
@@ -972,6 +979,9 @@ async def test_drain_timeout_uses_restart_reason_when_restarting():
 
     running_agent = MagicMock()
     runner._running_agents = {"agent:main:telegram:dm:A": running_agent}
+    active_store = MagicMock()
+    active_store.mark_interrupted_many = MagicMock(return_value=1)
+    runner._active_run_store = active_store
 
     session_store = MagicMock()
     session_store.mark_resume_pending = MagicMock(return_value=True)
@@ -986,6 +996,10 @@ async def test_drain_timeout_uses_restart_reason_when_restarting():
     assert calls, "expected at least one mark_resume_pending call"
     for args in calls:
         assert args[0][1] == "restart_timeout"
+    active_store.mark_interrupted_many.assert_called_once_with(
+        ["agent:main:telegram:dm:A"],
+        reason="gateway_restart",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -768,7 +768,13 @@ class QueuedCommentaryAgent:
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
         self.tools = []
 
-    def run_conversation(self, message, conversation_history=None, task_id=None):
+    def run_conversation(
+        self,
+        message,
+        conversation_history=None,
+        task_id=None,
+        persist_user_message_id=None,
+    ):
         type(self).calls += 1
         if type(self).calls == 1 and self.interim_assistant_callback:
             self.interim_assistant_callback("I'll inspect the repo first.", already_streamed=False)
@@ -787,7 +793,13 @@ class QueuedSilenceAgent:
     def __init__(self, **kwargs):
         self.tools = []
 
-    def run_conversation(self, message, conversation_history=None, task_id=None):
+    def run_conversation(
+        self,
+        message,
+        conversation_history=None,
+        task_id=None,
+        persist_user_message_id=None,
+    ):
         type(self).calls += 1
         return {
             "final_response": "NO_REPLY" if type(self).calls == 1 else "follow-up processed",
@@ -804,7 +816,13 @@ class QueuedFailedEmptyAgent:
     def __init__(self, **kwargs):
         self.tools = []
 
-    def run_conversation(self, message, conversation_history=None, task_id=None):
+    def run_conversation(
+        self,
+        message,
+        conversation_history=None,
+        task_id=None,
+        persist_user_message_id=None,
+    ):
         type(self).calls += 1
         if type(self).calls == 1:
             return {

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -947,6 +947,9 @@ class TestSessionStoreLookupBySessionId:
         assert store.lookup_by_session_id(entry.session_id) is entry
         assert store.lookup_by_session_id("missing") is None
         assert store.lookup_by_session_id("") is None
+        assert store.lookup_by_session_key(entry.session_key) is entry
+        assert store.lookup_by_session_key("missing") is None
+        assert store.lookup_by_session_key("") is None
 
 
 class TestSlackWorkspaceSessionIsolation:

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -7,6 +7,7 @@ import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
+from gateway.recovery import ActiveRunStore
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
@@ -107,6 +108,32 @@ async def test_reset_fires_reset_hook(mock_invoke_hook):
         and c.kwargs["new_session_id"] == "sess-new"
         for c in mock_invoke_hook.call_args_list
     )
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_new_discards_active_run_journal(mock_invoke_hook, tmp_path):
+    runner = _make_runner()
+    session_key = next(iter(runner.session_store._entries))
+    runner._active_run_store = ActiveRunStore(tmp_path)
+    runner._active_run_store.begin(session_key, trigger_message_id="m1")
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    assert runner._active_run_store.get(session_key) is None
+
+
+@pytest.mark.asyncio
+async def test_stop_discards_active_run_journal(tmp_path):
+    runner = _make_runner()
+    session_key = next(iter(runner.session_store._entries))
+    runner._active_run_store = ActiveRunStore(tmp_path)
+    runner._active_run_store.begin(session_key, trigger_message_id="m1")
+
+    await runner._handle_stop_command(_make_event("/stop"))
+
+    assert runner._active_run_store.get(session_key) is None
+    runner.session_store.clear_resume_pending.assert_called_with(session_key)
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -188,6 +188,27 @@ def test_flush_persist_override_replaces_api_local_multimodal_note(agent):
     assert api_content[0]["text"] == "[MODEL SWITCH NOTE]\n\nDescribe this screenshot"
 
 
+def test_turn_start_flush_persists_platform_message_id(agent):
+    """The recovery journal id must be durable before agent work begins."""
+    agent._session_db = MagicMock()
+    agent._session_db_created = True
+    agent.session_id = "session-123"
+    agent._last_flushed_db_idx = 0
+    agent._persist_user_message_idx = 0
+    agent._persist_user_message_override = "recover me"
+    agent._persist_user_message_timestamp = 123.0
+    agent._persist_user_message_id = "discord-message-123"
+
+    agent._flush_messages_to_session_db(
+        [{"role": "user", "content": "recover me"}],
+        [],
+    )
+
+    db_write = agent._session_db.append_message.call_args.kwargs
+    assert db_write["platform_message_id"] == "discord-message-123"
+    assert db_write["timestamp"] == 123.0
+
+
 def test_direct_session_db_flushes_share_marker_claim(agent):
     """A direct flush cannot interleave its marker check with `_persist_session`."""
     class _BarrierDB:


### PR DESCRIPTION
> **Critical availability issue:** Under high-concurrency gateway workloads, a forced restart can strand otherwise recoverable sessions or leave already-generated replies undelivered. One restart can therefore stall many active conversations at once and require manual user intervention.

## What does this PR do?

Makes in-flight gateway recovery crash-safe and deterministic across process death, drain timeouts, and delivery ambiguity.

### Root causes

The previous recovery path had several independent gaps:

1. in-flight work was inferred from a short routing-activity window instead of a durable per-run identity;
2. the triggering platform message ID was persisted too late to prove which durable user request belonged to the interrupted run;
3. startup recovery could replay sessions before process/delegation consumers and pending outbound replies were reconciled;
4. the recovery branch accidentally stopped invoking the delivery-ledger sweep and retained a call to a removed startup method;
5. a controlled drain-timeout interruption looked identical to unknown assistant delivery, so safe sessions paused instead of continuing; and
6. rejected recovery inbox claims could remain at the FIFO head and block later user turns.

### Implementation

- Adds an atomic `sessions/.active_runs.json` journal with `session_key`, random `run_id`, trigger message ID, phase, recovery attempts, and controlled-interruption metadata. It stores no user message content.
- Persists the raw inbound platform message ID during the agent's first turn-start SQLite flush, before model or tool execution.
- Classifies recovery conservatively: durable requests and unfinished read-only work can resume; missing trigger identity, uncertain external side effects, or exhausted retry budgets pause for user input.
- Marks all turns interrupted by a drain timeout in one atomic journal write. This avoids one fsync per active session under high concurrency.
- Starts recovered process/delegation consumers first, redelivers durable outbound obligations second, and only then schedules session replay.
- Adds a nullable `run_id` to `delivery_obligations` through a backward-compatible additive migration. A confirmed redelivery CAS-clears only the matching active run, so an old reply cannot clear a newer task.
- Keeps failed redeliveries recoverable and recovery-paused. Resume state is cleared only after the platform confirms a successful send.
- Removes the stale `_finish_startup_restore()` call that could abort startup after recovery consumers were initialized.
- Preserves per-session preclaims and bounded recovery concurrency, and releases rejected durable-inbox claims so later explicit instructions are not permanently queued.

| Recovered state | Behavior |
| --- | --- |
| Controlled gateway interruption, durable trigger, no uncertain side effect | Auto-resume |
| Pending final reply with matching `run_id` | Redeliver first; clear recovery state only after confirmed delivery |
| Ambiguous mid-send reply | Redeliver with a visible recovered-reply marker |
| Active recovered background process | Wait for its watcher; do not relaunch duplicate work |
| Dangling or interrupted side-effecting tool | Pause and notify; never replay blindly |
| Trigger request missing or identity unavailable | Ask the user to resend |
| Three interrupted recovery boots | Pause and notify |

### Safety boundaries

- No exactly-once guarantee is claimed for arbitrary external systems.
- Uncertain side-effecting tools remain human-gated.
- Legacy delivery rows without `run_id` are still deliverable, but cannot clear a currently journaled run without exact identity.
- Failed ledger or journal maintenance remains best-effort and cannot block the primary platform send path.

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] Feature
- [ ] Security fix
- [ ] Documentation-only change

## Validation

Validated after rebasing linearly onto `main@c4f5a45d5d9903998fb318ac6f3c5e6623e60445`:

- Recovery, delivery-ledger, drain-timeout, producer, and Slack ignored-channel matrix: **169 passed, 0 failed**.
- Broader startup/shutdown/reconnect matrix: **109 passed, 0 failed**; one pre-existing timing-sensitive startup-race test passed on automatic retry and then passed **5/5** in an isolated rerun.
- Full gateway config test file after correcting its stale short-key fixture to meet the current 16-character API-server security gate: **149 passed, 0 failed**.
- `ruff check` on all touched recovery files and tests: passed.
- Python bytecode compilation and `git diff --check`: passed.
- Active-run fault injection still verifies that a SIGKILL leaves exactly one durable recoverable run.
- All nine PR commits are signed and the history is linear with no merge commits.

## Compatibility and rollback

- The delivery-ledger change is an additive nullable SQLite column migration; existing rows remain valid.
- Older versions ignore the active-run sidecar, which contains no message text.
- Corrupt or unsupported sidecar data fails safe without preventing gateway startup.
- Rollback is a normal revert of this PR; no config key or public command schema is introduced.

## Checklist

- [x] Conventional, signed commits
- [x] Regression and fault-injection coverage
- [x] High-concurrency shutdown path avoids per-session journal fsync
- [x] Uncertain side effects remain fail-closed
- [x] Existing PR refreshed onto current upstream `main`
- [ ] Full repository suite locally; GitHub CI is running on this head

## Infographic

![Crash-safe gateway session recovery flow and safety boundaries](https://github.com/user-attachments/assets/6a5c24ef-7667-43a1-bf30-bae250de72e9)

## Final head

`65fac02e2`
