### PR TITLE
fix(cron): make execution ledger failure-atomic

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -19,17 +19,174 @@ from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
 EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
+_DEFAULT_EXECUTIONS_FILE = EXECUTIONS_FILE
 MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
+_ERROR_CODES = frozenset({
+    "delivery_failed",
+    "dispatch_rejected",
+    "empty_response",
+    "execution_failed",
+    "executor_dispatch_failed",
+    "legacy_error_redacted",
+    "scheduler_failed",
+    "scheduler_restarted",
+})
+_RESULT_KINDS = frozenset({
+    "delivery_failed",
+    "dispatch_rejected",
+    "empty_response",
+    "execution_failed",
+    "executor_dispatch_failed",
+    "output_produced",
+    "scheduler_failed",
+    "scheduler_restarted",
+    "silent",
+})
+_SOURCE_KINDS = frozenset({"builtin", "direct", "external", "unknown"})
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
 
 
+def _source_kind(source: Any) -> str:
+    normalized = str(source or "").strip().lower()
+    if normalized == "chronos":
+        return "external"
+    return normalized if normalized in _SOURCE_KINDS else "unknown"
+
+
+def _bounded_exit_code(value: Any) -> Optional[int]:
+    if type(value) is not int:
+        return None
+    return value if -(2**31) <= value <= (2**31 - 1) else None
+
+
+def _current_executions_file() -> Path:
+    """Resolve the active profile ledger without breaking test overrides."""
+    if EXECUTIONS_FILE != _DEFAULT_EXECUTIONS_FILE:
+        return Path(EXECUTIONS_FILE).resolve()
+    return get_hermes_home().resolve() / "cron" / "executions.db"
+
+
+def _migrate_schema(conn: sqlite3.Connection) -> None:
+    """Apply retryable privacy migrations before any rows are returned."""
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS schema_meta (
+             key TEXT PRIMARY KEY,
+             value TEXT NOT NULL
+           )"""
+    )
+    row = conn.execute(
+        "SELECT value FROM schema_meta WHERE key='schema_version'"
+    ).fetchone()
+    version = int(row[0]) if row is not None else 1
+    if version >= 5:
+        return
+
+    conn.commit()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(executions)")
+        }
+        additions = {
+            "result_kind": "TEXT",
+            "exit_code": "INTEGER",
+            "delivery_requested": "INTEGER NOT NULL DEFAULT 0",
+            "delivery_attempted": "INTEGER NOT NULL DEFAULT 0",
+            "delivery_failed": "INTEGER NOT NULL DEFAULT 0",
+        }
+        for name, definition in additions.items():
+            if name not in columns:
+                conn.execute(
+                    f"ALTER TABLE executions ADD COLUMN {name} {definition}"
+                )
+
+        error_placeholders = ",".join("?" for _ in _ERROR_CODES)
+        conn.execute(
+            f"""UPDATE executions SET error='legacy_error_redacted'
+                 WHERE error IS NOT NULL AND error NOT IN ({error_placeholders})""",
+            tuple(sorted(_ERROR_CODES)),
+        )
+        conn.execute(
+            "UPDATE executions SET source='external' WHERE lower(source)='chronos'"
+        )
+        source_placeholders = ",".join("?" for _ in _SOURCE_KINDS)
+        conn.execute(
+            f"""UPDATE executions SET source='unknown'
+                 WHERE source NOT IN ({source_placeholders})""",
+            tuple(sorted(_SOURCE_KINDS)),
+        )
+        result_placeholders = ",".join("?" for _ in _RESULT_KINDS)
+        conn.execute(
+            f"""UPDATE executions SET result_kind=CASE status
+                   WHEN 'completed' THEN 'output_produced'
+                   WHEN 'failed' THEN 'execution_failed'
+                   WHEN 'unknown' THEN 'scheduler_restarted'
+                   ELSE NULL END
+                 WHERE result_kind IS NULL
+                    OR result_kind NOT IN ({result_placeholders})""",
+            tuple(sorted(_RESULT_KINDS)),
+        )
+        conn.execute(
+            """UPDATE executions SET exit_code=NULL
+                 WHERE typeof(exit_code) != 'integer'
+                    OR exit_code < ? OR exit_code > ?""",
+            (-(2**31), 2**31 - 1),
+        )
+        for column in (
+            "delivery_requested",
+            "delivery_attempted",
+            "delivery_failed",
+        ):
+            conn.execute(
+                f"""UPDATE executions SET {column}=CASE
+                       WHEN typeof({column})='integer' AND {column} != 0 THEN 1
+                       ELSE 0 END"""
+            )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    checkpoint = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+    if checkpoint and checkpoint[0]:
+        raise sqlite3.OperationalError(
+            "privacy migration checkpoint was busy; migration remains retryable"
+        )
+
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            """INSERT INTO schema_meta(key, value) VALUES('schema_version', '5')
+               ON CONFLICT(key) DO UPDATE SET value=excluded.value"""
+        )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _secure_storage(executions_file: Path) -> None:
+    """Enforce owner-only modes without changing the process-global umask."""
+    executions_file.parent.chmod(0o700)
+    for path in (
+        executions_file,
+        Path(f"{executions_file}-wal"),
+        Path(f"{executions_file}-shm"),
+    ):
+        if path.exists():
+            path.chmod(0o600)
+
+
 def _connect() -> sqlite3.Connection:
-    EXECUTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(EXECUTIONS_FILE, timeout=5)
+    executions_file = _current_executions_file()
+    executions_file.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    executions_file.parent.chmod(0o700)
+    conn = sqlite3.connect(executions_file, timeout=5)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA busy_timeout=5000")
+    conn.execute("PRAGMA secure_delete=ON")
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=FULL")
     conn.execute(
@@ -45,7 +202,12 @@ def _connect() -> sqlite3.Connection:
              claimed_at TEXT NOT NULL,
              started_at TEXT,
              finished_at TEXT,
-             error TEXT
+             error TEXT,
+             result_kind TEXT,
+             exit_code INTEGER,
+             delivery_requested INTEGER NOT NULL DEFAULT 0,
+             delivery_attempted INTEGER NOT NULL DEFAULT 0,
+             delivery_failed INTEGER NOT NULL DEFAULT 0
            )"""
     )
     conn.execute(
@@ -56,6 +218,12 @@ def _connect() -> sqlite3.Connection:
         "CREATE INDEX IF NOT EXISTS idx_executions_status_claimed "
         "ON executions(status, claimed_at DESC, id DESC)"
     )
+    try:
+        _migrate_schema(conn)
+        _secure_storage(executions_file)
+    except Exception:
+        conn.close()
+        raise
     return conn
 
 
@@ -107,7 +275,7 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
                (id, job_id, source, process_id, pid, process_started_at,
                 status, claimed_at)
                VALUES (?, ?, ?, ?, ?, ?, 'claimed', ?)""",
-            (execution_id, str(job_id), str(source), _PROCESS_ID, pid,
+            (execution_id, str(job_id), _source_kind(source), _PROCESS_ID, pid,
              _process_start_time(pid), now),
         )
         row = conn.execute(
@@ -133,17 +301,55 @@ def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
 
 
 def finish_execution(
-    execution_id: str, *, success: bool, error: Optional[str] = None,
+    execution_id: str,
+    *,
+    success: bool,
+    error: Optional[str] = None,
+    error_code: Optional[str] = None,
+    result_kind: Optional[str] = None,
+    exit_code: Optional[int] = None,
+    delivery_requested: bool = False,
+    delivery_attempted: bool = False,
+    delivery_failed: bool = False,
 ) -> Optional[Dict[str, Any]]:
-    """Write a terminal result once; terminal attempts cannot be rewritten."""
+    """Write a terminal categorical result once.
+
+    ``error`` remains accepted for caller compatibility and local logging, but
+    arbitrary text never crosses the durable-ledger boundary.
+    """
+    del error
     now = _hermes_now().isoformat()
-    status = "completed" if success else "failed"
-    detail = None if success else (str(error) if error else "unknown failure")
+    terminal_success = bool(success and not delivery_failed)
+    status = "completed" if terminal_success else "failed"
+    if result_kind not in _RESULT_KINDS:
+        if delivery_failed:
+            result_kind = "delivery_failed"
+        elif terminal_success:
+            result_kind = "output_produced"
+        else:
+            result_kind = "execution_failed"
+    detail = None
+    if not terminal_success:
+        detail = error_code if error_code in _ERROR_CODES else result_kind
+        if detail not in _ERROR_CODES:
+            detail = "execution_failed"
     with _lock, _connect() as conn:
         cur = conn.execute(
-            """UPDATE executions SET status=?, finished_at=?, error=?
+            """UPDATE executions
+               SET status=?, finished_at=?, error=?, result_kind=?, exit_code=?,
+                   delivery_requested=?, delivery_attempted=?, delivery_failed=?
                WHERE id=? AND status IN ('claimed','running')""",
-            (status, now, detail, execution_id),
+            (
+                status,
+                now,
+                detail,
+                result_kind,
+                _bounded_exit_code(exit_code),
+                int(bool(delivery_requested)),
+                int(bool(delivery_attempted)),
+                int(bool(delivery_failed)),
+                execution_id,
+            ),
         )
         if cur.rowcount != 1:
             return None
@@ -168,12 +374,11 @@ def recover_interrupted_executions() -> int:
             if _owner_is_live(int(row["pid"]), row["process_started_at"]):
                 continue
             cur = conn.execute(
-                """UPDATE executions SET status='unknown', finished_at=?, error=?
+                """UPDATE executions
+                   SET status='unknown', finished_at=?, error='scheduler_restarted',
+                       result_kind='scheduler_restarted'
                    WHERE id=? AND status IN ('claimed','running')""",
-                (now,
-                 "Scheduler restarted after this execution's owner exited before a durable "
-                 "terminal state; whether side effects ran is unknown.",
-                 row["id"]),
+                (now, row["id"]),
             )
             changed += cur.rowcount
         if changed:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1745,26 +1745,118 @@ def _machine_id() -> str:
     return f"{host}:{os.getpid()}"
 
 
-def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
-    """Atomically claim a job for a single external 'fire' (multi-machine
-    at-most-once). Returns True iff THIS caller won the claim.
+_DISPATCH_RECEIPT_KEY = "_cron_dispatch_rollback"
+_DISPATCH_STATE_FIELDS = ("next_run_at", "run_claim", "fire_claim")
 
-    Used by the external-provider fire path (``CronScheduler.fire_due``) when an
-    external scheduler (Chronos) signals a job is due across N gateway replicas:
-    exactly one wins. Single-machine deployments always win.
 
-    Under the file lock: reject if the job is missing/disabled/paused. If a
-    fresh claim (younger than ``claim_ttl_seconds``) already exists, lose.
-    Otherwise stamp a ``fire_claim`` and, for recurring jobs, advance
-    ``next_run_at`` (mirrors ``advance_next_run``'s at-most-once bump so a stale
-    re-delivery for the old time can't re-fire). One-shots keep ``next_run_at``
-    but the fresh ``fire_claim`` blocks a duplicate retry for the same fire.
-    ``mark_job_run`` clears the claim on completion so a re-armed recurring job
-    is claimable again next fire.
+def _snapshot_dispatch_state(job: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Capture only scheduler-owned fields, preserving absent vs explicit null."""
+    return {
+        field: {
+            "present": field in job,
+            "value": copy.deepcopy(job.get(field)),
+        }
+        for field in _DISPATCH_STATE_FIELDS
+    }
 
-    The stale-claim TTL means a machine that crashed after claiming but before
-    completing doesn't wedge the job forever — after the TTL another fire can
-    reclaim it.
+
+def _dispatch_receipt(
+    job_id: str,
+    before: Dict[str, Dict[str, Any]],
+    expected: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    return {
+        "job_id": job_id,
+        "before": copy.deepcopy(before),
+        "expected": copy.deepcopy(expected),
+    }
+
+
+def pop_dispatch_receipt(job: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Remove and return get_due_jobs()'s non-persisted rollback receipt."""
+    return job.pop(_DISPATCH_RECEIPT_KEY, None)
+
+
+def prepare_dispatch_receipt(job_id: str, receipt: Dict[str, Any]) -> bool:
+    """Authenticate and advance a due job while updating its receipt atomically.
+
+    The current dispatch state must exactly match the receipt. For recurring
+    jobs, ``next_run_at`` is then advanced under the same jobs lock and the
+    receipt is updated to that exact state. No concurrent value is ever adopted.
+    """
+    expected = receipt.get("expected")
+    if not isinstance(expected, dict):
+        return False
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job.get("id") != job_id:
+                continue
+            if _snapshot_dispatch_state(job) != expected:
+                return False
+            kind = job.get("schedule", {}).get("kind")
+            if kind in {"cron", "interval"}:
+                new_next = compute_next_run(job["schedule"], _hermes_now().isoformat())
+                if new_next and new_next != job.get("next_run_at"):
+                    job["next_run_at"] = new_next
+                    save_jobs(jobs)
+            receipt["expected"] = _snapshot_dispatch_state(job)
+            return True
+    return False
+
+
+def refresh_dispatch_receipt(job_id: str, receipt: Dict[str, Any]) -> bool:
+    """Verify that no tracked dispatch field changed after locked preparation."""
+    expected = receipt.get("expected")
+    if not isinstance(expected, dict):
+        return False
+    with _jobs_lock():
+        for job in load_jobs():
+            if job.get("id") == job_id:
+                return _snapshot_dispatch_state(job) == expected
+    return False
+
+
+def restore_job_dispatch_state(receipt: Dict[str, Any]) -> bool:
+    """CAS-restore scheduler-owned fields after pre-dispatch ledger failure.
+
+    False means the job disappeared or another writer changed a tracked field;
+    callers must then fail loudly rather than overwrite unauthenticated state.
+    """
+    job_id = receipt.get("job_id")
+    before = receipt.get("before")
+    expected = receipt.get("expected")
+    if not job_id or not isinstance(before, dict) or not isinstance(expected, dict):
+        return False
+
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job.get("id") != job_id:
+                continue
+            if _snapshot_dispatch_state(job) != expected:
+                return False
+            for field in _DISPATCH_STATE_FIELDS:
+                prior = before.get(field, {"present": False, "value": None})
+                if prior.get("present"):
+                    job[field] = copy.deepcopy(prior.get("value"))
+                else:
+                    job.pop(field, None)
+            save_jobs(jobs)
+            return True
+    return False
+
+
+def claim_job_for_fire_with_receipt(
+    job_id: str,
+    *,
+    claim_ttl_seconds: int = 300,
+) -> Optional[Dict[str, Any]]:
+    """Atomically claim an external fire and return its rollback receipt.
+
+    The receipt authenticates both the state before the claim and the exact
+    provisional state written by this caller. It can therefore be safely
+    restored if durable execution-ledger creation fails before dispatch.
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -1772,23 +1864,19 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
             if job["id"] != job_id:
                 continue
             if not job.get("enabled", True) or job.get("state") == "paused":
-                return False
+                return None
             now = _hermes_now()
+            before = _snapshot_dispatch_state(job)
             existing = job.get("fire_claim")
             if existing:
                 try:
                     claimed_at = _ensure_aware(datetime.fromisoformat(existing["at"]))
-                    # Bounded on BOTH sides (#60703): a claim stamped in the
-                    # future (clock/TZ skew across a restart, or a corrupted
-                    # timestamp) would otherwise have a negative age and stay
-                    # "fresh" forever — the job becomes permanently unfireable
-                    # and every manual `cron run` reports "already being
-                    # fired". Treat future-dated claims as stale/overwritable.
-                    _age = (now - claimed_at).total_seconds()
-                    if 0 <= _age < claim_ttl_seconds:
-                        return False  # someone holds a fresh claim
+                    # Future-dated and malformed claims are stale/overwritable.
+                    age = (now - claimed_at).total_seconds()
+                    if 0 <= age < claim_ttl_seconds:
+                        return None
                 except Exception:
-                    pass  # malformed claim → overwrite
+                    pass
             job["fire_claim"] = {"at": now.isoformat(), "by": _machine_id()}
             kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
@@ -1796,8 +1884,20 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
                 if nxt:
                     job["next_run_at"] = nxt
             save_jobs(jobs)
-            return True
-        return False
+            return _dispatch_receipt(
+                job_id,
+                before,
+                _snapshot_dispatch_state(job),
+            )
+        return None
+
+
+def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
+    """Backward-compatible boolean wrapper for external fire claims."""
+    return claim_job_for_fire_with_receipt(
+        job_id,
+        claim_ttl_seconds=claim_ttl_seconds,
+    ) is not None
 
 
 def get_due_jobs() -> List[Dict[str, Any]]:
@@ -1927,6 +2027,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
         # job this tick" so healthy siblings still run and their recovered
         # state still reaches save_jobs() below.
         try:
+            dispatch_before = _snapshot_dispatch_state(job)
             if not job.get("enabled", True):
                 continue
 
@@ -2140,6 +2241,14 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                             needs_save = True
                             break
 
+                for raw_job in raw_jobs:
+                    if raw_job["id"] == job["id"]:
+                        job[_DISPATCH_RECEIPT_KEY] = _dispatch_receipt(
+                            job["id"],
+                            dispatch_before,
+                            _snapshot_dispatch_state(raw_job),
+                        )
+                        break
                 due.append(job)
         except Exception:
             logger.exception(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -277,7 +277,18 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    get_due_jobs,
+    mark_job_run,
+    save_job_output,
+    advance_next_run,
+    claim_dispatch,
+    heartbeat_run_claim,
+    pop_dispatch_receipt,
+    prepare_dispatch_receipt,
+    refresh_dispatch_receipt,
+    restore_job_dispatch_state,
+)
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -1237,6 +1248,16 @@ def _normalize_deliver_value(deliver) -> str:
         parts = [str(p).strip() for p in deliver if str(p).strip()]
         return ",".join(parts) if parts else "local"
     return str(deliver)
+
+
+def _delivery_requested(deliver) -> bool:
+    """Whether a normalized delivery value includes any non-local target."""
+    normalized = _normalize_deliver_value(deliver)
+    return any(
+        part.strip().lower() != "local"
+        for part in normalized.split(",")
+        if part.strip()
+    )
 
 
 # Routing intent tokens — resolved at fire time, not create time, so a
@@ -3723,7 +3744,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             finish_execution(
                 execution_id,
                 success=False,
-                error="Dispatch claim rejected; execution was not started.",
+                error_code="dispatch_rejected",
+                result_kind="dispatch_rejected",
             )
             return True  # not an error — already handled/removed
 
@@ -3831,20 +3853,59 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # Treat empty final_response as a soft failure so last_status
         # is not "ok" — the agent ran but produced nothing useful.
         # (issue #8585)
-        if success and not final_response.strip():
+        empty_response = bool(success and not final_response.strip())
+        if empty_response:
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
         if not _consume_interrupted_flag(job["id"]):
             mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-        finish_execution(execution_id, success=success, error=error)
+
+        raw_delivery = job.get("deliver")
+        delivery_requested = _delivery_requested(raw_delivery)
+        delivery_attempted = bool(delivery_requested and should_deliver)
+        is_silent = bool(success and _is_cron_silence_response(final_response))
+        if empty_response:
+            result_kind = "empty_response"
+            error_code = "empty_response"
+        elif not success:
+            result_kind = "execution_failed"
+            error_code = "execution_failed"
+        elif delivery_error:
+            result_kind = "delivery_failed"
+            error_code = "delivery_failed"
+        elif is_silent:
+            result_kind = "silent"
+            error_code = None
+        elif success:
+            result_kind = "output_produced"
+            error_code = None
+        else:
+            result_kind = "execution_failed"
+            error_code = "execution_failed"
+        finish_execution(
+            execution_id,
+            success=success,
+            error_code=error_code,
+            result_kind=result_kind,
+            exit_code=0 if success else 1,
+            delivery_requested=delivery_requested,
+            delivery_attempted=delivery_attempted,
+            delivery_failed=bool(delivery_error),
+        )
         return True
 
     except Exception as e:
         logger.error("Error processing job %s: %s", job['id'], e)
         if not _consume_interrupted_flag(job["id"]):
             mark_job_run(job["id"], False, str(e))
-        finish_execution(execution_id, success=False, error=str(e))
+        finish_execution(
+            execution_id,
+            success=False,
+            error_code="scheduler_failed",
+            result_kind="scheduler_failed",
+            exit_code=1,
+        )
         return False
 
 
@@ -3926,8 +3987,43 @@ def tick(
         # For parallel jobs that are already running, advance_next_run keeps
         # bumping next_run_at forward so the grace window never expires.
         # mark_job_run() overwrites next_run_at on completion.
-        for job in due_jobs:
-            advance_next_run(job["id"])
+        dispatch_receipts: dict[str, dict] = {}
+
+        def _restore_pending_dispatches(cause: Exception, phase: str) -> None:
+            ambiguous = []
+            for pending_id, pending_receipt in reversed(
+                list(dispatch_receipts.items())
+            ):
+                if restore_job_dispatch_state(pending_receipt):
+                    dispatch_receipts.pop(pending_id, None)
+                else:
+                    ambiguous.append(pending_id)
+            if ambiguous:
+                raise RuntimeError(
+                    f"{phase} failed and rollback was ambiguous for job(s): "
+                    f"{', '.join(ambiguous)}"
+                ) from cause
+
+        try:
+            for job in due_jobs:
+                receipt = pop_dispatch_receipt(job)
+                if receipt is None:
+                    advance_next_run(job["id"])
+                    continue
+                if not prepare_dispatch_receipt(job["id"], receipt):
+                    raise RuntimeError(
+                        f"job {job['id']} changed while preparing dispatch"
+                    )
+                # The receipt stays pending until this job either owns an
+                # existing run, gets a durable ledger row, or is CAS-restored.
+                dispatch_receipts[job["id"]] = receipt
+                if not refresh_dispatch_receipt(job["id"], receipt):
+                    raise RuntimeError(
+                        f"job {job['id']} changed after dispatch preparation"
+                    )
+        except Exception as preparation_err:
+            _restore_pending_dispatches(preparation_err, "dispatch preparation")
+            raise
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
@@ -3989,6 +4085,13 @@ def tick(
             # the job stays due and will fire on the next healthy tick
             # (#58720, #55924).
             if _interpreter_shutting_down():
+                receipt = dispatch_receipts.get(job_id)
+                if receipt is None or not restore_job_dispatch_state(receipt):
+                    raise RuntimeError(
+                        f"interpreter shutdown prevented dispatch and state for job "
+                        f"{job_id} could not be authenticated and restored"
+                    )
+                dispatch_receipts.pop(job_id, None)
                 logger.warning(
                     "Job '%s' not dispatched — interpreter is shutting down",
                     job.get("name", job_id),
@@ -3996,12 +4099,41 @@ def tick(
                 return None
             with _running_lock:
                 if job_id in _running_job_ids:
-                    logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+                    # The active run owns an earlier occurrence. This newly due
+                    # occurrence has no ledger owner, so restore it for retry.
+                    receipt = dispatch_receipts.get(job_id)
+                    if receipt is None or not restore_job_dispatch_state(receipt):
+                        raise RuntimeError(
+                            f"job {job_id} is already running and its newly due "
+                            "dispatch state could not be authenticated and restored"
+                        )
+                    dispatch_receipts.pop(job_id, None)
+                    logger.info("Job '%s' already running — later occurrence remains due", job.get("name", job_id))
                     return None
                 _running_job_ids.add(job_id)
             # Record the attempt before executor dispatch. Recovery classifies
             # abandoned records as unknown; it never automatically retries them.
-            execution = create_execution(job_id, source="builtin")
+            try:
+                execution = create_execution(job_id, source="builtin")
+            except Exception as ledger_err:
+                with _running_lock:
+                    _running_job_ids.discard(job_id)
+                receipt = dispatch_receipts.get(job_id)
+                if receipt is None or not restore_job_dispatch_state(receipt):
+                    raise RuntimeError(
+                        f"ledger creation failed and dispatch state for job {job_id} "
+                        "could not be authenticated and restored"
+                    ) from ledger_err
+                dispatch_receipts.pop(job_id, None)
+                logger.error(
+                    "Job '%s' not dispatched — execution ledger creation failed (%s)",
+                    job.get("name", job_id),
+                    type(ledger_err).__name__,
+                )
+                return None
+            # The durable row now owns this attempt. Later executor failure is
+            # recorded in that row rather than rolling scheduler state back.
+            dispatch_receipts.pop(job_id, None)
             dispatched_job = dict(job, execution_id=execution["id"])
             _ctx = contextvars.copy_context()
 
@@ -4020,7 +4152,8 @@ def tick(
                 finish_execution(
                     execution["id"],
                     success=False,
-                    error=f"Executor dispatch failed: {submit_err}",
+                    error_code="executor_dispatch_failed",
+                    result_kind="executor_dispatch_failed",
                 )
                 # Interpreter began finalizing between the guard above and the
                 # submit — release the in-flight claim we just took and skip.
@@ -4037,36 +4170,38 @@ def tick(
                 )
                 return None
 
-        # Sequential pass for env-mutating (workdir) jobs.
-        # Queued to a persistent single-thread pool so they run one at a time
-        # WITHOUT blocking the ticker thread — a long workdir job no
-        # longer starves the rest of the schedule (same fix as the parallel
-        # pass, just serialized).  The in-flight guard prevents a still-running
-        # job from being re-queued on the next tick.
-        if sequential_jobs:
-            seq_pool = _get_sequential_pool()
-            for job in sequential_jobs:
-                fut = _submit_with_guard(job, seq_pool)
-                if fut is None:
-                    continue
-                _all_futures.append(fut)
-                if not sync:
-                    _results.append(True)  # optimistically counted
+        try:
+            # Sequential pass for env-mutating (workdir) jobs.
+            if sequential_jobs:
+                seq_pool = _get_sequential_pool()
+                for job in sequential_jobs:
+                    fut = _submit_with_guard(job, seq_pool)
+                    if fut is None:
+                        continue
+                    _all_futures.append(fut)
+                    if not sync:
+                        _results.append(True)  # optimistically counted
 
-        # Parallel pass — persistent pool, non-blocking dispatch.
-        # Jobs that are already running (from a previous tick) are skipped.
-        # mark_job_run() updates next_run_at on completion, so the next tick
-        # after completion finds the job due again naturally.  No catch-up
-        # queue needed.
-        if parallel_jobs:
-            pool = _get_parallel_pool(_max_workers)
-            for job in parallel_jobs:
-                fut = _submit_with_guard(job, pool)
-                if fut is None:
-                    continue
-                _all_futures.append(fut)
-                if not sync:
-                    _results.append(True)  # optimistically counted
+            # Parallel pass — persistent pool, non-blocking dispatch.
+            if parallel_jobs:
+                pool = _get_parallel_pool(_max_workers)
+                for job in parallel_jobs:
+                    fut = _submit_with_guard(job, pool)
+                    if fut is None:
+                        continue
+                    _all_futures.append(fut)
+                    if not sync:
+                        _results.append(True)  # optimistically counted
+        except Exception as submission_err:
+            _restore_pending_dispatches(submission_err, "dispatch submission")
+            raise
+
+        if dispatch_receipts:
+            pending_err = RuntimeError(
+                "dispatch submission ended with prepared jobs lacking ownership"
+            )
+            _restore_pending_dispatches(pending_err, "dispatch submission")
+            raise pending_err
 
         # Best-effort sweep of MCP stdio subprocesses that survived their
         # session teardown.  Must run AFTER jobs finish so active sessions

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -100,16 +100,29 @@ class CronScheduler(ABC):
         Returns True if THIS caller claimed and ran the job, False if the claim
         was lost (another machine/retry won it) or the job no longer exists.
         """
-        from cron.jobs import claim_job_for_fire, get_job
+        from cron.jobs import (
+            claim_job_for_fire_with_receipt,
+            get_job,
+            restore_job_dispatch_state,
+        )
         from cron.executions import create_execution
         from cron.scheduler import run_one_job
 
-        if not claim_job_for_fire(job_id):
+        receipt = claim_job_for_fire_with_receipt(job_id)
+        if receipt is None:
             return False  # another machine already claimed this fire
         job = get_job(job_id)
         if job is None:
             return False  # job removed (e.g. repeat-N exhausted) between arm and fire
-        job["execution_id"] = create_execution(job_id, source=self.name)["id"]
+        try:
+            job["execution_id"] = create_execution(job_id, source=self.name)["id"]
+        except Exception as ledger_err:
+            if not restore_job_dispatch_state(receipt):
+                raise RuntimeError(
+                    f"ledger creation failed and external fire state for job {job_id} "
+                    "could not be authenticated and restored"
+                ) from ledger_err
+            raise
         return run_one_job(job, adapters=adapters, loop=loop)
 
     def reconcile(self) -> None:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -210,8 +210,22 @@ def cron_runs(job_id: Optional[str] = None, limit: int = 20):
             f"job={record.get('job_id', '?')}  source={record.get('source', '?')}  "
             f"{record.get('claimed_at', '?')}"
         )
-        if record.get("error"):
-            print(f"    {record['error']}")
+        if record.get("delivery_failed"):
+            delivery_state = "failed"
+        elif record.get("delivery_attempted"):
+            delivery_state = "attempted"
+        elif record.get("delivery_requested"):
+            delivery_state = "suppressed"
+        else:
+            delivery_state = "not_requested"
+        exit_code = record.get("exit_code")
+        print(
+            f"    result={record.get('result_kind') or '?'}  "
+            f"exit={exit_code if exit_code is not None else '?'}  "
+            f"delivery={delivery_state}"
+        )
+        if record.get("error") and record.get("error") != record.get("result_kind"):
+            print(f"    error={record['error']}")
 
 
 def cron_status():

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -17,6 +17,29 @@ def _point_ledger(monkeypatch, tmp_path):
     return executions
 
 
+def test_late_hermes_home_repoint_scopes_execution_ledger(monkeypatch, tmp_path):
+    import cron.executions as executions
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "late-home"))
+
+    assert executions._current_executions_file() == (
+        tmp_path / "late-home" / "cron" / "executions.db"
+    ).resolve()
+
+
+def test_execution_source_is_categorical(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    private_source = "PRIVATE_PROVIDER_SOURCE_5c2a"
+
+    record = executions.create_execution("source-job", source=private_source)
+
+    assert record["source"] == "unknown"
+    assert private_source.encode() not in executions.EXECUTIONS_FILE.read_bytes()
+
+    external = executions.create_execution("external-job", source="chronos")
+    assert external["source"] == "external"
+
+
 def test_execution_transitions_are_durable(monkeypatch, tmp_path):
     executions = _point_ledger(monkeypatch, tmp_path)
 
@@ -65,6 +88,16 @@ def test_retention_bounds_terminal_history_but_preserves_inflight(monkeypatch, t
     assert executions.latest_execution("live")["status"] == "running"
 
 
+def test_execution_storage_is_owner_only(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("private", source="builtin")
+    executions.mark_execution_running(record["id"])
+
+    assert executions.EXECUTIONS_FILE.parent.stat().st_mode & 0o777 == 0o700
+    for path in executions.EXECUTIONS_FILE.parent.glob("executions.db*"):
+        assert path.stat().st_mode & 0o777 == 0o600
+
+
 def test_corrupt_store_fails_closed_without_overwrite(monkeypatch, tmp_path):
     executions = _point_ledger(monkeypatch, tmp_path)
     executions.EXECUTIONS_FILE.parent.mkdir(parents=True)
@@ -91,10 +124,11 @@ def test_execution_history_is_paginated(monkeypatch, tmp_path):
     assert set(row["id"] for row in first).isdisjoint(row["id"] for row in second)
 
 
-def test_cron_runs_cli_prints_execution_history(monkeypatch, tmp_path, capsys):
+def test_cron_runs_cli_prints_categorical_execution_history(monkeypatch, tmp_path, capsys):
     executions = _point_ledger(monkeypatch, tmp_path)
+    private_error = "PRIVATE_CLI_ERROR_TEXT_2b8d"
     row = executions.create_execution("cli-job", source="builtin")
-    executions.finish_execution(row["id"], success=False, error="boom")
+    executions.finish_execution(row["id"], success=False, error=private_error)
     from hermes_cli.cron import cron_runs
 
     cron_runs("cli-job", limit=10)
@@ -102,7 +136,41 @@ def test_cron_runs_cli_prints_execution_history(monkeypatch, tmp_path, capsys):
     output = capsys.readouterr().out
     assert row["id"] in output
     assert "failed" in output
-    assert "boom" in output
+    assert "execution_failed" in output
+    assert "result=execution_failed" in output
+    assert "exit=?" in output
+    assert "delivery=not_requested" in output
+    assert private_error not in output
+
+
+def test_exit_code_rejects_private_boolean_and_unbounded_values(
+    monkeypatch, tmp_path, capsys
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    private_exit = "PRIVATE_EXIT_CODE_TEXT_3a91"
+    invalid_values = (private_exit, True, 2**63)
+
+    for index, invalid in enumerate(invalid_values):
+        record = executions.create_execution(f"invalid-exit-{index}", source="builtin")
+        executions.finish_execution(
+            record["id"],
+            success=False,
+            result_kind="execution_failed",
+            exit_code=invalid,  # type: ignore[arg-type] - exercise runtime boundary
+        )
+        latest = executions.latest_execution(f"invalid-exit-{index}")
+        assert latest is not None
+        assert latest["exit_code"] is None
+
+    from hermes_cli.cron import cron_runs
+
+    cron_runs(limit=10)
+    assert private_exit not in capsys.readouterr().out
+    persisted = b"".join(
+        path.read_bytes()
+        for path in executions.EXECUTIONS_FILE.parent.glob("executions.db*")
+    )
+    assert private_exit.encode() not in persisted
 
 
 def test_quick_backup_includes_execution_ledger():
@@ -111,14 +179,154 @@ def test_quick_backup_includes_execution_ledger():
     assert "cron/executions.db" in _QUICK_STATE_FILES
 
 
-def test_failed_execution_keeps_error(monkeypatch, tmp_path):
+def test_failed_execution_keeps_only_categorical_error(monkeypatch, tmp_path):
     executions = _point_ledger(monkeypatch, tmp_path)
+    private_error = "PRIVATE_PROVIDER_FAILURE_TEXT_7f3e"
 
     record = executions.create_execution("job-2", source="external")
-    failed = executions.finish_execution(record["id"], success=False, error="provider exploded")
+    failed = executions.finish_execution(
+        record["id"],
+        success=False,
+        error=private_error,
+        error_code="execution_failed",
+    )
 
     assert failed["status"] == "failed"
-    assert failed["error"] == "provider exploded"
+    assert failed["error"] == "execution_failed"
+    assert private_error.encode() not in executions.EXECUTIONS_FILE.read_bytes()
+
+
+def test_delivery_outcome_is_categorical_metadata(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("job-delivery", source="builtin")
+
+    finished = executions.finish_execution(
+        record["id"],
+        success=True,
+        result_kind="silent",
+        exit_code=0,
+        delivery_requested=True,
+        delivery_attempted=False,
+        delivery_failed=False,
+    )
+
+    assert finished["status"] == "completed"
+    assert finished["result_kind"] == "silent"
+    assert finished["exit_code"] == 0
+    assert finished["delivery_requested"] == 1
+    assert finished["delivery_attempted"] == 0
+    assert finished["delivery_failed"] == 0
+
+
+def test_upgrade_scrubs_historical_raw_errors(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    private_error = "PRIVATE_LEGACY_ERROR_TEXT_9c41"
+    private_source = "PRIVATE_LEGACY_SOURCE_TEXT_a13d"
+    executions.EXECUTIONS_FILE.parent.mkdir(parents=True)
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as conn:
+        conn.execute(
+            """CREATE TABLE executions (
+                 id TEXT PRIMARY KEY, job_id TEXT NOT NULL, source TEXT NOT NULL,
+                 process_id TEXT NOT NULL, pid INTEGER NOT NULL,
+                 process_started_at INTEGER, status TEXT NOT NULL,
+                 claimed_at TEXT NOT NULL, started_at TEXT, finished_at TEXT,
+                 error TEXT
+               )"""
+        )
+        conn.execute(
+            """INSERT INTO executions VALUES
+               ('legacy-1','job-legacy',?,'old-process',1,NULL,'failed',
+                '2026-01-01T00:00:00+00:00',NULL,'2026-01-01T00:00:01+00:00',?)""",
+            (private_source, private_error),
+        )
+
+    rows = executions.list_executions(job_id="job-legacy")
+
+    assert rows[0]["error"] == "legacy_error_redacted"
+    assert rows[0]["source"] == "unknown"
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as conn:
+        assert conn.execute(
+            "SELECT value FROM schema_meta WHERE key='schema_version'"
+        ).fetchone()[0] == "5"
+    persisted = b"".join(
+        path.read_bytes()
+        for path in executions.EXECUTIONS_FILE.parent.glob("executions.db*")
+        if path.is_file()
+    )
+    assert private_error.encode() not in persisted
+    assert private_source.encode() not in persisted
+
+
+def test_busy_privacy_checkpoint_stays_retryable(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("busy-migration", source="builtin")
+    executions.finish_execution(record["id"], success=False)
+    private_error = "PRIVATE_BUSY_ERROR_4b17"
+    private_source = "PRIVATE_BUSY_SOURCE_5c28"
+    private_exit = "PRIVATE_BUSY_EXIT_6d39"
+
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as writer:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        writer.execute(
+            "UPDATE executions SET error=?,source=?,exit_code=? WHERE id=?",
+            (private_error, private_source, private_exit, record["id"]),
+        )
+        writer.execute(
+            "UPDATE schema_meta SET value='1' WHERE key='schema_version'"
+        )
+        writer.commit()
+        writer.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+    reader = sqlite3.connect(executions.EXECUTIONS_FILE)
+    reader.execute("BEGIN")
+    assert reader.execute(
+        "SELECT error FROM executions WHERE id=?", (record["id"],)
+    ).fetchone()[0] == private_error
+    try:
+        try:
+            executions.list_executions(job_id="busy-migration")
+        except sqlite3.OperationalError as exc:
+            assert "checkpoint" in str(exc).lower()
+        else:
+            raise AssertionError("busy privacy checkpoint was accepted")
+        with sqlite3.connect(executions.EXECUTIONS_FILE) as observer:
+            assert observer.execute(
+                "SELECT value FROM schema_meta WHERE key='schema_version'"
+            ).fetchone()[0] != "5"
+    finally:
+        reader.close()
+
+    migrated = executions.list_executions(job_id="busy-migration")
+    assert migrated[0]["error"] == "legacy_error_redacted"
+    assert migrated[0]["source"] == "unknown"
+    assert migrated[0]["exit_code"] is None
+    persisted = b"".join(
+        path.read_bytes()
+        for path in executions.EXECUTIONS_FILE.parent.glob("executions.db*")
+    )
+    assert private_error.encode() not in persisted
+    assert private_source.encode() not in persisted
+    assert private_exit.encode() not in persisted
+
+
+def test_schema_v4_genericizes_existing_chronos_source(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("legacy-external", source="builtin")
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as conn:
+        conn.execute("UPDATE executions SET source='chronos' WHERE id=?", (record["id"],))
+        conn.execute(
+            "UPDATE schema_meta SET value='4' WHERE key='schema_version'"
+        )
+
+    migrated = executions.latest_execution("legacy-external")
+
+    assert migrated is not None
+    assert migrated["source"] == "external"
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as conn:
+        assert conn.execute(
+            "SELECT value FROM schema_meta WHERE key='schema_version'"
+        ).fetchone()[0] == "5"
 
 
 def test_recovery_does_not_mark_live_process_execution_unknown(monkeypatch, tmp_path):
@@ -201,7 +409,8 @@ def test_restart_marks_interrupted_execution_unknown_without_requeue(tmp_path):
     assert records[0]["id"] == execution_id
     assert records[0]["status"] == "unknown"
     assert records[0]["finished_at"]
-    assert "restart" in records[0]["error"].lower()
+    assert records[0]["error"] == "scheduler_restarted"
+    assert records[0]["result_kind"] == "scheduler_restarted"
     # Recovery only classifies the old attempt. It must not manufacture a new
     # claimed record (which would imply an automatic retry).
     assert [r["status"] for r in records] == ["unknown"]
@@ -231,7 +440,8 @@ def test_generic_submit_failure_finishes_attempt_and_releases_guard(monkeypatch)
     assert finished == [
         ("exec-submit-fail", {
             "success": False,
-            "error": "Executor dispatch failed: executor rejected",
+            "error_code": "executor_dispatch_failed",
+            "result_kind": "executor_dispatch_failed",
         })
     ]
     assert "submit-fail" not in scheduler.get_running_job_ids()
@@ -267,6 +477,468 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
     assert events[0] == ("running", "exec-3")
     assert events[-1][0:2] == ("finish", "exec-3")
     assert events[-1][2]["success"] is True
+    assert events[-1][2]["result_kind"] == "output_produced"
+    assert events[-1][2]["exit_code"] == 0
+    assert events[-1][2]["delivery_requested"] is False
+    assert events[-1][2]["delivery_attempted"] is False
+    assert events[-1][2]["delivery_failed"] is False
+
+
+def test_local_only_delivery_list_is_not_requested(monkeypatch):
+    import cron.scheduler as scheduler
+
+    finished = []
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        scheduler,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda job, *, defer_agent_teardown=None: (True, "output", "response", None),
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
+
+    assert scheduler.run_one_job(
+        {"id": "job-local-list", "execution_id": "exec-local-list", "deliver": ["local"]}
+    ) is True
+
+    result = finished[-1][1]
+    assert result["delivery_requested"] is False
+    assert result["delivery_attempted"] is False
+
+
+def test_execution_failure_remains_primary_when_delivery_also_fails(monkeypatch):
+    import cron.scheduler as scheduler
+
+    finished = []
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        scheduler,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda job, *, defer_agent_teardown=None: (
+            False,
+            "output",
+            "failure response",
+            "PRIVATE_EXECUTION_ERROR_18cf",
+        ),
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda *_args, **_kwargs: "PRIVATE_DELIVERY_ERROR_29df",
+    )
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
+
+    assert scheduler.run_one_job(
+        {"id": "job-both-fail", "execution_id": "exec-both-fail", "deliver": "origin"}
+    ) is True
+
+    result = finished[-1][1]
+    assert result["success"] is False
+    assert result["result_kind"] == "execution_failed"
+    assert result["error_code"] == "execution_failed"
+    assert result["delivery_requested"] is True
+    assert result["delivery_attempted"] is True
+    assert result["delivery_failed"] is True
+    assert "PRIVATE" not in repr(result)
+
+
+def _fail_execution_creation(*_args, **_kwargs):
+    raise sqlite3.OperationalError("synthetic ledger failure")
+
+
+def test_ledger_creation_failure_restores_real_stale_cron_catchup(
+    monkeypatch, tmp_path
+):
+    from datetime import datetime, timezone
+
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    home = tmp_path / "home"
+    now = datetime(2026, 7, 18, 15, 30, tzinfo=timezone.utc)
+    old_due = "2026-07-16T14:00:00+00:00"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "create_execution", _fail_execution_creation)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(scheduler, "_interpreter_shutting_down", lambda *_args: False)
+
+    job = jobs.create_job(
+        prompt="stale catchup",
+        schedule="0 * * * *",
+        name="stale catchup",
+    )
+    stored = jobs.load_jobs()
+    stored[0]["next_run_at"] = old_due
+    jobs.save_jobs(stored)
+
+    assert scheduler.tick(verbose=False, sync=False) == 0
+
+    restored = jobs.get_job(job["id"])
+    assert restored["next_run_at"] == old_due
+    assert job["id"] not in scheduler.get_running_job_ids()
+
+
+def test_ledger_creation_failure_releases_real_builtin_oneshot_claim(
+    monkeypatch, tmp_path
+):
+    from datetime import datetime, timedelta, timezone
+
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    home = tmp_path / "home"
+    now = datetime(2026, 7, 18, 15, 30, tzinfo=timezone.utc)
+    due_at = (now - timedelta(seconds=10)).isoformat()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "create_execution", _fail_execution_creation)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(scheduler, "_interpreter_shutting_down", lambda *_args: False)
+
+    job = jobs.create_job(prompt="one shot", schedule=due_at, name="one shot")
+
+    assert scheduler.tick(verbose=False, sync=False) == 0
+
+    restored = jobs.get_job(job["id"])
+    assert restored["next_run_at"] == due_at
+    assert restored.get("run_claim") is None
+    assert job["id"] not in scheduler.get_running_job_ids()
+
+
+def test_external_ledger_creation_failure_restores_claim_and_schedule(
+    monkeypatch, tmp_path
+):
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+    from cron.scheduler_provider import CronScheduler
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    job = jobs.create_job(prompt="external", schedule="every 1h", name="external")
+    before = jobs.get_job(job["id"])
+    dispatched = []
+    monkeypatch.setattr(executions, "create_execution", _fail_execution_creation)
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda *_args, **_kwargs: dispatched.append(True) or True,
+    )
+
+    class ExternalScheduler(CronScheduler):
+        @property
+        def name(self):
+            return "external-test"
+
+        def start(self, stop_event, **kwargs):
+            return None
+
+    try:
+        ExternalScheduler().fire_due(job["id"])
+    except sqlite3.OperationalError:
+        pass
+    else:
+        raise AssertionError("ledger creation failure must propagate")
+
+    restored = jobs.get_job(job["id"])
+    assert restored["next_run_at"] == before["next_run_at"]
+    assert restored.get("fire_claim") == before.get("fire_claim")
+    assert dispatched == []
+
+
+def test_dispatch_rollback_refuses_to_clobber_concurrent_claim(monkeypatch, tmp_path):
+    import cron.jobs as jobs
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    job = jobs.create_job(prompt="race", schedule="every 1h", name="race")
+    receipt = jobs.claim_job_for_fire_with_receipt(job["id"])
+    assert receipt is not None
+
+    concurrent_claim = {"at": "2026-07-18T18:00:00+00:00", "by": "other:42"}
+    stored = jobs.load_jobs()
+    stored[0]["fire_claim"] = concurrent_claim
+    jobs.save_jobs(stored)
+
+    assert jobs.restore_job_dispatch_state(receipt) is False
+    assert jobs.get_job(job["id"])["fire_claim"] == concurrent_claim
+
+
+def test_tick_does_not_adopt_or_rollback_concurrent_schedule_change(
+    monkeypatch, tmp_path
+):
+    from datetime import datetime, timedelta, timezone
+
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    now = datetime(2026, 7, 18, 15, 30, tzinfo=timezone.utc)
+    due_at = (now - timedelta(seconds=10)).isoformat()
+    concurrent_next = "2031-09-09T09:09:09+00:00"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "create_execution", _fail_execution_creation)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(scheduler, "_interpreter_shutting_down", lambda *_args: False)
+
+    job = jobs.create_job(prompt="schedule race", schedule="every 1h", name="schedule race")
+    stored = jobs.load_jobs()
+    stored[0]["next_run_at"] = due_at
+    jobs.save_jobs(stored)
+
+    original_refresh = scheduler.refresh_dispatch_receipt
+
+    def refresh_after_concurrent_schedule_write(job_id, receipt):
+        current = jobs.load_jobs()
+        current[0]["next_run_at"] = concurrent_next
+        jobs.save_jobs(current)
+        return original_refresh(job_id, receipt)
+
+    monkeypatch.setattr(
+        scheduler,
+        "refresh_dispatch_receipt",
+        refresh_after_concurrent_schedule_write,
+    )
+
+    try:
+        scheduler.tick(verbose=False, sync=False)
+    except RuntimeError:
+        pass
+
+    assert jobs.get_job(job["id"])["next_run_at"] == concurrent_next
+
+
+def test_tick_unwinds_earlier_jobs_when_later_preparation_becomes_ambiguous(
+    monkeypatch, tmp_path
+):
+    from datetime import datetime, timedelta, timezone
+
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    now = datetime(2026, 7, 18, 15, 30, tzinfo=timezone.utc)
+    due_at = (now - timedelta(seconds=10)).isoformat()
+    concurrent_next = "2034-04-04T04:04:04+00:00"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(scheduler, "_interpreter_shutting_down", lambda *_args: False)
+
+    first = jobs.create_job(prompt="first", schedule="every 1h", name="first")
+    second = jobs.create_job(prompt="second", schedule="every 1h", name="second")
+    stored = jobs.load_jobs()
+    for item in stored:
+        item["next_run_at"] = due_at
+    jobs.save_jobs(stored)
+
+    ledger_calls = []
+    dispatch_calls = []
+    monkeypatch.setattr(
+        scheduler,
+        "create_execution",
+        lambda *_args, **_kwargs: ledger_calls.append(True),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda *_args, **_kwargs: dispatch_calls.append(True),
+    )
+    original_refresh = scheduler.refresh_dispatch_receipt
+    refresh_count = 0
+
+    def race_on_second_refresh(job_id, receipt):
+        nonlocal refresh_count
+        refresh_count += 1
+        if refresh_count == 2:
+            current = jobs.load_jobs()
+            for item in current:
+                if item["id"] == job_id:
+                    item["next_run_at"] = concurrent_next
+            jobs.save_jobs(current)
+        return original_refresh(job_id, receipt)
+
+    monkeypatch.setattr(scheduler, "refresh_dispatch_receipt", race_on_second_refresh)
+
+    error = None
+    try:
+        scheduler.tick(verbose=False, sync=False)
+    except RuntimeError as exc:
+        error = str(exc)
+
+    assert error is not None
+    assert second["id"] in error
+    assert first["id"] not in error
+    assert jobs.get_job(first["id"])["next_run_at"] == due_at
+    assert jobs.get_job(second["id"])["next_run_at"] == concurrent_next
+    assert ledger_calls == []
+    assert dispatch_calls == []
+
+
+def test_tick_unwinds_later_jobs_after_ambiguous_submission_failure(
+    monkeypatch, tmp_path
+):
+    from datetime import datetime, timedelta, timezone
+
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    now = datetime(2026, 7, 18, 15, 30, tzinfo=timezone.utc)
+    due_at = (now - timedelta(seconds=10)).isoformat()
+    concurrent_next = "2035-05-05T05:05:05+00:00"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(scheduler, "_interpreter_shutting_down", lambda *_args: False)
+
+    first = jobs.create_job(prompt="first submit", schedule="every 1h", name="first submit")
+    second = jobs.create_job(prompt="second submit", schedule="every 1h", name="second submit")
+    stored = jobs.load_jobs()
+    for item in stored:
+        item["next_run_at"] = due_at
+    jobs.save_jobs(stored)
+
+    ledger_calls = []
+    dispatch_calls = []
+
+    def fail_first_ledger(job_id, **_kwargs):
+        ledger_calls.append(job_id)
+        current = jobs.load_jobs()
+        for item in current:
+            if item["id"] == job_id:
+                item["next_run_at"] = concurrent_next
+        jobs.save_jobs(current)
+        raise sqlite3.OperationalError("ledger unavailable")
+
+    monkeypatch.setattr(scheduler, "create_execution", fail_first_ledger)
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda *_args, **_kwargs: dispatch_calls.append(True),
+    )
+
+    error = None
+    try:
+        scheduler.tick(verbose=False, sync=False)
+    except RuntimeError as exc:
+        error = str(exc)
+
+    assert error is not None
+    assert first["id"] in error
+    assert jobs.get_job(first["id"])["next_run_at"] == concurrent_next
+    assert jobs.get_job(second["id"])["next_run_at"] == due_at
+    assert ledger_calls == [first["id"]]
+    assert dispatch_calls == []
+
+
+def test_tick_restores_prepared_jobs_when_interpreter_is_shutting_down(
+    monkeypatch, tmp_path
+):
+    from datetime import datetime, timedelta, timezone
+
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    now = datetime(2026, 7, 18, 15, 30, tzinfo=timezone.utc)
+    due_at = (now - timedelta(seconds=10)).isoformat()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(scheduler, "_interpreter_shutting_down", lambda *_args: True)
+
+    first = jobs.create_job(prompt="shutdown one", schedule="every 1h", name="shutdown one")
+    second = jobs.create_job(prompt="shutdown two", schedule="every 1h", name="shutdown two")
+    stored = jobs.load_jobs()
+    for item in stored:
+        item["next_run_at"] = due_at
+    jobs.save_jobs(stored)
+
+    ledger_calls = []
+    dispatch_calls = []
+    monkeypatch.setattr(
+        scheduler,
+        "create_execution",
+        lambda *_args, **_kwargs: ledger_calls.append(True),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda *_args, **_kwargs: dispatch_calls.append(True),
+    )
+
+    assert scheduler.tick(verbose=False, sync=False) == 0
+
+    assert jobs.get_job(first["id"])["next_run_at"] == due_at
+    assert jobs.get_job(second["id"])["next_run_at"] == due_at
+    assert ledger_calls == []
+    assert dispatch_calls == []
+
+
+def test_tick_restores_new_occurrence_when_previous_run_is_still_active(
+    monkeypatch, tmp_path
+):
+    from datetime import datetime, timedelta, timezone
+
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    now = datetime(2026, 7, 18, 15, 30, tzinfo=timezone.utc)
+    due_at = (now - timedelta(seconds=10)).isoformat()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(scheduler, "_interpreter_shutting_down", lambda *_args: False)
+
+    job = jobs.create_job(prompt="long running", schedule="every 1h", name="long running")
+    running = executions.create_execution(job["id"], source="builtin")
+    executions.mark_execution_running(running["id"])
+    stored = jobs.load_jobs()
+    stored[0]["next_run_at"] = due_at
+    jobs.save_jobs(stored)
+
+    ledger_calls = []
+    dispatch_calls = []
+    monkeypatch.setattr(
+        scheduler,
+        "create_execution",
+        lambda *_args, **_kwargs: ledger_calls.append(True),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda *_args, **_kwargs: dispatch_calls.append(True),
+    )
+
+    scheduler._running_job_ids.add(job["id"])
+    try:
+        assert scheduler.tick(verbose=False, sync=False) == 0
+    finally:
+        scheduler._running_job_ids.discard(job["id"])
+
+    assert jobs.get_job(job["id"])["next_run_at"] == due_at
+    assert len(executions.list_executions(job_id=job["id"])) == 1
+    assert ledger_calls == []
+    assert dispatch_calls == []
 
 
 def test_provider_start_recovers_interrupted_records_before_tick(monkeypatch):

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -82,8 +82,17 @@ class TestRunningJobGuard:
         sched._running_job_ids.add("guard-job")
 
         dispatched = []
+        receipt = {"job_id": "guard-job"}
+        restored = []
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
-        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sched, "pop_dispatch_receipt", lambda _job: receipt)
+        monkeypatch.setattr(sched, "prepare_dispatch_receipt", lambda *_a, **_kw: True)
+        monkeypatch.setattr(sched, "refresh_dispatch_receipt", lambda *_a, **_kw: True)
+        monkeypatch.setattr(
+            sched,
+            "restore_job_dispatch_state",
+            lambda value: restored.append(value) or True,
+        )
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: dispatched.append(j["id"]) or (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
@@ -92,6 +101,7 @@ class TestRunningJobGuard:
         n = sched.tick(verbose=False)
         assert n == 0  # skipped, not dispatched
         assert dispatched == []
+        assert restored == [receipt]
 
         sched._running_job_ids.discard("guard-job")
         sched._shutdown_parallel_pool()
@@ -247,8 +257,17 @@ class TestSequentialPool:
         sched._running_job_ids.add("guard-seq")
 
         dispatched = []
+        receipt = {"job_id": "guard-seq"}
+        restored = []
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
-        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sched, "pop_dispatch_receipt", lambda _job: receipt)
+        monkeypatch.setattr(sched, "prepare_dispatch_receipt", lambda *_a, **_kw: True)
+        monkeypatch.setattr(sched, "refresh_dispatch_receipt", lambda *_a, **_kw: True)
+        monkeypatch.setattr(
+            sched,
+            "restore_job_dispatch_state",
+            lambda value: restored.append(value) or True,
+        )
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: dispatched.append(j["id"]) or (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
@@ -257,6 +276,7 @@ class TestSequentialPool:
         n = sched.tick(verbose=False)
         assert n == 0  # skipped, not dispatched
         assert dispatched == []
+        assert restored == [receipt]
 
         sched._running_job_ids.discard("guard-seq")
         sched._shutdown_parallel_pool()

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -358,13 +358,19 @@ def test_builtin_inherits_hook_defaults():
 def test_fire_due_default_claims_then_runs(monkeypatch):
     """The default fire_due claims via the store CAS, fetches the job, and runs
     it through the shared run_one_job body."""
+    import cron.executions as executions
     import cron.jobs as jobs
     import cron.scheduler as sched
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
-    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: True, raising=False)
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire_with_receipt",
+        lambda jid: {"job_id": jid},
+    )
     monkeypatch.setattr(jobs, "get_job", lambda jid: {"id": jid, "name": "t"})
+    monkeypatch.setattr(executions, "create_execution", lambda *_a, **_kw: {"id": "exec-1"})
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
 
     assert InProcessCronScheduler().fire_due("j1") is True
@@ -379,7 +385,7 @@ def test_fire_due_lost_claim_does_not_run(monkeypatch):
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
-    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: False, raising=False)
+    monkeypatch.setattr(jobs, "claim_job_for_fire_with_receipt", lambda jid: None)
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
 
     assert InProcessCronScheduler().fire_due("j1") is False
@@ -394,7 +400,11 @@ def test_fire_due_missing_job_does_not_run(monkeypatch):
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
-    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: True, raising=False)
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire_with_receipt",
+        lambda jid: {"job_id": jid},
+    )
     monkeypatch.setattr(jobs, "get_job", lambda jid: None)
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
 

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -7,6 +7,7 @@ last_run_at stayed null forever. Now action='run' claims the job (at-most-once,
 blocking a concurrent tick) and fires it inline via the shared run_one_job body.
 """
 import json
+import sqlite3
 from unittest.mock import patch
 
 from tools.cronjob_tools import cronjob, _execute_job_now
@@ -21,7 +22,8 @@ class TestCronjobRunExecutesImmediately:
         """action='run' must claim the job then fire it through run_one_job."""
         ran = {"job": "after-run", "last_status": "ok", "last_error": None}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
+             patch("tools.cronjob_tools.claim_job_for_fire_with_receipt", return_value={"job_id": "job-run-1"}) as m_claim, \
+             patch("cron.scheduler.create_execution", return_value={"id": "exec-direct"}), \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=ran):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -35,7 +37,7 @@ class TestCronjobRunExecutesImmediately:
     def test_run_skips_when_claim_lost(self):
         """If the scheduler already holds the fire claim, do NOT double-run."""
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+             patch("tools.cronjob_tools.claim_job_for_fire_with_receipt", return_value=None), \
              patch("cron.scheduler.run_one_job") as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -50,7 +52,8 @@ class TestCronjobRunExecutesImmediately:
         """A failed run is reported via the re-read job's last_status/last_error."""
         failed = {"id": "job-run-1", "last_status": "error", "last_error": "provider 500"}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("tools.cronjob_tools.claim_job_for_fire_with_receipt", return_value={"job_id": "job-run-1"}), \
+             patch("cron.scheduler.create_execution", return_value={"id": "exec-direct"}), \
              patch("cron.scheduler.run_one_job", return_value=True), \
              patch("tools.cronjob_tools.get_job", return_value=failed):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -61,16 +64,55 @@ class TestCronjobRunExecutesImmediately:
 
     def test_execute_job_now_bails_without_claim(self):
         """_execute_job_now never calls run_one_job when the claim is lost."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+        with patch("tools.cronjob_tools.claim_job_for_fire_with_receipt", return_value=None), \
              patch("cron.scheduler.run_one_job") as m_run:
             res = _execute_job_now(dict(_JOB))
         assert res["claimed"] is False
         assert res["success"] is False
         m_run.assert_not_called()
 
+    def test_direct_ledger_failure_restores_claim_without_failure_metadata(
+        self, monkeypatch, tmp_path
+    ):
+        import cron.jobs as jobs
+        import cron.scheduler as scheduler
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        job = jobs.create_job(
+            prompt="manual ledger failure",
+            schedule="every 1h",
+            name="manual ledger failure",
+        )
+        before = jobs.get_job(job["id"])
+        side_effects = []
+        monkeypatch.setattr(
+            scheduler,
+            "create_execution",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                sqlite3.OperationalError("ledger unavailable")
+            ),
+        )
+        monkeypatch.setattr(
+            scheduler,
+            "run_job",
+            lambda *_args, **_kwargs: side_effects.append(True),
+        )
+
+        result = _execute_job_now(job)
+
+        after = jobs.get_job(job["id"])
+        assert result["claimed"] is True
+        assert result["success"] is False
+        assert after["next_run_at"] == before["next_run_at"]
+        assert after.get("fire_claim") == before.get("fire_claim")
+        assert after.get("last_status") == before.get("last_status")
+        assert after.get("last_error") == before.get("last_error")
+        assert side_effects == []
+
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+        with patch("tools.cronjob_tools.claim_job_for_fire_with_receipt", return_value={"job_id": "job-run-1"}), \
+             patch("cron.scheduler.create_execution", return_value={"id": "exec-direct"}), \
              patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
              patch("tools.cronjob_tools.mark_job_run") as m_mark, \
              patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -21,7 +21,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cron.jobs import (
     AmbiguousJobReference,
-    claim_job_for_fire,
+    claim_job_for_fire_with_receipt,
     create_job,
     get_job,
     list_jobs,
@@ -30,6 +30,7 @@ from cron.jobs import (
     pause_job,
     remove_job,
     resolve_job_ref,
+    restore_job_dispatch_state,
     resume_job,
     update_job,
 )
@@ -602,43 +603,46 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
-    """Execute a cron job immediately, outside the scheduler tick.
+    """Claim and execute a cron job immediately outside the scheduler tick.
 
-    Atomically claims the job first via ``claim_job_for_fire`` — the same
-    at-most-once CAS the scheduler/external-provider fire path uses — so a
-    concurrently-running gateway ticker cannot also fire it (the claim both
-    blocks a duplicate fire and advances ``next_run_at`` for recurring jobs).
-    If the claim is lost (another fire is in flight), this is a no-op.
-
-    The actual firing is delegated to ``run_one_job`` — the single shared
-    execute→save→deliver→mark body the ticker and external providers use — so
-    failure delivery, ``[SILENT]`` handling, and live-adapter delivery stay
-    identical across paths and can't drift.
-
-    Returns {"claimed": bool, "success": bool, "error": str|None}.
+    The durable execution row is mandatory: if ledger creation fails, restore
+    the exact claim/schedule state with the claim receipt and do not dispatch.
     """
     job_id = job["id"]
+    from cron.scheduler import create_execution, run_one_job
+
+    receipt = claim_job_for_fire_with_receipt(job_id)
+    if receipt is None:
+        # The claim helper also returns None for paused/disabled/missing jobs;
+        # distinguish those from a genuine competing fire for honest UX.
+        refreshed = get_job(job_id)
+        if refreshed is None:
+            reason = "Job no longer exists; nothing to run."
+        elif not refreshed.get("enabled", True) or refreshed.get("state") == "paused":
+            reason = "Job is paused/disabled; resume it before running."
+        else:
+            reason = "Job is already being fired by the scheduler; not run again."
+        return {"claimed": False, "success": False, "error": reason}
+
     try:
-        from cron.scheduler import run_one_job
+        execution_id = create_execution(job_id, source="direct")["id"]
+    except Exception as ledger_err:
+        if not restore_job_dispatch_state(receipt):
+            raise RuntimeError(
+                f"ledger creation failed and direct dispatch state for job {job_id} "
+                "could not be authenticated and restored"
+            ) from ledger_err
+        logger.error(
+            "Job %s not dispatched immediately — execution ledger creation failed (%s)",
+            job_id,
+            type(ledger_err).__name__,
+        )
+        return {"claimed": True, "success": False, "error": str(ledger_err)}
 
-        # At-most-once claim: bail without running if a tick/other fire owns it.
-        if not claim_job_for_fire(job_id):
-            # claim_job_for_fire returns False for paused/disabled/missing
-            # jobs too — don't mislabel those as "already being fired"
-            # (#60703): that message sends the user chasing a phantom
-            # in-flight run when the job simply isn't runnable.
-            refreshed = get_job(job_id)
-            if refreshed is None:
-                reason = "Job no longer exists; nothing to run."
-            elif not refreshed.get("enabled", True) or refreshed.get("state") == "paused":
-                reason = "Job is paused/disabled; resume it before running."
-            else:
-                reason = "Job is already being fired by the scheduler; not run again."
-            return {"claimed": False, "success": False, "error": reason}
-
-        # run_one_job records last_run_at/last_status via mark_job_run (which
-        # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
+    try:
+        # run_one_job records last_run_at/last_status via mark_job_run and clears
+        # the fire claim. Supplying execution_id prevents a second ledger claim.
+        processed = run_one_job(dict(job, execution_id=execution_id))
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
         return {
@@ -646,7 +650,6 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
             "success": bool(processed and ok),
             "error": refreshed.get("last_error"),
         }
-
     except Exception as e:
         logger.error("Failed to execute cron job %s immediately: %s", job_id, e)
         try:


### PR DESCRIPTION
## Summary

Hardens the recently added cron execution-attempt ledger (`d9dd05b69`, `abc22cdf1`) so durable history remains useful without becoming a second store for arbitrary provider, exception, or delivery text.

## Problem

The current ledger persists raw `error` strings. Those strings can include provider details or other high-entropy runtime text and remain in SQLite after transient logs/output are gone. The store also has no explicit schema version or privacy migration.

A durable-ledger failure must prevent dispatch without consuming the due occurrence. Built-in stale catch-up, external-provider claims, and direct/manual `cron run` all mutate scheduler state before dispatch, so rollback must cover `next_run_at`, `run_claim`, and `fire_claim` without overwriting a concurrent writer.

## Changes

- migrate the execution store to schema 5 with retryable, transactional normalization;
- replace historical arbitrary errors with bounded categorical codes;
- persist bounded `result_kind`, exit-code, and delivery requested/attempted/failed metadata;
- normalize source values while keeping `finish_execution(error=...)` caller-compatible without persisting free-form text;
- enforce owner-only permissions on the cron directory, database, WAL, and SHM;
- fail closed before executor dispatch if a durable execution row cannot be written;
- attach non-persisted dispatch receipts to built-in due jobs and strip them before execution;
- CAS-restore `next_run_at`, `run_claim`, and `fire_claim` after ledger creation failure;
- apply the same receipt/rollback contract to external-provider and direct/manual claims;
- create the direct/manual execution row before dispatch and pass its `execution_id` into the shared runner;
- refuse ambiguous rollback rather than clobber state changed by another writer;
- display bounded result/delivery metadata through `hermes cron runs`.

The ledger stores no prompt, output, response body, model/provider identifier, route, destination, or arbitrary exception text.

## Files modified

- `cron/executions.py` — Schema migration, error categorization, secure storage
- `cron/jobs.py` — Dispatch receipts, CAS-restore rollback, receipt-aware claims
- `cron/scheduler.py` — Receipt lifecycle integration, ledger-failure rollback
- `cron/scheduler_provider.py` — External-provider receipt/rollback
- `hermes_cli/cron.py` — Bounded result/delivery display
- `tools/cronjob_tools.py` — Direct execution ledger row + rollback
- `tests/cron/test_execution_ledger.py` — 688 lines of regressions
- `tests/cron/test_parallel_pool.py` — Receipt-aware running-guard tests
- `tests/cron/test_scheduler_provider.py` — Receipt-aware fire_due tests
- `tests/tools/test_cronjob_run_immediate.py` — Direct/manual rollback test

Closes #67085