### PR TITLE
fix(agent): flatten multimodal content in strip_think_blocks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -639,7 +639,7 @@ def repair_message_sequence_with_cursor(agent, messages: List[Dict]) -> int:
 
 
 
-def strip_think_blocks(agent, content: str) -> str:
+def strip_think_blocks(agent, content) -> str:
     """Remove reasoning/thinking blocks from content, returning only visible text.
 
     Handles four cases:
@@ -669,7 +669,22 @@ def strip_think_blocks(agent, content: str) -> str:
     boundary-gated (only strips when the tag sits at start-of-line or
     after punctuation and carries a ``name="..."`` attribute) so prose
     mentions like "Use <function> in JavaScript" are preserved.
+
+    ``content`` may be a plain string or a multimodal content-part list
+    (``[{type: text}, {type: image_url}, ...]``). Common list shapes:
+    user turns with attached images, and tool results that include
+    vision payloads. Callers such as interim-text extraction pass
+    ``messages[-1]`` without role/shape checks, so this entry point
+    must flatten before any ``re.sub``.
     """
+    # Multimodal user/tool content arrives as a list of parts.
+    # Flatten first — re.sub requires str/bytes and previously crashed
+    # with TypeError, spinning the outer conversation loop (e.g. Telegram
+    # photo + caption on the turn that returns tool_calls).
+    if not isinstance(content, str):
+        from agent.message_content import flatten_message_text
+
+        content = flatten_message_text(content)
     if not content:
         return ""
     # Coerce non-string content to text before any regex runs.  Providers

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -482,6 +482,30 @@ class TestStripThinkBlocks:
     def test_no_blocks_unchanged(self, agent):
         assert agent._strip_think_blocks("hello world") == "hello world"
 
+    def test_multimodal_content_list_flattens_and_strips(self, agent):
+        """Vision/tool payloads use content-part lists; must not TypeError."""
+        content = [
+            {"type": "text", "text": "<think>hidden</think>cover ok"},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,xx"}},
+            {"type": "text", "text": " second"},
+        ]
+        result = agent._strip_think_blocks(content)
+        assert "hidden" not in result
+        assert "cover ok" in result
+        assert "second" in result
+        assert "image" not in result.lower()
+
+    def test_interim_visible_text_accepts_tool_list_content(self, agent):
+        """conversation_loop passes messages[-1] (often tool+vision list)."""
+        msg = {
+            "role": "tool",
+            "content": [
+                {"type": "text", "text": "done"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/x.jpg"}},
+            ],
+        }
+        assert agent._interim_assistant_visible_text(msg) == "done"
+
     def test_single_block_removed(self, agent):
         result = agent._strip_think_blocks("<think>reasoning</think> answer")
         assert "reasoning" not in result


### PR DESCRIPTION
## Bug Description

After a multimodal user turn (e.g. Telegram photo + caption), the first assistant response that includes `tool_calls` crashes the outer conversation loop with:

```
TypeError: expected string or bytes-like object, got 'list'
```

in `strip_think_blocks` → `re.sub`. The loop retries the same API call indefinitely (observed 50+ iterations), burning tokens and tripping Telegram flood control.

## Root Cause

`b008131b5` (`fix(agent): harden Codex commentary interim delivery`) started calling:

```python
previous_msg = messages[-1]
agent._interim_assistant_visible_text(previous_msg)
```

on every tool-call turn, without checking role or content shape.

For a vision turn, `messages[-1]` is the **user** message whose `content` is a list of parts (`[{type: text}, {type: image_url}, ...]`). `_interim_assistant_visible_text` passes that list into `strip_think_blocks`, which assumes a string and hands it to `re.sub`.

The same crash path also applies to multimodal **tool** results (list content), which are a documented shape in `tool_dispatch_helpers`.

This only surfaces on multimodal turns. Text-only sessions keep working, which is why the regression can sit unnoticed after update until the first photo.

## Fix

Normalize non-string `content` via the existing `agent.message_content.flatten_message_text` helper before any think/tool-call XML scrubbing. String path is unchanged.

## How to Verify

1. Gateway session with a vision-capable model (e.g. grok-4.5).
2. Send a photo + short caption that should trigger tools.
3. Confirm the agent proceeds past API call #1 (no `TypeError: ... got 'list'` in `errors.log`, no outer-loop spin).
4. Unit: new tests in `TestStripThinkBlocks`.

## Test Plan

- [x] Added regression test for list content + interim path
- [x] Manual smoke: `strip_think_blocks` on multimodal list returns text
- [ ] Full `scripts/run_tests.sh tests/run_agent/test_run_agent.py::TestStripThinkBlocks` (pytest not installed in this runtime venv; CI should cover)

## Risk Assessment

**Low** — single entry-point guard; reuses an established flattener already used for MoA/cache list content. No change to string scrubbing behavior.