### PR TITLE
fix(desktop): accept shift modifier for keyboard zoom-in on macOS (#43517)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4967,19 +4967,31 @@ function installZoomShortcuts(window) {
   window.webContents.on('before-input-event', (event, input) => {
     const mod = IS_MAC ? input.meta : input.control
 
-    if (!mod || input.alt || input.shift) {
+    if (!mod || input.alt) {
       return
     }
 
     const key = input.key
 
     if (key === '0') {
+      if (input.shift) {
+        return // Ctrl/Cmd+Shift+0 is not a zoom chord — leave it alone
+      }
+
       event.preventDefault()
       setAndPersistZoomLevel(window, 0)
     } else if (key === '=' || key === '+') {
+      // Zoom-in must accept the shift modifier: on US layouts Plus is
+      // physically Shift+=, so Cmd+Plus arrives as Cmd+Shift+'+' (or '='
+      // depending on platform). The old blanket shift guard silently
+      // dropped keyboard zoom-in on macOS (#43517).
       event.preventDefault()
       setAndPersistZoomLevel(window, window.webContents.getZoomLevel() + ZOOM_STEP)
     } else if (key === '-') {
+      if (input.shift) {
+        return // Shift+'-' is '_' territory on most layouts, not zoom-out
+      }
+
       event.preventDefault()
       setAndPersistZoomLevel(window, window.webContents.getZoomLevel() - ZOOM_STEP)
     }


### PR DESCRIPTION
## Summary

Salvage of the surviving half of #43517 (@jingsong-liu) — keyboard zoom-in (Cmd+Plus) now works on macOS.

On US layouts Plus is physically Shift+=, so Cmd+Plus arrives with the shift modifier set. The blanket `input.shift` early-return in `installZoomShortcuts` swallowed the chord silently: it matched neither branch and fell through to nothing. The other half of #43517 (zoom restore after reload/navigation) already landed via #66989.

## Changes

- `apps/desktop/electron/main.ts`: shift is evaluated per-chord instead of globally — zoom-in (`=`/`+`) accepts it, zoom-reset (`0`) and zoom-out (`-`) still reject it (Ctrl/Cmd+Shift+0 and Shift+`-` are different chords that must not trigger zoom)

The original branch predates the ts-ify migration, so the change was surgically reapplied under @jingsong-liu's authorship (id+login noreply email — CI resolves attribution automatically).

## Validation

| Check | Result |
|---|---|
| Full desktop electron suite | 433 passed, 1 skipped |
| prettier | clean |

Credit: @jingsong-liu (#43517), authorship preserved on the commit.

## Infographic

![macos-zoom-plus](https://v3b.fal.media/files/b/0aa2c86e/eABI34_TkM-FlefHI13wI_03gBGo85.png)
