### PR TITLE
fix(browser): preserve only local headed sessions

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2126,10 +2126,11 @@ def cleanup_task_resources(agent, task_id: str) -> None:
     torn down per-turn as before to prevent resource leakage (the original
     intent of this hook for the Morph backend, see commit fbd3a2fd).
 
-    Skips ``cleanup_browser`` in headed mode so the browser window stays
-    visible between turns. The inactivity reaper in
-    ``browser_tool._cleanup_inactive_browser_sessions`` still handles
-    idle sessions.
+    In headed mode, asks browser cleanup to preserve only local visible Chrome
+    sessions. Cloud/CDP and Camofox sessions are still released per turn so
+    remote paid resources cannot leak. The inactivity reaper in
+    ``browser_tool._cleanup_inactive_browser_sessions`` handles preserved local
+    sessions.
     """
     try:
         if is_persistent_env(task_id):
@@ -2149,12 +2150,16 @@ def cleanup_task_resources(agent, task_id: str) -> None:
             from tools.browser_tool import _is_headed_mode
             headed = _is_headed_mode()
         except Exception:
-            headed = bool(os.environ.get("AGENT_BROWSER_HEADED"))
+            headed = (
+                os.environ.get("AGENT_BROWSER_HEADED", "").strip().lower()
+                in {"true", "1", "yes"}
+            )
         if headed:
+            _ra().cleanup_browser(task_id, preserve_local_headed=True)
             if agent.verbose_logging:
                 logging.debug(
-                    f"Skipping per-turn cleanup_browser for headed session {task_id}; "
-                    f"idle reaper will handle it."
+                    f"Preserved local headed browser session for {task_id}; "
+                    f"cloud/CDP sessions were cleaned."
                 )
         else:
             _ra().cleanup_browser(task_id)

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -32,6 +32,7 @@ class TestBrowserCleanup:
         self.orig_session_last_activity = browser_tool._session_last_activity.copy()
         self.orig_recording_sessions = browser_tool._recording_sessions.copy()
         self.orig_cleanup_done = browser_tool._cleanup_done
+        self.orig_last_active_session_key = browser_tool._last_active_session_key.copy()
 
     def teardown_method(self):
         self.browser_tool._active_sessions.clear()
@@ -41,6 +42,8 @@ class TestBrowserCleanup:
         self.browser_tool._recording_sessions.clear()
         self.browser_tool._recording_sessions.update(self.orig_recording_sessions)
         self.browser_tool._cleanup_done = self.orig_cleanup_done
+        self.browser_tool._last_active_session_key.clear()
+        self.browser_tool._last_active_session_key.update(self.orig_last_active_session_key)
 
     def test_cleanup_browser_clears_tracking_state(self):
         browser_tool = self.browser_tool
@@ -64,6 +67,69 @@ class TestBrowserCleanup:
         assert "task-1" not in browser_tool._session_last_activity
         mock_stop.assert_called_once_with("task-1")
         mock_run.assert_called_once_with("task-1", "close", [], timeout=10)
+
+    def test_headed_cleanup_preserves_local_session(self):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-1"] = {
+            "session_name": "sess-local",
+            "bb_session_id": None,
+        }
+        browser_tool._session_last_activity["task-1"] = 123.0
+        browser_tool._last_active_session_key["task-1"] = "task-1"
+
+        with patch("tools.browser_tool._cleanup_single_browser_session") as cleanup:
+            browser_tool.cleanup_browser("task-1", preserve_local_headed=True)
+
+        cleanup.assert_not_called()
+        assert "task-1" in browser_tool._active_sessions
+        assert browser_tool._last_active_session_key["task-1"] == "task-1"
+
+    def test_headed_cleanup_still_releases_cloud_session(self):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-1"] = {
+            "session_name": "sess-cloud",
+            "bb_session_id": "bb-1",
+            "cdp_url": "wss://example.invalid/cdp",
+        }
+
+        with patch("tools.browser_tool._cleanup_single_browser_session") as cleanup:
+            browser_tool.cleanup_browser("task-1", preserve_local_headed=True)
+
+        cleanup.assert_called_once_with("task-1")
+
+    def test_headed_hybrid_cleanup_releases_cloud_and_preserves_local_sidecar(self):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-1"] = {
+            "session_name": "sess-cloud",
+            "bb_session_id": "bb-1",
+            "cdp_url": "wss://example.invalid/cdp",
+        }
+        browser_tool._active_sessions["task-1::local"] = {
+            "session_name": "sess-local",
+            "bb_session_id": None,
+        }
+        browser_tool._last_active_session_key["task-1"] = "task-1::local"
+
+        with patch("tools.browser_tool._cleanup_single_browser_session") as cleanup:
+            browser_tool.cleanup_browser("task-1", preserve_local_headed=True)
+
+        cleanup.assert_called_once_with("task-1")
+        assert browser_tool._last_active_session_key["task-1"] == "task-1::local"
+
+    def test_headed_cleanup_does_not_preserve_camofox(self):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-1"] = {
+            "session_name": "sess-camofox",
+            "bb_session_id": None,
+        }
+
+        with (
+            patch("tools.browser_tool._is_camofox_mode", return_value=True),
+            patch("tools.browser_tool._cleanup_single_browser_session") as cleanup,
+        ):
+            browser_tool.cleanup_browser("task-1", preserve_local_headed=True)
+
+        cleanup.assert_called_once_with("task-1")
 
     def test_cleanup_camofox_managed_persistence_skips_close(self):
         """When camofox mode + managed persistence, soft_cleanup fires instead of close."""

--- a/tests/tools/test_browser_headed_mode.py
+++ b/tests/tools/test_browser_headed_mode.py
@@ -57,6 +57,13 @@ class TestIsHeadedMode:
             with patch("hermes_cli.config.read_raw_config", return_value=cfg):
                 assert _is_headed_mode() is False
 
+    def test_config_false_beats_true_legacy_env(self):
+        from tools.browser_tool import _is_headed_mode
+        cfg = {"browser": {"headed": False}}
+        with patch.dict(os.environ, {"AGENT_BROWSER_HEADED": "1"}):
+            with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+                assert _is_headed_mode() is False
+
     def test_env_var_fallback(self):
         from tools.browser_tool import _is_headed_mode
         with patch.dict(os.environ, {"AGENT_BROWSER_HEADED": "1"}):
@@ -101,7 +108,7 @@ class TestCleanupTaskResourcesHeadedSkip:
             cleanup_task_resources(_make_agent(), "task-x")
             mock_cb.assert_called_once_with("task-x")
 
-    def test_headed_skips_browser_cleanup(self):
+    def test_headed_cleanup_preserves_only_local_browser(self):
         from agent.chat_completion_helpers import cleanup_task_resources
         with (
             patch("tools.browser_tool._is_headed_mode", return_value=True),
@@ -113,10 +120,10 @@ class TestCleanupTaskResourcesHeadedSkip:
             ),
         ):
             cleanup_task_resources(_make_agent(), "task-x")
-            mock_cb.assert_not_called()
+            mock_cb.assert_called_once_with("task-x", preserve_local_headed=True)
 
     def test_headed_env_var_fallback_when_import_fails(self):
-        """If browser_tool import blows up, the env var still gates the skip."""
+        """If browser_tool import blows up, the env var still gates preservation."""
         from agent.chat_completion_helpers import cleanup_task_resources
         with (
             patch(
@@ -132,7 +139,25 @@ class TestCleanupTaskResourcesHeadedSkip:
             ),
         ):
             cleanup_task_resources(_make_agent(), "task-x")
-            mock_cb.assert_not_called()
+            mock_cb.assert_called_once_with("task-x", preserve_local_headed=True)
+
+    def test_false_headed_env_fallback_does_not_preserve_browser(self):
+        from agent.chat_completion_helpers import cleanup_task_resources
+        with (
+            patch(
+                "tools.browser_tool._is_headed_mode",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch.dict(os.environ, {"AGENT_BROWSER_HEADED": "false"}),
+            patch("run_agent.cleanup_vm"),
+            patch("run_agent.cleanup_browser") as mock_cb,
+            patch(
+                "agent.chat_completion_helpers.is_persistent_env",
+                return_value=False,
+            ),
+        ):
+            cleanup_task_resources(_make_agent(), "task-x")
+            mock_cb.assert_called_once_with("task-x")
 
     def test_headed_does_not_skip_vm_cleanup(self):
         """Headed mode only affects the browser; VM teardown is untouched."""
@@ -155,7 +180,7 @@ class TestCleanupTaskResourcesHeadedSkip:
 # ---------------------------------------------------------------------------
 
 class TestHeadedFlagInjection:
-    def _run_and_capture(self, bt):
+    def _run_and_capture(self, bt, engine_override="auto"):
         """Run a snapshot command with Popen mocked; return captured argv."""
         captured_cmds = []
         mock_proc = MagicMock()
@@ -182,7 +207,9 @@ class TestHeadedFlagInjection:
              ))), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch("tools.browser_tool._write_owner_pid"):
-            bt._run_browser_command("task1", "snapshot", [], _engine_override="auto")
+            bt._run_browser_command(
+                "task1", "snapshot", [], _engine_override=engine_override
+            )
         return captured_cmds
 
     @patch("tools.browser_tool._get_session_info")
@@ -246,3 +273,24 @@ class TestHeadedFlagInjection:
         assert len(captured) == 1
         assert "--headed" not in captured[0]
         assert "--cdp" in captured[0]
+
+    @patch("tools.browser_tool._get_session_info")
+    @patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser")
+    @patch("tools.browser_tool._is_local_mode", return_value=True)
+    @patch("tools.browser_tool._chromium_installed", return_value=True)
+    @patch("tools.browser_tool._get_cloud_provider", return_value=None)
+    @patch("tools.browser_tool._get_cdp_override", return_value="")
+    @patch("tools.browser_tool._is_camofox_mode", return_value=False)
+    def test_headed_mode_uses_chrome_instead_of_lightpanda(
+        self, _camofox, _cdp, _cloud, _chromium, _local, _find, _session
+    ):
+        import tools.browser_tool as bt
+        bt._cached_headed_mode = True
+        bt._headed_mode_resolved = True
+        _session.return_value = {"session_name": "test-sess"}
+
+        captured = self._run_and_capture(bt, engine_override="lightpanda")
+        assert len(captured) == 1
+        assert "--headed" in captured[0]
+        engine_index = captured[0].index("--engine")
+        assert captured[0][engine_index + 1] == "chrome"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -901,20 +901,26 @@ def _is_headed_mode() -> bool:
 
     _headed_mode_resolved = True
     _cached_headed_mode = False
+    config_has_headed = False
 
     try:
         from hermes_cli.config import read_raw_config
         cfg = read_raw_config()
-        val = cfg.get("browser", {}).get("headed")
-        if val is not None:
+        browser_cfg = cfg.get("browser", {})
+        if (
+            isinstance(browser_cfg, dict)
+            and "headed" in browser_cfg
+            and browser_cfg["headed"] is not None
+        ):
+            config_has_headed = True
+            val = browser_cfg["headed"]
             _cached_headed_mode = str(val).strip().lower() in ("true", "1", "yes")
     except Exception as e:
         logger.debug("Could not read browser.headed from config: %s", e)
 
-    if not _cached_headed_mode:
-        env_val = os.environ.get("AGENT_BROWSER_HEADED", "").strip()
-        if env_val and env_val.lower() in ("true", "1", "yes"):
-            _cached_headed_mode = True
+    if not config_has_headed:
+        env_val = os.environ.get("AGENT_BROWSER_HEADED", "").strip().lower()
+        _cached_headed_mode = env_val in ("true", "1", "yes")
 
     return _cached_headed_mode
 
@@ -2323,8 +2329,18 @@ def _run_browser_command(
     if timeout is None:
         timeout = _safe_command_timeout()
     args = args or []
+    configured_engine = _engine_override or _get_browser_engine()
+    headed_mode = _is_headed_mode()
+    # Lightpanda has no graphical renderer. Preserve the user's visible-browser
+    # request by selecting Chrome for local commands instead of emitting the
+    # invalid ``--headed --engine lightpanda`` combination.
+    local_engine = (
+        "chrome"
+        if headed_mode and configured_engine == "lightpanda"
+        else configured_engine
+    )
 
-    # Build the command
+    # Find agent-browser
     try:
         browser_cmd = _find_agent_browser()
     except FileNotFoundError as e:
@@ -2342,7 +2358,7 @@ def _run_browser_command(
     if (
         _is_local_mode()
         and not _chromium_installed()
-        and _get_browser_engine() != "lightpanda"
+        and local_engine != "lightpanda"
         and not _maybe_autoinstall_chromium()
     ):
         if _running_in_docker():
@@ -2380,17 +2396,24 @@ def _run_browser_command(
         # IMPORTANT: Do NOT use --session with --cdp. In agent-browser >=0.13,
         # --session creates a local browser instance and silently ignores --cdp.
         backend_args = ["--cdp", session_info["cdp_url"]]
+        engine = configured_engine
     else:
         # Local mode — launch Chromium (headless by default, headed when configured)
         backend_args = ["--session", session_info["session_name"]]
-        if _is_headed_mode():
+        engine = local_engine
+        if headed_mode:
             backend_args.append("--headed")
+            if configured_engine == "lightpanda":
+                logger.info(
+                    "browser: headed mode requires Chrome; overriding Lightpanda "
+                    "for task=%s",
+                    task_id,
+                )
 
     # Lightpanda engine injection (local mode only, agent-browser v0.25.3+).
     # Use the resolved session backend rather than global cloud-provider state:
     # hybrid private-URL routing can create a local sidecar while a cloud
     # provider remains configured for public URLs.
-    engine = _engine_override or _get_browser_engine()
     if engine != "auto" and not _is_camofox_mode() and not session_info.get("cdp_url"):
         backend_args += ["--engine", engine]
 
@@ -4378,12 +4401,21 @@ def _cleanup_old_recordings(max_age_hours=72):
 # Cleanup and Management Functions
 # ============================================================================
 
-def cleanup_browser(task_id: Optional[str] = None) -> None:
+def cleanup_browser(
+    task_id: Optional[str] = None,
+    *,
+    preserve_local_headed: bool = False,
+) -> None:
     """
     Clean up browser session(s) for a task.
 
     Called automatically when a task completes or when inactivity timeout is reached.
     Closes both the agent-browser/Browserbase session and Camofox sessions.
+
+    When ``preserve_local_headed`` is true, local agent-browser sessions are
+    left alive so their visible Chrome windows survive between turns. Cloud/CDP
+    sessions and Camofox sessions are still released; headed mode does not apply
+    to either backend.
 
     When ``task_id`` is a bare task identifier (no ``::local`` suffix), reaps
     BOTH the cloud/primary session AND any hybrid-routing local sidecar that
@@ -4410,18 +4442,30 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
                 session_keys.append(sidecar_key)
         bare_task_id = task_id
 
-    for session_key in session_keys:
-        _cleanup_single_browser_session(session_key)
+    preserved_keys: set[str] = set()
+    if preserve_local_headed and not _is_camofox_mode():
+        with _cleanup_lock:
+            for session_key in session_keys:
+                session_info = _active_sessions.get(session_key)
+                # The command path treats a session as local exactly when it
+                # has no CDP URL. Unknown/stale entries are not preserved.
+                if session_info and not session_info.get("cdp_url"):
+                    preserved_keys.add(session_key)
 
-    # Drop stale last-active ownership. Cleaning a bare task drops its binding;
-    # cleaning a sidecar drops the binding only if that sidecar was still the
-    # recorded owner. This prevents a later click/snapshot from resurrecting a
-    # cleaned sidecar on about:blank while preserving a primary-session binding.
-    if _is_local_sidecar_key(task_id):
-        if _last_active_session_key.get(bare_task_id) == task_id:
+    for session_key in session_keys:
+        if session_key not in preserved_keys:
+            _cleanup_single_browser_session(session_key)
+
+    # Drop stale last-active ownership unless it still names a preserved local
+    # headed session. Cleaning an explicit sidecar keeps an unrelated primary
+    # binding, matching the normal cleanup contract.
+    bound_key = _last_active_session_key.get(bare_task_id)
+    if bound_key not in preserved_keys:
+        if _is_local_sidecar_key(task_id):
+            if bound_key == task_id:
+                _last_active_session_key.pop(bare_task_id, None)
+        else:
             _last_active_session_key.pop(bare_task_id, None)
-    else:
-        _last_active_session_key.pop(bare_task_id, None)
 
 
 def _cleanup_single_browser_session(task_id: str) -> None:


### PR DESCRIPTION
## Summary
- Honor explicit `browser.headed: false` over the legacy environment fallback
- Preserve only local visible Chrome sessions between turns while still releasing cloud/CDP and Camofox resources
- Select Chrome when headed mode is combined with Lightpanda, which has no graphical renderer
- Parse emergency headed env values consistently

## Regression coverage
- local, cloud, Camofox, and hybrid cloud + local-sidecar cleanup
- explicit config precedence over `AGENT_BROWSER_HEADED`
- false legacy env values
- headed Lightpanda command construction

## Verification
- `uv run pytest tests/tools/test_browser*.py -o 'addopts=' -q` — 514 passed, 22 skipped
- `uv run pytest tests/tools/test_browser_cleanup.py tests/tools/test_browser_headed_mode.py -o 'addopts=' -q` — 27 passed
- `python3 -m py_compile tools/browser_tool.py agent/chat_completion_helpers.py`
- `git diff --check`

Closes #67072