### PR TITLE
fix(plugins/honcho): monkeypatch SDK to ignore new server fields

### DIFF
--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -1,7 +1,7 @@
 # nix/tui.nix — Hermes TUI (Ink/React) compiled with tsc and bundled
 { pkgs, hermesNpmLib, ... }:
 let
-  npm = hermesNpmLib.mkNpmPassthru { dirs = [ "ui-tui" ]; };
+  npm = hermesNpmLib.mkNpmPassthru { dirs = [ "ui-tui" "apps/shared" ]; };
 
   packageJson = builtins.fromJSON (builtins.readFile (npm.src + "/ui-tui/package.json"));
   version = packageJson.version;

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -16,6 +16,18 @@ from plugins.memory.honcho.client import get_honcho_client
 if TYPE_CHECKING:
     from honcho import Honcho
 
+# Workaround for issue #67013: newer Honcho servers send fields (like observe_others)
+# that the honcho-ai<=2.2.0 SDK strictly rejects. We monkeypatch the Pydantic models
+# to ignore extra fields until the upstream SDK is updated on PyPI.
+try:
+    from honcho.api_types import PeerConfig, PeerResponse
+    if PeerConfig.model_config.get("extra") == "forbid":
+        PeerConfig.model_config["extra"] = "ignore"
+        PeerConfig.model_rebuild(force=True)
+        PeerResponse.model_rebuild(force=True)
+except ImportError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 # Sentinel to signal the async writer thread to shut down


### PR DESCRIPTION
Fixes #67013

The Honcho server has updated its schema (adding fields like `observe_others`), but the latest Python SDK available on PyPI (`honcho-ai==2.2.0`) is strictly typed to reject unknown fields, causing a `1 validation error for PeerResponse` crash upon session initialization.

Since we cannot bump the dependency until upstream publishes a new release to PyPI, this applies a targeted Pydantic monkeypatch to `PeerConfig` at module load time. By setting `extra = 'ignore'` and recompiling the model via `model_rebuild(force=True)`, Hermes gracefully ignores any new API fields sent by newer servers while still remaining compatible with the pinned 2.2.0 SDK.