### PR TITLE
fix(web): load plugins before resolving extract backend

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -855,6 +855,14 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
+            # Ensure plugin-registered providers (including custom
+            # extract-only backends like web-local) are loaded BEFORE
+            # resolving the backend, so _is_backend_available() can see
+            # them via the registry. Loading after resolution caused the
+            # configured extract_backend to be reported as "unavailable"
+            # and silently fall back to web.backend (e.g. searxng),
+            # producing a "search-only backend" error.
+            _ensure_web_plugins_loaded()
             backend = _get_extract_backend()
 
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
@@ -864,7 +872,6 @@ async def web_extract_tool(
             # detect coroutine functions and await; sync functions run
             # inline (the policy gate, SSRF re-check, etc. live inside the
             # provider itself for the firecrawl per-URL loop).
-            _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
                 get_active_extract_provider,
                 get_provider as _wsp_get_provider,


### PR DESCRIPTION
## Summary

`web_extract_tool` resolved `web.extract_backend` **before** calling `_ensure_web_plugins_loaded()`. For plugin-registered extract backends (e.g. `local` / web-local), availability is a registry lookup because the name is not in `_LEGACY_WEB_BACKENDS`. With plugins not loaded yet, the registry was empty, so the configured backend looked unavailable and silently fell through to shared `web.backend` (often `searxng`). SearXNG is search-only → users got:

> SearXNG is a search-only backend and cannot extract URL content

…even when extract was correctly configured, the plugin was enabled, and trafilatura was installed.

`web_search_tool` already loads plugins **before** resolving the search backend. This PR applies the same order to extract.

## Change

- Move `_ensure_web_plugins_loaded()` above `_get_extract_backend()` in `web_extract_tool`
- Document why the order matters

## Test plan

- [x] Confirmed on a local install with `web.search_backend=searxng`, `web.extract_backend=local`, web-local enabled:
  - before: `_get_extract_backend()` → `searxng` (wrong)
  - after: `_get_extract_backend()` → `local`; `_get_search_backend()` still `searxng`
  - `web_extract(["https://example.com"])` returns content via trafilatura
  - `web_search` still succeeds via SearXNG
- [ ] CI passes

## Notes

Not a config problem — config was already correct. This is a logic/ordering bug in tool dispatch that affects any harness path using Hermes web tools with a plugin-only extract backend.