### PR TITLE
fix(cli): try bundled TUI before requiring ui-tui workspace

### DIFF
--- a/contributors/emails/lucaskvasir@duck.com
+++ b/contributors/emails/lucaskvasir@duck.com
@@ -1,0 +1,2 @@
+lucaskvasirr
+# PR #56672 salvage (fix(cli): try bundled TUI before requiring ui-tui workspace; #56665)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1766,10 +1766,14 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         )
         sys.exit(1)
 
-    if not ext_dir:
-        _ensure_tui_workspace(tui_dir)
-
     # 1. Prebuilt bundle (nix / packaged release): just run it.
+    #
+    # This must run BEFORE _ensure_tui_workspace() below. A pip/pipx install
+    # ships hermes_cli/tui_dist/entry.js in the wheel but never ships ui-tui/
+    # at all (that directory only exists in a git checkout) — so requiring
+    # the workspace to exist first made every pip/pipx dashboard Chat tab
+    # connection hard-exit before it ever got a chance to try the bundled
+    # entry.js it already has. See #56665.
     if not tui_dev:
         if ext_dir:
             p = Path(ext_dir)
@@ -1782,6 +1786,11 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if bundled is not None:
             node = _node_bin("node")
             return [node, "--expose-gc", str(bundled)], bundled.parent
+
+    # No prebuilt bundle available (or --dev, which never uses one) — we're
+    # about to npm install/build from source, so the workspace must exist.
+    if not ext_dir:
+        _ensure_tui_workspace(tui_dir)
 
     # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -361,6 +361,79 @@ def test_make_tui_argv_decodes_dev_prebuild_with_utf8_replace(
     _assert_utf8_replace_capture(calls[0][1])
 
 
+def test_make_tui_argv_uses_bundled_tui_when_workspace_missing(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """pip/pipx install regression (#56665): the wheel ships
+    hermes_cli/tui_dist/entry.js but never ships ui-tui/ (that directory only
+    exists in a git checkout). Before this fix, _make_tui_argv called
+    _ensure_tui_workspace() unconditionally before checking for the bundled
+    entry.js, so every pip/pipx dashboard Chat tab connection hard-exited
+    with `sys.exit(1)` — surfaced to the user as the unhelpful "Chat
+    unavailable: 1" — despite having a perfectly runnable bundled TUI on
+    disk. The bundled-wheel shortcut must be tried first and succeed without
+    ever touching the (missing) ui-tui workspace or git.
+    """
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+
+    bundled_entry = tmp_path / "bundled" / "entry.js"
+    bundled_entry.parent.mkdir(parents=True)
+    bundled_entry.write_text("// bundled TUI")
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: bundled_entry)
+
+    def which(name: str) -> str | None:
+        if name == "node":
+            return "/usr/bin/node"
+        raise AssertionError(f"unexpected shutil.which({name!r}) call — bundled path must not need npm/git")
+
+    monkeypatch.setattr(main_mod.shutil, "which", which)
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("bundled TUI path must not spawn any subprocess (no npm install/build, no git restore)")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fail_run)
+
+    # ui-tui/ deliberately does not exist under tmp_path, and there is no
+    # .git either — this mirrors a pip/pipx install exactly.
+    tui_dir = tmp_path / "ui-tui"
+    assert not tui_dir.exists()
+
+    argv, cwd = main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert argv == ["/usr/bin/node", "--expose-gc", str(bundled_entry)]
+    assert cwd == bundled_entry.parent
+
+
+def test_make_tui_argv_dev_mode_still_requires_workspace_even_with_bundle(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    """--dev never uses the prebuilt bundle (there's no source to hot-reload
+    from a bundled entry.js), so it must still hit the workspace guard when
+    ui-tui/ is missing — the bundled-first reordering must not weaken --dev.
+    """
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+
+    bundled_entry = tmp_path / "bundled" / "entry.js"
+    bundled_entry.parent.mkdir(parents=True)
+    bundled_entry.write_text("// bundled TUI")
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: bundled_entry)
+
+    def which(name: str) -> str | None:
+        if name == "git":
+            return "/usr/bin/git"
+        raise AssertionError("node/npm lookup must not run when ui-tui is missing")
+
+    monkeypatch.setattr(main_mod.shutil, "which", which)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._make_tui_argv(tmp_path / "ui-tui", tui_dev=True)
+
+    assert exc.value.code == 1
+    assert "TUI workspace is missing" in capsys.readouterr().err
+
+
 def test_make_tui_argv_exits_with_recovery_hint_when_workspace_unrecoverable(
     tmp_path: Path, main_mod, monkeypatch, capsys
 ) -> None:


### PR DESCRIPTION
Supersedes #56672 (rebased onto current `main` with green CI). Fixes #56665.

Salvage of @lucaskvasirr's fix — original PR #56672 was correct but its CI was red on two counts:
- **`Check contributors / check-attribution`** — the author's commit email wasn't mapped. Added `contributors/emails/lucaskvasir@duck.com` → `lucaskvasirr` (the new one-file-per-email mechanism that replaced editing `AUTHOR_MAP`).
- **`Python tests / slice 2/8`** — a subprocess-timeout **flake** in `test_gateway_status_subparser_accepts_full_flag` (15s subprocess timeout), entirely unrelated to this change (which only touches `_make_tui_argv`). Cleared by rebasing onto fresh `main`.

Full author credit preserved via `Co-authored-by`.

## What changed and why

`_make_tui_argv()` called `_ensure_tui_workspace(tui_dir)` unconditionally before checking for a prebuilt bundle. That function `sys.exit(1)`s when `ui-tui/` doesn't exist — which it never does on a pip/pipx install, since the wheel ships `hermes_cli/tui_dist/entry.js` but never ships `ui-tui/` at all (that directory only exists in a git checkout).

Every dashboard Chat tab connection on a pip/pipx install therefore hard-exited before ever reaching `_find_bundled_tui()`, surfacing to the user as the unhelpful `Chat unavailable: 1` banner (via `pty_ws`'s `SystemExit` catch in `hermes_cli/web_server.py`) despite having a fully valid bundled `entry.js` on disk.

This is a different trigger than #20500 / #20739 (Docker image, root-owned `ui-tui/`, `EACCES`) — those images ship a `ui-tui/` directory that exists but has the wrong permissions; a pip/pipx install has no `ui-tui/` at all by design.

The fix moves the bundled-wheel / `HERMES_TUI_DIR` shortcut ahead of the workspace check, so a pip/pipx install (or anyone with `HERMES_TUI_DIR` pointed at a prebuilt bundle) never needs the `ui-tui/` source tree to exist. `_ensure_tui_workspace()` now only runs once we know we don't have a usable prebuilt bundle and are about to `npm install`/build from source.

## Behavior by case (unchanged except the bug)

- **`--dev`**: never uses the bundled path, so it still hits `_ensure_tui_workspace()` exactly as before.
- **`HERMES_TUI_DIR` at a valid prebuilt bundle, non-dev**: already returned before `_ensure_tui_workspace()` was ever reached — unchanged.
- **pip/pipx wheel, non-dev, no `HERMES_TUI_DIR`**: now finds `_find_bundled_tui()` and returns immediately. **This is the fix** — previously hard-exited here.
- **git checkout, non-dev, no bundled `tui_dist/entry.js`, no `HERMES_TUI_DIR`**: `_find_bundled_tui()` returns `None`, falls through to `_ensure_tui_workspace()` and the existing git-restore/npm-install/build flow — unchanged.

## Tests

- `test_make_tui_argv_uses_bundled_tui_when_workspace_missing` — bundled `entry.js` present, `ui-tui/` missing, no `.git` (pip/pipx shape): asserts `_make_tui_argv` returns the bundled argv without ever spawning a subprocess or looking up `git`/`npm`. Verified **non-vacuous**: reverting the reorder makes it fail on the old `_ensure_tui_workspace` → `_restore_tui_workspace` → `shutil.which("git")` path.
- `test_make_tui_argv_dev_mode_still_requires_workspace_even_with_bundle` — same setup with `tui_dev=True`: still `sys.exit(1)`s with the workspace-missing message, confirming `--dev` is unaffected by the reorder.

```
tests/hermes_cli/test_tui_npm_install.py tests/hermes_cli/test_tui_bundled.py → 34 passed
```