### PR TITLE
fix(doctor): normalize model IDs during config repair

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -962,6 +962,15 @@ def run_doctor(args):
             # Raw-file diagnostic: inspects what the user actually wrote.
             from hermes_cli.config import read_user_config_raw
             cfg = read_user_config_raw(config_path)
+            migrated_root_model_keys = False
+            normalized_native_model = False
+            if should_fix:
+                from hermes_cli.config import _normalize_root_model_keys
+
+                normalized_cfg = _normalize_root_model_keys(cfg)
+                if normalized_cfg != cfg:
+                    cfg = normalized_cfg
+                    migrated_root_model_keys = True
             model_section = cfg.get("model") or {}
             provider_raw = (model_section.get("provider") or "").strip()
             provider = provider_raw.lower()
@@ -1100,14 +1109,38 @@ def run_doctor(args):
                 and provider_policy_id
                 and not provider_accepts_vendor_slug
             ):
-                check_warn(
-                    f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider_raw}'",
-                    "(vendor-prefixed slugs belong to aggregators like openrouter)",
-                )
-                issues.append(
-                    f"model.default '{default_model}' is vendor-prefixed but model.provider is '{provider_raw}'. "
-                    "Either set model.provider to 'openrouter', or drop the vendor prefix."
-                )
+                if should_fix:
+                    from hermes_cli.model_normalize import normalize_model_for_provider
+
+                    normalized_model = normalize_model_for_provider(
+                        default_model, provider_policy_id
+                    )
+                    if normalized_model != default_model:
+                        model_section["default"] = normalized_model
+                        cfg["model"] = model_section
+                        normalized_native_model = True
+                if not normalized_native_model:
+                    check_warn(
+                        f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider_raw}'",
+                        "(vendor-prefixed slugs belong to aggregators like openrouter)",
+                    )
+                    issues.append(
+                        f"model.default '{default_model}' is vendor-prefixed but model.provider is '{provider_raw}'. "
+                        "Either set model.provider to 'openrouter', or drop the vendor prefix."
+                    )
+
+            if should_fix and (migrated_root_model_keys or normalized_native_model):
+                from hermes_cli.config import atomic_config_write
+
+                atomic_config_write(config_path, cfg)
+                if migrated_root_model_keys:
+                    check_ok("Migrated stale root-level keys into model section")
+                    fixed_count += 1
+                if normalized_native_model:
+                    check_ok(
+                        f"Normalized model.default for native provider '{provider_raw}'"
+                    )
+                    fixed_count += 1
 
             # Check credentials for the configured provider.
             # Limit to API-key providers in PROVIDER_REGISTRY — other provider

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1410,3 +1410,84 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+@pytest.mark.parametrize(
+    ("provider", "model", "expected_model", "extra_config"),
+    [
+        ("openai-codex", "openai-codex/gpt-5.6-sol", "gpt-5.6-sol", ""),
+        ("openrouter", "openai/gpt-5.6-sol", "openai/gpt-5.6-sol", ""),
+        (
+            "custom:hpc-ai",
+            "deepseek/deepseek-v4-flash",
+            "deepseek/deepseek-v4-flash",
+            "custom_providers:\n"
+            "  - name: hpc-ai\n"
+            "    base_url: https://hpc-ai.example/v1\n"
+            "    api_key: test-key\n",
+        ),
+    ],
+)
+def test_doctor_fix_canonicalizes_legacy_model_config(
+    monkeypatch, tmp_path, provider, model, expected_model, extra_config
+):
+    """One repair pass canonicalizes safely and remains idempotent."""
+    import yaml
+
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        f"model: {model}\n"
+        f"provider: {provider}\n"
+        f"{extra_config}",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    from hermes_cli import auth as _auth_mod
+
+    monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+
+    from hermes_cli import config as config_mod
+
+    writes = 0
+    real_atomic_config_write = config_mod.atomic_config_write
+
+    def count_atomic_write(*args, **kwargs):
+        nonlocal writes
+        writes += 1
+        return real_atomic_config_write(*args, **kwargs)
+
+    monkeypatch.setattr(config_mod, "atomic_config_write", count_atomic_write)
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        doctor_mod.run_doctor(Namespace(fix=True))
+
+    repaired_text = (home / "config.yaml").read_text(encoding="utf-8")
+    repaired = yaml.safe_load(repaired_text)
+    assert repaired["model"] == {
+        "default": expected_model,
+        "provider": provider,
+    }
+    assert "provider" not in repaired
+    assert writes == 1
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        doctor_mod.run_doctor(Namespace(fix=True))
+
+    assert (home / "config.yaml").read_text(encoding="utf-8") == repaired_text
+    assert writes == 1

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1491,3 +1491,138 @@ def test_doctor_fix_canonicalizes_legacy_model_config(
 
     assert (home / "config.yaml").read_text(encoding="utf-8") == repaired_text
     assert writes == 1
+
+
+@pytest.mark.parametrize(
+    ("provider", "default_model", "extra_config", "expect_warning"),
+    [
+        # Native provider + vendor-prefixed model: diagnose, do not rewrite.
+        ("openai-codex", "openai-codex/gpt-5.6-sol", "", True),
+        # Aggregator: vendor/model is the correct shape — stay silent.
+        ("openrouter", "openai/gpt-5.6-sol", "", False),
+        # Named custom provider: also exempt from the vendor-prefix warning.
+        (
+            "custom:hpc-ai",
+            "deepseek/deepseek-v4-flash",
+            "custom_providers:\n"
+            "  - name: hpc-ai\n"
+            "    base_url: https://hpc-ai.example/v1\n"
+            "    api_key: test-key\n",
+            False,
+        ),
+    ],
+)
+def test_doctor_without_fix_reports_vendor_prefix_without_writing(
+    monkeypatch, tmp_path, provider, default_model, extra_config, expect_warning
+):
+    """``doctor`` (no --fix) diagnoses the native vendor-prefix case read-only.
+
+    Locks the warning shape for the diagnostic path and pins that the
+    aggregator/custom-provider exemptions stay silent. The read-only run must
+    never touch config.yaml — the repair is opt-in via --fix.
+
+    Uses the already-nested ``model:`` mapping rather than the legacy scalar
+    form: without --fix the root-key migration does not run, so a scalar
+    ``model:`` leaves ``model_section`` a string and the vendor-prefix check
+    is skipped entirely. That read-only blind spot predates this change (see
+    the companion test below, which pins it as known behaviour).
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("", encoding="utf-8")
+    original_text = (
+        "model:\n"
+        f"  default: {default_model}\n"
+        f"  provider: {provider}\n"
+        f"{extra_config}"
+    )
+    (home / "config.yaml").write_text(original_text, encoding="utf-8")
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    from hermes_cli import auth as _auth_mod
+
+    monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+
+    from hermes_cli import config as config_mod
+
+    def fail_atomic_write(*args, **kwargs):
+        raise AssertionError("doctor without --fix must not write config.yaml")
+
+    monkeypatch.setattr(config_mod, "atomic_config_write", fail_atomic_write)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    warning = (
+        f"model.default '{default_model}' uses a vendor/model slug "
+        f"but provider is '{provider}'"
+    )
+    if expect_warning:
+        assert warning in out
+    else:
+        assert warning not in out
+
+    # Read-only: the file is byte-for-byte untouched.
+    assert (home / "config.yaml").read_text(encoding="utf-8") == original_text
+
+
+def test_doctor_without_fix_skips_vendor_prefix_check_on_legacy_scalar_config(
+    monkeypatch, tmp_path
+):
+    """Known gap: the read-only path cannot see into a legacy scalar ``model:``.
+
+    ``_normalize_root_model_keys`` only runs under --fix, so a config using the
+    old ``model: <id>`` + root ``provider:`` shape leaves ``model_section`` as a
+    string. ``model_section.get(...)`` then yields nothing and the
+    vendor-prefix check is skipped, so plain ``hermes doctor`` stays silent on a
+    config that ``--fix`` does repair.
+
+    Pinned deliberately so the day someone hoists the migration out of the
+    ``should_fix`` branch, this test fails and is updated to assert the warning.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("", encoding="utf-8")
+    original_text = "model: openai-codex/gpt-5.6-sol\nprovider: openai-codex\n"
+    (home / "config.yaml").write_text(original_text, encoding="utf-8")
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    from hermes_cli import auth as _auth_mod
+
+    monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    assert "uses a vendor/model slug" not in buf.getvalue()
+    # Still strictly read-only.
+    assert (home / "config.yaml").read_text(encoding="utf-8") == original_text


### PR DESCRIPTION
## Summary

- migrate legacy scalar/root-level model configuration before validation during `hermes doctor --fix`
- normalize matching vendor-prefixed model IDs for native providers with the existing provider-aware normalizer
- preserve slash-form IDs for aggregators, custom providers, and unmatched vendor prefixes
- apply the combined migration and normalization in one fail-closed atomic write
- verify that repair is idempotent

## Reproduction

Given:

```yaml
model: openai-codex/gpt-5.6-sol
provider: openai-codex
```

`hermes doctor --fix` previously migrated the structure but retained the vendor-prefixed model ID. A subsequent Doctor run then reported another issue.

## Result

One repair pass now produces:

```yaml
model:
  default: gpt-5.6-sol
  provider: openai-codex
```

## Platforms tested

- WSL2: Linux 6.6.87.2-microsoft-standard-WSL2, Python 3.11.15

## Test plan

- [x] Regression test failed before the implementation
- [x] Canonical Doctor and model-normalization suites: 149 passed
- [x] Manual CLI test with an isolated `HERMES_HOME`: one `doctor --fix` run migrated the root provider and normalized `openai-codex/gpt-5.6-sol` to `gpt-5.6-sol`
- [x] Windows footgun scan: no findings across the two changed files
- [x] Ruff and diff checks pass
- [x] Combined repair performs exactly one atomic config write
- [x] Repair is idempotent
- [x] Aggregator and named custom-provider slash slugs are preserved explicitly
- [x] Full suite run completed; 10 failures in 5 unrelated cache/audio test files were reproduced unchanged against clean upstream `main`

Closes #67106