### PR TITLE
feat(skills): add static chart attachments

### DIFF
--- a/skills/data-science/static-charts/SKILL.md
+++ b/skills/data-science/static-charts/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: static-charts
+description: Render supplied data as static chart attachments.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [charts, graphs, matplotlib, seaborn, discord, data-visualization]
+    category: data-science
+    related_skills: [jupyter-live-kernel]
+---
+
+# Static Charts Skill
+
+Render user-supplied numeric data as a legible PNG chart using Matplotlib and Seaborn. The output is static by design, so it works as a native attachment in Discord and other Hermes messaging platforms; it does not provide browser-style hover or zoom interactions.
+
+## When to Use
+
+Use this skill when the user asks to chart, graph, compare, trend, or visualize supplied values. It is appropriate for time series, category comparisons, distributions, proportions, and numeric relationships.
+
+Do not invent missing values or choose a chart when units, periods, or categories are ambiguous. Ask a concise question instead. If the user has not asked for a graph, suggest one when a chart would materially clarify at least three related values; do not generate it unsolicited.
+
+## Prerequisites
+
+Use the `terminal` tool in the Python environment that will render the image. Install the bounded dependencies in this skill before the first render:
+
+```bash
+python -m pip install -r ${HERMES_SKILL_DIR}/requirements.txt
+```
+
+The renderer requires `HERMES_HOME` so it can save output below the gateway's safe attachment directory: `$HERMES_HOME/cache/images/`. `japanize-matplotlib` bundles IPAexゴシック, so Japanese labels render consistently without relying on the host font set. Its bundled font is covered by the IPA Font License v1.0; install and use it only when that license is acceptable for the deployment.
+
+## How to Run
+
+1. Write a UTF-8 JSON chart specification to a temporary file.
+2. Use `terminal` to run the bundled renderer:
+
+```bash
+python ${HERMES_SKILL_DIR}/scripts/render_chart.py /tmp/chart.json \
+  --output "$HERMES_HOME/cache/images/monthly-sales.png"
+```
+
+3. Read the JSON result. On success it contains a `media` value with the exact `MEDIA:/absolute/path.png` directive.
+4. Give the user a short interpretation, then include that exact `MEDIA:` directive on its own line in the final response. Hermes strips the directive and attaches the PNG natively in Discord.
+
+## Quick Reference
+
+Use one of five chart types: `line`, `bar`, `scatter`, `histogram`, or `pie`.
+
+For line, bar, and scatter charts, every series needs `name`, `x`, and `y`:
+
+```json
+{
+  "type": "line",
+  "title": "月次売上",
+  "x_label": "月",
+  "y_label": "売上（万円）",
+  "source": "ユーザー提供データ",
+  "series": [
+    {"name": "売上", "x": ["1月", "2月", "3月"], "y": [120, 148, 136]}
+  ]
+}
+```
+
+For a histogram, use `values` instead of `x` and `y`; `bins` is optional (2–100):
+
+```json
+{
+  "type": "histogram",
+  "title": "応答時間の分布",
+  "x_label": "秒",
+  "y_label": "件数",
+  "bins": 12,
+  "series": [{"name": "応答時間", "values": [1.2, 1.5, 1.9, 2.4]}]
+}
+```
+
+For a pie chart, provide exactly one series with `labels` and non-negative `values`:
+
+```json
+{
+  "type": "pie",
+  "title": "支出の内訳",
+  "series": [
+    {"name": "支出", "labels": ["家賃", "食費", "交通"], "values": [90000, 35000, 12000]}
+  ]
+}
+```
+
+## Procedure
+
+1. Restate the data source, time range, and unit when they matter to interpretation.
+2. Select a line chart for changes over ordered time, a bar chart for category comparison, a scatter chart for relationships, a histogram for distributions, or a pie chart only for a small whole-part breakdown.
+3. Keep labels, units, and titles explicit. Use at most 12 slices in a pie chart and avoid pie charts when a bar chart would make close values easier to compare.
+4. Render the PNG under `$HERMES_HOME/cache/images/` using the script. Do not place generated output in a source repository or a credential/config directory.
+5. Confirm the renderer returned `success: true`; if it did not, fix the specification or missing dependency before responding.
+6. State the key takeaway and any assumption in prose. Place the `MEDIA:` directive on its own final line so the gateway attaches the chart.
+
+## Pitfalls
+
+- Do not graph values copied from an uncertain source without marking the source or uncertainty in the response.
+- Do not compare values with incompatible units, periods, or denominators.
+- The renderer accepts at most eight series and 500 points per series to keep a Discord image legible.
+- Static PNGs cannot preserve Plotly-style hover, filtering, or zoom. Publish an interactive page separately only when the user explicitly needs exploration.
+- If Japanese text renders as boxes, confirm that `japanize-matplotlib` was installed into the same Python environment as the renderer and that `japanize()` runs after the Seaborn theme; do not replace the user’s Japanese labels with romanized text.
+
+## Verification
+
+Verify that the renderer exits with code 0, returns `success: true`, and reports an absolute `.png` path below `$HERMES_HOME/cache/images/`. In Discord, verify the response contains the attached image rather than a visible `MEDIA:` path, and verify that the title, units, and series labels are readable.

--- a/skills/data-science/static-charts/requirements.txt
+++ b/skills/data-science/static-charts/requirements.txt
@@ -1,0 +1,8 @@
+# Static chart renderer dependencies. Keep ranges bounded so an unrelated
+# major release cannot silently change generated chart output.
+matplotlib>=3.10,<4
+seaborn>=0.13,<0.14
+japanize-matplotlib>=1.1.3,<1.2
+# japanize-matplotlib imports distutils; setuptools provides the compatible
+# implementation on Python 3.12+ where distutils is no longer in stdlib.
+setuptools>=77,<83

--- a/skills/data-science/static-charts/scripts/render_chart.py
+++ b/skills/data-science/static-charts/scripts/render_chart.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Render a validated static chart and emit a Hermes MEDIA directive.
+
+The renderer deliberately accepts a small JSON chart specification instead of
+arbitrary Python. This keeps generated charts predictable and makes it easy to
+validate data before a messaging gateway uploads the resulting PNG.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import secrets
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_CHART_TYPES = frozenset({"line", "bar", "scatter", "histogram", "pie"})
+MAX_SERIES = 8
+MAX_POINTS_PER_SERIES = 500
+MAX_PIE_SLICES = 12
+MAX_TITLE_LENGTH = 160
+MAX_LABEL_LENGTH = 100
+MAX_SOURCE_LENGTH = 240
+
+
+class ChartSpecError(ValueError):
+    """Raised when a chart specification is incomplete or unsafe to render."""
+
+
+def _require_mapping(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ChartSpecError(f"{field} must be an object")
+    return value
+
+
+def _require_list(value: Any, field: str, *, minimum: int = 1, maximum: int = MAX_POINTS_PER_SERIES) -> list[Any]:
+    if not isinstance(value, list):
+        raise ChartSpecError(f"{field} must be an array")
+    if not minimum <= len(value) <= maximum:
+        raise ChartSpecError(f"{field} must contain between {minimum} and {maximum} values")
+    return value
+
+
+def _require_text(value: Any, field: str, *, maximum: int = MAX_LABEL_LENGTH, required: bool = True) -> str:
+    if value is None and not required:
+        return ""
+    if not isinstance(value, str):
+        raise ChartSpecError(f"{field} must be text")
+    value = value.strip()
+    if required and not value:
+        raise ChartSpecError(f"{field} cannot be empty")
+    if len(value) > maximum:
+        raise ChartSpecError(f"{field} must be at most {maximum} characters")
+    return value
+
+
+def _require_number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ChartSpecError(f"{field} must be a finite number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ChartSpecError(f"{field} must be a finite number")
+    return number
+
+
+def _validate_xy_series(raw_series: Any, chart_type: str) -> list[dict[str, Any]]:
+    series_items = _require_list(raw_series, "series", maximum=MAX_SERIES)
+    normalized: list[dict[str, Any]] = []
+    first_x: list[Any] | None = None
+
+    for index, item in enumerate(series_items, start=1):
+        series = _require_mapping(item, f"series[{index}]")
+        name = _require_text(series.get("name", f"Series {index}"), f"series[{index}].name")
+        x_values = _require_list(series.get("x"), f"series[{index}].x")
+        y_values = _require_list(series.get("y"), f"series[{index}].y")
+        if len(x_values) != len(y_values):
+            raise ChartSpecError(f"series[{index}].x and series[{index}].y must have the same length")
+
+        if chart_type == "scatter":
+            x_normalized = [_require_number(value, f"series[{index}].x[{point_index}]")
+                            for point_index, value in enumerate(x_values, start=1)]
+        else:
+            x_normalized = []
+            for point_index, value in enumerate(x_values, start=1):
+                if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+                    raise ChartSpecError(
+                        f"series[{index}].x[{point_index}] must be text or a finite number"
+                    )
+                if isinstance(value, float) and not math.isfinite(value):
+                    raise ChartSpecError(f"series[{index}].x[{point_index}] must be finite")
+                x_normalized.append(value)
+
+        y_normalized = [_require_number(value, f"series[{index}].y[{point_index}]")
+                        for point_index, value in enumerate(y_values, start=1)]
+        if chart_type == "bar":
+            if first_x is None:
+                first_x = x_normalized
+            elif x_normalized != first_x:
+                raise ChartSpecError("all bar series must use the same x labels")
+        normalized.append({"name": name, "x": x_normalized, "y": y_normalized})
+
+    return normalized
+
+
+def _validate_histogram_series(raw_series: Any) -> list[dict[str, Any]]:
+    series_items = _require_list(raw_series, "series", maximum=MAX_SERIES)
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(series_items, start=1):
+        series = _require_mapping(item, f"series[{index}]")
+        name = _require_text(series.get("name", f"Series {index}"), f"series[{index}].name")
+        values = _require_list(series.get("values"), f"series[{index}].values")
+        normalized.append(
+            {
+                "name": name,
+                "values": [
+                    _require_number(value, f"series[{index}].values[{point_index}]")
+                    for point_index, value in enumerate(values, start=1)
+                ],
+            }
+        )
+    return normalized
+
+
+def _validate_pie_series(raw_series: Any) -> list[dict[str, Any]]:
+    series_items = _require_list(raw_series, "series", maximum=1)
+    series = _require_mapping(series_items[0], "series[1]")
+    name = _require_text(series.get("name", "Breakdown"), "series[1].name")
+    labels = _require_list(series.get("labels"), "series[1].labels", maximum=MAX_PIE_SLICES)
+    values = _require_list(series.get("values"), "series[1].values", maximum=MAX_PIE_SLICES)
+    if len(labels) != len(values):
+        raise ChartSpecError("series[1].labels and series[1].values must have the same length")
+
+    normalized_labels = [
+        _require_text(value, f"series[1].labels[{index}]")
+        for index, value in enumerate(labels, start=1)
+    ]
+    normalized_values = [
+        _require_number(value, f"series[1].values[{index}]")
+        for index, value in enumerate(values, start=1)
+    ]
+    if any(value < 0 for value in normalized_values) or not any(normalized_values):
+        raise ChartSpecError("pie values must be non-negative and add up to more than zero")
+    return [{"name": name, "labels": normalized_labels, "values": normalized_values}]
+
+
+def validate_spec(raw_spec: Any) -> dict[str, Any]:
+    """Normalize and validate the JSON chart schema before importing plotting libraries."""
+    spec = _require_mapping(raw_spec, "chart spec")
+    chart_type = _require_text(spec.get("type"), "type").lower()
+    if chart_type not in SUPPORTED_CHART_TYPES:
+        choices = ", ".join(sorted(SUPPORTED_CHART_TYPES))
+        raise ChartSpecError(f"type must be one of: {choices}")
+
+    title = _require_text(spec.get("title"), "title", maximum=MAX_TITLE_LENGTH)
+    x_label = _require_text(spec.get("x_label", ""), "x_label", required=False)
+    y_label = _require_text(spec.get("y_label", ""), "y_label", required=False)
+    source = _require_text(
+        spec.get("source", ""), "source", maximum=MAX_SOURCE_LENGTH, required=False
+    )
+
+    if chart_type == "histogram":
+        series = _validate_histogram_series(spec.get("series"))
+    elif chart_type == "pie":
+        series = _validate_pie_series(spec.get("series"))
+    else:
+        series = _validate_xy_series(spec.get("series"), chart_type)
+
+    bins = spec.get("bins")
+    if chart_type == "histogram" and bins is not None:
+        if isinstance(bins, bool) or not isinstance(bins, int) or not 2 <= bins <= 100:
+            raise ChartSpecError("bins must be an integer between 2 and 100")
+    elif bins is not None:
+        raise ChartSpecError("bins is only supported for histogram charts")
+
+    return {
+        "type": chart_type,
+        "title": title,
+        "x_label": x_label,
+        "y_label": y_label,
+        "source": source,
+        "series": series,
+        "bins": bins,
+    }
+
+
+def _output_root() -> Path:
+    hermes_home = os.environ.get("HERMES_HOME", "").strip()
+    if not hermes_home:
+        raise ChartSpecError("HERMES_HOME is required so charts can be delivered safely")
+    return (Path(hermes_home).expanduser().resolve() / "cache" / "images")
+
+
+def resolve_output_path(raw_output: str | None) -> Path:
+    """Return an absolute PNG path contained in Hermes' image cache."""
+    root = _output_root()
+    if raw_output:
+        output = Path(raw_output).expanduser().resolve()
+    else:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        output = root / f"chart-{timestamp}-{secrets.token_hex(3)}.png"
+
+    if output.suffix.lower() != ".png":
+        raise ChartSpecError("output must use the .png extension")
+    try:
+        output.relative_to(root)
+    except ValueError as exc:
+        raise ChartSpecError(f"output must be inside {root}") from exc
+    return output
+
+
+def load_spec(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ChartSpecError(f"specification file not found: {path}") from exc
+    except UnicodeDecodeError as exc:
+        raise ChartSpecError("specification file must be UTF-8 JSON") from exc
+    except json.JSONDecodeError as exc:
+        raise ChartSpecError(f"invalid JSON: {exc.msg}") from exc
+    return validate_spec(raw)
+
+
+def _load_plotting_libraries():
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as pyplot
+        import japanize_matplotlib
+        import seaborn
+    except ImportError as exc:
+        raise ChartSpecError(
+            "missing chart dependencies; install the skill requirements into the renderer Python environment"
+        ) from exc
+    return matplotlib, pyplot, seaborn, japanize_matplotlib
+
+
+def _configure_japanese_font(matplotlib: Any, japanize_matplotlib: Any) -> str:
+    """Apply japanize-matplotlib after any Seaborn theme resets font settings."""
+    japanize_matplotlib.japanize()
+    matplotlib.rcParams["axes.unicode_minus"] = False
+    return str(matplotlib.rcParams["font.family"][0])
+
+
+def _render_line(axis: Any, series: list[dict[str, Any]], colors: list[Any]) -> None:
+    for item, color in zip(series, colors):
+        axis.plot(item["x"], item["y"], marker="o", linewidth=2, label=item["name"], color=color)
+
+
+def _render_bar(axis: Any, series: list[dict[str, Any]], colors: list[Any]) -> None:
+    labels = series[0]["x"]
+    positions = list(range(len(labels)))
+    width = 0.8 / len(series)
+    for index, (item, color) in enumerate(zip(series, colors)):
+        offset = (index - (len(series) - 1) / 2) * width
+        axis.bar([position + offset for position in positions], item["y"], width, label=item["name"], color=color)
+    axis.set_xticks(positions, labels)
+
+
+def _render_scatter(axis: Any, series: list[dict[str, Any]], colors: list[Any]) -> None:
+    for item, color in zip(series, colors):
+        axis.scatter(item["x"], item["y"], s=55, label=item["name"], color=color)
+
+
+def _render_histogram(axis: Any, series: list[dict[str, Any]], colors: list[Any], bins: int | None) -> None:
+    values = [item["values"] for item in series]
+    names = [item["name"] for item in series]
+    axis.hist(
+        values,
+        bins=bins or 20,
+        label=names,
+        color=colors[:len(values)],
+        alpha=0.72,
+        edgecolor="white",
+    )
+
+
+def _render_pie(axis: Any, series: list[dict[str, Any]], colors: list[Any]) -> None:
+    item = series[0]
+    axis.pie(
+        item["values"],
+        labels=item["labels"],
+        autopct="%1.1f%%",
+        startangle=90,
+        colors=colors,
+        wedgeprops={"edgecolor": "white", "linewidth": 1},
+    )
+    axis.axis("equal")
+
+
+def render_chart(spec: dict[str, Any], output_path: Path) -> str:
+    """Render one validated chart and return the active Japanese font name."""
+    matplotlib, pyplot, seaborn, japanize_matplotlib = _load_plotting_libraries()
+    seaborn.set_theme(style="whitegrid", context="notebook")
+    # Seaborn's theme sets a default sans-serif family, so reapply the bundled
+    # IPAexGothic font afterwards rather than allowing it to reset to Arial.
+    selected_font = _configure_japanese_font(matplotlib, japanize_matplotlib)
+    figure, axis = pyplot.subplots(figsize=(10, 6), layout="constrained")
+    colors = seaborn.color_palette("colorblind", n_colors=max(3, len(spec["series"])))
+
+    try:
+        chart_type = spec["type"]
+        if chart_type == "line":
+            _render_line(axis, spec["series"], colors)
+        elif chart_type == "bar":
+            _render_bar(axis, spec["series"], colors)
+        elif chart_type == "scatter":
+            _render_scatter(axis, spec["series"], colors)
+        elif chart_type == "histogram":
+            _render_histogram(axis, spec["series"], colors, spec["bins"])
+        else:
+            _render_pie(axis, spec["series"], colors)
+
+        axis.set_title(spec["title"], loc="left", fontsize=16, pad=16)
+        if chart_type != "pie":
+            axis.set_xlabel(spec["x_label"])
+            axis.set_ylabel(spec["y_label"])
+            if len(spec["series"]) > 1:
+                axis.legend(frameon=False)
+            axis.tick_params(axis="x", rotation=25 if chart_type == "bar" else 0)
+        if spec["source"]:
+            figure.text(0.01, 0.01, f"Source: {spec['source']}", ha="left", va="bottom", fontsize=8, color="#555555")
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        figure.savefig(output_path, format="png", dpi=180, bbox_inches="tight")
+    finally:
+        pyplot.close(figure)
+    return selected_font
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render a validated static chart for Hermes")
+    parser.add_argument("spec", type=Path, help="UTF-8 JSON chart specification")
+    parser.add_argument("--output", help="PNG path under $HERMES_HOME/cache/images")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        spec = load_spec(args.spec)
+        output_path = resolve_output_path(args.output)
+        selected_font = render_chart(spec, output_path)
+    except (ChartSpecError, OSError) as exc:
+        print(json.dumps({"success": False, "error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+    payload = {
+        "success": True,
+        "file_path": str(output_path),
+        "media": f"MEDIA:{output_path}",
+    }
+    if selected_font:
+        payload["font"] = selected_font
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_static_charts_skill.py
+++ b/tests/skills/test_static_charts_skill.py
@@ -1,0 +1,168 @@
+"""Tests for the bundled static-charts skill without importing plotting packages."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "data-science" / "static-charts"
+SCRIPT_PATH = SKILL_DIR / "scripts" / "render_chart.py"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("static_charts_renderer", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    source = SKILL_MD.read_text(encoding="utf-8")
+    match = re.search(r"^---\n(.*?)\n---", source, re.DOTALL)
+    assert match, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(match.group(1))
+
+
+def test_skill_frontmatter_matches_hardline_requirements(frontmatter: dict) -> None:
+    assert frontmatter["name"] == "static-charts"
+    assert len(frontmatter["description"]) <= 60
+    assert frontmatter["description"].endswith(".")
+    assert set(frontmatter["platforms"]) == {"linux", "macos", "windows"}
+
+
+def test_skill_documentation_describes_media_delivery() -> None:
+    source = SKILL_MD.read_text(encoding="utf-8")
+    assert "MEDIA:/absolute/path.png" in source
+    assert "$HERMES_HOME/cache/images/" in source
+    assert "IPA Font License v1.0" in source
+    assert "## Pitfalls" in source
+    assert "## Verification" in source
+
+
+def test_requirements_include_a_bundled_japanese_font() -> None:
+    requirements = (SKILL_DIR / "requirements.txt").read_text(encoding="utf-8")
+    assert "japanize-matplotlib>=1.1.3,<1.2" in requirements
+    assert "setuptools>=77,<83" in requirements
+
+
+def test_line_chart_spec_is_normalized() -> None:
+    renderer = load_module()
+    result = renderer.validate_spec(
+        {
+            "type": "line",
+            "title": "Monthly sales",
+            "x_label": "Month",
+            "y_label": "Sales",
+            "series": [{"name": "Sales", "x": ["Jan", "Feb"], "y": [10, 12]}],
+        }
+    )
+    assert result["type"] == "line"
+    assert result["series"][0]["y"] == [10.0, 12.0]
+
+
+def test_bar_chart_rejects_misaligned_categories() -> None:
+    renderer = load_module()
+    with pytest.raises(renderer.ChartSpecError, match="same x labels"):
+        renderer.validate_spec(
+            {
+                "type": "bar",
+                "title": "Comparison",
+                "series": [
+                    {"name": "A", "x": ["One", "Two"], "y": [1, 2]},
+                    {"name": "B", "x": ["One", "Three"], "y": [3, 4]},
+                ],
+            }
+        )
+
+
+def test_histogram_and_pie_specs_have_type_specific_validation() -> None:
+    renderer = load_module()
+    histogram = renderer.validate_spec(
+        {
+            "type": "histogram",
+            "title": "Latency",
+            "bins": 8,
+            "series": [{"name": "Requests", "values": [1.2, 1.5, 2.0]}],
+        }
+    )
+    assert histogram["bins"] == 8
+
+    with pytest.raises(renderer.ChartSpecError, match="add up to more than zero"):
+        renderer.validate_spec(
+            {
+                "type": "pie",
+                "title": "Breakdown",
+                "series": [{"labels": ["A", "B"], "values": [0, 0]}],
+            }
+        )
+
+
+def test_histogram_renderer_uses_one_color_per_series() -> None:
+    renderer = load_module()
+
+    class FakeAxis:
+        def hist(self, values, **kwargs):
+            self.values = values
+            self.kwargs = kwargs
+
+    axis = FakeAxis()
+    renderer._render_histogram(
+        axis,
+        [{"name": "Requests", "values": [1.2, 1.5, 2.0]}],
+        ["blue", "orange", "green"],
+        8,
+    )
+    assert axis.values == [[1.2, 1.5, 2.0]]
+    assert axis.kwargs["color"] == ["blue"]
+
+
+def test_output_path_is_limited_to_hermes_image_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    renderer = load_module()
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    output = renderer.resolve_output_path(str(hermes_home / "cache" / "images" / "chart.png"))
+    assert output == hermes_home / "cache" / "images" / "chart.png"
+
+    with pytest.raises(renderer.ChartSpecError, match="inside"):
+        renderer.resolve_output_path(str(tmp_path / "chart.png"))
+
+
+def test_main_prints_gateway_media_directive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    renderer = load_module()
+    hermes_home = tmp_path / "hermes-home"
+    output = hermes_home / "cache" / "images" / "chart.png"
+    spec_path = tmp_path / "chart.json"
+    spec_path.write_text(
+        json.dumps(
+            {
+                "type": "scatter",
+                "title": "Relationship",
+                "series": [{"name": "Values", "x": [1, 2], "y": [3, 5]}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with patch.object(renderer, "render_chart", return_value="Noto Sans CJK JP") as render_chart:
+        assert renderer.main([str(spec_path), "--output", str(output)]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is True
+    assert payload["file_path"] == str(output)
+    assert payload["media"] == f"MEDIA:{output}"
+    assert payload["font"] == "Noto Sans CJK JP"
+    render_chart.assert_called_once()


### PR DESCRIPTION
## Summary

Add a `data-science/static-charts` skill that renders user-supplied numeric data as legible static PNG charts using Matplotlib and Seaborn. The output is static by design, so it works as a native attachment in Discord and other Hermes messaging platforms.

## What's Included

- **SKILL.md** — Full skill documentation with YAML frontmatter, usage guide, quick reference for 5 chart types (line, bar, scatter, histogram, pie), procedure, pitfalls, and verification steps
- **requirements.txt** — Bounded dependencies (matplotlib, seaborn, japanize-matplotlib, setuptools)
- **scripts/render_chart.py** — Bundled renderer with strict JSON spec validation, per-type rendering helpers, output-path sandboxing, and gateway `MEDIA:` directive emission
- **tests/skills/test_static_charts_skill.py** — Comprehensive validation tests (no plotting import needed) covering frontmatter, spec normalization, error cases, and gateway output

## Key Design Decisions

- **Safety**: Output restricted to `$HERMES_HOME/cache/images/` only
- **Caps**: Max 8 series, 500 points/series, 12 pie slices — keeps Discord attachments legible
- **CJK**: `japanize-matplotlib` bundles IPAex Gothic for consistent Japanese rendering
- **No plotting in tests**: Tests validate spec normalization without importing matplotlib/seaborn

Closes #67067