### PR TITLE
fix(tui_gateway): register shell hooks in _make_agent so they dispatch interactively

### DIFF
--- a/tests/tui_gateway/test_issue_67053_shell_hook_registration.py
+++ b/tests/tui_gateway/test_issue_67053_shell_hook_registration.py
@@ -1,0 +1,133 @@
+"""Regression test for issue #67053 — tui_gateway daemon must register
+config-based shell hooks so they dispatch during an interactive
+``hermes chat`` session.
+
+Before the fix, ``register_from_config`` ran only in the transient
+``hermes chat`` launcher process. The long-lived ``tui_gateway``
+daemon built its agent via ``_make_agent`` without ever registering
+hooks, and ``PluginManager._hooks`` (an in-memory per-process dict)
+ended up with only the built-in plugin callbacks. Configured shell
+hooks silently never fired during interactive sessions even though
+``hermes hooks doctor`` / ``list`` / ``test`` reported healthy.
+
+The fix introduces ``tui_gateway.server._register_shell_hooks_from_config``
+and calls it from inside ``_make_agent``. The function is idempotent
+(deduped on ``(event, matcher, command)``), so launcher-side
+pre-registration is a safe no-op when both call paths run.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path, monkeypatch):
+    """Reset shell-hook registration state and use a per-test HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "1")
+
+    from agent import shell_hooks
+    from hermes_cli import plugins
+
+    shell_hooks.reset_for_tests()
+    plugins._plugin_manager = plugins.PluginManager()
+    yield
+    shell_hooks.reset_for_tests()
+    plugins._plugin_manager = plugins.PluginManager()
+
+
+def _write_hook_script(tmp_path: Path, name: str = "hook.sh") -> Path:
+    script = tmp_path / name
+    script.write_text("#!/usr/bin/env bash\nprintf '{}\\n'\n")
+    script.chmod(0o755)
+    return script
+
+
+def _write_config_yaml(home: Path, hook_command: str) -> Path:
+    """Write a minimal config.yaml with one shell hook under HERMES_HOME."""
+    config_path = home / "config.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "hooks:\n"
+        "  on_session_start:\n"
+        f"    - command: {hook_command}\n"
+    )
+    return config_path
+
+
+def test_register_shell_hooks_helper_exists_and_registers(tmp_path):
+    """The fix added ``_register_shell_hooks_from_config`` to
+    ``tui_gateway.server``. Calling it must wire up the configured
+    shell hook on the in-process ``PluginManager`` — this is the exact
+    code path ``_make_agent`` runs during agent build."""
+    from hermes_cli import plugins
+
+    script = _write_hook_script(tmp_path)
+    _write_config_yaml(Path(os.environ["HERMES_HOME"]), str(script))
+
+    server = importlib.import_module("tui_gateway.server")
+    assert hasattr(server, "_register_shell_hooks_from_config"), (
+        "fix for #67053 missing: tui_gateway.server must expose "
+        "_register_shell_hooks_from_config"
+    )
+
+    server._register_shell_hooks_from_config()
+
+    mgr = plugins.get_plugin_manager()
+    on_session_start = mgr._hooks.get("on_session_start", [])
+    assert any(
+        "shell_hook" in repr(cb).lower() for cb in on_session_start
+    ), (
+        f"shell hook callback not registered on plugin manager after "
+        f"calling _register_shell_hooks_from_config; got {on_session_start!r}"
+    )
+
+
+def test_register_shell_hooks_helper_is_idempotent(tmp_path):
+    """Two consecutive calls must dedupe to a single registration. This
+    is the property that makes it safe to deploy the fix alongside the
+    existing CLI registration call site."""
+    from hermes_cli import plugins
+
+    script = _write_hook_script(tmp_path, "h.sh")
+    _write_config_yaml(Path(os.environ["HERMES_HOME"]), str(script))
+
+    server = importlib.import_module("tui_gateway.server")
+
+    server._register_shell_hooks_from_config()
+    server._register_shell_hooks_from_config()
+
+    mgr = plugins.get_plugin_manager()
+    on_session_start = mgr._hooks.get("on_session_start", [])
+    shell_hook_cbs = [cb for cb in on_session_start if "shell_hook" in repr(cb).lower()]
+    assert len(shell_hook_cbs) == 1, (
+        f"idempotency broken: expected 1 shell hook callback, got "
+        f"{len(shell_hook_cbs)} ({on_session_start!r})"
+    )
+
+
+def test_safe_mode_skips_registration(tmp_path, monkeypatch):
+    """``HERMES_SAFE_MODE=1`` must short-circuit registration — a
+    troubleshooting run should fire zero user-configured code (plugins,
+    MCP, AND hooks). The helper must inherit this property from
+    ``register_from_config``."""
+    monkeypatch.setenv("HERMES_SAFE_MODE", "1")
+    from hermes_cli import plugins
+
+    script = _write_hook_script(tmp_path, "safe.sh")
+    _write_config_yaml(Path(os.environ["HERMES_HOME"]), str(script))
+
+    server = importlib.import_module("tui_gateway.server")
+    server._register_shell_hooks_from_config()
+
+    mgr = plugins.get_plugin_manager()
+    on_session_start = mgr._hooks.get("on_session_start", [])
+    shell_hook_cbs = [cb for cb in on_session_start if "shell_hook" in repr(cb).lower()]
+    assert shell_hook_cbs == [], (
+        f"HERMES_SAFE_MODE=1 must skip shell-hook registration; got {shell_hook_cbs!r}"
+    )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4832,6 +4832,25 @@ def _resolve_runtime_with_fallback(
         raise
 
 
+def _register_shell_hooks_from_config() -> None:
+    """Load ``config.yaml`` and register every configured shell hook on the
+    in-process ``PluginManager``. Used by ``_make_agent`` so that the
+    long-lived ``tui_gateway`` daemon wires up shell hooks the same way
+    the transient ``hermes chat`` launcher does — without this, hooks
+    registered in the launcher never reach the daemon process and
+    silently never dispatch during an interactive session.
+
+    ``register_from_config`` is idempotent (deduped on
+    ``(event, matcher, command)``), so it is safe to call alongside the
+    launcher's own registration call site. ``HERMES_SAFE_MODE=1`` is
+    honored inside ``register_from_config`` and turns this into a no-op.
+    """
+    from agent.shell_hooks import register_from_config
+    from hermes_cli.config import load_config
+
+    register_from_config(load_config())
+
+
 def _make_agent(
     sid: str,
     key: str,
@@ -4853,6 +4872,16 @@ def _make_agent(
         return synthetic
 
     from run_agent import AIAgent
+
+    # Register config-based shell hooks in the gateway process so they
+    # dispatch during interactive sessions (issue #67053). The launcher
+    # also calls register_from_config, but PluginManager._hooks is
+    # per-process and the launcher is a different OS process — see
+    # _register_shell_hooks_from_config for the full rationale.
+    try:
+        _register_shell_hooks_from_config()
+    except Exception:
+        logger.warning("shell-hook registration failed in gateway _make_agent", exc_info=True)
 
     # MCP tool discovery runs in a background daemon thread at startup so a
     # dead server can't freeze the shell.  The agent snapshots its tool list


### PR DESCRIPTION
## Problem

Shell hooks configured under `hooks:` in `~/.hermes/config.yaml` silently never fired during interactive `hermes chat` sessions. `hermes hooks doctor` / `list` / `test` reported healthy, but the live run dispatched only the built-in plugin callbacks — every configured `pre_llm_call` / `on_session_start` / etc. hook was a no-op.

## Root cause

`register_from_config()` is called from `hermes_cli/main.py` and `cli.py` (the transient launcher process), but **not** from anywhere in the `tui_gateway` daemon that actually runs the agent conversation. `PluginManager._hooks` is an in-memory per-process dict, so the launcher's registrations are invisible to the gateway. The daemon builds agents through `tui_gateway/server.py::_make_agent` without ever wiring hooks up.

`hermes hooks test` is misleading here — it invokes the configured script directly via `shell_hooks.run_once()`, bypassing the plugin dispatcher entirely. The script runs fine; real events never reach it.

## Fix

Add a small helper `_register_shell_hooks_from_config()` in `tui_gateway.server` that loads `config.yaml` and calls `register_from_config()`, and invoke it inside `_make_agent` under the existing `try/except` pattern used by neighboring init steps (e.g. `wait_for_mcp_discovery`).

`register_from_config` is idempotent (deduped on `(event, matcher, command)`), so launcher + gateway calls register the hook exactly once. `HERMES_SAFE_MODE=1` is honored inside `register_from_config` and turns this into a no-op.

This mirrors the issue reporter's verified fix (see #67053 root cause analysis) — placement in `_make_agent` was chosen over `tui_gateway/entry.py:main` so the gateway's two agent-construction paths (inline and compute-host) both pick it up.

## Reproduction

1. Add a shell hook to `~/.hermes/config.yaml`, e.g.:
   ```yaml
   hooks:
     on_session_start:
       - command: "/abs/path/to/hook.sh"
   ```
   (`hook.sh`: `printf '{}\n'`)
2. Allowlist: `hermes hooks allow /abs/path/to/hook.sh`
3. `hermes --accept-hooks chat` → send one message
4. **Before fix**: hook callback absent from `PluginManager._hooks` in the daemon process; script never executes.
5. **After fix**: `register_from_config` runs in `_make_agent`, callback is wired up, hook fires.

## Verification

Three targeted regression tests in `tests/tui_gateway/test_issue_67053_shell_hook_registration.py`:

- `test_register_shell_hooks_helper_exists_and_registers` — calls the patched helper directly, asserts the configured hook shows up on `PluginManager._hooks`. **Fails on `main` (helper doesn't exist); passes with the fix.**
- `test_register_shell_hooks_helper_is_idempotent` — two calls register exactly one callback, confirming launcher + gateway calls dedupe safely.
- `test_safe_mode_skips_registration` — `HERMES_SAFE_MODE=1` short-circuits the helper, matching the safety guarantee `register_from_config` already provides.

Iron Rule 1 verified via the stash three-step dance: stash the source fix → `test_register_shell_hooks_helper_exists_and_registers` fails on `main`; pop the fix → all three tests pass.

```
$ python3 -m pytest tests/tui_gateway/test_issue_67053_shell_hook_registration.py -v
tests/tui_gateway/test_issue_67053_shell_hook_registration.py::test_register_shell_hooks_helper_exists_and_registers PASSED
tests/tui_gateway/test_issue_67053_shell_hook_registration.py::test_register_shell_hooks_helper_is_idempotent PASSED
tests/tui_gateway/test_issue_67053_shell_hook_registration.py::test_safe_mode_skips_registration PASSED
3 passed
```

## Out of scope

- Re-running `register_from_config` on `config.yaml` reload events — the current call-on-`_make_agent` model is enough for the common case (one `_make_agent` per session). Config-reload mid-session is a separate concern.
- Adding telemetry for "hook registered vs dispatched" — out of scope for a bug fix.

Closes #67053