### PR TITLE
fix(desktop): make one-click updates durable across restart

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -396,6 +396,19 @@ def _git_root(cwd: Path) -> Optional[Path]:
     return None
 
 
+def _git_workspace_root(cwd: Path) -> Optional[Path]:
+    """Git root for a real workspace, excluding a dotfiles repo at ``$HOME``."""
+    resolved = cwd.resolve()
+    root = _git_root(resolved)
+    home = _home()
+    if root is not None and home is not None:
+        cwd_is_under_home = resolved == home or home in resolved.parents
+        root_is_under_home = root == home or home in root.parents
+        if root == home or (cwd_is_under_home and not root_is_under_home):
+            return None
+    return root
+
+
 def _home() -> Optional[Path]:
     try:
         return Path.home().resolve()
@@ -424,8 +437,11 @@ def _marker_root(cwd: Path) -> Optional[Path]:
     for depth, parent in enumerate([current, *current.parents]):
         if depth > 6:
             break
+        # Treat these as traversal boundaries, not merely roots to skip. A
+        # test/work directory nested under HOME must not walk past the mocked
+        # HOME and rediscover a real dotfiles repo or global AGENTS.md above it.
         if parent == home or (temp_root is not None and parent == temp_root):
-            continue
+            break
         for marker in _PROJECT_MARKERS:
             if (parent / marker).exists():
                 return parent
@@ -459,9 +475,7 @@ def _detect_profile_name(mode: str, platform: str, cwd_str: str) -> str:
     # workspace on its own — cheap stat checks, no scan.
     if _marker_root(cwd) is not None:
         return CODING_PROFILE.name
-    git_root = _git_root(cwd)
-    if git_root is not None and git_root == _home():
-        git_root = None  # dotfiles repo at $HOME — not a code workspace
+    git_root = _git_workspace_root(cwd)
     # A bare git repo only counts when it actually holds code, so `git init` on a
     # notes/writing/research folder stays in the general posture.
     if git_root is not None and _has_code_files(git_root):
@@ -824,7 +838,7 @@ def project_facts_for(cwd: Optional[str | Path] = None) -> Optional[dict[str, An
     re-derive "are we coding?" or duplicate the verify-command sniffing.
     """
     resolved = _resolve_cwd(cwd)
-    root = _git_root(resolved) or _marker_root(resolved)
+    root = _git_workspace_root(resolved) or _marker_root(resolved)
     if root is None:
         return None
 
@@ -846,7 +860,7 @@ def build_coding_workspace_block(cwd: Optional[str | Path] = None) -> str:
     — so marker-only (non-git) projects still get a snapshot.
     """
     resolved = _resolve_cwd(cwd)
-    git_root = _git_root(resolved)
+    git_root = _git_workspace_root(resolved)
     root = git_root or _marker_root(resolved)
     if root is None:
         return ""

--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -163,47 +163,190 @@ pub async fn get_bootstrap_status(
 /// (e.g. when Stage-Desktop was skipped) so the frontend can present
 /// actionable failure UI rather than silently doing nothing.
 #[tauri::command]
-pub async fn launch_hermes_desktop(
-    app: AppHandle,
-    install_root: String,
-) -> Result<(), String> {
+pub async fn launch_hermes_desktop(app: AppHandle, install_root: String) -> Result<(), String> {
     let install_root = PathBuf::from(install_root);
     let exe_path = resolve_hermes_desktop_exe(&install_root).ok_or_else(|| {
         format!(
             "Couldn't find a built Hermes desktop at {}. The desktop build step \
              may have been skipped or failed. Run `hermes desktop` from a \
              terminal to build and launch it.",
-            install_root.join("apps").join("desktop").join("release").display()
+            install_root
+                .join("apps")
+                .join("desktop")
+                .join("release")
+                .display()
         )
     })?;
 
     tracing::info!(?exe_path, "launching Hermes desktop");
 
-    // Detach from us — the installer is about to exit. On macOS launch the
-    // bundle through LaunchServices instead of exec'ing Contents/MacOS/Hermes
-    // directly; this matches user double-click/open behavior and avoids cwd /
-    // quarantine oddities after a self-update rebuild.
-    let mut cmd = desktop_launch_command(&exe_path, &install_root);
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
-        // DETACHED_PROCESS = 0x00000008
-        cmd.creation_flags(0x0000_0008);
+        launch_windows_desktop_via_task(&exe_path, &install_root)
+            .await
+            .map_err(|e| format!("failed to launch {}: {e:#}", exe_path.display()))?;
+        crate::allow_update_close(&app);
+        app.exit(0);
+        return Ok(());
     }
 
-    cmd.spawn().map_err(|e| {
-        format!(
-            "failed to launch {}: {e}",
-            exe_path.display()
-        )
-    })?;
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Detach from us — the installer is about to exit. On macOS launch the
+        // bundle through LaunchServices instead of exec'ing Contents/MacOS/Hermes
+        // directly; this matches user double-click/open behavior and avoids cwd /
+        // quarantine oddities after a self-update rebuild.
+        let mut cmd = desktop_launch_command(&exe_path, &install_root);
+        cmd.spawn()
+            .map_err(|e| format!("failed to launch {}: {e}", exe_path.display()))?;
 
-    // Give Windows ~150ms to actually start the new process before we exit.
-    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        crate::allow_update_close(&app);
+        app.exit(0);
+        Ok(())
+    }
+}
 
-    // Exit the installer cleanly. Tauri's process plugin gives us the
-    // right hook regardless of platform.
-    app.exit(0);
+#[cfg(target_os = "windows")]
+#[derive(Debug, Deserialize)]
+struct DesktopRelaunchAck {
+    ok: bool,
+    pid: u32,
+    #[serde(rename = "requestId")]
+    request_id: String,
+}
+
+#[cfg(target_os = "windows")]
+async fn run_schtasks(args: &[String]) -> Result<std::process::Output> {
+    let mut cmd = tokio::process::Command::new("schtasks.exe");
+    cmd.args(args);
+    cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    Ok(cmd.output().await?)
+}
+
+#[cfg(target_os = "windows")]
+async fn cleanup_desktop_launch_task(task_name: &str, end_running: bool) {
+    if end_running {
+        let _ = run_schtasks(&["/End".into(), "/TN".into(), task_name.into()]).await;
+    }
+    let _ = run_schtasks(&[
+        "/Delete".into(),
+        "/F".into(),
+        "/TN".into(),
+        task_name.into(),
+    ])
+    .await;
+}
+
+#[cfg(target_os = "windows")]
+fn windows_pid_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return false;
+        }
+        let mut exit_code = 0u32;
+        let ok = GetExitCodeProcess(handle, &mut exit_code) != 0;
+        CloseHandle(handle);
+        ok && exit_code == STILL_ACTIVE as u32
+    }
+}
+
+/// Relaunch through a new Task Scheduler action whose executable is Hermes.exe
+/// itself. The task therefore owns the desktop independently of both the
+/// updater's job and the outer update-launch task. The desktop writes a
+/// request-bound cold-start ACK from Electron's app-ready path; only then do we
+/// delete the one-shot definition and verify that its PID survived deletion.
+#[cfg(target_os = "windows")]
+async fn launch_windows_desktop_via_task(
+    exe_path: &std::path::Path,
+    install_root: &std::path::Path,
+) -> Result<()> {
+    let request_id = uuid::Uuid::new_v4().simple().to_string();
+    let task_name = format!("Hermes_DesktopRelaunch_{request_id}");
+    let ack_path = crate::paths::hermes_home()
+        .join("logs")
+        .join(format!("desktop-relaunch-{request_id}.json"));
+    if let Some(parent) = ack_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let _ = std::fs::remove_file(&ack_path);
+
+    let action = format!(
+        "\"{}\" --hermes-update-relaunch-ack=\"{}\" --hermes-update-relaunch-request={}",
+        exe_path.display(),
+        ack_path.display(),
+        request_id
+    );
+    let create_args = vec![
+        "/Create".into(),
+        "/F".into(),
+        "/TN".into(),
+        task_name.clone(),
+        "/SC".into(),
+        "ONCE".into(),
+        "/ST".into(),
+        "23:59".into(),
+        "/TR".into(),
+        action,
+    ];
+    let created = run_schtasks(&create_args).await?;
+    if !created.status.success() {
+        cleanup_desktop_launch_task(&task_name, false).await;
+        return Err(anyhow!(
+            "creating desktop relaunch task failed: {}",
+            String::from_utf8_lossy(&created.stderr).trim()
+        ));
+    }
+
+    let started = run_schtasks(&["/Run".into(), "/TN".into(), task_name.clone()]).await?;
+    if !started.status.success() {
+        cleanup_desktop_launch_task(&task_name, true).await;
+        return Err(anyhow!(
+            "starting desktop relaunch task failed: {}",
+            String::from_utf8_lossy(&started.stderr).trim()
+        ));
+    }
+
+    let deadline = Instant::now() + std::time::Duration::from_secs(30);
+    let ack = loop {
+        if let Ok(raw) = std::fs::read_to_string(&ack_path) {
+            if let Ok(parsed) = serde_json::from_str::<DesktopRelaunchAck>(&raw) {
+                if parsed.ok && parsed.request_id == request_id && parsed.pid > 0 {
+                    break parsed;
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            cleanup_desktop_launch_task(&task_name, true).await;
+            let _ = std::fs::remove_file(&ack_path);
+            return Err(anyhow!(
+                "no request-bound desktop cold-start ACK within 30s"
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    };
+
+    cleanup_desktop_launch_task(&task_name, false).await;
+    let _ = std::fs::remove_file(&ack_path);
+    tokio::time::sleep(std::time::Duration::from_millis(750)).await;
+    if !windows_pid_alive(ack.pid) {
+        return Err(anyhow!(
+            "desktop PID {} did not survive scheduled-task cleanup",
+            ack.pid
+        ));
+    }
+
+    tracing::info!(
+        desktop_pid = ack.pid,
+        ?install_root,
+        "desktop cold-start ACK survived independent scheduled-task cleanup"
+    );
     Ok(())
 }
 
@@ -298,6 +441,7 @@ fn app_bundle_for_exe(exe: &std::path::Path) -> Option<PathBuf> {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 fn desktop_launch_command(
     exe_path: &std::path::Path,
     install_root: &std::path::Path,
@@ -348,8 +492,12 @@ async fn run_bootstrap(
     let kind = ScriptKind::for_current_os();
 
     let pin = Pin {
-        commit: args.commit.or_else(|| option_env_string("BUILD_PIN_COMMIT")),
-        branch: args.branch.or_else(|| option_env_string("BUILD_PIN_BRANCH")),
+        commit: args
+            .commit
+            .or_else(|| option_env_string("BUILD_PIN_COMMIT")),
+        branch: args
+            .branch
+            .or_else(|| option_env_string("BUILD_PIN_BRANCH")),
     };
 
     tracing::info!(
@@ -443,20 +591,21 @@ async fn run_bootstrap(
         return Err(anyhow!(err));
     }
 
-    let manifest: Manifest = powershell::parse_manifest(&manifest_result.stdout).ok_or_else(|| {
-        let err = format!(
-            "install.ps1 -Manifest produced no parseable JSON payload\n{}",
-            truncate(&manifest_result.stdout, 4000)
-        );
-        emit_event(
-            &app,
-            BootstrapEvent::Failed {
-                stage: None,
-                error: err.clone(),
-            },
-        );
-        anyhow!(err)
-    })?;
+    let manifest: Manifest =
+        powershell::parse_manifest(&manifest_result.stdout).ok_or_else(|| {
+            let err = format!(
+                "install.ps1 -Manifest produced no parseable JSON payload\n{}",
+                truncate(&manifest_result.stdout, 4000)
+            );
+            emit_event(
+                &app,
+                BootstrapEvent::Failed {
+                    stage: None,
+                    error: err.clone(),
+                },
+            );
+            anyhow!(err)
+        })?;
 
     emit_event(
         &app,
@@ -650,7 +799,10 @@ async fn run_bootstrap(
     // we're already running from that path. Best-effort — a failure here must
     // not fail an otherwise-successful install.
     if let Err(err) = crate::paths::copy_self_to_hermes_home() {
-        tracing::warn!(?err, "failed to copy installer into HERMES_HOME (non-fatal)");
+        tracing::warn!(
+            ?err,
+            "failed to copy installer into HERMES_HOME (non-fatal)"
+        );
         emit_log(&format!(
             "[bootstrap] warning: could not stage updater binary: {err}"
         ));
@@ -821,8 +973,8 @@ fn truncate(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
     use std::path::Path;
+    use std::path::PathBuf;
 
     fn unique_tmp_dir(tag: &str) -> PathBuf {
         let base = std::env::temp_dir().join(format!(

--- a/apps/bootstrap-installer/src-tauri/src/lib.rs
+++ b/apps/bootstrap-installer/src-tauri/src/lib.rs
@@ -11,11 +11,13 @@
 mod bootstrap;
 mod events;
 mod install_script;
-mod powershell;
 mod paths;
+mod powershell;
 mod update;
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use tauri::Manager;
 use tokio::sync::Mutex;
 
 /// How the installer was invoked. Resolved once from the process args in
@@ -74,6 +76,10 @@ pub struct AppState {
     /// How this process was launched (install vs update). Immutable for the
     /// lifetime of the process; read by the `get_mode` command.
     pub mode: AppMode,
+    /// Native close gate for update mode. Starts blocked before the webview or
+    /// frontend store exists and opens only after a verified desktop relaunch
+    /// or a terminal error.
+    pub update_close_allowed: AtomicBool,
 }
 
 impl AppState {
@@ -81,8 +87,18 @@ impl AppState {
         Self {
             bootstrap: Mutex::new(None),
             mode,
+            update_close_allowed: AtomicBool::new(mode != AppMode::Update),
         }
     }
+}
+
+fn should_prevent_window_close(mode: AppMode, update_close_allowed: bool) -> bool {
+    mode == AppMode::Update && !update_close_allowed
+}
+
+pub(crate) fn allow_update_close(app: &tauri::AppHandle) {
+    let state = app.state::<Arc<AppState>>();
+    state.update_close_allowed.store(true, Ordering::SeqCst);
 }
 
 /// Frontend → Rust: which flow should the UI render?
@@ -111,6 +127,18 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
         .manage(Arc::new(AppState::new(mode)))
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let state = window.state::<Arc<AppState>>();
+                if should_prevent_window_close(
+                    state.mode,
+                    state.update_close_allowed.load(Ordering::SeqCst),
+                ) {
+                    tracing::warn!("ignored close request while update/relaunch is still active");
+                    api.prevent_close();
+                }
+            }
+        })
         .setup(move |app| {
             use tauri::Manager;
             // Launcher fast path (macOS only): a bare ("Install") launch when
@@ -160,7 +188,9 @@ pub fn run() {
                     }
                 }
                 None => {
-                    tracing::error!("main installer window not found; installer UI will not appear");
+                    tracing::error!(
+                        "main installer window not found; installer UI will not appear"
+                    );
                 }
             }
             Ok(())
@@ -187,7 +217,7 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::{force_setup_from_args, AppMode};
+    use super::{force_setup_from_args, should_prevent_window_close, AppMode};
 
     #[test]
     fn bare_args_are_install() {
@@ -228,5 +258,12 @@ mod tests {
             AppMode::from_args(["--update", "--reinstall"]),
             AppMode::Update
         );
+    }
+
+    #[test]
+    fn native_update_close_gate_covers_startup_and_relaunch_windows() {
+        assert!(should_prevent_window_close(AppMode::Update, false));
+        assert!(!should_prevent_window_close(AppMode::Update, true));
+        assert!(!should_prevent_window_close(AppMode::Install, false));
     }
 }

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -92,6 +92,7 @@ pub async fn start_update(app: AppHandle) -> Result<(), String> {
                     error: format!("{err:#}"),
                 },
             );
+            crate::allow_update_close(&app);
         }
         UPDATE_RUNNING.store(false, Ordering::SeqCst);
     });
@@ -455,6 +456,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
 
     if let Some(target_app) = launch_target {
         if let Err(err) = launch_macos_app_and_exit(&app, &target_app).await {
+            crate::allow_update_close(&app);
             emit_log(
                 &app,
                 None,
@@ -465,6 +467,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
     } else if let Err(err) =
         crate::bootstrap::launch_hermes_desktop(app.clone(), install_root.to_string_lossy().into_owned()).await
     {
+        crate::allow_update_close(&app);
         // Launch failed: don't hard-fail the update (it succeeded); surface a
         // log line so the success screen can still tell the user to launch
         // manually.

--- a/apps/bootstrap-installer/src/app.tsx
+++ b/apps/bootstrap-installer/src/app.tsx
@@ -1,11 +1,14 @@
 import { useStore } from '@nanostores/react'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { message } from '@tauri-apps/plugin-dialog'
 import { useEffect } from 'react'
 
 import Failure from './routes/failure'
 import Progress from './routes/progress'
 import Success from './routes/success'
 import Welcome from './routes/welcome'
-import { $bootstrap, $route, initialize } from './store'
+import { $bootstrap, $mode, $route, initialize } from './store'
+import { shouldBlockUpdateClose } from './update-close-guard'
 
 /*
  * App shell — Hermes Setup.
@@ -21,6 +24,46 @@ export default function App() {
 
   useEffect(() => {
     void initialize()
+  }, [])
+
+  useEffect(() => {
+    let disposed = false
+    let noticeOpen = false
+    let unlisten: () => void = () => undefined
+
+    void getCurrentWindow()
+      .onCloseRequested(event => {
+        const state = $bootstrap.get()
+
+        if (!shouldBlockUpdateClose($mode.get(), state.status)) {
+          return
+        }
+
+        event.preventDefault()
+
+        if (!noticeOpen) {
+          noticeOpen = true
+          void message('Hermes is still updating and will restart automatically. Keep this window open.', {
+            kind: 'info',
+            title: 'Update in progress'
+          }).finally(() => {
+            noticeOpen = false
+          })
+        }
+      })
+      .then(stop => {
+        if (disposed) {
+          stop()
+        } else {
+          unlisten = stop
+        }
+      })
+      .catch(() => undefined)
+
+    return () => {
+      disposed = true
+      unlisten()
+    }
   }, [])
 
   return (

--- a/apps/bootstrap-installer/src/routes/progress.tsx
+++ b/apps/bootstrap-installer/src/routes/progress.tsx
@@ -160,10 +160,13 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
           <ChevronRight className={clsx('transition-transform', showLogs && 'rotate-90')} size={12} />
         </button>
 
-        {bootstrap.status === 'running' && (
+        {bootstrap.status === 'running' && !isUpdate && (
           <Button onClick={() => void cancelInstall()} size="sm" variant="outline">
             Cancel
           </Button>
+        )}
+        {bootstrap.status === 'running' && isUpdate && (
+          <span className="text-xs text-muted-foreground">Keep this window open — Hermes restarts automatically.</span>
         )}
       </div>
     </div>

--- a/apps/bootstrap-installer/src/update-close-guard.test.ts
+++ b/apps/bootstrap-installer/src/update-close-guard.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldBlockUpdateClose } from './update-close-guard'
+
+describe('update close guard', () => {
+  it('blocks user close only while an update is running', () => {
+    expect(shouldBlockUpdateClose('update', 'running')).toBe(true)
+    expect(shouldBlockUpdateClose('update', 'completed')).toBe(false)
+    expect(shouldBlockUpdateClose('update', 'failed')).toBe(false)
+    expect(shouldBlockUpdateClose('install', 'running')).toBe(false)
+  })
+})

--- a/apps/bootstrap-installer/src/update-close-guard.ts
+++ b/apps/bootstrap-installer/src/update-close-guard.ts
@@ -1,0 +1,6 @@
+export function shouldBlockUpdateClose(
+  mode: 'install' | 'update',
+  status: 'completed' | 'failed' | 'idle' | 'running'
+): boolean {
+  return mode === 'update' && status === 'running'
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -116,7 +116,7 @@ import {
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
-import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
+import { clearUpdateMarkerIfOwnedBy, readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
 import {
   buildRelaunchScript,
@@ -129,6 +129,9 @@ import {
 } from './update-relaunch'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import { spawnUpdaterProcess } from './updater-process'
+import { launchUpdaterViaScheduledTask } from './windows-update-launch'
+import { acknowledgeUpdateRelaunch } from './windows-update-relaunch'
+import { collectProcessTreePids, parseWindowsProcessList } from './windows-update-runtime'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import {
   computeWindowOptions,
@@ -2424,26 +2427,107 @@ function isShimLocked(shimPath) {
 // Force-kill the entire process TREE rooted at each PID. Node's child.kill()
 // only signals the direct child, so on Windows a backend `hermes.exe` that
 // spawned its own grandchildren (a `hermes` REPL, a pty terminal session, the
-// gateway) would survive and keep the venv shim locked. taskkill /T /F reaps
-// the whole tree synchronously. Windows-only: this is called solely from the
-// Windows shim-unlock path, and the backend is NOT spawned detached (so it's
-// not a process-group leader — a POSIX negative-pgid kill would be meaningless
-// here anyway). POSIX teardown stays with the existing before-quit SIGTERM.
-function forceKillProcessTree(pid) {
+// gateway) would survive and keep the venv shim locked. Windows-only: this is
+// called solely from the Windows shim-unlock path, and the backend is NOT
+// spawned detached (so it's not a process-group leader — a POSIX negative-pgid
+// kill would be meaningless here anyway). POSIX teardown stays with the
+// existing before-quit SIGTERM.
+//
+// NOT `taskkill /T`: taskkill builds its tree from raw ParentProcessId links
+// with no creation-time check. Our own dead launcher-parent PID gets recycled
+// by short-lived backend grandchildren, at which point taskkill /T counts the
+// DESKTOP as a descendant of the backend and kills us mid-handoff (that was
+// the "all Hermes processes die within 1s of Update now" failure). Instead we
+// enumerate the tree from a CIM inventory with our own pid hard-excluded and
+// kill each pid individually.
+function forceKillProcessTree(pid, processes = null) {
   if (!IS_WINDOWS) {
     return
   }
 
-  if (!Number.isInteger(pid) || pid <= 0) {
+  if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) {
     return
   }
 
-  try {
-    execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], hiddenWindowsChildOptions({ stdio: 'ignore' }))
-  } catch {
-    // Already gone, or no permission — best effort; the unlock wait below is
-    // the real gate.
+  const expectedRootCreationTimeMs = desktopOwnedWindowsProcessCreationTimes.get(pid)
+
+  if (!expectedRootCreationTimeMs) {
+    rememberLog(`[process] refusing tree-kill for untracked or identity-unknown PID ${pid}`)
+    return
   }
+
+  const inventory = processes || listWindowsProcessesForUpdate()
+  const tree = collectProcessTreePids(inventory, pid, {
+    excludePids: [process.pid],
+    expectedRootCreationTimeMs
+  })
+  // No fallback to the bare PID: when the tracked child has already exited,
+  // Windows may have recycled its PID for an unrelated process. The live
+  // inventory (including creation times) is the identity/lineage gate.
+  const targets = tree
+
+  for (const target of targets) {
+    if (target === process.pid) {
+      continue
+    }
+
+    try {
+      execFileSync('taskkill', ['/PID', String(target), '/F'], hiddenWindowsChildOptions({ stdio: 'ignore' }))
+    } catch {
+      // Already gone, or no permission — best effort; the unlock wait below is
+      // the real gate.
+    }
+  }
+}
+
+// Inventory Windows processes through CIM so the update handoff can reap every
+// process whose executable lives under this install's venv (the same set the
+// hermes update holder guard refuses to race). Fail-closed: empty inventory.
+function listWindowsProcessesForUpdate() {
+  if (!IS_WINDOWS) {
+    return []
+  }
+
+  const powershell = windowsPowerShellPath() || 'powershell.exe'
+  const script =
+    '$OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::new(); ' +
+    'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,@{Name="CreationTimeMs";Expression={([DateTimeOffset]$_.CreationDate).ToUnixTimeMilliseconds()}},ExecutablePath,CommandLine | ConvertTo-Json -Compress -Depth 3'
+
+  try {
+    const raw = execFileSync(
+      powershell,
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      hiddenWindowsChildOptions({
+        encoding: 'utf8',
+        maxBuffer: 4 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+    )
+
+    return parseWindowsProcessList(raw)
+  } catch (err) {
+    rememberLog(`[updates] managed runtime inventory unavailable; holder guard remains active: ${err.message}`)
+    return []
+  }
+}
+
+const desktopOwnedWindowsProcessCreationTimes = new Map<number, number>()
+
+function trackDesktopOwnedWindowsProcess(child) {
+  if (!IS_WINDOWS || !Number.isInteger(child?.pid)) {
+    return
+  }
+
+  const pid = child.pid
+  const info = listWindowsProcessesForUpdate().find(candidate => candidate.pid === pid)
+
+  if (info?.creationTimeMs) {
+    desktopOwnedWindowsProcessCreationTimes.set(pid, info.creationTimeMs)
+  } else {
+    rememberLog(`[process] could not establish creation-time identity for Desktop child PID ${pid}`)
+  }
+
+  child.once('exit', () => desktopOwnedWindowsProcessCreationTimes.delete(pid))
 }
 
 // Before handing off the update on Windows, the desktop MUST stop every backend
@@ -2504,11 +2588,15 @@ async function releaseBackendLock(updateRoot, tag) {
     }
   }
 
+  traceUpdateHandoff(`${tag}: sigterm sent; stopping pool backends`)
   stopAllPoolBackends()
+  traceUpdateHandoff(`${tag}: pool stopped; tree-killing ${pids.length} backend pid(s)`)
 
   for (const pid of pids) {
     forceKillProcessTree(pid)
   }
+
+  traceUpdateHandoff(`${tag}: owned backend tree-kills done; waiting for shim unlock`)
 
   const shim = venvHermesShimPath(updateRoot)
   const deadlineMs = Date.now() + 15000
@@ -2556,6 +2644,21 @@ async function releaseBackendLock(updateRoot, tag) {
   )
 
   return { unlocked: false }
+}
+
+// Hand-off phase trace — appendFileSync straight to disk, because desktop.log
+// only flushes the in-memory ring buffer: a hand-off that dies mid-flight
+// leaves no evidence there, which is exactly what made the one-click failures
+// so hard to diagnose. One line per phase; the updater side has its own logs.
+function traceUpdateHandoff(step) {
+  try {
+    fs.appendFileSync(
+      path.join(HERMES_HOME, 'logs', 'update-handoff.log'),
+      `${new Date().toISOString()} pid=${process.pid} ${step}\n`
+    )
+  } catch {
+    void 0
+  }
 }
 
 // applyUpdates — hand off to the installer's --update flow, then exit.
@@ -2642,11 +2745,19 @@ async function applyUpdates(opts = {}) {
 
     const venvBin = path.join(updateRoot, 'venv', IS_WINDOWS ? 'Scripts' : 'bin')
 
+    // Latch handoff BEFORE tearing down the backend. The renderer reconnect
+    // path otherwise respawns serve and re-locks the venv before the updater runs.
+    isQuittingForHandoff = true
+    traceUpdateHandoff('applyUpdates: handoff latched')
+    writeUpdateMarker(HERMES_HOME, process.pid)
+    traceUpdateHandoff('applyUpdates: marker written (desktop pid placeholder)')
+
     // Stop our own backend(s) and wait for the venv shim to unlock BEFORE we
     // spawn the updater. Without this the updater races a still-locked
     // hermes.exe (held by the backend child / its grandchildren) and the update
     // bricks. See releaseBackendLockForUpdate for the full failure analysis.
     const lock = await releaseBackendLockForUpdate(updateRoot)
+    traceUpdateHandoff(`applyUpdates: backend lock released unlocked=${lock.unlocked}`)
 
     if (!lock.unlocked) {
       // Something OUTSIDE this app holds the venv (a second window, a user
@@ -2659,23 +2770,68 @@ async function applyUpdates(opts = {}) {
         '(a second Hermes window or a terminal running hermes?). Close it and retry.'
 
       emitUpdateProgress({ stage: 'error', message, percent: null })
+      clearUpdateMarkerIfOwnedBy(HERMES_HOME, process.pid)
+      isQuittingForHandoff = false
       startHermes().catch(() => {})
 
       return { ok: false, error: message }
     }
 
-    // Detached so the updater outlives this process — it needs us GONE before
-    // `hermes update` will run (the venv shim is locked while we live).
-    const child = spawnUpdaterProcess(updater, updaterArgs, {
-      cwd: HERMES_HOME,
-      env: {
-        ...process.env,
-        HERMES_HOME,
-        PATH: pathWithHermesManagedNode(venvBin)
-      },
-      detached: true,
-      stdio: 'ignore'
-    })
+    const updaterEnvPath = pathWithHermesManagedNode(venvBin)
+    let updaterPid: number | null = null
+    let launchVehicle = IS_WINDOWS ? 'scheduled-task' : 'spawn'
+
+    if (IS_WINDOWS) {
+      // The desktop usually runs inside a Job Object with KILL_ON_JOB_CLOSE
+      // (scheduled-task launchers, the bootstrap chain), and Node's
+      // `detached: true` does NOT set CREATE_BREAKAWAY_FROM_JOB — a directly
+      // spawned updater stays in our job and dies the moment we quit for the
+      // hand-off. That was the one-click-update failure: bootstrap-installer.log
+      // stopped after its init line. Launch through a one-shot scheduled task
+      // instead (the Task Scheduler service creates the process outside our
+      // job) and wait for the launcher's ACK so the hand-off is confirmed
+      // before we quit.
+      traceUpdateHandoff('applyUpdates: launching updater via scheduled task')
+      const launch = await launchUpdaterViaScheduledTask({
+        updaterPath: updater,
+        updaterArgs,
+        hermesHome: HERMES_HOME,
+        pathEnv: updaterEnvPath
+      })
+      traceUpdateHandoff(`applyUpdates: scheduled-task launch ok=${launch.ok} pid=${launch.updaterPid} err=${launch.error || '-'}`)
+
+      if (launch.ok) {
+        updaterPid = launch.updaterPid
+      } else {
+        const message = `Update handoff failed safely: ${launch.error || 'Task Scheduler did not confirm the updater.'}`
+
+        rememberLog(`[updates] ${message}`)
+        emitUpdateProgress({ stage: 'error', message, percent: null })
+        clearUpdateMarkerIfOwnedBy(HERMES_HOME, process.pid)
+        isQuittingForHandoff = false
+        startHermes().catch(() => {})
+
+        return { ok: false, error: message }
+      }
+    }
+
+    if (!IS_WINDOWS) {
+      // Detached so the updater outlives this process — it needs us GONE before
+      // `hermes update` will run (the venv shim is locked while we live). On
+      // Windows this is only the fallback path: detached does not escape the job.
+      const child = spawnUpdaterProcess(updater, updaterArgs, {
+        cwd: HERMES_HOME,
+        env: {
+          ...process.env,
+          HERMES_HOME,
+          PATH: updaterEnvPath
+        },
+        detached: true,
+        stdio: 'ignore'
+      })
+
+      updaterPid = Number.isInteger(child.pid) ? child.pid : null
+    }
 
     // Write the update-in-progress marker IMMEDIATELY — before the 2.5s
     // quit dwell. The Tauri updater won't write its own marker for several
@@ -2684,19 +2840,25 @@ async function applyUpdates(opts = {}) {
     // the venv. By writing the marker ourselves the renderer's
     // waitForUpdateToFinish() gate sees a live update and parks instead.
     // The updater overwrites this with its own PID later; same format.
-    if (Number.isInteger(child.pid)) {
-      writeUpdateMarker(HERMES_HOME, child.pid)
+    if (Number.isInteger(updaterPid)) {
+      writeUpdateMarker(HERMES_HOME, updaterPid)
     }
 
-    rememberLog(`[updates] launched updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release venv shim`)
+    rememberLog(
+      `[updates] launched updater via ${launchVehicle}: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release venv shim`
+    )
+
+    app.once('before-quit', () => traceUpdateHandoff('applyUpdates: before-quit fired'))
+    process.once('exit', code => traceUpdateHandoff(`applyUpdates: process exit code=${code}`))
 
     // Linger on the "updating — don't reopen" overlay long enough for the user
     // to actually read it (and to bridge the gap until the updater's own window
     // appears), THEN quit to release the venv shim. The updater rebuilds and
     // relaunches us when it's done. (#50419 — a 600ms quit looked like a crash
     // and lured users into the #50238 relaunch loop.)
-    isQuittingForHandoff = true
+    traceUpdateHandoff(`applyUpdates: dwell started (vehicle=${launchVehicle}); quitting in ${UPDATE_HANDOFF_DWELL_MS}ms`)
     setTimeout(() => {
+      traceUpdateHandoff('applyUpdates: app.quit()')
       app.quit()
     }, UPDATE_HANDOFF_DWELL_MS)
 
@@ -2739,28 +2901,43 @@ async function handOffWindowsBootstrapRecovery(reason) {
 
   const updaterArgs = chooseUpdaterArgs(haveRealInstall, branch)
 
-  await releaseBackendLockForUpdate(updateRoot)
+  const lock = await releaseBackendLockForUpdate(updateRoot)
 
-  const child = spawnUpdaterProcess(updater, updaterArgs, {
-    cwd: HERMES_HOME,
-    env: {
-      ...process.env,
-      HERMES_HOME,
-      PATH: pathWithHermesManagedNode(venvBin)
-    },
-    detached: true,
-    stdio: 'ignore'
+  if (!lock.unlocked) {
+    rememberLog(`[bootstrap] ${reason} recovery aborted: an external process still holds the Hermes venv`)
+
+    return false
+  }
+
+  // Same Job-Object problem as applyUpdates: a detached spawn dies with our
+  // job when we quit. Require the scheduled-task launch (outside the job, with
+  // a positive ACK); an ambiguous status fails closed without a second updater.
+  const updaterEnvPath = pathWithHermesManagedNode(venvBin)
+
+  const launch = await launchUpdaterViaScheduledTask({
+    updaterPath: updater,
+    updaterArgs,
+    hermesHome: HERMES_HOME,
+    pathEnv: updaterEnvPath
   })
+
+  if (!launch.ok || !Number.isInteger(launch.updaterPid)) {
+    rememberLog(`[bootstrap] scheduled-task launch failed safely: ${launch.error || 'missing updater pid'}`)
+
+    return false
+  }
+
+  const updaterPid = launch.updaterPid
 
   // Same marker pre-write as applyUpdates — see comment there. The recovery
   // hand-off has the same window where the renderer can respawn a backend
   // before the updater writes its own marker.
-  if (Number.isInteger(child.pid)) {
-    writeUpdateMarker(HERMES_HOME, child.pid)
+  if (Number.isInteger(updaterPid)) {
+    writeUpdateMarker(HERMES_HOME, updaterPid)
   }
 
   rememberLog(
-    `[bootstrap] handed off ${reason} recovery to updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release app.asar`
+    `[bootstrap] handed off ${reason} recovery to updater via scheduled-task: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release app.asar`
   )
   // Same dwell as the in-app update hand-off (#50419): give the updater's
   // window time to appear before we vanish, so the recovery doesn't look like
@@ -6786,6 +6963,8 @@ async function spawnPoolBackend(profile, entry) {
     })
   )
 
+  trackDesktopOwnedWindowsProcess(child)
+
   entry.process = child
   entry.token = token
 
@@ -7035,6 +7214,8 @@ async function startHermes() {
         stdio: ['ignore', 'pipe', 'pipe']
       })
     )
+
+    trackDesktopOwnedWindowsProcess(hermesProcess)
 
     const processOwner = backendConnectionState.attachProcess(connectionAttempt, hermesProcess)
 
@@ -9458,6 +9639,7 @@ app.whenReady().then(() => {
   configureSpellChecker()
   registerPowerResumeListeners()
   createWindow()
+  acknowledgeUpdateRelaunch(process.argv, HERMES_HOME)
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
   const _coldStartLink = _extractDeepLink(process.argv)

--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -20,6 +20,7 @@ import path from 'path'
 import { test } from 'vitest'
 
 import {
+  clearUpdateMarkerIfOwnedBy,
   isPidAlive,
   markerPath,
   readLiveUpdateMarker,
@@ -127,4 +128,16 @@ test('writeUpdateMarker + dead pid => self-heals on read', () => {
   const res = readLiveUpdateMarker(home, { kill: DEAD })
   assert.equal(res, null, 'a dead-pid marker from writeUpdateMarker self-heals')
   assert.ok(!fs.existsSync(markerPath(home)), 'marker file is pruned')
+})
+
+test('pre-handoff cleanup removes only the desktop-owned provisional marker', () => {
+  const home = tmpHome('owned-cleanup')
+
+  writeMarker(home, 4242, Math.floor(Date.now() / 1000))
+  assert.equal(clearUpdateMarkerIfOwnedBy(home, 4242), true)
+  assert.ok(!fs.existsSync(markerPath(home)))
+
+  writeMarker(home, 7777, Math.floor(Date.now() / 1000))
+  assert.equal(clearUpdateMarkerIfOwnedBy(home, 4242), false)
+  assert.ok(fs.existsSync(markerPath(home)), 'an updater-owned replacement marker must survive desktop cleanup')
 })

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -136,3 +136,32 @@ export function writeUpdateMarker(hermesHome, pid, { now = Date.now } = {}) {
     // updater will write its own when it reaches run_update.
   }
 }
+
+/** Remove only the desktop's provisional marker after a pre-handoff failure. */
+export function clearUpdateMarkerIfOwnedBy(hermesHome, expectedPid) {
+  const file = markerPath(hermesHome)
+  let raw
+
+  try {
+    raw = fs.readFileSync(file, 'utf8')
+  } catch {
+    return false
+  }
+
+  const [pidLine] = String(raw).split('\n')
+  const markerPid = Number.parseInt((pidLine || '').trim(), 10)
+
+  // The updater may already have replaced our placeholder with its own PID.
+  // In that case leave the real marker intact so backend startup stays parked.
+  if (!Number.isInteger(expectedPid) || markerPid !== expectedPid) {
+    return false
+  }
+
+  try {
+    fs.unlinkSync(file)
+
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/electron/windows-update-handoff-regression.test.ts
+++ b/apps/desktop/electron/windows-update-handoff-regression.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildUpdateLaunchScript, schtasksCreateArgs } from './windows-update-launch'
+import { collectProcessTreePids } from './windows-update-runtime'
+
+describe('Windows one-click update handoff regression', () => {
+  it('launches through a hidden scheduled task and waits for an updater ACK', () => {
+    const script = buildUpdateLaunchScript({
+      updaterPath: 'C:\\Hermes\\hermes-setup.exe',
+      updaterArgs: ['--update', '--branch', 'main'],
+      hermesHome: 'C:\\Hermes',
+      pathEnv: 'C:\\Hermes\\venv\\Scripts',
+      ackPath: 'C:\\Hermes\\logs\\ack.json',
+      logPath: 'C:\\Hermes\\logs\\launch.log',
+      requestId: 'request-1'
+    })
+
+    expect(schtasksCreateArgs('Hermes_UpdateLaunch', 'C:\\Hermes\\update-launch.ps1', '12:34').join(' '))
+      .toContain('-WindowStyle Hidden')
+    expect(script).toContain('Set-Content -LiteralPath $ack')
+    expect(script).toContain('Wait-Process -Id $p.Id')
+  })
+
+  it('never includes the desktop itself when a recycled parent PID creates a false cycle', () => {
+    const processes = [
+      {
+        pid: 200,
+        parentPid: 100,
+        creationTimeMs: 2_000,
+        executablePath: 'C:\\Hermes\\venv\\Scripts\\hermes.exe',
+        commandLine: ''
+      },
+      {
+        pid: 100,
+        parentPid: 200,
+        creationTimeMs: 1_000,
+        executablePath: 'C:\\Hermes\\Hermes.exe',
+        commandLine: ''
+      }
+    ]
+
+    expect(
+      collectProcessTreePids(processes, 200, { excludePids: [100], expectedRootCreationTimeMs: 2_000 })
+    ).toEqual([200])
+  })
+})

--- a/apps/desktop/electron/windows-update-launch.test.ts
+++ b/apps/desktop/electron/windows-update-launch.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for electron/windows-update-launch.ts — the one-shot scheduled-task
+ * launch that gets the Windows updater OUT of the desktop's Job Object.
+ *
+ * What this locks:
+ *   1. The generated PowerShell launcher embeds env, updater path/args, ACK
+ *      path and request id with correct single-quote escaping, guards against
+ *      duplicate firings, and self-deletes the task.
+ *   2. schtasks argv shape: forced one-shot creation plus explicit /Run.
+ *   3. ACK parsing is bound to the request id and fail-closed on garbage.
+ *   4. The full launch flow ACKs the updater PID (happy path), surfaces
+ *      launcher-reported failures, and times out instead of hanging.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import {
+  buildUpdateLaunchScript,
+  launchUpdaterViaScheduledTask,
+  nextStartTime,
+  parseLaunchAck,
+  schtasksCreateArgs,
+  schtasksDeleteArgs,
+  schtasksEndArgs,
+  schtasksRunArgs,
+  UPDATE_LAUNCH_TASK_NAME,
+  updateLaunchPaths
+} from './windows-update-launch'
+
+const SCRIPT_ARGS = {
+  updaterPath: 'C:\\Users\\o\'brien\\AppData\\Local\\hermes\\hermes-setup.exe',
+  updaterArgs: ['--update', '--branch', 'main'],
+  hermesHome: 'C:\\Users\\o\'brien\\AppData\\Local\\hermes',
+  pathEnv: 'C:\\venv\\Scripts;C:\\Windows\\system32',
+  ackPath: 'C:\\Users\\o\'brien\\AppData\\Local\\hermes\\logs\\update-launch-ack.json',
+  logPath: 'C:\\Users\\o\'brien\\AppData\\Local\\hermes\\logs\\update-launch.log',
+  requestId: 'req-123'
+}
+
+test('launcher script embeds env, updater, ack and request id with escaped quotes', () => {
+  const script = buildUpdateLaunchScript(SCRIPT_ARGS)
+
+  assert.ok(script.includes(`$env:HERMES_HOME = 'C:\\Users\\o''brien\\AppData\\Local\\hermes'`))
+  assert.ok(script.includes(`$env:PATH = 'C:\\venv\\Scripts;C:\\Windows\\system32'`))
+  assert.ok(script.includes(`-FilePath 'C:\\Users\\o''brien\\AppData\\Local\\hermes\\hermes-setup.exe'`))
+  assert.ok(script.includes(`@('--update', '--branch', 'main')`))
+  assert.ok(script.includes(`$requestId = 'req-123'`))
+  assert.ok(script.includes(`$ack = 'C:\\Users\\o''brien\\AppData\\Local\\hermes\\logs\\update-launch-ack.json'`))
+})
+
+test('launcher script guards duplicates, waits for the updater, and self-deletes the task', () => {
+  const script = buildUpdateLaunchScript(SCRIPT_ARGS)
+
+  // Duplicate-firing guard is bound to the request id and exits early.
+  assert.ok(script.includes(`$existing.requestId -eq $requestId`))
+  assert.ok(script.includes('duplicate invocation ignored'))
+  // Keeps the task instance alive while the updater runs (IgnoreNew shield).
+  assert.ok(script.includes('Wait-Process -Id $p.Id'))
+  // Cleans up its own one-shot task definition.
+  assert.ok(script.includes(`schtasks.exe /Delete /F /TN '${UPDATE_LAUNCH_TASK_NAME}'`))
+  // Failure path still writes a (negative) ACK so the desktop can react.
+  assert.ok(script.includes('ok = $false'))
+})
+
+test('schtasks argv: forced one-shot create and explicit run', () => {
+  const create = schtasksCreateArgs('Hermes_UpdateLaunch', 'C:\\hh\\update-launch.ps1', '12:34')
+
+  assert.deepEqual(create.slice(0, 8), ['/Create', '/F', '/TN', 'Hermes_UpdateLaunch', '/SC', 'ONCE', '/ST', '12:34'])
+  assert.equal(create[8], '/TR')
+  assert.ok(create[9].startsWith('powershell.exe -NoProfile -ExecutionPolicy Bypass'))
+  assert.ok(create[9].endsWith('-File "C:\\hh\\update-launch.ps1"'))
+
+  assert.deepEqual(schtasksRunArgs('Hermes_UpdateLaunch'), ['/Run', '/TN', 'Hermes_UpdateLaunch'])
+  assert.deepEqual(schtasksEndArgs('Hermes_UpdateLaunch'), ['/End', '/TN', 'Hermes_UpdateLaunch'])
+  assert.deepEqual(schtasksDeleteArgs('Hermes_UpdateLaunch'), ['/Delete', '/F', '/TN', 'Hermes_UpdateLaunch'])
+})
+
+test('nextStartTime pads and wraps around midnight', () => {
+  assert.equal(nextStartTime(new Date(2026, 6, 17, 9, 5, 0)), '09:07')
+  assert.equal(nextStartTime(new Date(2026, 6, 17, 23, 59, 0)), '00:01')
+})
+
+test('parseLaunchAck accepts only the matching request id and sane pids', () => {
+  const ok = parseLaunchAck('﻿{"ok":true,"requestId":"r1","updaterPid":4321}', 'r1')
+
+  assert.ok(ok)
+  assert.equal(ok.ok, true)
+  assert.equal(ok.updaterPid, 4321)
+
+  const failed = parseLaunchAck('{"ok":false,"requestId":"r1","error":"boom"}', 'r1')
+
+  assert.ok(failed)
+  assert.equal(failed.ok, false)
+  assert.equal(failed.error, 'boom')
+
+  assert.equal(parseLaunchAck('{"ok":true,"requestId":"other","updaterPid":1}', 'r1'), null)
+  assert.equal(parseLaunchAck('not json', 'r1'), null)
+  assert.equal(parseLaunchAck('', 'r1'), null)
+  assert.equal(parseLaunchAck('{"ok":true,"requestId":"r1","updaterPid":"4242junk"}', 'r1')?.updaterPid, null)
+})
+
+function tempHome(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-update-launch-'))
+}
+
+test('launch flow: writes launcher script, fires task, returns ACKed updater pid', async () => {
+  const home = tempHome()
+  const calls: string[][] = []
+
+  const result = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update', '--branch', 'main'],
+    hermesHome: home,
+    pathEnv: 'C:\\x',
+    timeoutMs: 3000,
+    pollMs: 10,
+    runCommand: async (file, args) => {
+      calls.push([file, ...args])
+
+      if (args[0] === '/Run') {
+        // Simulate the launcher: read the request id back out of the script
+        // the flow just wrote, then ACK with an updater pid.
+        const scriptPath = calls[0][calls[0].indexOf('/TR') + 1].match(/-File "([^"]+)"/)?.[1] ?? ''
+
+        const paths = {
+          scriptPath,
+          ackPath: fs
+            .readFileSync(scriptPath, 'utf8')
+            .match(/\$ack = '([^']+)'/)?.[1]
+            .replace(/''/g, "'") ?? ''
+        }
+
+        const script = fs.readFileSync(paths.scriptPath, 'utf8')
+        const requestId = /\$requestId = '([^']+)'/.exec(script)?.[1] ?? ''
+
+        fs.writeFileSync(paths.ackPath, JSON.stringify({ ok: true, requestId, updaterPid: 777 }))
+      }
+
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  assert.deepEqual(result, { ok: true, updaterPid: 777, error: null })
+  assert.equal(calls.length, 2)
+  assert.equal(calls[0][0], 'schtasks.exe')
+  assert.equal(calls[0][1], '/Create')
+  assert.ok(calls[0].includes('ONCE'))
+  assert.match(calls[0][calls[0].indexOf('/TN') + 1], /^Hermes_UpdateLaunch_[a-f0-9]+$/)
+  assert.equal(calls[1][1], '/Run')
+})
+
+test('launch flow: surfaces schtasks create failure without firing the task', async () => {
+  const home = tempHome()
+  const calls: string[][] = []
+
+  const result = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update'],
+    hermesHome: home,
+    pathEnv: 'C:\\x',
+    runCommand: async (_file, args) => {
+      calls.push(args)
+
+      return { code: 1, stdout: '', stderr: 'ERROR: Access is denied.' }
+    }
+  })
+
+  assert.equal(result.ok, false)
+  assert.match(result.error ?? '', /schtasks create failed/)
+  assert.equal(calls.length, 2)
+  assert.equal(calls[1][0], '/Delete')
+})
+
+test('launch flow: surfaces launcher-reported failure and stale-ack timeout', async () => {
+  const home = tempHome()
+
+  const reported = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update'],
+    hermesHome: home,
+    pathEnv: 'C:\\x',
+    timeoutMs: 3000,
+    pollMs: 10,
+    runCommand: async (_file, args) => {
+      if (args[0] === '/Run') {
+        const scriptPath = fs
+          .readdirSync(home)
+          .map(name => path.join(home, name))
+          .find(candidate => candidate.endsWith('.ps1')) ?? ''
+
+        const paths = {
+          scriptPath,
+          ackPath: fs
+            .readFileSync(scriptPath, 'utf8')
+            .match(/\$ack = '([^']+)'/)?.[1]
+            .replace(/''/g, "'") ?? ''
+        }
+
+        const script = fs.readFileSync(paths.scriptPath, 'utf8')
+        const requestId = /\$requestId = '([^']+)'/.exec(script)?.[1] ?? ''
+
+        fs.writeFileSync(paths.ackPath, JSON.stringify({ ok: false, requestId, error: 'spawn denied' }))
+      }
+
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  assert.equal(reported.ok, false)
+  assert.match(reported.error ?? '', /spawn denied/)
+
+  // An ACK from a PREVIOUS request must not satisfy this run: the flow
+  // deletes stale ACKs up front and re-checks the embedded request id.
+  const staleHome = tempHome()
+  const stalePaths = updateLaunchPaths(staleHome)
+
+  fs.mkdirSync(path.dirname(stalePaths.ackPath), { recursive: true })
+  fs.writeFileSync(stalePaths.ackPath, JSON.stringify({ ok: true, requestId: 'stale', updaterPid: 1 }))
+
+  const timedOut = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update'],
+    hermesHome: staleHome,
+    pathEnv: 'C:\\x',
+    timeoutMs: 100,
+    pollMs: 10,
+    runCommand: async () => ({ code: 0, stdout: '', stderr: '' })
+  })
+
+  assert.equal(timedOut.ok, false)
+  assert.match(timedOut.error ?? '', /no launcher ACK/)
+})
+
+test('launch flow ends and deletes the one-shot task after run failure or ACK timeout', async () => {
+  const runFailureCalls: string[][] = []
+
+  const runFailed = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update'],
+    hermesHome: tempHome(),
+    pathEnv: 'C:\\x',
+    runCommand: async (_file, args) => {
+      runFailureCalls.push(args)
+
+      return args[0] === '/Run'
+        ? { code: 1, stdout: '', stderr: 'run failed' }
+        : { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  assert.equal(runFailed.ok, false)
+  assert.deepEqual(
+    runFailureCalls.map(args => args[0]),
+    ['/Create', '/Run', '/End', '/Delete']
+  )
+
+  const timeoutCalls: string[][] = []
+
+  const timedOut = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update'],
+    hermesHome: tempHome(),
+    pathEnv: 'C:\\x',
+    timeoutMs: 25,
+    pollMs: 5,
+    runCommand: async (_file, args) => {
+      timeoutCalls.push(args)
+
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  assert.equal(timedOut.ok, false)
+  assert.deepEqual(
+    timeoutCalls.map(args => args[0]),
+    ['/Create', '/Run', '/End', '/Delete']
+  )
+})

--- a/apps/desktop/electron/windows-update-launch.ts
+++ b/apps/desktop/electron/windows-update-launch.ts
@@ -1,0 +1,339 @@
+/**
+ * windows-update-launch.ts
+ *
+ * Launch the staged Windows updater OUTSIDE the desktop's Job Object.
+ *
+ * Why: the desktop process usually lives inside a Windows Job Object with
+ * KILL_ON_JOB_CLOSE (scheduled-task launchers, the Tauri bootstrap chain).
+ * Node's `detached: true` does NOT set CREATE_BREAKAWAY_FROM_JOB, so a
+ * directly spawned hermes-setup.exe stays in that job and dies together with
+ * the desktop when it quits for the hand-off — bootstrap-installer.log then
+ * shows only the init line and the update never runs. Processes started by
+ * the Task Scheduler service are not part of the desktop's job, so a
+ * one-shot task is used as the launch vehicle.
+ *
+ * The launcher script writes an ACK file once the updater process is running;
+ * the desktop waits for that ACK before quitting, turning the hand-off from
+ * fire-and-forget into a positively confirmed exchange. Ambiguous launch
+ * status fails closed; callers must never start a second updater in parallel.
+ */
+
+import { execFile } from 'node:child_process'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { hiddenWindowsChildOptions } from './windows-child-options'
+
+export const UPDATE_LAUNCH_TASK_NAME = 'Hermes_UpdateLaunch'
+
+export type UpdateLaunchPaths = {
+  scriptPath: string
+  ackPath: string
+  logPath: string
+}
+
+export function updateLaunchPaths(hermesHome: string, requestId = ''): UpdateLaunchPaths {
+  const logsDir = path.join(hermesHome, 'logs')
+  const suffix = requestId ? `-${requestId.replace(/[^a-z0-9]/gi, '')}` : ''
+
+  return {
+    scriptPath: path.join(hermesHome, `update-launch${suffix}.ps1`),
+    ackPath: path.join(logsDir, `update-launch-ack${suffix}.json`),
+    logPath: path.join(logsDir, 'update-launch.log')
+  }
+}
+
+// Single-quoted PowerShell string literal: only ' needs doubling.
+function psQuote(value: string): string {
+  return `'${String(value).replace(/'/g, "''")}'`
+}
+
+export type LaunchScriptArgs = {
+  updaterPath: string
+  updaterArgs: string[]
+  hermesHome: string
+  pathEnv: string
+  ackPath: string
+  logPath: string
+  requestId: string
+  taskName?: string
+}
+
+/**
+ * Build the PowerShell launcher the one-shot task executes. It runs outside
+ * the desktop's job, starts the updater, writes the ACK (with the updater
+ * PID), then stays alive until the updater exits so Task Scheduler's
+ * IgnoreNew instance policy shields against duplicate firings, and finally
+ * removes the one-shot task definition.
+ */
+export function buildUpdateLaunchScript(args: LaunchScriptArgs): string {
+  const taskName = args.taskName || UPDATE_LAUNCH_TASK_NAME
+  const updaterArgsList = args.updaterArgs.map(psQuote).join(', ')
+
+  return [
+    `$ErrorActionPreference = 'Stop'`,
+    `$ack = ${psQuote(args.ackPath)}`,
+    `$log = ${psQuote(args.logPath)}`,
+    `$requestId = ${psQuote(args.requestId)}`,
+    `function Write-LaunchLog([string]$m) {`,
+    `  try { Add-Content -Path $log -Value ("{0} [{1}] {2}" -f (Get-Date).ToString('o'), $requestId, $m) } catch {}`,
+    `}`,
+    `# Duplicate-invocation guard: the schedule (a past-tense one-shot) should`,
+    `# never fire on its own, but if it ever does, the ACK for this request id`,
+    `# marks the work as already claimed.`,
+    `if (Test-Path -LiteralPath $ack) {`,
+    `  $existing = $null`,
+    `  try { $existing = Get-Content -LiteralPath $ack -Raw | ConvertFrom-Json } catch {}`,
+    `  if ($existing -and $existing.requestId -eq $requestId) {`,
+    `    Write-LaunchLog 'duplicate invocation ignored'`,
+    `    exit 0`,
+    `  }`,
+    `}`,
+    `try {`,
+    `  $env:HERMES_HOME = ${psQuote(args.hermesHome)}`,
+    `  $env:PATH = ${psQuote(args.pathEnv)}`,
+    `  Write-LaunchLog 'launcher started (outside desktop job object)'`,
+    `  $p = Start-Process -FilePath ${psQuote(args.updaterPath)} -ArgumentList @(${updaterArgsList}) -WorkingDirectory $env:HERMES_HOME -PassThru`,
+    `  $payload = @{ ok = $true; requestId = $requestId; updaterPid = $p.Id; startedAt = (Get-Date).ToString('o') } | ConvertTo-Json -Compress`,
+    `  Set-Content -LiteralPath $ack -Value $payload -Encoding UTF8`,
+    `  Write-LaunchLog ("updater started pid=" + $p.Id)`,
+    `  try { Wait-Process -Id $p.Id -ErrorAction SilentlyContinue } catch {}`,
+    `  Write-LaunchLog 'updater exited; removing one-shot task'`,
+    `} catch {`,
+    `  $err = @{ ok = $false; requestId = $requestId; error = $_.Exception.Message } | ConvertTo-Json -Compress`,
+    `  try { Set-Content -LiteralPath $ack -Value $err -Encoding UTF8 } catch {}`,
+    `  Write-LaunchLog ("launcher failed: " + $_.Exception.Message)`,
+    `} finally {`,
+    `  try { schtasks.exe /Delete /F /TN ${psQuote(taskName)} | Out-Null } catch {}`,
+    `}`,
+    ``
+  ].join('\r\n')
+}
+
+/**
+ * Next /ST value (HH:mm, locale-independent) a couple of minutes ahead, so
+ * schtasks never warns about a start time in the past. The schedule itself is
+ * irrelevant — the task is triggered explicitly via /Run and the launcher's
+ * request-id guard ignores any stray timed firing.
+ */
+export function nextStartTime(now: Date = new Date(), minutesAhead = 2): string {
+  const t = new Date(now.getTime() + minutesAhead * 60_000)
+  const hh = String(t.getHours()).padStart(2, '0')
+  const mm = String(t.getMinutes()).padStart(2, '0')
+
+  return `${hh}:${mm}`
+}
+
+export function schtasksCreateArgs(taskName: string, scriptPath: string, startTime: string): string[] {
+  const action = `powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "${scriptPath}"`
+
+  return ['/Create', '/F', '/TN', taskName, '/SC', 'ONCE', '/ST', startTime, '/TR', action]
+}
+
+export function schtasksRunArgs(taskName: string): string[] {
+  return ['/Run', '/TN', taskName]
+}
+
+export function schtasksEndArgs(taskName: string): string[] {
+  return ['/End', '/TN', taskName]
+}
+
+export function schtasksDeleteArgs(taskName: string): string[] {
+  return ['/Delete', '/F', '/TN', taskName]
+}
+
+export type LaunchAck = {
+  ok: boolean
+  requestId: string
+  updaterPid: number | null
+  error: string | null
+}
+
+export function parseLaunchAck(raw: unknown, requestId: string): LaunchAck | null {
+  const text = String(raw ?? '')
+    .replace(/^\uFEFF/, '')
+    .trim()
+
+  if (!text) {
+    return null
+  }
+
+  let parsed: any
+
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return null
+  }
+
+  if (!parsed || parsed.requestId !== requestId) {
+    return null
+  }
+
+  const pid = Number(parsed.updaterPid)
+
+  return {
+    ok: parsed.ok === true,
+    requestId,
+    updaterPid: Number.isInteger(pid) && pid > 0 ? pid : null,
+    error: typeof parsed.error === 'string' ? parsed.error : null
+  }
+}
+
+export type RunCommand = (file: string, args: string[]) => Promise<{ code: number; stdout: string; stderr: string }>
+
+function defaultRunCommand(file: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise(resolve => {
+    execFile(
+      file,
+      args,
+      hiddenWindowsChildOptions({ encoding: 'utf8' }),
+      (error: any, stdout: any, stderr: any) => {
+        resolve({
+          code: error ? (typeof error.code === 'number' ? error.code : 1) : 0,
+          stdout: String(stdout ?? ''),
+          stderr: String(stderr ?? '')
+        })
+      }
+    )
+  })
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export type LaunchResult = { ok: boolean; updaterPid: number | null; error: string | null }
+
+function launchFailure(error: string): LaunchResult {
+  return { ok: false, updaterPid: null, error }
+}
+
+/**
+ * Full launch flow: write the launcher script, register + fire the one-shot
+ * task, then wait for the launcher's ACK. Never throws — callers use the
+ * error result to keep the desktop alive and report the failed handoff.
+ */
+export async function launchUpdaterViaScheduledTask(opts: {
+  updaterPath: string
+  updaterArgs: string[]
+  hermesHome: string
+  pathEnv: string
+  taskName?: string
+  runCommand?: RunCommand
+  timeoutMs?: number
+  pollMs?: number
+  now?: Date
+}): Promise<LaunchResult> {
+  const runCommand = opts.runCommand || defaultRunCommand
+  const timeoutMs = opts.timeoutMs ?? 30_000
+  const pollMs = opts.pollMs ?? 250
+  const requestId = crypto.randomUUID()
+  const taskName = opts.taskName || `${UPDATE_LAUNCH_TASK_NAME}_${requestId.replaceAll('-', '')}`
+  const paths = updateLaunchPaths(opts.hermesHome, requestId)
+
+  const cleanupFiles = (): void => {
+    try {
+      fs.rmSync(paths.scriptPath, { force: true })
+      fs.rmSync(paths.ackPath, { force: true })
+    } catch {
+      // Best effort; request-specific filenames make leftovers inert.
+    }
+  }
+
+  const cleanupTask = async (endRunning: boolean): Promise<void> => {
+    if (endRunning) {
+      try {
+        await runCommand('schtasks.exe', schtasksEndArgs(taskName))
+      } catch {
+        // Best effort. Deleting the definition below is still required even
+        // when Task Scheduler cannot confirm that the action has ended.
+      }
+    }
+
+    try {
+      await runCommand('schtasks.exe', schtasksDeleteArgs(taskName))
+    } catch {
+      // Best effort. The unique task name prevents collision with a later
+      // request even if Task Scheduler is temporarily unavailable.
+    }
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(paths.ackPath), { recursive: true })
+    fs.rmSync(paths.ackPath, { force: true })
+    fs.writeFileSync(
+      paths.scriptPath,
+      buildUpdateLaunchScript({
+        updaterPath: opts.updaterPath,
+        updaterArgs: opts.updaterArgs,
+        hermesHome: opts.hermesHome,
+        pathEnv: opts.pathEnv,
+        ackPath: paths.ackPath,
+        logPath: paths.logPath,
+        requestId,
+        taskName
+      }),
+      'utf8'
+    )
+  } catch (err: any) {
+    return launchFailure(`launcher script write failed: ${err.message}`)
+  }
+
+  const create = await runCommand('schtasks.exe', schtasksCreateArgs(taskName, paths.scriptPath, nextStartTime(opts.now)))
+
+  if (create.code !== 0) {
+    await cleanupTask(false)
+    cleanupFiles()
+
+    return launchFailure(`schtasks create failed (${create.code}): ${(create.stderr || create.stdout).trim()}`)
+  }
+
+  const run = await runCommand('schtasks.exe', schtasksRunArgs(taskName))
+
+  if (run.code !== 0) {
+    await cleanupTask(true)
+    cleanupFiles()
+
+    return launchFailure(`schtasks run failed (${run.code}): ${(run.stderr || run.stdout).trim()}`)
+  }
+
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    let raw: string | null = null
+
+    try {
+      raw = fs.readFileSync(paths.ackPath, 'utf8')
+    } catch {
+      // ACK not written yet.
+    }
+
+    const ack = raw === null ? null : parseLaunchAck(raw, requestId)
+
+    if (ack) {
+      if (ack.ok && ack.updaterPid !== null) {
+        cleanupFiles()
+
+        return { ok: true, updaterPid: ack.updaterPid, error: null }
+      }
+
+      await cleanupTask(true)
+      cleanupFiles()
+
+      return launchFailure(`launcher reported failure: ${ack.error || 'missing updater pid'}`)
+    }
+
+    await sleep(pollMs)
+  }
+
+  // Remove the scheduled definition so it cannot fire at its nominal time
+  // after /Run failed or was delayed. Never start a fallback updater here: if
+  // the task already started but its ACK was inaccessible, the live desktop
+  // makes it fail on the holder guard instead of racing a second mutator.
+  await cleanupTask(true)
+  cleanupFiles()
+
+  return launchFailure(`no launcher ACK within ${timeoutMs}ms`)
+}

--- a/apps/desktop/electron/windows-update-relaunch.test.ts
+++ b/apps/desktop/electron/windows-update-relaunch.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+
+import { acknowledgeUpdateRelaunch, parseUpdateRelaunchAckRequest } from './windows-update-relaunch'
+
+test('accepts only a request-bound ACK path below HERMES_HOME logs', () => {
+  const home = path.join('C:\\Users\\damian', 'hermes')
+  const ack = path.join(home, 'logs', 'desktop-relaunch-abc.json')
+  const id = 'a'.repeat(32)
+
+  assert.deepEqual(
+    parseUpdateRelaunchAckRequest(
+      [`--hermes-update-relaunch-ack=${ack}`, `--hermes-update-relaunch-request=${id}`],
+      home
+    ),
+    { ackPath: path.resolve(ack), requestId: id }
+  )
+  assert.equal(
+    parseUpdateRelaunchAckRequest(
+      ['--hermes-update-relaunch-ack=C:\\Temp\\owned.json', `--hermes-update-relaunch-request=${id}`],
+      home
+    ),
+    null
+  )
+  assert.equal(parseUpdateRelaunchAckRequest([`--hermes-update-relaunch-ack=${ack}`], home), null)
+})
+
+test('writes the cold-start PID ACK for the updater', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-relaunch-'))
+  const ack = path.join(home, 'logs', 'desktop-relaunch.json')
+  const id = 'b'.repeat(32)
+
+  assert.equal(
+    acknowledgeUpdateRelaunch(
+      [`--hermes-update-relaunch-ack=${ack}`, `--hermes-update-relaunch-request=${id}`],
+      home,
+      4242
+    ),
+    true
+  )
+  assert.deepEqual(JSON.parse(fs.readFileSync(ack, 'utf8')), {
+    ok: true,
+    pid: 4242,
+    requestId: id,
+    readyAt: JSON.parse(fs.readFileSync(ack, 'utf8')).readyAt
+  })
+})

--- a/apps/desktop/electron/windows-update-relaunch.ts
+++ b/apps/desktop/electron/windows-update-relaunch.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ACK_ARG = '--hermes-update-relaunch-ack='
+const REQUEST_ARG = '--hermes-update-relaunch-request='
+
+export type UpdateRelaunchAckRequest = { ackPath: string; requestId: string }
+
+export function parseUpdateRelaunchAckRequest(argv: string[], hermesHome: string): UpdateRelaunchAckRequest | null {
+  const rawAck = argv.find(arg => arg.startsWith(ACK_ARG))?.slice(ACK_ARG.length).trim()
+  const requestId = argv.find(arg => arg.startsWith(REQUEST_ARG))?.slice(REQUEST_ARG.length).trim()
+
+  if (!rawAck || !requestId || !/^[a-f0-9]{32}$/i.test(requestId)) {
+    return null
+  }
+
+  const ackPath = path.resolve(rawAck)
+  const logsRoot = path.resolve(hermesHome, 'logs')
+  const relativeAckPath = path.relative(logsRoot, ackPath)
+
+  if (
+    !relativeAckPath ||
+    relativeAckPath === '..' ||
+    relativeAckPath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeAckPath)
+  ) {
+    return null
+  }
+
+  return { ackPath, requestId }
+}
+
+/** Cold-start ACK consumed by the updater before it exits its own job chain. */
+export function acknowledgeUpdateRelaunch(argv: string[], hermesHome: string, pid = process.pid): boolean {
+  const request = parseUpdateRelaunchAckRequest(argv, hermesHome)
+
+  if (!request || !Number.isInteger(pid) || pid <= 0) {
+    return false
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(request.ackPath), { recursive: true })
+    fs.writeFileSync(
+      request.ackPath,
+      JSON.stringify({ ok: true, pid, requestId: request.requestId, readyAt: new Date().toISOString() }),
+      'utf8'
+    )
+
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/electron/windows-update-runtime.ts
+++ b/apps/desktop/electron/windows-update-runtime.ts
@@ -1,0 +1,168 @@
+export type WindowsProcessInfo = {
+  pid: number | null
+  parentPid: number | null
+  creationTimeMs: number | null
+  executablePath: string
+  commandLine: string
+}
+
+function parsedCreationTimeMs(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value
+  }
+
+  const text = String(value ?? '').trim()
+
+  if (!text) {
+    return null
+  }
+
+  const numeric = Number(text)
+
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return numeric
+  }
+
+  const parsed = Date.parse(text)
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function normalizedProcessInfo(value: any): WindowsProcessInfo {
+  const rawPid = value?.pid ?? value?.ProcessId
+  const numericPid = Number(rawPid)
+  const rawParent = value?.parentPid ?? value?.ParentProcessId
+  const numericParent = Number(rawParent)
+
+  return {
+    pid: Number.isInteger(numericPid) && numericPid > 0 ? numericPid : null,
+    parentPid: Number.isInteger(numericParent) && numericParent > 0 ? numericParent : null,
+    creationTimeMs: parsedCreationTimeMs(value?.creationTimeMs ?? value?.CreationTimeMs ?? value?.CreationDate),
+    executablePath: String(value?.executablePath ?? value?.ExecutablePath ?? ''),
+    commandLine: String(value?.commandLine ?? value?.CommandLine ?? '')
+  }
+}
+
+export function parseWindowsProcessList(raw: unknown): WindowsProcessInfo[] {
+  const text = String(raw ?? '')
+    .replace(/^\uFEFF/, '')
+    .trim()
+
+  if (!text) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(text)
+    const rows = Array.isArray(parsed) ? parsed : [parsed]
+    return rows.map(normalizedProcessInfo)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Enumerate a process tree from a live inventory instead of `taskkill /T`.
+ *
+ * taskkill /T builds its tree from bare ParentProcessId links with no
+ * creation-time validation. The desktop's own parent (the task-launcher
+ * PowerShell) dies immediately after boot, so its PID gets recycled — and
+ * when a process in the tree being killed recycles it, taskkill considers
+ * the DESKTOP a descendant and kills it mid-handoff (observed: the whole
+ * Electron tree died within 1s of the backend tree-kill). This walk has the
+ * parent/child edge is accepted only when both creation times exist and the
+ * parent predates the child. That rejects stale ParentProcessId links after
+ * PID reuse. Callers MUST additionally pass their own pid (and anything else
+ * that must survive) in excludePids: excluded pids are neither killed nor
+ * expanded.
+ */
+export function collectProcessTreePids(
+  processes: Array<WindowsProcessInfo | Record<string, unknown>>,
+  rootPid: number,
+  {
+    excludePids = [],
+    expectedRootCreationTimeMs
+  }: { excludePids?: number[]; expectedRootCreationTimeMs: number }
+): number[] {
+  if (
+    !Number.isInteger(rootPid) ||
+    rootPid <= 0 ||
+    !Number.isFinite(expectedRootCreationTimeMs) ||
+    expectedRootCreationTimeMs <= 0
+  ) {
+    return []
+  }
+
+  const excluded = new Set(excludePids.filter(pid => Number.isInteger(pid) && pid > 0))
+
+  if (excluded.has(rootPid)) {
+    return []
+  }
+
+  const infoByPid = new Map<number, WindowsProcessInfo>()
+
+  for (const value of processes || []) {
+    const info = normalizedProcessInfo(value)
+
+    if (info.pid === null) {
+      continue
+    }
+
+    infoByPid.set(info.pid, info)
+  }
+
+  // The root must still exist in this exact inventory. If the tracked child
+  // already exited, do not kill a newly recycled PID with the same number.
+  if (infoByPid.get(rootPid)?.creationTimeMs !== expectedRootCreationTimeMs) {
+    return []
+  }
+
+  const childrenByParent = new Map<number, number[]>()
+
+  for (const info of infoByPid.values()) {
+    if (info.parentPid === null || info.creationTimeMs === null) {
+      continue
+    }
+
+    const parent = infoByPid.get(info.parentPid)
+
+    if (parent?.creationTimeMs === null || parent?.creationTimeMs === undefined) {
+      continue
+    }
+
+    // A real parent was already alive when its child started. If the current
+    // process carrying parentPid was created later, the PPID is a stale link
+    // through a recycled PID and must not be traversed.
+    if (parent.creationTimeMs > info.creationTimeMs) {
+      continue
+    }
+
+    const siblings = childrenByParent.get(info.parentPid) || []
+
+    siblings.push(info.pid as number)
+    childrenByParent.set(info.parentPid, siblings)
+  }
+
+  const tree: number[] = []
+  const seen = new Set<number>([rootPid])
+  const queue = [rootPid]
+
+  while (queue.length) {
+    const pid = queue.shift() as number
+
+    if (excluded.has(pid)) {
+      continue
+    }
+
+    tree.push(pid)
+
+    for (const child of childrenByParent.get(pid) || []) {
+      if (!seen.has(child)) {
+        seen.add(child)
+        queue.push(child)
+      }
+    }
+  }
+
+  return tree
+}

--- a/apps/desktop/electron/windows-update-tree.test.ts
+++ b/apps/desktop/electron/windows-update-tree.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for collectProcessTreePids in electron/windows-update-runtime.ts —
+ * the taskkill-/T-replacement that enumerates a kill tree from a CIM
+ * inventory with the caller's own pid hard-excluded.
+ *
+ * What this locks:
+ *   1. Plain descendant enumeration (children + grandchildren, no strays).
+ *   2. The PID-reuse self-kill guard: when a process in the tree has recycled
+ *      the desktop's dead launcher-parent PID, the desktop (excluded) and its
+ *      Electron children are NOT collected — the exact "all Hermes processes
+ *      die within 1s of Update now" incident.
+ *   3. Robustness: cycles terminate, excluded root yields nothing.
+ */
+
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import { collectProcessTreePids } from './windows-update-runtime'
+
+function proc(pid: number, parentPid: number, creationTimeMs = pid): Record<string, number> {
+  return { ProcessId: pid, ParentProcessId: parentPid, CreationTimeMs: creationTimeMs }
+}
+
+test('collects the root and all transitive descendants', () => {
+  const inventory = [proc(100, 1), proc(200, 100), proc(201, 100), proc(300, 200), proc(999, 1)]
+
+  assert.deepEqual(collectProcessTreePids(inventory, 100, { expectedRootCreationTimeMs: 100 }).sort(), [100, 200, 201, 300])
+})
+
+test('recycled launcher-parent pid cannot pull the excluded desktop into the kill tree', () => {
+  // Desktop 5000 was started by launcher 4000 (dead). Backend 100 spawned a
+  // short-lived child that recycled pid 4000 — raw ppid links now claim the
+  // desktop descends from the backend. taskkill /T would kill 5000 + its
+  // Electron children; the exclude guard must keep them all out.
+  const inventory = [
+    proc(100, 5000, 1_000), // backend (child of desktop)
+    proc(4000, 100, 2_000), // backend child that RECYCLED the dead launcher pid
+    proc(5000, 4000, 500), // desktop is older: current 4000 cannot be its real parent
+    proc(5001, 5000, 600), // Electron renderer
+    proc(5002, 5000, 700) // Electron gpu
+  ]
+
+  const tree = collectProcessTreePids(inventory, 100, {
+    excludePids: [5000],
+    expectedRootCreationTimeMs: 1_000
+  })
+
+  assert.deepEqual(tree.sort(), [100, 4000])
+  assert.ok(!tree.includes(5000))
+  assert.ok(!tree.includes(5001))
+  assert.ok(!tree.includes(5002))
+})
+
+test('parent-link cycles terminate and excluded root returns empty', () => {
+  const cycle = [proc(10, 20), proc(20, 10)]
+
+  assert.deepEqual(collectProcessTreePids(cycle, 10, { expectedRootCreationTimeMs: 10 }).sort(), [10, 20])
+  assert.deepEqual(
+    collectProcessTreePids(cycle, 10, { excludePids: [10], expectedRootCreationTimeMs: 10 }),
+    []
+  )
+  assert.deepEqual(collectProcessTreePids([], 0, { expectedRootCreationTimeMs: 1 }), [])
+})
+
+test('missing creation evidence never expands a raw PPID edge or kills a recycled root', () => {
+  const missingTimes = [
+    { ProcessId: 100, ParentProcessId: 1 },
+    { ProcessId: 200, ParentProcessId: 100 }
+  ]
+
+  assert.deepEqual(collectProcessTreePids(missingTimes, 100, { expectedRootCreationTimeMs: 1_000 }), [])
+  assert.deepEqual(
+    collectProcessTreePids([proc(200, 100, 2_000)], 100, { expectedRootCreationTimeMs: 1_000 }),
+    []
+  )
+})
+
+test('a recycled root PID is rejected unless its creation time matches the tracked child', () => {
+  const recycled = [proc(100, 1, 9_000), proc(200, 100, 9_100)]
+
+  assert.deepEqual(collectProcessTreePids(recycled, 100, { expectedRootCreationTimeMs: 1_000 }), [])
+  assert.deepEqual(collectProcessTreePids(recycled, 100, { expectedRootCreationTimeMs: 9_000 }), [100, 200])
+})

--- a/apps/desktop/src/app/contrib/hooks/use-update-continuation.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-update-continuation.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { type UpdateContinuation, updateContinuationToken } from '@/store/update-continuation'
+
+import { deliverUpdateContinuation } from './use-update-continuation'
+
+const continuation: UpdateContinuation = {
+  armedAt: 1_000,
+  requestId: 'a'.repeat(32),
+  sessionId: 'stored-1'
+}
+
+describe('deliverUpdateContinuation', () => {
+  it('submits once only after the durable transcript check', async () => {
+    const loadMessages = vi.fn().mockResolvedValue({ messages: [] })
+    const submitText = vi.fn().mockResolvedValue(true)
+    const markAttempt = vi.fn()
+
+    await expect(
+      deliverUpdateContinuation(continuation, loadMessages, submitText, { markAttempt })
+    ).resolves.toBe('submitted')
+    expect(loadMessages).toHaveBeenCalledWith('stored-1')
+    expect(markAttempt).toHaveBeenCalledOnce()
+    expect(submitText).toHaveBeenCalledOnce()
+    expect(submitText.mock.calls[0][0]).toContain(updateContinuationToken(continuation.requestId))
+  })
+
+  it('treats an existing request token as the idempotent gateway acknowledgement', async () => {
+    const submitText = vi.fn()
+
+    const loadMessages = vi.fn().mockResolvedValue({
+      messages: [{ role: 'user', text: `done ${updateContinuationToken(continuation.requestId)}` }]
+    })
+
+    await expect(deliverUpdateContinuation(continuation, loadMessages, submitText)).resolves.toBe('already-present')
+    expect(submitText).not.toHaveBeenCalled()
+  })
+
+  it('never retries within the same delivery run after an ambiguous submit timeout', async () => {
+    const loadMessages = vi.fn().mockResolvedValue({ messages: [] })
+    const submitText = vi.fn().mockRejectedValueOnce(new Error('request timed out'))
+
+    await expect(
+      deliverUpdateContinuation(continuation, loadMessages, submitText, {
+        sleep: vi.fn().mockResolvedValue(undefined)
+      })
+    ).resolves.toBe(false)
+    expect(loadMessages).toHaveBeenCalledOnce()
+    expect(submitText).toHaveBeenCalledOnce()
+  })
+
+  it('keeps an explicitly rejected marker for a later confirmed idle phase', async () => {
+    const noWait = vi.fn().mockResolvedValue(undefined)
+    const submitText = vi.fn().mockResolvedValue(false)
+
+    await expect(
+      deliverUpdateContinuation(continuation, vi.fn().mockResolvedValue({ messages: [] }), submitText, {
+        sleep: noWait
+      })
+    ).resolves.toBe(false)
+    expect(submitText).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-update-continuation.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-update-continuation.ts
@@ -1,0 +1,159 @@
+import { type RefObject, useEffect, useRef } from 'react'
+
+import { getSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
+import {
+  clearUpdateContinuation,
+  markUpdateContinuationAttempt,
+  readUpdateContinuation,
+  type UpdateContinuation,
+  updateContinuationPrompt,
+  updateContinuationToken
+} from '@/store/update-continuation'
+
+import type { GatewayRequester } from '../types'
+
+interface UpdateContinuationParams {
+  activeSessionId: null | string
+  awaitingResponse: boolean
+  busy: boolean
+  gatewayState: string
+  routedSessionId: null | string
+  runtimeIdByStoredSessionIdRef: RefObject<Map<string, string>>
+  selectedStoredSessionId: null | string
+  requestGateway: GatewayRequester
+}
+
+type DeliveryResult = 'already-present' | 'submitted' | false
+type MessagesLoader = (sessionId: string) => Promise<{ messages: unknown[] }>
+type ContinuationSubmitter = (text: string) => Promise<unknown> | unknown
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export async function deliverUpdateContinuation(
+  continuation: UpdateContinuation,
+  loadMessages: MessagesLoader,
+  submitContinuation: ContinuationSubmitter,
+  opts: { markAttempt?: () => void; now?: () => number; sleep?: (ms: number) => Promise<void> } = {}
+): Promise<DeliveryResult> {
+  const wait = opts.sleep ?? sleep
+
+  // A prior renderer may have died after prompt.submit reached the gateway but
+  // before localStorage was cleared. Give persistence a moment, then use the
+  // request token in the stored transcript as the idempotency acknowledgement.
+  if (continuation.attemptedAt) {
+    const remaining = 3_000 - ((opts.now ?? Date.now)() - continuation.attemptedAt)
+
+    if (remaining > 0) {
+      await wait(remaining)
+    }
+  }
+
+  const token = updateContinuationToken(continuation.requestId)
+  const prompt = updateContinuationPrompt(continuation.requestId)
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const transcript = await loadMessages(continuation.sessionId)
+
+      if (JSON.stringify(transcript.messages).includes(token)) {
+        return 'already-present'
+      }
+    } catch {
+      // Without the transcript check we cannot distinguish a retry from a
+      // prompt accepted just before a renderer crash. Fail closed and retry
+      // the read on a bounded backoff.
+      await wait(750 * (attempt + 1))
+
+      continue
+    }
+
+    opts.markAttempt?.()
+
+    try {
+      const accepted = await submitContinuation(prompt)
+
+      if (accepted !== false) {
+        return 'submitted'
+      }
+    } catch {
+      // A transport timeout is ambiguous: prompt.submit may already have
+      // reached the gateway before its user message is durable. Keep the
+      // marker and stop this delivery run. A later, freshly confirmed idle
+      // phase (or next launch) re-enters through the transcript check above.
+    }
+
+    return false
+  }
+
+  return false
+}
+
+/** Continue only after the normal route-resume loaded the exact, idle chat. */
+export function useUpdateContinuation({
+  activeSessionId,
+  awaitingResponse,
+  busy,
+  gatewayState,
+  routedSessionId,
+  runtimeIdByStoredSessionIdRef,
+  selectedStoredSessionId,
+  requestGateway
+}: UpdateContinuationParams): void {
+  const inFlightRequestRef = useRef<null | string>(null)
+
+  useEffect(() => {
+    const continuation = readUpdateContinuation()
+
+    const runtimeId = continuation
+      ? runtimeIdByStoredSessionIdRef.current.get(continuation.sessionId) ?? null
+      : null
+
+    const exactIdleSessionReady =
+      continuation !== null &&
+      gatewayState === 'open' &&
+      routedSessionId === continuation.sessionId &&
+      selectedStoredSessionId === continuation.sessionId &&
+      runtimeId !== null &&
+      runtimeId === activeSessionId &&
+      !busy &&
+      !awaitingResponse
+
+    if (!exactIdleSessionReady || inFlightRequestRef.current === continuation.requestId) {
+      return
+    }
+
+    inFlightRequestRef.current = continuation.requestId
+    void deliverUpdateContinuation(
+      continuation,
+      sessionId => getSessionMessages(sessionId),
+      prompt =>
+        requestGateway(
+          'prompt.submit',
+          { session_id: runtimeId, text: prompt },
+          PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+        ),
+      {
+        markAttempt: () => markUpdateContinuationAttempt(continuation)
+      }
+    )
+      .then(delivered => {
+        if (delivered) {
+          clearUpdateContinuation()
+        }
+      })
+      .finally(() => {
+        inFlightRequestRef.current = null
+      })
+  }, [
+    activeSessionId,
+    awaitingResponse,
+    busy,
+    gatewayState,
+    routedSessionId,
+    runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionId,
+    requestGateway
+  ])
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -34,6 +34,8 @@ import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActi
 import { $startWorkSessionRequest, followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
 import {
   $activeSessionId,
+  $awaitingResponse,
+  $busy,
   $connection,
   $currentCwd,
   $freshDraftReady,
@@ -98,6 +100,7 @@ import { useBackgroundSync } from './hooks/use-background-sync'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
 import { usePetBridge } from './hooks/use-pet-bridge'
 import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
+import { useUpdateContinuation } from './hooks/use-update-continuation'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
@@ -131,6 +134,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   const gatewayState = useStore($gatewayState)
   const activeSessionId = useStore($activeSessionId)
+  const awaitingResponse = useStore($awaitingResponse)
+  const busy = useStore($busy)
   const currentCwd = useStore($currentCwd)
   const freshDraftReady = useStore($freshDraftReady)
   const resumeFailedSessionId = useStore($resumeFailedSessionId)
@@ -535,6 +540,17 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     startFreshSessionDraft,
     sttEnabled,
     updateSessionState
+  })
+
+  useUpdateContinuation({
+    activeSessionId,
+    awaitingResponse,
+    busy,
+    gatewayState,
+    routedSessionId,
+    runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionId,
+    requestGateway
   })
 
   // Runs outside the selected ChatBar so queues belonging to background

--- a/apps/desktop/src/store/update-continuation.test.ts
+++ b/apps/desktop/src/store/update-continuation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  armUpdateContinuation,
+  clearUpdateContinuation,
+  continuationSessionId,
+  readUpdateContinuation,
+  type UpdateContinuationStorage
+} from './update-continuation'
+
+function memoryStorage(): UpdateContinuationStorage {
+  const values = new Map<string, string>()
+
+  return {
+    getItem: key => values.get(key) ?? null,
+    removeItem: key => values.delete(key),
+    setItem: (key, value) => values.set(key, value)
+  }
+}
+
+describe('update continuation handoff', () => {
+  it('arms only for an in-flight turn and prefers the durable stored id', () => {
+    expect(
+      continuationSessionId({ activeStoredSessionId: 'stored-1', selectedStoredSessionId: 'selected-1', busy: true })
+    ).toBe('stored-1')
+    expect(
+      continuationSessionId({ activeStoredSessionId: null, selectedStoredSessionId: 'selected-1', busy: false })
+    ).toBeNull()
+  })
+
+  it('keeps the handoff durable until delivery is explicitly acknowledged', () => {
+    const storage = memoryStorage()
+
+    armUpdateContinuation('stored-1', { now: 1_000, storage })
+
+    expect(readUpdateContinuation({ now: 2_000, storage })?.sessionId).toBe('stored-1')
+    expect(readUpdateContinuation({ now: 2_001, storage })?.sessionId).toBe('stored-1')
+    clearUpdateContinuation(storage)
+    expect(readUpdateContinuation({ now: 2_002, storage })).toBeNull()
+  })
+
+  it('drops stale handoffs instead of reviving an old task', () => {
+    const storage = memoryStorage()
+
+    armUpdateContinuation('stored-1', { now: 1_000, storage })
+
+    expect(readUpdateContinuation({ maxAgeMs: 500, now: 2_000, storage })).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/update-continuation.ts
+++ b/apps/desktop/src/store/update-continuation.ts
@@ -1,0 +1,130 @@
+const UPDATE_CONTINUATION_KEY = 'hermes.desktop.update-continuation'
+const DEFAULT_MAX_AGE_MS = 2 * 60 * 60 * 1000
+
+const UPDATE_CONTINUATION_PROMPT_BASE =
+  'Hermes wurde für das Update neu gestartet. Setze die zuvor unterbrochene Aufgabe in diesem Chat fort. ' +
+  'Prüfe zuerst, ob Update und Laufzeit gesund sind, und beende dann den ursprünglichen Auftrag. ' +
+  'Starte keinen weiteren Update-Lauf, wenn der aktuelle bereits erfolgreich war.'
+
+export interface UpdateContinuationStorage {
+  getItem: (key: string) => null | string
+  removeItem: (key: string) => void
+  setItem: (key: string, value: string) => void
+}
+
+export interface UpdateContinuation {
+  armedAt: number
+  attemptedAt?: number
+  requestId: string
+  sessionId: string
+}
+
+function newRequestId(): string {
+  return globalThis.crypto?.randomUUID?.().replaceAll('-', '') ?? `${Date.now()}${Math.random()}`.replace(/\D/g, '')
+}
+
+export function updateContinuationPrompt(requestId: string): string {
+  return `${UPDATE_CONTINUATION_PROMPT_BASE}\n\n<!-- hermes-update-continuation:${requestId} -->`
+}
+
+export function updateContinuationToken(requestId: string): string {
+  return `hermes-update-continuation:${requestId}`
+}
+
+function browserStorage(): null | UpdateContinuationStorage {
+  return typeof globalThis.localStorage === 'undefined' ? null : globalThis.localStorage
+}
+
+export function continuationSessionId(input: {
+  activeStoredSessionId: null | string
+  selectedStoredSessionId: null | string
+  busy: boolean
+  awaitingResponse?: boolean
+}): null | string {
+  if (!input.busy && !input.awaitingResponse) {
+    return null
+  }
+
+  return input.activeStoredSessionId || input.selectedStoredSessionId || null
+}
+
+export function armUpdateContinuation(
+  sessionId: string,
+  opts: { now?: number; storage?: null | UpdateContinuationStorage } = {}
+): boolean {
+  const storage = opts.storage === undefined ? browserStorage() : opts.storage
+  const normalized = sessionId.trim()
+
+  if (!storage || !normalized) {
+    return false
+  }
+
+  storage.setItem(
+    UPDATE_CONTINUATION_KEY,
+    JSON.stringify({
+      armedAt: opts.now ?? Date.now(),
+      requestId: newRequestId(),
+      sessionId: normalized
+    } satisfies UpdateContinuation)
+  )
+
+  return true
+}
+
+export function clearUpdateContinuation(storage: null | UpdateContinuationStorage = browserStorage()): void {
+  storage?.removeItem(UPDATE_CONTINUATION_KEY)
+}
+
+export function markUpdateContinuationAttempt(
+  continuation: UpdateContinuation,
+  opts: { now?: number; storage?: null | UpdateContinuationStorage } = {}
+): void {
+  const storage = opts.storage === undefined ? browserStorage() : opts.storage
+
+  storage?.setItem(
+    UPDATE_CONTINUATION_KEY,
+    JSON.stringify({ ...continuation, attemptedAt: opts.now ?? Date.now() } satisfies UpdateContinuation)
+  )
+}
+
+export function readUpdateContinuation(
+  opts: { maxAgeMs?: number; now?: number; storage?: null | UpdateContinuationStorage } = {}
+): null | UpdateContinuation {
+  const storage = opts.storage === undefined ? browserStorage() : opts.storage
+
+  if (!storage) {
+    return null
+  }
+
+  const raw = storage.getItem(UPDATE_CONTINUATION_KEY)
+
+  if (!raw) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<UpdateContinuation>
+    const sessionId = typeof parsed.sessionId === 'string' ? parsed.sessionId.trim() : ''
+    const requestId = typeof parsed.requestId === 'string' ? parsed.requestId.trim() : ''
+    const armedAt = Number(parsed.armedAt)
+    const attemptedAt = parsed.attemptedAt === undefined ? undefined : Number(parsed.attemptedAt)
+    const age = (opts.now ?? Date.now()) - armedAt
+
+    if (
+      !sessionId ||
+      !/^[a-z0-9]{16,64}$/i.test(requestId) ||
+      !Number.isFinite(armedAt) ||
+      (attemptedAt !== undefined && !Number.isFinite(attemptedAt)) ||
+      age < 0 ||
+      age > (opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS)
+    ) {
+      storage.removeItem(UPDATE_CONTINUATION_KEY)
+      return null
+    }
+
+    return { armedAt, ...(attemptedAt === undefined ? {} : { attemptedAt }), requestId, sessionId }
+  } catch {
+    storage.removeItem(UPDATE_CONTINUATION_KEY)
+    return null
+  }
+}

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -17,7 +17,18 @@ import { checkHermesUpdate, getActionStatus, updateHermes } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { persistString, storedString } from '@/lib/storage'
 import { dismissNotification, notify } from '@/store/notifications'
-import { $connection } from '@/store/session'
+import {
+  $activeSessionStoredId,
+  $awaitingResponse,
+  $busy,
+  $connection,
+  $selectedStoredSessionId
+} from '@/store/session'
+import {
+  armUpdateContinuation,
+  clearUpdateContinuation,
+  continuationSessionId
+} from '@/store/update-continuation'
 import type { BackendUpdateCheckResponse } from '@/types/hermes'
 
 export interface UpdateApplyState {
@@ -372,8 +383,25 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
   dismissNotification(UPDATE_TOAST_ID)
   $updateApply.set({ ...IDLE, applying: true, stage: 'prepare', message: 'Starting update…' })
 
+  const continuationId = continuationSessionId({
+    activeStoredSessionId: $activeSessionStoredId.get(),
+    awaitingResponse: $awaitingResponse.get(),
+    busy: $busy.get(),
+    selectedStoredSessionId: $selectedStoredSessionId.get()
+  })
+
+  if (continuationId) {
+    armUpdateContinuation(continuationId)
+  } else {
+    clearUpdateContinuation()
+  }
+
   try {
     const result = await bridge.apply(opts)
+
+    if (!result?.handedOff) {
+      clearUpdateContinuation()
+    }
 
     // CLI install with no staged updater: not an error — the user just runs
     // `hermes update` themselves. Land on a dedicated manual state so the
@@ -458,6 +486,7 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
 
     return result
   } catch (error) {
+    clearUpdateContinuation()
     const message = error instanceof Error ? error.message : String(error)
     $updateApply.set({ ...$updateApply.get(), applying: false, stage: 'error', error: 'apply-failed', message })
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9646,6 +9646,31 @@ def _discard_lockfile_churn(git_cmd, repo_root):
         pass
 
 
+def _preserve_local_update_commits(git_cmd, repo_root) -> bool:
+    """Whether this checkout keeps its local patch stack across updates.
+
+    This is an install-local Git setting rather than a tracked config value so
+    a managed downstream patch can protect the very update code that performs
+    the rebase.  The default stays compatible with ordinary managed installs;
+    operators opt in with::
+
+        git config hermes.updatePreserveLocalCommits true
+    """
+    try:
+        result = subprocess.run(
+            git_cmd
+            + ["config", "--bool", "--get", "hermes.updatePreserveLocalCommits"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except Exception:
+        return False
+
+    return result.returncode == 0 and result.stdout.strip().lower() == "true"
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -10123,26 +10148,56 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True,
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
-                )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
+                # ff-only failed — local and remote have diverged. Managed
+                # downstream installs may carry a deliberately-maintained
+                # local patch stack. Rebase that stack when the install-local
+                # guard is enabled; fail closed on conflicts so an update can
+                # never silently delete the fix that launched it.
+                if _preserve_local_update_commits(git_cmd, PROJECT_ROOT):
                     print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        "  ⚠ Fast-forward not possible. Preserving local commits "
+                        "and rebasing them onto the update..."
                     )
-                    sys.exit(1)
+                    rebase_result = subprocess.run(
+                        git_cmd + ["rebase", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if rebase_result.returncode != 0:
+                        subprocess.run(
+                            git_cmd + ["rebase", "--abort"],
+                            cwd=PROJECT_ROOT,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                        )
+                        print("✗ Local update patches conflict with the new version.")
+                        print("  Update stopped without discarding local commits.")
+                        if rebase_result.stderr.strip():
+                            print(f"  {rebase_result.stderr.strip().splitlines()[0]}")
+                        sys.exit(1)
+                else:
+                    # Historical managed-install behavior for upstream history
+                    # rewrites: local working changes are already stashed, so
+                    # reset to match the remote exactly.
+                    print(
+                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    )
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print(
+                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        )
+                        sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/tests/agent/test_coding_context_home_project_facts.py
+++ b/tests/agent/test_coding_context_home_project_facts.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import shutil
+import subprocess
+
+from agent import coding_context as cc
+
+
+def test_project_facts_ignore_dotfiles_repo_at_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "main.py").write_text("print('hi')\n")
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+        "HOME": str(home),
+    }
+
+    for args in (
+        ["init", "-q", "-b", "main"],
+        ["add", "-A"],
+        ["commit", "-q", "-m", "init"],
+    ):
+        subprocess.run([shutil.which("git"), "-C", str(home), *args], check=True, env=env)
+
+    monkeypatch.setattr(Path, "home", lambda: home)
+    workspace = home / "scratch"
+    workspace.mkdir()
+
+    assert cc.project_facts_for(workspace) is None

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -580,10 +580,32 @@ def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path
 
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
     assert len(reset_calls) == 1
-    assert reset_calls[0] == ["git", "reset", "--hard", "origin/main"]
+    assert reset_calls[0][-3:] == ["reset", "--hard", "origin/main"]
 
     out = capsys.readouterr().out
     assert "Fast-forward not possible" in out
+
+
+def test_cmd_update_rebases_local_patch_stack_when_preservation_is_enabled(
+    monkeypatch, tmp_path, capsys
+):
+    """A managed local fix must survive the update that it launches."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        hermes_main,
+        "_preserve_local_update_commits",
+        lambda *args: True,
+    )
+
+    side_effect, recorded = _make_update_side_effect(ff_only_fails=True)
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert any(call[-2:] == ["rebase", "origin/main"] for call in recorded)
+    assert not any("reset" in call and "--hard" in call for call in recorded)
+    assert "Preserving local commits" in capsys.readouterr().out
 
 
 def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

The Windows one-click update handoff is not durable across the desktop restart: the update marker and the ACK/handoff bookkeeping do not survive the full close→update→relaunch cycle, so a mid-update crash or a second desktop instance can leave the install in a half-updated state (venv shim locked, marker stale, backend respawn racing the updater).

## Root cause

- The update marker (`update-marker.ts`) was not consistently owned/verified across the restart boundary.
- The desktop had no close-guard preventing the updater window from being terminated mid-update, and no regression coverage for the handoff path.

## Fix

- Make the update marker lifecycle explicit and verified across restart (write → own → verify → consume) with tests.
- Add an update close-guard in the bootstrap installer so the updater window cannot be closed while a mutation phase is in flight.
- Add a Windows handoff regression test covering the full close→update→relaunch sequence.

## Validation

- `apps/desktop/electron/update-marker.test.ts` — new.
- `apps/desktop/electron/windows-update-handoff-regression.test.ts` — new.
- `apps/bootstrap-installer/src/update-close-guard.test.ts` — new.
- E2E on Windows: staged `hermes-setup.exe --update --branch main` completes with desktop relaunch (desktop.log: `launched updater ... exiting desktop to release venv shim`, exit marker 0).

## Stack

Part 1 of 4. Base: `origin/main`.
