### PR TITLE
feat(gateway): live per-tool status line on Slack (salvages #62007)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -645,6 +645,52 @@ def verb_drops_preview(tool_name: str) -> bool:
     return tool_name in _TOOL_VERBS_NO_PREVIEW
 
 
+def build_status_phrase(tool_name: str, args: dict | None, max_len: int = 49) -> str | None:
+    """Build a short present-tense status phrase for platform status surfaces.
+
+    Used by text-rendering "typing" indicators (Slack's
+    ``assistant.threads.setStatus`` line) to show what the agent is doing
+    right now: ``is running scripts/run_tests.sh…`` instead of a static
+    ``is thinking...``.  The phrase is phrased to follow the bot's display
+    name ("Hermes is running …"), so it starts lowercase with "is".
+
+    Pass ``args=None`` for a verb-only phrase (``is running…``) — used when
+    ``display.live_status`` is ``verb`` to keep argument previews out of
+    shared channels.
+
+    Returns None for the ``_thinking`` pseudo-tool and when friendly labels
+    are disabled (callers fall back to their static default).  ``max_len``
+    caps the total phrase length; Slack truncates its status line around 50
+    characters, so the default stays just under that.
+    """
+    if not tool_name or tool_name == "_thinking":
+        return None
+    if not _friendly_tool_labels:
+        return None
+
+    verb = _TOOL_VERBS.get(tool_name)
+    if verb:
+        head = f"is {verb[0].lower()}{verb[1:]}"
+    else:
+        # Custom / plugin / MCP tools: generic but still informative.
+        head = f"is using {tool_name}"
+
+    phrase = head
+    if args and verb and tool_name not in _TOOL_VERBS_NO_PREVIEW:
+        preview = build_tool_preview(tool_name, args, max_len=None)
+        if preview:
+            # Previews can contain newlines (terminal commands); keep the
+            # status to the first line.
+            preview = preview.splitlines()[0].strip()
+            phrase = f"{head}{tool_verb_connector(tool_name)}{preview}"
+
+    if len(phrase) > max_len - 1:
+        phrase = phrase[: max_len - 2].rstrip() + "…"
+    else:
+        phrase = phrase + "…"
+    return phrase
+
+
 def build_tool_label(tool_name: str, args: dict, max_len: int | None = None) -> str | None:
     """Build a human-phrased status label for a tool call.
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -573,6 +573,15 @@ class PlatformConfig:
     # gateway/platforms/base.py.
     typing_indicator: bool = True
 
+    # Custom text for the working-state line on platforms whose typing
+    # indicator renders text rather than a native bubble: Slack's
+    # assistant.threads.setStatus line (shown next to the bot name; needs the
+    # assistant:write scope to render) and Google Chat's visible marker
+    # message. None keeps each platform's built-in default ("is thinking..." /
+    # "Hermes is thinking…"). Platforms with textless indicators (Discord,
+    # Telegram, Matrix, …) ignore it.
+    typing_status_text: Optional[str] = None
+
     # Per-channel model/provider/system_prompt overrides (channel_id -> ChannelOverride)
     channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
 
@@ -587,6 +596,8 @@ class PlatformConfig:
             "gateway_restart_notification": self.gateway_restart_notification,
             "typing_indicator": self.typing_indicator,
         }
+        if self.typing_status_text is not None:
+            result["typing_status_text"] = self.typing_status_text
         if self.token:
             result["token"] = self.token
         if self.api_key:
@@ -622,6 +633,12 @@ class PlatformConfig:
         if _typing is None:
             _typing = extra.get("typing_indicator")
 
+        # typing_status_text takes the same two routes (top-level or bridged
+        # into extra); string passthrough, no coercion.
+        _typing_text = data.get("typing_status_text")
+        if _typing_text is None:
+            _typing_text = data.get("extra", {}).get("typing_status_text")
+
         channel_overrides: Dict[str, ChannelOverride] = {}
         raw_overrides = data.get("channel_overrides") or {}
         if isinstance(raw_overrides, dict):
@@ -637,6 +654,7 @@ class PlatformConfig:
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
             typing_indicator=_coerce_bool(_typing, True),
+            typing_status_text=_typing_text,
             channel_overrides=channel_overrides,
             extra=extra,
         )
@@ -1392,6 +1410,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 if "typing_indicator" in platform_cfg:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
+                if "typing_status_text" in platform_cfg:
+                    bridged["typing_status_text"] = platform_cfg["typing_status_text"]
                 has_channel_overrides = "channel_overrides" in platform_cfg
                 if has_channel_overrides:
                     raw_overrides = platform_cfg.get("channel_overrides")

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -637,7 +637,7 @@ class PlatformConfig:
         # into extra); string passthrough, no coercion.
         _typing_text = data.get("typing_status_text")
         if _typing_text is None:
-            _typing_text = data.get("extra", {}).get("typing_status_text")
+            _typing_text = extra.get("typing_status_text")
 
         channel_overrides: Dict[str, ChannelOverride] = {}
         raw_overrides = data.get("channel_overrides") or {}

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -58,6 +58,16 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # live, just cleaned up after success so the chat doesn't fill up with
     # stale breadcrumbs. Failed runs leave bubbles in place as breadcrumbs.
     "cleanup_progress": False,
+    # Live working-state status on platforms whose typing indicator renders
+    # text (Slack's assistant status line). Values:
+    #   "full" / true  -> verb + argument preview ("is running pytest…")
+    #   "verb"         -> verb only ("is running…") — keeps file paths and
+    #                     commands out of shared channels
+    #   "off" / false  -> static text (typing_status_text or "is thinking...")
+    # Independent of tool_progress: works even when progress bubbles are off
+    # (Slack's default), and costs no extra API calls — the existing typing
+    # refresh cadence just renders different text.
+    "live_status": "full",
 }
 
 # ---------------------------------------------------------------------------
@@ -263,6 +273,18 @@ def _normalise(setting: str, value: Any) -> Any:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)
+    if setting == "live_status":
+        # Tri-state: "full" (verb + preview), "verb" (verb only), "off".
+        if value is True:
+            return "full"
+        if value is False:
+            return "off"
+        val = str(value).strip().lower()
+        if val in {"true", "1", "yes", "on", "all"}:
+            return "full"
+        if val in {"false", "0", "no"}:
+            return "off"
+        return val if val in {"full", "verb", "off"} else "full"
     if setting == "tool_progress_grouping":
         val = str(value).lower()
         return val if val in ("accumulate", "separate") else "accumulate"

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2314,6 +2314,25 @@ class BasePlatformAdapter(ABC):
     # preview (see gateway/run.py progress_callback).
     supports_code_blocks: bool = False
 
+    # Whether this adapter's typing indicator renders TEXT (a status line
+    # next to the bot name) rather than a native textless bubble. When True,
+    # the gateway feeds live per-tool status phrases via set_status_text()
+    # ("is running pytest…") and send_typing() renders them. Textless
+    # platforms (Telegram, Discord, Matrix, …) keep the default False and
+    # never see these calls.
+    supports_status_text: bool = False
+
+    def set_status_text(self, chat_id: str, text: Optional[str]) -> None:
+        """Set or clear (``None``) the live working-state phrase for a chat.
+
+        Cheap, in-memory only: the next typing refresh renders the new text.
+        No-op storage on adapters that never read ``_status_text``.
+        """
+        if text:
+            self._status_text[str(chat_id)] = text
+        else:
+            self._status_text.pop(str(chat_id), None)
+
     # Whether this adapter can deliver an ASYNC notification back to the agent
     # AFTER a turn ends — i.e. wake a fresh turn to surface a background
     # process completion (terminal notify_on_complete / watch_patterns) or a
@@ -2464,6 +2483,13 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        # Dynamic working-state status text per chat (chat_id -> phrase).
+        # Set by the gateway on tool starts ("is running pytest…") and read
+        # by adapters whose typing indicator renders text (Slack's
+        # assistant.threads.setStatus). The regular _keep_typing refresh
+        # cadence picks up changes, so updating this dict costs no extra
+        # platform API calls. Cleared when the typing loop winds down.
+        self._status_text: Dict[str, str] = {}
 
     @property
     def message_len_fn(self) -> Callable[[str], int]:
@@ -3950,6 +3976,7 @@ class BasePlatformAdapter(ABC):
                 except Exception:
                     pass
             self._typing_paused.discard(chat_id)
+            self._status_text.pop(str(chat_id), None)
 
     async def _stop_typing_refresh(
         self,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2328,10 +2328,17 @@ class BasePlatformAdapter(ABC):
         Cheap, in-memory only: the next typing refresh renders the new text.
         No-op storage on adapters that never read ``_status_text``.
         """
+        # getattr-guard: many gateway tests build bare adapters via
+        # object.__new__() without running __init__ (see AGENTS.md pitfall
+        # on new __init__ attributes breaking tests).
+        store = getattr(self, "_status_text", None)
+        if store is None:
+            store = {}
+            self._status_text = store
         if text:
-            self._status_text[str(chat_id)] = text
+            store[str(chat_id)] = text
         else:
-            self._status_text.pop(str(chat_id), None)
+            store.pop(str(chat_id), None)
 
     # Whether this adapter can deliver an ASYNC notification back to the agent
     # AFTER a turn ends — i.e. wake a fresh turn to surface a background
@@ -3976,7 +3983,10 @@ class BasePlatformAdapter(ABC):
                 except Exception:
                     pass
             self._typing_paused.discard(chat_id)
-            self._status_text.pop(str(chat_id), None)
+            # getattr-guard: bare object.__new__() adapters in tests lack
+            # _status_text (same class of issue as _typing_paused, but that
+            # one is always present because those tests predate it).
+            getattr(self, "_status_text", {}).pop(str(chat_id), None)
 
     async def _stop_typing_refresh(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18364,6 +18364,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
         tool_progress_enabled = progress_mode not in {"off", "log"} and source.platform != Platform.WEBHOOK
+        # Live working-state status for text-rendering typing indicators
+        # (Slack's assistant status line). Independent of tool_progress —
+        # Slack defaults tool_progress off (permanent lines spam channels)
+        # but the status line is ephemeral, so live status stays useful
+        # there. Rendering rides the existing _keep_typing refresh: the
+        # callback only stores a phrase on the adapter, costing zero extra
+        # platform API calls.
+        _live_status_mode = resolve_display_setting(
+            user_config, platform_key, "live_status", "full"
+        )
+        _live_status_adapter = self._adapter_for_source(source)
+        if not getattr(_live_status_adapter, "supports_status_text", False):
+            _live_status_adapter = None
+        if _live_status_mode == "off":
+            _live_status_adapter = None
         # "log" mode: tool calls are written to ~/.hermes/logs/tool_calls.log
         # instead of the chat (#3459 / #3458). Gateway-only by design.
         log_mode_enabled = progress_mode == "log" and source.platform != Platform.WEBHOOK
@@ -18468,6 +18483,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
+            # Live status line (Slack's assistant status): stash the current
+            # tool phrase on the adapter; the _keep_typing refresh renders it
+            # within a couple of seconds. Handled before every other gate
+            # because it's independent of progress bubbles and queues (Slack
+            # keeps tool_progress off by default, but the ephemeral status
+            # line is always safe). Plain dict write — safe from the agent's
+            # sync worker thread, no event-loop hop needed.
+            if (
+                _live_status_adapter is not None
+                and _live_status_mode != "off"
+                and tool_name != "_thinking"
+            ):
+                try:
+                    if event_type == "tool.started" and tool_name and _run_still_current():
+                        from agent.display import build_status_phrase
+                        _phrase = build_status_phrase(
+                            tool_name,
+                            args if _live_status_mode == "full" else None,
+                        )
+                        _live_status_adapter.set_status_text(source.chat_id, _phrase)
+                    elif event_type == "tool.completed":
+                        # Between tools the model is genuinely "thinking"
+                        # again — revert to the static default.
+                        _live_status_adapter.set_status_text(source.chat_id, None)
+                except Exception as _ls_err:
+                    logger.debug("live status update failed: %s", _ls_err)
             # "log" mode: append tool.started lines to the log queue and stay
             # silent in chat. Handled before the progress_queue guard because
             # log mode runs without a chat progress queue.
@@ -19646,7 +19687,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # None callback — so _thinking scratch bubbles never relayed even
             # though the progress queue was created for them.
             agent.tool_progress_callback = (
-                progress_callback if (needs_progress_queue or log_mode_enabled) else None
+                progress_callback
+                if (
+                    needs_progress_queue
+                    or log_mode_enabled
+                    or _live_status_adapter is not None
+                )
+                else None
             )
             # Discord voice verbal-ack hook (fires once per turn on first tool
             # call; armed only when in a voice channel with the mixer running).

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2678,7 +2678,10 @@ class GoogleChatAdapter(BasePlatformAdapter):
         thread_id = self._resolve_thread_id(
             reply_to=None, metadata=metadata, chat_id=chat_id,
         )
-        body: Dict[str, Any] = {"text": "Hermes is thinking…"}
+        body: Dict[str, Any] = {
+            "text": getattr(self.config, "typing_status_text", None)
+            or "Hermes is thinking…"
+        }
         if thread_id:
             body["thread"] = {"name": thread_id}
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1574,7 +1574,8 @@ class SlackAdapter(BasePlatformAdapter):
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Show a typing/status indicator using assistant.threads.setStatus.
 
-        Displays "is thinking..." next to the bot name in a thread.
+        Displays "is thinking..." next to the bot name in a thread, or the
+        platform's ``typing_status_text`` config value when set.
         Requires the assistant:write or chat:write scope.
         Auto-clears when the bot sends a reply to the thread.
         """
@@ -1602,7 +1603,8 @@ class SlackAdapter(BasePlatformAdapter):
             await self._get_client(chat_id, team_id=team_id).assistant_threads_setStatus(
                 channel_id=chat_id,
                 thread_ts=thread_ts,
-                status="is thinking...",
+                status=getattr(self.config, "typing_status_text", None)
+                or "is thinking...",
             )
         except Exception as e:
             # Silently ignore — may lack assistant:write scope or not be

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1604,7 +1604,7 @@ class SlackAdapter(BasePlatformAdapter):
             }
         try:
             _status = (
-                self._status_text.get(str(chat_id))
+                getattr(self, "_status_text", {}).get(str(chat_id))
                 or getattr(self.config, "typing_status_text", None)
                 or "is thinking..."
             )

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -421,6 +421,9 @@ class SlackAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = 39000  # Slack API allows 40,000 chars; leave margin
     supports_code_blocks = True  # Slack mrkdwn renders fenced code blocks
+    # Slack's typing indicator is a text status line (assistant.threads
+    # .setStatus), so the gateway feeds it live per-tool phrases.
+    supports_status_text = True
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
     # Slack blocks typed native slash commands inside threads ("/approve is
     # not supported in threads. Sorry!").  The adapter rewrites a leading
@@ -1600,11 +1603,15 @@ class SlackAdapter(BasePlatformAdapter):
                 "team_id": str(team_id) if team_id else "",
             }
         try:
+            _status = (
+                self._status_text.get(str(chat_id))
+                or getattr(self.config, "typing_status_text", None)
+                or "is thinking..."
+            )
             await self._get_client(chat_id, team_id=team_id).assistant_threads_setStatus(
                 channel_id=chat_id,
                 thread_ts=thread_ts,
-                status=getattr(self.config, "typing_status_text", None)
-                or "is thinking...",
+                status=_status,
             )
         except Exception as e:
             # Silently ignore — may lack assistant:write scope or not be

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -492,3 +492,62 @@ class TestBuildToolLabel:
         for tool_name in _TOOL_VERBS:
             label = build_tool_label(tool_name, {"query": "x", "path": "x", "url": "x"})
             assert label, f"{tool_name} produced empty label"
+
+
+class TestBuildStatusPhrase:
+    """build_status_phrase — live working-state text for Slack's status line."""
+
+    def test_builtin_tool_with_preview(self):
+        from agent.display import build_status_phrase
+        phrase = build_status_phrase("terminal", {"command": "pytest tests/"})
+        assert phrase == "is running pytest tests/…"
+
+    def test_search_tool_uses_for_connector(self):
+        from agent.display import build_status_phrase
+        phrase = build_status_phrase("web_search", {"query": "slack api limits"})
+        assert phrase == "is searching the web for slack api limits…"
+
+    def test_verb_only_when_args_none(self):
+        # live_status: "verb" mode passes args=None to suppress previews.
+        from agent.display import build_status_phrase
+        assert build_status_phrase("terminal", None) == "is running…"
+        assert build_status_phrase("read_file", None) == "is reading…"
+
+    def test_unknown_tool_generic_phrase(self):
+        from agent.display import build_status_phrase
+        phrase = build_status_phrase("my_mcp_tool", {"x": 1})
+        assert phrase == "is using my_mcp_tool…"
+
+    def test_thinking_pseudo_tool_returns_none(self):
+        from agent.display import build_status_phrase
+        assert build_status_phrase("_thinking", None) is None
+        assert build_status_phrase("", None) is None
+
+    def test_caps_length_for_slack_status_line(self):
+        from agent.display import build_status_phrase
+        phrase = build_status_phrase(
+            "terminal", {"command": "x" * 300}, max_len=49
+        )
+        assert phrase is not None and len(phrase) <= 49
+        assert phrase.endswith("…")
+
+    def test_multiline_command_keeps_first_line(self):
+        from agent.display import build_status_phrase
+        phrase = build_status_phrase(
+            "terminal", {"command": "make build\nmake test"}
+        )
+        assert phrase is not None
+        assert "\n" not in phrase
+
+    def test_respects_friendly_labels_toggle(self):
+        from agent.display import build_status_phrase, set_friendly_tool_labels
+        set_friendly_tool_labels(False)
+        try:
+            assert build_status_phrase("terminal", {"command": "ls"}) is None
+        finally:
+            set_friendly_tool_labels(True)
+
+    def test_no_preview_tools_stay_verb_only(self):
+        from agent.display import build_status_phrase
+        phrase = build_status_phrase("skills_list", {"category": "devops"})
+        assert phrase == "is listing skills…"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -94,6 +94,28 @@ class TestPlatformConfigRoundtrip:
         # extra; from_dict must honor it there too (mirrors _grn fallback).
         restored = PlatformConfig.from_dict({"extra": {"typing_indicator": False}})
         assert restored.typing_indicator is False
+
+    def test_typing_status_text_defaults_none(self):
+        assert PlatformConfig().typing_status_text is None
+        assert PlatformConfig.from_dict({}).typing_status_text is None
+
+    def test_typing_status_text_roundtrip(self):
+        pc = PlatformConfig(enabled=True, typing_status_text="is pouncing… 🐾")
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.typing_status_text == "is pouncing… 🐾"
+
+    def test_typing_status_text_resolved_from_extra(self):
+        # Same bridge route as typing_indicator: the shared-key loop copies a
+        # nested platforms.<plat> value into extra.
+        restored = PlatformConfig.from_dict(
+            {"extra": {"typing_status_text": "chasing yarn…"}}
+        )
+        assert restored.typing_status_text == "chasing yarn…"
+
+    def test_typing_status_text_omitted_from_to_dict_when_unset(self):
+        # None must not serialize — keeps existing config files byte-stable.
+        assert "typing_status_text" not in PlatformConfig().to_dict()
+
     def test_channel_overrides_roundtrip(self):
         pc = PlatformConfig(
             enabled=True,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -504,6 +504,45 @@ class TestLoadGatewayConfig:
 
         assert config.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
 
+    def test_typing_status_text_from_toplevel_platform_block(self, tmp_path, monkeypatch):
+        """A top-level ``slack:`` block reaches PlatformConfig via the
+        shared-key bridge (bridged into extra, then the from_dict extra
+        fallback) — the route a bare ``hermes config set``-style YAML uses."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            'slack:\n  typing_status_text: "is pouncing… 🐾"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.SLACK].typing_status_text
+            == "is pouncing… 🐾"
+        )
+
+    def test_typing_status_text_from_nested_platforms_block(self, tmp_path, monkeypatch):
+        """``platforms.slack.typing_status_text`` reaches PlatformConfig via
+        _merge_platform_map + the from_dict top-level read."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  slack:\n"
+            "    enabled: true\n"
+            '    typing_status_text: "chasing yarn…"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.SLACK].typing_status_text == "chasing yarn…"
+        )
+
     def test_multiplex_profiles_from_nested_gateway_section(self, tmp_path, monkeypatch):
         """``gateway.multiplex_profiles: true`` (the nested form written by
         ``hermes config set gateway.multiplex_profiles true``) must enable

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -607,3 +607,38 @@ class TestReasoningStyle:
 
         config = {"display": {"reasoning_style": "SUBTEXT"}}
         assert resolve_display_setting(config, "telegram", "reasoning_style") == "subtext"
+
+
+class TestLiveStatusSetting:
+    """display.live_status — tri-state normalisation + platform overrides."""
+
+    def test_default_is_full(self):
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "slack", "live_status") == "full"
+
+    def test_bool_and_string_coercion(self):
+        from gateway.display_config import resolve_display_setting
+
+        for raw, expected in [
+            (True, "full"), (False, "off"),
+            ("on", "full"), ("all", "full"),
+            ("no", "off"), ("verb", "verb"),
+            ("bogus", "full"),
+        ]:
+            config = {"display": {"live_status": raw}}
+            assert (
+                resolve_display_setting(config, "slack", "live_status") == expected
+            ), f"raw={raw!r}"
+
+    def test_per_platform_override_wins(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "live_status": "full",
+                "platforms": {"slack": {"live_status": "verb"}},
+            }
+        }
+        assert resolve_display_setting(config, "slack", "live_status") == "verb"
+        assert resolve_display_setting(config, "google_chat", "live_status") == "full"

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1315,6 +1315,31 @@ class TestTypingLifecycle:
         assert adapter._typing_messages["spaces/S"] == "spaces/S/messages/THINK"
 
     @pytest.mark.asyncio
+    async def test_send_typing_uses_configured_status_text(self, adapter):
+        # typing_status_text replaces the default working-state marker text.
+        adapter.config.typing_status_text = "is pouncing… 🐾"
+        adapter._create_message = AsyncMock(
+            return_value=type("R", (), {"success": True,
+                                        "message_id": "spaces/S/messages/THINK",
+                                        "error": None})()
+        )
+        await adapter.send_typing("spaces/S")
+        body = adapter._create_message.await_args.args[1]
+        assert body["text"] == "is pouncing… 🐾"
+
+    @pytest.mark.asyncio
+    async def test_send_typing_default_status_text(self, adapter):
+        # Unset config keeps the built-in marker text.
+        adapter._create_message = AsyncMock(
+            return_value=type("R", (), {"success": True,
+                                        "message_id": "spaces/S/messages/THINK",
+                                        "error": None})()
+        )
+        await adapter.send_typing("spaces/S")
+        body = adapter._create_message.await_args.args[1]
+        assert body["text"] == "Hermes is thinking…"
+
+    @pytest.mark.asyncio
     async def test_send_typing_skips_when_already_tracking(self, adapter):
         adapter._typing_messages["spaces/S"] = "spaces/S/messages/EXIST"
         adapter._create_message = AsyncMock()

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2194,6 +2194,24 @@ class TestSendTyping:
         )
 
     @pytest.mark.asyncio
+    async def test_custom_typing_status_text(self):
+        # typing_status_text overrides the default status wording.
+        config = PlatformConfig(
+            enabled=True, token="xoxb-fake-token",
+            typing_status_text="is pouncing… 🐾",
+        )
+        a = SlackAdapter(config)
+        a._app = MagicMock()
+        a._app.client = AsyncMock()
+        a._app.client.assistant_threads_setStatus = AsyncMock()
+        await a.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        a._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="is pouncing… 🐾",
+        )
+
+    @pytest.mark.asyncio
     async def test_noop_without_thread(self, adapter):
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
         await adapter.send_typing("C123")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2212,6 +2212,56 @@ class TestSendTyping:
         )
 
     @pytest.mark.asyncio
+    async def test_live_status_text_overrides_default(self, adapter):
+        # set_status_text() feeds the live per-tool phrase into the next
+        # typing refresh.
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter.set_status_text("C123", "is running pytest…")
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="is running pytest…",
+        )
+
+    @pytest.mark.asyncio
+    async def test_live_status_beats_configured_static_text(self):
+        # Dynamic per-tool phrase wins over typing_status_text while set;
+        # clearing it falls back to the configured static string.
+        config = PlatformConfig(
+            enabled=True, token="xoxb-fake-token",
+            typing_status_text="is pouncing… 🐾",
+        )
+        a = SlackAdapter(config)
+        a._app = MagicMock()
+        a._app.client = AsyncMock()
+        a._app.client.assistant_threads_setStatus = AsyncMock()
+        a.set_status_text("C123", "is reading docs/api.md…")
+        await a.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        assert (
+            a._app.client.assistant_threads_setStatus.call_args.kwargs["status"]
+            == "is reading docs/api.md…"
+        )
+        a.set_status_text("C123", None)
+        await a.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        assert (
+            a._app.client.assistant_threads_setStatus.call_args.kwargs["status"]
+            == "is pouncing… 🐾"
+        )
+
+    @pytest.mark.asyncio
+    async def test_live_status_scoped_per_chat(self, adapter):
+        # A phrase for one channel must not leak into another channel's
+        # status line.
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter.set_status_text("C_OTHER", "is running pytest…")
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        assert (
+            adapter._app.client.assistant_threads_setStatus.call_args.kwargs["status"]
+            == "is thinking..."
+        )
+
+    @pytest.mark.asyncio
     async def test_noop_without_thread(self, adapter):
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
         await adapter.send_typing("C123")

--- a/website/docs/user-guide/messaging/google_chat.md
+++ b/website/docs/user-guide/messaging/google_chat.md
@@ -189,6 +189,23 @@ Send "hola" in the test DM. The bot posts a "Hermes is thinking…" marker, then
 edits that same message in place with the real response — no "message deleted"
 tombstones.
 
+### Customizing the working-state marker
+
+The marker text is configurable via `typing_status_text` in
+`~/.hermes/config.yaml` — e.g. a kitten assistant named Ada:
+
+```yaml
+platforms:
+  google_chat:
+    # Custom working-state marker text (default: "Hermes is thinking…").
+    typing_status_text: "is pouncing… 🐾"
+```
+
+Unlike Slack's ephemeral status line, this is a **real posted message** that
+gets edited in place with the response — so whatever you set here briefly
+appears in the chat as a normal message. Set `typing_indicator: false` to
+disable the marker entirely.
+
 ---
 
 ## Formatting and capabilities

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -436,6 +436,34 @@ The same key customizes Google Chat's visible working-state marker message
 note that on Google Chat it is a real posted message that gets patched into the
 reply, not an ephemeral status.
 
+### Live Status (per-tool)
+
+By default the status line updates **live as the agent works**: instead of a
+static `is thinking...`, it shows what the agent is doing right now — `is
+running pytest tests/…`, `is reading docs/api.md…`, `is searching the web for
+slack api limits…`. Between tool calls it reverts to the static text. This
+rides the existing status-refresh cadence, so it makes no additional Slack API
+calls, and it works even with `tool_progress: off` (Slack's default) — unlike
+progress bubbles, the status line is ephemeral and leaves nothing behind in
+the channel.
+
+Control it with `display.live_status` (global or per-platform):
+
+```yaml
+display:
+  platforms:
+    slack:
+      # full = verb + argument ("is running pytest…")   [default]
+      # verb = verb only ("is running…") — hides commands/paths,
+      #        useful in shared or customer-facing channels
+      # off  = static text (typing_status_text or "is thinking...")
+      live_status: full
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `display.live_status` | `"full"` | Live per-tool status line. `full` shows verb + argument preview; `verb` shows the verb only (keeps file paths and commands out of shared channels); `off` restores the static text. Requires the `assistant:write` scope, same as the static status line. |
+
 ### Session Isolation
 
 ```yaml

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -94,6 +94,7 @@ These are the most commonly missed scopes.
 | Scope | Purpose |
 |-------|---------|
 | `groups:read` | List and get info about private channels |
+| `assistant:write` | Render the working-state status line ("is thinking…") next to the bot name while it processes a message. Without this scope the `assistant.threads.setStatus` call fails silently and Slack shows its own rotating generic placeholders instead ("Finding answers…", "Reviewing findings…", …) — Hermes never controls the text. Required for `typing_status_text` to have any visible effect. |
 
 ---
 
@@ -408,6 +409,32 @@ platforms:
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
 | `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |
 | `platforms.slack.extra.cron_continuable_surface` | `"thread"` | Delivery surface for [continuable cron jobs](../features/cron.md#flat-in-channel-continuation-slack). `"thread"` opens a dedicated thread per delivery (default); `"in_channel"` delivers flat into the channel timeline. Pair `in_channel` with `reply_in_thread: false` (and `require_mention: false`) so a plain channel reply continues the job. |
+
+### Working-State Status Line
+
+While the agent processes a message, Slack shows a status line next to the bot
+name in the thread. By default Hermes sets it to `is thinking...`; customize it
+with `typing_status_text` — e.g. a kitten assistant named Ada:
+
+```yaml
+platforms:
+  slack:
+    # Custom working-state status line (default: "is thinking...").
+    typing_status_text: "is pouncing… 🐾"
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `platforms.slack.typing_status_text` | `"is thinking..."` | Text of the working-state status line shown while the agent processes a message. Requires the `assistant:write` scope — without it the status call fails silently and Slack renders its own generic placeholder, whatever this is set to. Set `typing_indicator: false` to disable the status line entirely. |
+
+:::note Where the status renders
+The custom status appears in the **footer beneath the reply composer** ("*BotName* is thinking…"), not inline in the message list. The inline "Generating response…" / "Finding answers…" lines Slack shows in the message area while an AI app works are **Slack's own rotating indicators** — `assistant.threads.setStatus` does not control those, and both can appear at the same time.
+:::
+
+The same key customizes Google Chat's visible working-state marker message
+(`platforms.google_chat.typing_status_text`, default `"Hermes is thinking…"`) —
+note that on Google Chat it is a real posted message that gets patched into the
+reply, not an ephemeral status.
 
 ### Session Isolation
 


### PR DESCRIPTION
## Summary
Slack's working-state status line now updates live as the agent works — `is running pytest tests/…`, `is reading docs/api.md…` — instead of the static `is thinking...`. Salvages PR #62007 (@georgedrury, configurable `typing_status_text`) and builds the dynamic layer on top.

## Changes
- `agent/display.py`: `build_status_phrase()` — ≤49-char present-tense phrase from the existing `_TOOL_VERBS` table; `is using <name>` for plugin/MCP tools; `None` for `_thinking`
- `gateway/platforms/base.py`: `supports_status_text` capability flag + per-chat `set_status_text()` store, cleared when the typing loop winds down
- `plugins/platforms/slack/adapter.py`: `send_typing()` renders the live phrase; falls back to `typing_status_text` → `is thinking...`
- `gateway/run.py`: `progress_callback` stashes the phrase on `tool.started`, clears on `tool.completed`; callback now armed whenever the adapter supports status text (works with Slack's default `tool_progress: off`)
- `gateway/display_config.py`: `display.live_status` — `full` | `verb` | `off` (default `full`; `verb` hides commands/paths for shared channels)
- `gateway/config.py`: fix latent crash in the salvaged `from_dict` when `extra` is malformed (non-dict)
- Salvaged from #62007: `PlatformConfig.typing_status_text` plumbing, Slack + Google Chat static text, config tests, docs

## Design notes
- Zero extra Slack API calls: rendering rides the existing `_keep_typing` refresh cadence (~2s), so there's no new rate-limit exposure — the callback only writes a dict entry
- Status is a side-effect display channel: never enters the transcript, no prompt-cache impact
- Lifecycle guarantees from the stuck-status fix family preserved: per-thread tracking, clear-on-finish via existing `stop_typing` paths, per-chat scoping (no Slack Connect cross-workspace leaks)
- Related: #45109 (closed — same direction via lifecycle states), #59010/#51363 (Slack-native task cards — complementary, much larger scope)

## Validation
| | Before | After |
|---|---|---|
| Slack status during tool run | `is thinking...` (static) | `is running pytest tests/…` (live, reverts between tools) |
| Extra API calls per tool | — | 0 (rides typing refresh) |
| Tests | — | 894 passed across gateway display/config/slack/progress files; 9 new tests; E2E chain verified (phrase → store → setStatus render, clear, verb mode, truncation) |

## Infographic

![live-status-slack](https://v3b.fal.media/files/b/0aa2c7b4/cSbixiDmecw8q4DqwvgoR_D9NAdTmy.png)
