### PR TITLE
fix(acp): materialize binary prompt attachments into the document cache instead of dropping them

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -213,6 +213,21 @@ def _format_resource_text(
     return f"{header}\nURI: {uri}\n\n{body}"
 
 
+def _save_attachment_to_cache(data: bytes, display_name: str) -> str | None:
+    """Materialize undeliverable attachment bytes into the document cache.
+
+    Returns the saved path, or None when saving fails — an attachment must
+    never fail the prompt; callers fall back to the omit placeholder.
+    """
+    try:
+        from gateway.platforms.base import cache_document_from_bytes
+
+        return cache_document_from_bytes(data, display_name or "attachment.bin")
+    except Exception:
+        logger.warning("Could not persist ACP attachment %r", display_name, exc_info=True)
+        return None
+
+
 def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]:
     """Convert an ACP resource_link block to OpenAI content parts.
 
@@ -254,7 +269,10 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
                         uri=uri,
                         name=name,
                         title=title,
-                        body=f"[Image too large to inline: {size} bytes, cap={_MAX_ACP_RESOURCE_BYTES}]",
+                        body=(
+                            f"[Image too large to inline: {size} bytes, "
+                            f"cap={_MAX_ACP_RESOURCE_BYTES}. File is at {path}.]"
+                        ),
                     ),
                 }]
             with path.open("rb") as fh:
@@ -289,7 +307,11 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
                     uri=uri,
                     name=name,
                     title=title,
-                    body=f"[Binary file omitted: {size} bytes, mime={mime_type or 'unknown'}]",
+                    body=(
+                        f"[Binary file at {path} — {size} bytes, "
+                        f"mime={mime_type or 'unknown'}. Not inlined; use your tools "
+                        f"to read or process it.]"
+                    ),
                 ),
             }]
         note = None
@@ -333,12 +355,18 @@ def _embedded_resource_to_parts(block: EmbeddedResourceContentBlock) -> list[dic
         # Image blobs go through as image_url so vision models can see them.
         if _is_image_resource(mime_type):
             if len(data) > _MAX_ACP_RESOURCE_BYTES:
+                saved = _save_attachment_to_cache(data, _resource_display_name(uri) or "attachment.bin")
+                if saved is not None:
+                    body = (
+                        f"[Embedded image too large to inline: {len(data)} bytes, "
+                        f"cap={_MAX_ACP_RESOURCE_BYTES}. Image saved to {saved} — "
+                        f"use your tools to read or process it.]"
+                    )
+                else:
+                    body = f"[Embedded image too large to inline: {len(data)} bytes, cap={_MAX_ACP_RESOURCE_BYTES}]"
                 return [{
                     "type": "text",
-                    "text": _format_resource_text(
-                        uri=uri,
-                        body=f"[Embedded image too large to inline: {len(data)} bytes, cap={_MAX_ACP_RESOURCE_BYTES}]",
-                    ),
+                    "text": _format_resource_text(uri=uri, body=body),
                 }]
             display = _resource_display_name(uri)
             return [
@@ -348,11 +376,22 @@ def _embedded_resource_to_parts(block: EmbeddedResourceContentBlock) -> list[dic
 
         text = _decode_text_bytes(data[:_MAX_ACP_RESOURCE_BYTES], mime_type)
         if text is None:
-            body = f"[Binary embedded file omitted: {len(data)} bytes, mime={mime_type or 'unknown'}]"
+            saved = _save_attachment_to_cache(data, _resource_display_name(uri) or "attachment.bin")
+            if saved is not None:
+                body = (
+                    f"[Binary attachment saved to {saved} — {len(data)} bytes, "
+                    f"mime={mime_type or 'unknown'}. Use your tools to read or process it.]"
+                )
+            else:
+                body = f"[Binary embedded file omitted: {len(data)} bytes, mime={mime_type or 'unknown'}]"
         else:
             body = text
             if len(data) > _MAX_ACP_RESOURCE_BYTES:
-                body += f"\n\n[Truncated to {_MAX_ACP_RESOURCE_BYTES} of {len(data)} bytes]"
+                note = f"[Truncated to {_MAX_ACP_RESOURCE_BYTES} of {len(data)} bytes"
+                saved = _save_attachment_to_cache(data, _resource_display_name(uri) or "attachment.bin")
+                if saved is not None:
+                    note += f"; full file saved to {saved}"
+                body += f"\n\n{note}]"
         return [{"type": "text", "text": _format_resource_text(uri=uri, body=body)}]
 
     text = getattr(resource, "text", None)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1,7 +1,10 @@
 """Tests for acp_adapter.server — HermesACPAgent ACP server."""
 
 import asyncio
+import base64
 import os
+import re
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 
@@ -1903,3 +1906,127 @@ class TestRegisterSessionMcpServers:
         with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])
+
+
+class TestBinaryAttachmentPersistence:
+    """Binary prompt attachments must be materialized into the document
+    cache and the model pointed at the saved path — not dropped."""
+
+    @staticmethod
+    def _make_embedded_blob_block(name, blob, mime_type):
+        from acp.schema import BlobResourceContents, EmbeddedResourceContentBlock
+
+        return EmbeddedResourceContentBlock(
+            type="resource",
+            resource=BlobResourceContents(uri=name, blob=blob, mime_type=mime_type),
+        )
+
+    def test_embedded_binary_blob_saved_not_dropped(self, tmp_path, monkeypatch):
+        from acp_adapter import server as server_mod
+
+        monkeypatch.setattr(
+            "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
+        )
+        block = self._make_embedded_blob_block(
+            name="trace.json.gz",
+            blob=base64.b64encode(b"\x1f\x8b" + b"\x00" * 64).decode(),
+            mime_type="application/x-gzip",
+        )
+        parts = server_mod._embedded_resource_to_parts(block)
+        assert len(parts) == 1 and parts[0]["type"] == "text"
+        assert "omitted" not in parts[0]["text"]
+        assert "saved to" in parts[0]["text"]
+        saved = re.search(r"saved to (\S+)", parts[0]["text"]).group(1)
+        assert Path(saved).read_bytes()[:2] == b"\x1f\x8b"
+        assert "trace.json.gz" in Path(saved).name
+
+    def test_embedded_binary_blob_save_failure_falls_back(self, monkeypatch):
+        from acp_adapter import server as server_mod
+
+        def _boom(data, filename):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("gateway.platforms.base.cache_document_from_bytes", _boom)
+        block = self._make_embedded_blob_block(
+            name="x.bin",
+            blob=base64.b64encode(b"\x00\x01").decode(),
+            mime_type="application/octet-stream",
+        )
+        parts = server_mod._embedded_resource_to_parts(block)
+        assert "omitted" in parts[0]["text"]
+
+    def test_oversized_image_blob_saved_with_path(self, tmp_path, monkeypatch):
+        from acp_adapter import server as server_mod
+
+        monkeypatch.setattr(
+            "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
+        )
+        data = b"\x89PNG" + b"\x00" * (server_mod._MAX_ACP_RESOURCE_BYTES + 1)
+        block = self._make_embedded_blob_block(
+            name="big.png",
+            blob=base64.b64encode(data).decode(),
+            mime_type="image/png",
+        )
+        parts = server_mod._embedded_resource_to_parts(block)
+        assert len(parts) == 1 and parts[0]["type"] == "text"
+        assert "too large to inline" in parts[0]["text"]
+        assert "saved to" in parts[0]["text"]
+        saved = re.search(r"saved to (\S+)", parts[0]["text"]).group(1)
+        assert Path(saved).read_bytes()[:4] == b"\x89PNG"
+
+    def test_oversized_text_blob_notes_full_file_path(self, tmp_path, monkeypatch):
+        from acp_adapter import server as server_mod
+
+        monkeypatch.setattr(
+            "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
+        )
+        data = b"a" * (server_mod._MAX_ACP_RESOURCE_BYTES + 10)
+        block = self._make_embedded_blob_block(
+            name="big.txt",
+            blob=base64.b64encode(data).decode(),
+            mime_type="text/plain",
+        )
+        parts = server_mod._embedded_resource_to_parts(block)
+        assert "full file saved to" in parts[0]["text"]
+        saved = re.search(r"full file saved to (\S+?)\]?$", parts[0]["text"], re.M).group(1)
+        assert Path(saved).stat().st_size == len(data)
+
+
+class TestResourceLinkPathDisclosure:
+    """Non-inlined resource links must name the on-disk path so the model
+    can use its tools on the file (no copying — the file already exists)."""
+
+    @staticmethod
+    def _make_link_block(path, mime_type=None, name=None):
+        from acp.schema import ResourceContentBlock
+
+        return ResourceContentBlock(
+            type="resource_link",
+            uri=path.as_uri(),
+            name=name or path.name,
+            mime_type=mime_type,
+        )
+
+    def test_binary_file_link_includes_path(self, tmp_path):
+        from acp_adapter import server as server_mod
+
+        f = tmp_path / "blob.bin"
+        f.write_bytes(b"\x00\x01\x02\x03")
+        parts = server_mod._resource_link_to_parts(
+            self._make_link_block(f, mime_type="application/octet-stream")
+        )
+        assert len(parts) == 1 and parts[0]["type"] == "text"
+        assert str(f) in parts[0]["text"]
+        assert "use your tools" in parts[0]["text"].lower()
+
+    def test_oversized_image_link_includes_path(self, tmp_path):
+        from acp_adapter import server as server_mod
+
+        f = tmp_path / "big.png"
+        f.write_bytes(b"\x89PNG" + b"\x00" * (server_mod._MAX_ACP_RESOURCE_BYTES + 1))
+        parts = server_mod._resource_link_to_parts(
+            self._make_link_block(f, mime_type="image/png")
+        )
+        assert len(parts) == 1 and parts[0]["type"] == "text"
+        assert "too large to inline" in parts[0]["text"]
+        assert f"File is at {f}" in parts[0]["text"]


### PR DESCRIPTION
## What & why

Binary prompt attachments sent over ACP as embedded-resource blobs are currently discarded: the model receives only a dead-end placeholder like `[Binary embedded file omitted: 1610685 bytes, mime=application/x-gzip]` and can do nothing with the file. Hit in practice when attaching a 1.6 MB `Trace-*.json.gz` from an ACP editor client — the client delivered the blob correctly, the adapter decoded it, then threw the bytes away.

This completes the effort started in 1d98f8dd95 ("fix(mcp): materialize ResourceLink/EmbeddedResource/Audio blocks instead of dropping them") on the surface it missed: ACP *prompt* content blocks. Same approach, same helper.

Changes in `acp_adapter/server.py`:

- New `_save_attachment_to_cache(data, display_name)` — thin wrapper over `gateway.platforms.base.cache_document_from_bytes` (lazy import, the same pattern `tools/mcp_tool.py` uses). Catches all exceptions and returns `None`: an attachment must never fail the prompt; callers fall back to the previous omit placeholder.
- `_embedded_resource_to_parts`:
  - binary blob → bytes saved to the document cache, text part becomes `[Binary attachment saved to <path> — N bytes, mime=…. Use your tools to read or process it.]`
  - image blob over `_MAX_ACP_RESOURCE_BYTES` → saved, "too large to inline" phrasing kept so the model knows it can't *see* it but can open it
  - text blob over the cap → truncation note gains `; full file saved to <path>`
- `_resource_link_to_parts` (file already exists on disk — no copying): the binary-omit and oversized-image placeholders now name the resolved filesystem path so the model can use its file tools on it.

`_MAX_ACP_RESOURCE_BYTES` continues to govern inlining only. Saved files inherit the document cache's existing name sanitization, `doc_{uuid12}_` prefixing, traversal rejection, and 24 h TTL cleanup.

## How to test

```
scripts/run_tests.sh tests/acp/test_server.py -q
```

New tests: `TestBinaryAttachmentPersistence` (4: binary blob saved + name hint preserved, save-failure falls back to omit placeholder without failing the prompt, oversized image blob saved with path, oversized text blob notes full-file path) and `TestResourceLinkPathDisclosure` (2: binary file link and oversized image link name the on-disk path).

Manual: from an ACP client (e.g. Zed or a VS Code ACP extension), attach a binary file (`.gz`, `.xlsx`, …) to a prompt. The user message content should show `[Binary attachment saved to …/cache/documents/doc_…_<name>]` and the agent can read/process the file with its tools.

## Platforms tested

Linux fully verified (`tests/acp/` 88 passed on this branch; `scripts/check-windows-footguns.py` clean on both touched files). Windows/macOS not manually tested — no new platform-specific primitives; all filesystem writes go through the existing `cache_document_from_bytes` helper.

## Related

- Completes 1d98f8dd95 (MCP tool-result materialization) on the ACP prompt surface.
- #26607 (advertise embedded prompt context), #21731 (invalid base64 image blob), #16494 (`_extract_text` @-references) — same file, independent concerns; no overlap with the omit branches touched here.