### PR TITLE
docs(links): update moved boto3 credential-chain URL in aws-bedrock guide

### DIFF
--- a/website/docs/guides/aws-bedrock.md
+++ b/website/docs/guides/aws-bedrock.md
@@ -10,7 +10,7 @@ Hermes Agent supports Amazon Bedrock as a native provider using the **Converse A
 
 ## Prerequisites
 
-- **AWS credentials** — any source supported by the [boto3 credential chain](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html):
+- **AWS credentials** — any source supported by the [boto3 credential chain](https://docs.aws.amazon.com/boto3/latest/guide/credentials.html):
   - IAM instance role (EC2, ECS, Lambda — zero config)
   - `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` environment variables
   - `AWS_PROFILE` for SSO or named profiles

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/aws-bedrock.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/aws-bedrock.md
@@ -10,7 +10,7 @@ Hermes Agent 通过 **Converse API** 原生支持 Amazon Bedrock——而非 Ope
 
 ## 前提条件
 
-- **AWS 凭证** — [boto3 凭证链](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)支持的任意来源：
+- **AWS 凭证** — [boto3 凭证链](https://docs.aws.amazon.com/boto3/latest/guide/credentials.html)支持的任意来源：
   - IAM 实例角色（EC2、ECS、Lambda — 零配置）
   - `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` 环境变量
   - `AWS_PROFILE`（用于 SSO 或命名配置文件）


### PR DESCRIPTION
### Problem

The AWS Bedrock guide links the boto3 credential-chain docs at a legacy host that no longer serves the page directly:

```
https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
```

Fetching it returns a permanent redirect:

```
$ curl -sI https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
HTTP/1.1 301 Moved Permanently
Location: https://docs.aws.amazon.com/boto3/latest/guide/credentials.html
```

AWS consolidated the boto3 documentation under `docs.aws.amazon.com`; `boto3.amazonaws.com` is a legacy host kept alive only by the 301. The redirect target is a direct 200.

### Fix

Point the link straight at the canonical URL the server itself redirects to. The same link appears in the English guide and its zh-Hans mirror; both are updated to keep the translation in sync.

```diff
-- **AWS credentials** — any source supported by the [boto3 credential chain](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html):
+- **AWS credentials** — any source supported by the [boto3 credential chain](https://docs.aws.amazon.com/boto3/latest/guide/credentials.html):
```

Docs-only, no runtime or behavior change. The replacement URL is exactly the `Location` header returned by the old URL.

Closes #67081