### PR TITLE
fix(compaction): let tail token budget override the message-count floor on pathological tails

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3035,6 +3035,19 @@ This compaction should PRIORITISE preserving all information related to the focu
             if available_tail > 1 else 0
         )
         soft_ceiling = int(token_budget * 1.5)
+        # Pathological-tail escape hatch: a tail of very few but enormous
+        # messages (e.g. giant tool results) can dwarf even the soft ceiling
+        # while still under the message-count floor, leaving an incompressible
+        # tail that pins the request over the context window forever. Once the
+        # tail already protects the absolute minimum (3 messages) AND the most
+        # recent user message is safely inside it, let this hard ceiling override
+        # the count floor so the tail stops growing — auto-forget under
+        # pathology (see issue #21916). ``_ensure_last_user_message_in_tail`` /
+        # ``_ensure_last_assistant_message_in_tail`` still run afterwards and can
+        # only grow the tail, so the last user/assistant turn is never lost.
+        hard_ceiling = int(token_budget * 3)
+        last_user_idx = self._find_last_user_message_idx(messages, head_end)
+        _hard_ceiling_break = False
         accumulated = 0
         cut_idx = n  # start from beyond the end
 
@@ -3043,6 +3056,24 @@ This compaction should PRIORITISE preserving all information related to the focu
             msg_tokens = _estimate_msg_budget_tokens(msg)
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
+                break
+            # Hard-ceiling override: the count floor yields to the token ceiling
+            # once the tail is already viable — it holds >= 3 messages and the
+            # most recent user message is already captured (``last_user_idx`` at
+            # or beyond the current ``cut_idx``). Prevents a few-but-huge tail
+            # from growing to ``min_tail`` giant messages. Gated on the NEXT
+            # message being individually oversized (> soft ceiling) so this only
+            # engages on the genuine few-but-huge pathology, never on a long run
+            # of small turns under a tiny budget (which must still honour the
+            # message-count floor — see issue #9413).
+            if (
+                msg_tokens > soft_ceiling
+                and accumulated + msg_tokens > hard_ceiling
+                and (n - cut_idx) >= 3
+                and last_user_idx >= 0
+                and last_user_idx >= cut_idx
+            ):
+                _hard_ceiling_break = True
                 break
             accumulated += msg_tokens
             cut_idx = i
@@ -3076,8 +3107,12 @@ This compaction should PRIORITISE preserving all information related to the focu
             # transcript), fall through — the existing fallback logic below
             # will still force a minimal cut after head_end.
 
-        # Ensure we protect at least min_tail messages
-        fallback_cut = n - min_tail
+        # Ensure we protect at least min_tail messages — unless the hard-ceiling
+        # override fired, in which case the floor drops to the absolute minimum
+        # of 3 so a pathological few-but-huge tail is allowed to shrink below the
+        # count floor (min() must not silently re-expand it back to min_tail).
+        _tail_floor = 3 if _hard_ceiling_break else min_tail
+        fallback_cut = n - _tail_floor
         cut_idx = min(cut_idx, fallback_cut)
 
         # If the token budget would protect everything (small conversations),

--- a/tests/agent/test_compression_tail_token_cap.py
+++ b/tests/agent/test_compression_tail_token_cap.py
@@ -1,0 +1,194 @@
+"""Coverage for the pathological-tail token cap in ``_find_tail_cut_by_tokens``.
+
+The protected recent tail is bounded by a message-count floor (``protect_last_n``,
+capped at ``_MAX_TAIL_MESSAGE_FLOOR``). That floor keeps a short run of recent
+turns verbatim so the active task survives compaction. But when the tail holds a
+few *enormous* messages — e.g. giant tool results from a file read — the count
+floor forces all of them to be kept regardless of their token mass, leaving an
+incompressible tail that can pin the request over the model's context window
+forever (compression exhaustion; see issue #21916).
+
+Fix: a ``hard_ceiling = token_budget * 3`` lets the token budget override the
+count floor once the tail is already viable — it holds the absolute minimum of 3
+messages and the most recent user message is captured — but only when the next
+message is individually oversized (the genuine few-but-huge pathology). A long
+run of small turns under a tiny budget must still honour the count floor
+(#9413), and the last user/assistant turn is never dropped.
+
+Fixtures here are estimator-agnostic: message sizes are measured with the
+compressor's own ``_estimate_msg_budget_tokens`` and the tail budget is derived
+from those measurements, so the tests hold regardless of the token-estimator's
+exact chars-per-token calibration.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_compressor import (
+    _MAX_TAIL_MESSAGE_FLOOR,
+    _estimate_msg_budget_tokens,
+)
+
+
+@pytest.fixture()
+def compressor():
+    """ContextCompressor whose count floor wants 8 tail messages, so the
+    hard-ceiling override (which drops the floor to 3) is observable."""
+    from agent.context_compressor import ContextCompressor
+
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=0,
+            protect_last_n=8,  # count floor wants 8 — the fix must override it
+            quiet_mode=True,
+        )
+
+
+def _budget_for(huge_msg: dict, small_msgs: list[dict]) -> int:
+    """Pick a ``tail_token_budget`` (estimator-agnostic) such that:
+
+    * every small message is comfortably below the soft ceiling (1.5x budget),
+      so the oversized-message gate never trips on them; and
+    * the huge message alone exceeds the hard ceiling (3x budget), so the
+      override engages exactly on it.
+    """
+    huge_tok = _estimate_msg_budget_tokens(huge_msg)
+    small_max = max(_estimate_msg_budget_tokens(m) for m in small_msgs)
+    budget = max(small_max + 10, huge_tok // 6)
+    # Precondition: the pathology is only meaningful if the huge message dwarfs
+    # both ceilings derived from this budget.
+    assert huge_tok > budget * 3 > (small_max + 10) * 2
+    return budget
+
+
+class TestHardCeilingTailShrink:
+    def _pathological_messages(self):
+        """system + an OLD tool group + a huge OLD non-tool message + a recent
+        small tail carrying the most recent user message.
+
+        The count floor (``protect_last_n`` == 8) would otherwise drag the huge
+        OLD message (index 5) into the protected tail. The hard-ceiling override
+        breaks on that giant message once the recent tail already holds >= 3
+        messages and the last user message is captured. The older tool group
+        (indices 2/3) stays whole in the compressed region — the cut never
+        splits it.
+        """
+        huge = "x" * 40_000  # dwarfs any reasonable tail budget
+        return [
+            {"role": "system", "content": "sys"},                       # 0 head
+            {"role": "user", "content": "old q1"},                      # 1
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "c1", "function": {"name": "t", "arguments": "{}"}}]},  # 2
+            {"role": "tool", "tool_call_id": "c1", "content": "small"},  # 3 (old group)
+            {"role": "user", "content": "old q2"},                      # 4
+            {"role": "assistant", "content": huge},                     # 5 HUGE (non-tool)
+            {"role": "user", "content": "recent q"},                    # 6 recent window
+            {"role": "assistant", "content": "small reply"},            # 7
+            {"role": "user", "content": "LATEST TASK"},                 # 8 last user
+            {"role": "assistant", "content": "small reply 2"},          # 9
+        ]
+
+    def _tune(self, compressor, messages):
+        huge_msg = messages[5]
+        small = [m for i, m in enumerate(messages) if i != 5]
+        compressor.tail_token_budget = _budget_for(huge_msg, small)
+
+    def test_tail_shrinks_below_count_floor_but_not_below_three(self, compressor):
+        messages = self._pathological_messages()
+        self._tune(compressor, messages)
+        cut = compressor._find_tail_cut_by_tokens(messages, head_end=1)
+
+        tail = messages[cut:]
+        # The count floor would normally protect 8 messages …
+        min_tail_floor = max(3, min(compressor.protect_last_n, _MAX_TAIL_MESSAGE_FLOOR))
+        assert min_tail_floor == 8
+        assert len(tail) < min_tail_floor, (
+            f"hard ceiling should have shrunk the tail below {min_tail_floor}; "
+            f"got {len(tail)} messages"
+        )
+        # … but never below the absolute minimum of 3.
+        assert len(tail) >= 3
+
+    def test_pathology_regression_giant_excluded_where_floor_would_keep_it(
+        self, compressor
+    ):
+        """Behavioural delta vs the unfixed count floor.
+
+        Without the fix the tail floor is ``n - min_tail`` messages, which spans
+        the giant OLD message and keeps it verbatim forever. With the fix the
+        cut lands *after* the giant, excluding it — the whole point of the
+        auto-forget escape hatch.
+        """
+        messages = self._pathological_messages()
+        self._tune(compressor, messages)
+        n = len(messages)
+        giant_idx = 5
+
+        # Pre-fix behaviour: the count floor alone would start the tail at
+        # ``n - min_tail`` (== 2 here), which is at or before the giant — i.e.
+        # the giant would have been retained in the protected tail.
+        min_tail_floor = max(3, min(compressor.protect_last_n, _MAX_TAIL_MESSAGE_FLOOR))
+        unfixed_floor_cut = n - min_tail_floor
+        assert unfixed_floor_cut <= giant_idx, (
+            "fixture invariant: the count floor must otherwise reach the giant"
+        )
+
+        cut = compressor._find_tail_cut_by_tokens(messages, head_end=1)
+        assert cut > giant_idx, (
+            f"the giant message (idx {giant_idx}) must be excluded from the "
+            f"tail; got cut={cut}"
+        )
+        huge_bodies = [
+            m for m in messages[cut:]
+            if isinstance(m.get("content"), str) and len(m["content"]) >= 40_000
+        ]
+        assert huge_bodies == [], (
+            "the huge old message must not be dragged into the tail by the "
+            "message-count floor"
+        )
+
+    def test_last_user_message_kept_in_tail(self, compressor):
+        messages = self._pathological_messages()
+        self._tune(compressor, messages)
+        cut = compressor._find_tail_cut_by_tokens(messages, head_end=1)
+        tail_contents = [
+            m.get("content") for m in messages[cut:]
+            if isinstance(m.get("content"), str)
+        ]
+        assert any("LATEST TASK" in (t or "") for t in tail_contents)
+
+    def test_no_tool_group_split(self, compressor):
+        """The old tool group (assistant tool_call at idx 2 + its result at
+        idx 3) must land wholly on one side of the cut — never split."""
+        messages = self._pathological_messages()
+        self._tune(compressor, messages)
+        cut = compressor._find_tail_cut_by_tokens(messages, head_end=1)
+        assistant_side = 2 < cut
+        result_side = 3 < cut
+        assert assistant_side == result_side, (
+            f"cut={cut} split the tool group (assistant idx2 / result idx3)"
+        )
+
+    def test_normal_tail_unaffected_when_no_pathology(self, compressor):
+        """Small, uniform messages must still honour the count floor — the hard
+        ceiling only engages on a few-but-huge tail (regression guard for
+        #9413)."""
+        messages = [{"role": "system", "content": "sys"}]
+        for i in range(14):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({"role": role, "content": f"m{i}"})
+        # A budget whose soft ceiling sits above any single small message, so no
+        # message is ever "individually oversized" and the override cannot fire.
+        small_max = max(_estimate_msg_budget_tokens(m) for m in messages)
+        compressor.tail_token_budget = small_max * 4
+        cut = compressor._find_tail_cut_by_tokens(messages, head_end=1)
+        # Nothing huge → hard ceiling never fires → count floor preserved.
+        assert len(messages) - cut >= 8


### PR DESCRIPTION
## What does this PR do?

Fixes a compression-exhaustion failure mode: when the protected recent tail holds a **few enormous messages** (e.g. giant tool results from file reads), the message-count floor (`protect_last_n`, capped by `_MAX_TAIL_MESSAGE_FLOOR`) forces all of them to be kept verbatim regardless of their token mass. The tail becomes incompressible, every compression pass is a sub-5% no-op, the attempt budget burns down, and the turn dies with `max compression attempts reached` — even when the middle of the transcript is already fully summarized.

Observed in production on a long-running coding session (17 h, 1000+ messages, tool-heavy):

```
Preflight compression failed after 6 attempts: est_request~215,205 tok vs
threshold~204,000; split messages~204,844 + tools/overhead~10,361
```

The transcript middle was already a compaction summary; ~all of the token mass sat in 8 count-floor-protected giant tool results that no pass was allowed to touch.

**The fix:** in the backward tail walk of `_find_tail_cut_by_tokens`, add `hard_ceiling = token_budget * 3`. Once the tail is already *viable* — it holds the absolute minimum of 3 messages **and** the most recent user message — the count floor yields to the token ceiling if the next message is individually oversized (`> soft_ceiling`) and would push the accumulated tail past the hard ceiling. The oversized messages then fall into the summarized region instead of being pinned.

Why this approach: it changes nothing on healthy transcripts. The extra `msg_tokens > soft_ceiling` gate means a long run of normal-sized turns under a tiny budget still honors the message-count floor exactly as today (the #9413 behavior is regression-tested). Only the genuine few-but-huge pathology engages the override, and all existing invariants hold: tool_call/result groups are never split (`_align_boundary_backward` still runs), the last user/assistant messages are still guaranteed in the tail (`_ensure_last_*_message_in_tail` run afterwards and only grow), and the tail never shrinks below 3 messages.

This also addresses the "Auto-Forget when compression targets fail" ask in #21916, which was closed with `sweeper:implemented-on-main` — the token-budget tail protection on main is real, but it yields to the count floor, so the few-but-huge case documented there (37,299 → 34,080 tok, still far above target, session reset) still reproduces. This PR closes that gap.

## Related Issue

Fixes #21916

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py` — `_find_tail_cut_by_tokens`: added `hard_ceiling` (3× `token_budget`), a triple-gated hard-ceiling break in the backward walk (next message individually `> soft_ceiling` + accumulated `> hard_ceiling` + tail already ≥ 3 messages with the last user message inside), and a `_tail_floor` clamp so the fallback `min()` cannot silently re-expand the tail back to the count floor after the break fires. +39 lines, no behavior change outside the pathological case.
- `tests/agent/test_compression_tail_token_cap.py` — new: 5 tests covering the pathological shrink (below count floor, never below 3), tool-group integrity across the new cut, last-user-message retention, healthy-transcript no-op (count floor still honored under a tiny budget), and the pre-fix behavioral delta (the giant messages that the unfixed floor pins are excluded once the fix is active).

## How to Test

1. `python -m pytest tests/agent/test_compression_tail_token_cap.py -v` — 5 passed.
2. `python -m pytest tests/agent -k "tail or compress" -q` — 98 passed, 1 skipped (pre-existing skip), 0 failures.
3. Repro of the bug class without the fix: revert the `agent/context_compressor.py` hunk and re-run step 1 — the pathological-tail tests fail because the count floor pins all giant tail messages and the cut never moves past them.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full suite via `scripts/run_tests.sh` (the canonical CI-matching runner). Honest caveat: 20 environment-dependent failures on my macOS dev box (man-page binary tests, tempdir-path assumptions) — **reproduced byte-for-byte identical at the merge-base without this change** (the diff is 2 files, disjoint from every failing suite), so they are pre-existing local-environment issues, not regressions. Everything related to this change is green: the new test file 5/5, `tests/agent -k "tail or compress"` 98 passed / 1 pre-existing skip. Deferring to CI as the clean-environment arbiter.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior documented in code comments at the change site)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys; `hard_ceiling` derives from the existing `token_budget`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python arithmetic/slicing, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Production failure signature this fixes (long-running tool-heavy session, transcript middle already summarized, tail pinned by the count floor):

```
ERROR agent.conversation_loop: Preflight compression failed after 6 attempts:
est_request~215,205 tok vs threshold~204,000;
split messages~204,844 + tools/overhead~10,361
```
