### PR TITLE
fix(runtime): recover once after tool-call ceiling

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2656,6 +2656,79 @@ def _guard_job_credential_exfil(job: dict) -> None:
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
 
+def _is_max_iteration_summary(result: Any) -> bool:
+    """Return True when Hermes stopped at the tool-call ceiling with a summary."""
+    if not isinstance(result, dict):
+        return False
+    reason = str(result.get("turn_exit_reason") or "")
+    return (
+        result.get("failed") is not True
+        and result.get("completed") is False
+        and reason.startswith("max_iterations_reached(")
+        and bool(str(result.get("final_response") or "").strip())
+    )
+
+
+def _run_cron_recovery_turn(
+    agent: Any,
+    prompt: str,
+    history: Optional[list[dict]],
+    *,
+    inactivity_limit: Optional[float],
+    job_name: str,
+) -> dict:
+    """Run one continuation turn with the same inactivity protection as cron."""
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    context = contextvars.copy_context()
+
+    def invoke() -> dict:
+        return agent.run_conversation(prompt, conversation_history=history)
+
+    future = pool.submit(context.run, invoke)
+    try:
+        if inactivity_limit is None:
+            result = future.result()
+        else:
+            result = None
+            while True:
+                done, _ = concurrent.futures.wait({future}, timeout=5.0)
+                if done:
+                    result = future.result()
+                    break
+                idle_seconds = 0.0
+                if hasattr(agent, "get_activity_summary"):
+                    try:
+                        idle_seconds = float(
+                            agent.get_activity_summary().get("seconds_since_activity", 0.0)
+                        )
+                    except Exception:
+                        pass
+                if idle_seconds >= inactivity_limit:
+                    if hasattr(agent, "interrupt"):
+                        agent.interrupt("Cron recovery timed out (inactivity)")
+                    grace_seconds = float(
+                        os.getenv("HERMES_CRON_INTERRUPT_GRACE_SECONDS", "10")
+                    )
+                    try:
+                        result = future.result(timeout=max(0.1, grace_seconds))
+                    except concurrent.futures.TimeoutError as exc:
+                        raise TimeoutError(
+                            f"Cron recovery for '{job_name}' idle for "
+                            f"{int(idle_seconds)}s (limit {int(inactivity_limit)}s); "
+                            "interrupt grace expired and the turn may still be live"
+                        ) from exc
+                    break
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+
+    if not isinstance(result, dict):
+        raise RuntimeError(
+            "cron recovery run_conversation returned "
+            f"{type(result).__name__} instead of dict: {result!r}"
+        )
+    return result
+
+
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None
 ) -> tuple[bool, str, str, Optional[str]]:
@@ -3504,34 +3577,64 @@ def run_job(
                 f"agent.run_conversation returned {type(result).__name__} instead of dict: {result!r}"
             )
 
+        # A max-iteration summary is a progress checkpoint, not completion.
+        # Continue once in the same cron session with the first turn's full
+        # messages, then fail visibly if the bounded recovery also hits its cap.
+        if _is_max_iteration_summary(result):
+            first_summary = str(result.get("final_response") or "").strip()
+            try:
+                recovery_max_iterations = max(
+                    1,
+                    min(
+                        int(max_iterations),
+                        int(agent_cfg.get("max_iteration_recovery_max_turns", 30)),
+                    ),
+                )
+            except (TypeError, ValueError):
+                recovery_max_iterations = 30
+            recovery_prompt = f"""[System note: The previous cron turn hit the Hermes tool-call ceiling. This is one automatic bounded recovery turn, not a new scheduled run. Resume the original objective from the existing transcript and durable artifacts. Inspect what is already complete; finish only the unmet acceptance gates; verify the real result; and return the job's intended final output. Do not repeat non-idempotent external actions or restart from scratch. Process exit alone is not verification. You have at most {recovery_max_iterations} recovery iterations: converge rather than explore.]
+
+First-turn progress summary:
+{first_summary[-6000:]}
+"""
+            logger.warning(
+                "Job '%s' reached the iteration limit — starting one bounded continuation turn with %d iterations",
+                job_name,
+                recovery_max_iterations,
+            )
+            history = result.get("messages")
+            previous_max_iterations = agent.max_iterations
+            agent.max_iterations = recovery_max_iterations
+            try:
+                result = _run_cron_recovery_turn(
+                    agent,
+                    recovery_prompt,
+                    history if isinstance(history, list) else None,
+                    inactivity_limit=_cron_inactivity_limit,
+                    job_name=job_name,
+                )
+            finally:
+                agent.max_iterations = previous_max_iterations
+            if _is_max_iteration_summary(result):
+                exhausted_summary = str(result.get("final_response") or "").strip()
+                raise RuntimeError(
+                    "automatic max-iteration recovery exhausted its second turn"
+                    f"\n\nFirst-attempt checkpoint:\n{first_summary[:3000]}"
+                    f"\n\nRecovery checkpoint:\n{exhausted_summary[:3000]}"
+                )
+
         # If the agent itself reported failure (e.g. all retries exhausted on
         # API errors, model abort, mid-run interrupt), do not silently mark the
-        # job as successful. run_agent populates `failed=True`/`completed=False`
-        # on these paths and may put the error into `final_response`, which
-        # would otherwise be delivered as if it were the agent's reply and the
-        # job's `last_status` set to "ok". Raise so the except handler below
-        # builds the proper failure tuple. (issue #17855)
+        # job as successful. A zero exit or fallback summary is not enough.
         turn_exit_reason = str(result.get("turn_exit_reason") or "")
         final_response_text = (result.get("final_response") or "").strip()
-        max_iteration_summary = (
-            result.get("failed") is not True
-            and result.get("completed") is False
-            and turn_exit_reason.startswith("max_iterations_reached(")
-            and bool(final_response_text)
-        )
-        if result.get("failed") is True or (result.get("completed") is False and not max_iteration_summary):
+        if result.get("failed") is True or result.get("completed") is False:
             _err_text = (
                 result.get("error")
                 or final_response_text
                 or "agent reported failure"
             )
             raise RuntimeError(_err_text)
-        if max_iteration_summary:
-            logger.warning(
-                "Job '%s' reached the iteration limit but produced a final fallback response; "
-                "delivering the response instead of failing the cron run",
-                job_name,
-            )
 
         final_response = result.get("final_response", "") or ""
         # Strip leaked placeholder text that upstream may inject on empty completions.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2844,6 +2844,73 @@ def _is_gateway_hidden_reasoning_incomplete_turn(agent_result: dict) -> bool:
     return not final_response or final_response == error_text
 
 
+def _max_iteration_recovery_prompt(
+    agent_result: dict,
+    *,
+    pending_event: object = None,
+    pending: object = None,
+    recovery_depth: int = 0,
+    max_attempts: int = 1,
+    recovery_max_turns: int = 30,
+) -> str | None:
+    """Build one bounded continuation turn for a tool-call ceiling stop.
+
+    A queued human message always wins.  ``recovery_depth`` is shared with the
+    existing in-band follow-up recursion, which naturally prevents an infinite
+    recovery loop.  The prefix deliberately matches ``_AUTO_CONTINUE_NOTE_PREFIX``
+    so this synthetic instruction is stripped from future transcript replay.
+    """
+    if not isinstance(agent_result, dict) or pending_event is not None or pending:
+        return None
+    try:
+        attempts = max(0, min(3, int(max_attempts)))
+    except (TypeError, ValueError):
+        attempts = 1
+    if attempts == 0 or recovery_depth >= attempts:
+        return None
+
+    reason = str(agent_result.get("turn_exit_reason") or "").strip().lower()
+    diagnostic = "\n".join(
+        str(agent_result.get(field) or "")
+        for field in ("error", "final_response")
+    ).lower()
+    hit_ceiling = agent_result.get("completed") is not True and (
+        reason == "max_iterations"
+        or reason.startswith("max_iterations_reached(")
+        or (
+            agent_result.get("completed") is False
+            and any(
+                marker in diagnostic
+                for marker in (
+                    "reached maximum iterations",
+                    "maximum number of tool-calling iterations allowed",
+                    "tool-call ceiling",
+                )
+            )
+        )
+    )
+    if not hit_ceiling:
+        return None
+
+    try:
+        recovery_budget = max(1, min(90, int(recovery_max_turns)))
+    except (TypeError, ValueError):
+        recovery_budget = 30
+
+    return (
+        "[System note: Your previous turn hit the Hermes tool-call ceiling. "
+        "This is an automatic bounded recovery turn, not a new user request. "
+        "Continue the original task from durable progress rather than restarting: "
+        "inspect the transcript, todo state, files, and real system state; identify "
+        "only the unmet acceptance gates; finish them; and verify the result before "
+        "replying. Do not repeat non-idempotent external actions or claim success "
+        "from process exit alone. You have at most "
+        f"{recovery_budget} recovery iterations: converge rather than explore. "
+        "If the task is already complete, verify that and "
+        "return the final result. This is the final automatic recovery attempt.]"
+    )
+
+
 def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     """Return True only when a gateway turn really completed successfully.
 
@@ -18077,6 +18144,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        _max_iterations_override: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -18095,6 +18163,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                _max_iterations_override=_max_iterations_override,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -18106,6 +18175,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                _max_iterations_override=_max_iterations_override,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -18227,6 +18297,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        _max_iterations_override: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -19274,6 +19345,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 combined_ephemeral = (combined_ephemeral + "\n\n" + cfg_channel_prompt).strip()
 
             max_iterations = _current_max_iterations()
+            if _max_iterations_override is not None:
+                try:
+                    max_iterations = max(
+                        1,
+                        min(max_iterations, int(_max_iterations_override)),
+                    )
+                except (TypeError, ValueError):
+                    pass
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(
@@ -21091,6 +21170,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pending = _leftover_steer
                     logger.debug("Delivering leftover /steer as next turn: '%s...'", pending[:40])
 
+            # A max-iteration stop is recoverable, not a semantic completion.
+            # Reuse the existing in-band queued-turn machinery for one bounded
+            # continuation. Human queued messages and /steer always win, and the
+            # recursion depth prevents this from becoming an infinite loop.
+            _auto_iteration_recovery = False
+            _auto_iteration_recovery_max_turns = None
+            if result and not pending and not pending_event and not self._draining:
+                _agent_recovery_cfg = user_config.get("agent") or {}
+                _recovery_attempts = (
+                    _agent_recovery_cfg.get("max_iteration_recovery_attempts", 1)
+                    if isinstance(_agent_recovery_cfg, dict)
+                    else 1
+                )
+                _recovery_max_turns = (
+                    _agent_recovery_cfg.get("max_iteration_recovery_max_turns", 30)
+                    if isinstance(_agent_recovery_cfg, dict)
+                    else 30
+                )
+                _recovery_prompt = _max_iteration_recovery_prompt(
+                    result,
+                    pending_event=pending_event,
+                    pending=pending,
+                    recovery_depth=_interrupt_depth,
+                    max_attempts=_recovery_attempts,
+                    recovery_max_turns=_recovery_max_turns,
+                )
+                if _recovery_prompt:
+                    pending = _recovery_prompt
+                    _auto_iteration_recovery = True
+                    try:
+                        _auto_iteration_recovery_max_turns = max(
+                            1,
+                            min(_current_max_iterations(), int(_recovery_max_turns)),
+                        )
+                    except (TypeError, ValueError):
+                        _auto_iteration_recovery_max_turns = 30
+                    logger.warning(
+                        "Tool-call ceiling reached for session %s — starting bounded automatic recovery %d/%s",
+                        session_key or "?",
+                        _interrupt_depth + 1,
+                        _recovery_attempts,
+                    )
+
             # Safety net: if the pending text is a slash command (e.g. "/stop",
             # "/new"), discard it — commands should never be passed to the agent
             # as user input.  The primary fix is in base.py (commands bypass the
@@ -21146,7 +21268,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         adapter.queue_message(session_key, pending)
                     return result_holder[0] or {"final_response": response, "messages": history}
 
-                was_interrupted = result.get("interrupted")
+                was_interrupted = bool(isinstance(result, dict) and result.get("interrupted")) or _auto_iteration_recovery
                 if not was_interrupted:
                     # Queued message after normal completion — deliver the first
                     # response before processing the queued follow-up.
@@ -21284,18 +21406,52 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # what the follow-up's guard will consult.  Fail-safe in helper.
                 await self._refresh_agent_cache_message_count(session_key, session_id)
 
-                followup_result = await self._run_agent(
-                    message=next_message,
-                    context_prompt=context_prompt,
-                    history=updated_history,
-                    source=next_source,
-                    session_id=session_id,
-                    session_key=next_session_key,
-                    run_generation=run_generation,
-                    _interrupt_depth=_interrupt_depth + 1,
-                    event_message_id=next_message_id,
-                    channel_prompt=next_channel_prompt,
-                )
+                try:
+                    followup_result = await self._run_agent(
+                        message=next_message,
+                        context_prompt=context_prompt,
+                        history=updated_history,
+                        source=next_source,
+                        session_id=session_id,
+                        session_key=next_session_key,
+                        run_generation=run_generation,
+                        _interrupt_depth=_interrupt_depth + 1,
+                        event_message_id=next_message_id,
+                        channel_prompt=next_channel_prompt,
+                        _max_iterations_override=_auto_iteration_recovery_max_turns,
+                    )
+                except Exception as recovery_exc:
+                    if not _auto_iteration_recovery:
+                        raise
+                    partial_result = dict(result) if isinstance(result, dict) else {}
+                    first_summary = str(partial_result.get("final_response") or "").strip()
+                    partial_result.update(
+                        {
+                            "completed": False,
+                            "failed": True,
+                            "error": f"Automatic ceiling recovery failed: {recovery_exc}",
+                            "final_response": (
+                                "Automatic continuation failed. Partial result from the first attempt:\n\n"
+                                + (first_summary or "No first-attempt summary was available.")
+                            ),
+                        }
+                    )
+                    return partial_result
+                if _auto_iteration_recovery and isinstance(followup_result, dict):
+                    if followup_result.get("completed") is not True:
+                        first_summary = str(
+                            result.get("final_response") if isinstance(result, dict) else ""
+                        ).strip()
+                        recovery_summary = str(
+                            followup_result.get("final_response") or ""
+                        ).strip()
+                        followup_result["final_response"] = (
+                            "Automatic continuation did not reach verified completion.\n\n"
+                            "First-attempt checkpoint:\n"
+                            f"{first_summary or '(none)'}\n\n"
+                            "Recovery checkpoint:\n"
+                            f"{recovery_summary or '(none)'}"
+                        )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets, _run_cron_recovery_turn
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -1486,14 +1486,8 @@ class TestRunJobSessionPersistence:
         assert error is None
         assert final_response == "all good"
 
-    def test_run_job_delivers_max_iteration_fallback_summary(self, tmp_path):
-        """Cron should deliver a usable max-iteration fallback summary.
-
-        A cron run can exhaust the iteration budget, get a final text summary
-        from the no-tools fallback call, and still have ``completed=False`` in
-        the generic agent result. That should not make cron raise the report
-        text as a RuntimeError.
-        """
+    def test_run_job_auto_recovers_after_max_iteration_summary(self, tmp_path):
+        """Cron resumes once from the ceiling checkpoint before delivering."""
         job = {
             "id": "summary-job",
             "name": "summary",
@@ -1517,21 +1511,123 @@ class TestRunJobSessionPersistence:
              ), \
              patch("run_agent.AIAgent") as mock_agent_cls:
             mock_agent = MagicMock()
-            mock_agent.run_conversation.return_value = {
-                "final_response": "final fallback report",
-                "completed": False,
-                "failed": False,
-                "turn_exit_reason": "max_iterations_reached(60/60)",
-            }
+            mock_agent.max_iterations = 60
+            first_messages = [{"role": "assistant", "content": "checkpoint"}]
+            responses = iter([
+                {
+                    "final_response": "partial progress checkpoint",
+                    "messages": first_messages,
+                    "completed": False,
+                    "failed": False,
+                    "turn_exit_reason": "max_iterations_reached(60/60)",
+                },
+                {
+                    "final_response": "final recovered report",
+                    "completed": True,
+                    "failed": False,
+                    "turn_exit_reason": "completed_no_tools",
+                },
+            ])
+            observed_budgets = []
+
+            def run_conversation(*_args, **_kwargs):
+                observed_budgets.append(mock_agent.max_iterations)
+                return next(responses)
+
+            mock_agent.run_conversation.side_effect = run_conversation
             mock_agent_cls.return_value = mock_agent
 
             success, output, final_response, error = run_job(job)
 
         assert success is True
         assert error is None
-        assert final_response == "final fallback report"
-        assert "final fallback report" in output
+        assert final_response == "final recovered report"
+        assert "final recovered report" in output
         assert "(FAILED)" not in output
+        assert mock_agent.run_conversation.call_count == 2
+        recovery_call = mock_agent.run_conversation.call_args_list[1]
+        assert "automatic bounded recovery turn" in recovery_call.args[0]
+        assert "at most 30 recovery iterations" in recovery_call.args[0]
+        assert recovery_call.kwargs["conversation_history"] == first_messages
+        assert observed_budgets == [60, 30]
+        assert mock_agent.max_iterations == 60
+
+    def test_run_job_fails_after_second_max_iteration_summary(self, tmp_path):
+        """A second ceiling stop is terminal and visible, never false success."""
+        job = {
+            "id": "exhausted-summary-job",
+            "name": "exhausted summary",
+            "prompt": "finish the report",
+        }
+        fake_db = MagicMock()
+        ceiling_result = {
+            "final_response": "still partial",
+            "messages": [{"role": "assistant", "content": "checkpoint"}],
+            "completed": False,
+            "failed": False,
+            "turn_exit_reason": "max_iterations_reached(60/60)",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.max_iterations = 60
+            first_ceiling = dict(ceiling_result, final_response="first partial checkpoint")
+            second_ceiling = dict(ceiling_result, final_response="second partial checkpoint")
+            mock_agent.run_conversation.side_effect = [first_ceiling, second_ceiling]
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        assert "automatic max-iteration recovery exhausted" in str(error)
+        assert "first partial checkpoint" in str(error)
+        assert "second partial checkpoint" in str(error)
+        assert "(FAILED)" in output
+        assert mock_agent.run_conversation.call_count == 2
+        assert mock_agent.max_iterations == 60
+
+    def test_recovery_timeout_reports_that_turn_may_still_be_live(self, monkeypatch):
+        import time
+
+        class SlowAgent:
+            def run_conversation(self, *_args, **_kwargs):
+                time.sleep(0.15)
+                return {"completed": False, "final_response": "late"}
+
+            def get_activity_summary(self):
+                return {"seconds_since_activity": 999}
+
+            def interrupt(self, _reason):
+                return None
+
+        monkeypatch.setenv("HERMES_CRON_INTERRUPT_GRACE_SECONDS", "0.01")
+        with patch(
+            "cron.scheduler.concurrent.futures.wait",
+            return_value=(set(), set()),
+        ):
+            with pytest.raises(TimeoutError, match="turn may still be live"):
+                _run_cron_recovery_turn(
+                    SlowAgent(),
+                    "continue",
+                    [],
+                    inactivity_limit=1,
+                    job_name="slow recovery",
+                )
 
     def test_tick_skips_due_jobs_while_dispatch_is_paused(self, tmp_path):
         """The drain gate runs before advancing a due job's schedule."""

--- a/tests/gateway/test_max_iteration_auto_recovery.py
+++ b/tests/gateway/test_max_iteration_auto_recovery.py
@@ -1,0 +1,95 @@
+"""Bounded gateway continuation after the Hermes tool-call ceiling."""
+
+from gateway.run import (
+    _max_iteration_recovery_prompt,
+    _strip_auto_continue_noise,
+)
+
+
+def _ceiling_result(**overrides):
+    result = {
+        "turn_exit_reason": "max_iterations_reached(90/90)",
+        "completed": False,
+        "partial": True,
+        "final_response": "Reached maximum iterations (90).",
+    }
+    result.update(overrides)
+    return result
+
+
+def test_max_iteration_builds_one_recovery_turn():
+    prompt = _max_iteration_recovery_prompt(_ceiling_result())
+
+    assert prompt is not None
+    assert prompt.startswith("[System note: Your previous turn")
+    assert "durable progress" in prompt
+    assert "Do not repeat non-idempotent external actions" in prompt
+    assert "at most 30 recovery iterations" in prompt
+
+
+def test_recovery_budget_is_configurable_and_clamped():
+    prompt = _max_iteration_recovery_prompt(
+        _ceiling_result(), recovery_max_turns=12
+    )
+    assert prompt is not None
+    assert "at most 12 recovery iterations" in prompt
+
+    clamped = _max_iteration_recovery_prompt(
+        _ceiling_result(), recovery_max_turns=900
+    )
+    assert clamped is not None
+    assert "at most 90 recovery iterations" in clamped
+
+
+def test_recovery_is_bounded_by_depth():
+    assert _max_iteration_recovery_prompt(
+        _ceiling_result(), recovery_depth=1, max_attempts=1
+    ) is None
+
+
+def test_human_pending_message_wins_over_recovery():
+    assert _max_iteration_recovery_prompt(
+        _ceiling_result(), pending="new user instruction"
+    ) is None
+    assert _max_iteration_recovery_prompt(
+        _ceiling_result(), pending_event=object()
+    ) is None
+
+
+def test_normal_completion_does_not_recover():
+    assert _max_iteration_recovery_prompt(
+        {"turn_exit_reason": "completed", "completed": True, "final_response": "Done."}
+    ) is None
+
+
+def test_completed_response_discussing_ceiling_does_not_recover():
+    assert _max_iteration_recovery_prompt(
+        {
+            "turn_exit_reason": "completed_no_tools",
+            "completed": True,
+            "final_response": "I fixed the tool-call ceiling handling.",
+        }
+    ) is None
+
+
+def test_completed_response_with_stale_ceiling_reason_does_not_recover():
+    assert _max_iteration_recovery_prompt(
+        {
+            "turn_exit_reason": "max_iterations_reached(90/90)",
+            "completed": True,
+            "final_response": "Verified complete.",
+        }
+    ) is None
+
+
+def test_legacy_ceiling_text_is_classified():
+    prompt = _max_iteration_recovery_prompt(
+        {"completed": False, "error": "You've reached the maximum number of tool-calling iterations allowed"}
+    )
+    assert prompt is not None
+
+
+def test_synthetic_recovery_note_is_not_replayed_later():
+    prompt = _max_iteration_recovery_prompt(_ceiling_result())
+    assert prompt is not None
+    assert _strip_auto_continue_noise(prompt) == ""


### PR DESCRIPTION
## What does this PR do?

Adds one bounded automatic continuation when a gateway or cron agent exhausts its tool-call iteration budget before completing the task.

Today, a long-running tool workflow can stop at the ceiling after substantial progress and require the user to manually repeat the request. Cron runs fail outright. This change reuses Hermes's existing queued-turn machinery for one continuation, gives queued human messages priority, carries the same session and history, and prevents an unbounded recovery loop.

This is a draft while the full suite and broader maintainer review run.

## Related Issue

No linked issue. Reproduction: run a gateway or cron task that reaches `max_iterations` while still incomplete; Hermes currently returns the ceiling result instead of making one bounded continuation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Classify genuine max-iteration exits without matching normal responses that merely discuss iteration limits.
- Give queued user input and `/steer` precedence over automatic recovery.
- Bound recovery attempts and the continuation's iteration budget.
- Strip the synthetic continuation note from future transcript replay.
- Apply equivalent completion-aware recovery to cron runs while preserving session lineage and delivery semantics.
- Add gateway and cron regression tests covering depth limits, false positives, user-message precedence, config bounds, and retry completion.

## How to Test

1. `python -m pytest -q -o addopts='' tests/gateway/test_max_iteration_auto_recovery.py tests/cron/test_scheduler.py`
2. Confirm `233 passed`.
3. Full `scripts/run_tests.sh` remains pending while this PR is draft.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu Linux with Python 3.11

### Documentation & Housekeeping

- [ ] Config/documentation review is pending before this leaves draft
- [x] Cross-platform impact considered: the implementation is Python runtime logic with no new platform-specific system calls
- [x] Tool descriptions/schemas are unchanged

## Screenshots / Logs

Focused verification: `233 passed` on Python 3.11. One existing async-mock cleanup warning appeared in the broader cron test module; no test failed.
