### PR TITLE
fix(desktop): prevent stored-id rotations from stealing session focus (rebase of #66122)

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -394,6 +394,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     creatingSessionRef,
     ensureSessionState,
     getRouteToken,
+    getRoutedStoredSessionId,
     navigate,
     onFreshDraftRouteIntent: clearRoutedSessionIntent,
     requestGateway,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -9,18 +9,23 @@ import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
+  $activeSessionStoredIdRotation,
   $currentCwd,
   $messages,
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
+  $selectedStoredSessionId,
   setActiveSessionId,
+  setActiveSessionStoredIdRotation,
   setCurrentCwd,
   setMessages,
   setNewChatWorkspaceTarget,
   setResumeFailedSessionId,
+  setSelectedStoredSessionId,
   setSessions
 } from '@/store/session'
 
+import { sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
 
 import { useSessionActions } from './use-session-actions'
@@ -75,6 +80,7 @@ function Harness({
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
     getRouteToken: () => 'token',
+    getRoutedStoredSessionId: () => null,
     navigate: vi.fn() as never,
     requestGateway,
     resetViewSync: vi.fn(),
@@ -92,6 +98,166 @@ function Harness({
 
   return null
 }
+
+function StoredIdRotationHarness({
+  activeSessionIdRef,
+  getRoutedStoredSessionId,
+  navigate,
+  selectedStoredSessionIdRef
+}: {
+  activeSessionIdRef: MutableRefObject<string | null>
+  getRoutedStoredSessionId: () => null | string
+  navigate: (to: string, options?: { replace?: boolean }) => void
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
+}) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  useSessionActions({
+    activeSessionId: activeSessionIdRef.current,
+    activeSessionIdRef,
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    getRoutedStoredSessionId,
+    navigate: navigate as never,
+    requestGateway: async () => ({}) as never,
+    resetViewSync: vi.fn(),
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: selectedStoredSessionIdRef.current,
+    selectedStoredSessionIdRef,
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as ClientSessionState
+  })
+
+  return null
+}
+
+describe('active stored-session id rotation routing', () => {
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+    setActiveSessionStoredIdRotation(null)
+    setSelectedStoredSessionId(null)
+    vi.restoreAllMocks()
+  })
+
+  it('follows a rotation while the same conversation still owns the foreground route', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'runtime-A' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'stored-A' }
+    const navigate = vi.fn()
+
+    setSelectedStoredSessionId('stored-A')
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => 'stored-A'}
+        navigate={navigate}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+      />
+    )
+
+    act(() => {
+      setActiveSessionStoredIdRotation({
+        nextStoredSessionId: 'stored-A-next',
+        previousStoredSessionId: 'stored-A',
+        runtimeSessionId: 'runtime-A'
+      })
+    })
+
+    await waitFor(() => expect(selectedStoredSessionIdRef.current).toBe('stored-A-next'))
+    expect($selectedStoredSessionId.get()).toBe('stored-A-next')
+    expect(navigate).toHaveBeenCalledWith(sessionRoute('stored-A-next'), { replace: true })
+    expect($activeSessionStoredIdRotation.get()).toBeNull()
+  })
+
+  it('does not overwrite a newer route intent before its resume effect has synchronized selection', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'runtime-A' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'stored-A' }
+    const navigate = vi.fn()
+
+    setSelectedStoredSessionId('stored-A')
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => 'stored-C'}
+        navigate={navigate}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+      />
+    )
+
+    act(() => {
+      setActiveSessionStoredIdRotation({
+        nextStoredSessionId: 'stored-A-next',
+        previousStoredSessionId: 'stored-A',
+        runtimeSessionId: 'runtime-A'
+      })
+    })
+
+    await waitFor(() => expect($activeSessionStoredIdRotation.get()).toBeNull())
+    expect(selectedStoredSessionIdRef.current).toBe('stored-A')
+    expect($selectedStoredSessionId.get()).toBe('stored-A')
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('does not let the previous runtime jump back after selection already moved', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'runtime-A' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'stored-C' }
+    const navigate = vi.fn()
+
+    setSelectedStoredSessionId('stored-C')
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => 'stored-C'}
+        navigate={navigate}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+      />
+    )
+
+    act(() => {
+      setActiveSessionStoredIdRotation({
+        nextStoredSessionId: 'stored-A-next',
+        previousStoredSessionId: 'stored-A',
+        runtimeSessionId: 'runtime-A'
+      })
+    })
+
+    await waitFor(() => expect($activeSessionStoredIdRotation.get()).toBeNull())
+    expect(selectedStoredSessionIdRef.current).toBe('stored-C')
+    expect($selectedStoredSessionId.get()).toBe('stored-C')
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('updates the underlying selection without navigating out of an overlay or page', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'runtime-A' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'stored-A' }
+    const navigate = vi.fn()
+
+    setSelectedStoredSessionId('stored-A')
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => null}
+        navigate={navigate}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+      />
+    )
+
+    act(() => {
+      setActiveSessionStoredIdRotation({
+        nextStoredSessionId: 'stored-A-next',
+        previousStoredSessionId: 'stored-A',
+        runtimeSessionId: 'runtime-A'
+      })
+    })
+
+    await waitFor(() => expect(selectedStoredSessionIdRef.current).toBe('stored-A-next'))
+    expect($selectedStoredSessionId.get()).toBe('stored-A-next')
+    expect(navigate).not.toHaveBeenCalled()
+  })
+})
 
 async function createWith(
   profileSetup: () => void,
@@ -231,6 +397,7 @@ function ResumeHarness({
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
     getRouteToken: () => 'token',
+    getRoutedStoredSessionId: () => null,
     navigate: vi.fn() as never,
     requestGateway,
     resetViewSync: vi.fn(),
@@ -480,6 +647,7 @@ function BranchHarness({
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
     getRouteToken: () => 'token',
+    getRoutedStoredSessionId: () => null,
     navigate: vi.fn() as never,
     requestGateway,
     resetViewSync: vi.fn(),

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -13,7 +13,7 @@ import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { resolveNewSessionCwd, tombstoneSessions, untombstoneSessions } from '@/store/projects'
 import {
-  $activeSessionStoredId,
+  $activeSessionStoredIdRotation,
   $currentCwd,
   $currentFastMode,
   $currentModel,
@@ -26,6 +26,7 @@ import {
   type NewChatWorkspaceTarget,
   sessionPinId,
   setActiveSessionId,
+  setActiveSessionStoredIdRotation,
   setAwaitingResponse,
   setBusy,
   setCurrentBranch,
@@ -83,6 +84,7 @@ interface SessionActionsOptions {
   creatingSessionRef: MutableRefObject<boolean>
   ensureSessionState: (sessionId: string, storedSessionId?: string | null) => ClientSessionState
   getRouteToken: () => string
+  getRoutedStoredSessionId: () => null | string
   navigate: NavigateFunction
   onFreshDraftRouteIntent?: () => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
@@ -163,6 +165,7 @@ export function useSessionActions({
   creatingSessionRef,
   ensureSessionState,
   getRouteToken,
+  getRoutedStoredSessionId,
   navigate,
   onFreshDraftRouteIntent,
   requestGateway,
@@ -178,32 +181,49 @@ export function useSessionActions({
   const copy = t.desktop
   const resumeRequestRef = useRef(0)
 
-  // Follow auto-compression's stored-id rotation. When the active session's
-  // stored id changes (compression ends the SessionDB session and forks a
-  // continuation), re-anchor the URL route + selection to the new id so the
-  // next send doesn't hit a stale stored→runtime mapping and trigger a full
-  // thread reload. replace: true — it's the same conversation, not a new
-  // history entry.
-  const rotatedStoredId = useStore($activeSessionStoredId)
+  // Follow auto-compression's stored-id rotation only while the exact runtime,
+  // selection, and route intent still belong to the rotating conversation.
+  // The previous implementation carried only the next stored id and navigated
+  // unconditionally; a fast A → B → C switch could therefore be overwritten
+  // by A's delayed session.info event and visibly jump back to A.
+  const storedIdRotation = useStore($activeSessionStoredIdRotation)
 
   useEffect(() => {
-    if (!rotatedStoredId || rotatedStoredId === selectedStoredSessionIdRef.current) {
+    if (!storedIdRotation) {
       return
     }
 
-    const oldStoredId = selectedStoredSessionIdRef.current
+    // Consume the event even when it is stale. Rotation is an edge, not durable
+    // state; replaying it after a later remount/selection would steal focus.
+    setActiveSessionStoredIdRotation(current => (current === storedIdRotation ? null : current))
 
-    setSelectedStoredSessionId(rotatedStoredId)
-    selectedStoredSessionIdRef.current = rotatedStoredId
-    navigate(sessionRoute(rotatedStoredId), { replace: true })
+    const selectedStoredSessionId = selectedStoredSessionIdRef.current
+    const routedStoredSessionId = getRoutedStoredSessionId()
 
-    // Clean up the stale stored→runtime mapping so getRuntimeIdForStoredSession
-    // can't resolve the old id to this runtime (it would fail the storedSessionId
-    // check and return null, but leaving the stale key is sloppy).
-    if (oldStoredId) {
-      runtimeIdByStoredSessionIdRef.current.delete(oldStoredId)
+    if (
+      activeSessionIdRef.current !== storedIdRotation.runtimeSessionId ||
+      selectedStoredSessionId !== storedIdRotation.previousStoredSessionId ||
+      (routedStoredSessionId !== null && routedStoredSessionId !== storedIdRotation.previousStoredSessionId)
+    ) {
+      return
     }
-  }, [rotatedStoredId, navigate, runtimeIdByStoredSessionIdRef, selectedStoredSessionIdRef])
+
+    setSelectedStoredSessionId(storedIdRotation.nextStoredSessionId)
+    selectedStoredSessionIdRef.current = storedIdRotation.nextStoredSessionId
+
+    // A route overlay/page has no routed session id, but the underlying selected
+    // chat still needs to follow the continuation. Update that selection in
+    // place without navigating out of the surface the user deliberately opened.
+    if (routedStoredSessionId === storedIdRotation.previousStoredSessionId) {
+      navigate(sessionRoute(storedIdRotation.nextStoredSessionId), { replace: true })
+    }
+  }, [
+    activeSessionIdRef,
+    getRoutedStoredSessionId,
+    navigate,
+    selectedStoredSessionIdRef,
+    storedIdRotation
+  ])
 
   const startFreshSessionDraft = useCallback(
     (options: boolean | FreshSessionDraftOptions = false) => {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
 import {
+  $activeSessionStoredIdRotation,
   $currentFastMode,
   $currentModel,
   $currentProvider,
@@ -11,6 +12,8 @@ import {
   $currentServiceTier,
   $messages,
   $turnStartedAt,
+  setActiveSessionId,
+  setActiveSessionStoredIdRotation,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentProvider,
@@ -28,6 +31,50 @@ interface HarnessProps {
   onReady: (cache: Cache) => void
   selectedStoredSessionId: string | null
 }
+
+describe('useSessionStateCache — stored-id rotation provenance', () => {
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+    setActiveSessionStoredIdRotation(null)
+  })
+
+  it('emits the previous, next, and runtime ids and removes the stale reverse mapping', () => {
+    let cache!: Cache
+
+    setActiveSessionId('runtime-A')
+    render(<Harness activeSessionId="runtime-A" onReady={value => (cache = value)} selectedStoredSessionId="stored-A" />)
+
+    act(() => {
+      cache.updateSessionState('runtime-A', state => state, 'stored-A')
+      cache.updateSessionState('runtime-A', state => state, 'stored-A-next')
+    })
+
+    expect($activeSessionStoredIdRotation.get()).toEqual({
+      nextStoredSessionId: 'stored-A-next',
+      previousStoredSessionId: 'stored-A',
+      runtimeSessionId: 'runtime-A'
+    })
+    expect(cache.runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
+    expect(cache.runtimeIdByStoredSessionIdRef.current.get('stored-A-next')).toBe('runtime-A')
+  })
+
+  it('does not publish a foreground-navigation event for a background runtime rotation', () => {
+    let cache!: Cache
+
+    setActiveSessionId('runtime-B')
+    render(<Harness activeSessionId="runtime-B" onReady={value => (cache = value)} selectedStoredSessionId="stored-B" />)
+
+    act(() => {
+      cache.updateSessionState('runtime-A', state => state, 'stored-A')
+      cache.updateSessionState('runtime-A', state => state, 'stored-A-next')
+    })
+
+    expect($activeSessionStoredIdRotation.get()).toBeNull()
+    expect(cache.runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
+    expect(cache.runtimeIdByStoredSessionIdRef.current.get('stored-A-next')).toBe('runtime-A')
+  })
+})
 
 function Harness({ activeSessionId, onReady, selectedStoredSessionId }: HarnessProps) {
   const busyRef: MutableRefObject<boolean> = { current: false }

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -105,6 +105,16 @@ export function useSessionStateCache({
 
         sessionStateByRuntimeIdRef.current.set(sessionId, updated)
 
+        // Drop the obsolete stored→runtime reverse mapping as soon as the id
+        // rotates (e.g. auto-compression forks a continuation). Leaving the
+        // stale key lets getRuntimeIdForStoredSession resolve the old stored id
+        // to this runtime, which the compression route-follow logic relies on
+        // being absent. The rotation signal itself is emitted centrally from
+        // handleTransition (session-states.ts) off the published diff.
+        if (existing.storedSessionId && existing.storedSessionId !== storedSessionId) {
+          runtimeIdByStoredSessionIdRef.current.delete(existing.storedSessionId)
+        }
+
         if (storedSessionId) {
           runtimeIdByStoredSessionIdRef.current.set(storedSessionId, sessionId)
         }

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -34,7 +34,7 @@ import {
   $activeSessionId,
   $selectedStoredSessionId,
   $unreadFinishedSessionIds,
-  setActiveSessionStoredId
+  setActiveSessionStoredIdRotation
 } from './session'
 import { isSecondaryWindow } from './windows'
 
@@ -109,10 +109,18 @@ export function getRecentlySettledSessionIds(now: number = Date.now()): string[]
 
 // --- Transition detection (called automatically from publishSessionState) ---
 function handleTransition(previous: ClientSessionState | null, next: ClientSessionState, runtimeId: string) {
-  // Compression id rotation: signal the route-follow effect.
+  // Compression id rotation: signal the route-follow effect with enough
+  // provenance (previous id + runtime) that the consumer can reject the event
+  // if the user navigated elsewhere before React handled it. A bare next id
+  // could let a background session's delayed rotation steal the foreground
+  // route.
   if (previous?.storedSessionId && next.storedSessionId && previous.storedSessionId !== next.storedSessionId) {
     if (runtimeId === $activeSessionId.get()) {
-      setActiveSessionStoredId(next.storedSessionId)
+      setActiveSessionStoredIdRotation({
+        nextStoredSessionId: next.storedSessionId,
+        previousStoredSessionId: previous.storedSessionId,
+        runtimeSessionId: runtimeId
+      })
     }
 
     clearSettled(previous.storedSessionId)

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -247,13 +247,18 @@ export const $sessionProfileTotals = atom<Record<string, number>>({})
 export const $sessionsLoading = atom(true)
 export const $activeSessionId = atom<string | null>(null)
 export const $selectedStoredSessionId = atom<string | null>(null)
-// Reactive signal for when the active session's stored id rotates (auto-
-// compression ends the SessionDB session and forks a continuation). The
-// route + selection must follow the rotation so the next send doesn't
-// trigger a full thread reload (getRuntimeIdForStoredSession would return
-// null for the old stored id, forcing resumeStoredSession). Set in
-// ensureSessionState when the cache entry's storedSessionId changes.
-export const $activeSessionStoredId = atom<string | null>(null)
+export interface ActiveSessionStoredIdRotation {
+  nextStoredSessionId: string
+  previousStoredSessionId: string
+  runtimeSessionId: string
+}
+
+// One-shot event for when auto-compression rotates the active runtime's stored
+// id. Carrying the runtime + previous id is load-bearing: a bare next id cannot
+// tell whether the user has already navigated away while React is waiting to
+// run the route-following effect, which lets a background session steal the
+// foreground route.
+export const $activeSessionStoredIdRotation = atom<ActiveSessionStoredIdRotation | null>(null)
 export const $messages = atom<ChatMessage[]>([])
 
 // Streaming-stable derivations of $messages. During a token stream the array
@@ -326,7 +331,8 @@ export const setSessionProfileTotals = (next: Updater<Record<string, number>>) =
   updateAtom($sessionProfileTotals, next)
 export const setSessionsLoading = (next: Updater<boolean>) => updateAtom($sessionsLoading, next)
 export const setActiveSessionId = (next: Updater<string | null>) => updateAtom($activeSessionId, next)
-export const setActiveSessionStoredId = (next: Updater<string | null>) => updateAtom($activeSessionStoredId, next)
+export const setActiveSessionStoredIdRotation = (next: Updater<ActiveSessionStoredIdRotation | null>) =>
+  updateAtom($activeSessionStoredIdRotation, next)
 
 // Transient: a background session finished and the user hasn't opened it since.
 // Written by session-states.ts (handleTransition), cleared here on session open.


### PR DESCRIPTION
## Summary

Salvage / rebase of #66122 (by @UnathiCodex) onto current `main`, which the original PR conflicts with. Same fix and tests, re-homed to where the rotation-signal code now lives on `main`.

Prevents a delayed auto-compression stored-id rotation on a background session from stealing the foreground route. Previously the rotation signal carried only the *next* stored id and the route-follow effect navigated unconditionally, so a fast A → B → C switch could be overwritten by A's delayed `session.info` event — snapping both the sidebar selection and the transcript back to A.

## What changed vs the original PR

The original PR emitted the rotation signal from `use-session-state-cache.ts`'s `ensureSessionState`. On current `main`, that emit logic has since moved into `handleTransition` in `store/session-states.ts` (per #66454's `$sessionStates` refactor). The salvage adapts accordingly:

- **`store/session.ts`** — replace the bare `$activeSessionStoredId: string | null` atom with a one-shot `$activeSessionStoredIdRotation` carrying `{ previousStoredSessionId, nextStoredSessionId, runtimeSessionId }`. The provenance is load-bearing: a bare next-id cannot tell whether the user already navigated away while React is waiting to run the effect.
- **`store/session-states.ts`** — `handleTransition` now emits the provenance-carrying rotation event (instead of `setActiveSessionStoredId(next.storedSessionId)`).
- **`use-session-state-cache.ts`** — drops the obsolete stored→runtime reverse mapping in the cache hook as soon as the id rotates (the emit itself is centralized in `handleTransition`).
- **`use-session-actions/index.ts`** — the consumer effect now follows a rotation only while the exact runtime, current selection, and route intent still belong to the rotating conversation; consumes the event even when stale so it can't replay after a remount; and updates the underlying selection in place (without navigating) when a route overlay/page is open. Threads the existing `getRoutedStoredSessionId` helper (already present in `wiring.tsx`) into the hook.
- **`wiring.tsx`** — one line: pass `getRoutedStoredSessionId` into `useSessionActions`.

Consumer logic and all four route-following test cases are preserved verbatim from the original PR.

## Reproduction

1. Keep session A active while it reaches auto-compression.
2. Navigate A → B → C while A's delayed `session.info` reports its continuation stored id.
3. Old behavior: the rotation effect sees only the next stored id and unconditionally `navigate(..., { replace: true })`, snapping selection + transcript back to A.
4. New behavior: the effect rejects the event because the runtime / selected id / routed id no longer match the rotating conversation.

## Tests

- `npx vitest run --project ui use-session-actions.test.tsx use-session-state-cache.test.tsx` — **32 passed**
- `npm run typecheck` (tsc `-p .` + electron project) — clean
- `eslint` on all five changed source files — clean

Supersedes #66122. Credit to @UnathiCodex — commit authorship preserved.

Co-authored-by: UnathiCodex <theunathi@gmail.com>
