### PR TITLE
fix(agent): decode bytes content in strip_think_blocks (#66267 follow-up)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -701,6 +701,8 @@ def strip_think_blocks(agent, content: str) -> str:
             content = "".join(_parts)
         elif isinstance(content, dict):
             content = str(content.get("text") or content.get("content") or "")
+        elif isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
         else:
             content = str(content)
         if not content:

--- a/tests/agent/test_strip_think_blocks_bytes.py
+++ b/tests/agent/test_strip_think_blocks_bytes.py
@@ -1,0 +1,49 @@
+"""Regression tests for bytes input to strip_think_blocks (#66267 follow-up).
+
+PR #66567 added coercion for list/dict/non-str content.  One shape was left
+unhandled: ``bytes``.  ``str(b"hello")`` produces the literal string
+``"b'hello'"`` rather than decoding the bytes, which leaks the repr into
+assistant responses.  This file covers only the bytes gap so there is no
+overlap with the tests added in #66567.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from agent.agent_runtime_helpers import strip_think_blocks
+
+
+@pytest.fixture()
+def agent():
+    return MagicMock()
+
+
+class TestBytesInput:
+    def test_plain_bytes_decoded(self, agent):
+        assert strip_think_blocks(agent, b"hello world") == "hello world"
+
+    def test_bytes_think_block_stripped(self, agent):
+        result = strip_think_blocks(agent, b"<think>secret</think>visible")
+        assert "secret" not in result
+        assert "visible" in result
+
+    def test_empty_bytes_returns_empty(self, agent):
+        assert strip_think_blocks(agent, b"") == ""
+
+    def test_bytes_non_ascii_decoded(self, agent):
+        result = strip_think_blocks(agent, "em\u2014dash".encode("utf-8"))
+        assert "\u2014" in result
+
+    def test_bytes_invalid_utf8_uses_replacement(self, agent):
+        # Must not raise; replacement char used for undecodable bytes
+        result = strip_think_blocks(agent, b"ok\xff\xfedone")
+        assert "ok" in result
+        assert "done" in result
+
+    def test_bytes_not_repr_leaked(self, agent):
+        # The old str() path turned b"hi" into "b'hi'" — verify that is gone
+        result = strip_think_blocks(agent, b"hi")
+        assert result == "hi"
+        assert "b'" not in result


### PR DESCRIPTION
 Context
    
    PR #66567 added coercion for list/dict/non-str content in strip_think_blocks. One shape was left unhandled: bytes.
    
    Problem
    
    The existing else: content = str(content) fallback turns b"hello world" into the literal string "b'hello world'" instead of decoding the payload — leaking the Python bytes repr into assistant responses.
    
    Fix
    
    One additional elif branch before the str() fallback:
    
    python
    elif isinstance(content, bytes):
        content = content.decode("utf-8", errors="replace")
    
    
    Invalid UTF-8 sequences get the Unicode replacement character (\ufffd) rather than raising, matching the robustness intent of the surrounding code.
    
    Testing
    
    6 new tests in tests/agent/test_strip_think_blocks_bytes.py: plain bytes, think-block stripping, empty bytes, non-ASCII, invalid UTF-8 with replacement char, and an explicit repr-leak guard. All 35 related tests pass.
    
    Related
    
    Closes #66267 (follow-up to #66567)
