### PR TITLE
fix(nix): include apps/shared in tui build source

### DIFF
--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -1,7 +1,14 @@
 # nix/tui.nix — Hermes TUI (Ink/React) compiled with tsc and bundled
 { pkgs, hermesNpmLib, ... }:
 let
-  npm = hermesNpmLib.mkNpmPassthru { dirs = [ "ui-tui" ]; };
+  # @hermes/shared ships as a file: workspace dep of ui-tui, so its source
+  # must be in the filtered src tree too.
+  npm = hermesNpmLib.mkNpmPassthru {
+    dirs = [
+      "ui-tui"
+      "apps/shared"
+    ];
+  };
 
   packageJson = builtins.fromJSON (builtins.readFile (npm.src + "/ui-tui/package.json"));
   version = packageJson.version;


### PR DESCRIPTION
## Problem

`nix run github:NousResearch/hermes-agent#desktop` fails:

```
ERROR: Could not resolve "@hermes/shared/charge-settlement"
```

The TUI now depends on `@hermes/shared` (via `ui-tui/package.json`: `"@hermes/shared": "file:../apps/shared"`), and `topup.ts` imports `@hermes/shared/charge-settlement`. However, the Nix build for `hermes-tui` (`nix/tui.nix`) only included `ui-tui/` in its filtered source tree — the `apps/shared/` source was missing from the build sandbox. npm install symlinked `node_modules/@hermes/shared` to a directory that didn't exist in the sandbox, so esbuild couldn't resolve the import.

## Fix

Add `"apps/shared"` to the `dirs` list in `nix/tui.nix` so the shared package source is available during the esbuild bundle step.

This follows the exact same pattern already used by `nix/web.nix` and `nix/desktop.nix` — both include `apps/shared` with the comment `@hermes/shared ships as a file: workspace dep of ... so its source must be in the filtered src tree too.`
