### PR TITLE
fix(desktop): align sidebar sections and icon columns

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -135,7 +135,7 @@ export function SidebarCronJobsSection({
           onClick={onToggle}
           type="button"
         >
-          <SidebarPanelLabel>{label}</SidebarPanelLabel>
+          <SidebarPanelLabel className="pl-3">{label}</SidebarPanelLabel>
           <span className="text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{countLabel}</span>
           <DisclosureCaret
             className="text-(--ui-text-tertiary) opacity-0 transition group-hover/section-label:opacity-100"
@@ -144,7 +144,7 @@ export function SidebarCronJobsSection({
         </button>
       </div>
       {open && (
-        <SidebarGroupContent className="flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 compact:max-h-none compact:overflow-visible">
+        <SidebarGroupContent className="flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 pt-1 compact:max-h-none compact:overflow-visible">
           {shown.map(job => (
             <CronJobSidebarRow
               expanded={peekJobId === job.id}

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -182,7 +182,7 @@ export function SidebarCronJobsSection({
           onClick={onToggle}
           type="button"
         >
-          <SidebarPanelLabel>{label}</SidebarPanelLabel>
+          <SidebarPanelLabel className="pl-3">{label}</SidebarPanelLabel>
           <DisclosureCaret
             className="text-(--ui-text-tertiary) opacity-0 transition group-hover/section-label:opacity-100"
             open={open}
@@ -190,7 +190,7 @@ export function SidebarCronJobsSection({
         </button>
       </div>
       {open && (
-        <SidebarGroupContent className="scrollbar-fade flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 compact:max-h-none compact:overflow-visible">
+        <SidebarGroupContent className="scrollbar-fade flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 pt-1 compact:max-h-none compact:overflow-visible">
           {shown.map(job => (
             <CronJobSidebarRow
               busy={triggeringJobIds.has(job.id)}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1196,6 +1196,8 @@ export function ChatSidebar({
           <div className="shrink-0 px-2 pb-1 pt-1">
             <SearchField
               aria-label={s.searchAria}
+              containerClassName="gap-2 pl-px"
+              icon={<Codicon className="pointer-events-none size-4 shrink-0 text-muted-foreground/70" name="search" />}
               inputRef={searchInputRef}
               onChange={setSearchQuery}
               placeholder={s.searchPlaceholder}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1449,7 +1449,7 @@ export function ChatSidebar({
       )}
       collapsible="none"
     >
-      <SidebarContent className="gap-0 overflow-hidden bg-transparent px-2.5">
+      <SidebarContent className="gap-0 overflow-hidden bg-transparent pl-1 pr-0">
         <SidebarGroup className="shrink-0 p-0 pb-2 pt-[calc(var(--titlebar-height)+0.375rem)]">
           <SidebarGroupContent>
             <SidebarMenu className="gap-px">

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1552,6 +1552,8 @@ export function ChatSidebar({
           <div className="shrink-0 px-2 pb-1 pt-1">
             <SearchField
               aria-label={s.searchAria}
+              containerClassName="gap-2 pl-px"
+              icon={<Codicon className="pointer-events-none size-4 shrink-0 text-muted-foreground/70" name="search" />}
               inputRef={searchInputRef}
               onChange={setSearchQuery}
               placeholder={s.searchPlaceholder}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -5,7 +5,6 @@ import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 
-import { PlatformAvatar } from '@/app/messaging/platform-icon'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '@/components/ui/context-menu'
@@ -1834,13 +1833,6 @@ export function ChatSidebar({
                     }
                     key={group.sourceId}
                     label={group.label}
-                    labelIcon={
-                      <PlatformAvatar
-                        className="size-4 rounded-[4px] text-[0.5625rem] [&_svg]:size-3"
-                        platformId={group.sourceId}
-                        platformName={group.label}
-                      />
-                    }
                     onArchiveSession={onArchiveSession}
                     onDeleteSession={onDeleteSession}
                     onResumeSession={onResumeSession}

--- a/apps/desktop/src/app/chat/sidebar/section-states.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.tsx
@@ -44,7 +44,7 @@ export function SidebarPinnedEmptyState() {
   return (
     <div className="flex min-h-7 items-center gap-2 rounded-lg border-l border-transparent pl-2 text-[0.75rem] text-(--ui-text-tertiary)">
       <span className="grid size-4 shrink-0 place-items-center text-(--ui-text-quaternary)">
-        <Codicon name="pin" size="0.75rem" />
+        <Codicon name="pinned" size="1rem" />
       </span>
       <span>{t.sidebar.shiftClickHint}</span>
     </div>

--- a/apps/desktop/src/app/chat/sidebar/section-states.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.tsx
@@ -42,8 +42,8 @@ export function SidebarPinnedEmptyState() {
   const { t } = useI18n()
 
   return (
-    <div className="flex min-h-7 items-center gap-1.5 rounded-lg pl-2 text-[0.75rem] text-(--ui-text-tertiary)">
-      <span className="grid w-3.5 shrink-0 place-items-center text-(--ui-text-quaternary)">
+    <div className="flex min-h-7 items-center gap-2 rounded-lg border-l border-transparent pl-2 text-[0.75rem] text-(--ui-text-tertiary)">
+      <span className="grid size-4 shrink-0 place-items-center text-(--ui-text-quaternary)">
         <Codicon name="pin" size="0.75rem" />
       </span>
       <span>{t.sidebar.shiftClickHint}</span>

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -206,7 +206,7 @@ function useSessionActions({
     }),
     spec({
       disabled: !onPin,
-      icon: 'pin',
+      icon: 'pinned',
       label: pinned ? r.unpin : r.pin,
       onSelect: () => {
         triggerHaptic('selection')

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -303,7 +303,7 @@ function useSessionActions({
     }),
     spec({
       disabled: !onPin,
-      icon: 'pin',
+      icon: 'pinned',
       label: pinned ? r.unpin : r.pin,
       onSelect: () => {
         triggerHaptic('selection')

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -344,6 +344,7 @@ function SidebarSessionRowImpl({
     >
       <SidebarRowShell
         actions={card ? undefined : actionsNode}
+        actionsClassName="pr-1"
         className={cn(
           'group row-hover relative',
           card && SIDEBAR_ROW_CARD_MIN_H,

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -59,6 +59,29 @@ function generateSessions(count: number): SessionInfo[] {
 
 const noop = () => {}
 
+describe('SidebarSessionsSection header', () => {
+  it('renders exactly one leading section marker', () => {
+    const { container } = render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        label="Slack"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        onToggleUnread={noop}
+        open={true}
+        pinned={false}
+        sessions={[]}
+      />
+    )
+
+    expect(container.querySelectorAll('.dither')).toHaveLength(1)
+  })
+})
+
 describe('SidebarSessionsSection memoization & virtualizer stability', () => {
   it('memoizes flatRows and passes the exact same rows array reference across parent re-renders', () => {
     mockVirtualListPropsHistory.length = 0

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -52,7 +52,7 @@ function SidebarSectionHeader({
   const labelBody = (
     <>
       {icon}
-      <SidebarPanelLabel>{label}</SidebarPanelLabel>
+      <SidebarPanelLabel className={cn(!icon && 'pl-3')}>{label}</SidebarPanelLabel>
       {meta && <SidebarCount>{meta}</SidebarCount>}
     </>
   )

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -64,7 +64,7 @@ function SidebarSectionHeader({
   const labelBody = (
     <>
       {icon}
-      <SidebarPanelLabel>{label}</SidebarPanelLabel>
+      <SidebarPanelLabel className={cn(!icon && 'pl-3')}>{label}</SidebarPanelLabel>
       {meta && <SidebarSectionMeta>{meta}</SidebarSectionMeta>}
     </>
   )

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -45,7 +45,6 @@ interface SidebarSectionHeaderProps {
   onToggle: () => void
   action?: React.ReactNode
   meta?: React.ReactNode
-  icon?: React.ReactNode
   // When false the section can't be collapsed: the label renders static (no
   // toggle, no caret) and the section is always open. Used for the single-
   // project view, where collapsing one project makes no sense.
@@ -58,13 +57,13 @@ function SidebarSectionHeader({
   onToggle,
   action,
   meta,
-  icon,
   collapsible = true
 }: SidebarSectionHeaderProps) {
   const labelBody = (
     <>
-      {icon}
-      <SidebarPanelLabel className={cn(!icon && 'pl-3')}>{label}</SidebarPanelLabel>
+      {/* SidebarPanelLabel owns the section's one leading marker. Platform
+          identity belongs on rows, never beside the shared dither marker. */}
+      <SidebarPanelLabel className="pl-3">{label}</SidebarPanelLabel>
       {meta && <SidebarSectionMeta>{meta}</SidebarSectionMeta>}
     </>
   )
@@ -137,7 +136,6 @@ interface SidebarSessionsSectionProps {
   removedSessionIds?: ReadonlySet<string>
   activeProjectId?: null | string
   labelMeta?: React.ReactNode
-  labelIcon?: React.ReactNode
   // When false the section header is static (no caret/toggle) and always open.
   collapsible?: boolean
   sortable?: boolean
@@ -202,7 +200,6 @@ export function SidebarSessionsSection({
   removedSessionIds,
   activeProjectId,
   labelMeta,
-  labelIcon,
   collapsible = true,
   sortable = false,
   manualOrderIds,
@@ -502,7 +499,6 @@ export function SidebarSessionsSection({
       <SidebarSectionHeader
         action={headerAction}
         collapsible={collapsible}
-        icon={labelIcon}
         label={label}
         meta={labelMeta}
         onToggle={onToggle}

--- a/apps/desktop/src/components/ui/search-field.tsx
+++ b/apps/desktop/src/components/ui/search-field.tsx
@@ -19,6 +19,7 @@ interface SearchFieldProps {
   hints?: string[]
   containerClassName?: string
   inputClassName?: string
+  icon?: ReactNode
   loading?: boolean
   onClear?: () => void
   inputRef?: RefObject<HTMLInputElement | null>
@@ -39,6 +40,7 @@ export function SearchField({
   hints,
   containerClassName,
   inputClassName,
+  icon,
   loading = false,
   onClear,
   inputRef,
@@ -66,7 +68,7 @@ export function SearchField({
         containerClassName
       )}
     >
-      <Search className="pointer-events-none size-3.5 shrink-0 text-muted-foreground/70" />
+      {icon ?? <Search className="pointer-events-none size-3.5 shrink-0 text-muted-foreground/70" />}
       <input
         aria-label={ariaLabel ?? placeholder}
         className={cn(


### PR DESCRIPTION
## What does this PR do?

Ports the still-relevant sidebar alignment polish from #42690 onto the current desktop architecture, resolves the conflicts against current `main`, and includes the follow-up spacing polish from local Electron testing.

### Sidebar alignment and spacing

- Aligns the **PINNED**, **SESSIONS**, search-result, messaging, and **CRON JOBS** dither markers with the nav icon column.
- Tightens the sidebar's outer left gutter.
- Lets the session scrollbar reach the sidebar's right edge while preserving a small inner gutter between it and row timestamps / overflow actions.
- Aligns the pinned empty-state icon and text with the normal sidebar row columns.
- Matches the cron section's first-row spacing to the pinned section.

The **Mark all as read** / session-header action grouping requested during polish is already present on current `main`, so its now-redundant mechanical refactor commit was dropped during the final rebase.

### Icons and section labels

- Uses sidebar-consistent codicons for search and pin actions.
- Removes the extra platform avatar from **Webhook** and **Slack** section headings so every section has exactly one leading marker and the label column no longer shifts.
- Adds a regression assertion that messaging section headings render exactly one dither marker.
- Keeps the shared `SearchField` contract intact; the only API addition is the concrete `SearchField.icon` customization used by this sidebar.

## Before and after

| Before | After (local Hermes desktop) |
| --- | --- |
| ![Before: wider outer gutters and inset scrollbar](https://raw.githubusercontent.com/digitalbase/hermes-agent/pr-assets-67124/hermes-sidebar-before.png) | ![After: tighter gutter, flush scrollbar, inset row tails, aligned markers](https://raw.githubusercontent.com/digitalbase/hermes-agent/pr-assets-67124/hermes-sidebar-after.png) |

The after image is captured from the local Electron app running this branch. It shows the reduced left gutter, flush-right scrollbar, inset row tails, aligned section markers, and the single-marker Slack heading.

## Supersedes

Supersedes #42690, whose implementation conflicts with the current sidebar module extraction. The relevant changes now live in the current component structure and preserve the original contributor authorship in the replayed commits.

## How to test

1. Run `cd apps/desktop && npm run dev`.
2. Confirm nav rows, search, section markers, pinned empty state, and session rows share consistent columns.
3. Scroll the session list and confirm the scrollbar is flush with the sidebar edge while timestamps and overflow actions retain a small gutter.
4. Confirm **Mark all as read** remains grouped with the other session-header actions.
5. Switch between **Default** and **All Profiles** and confirm **Webhook** / **Slack** headings have one marker and aligned text.
6. Open a session action menu and confirm the upright pin glyph is used.

## Validation

- `cd apps/desktop && npm run typecheck`
- `cd apps/desktop && npm run lint -- --quiet`
- Session-row tests: 11 passed
- Sessions-section tests: 3 passed
- React Doctor: 84/100; only the three existing barrel-import / component-export warnings remain
- Local macOS Electron visual check

## Commits

1. `fix(desktop): align sidebar sections and empty state`
2. `fix(desktop): normalize sidebar search and pin icons`
3. `fix(desktop): tighten sidebar edge gutters`
4. `fix(desktop): inset sidebar row actions`
5. `fix(desktop): keep one sidebar section marker`
