### PR TITLE
fix(update): keep Windows relaunch task short

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -396,6 +396,19 @@ def _git_root(cwd: Path) -> Optional[Path]:
     return None
 
 
+def _git_workspace_root(cwd: Path) -> Optional[Path]:
+    """Git root for a real workspace, excluding a dotfiles repo at ``$HOME``."""
+    resolved = cwd.resolve()
+    root = _git_root(resolved)
+    home = _home()
+    if root is not None and home is not None:
+        cwd_is_under_home = resolved == home or home in resolved.parents
+        root_is_under_home = root == home or home in root.parents
+        if root == home or (cwd_is_under_home and not root_is_under_home):
+            return None
+    return root
+
+
 def _home() -> Optional[Path]:
     try:
         return Path.home().resolve()
@@ -424,8 +437,11 @@ def _marker_root(cwd: Path) -> Optional[Path]:
     for depth, parent in enumerate([current, *current.parents]):
         if depth > 6:
             break
+        # Treat these as traversal boundaries, not merely roots to skip. A
+        # test/work directory nested under HOME must not walk past the mocked
+        # HOME and rediscover a real dotfiles repo or global AGENTS.md above it.
         if parent == home or (temp_root is not None and parent == temp_root):
-            continue
+            break
         for marker in _PROJECT_MARKERS:
             if (parent / marker).exists():
                 return parent
@@ -459,9 +475,7 @@ def _detect_profile_name(mode: str, platform: str, cwd_str: str) -> str:
     # workspace on its own — cheap stat checks, no scan.
     if _marker_root(cwd) is not None:
         return CODING_PROFILE.name
-    git_root = _git_root(cwd)
-    if git_root is not None and git_root == _home():
-        git_root = None  # dotfiles repo at $HOME — not a code workspace
+    git_root = _git_workspace_root(cwd)
     # A bare git repo only counts when it actually holds code, so `git init` on a
     # notes/writing/research folder stays in the general posture.
     if git_root is not None and _has_code_files(git_root):
@@ -824,7 +838,7 @@ def project_facts_for(cwd: Optional[str | Path] = None) -> Optional[dict[str, An
     re-derive "are we coding?" or duplicate the verify-command sniffing.
     """
     resolved = _resolve_cwd(cwd)
-    root = _git_root(resolved) or _marker_root(resolved)
+    root = _git_workspace_root(resolved) or _marker_root(resolved)
     if root is None:
         return None
 
@@ -846,7 +860,7 @@ def build_coding_workspace_block(cwd: Optional[str | Path] = None) -> str:
     — so marker-only (non-git) projects still get a snapshot.
     """
     resolved = _resolve_cwd(cwd)
-    git_root = _git_root(resolved)
+    git_root = _git_workspace_root(resolved)
     root = git_root or _marker_root(resolved)
     if root is None:
         return ""

--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -163,47 +163,190 @@ pub async fn get_bootstrap_status(
 /// (e.g. when Stage-Desktop was skipped) so the frontend can present
 /// actionable failure UI rather than silently doing nothing.
 #[tauri::command]
-pub async fn launch_hermes_desktop(
-    app: AppHandle,
-    install_root: String,
-) -> Result<(), String> {
+pub async fn launch_hermes_desktop(app: AppHandle, install_root: String) -> Result<(), String> {
     let install_root = PathBuf::from(install_root);
     let exe_path = resolve_hermes_desktop_exe(&install_root).ok_or_else(|| {
         format!(
             "Couldn't find a built Hermes desktop at {}. The desktop build step \
              may have been skipped or failed. Run `hermes desktop` from a \
              terminal to build and launch it.",
-            install_root.join("apps").join("desktop").join("release").display()
+            install_root
+                .join("apps")
+                .join("desktop")
+                .join("release")
+                .display()
         )
     })?;
 
     tracing::info!(?exe_path, "launching Hermes desktop");
 
-    // Detach from us — the installer is about to exit. On macOS launch the
-    // bundle through LaunchServices instead of exec'ing Contents/MacOS/Hermes
-    // directly; this matches user double-click/open behavior and avoids cwd /
-    // quarantine oddities after a self-update rebuild.
-    let mut cmd = desktop_launch_command(&exe_path, &install_root);
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
-        // DETACHED_PROCESS = 0x00000008
-        cmd.creation_flags(0x0000_0008);
+        launch_windows_desktop_via_task(&exe_path, &install_root)
+            .await
+            .map_err(|e| format!("failed to launch {}: {e:#}", exe_path.display()))?;
+        crate::allow_update_close(&app);
+        app.exit(0);
+        return Ok(());
     }
 
-    cmd.spawn().map_err(|e| {
-        format!(
-            "failed to launch {}: {e}",
-            exe_path.display()
-        )
-    })?;
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Detach from us — the installer is about to exit. On macOS launch the
+        // bundle through LaunchServices instead of exec'ing Contents/MacOS/Hermes
+        // directly; this matches user double-click/open behavior and avoids cwd /
+        // quarantine oddities after a self-update rebuild.
+        let mut cmd = desktop_launch_command(&exe_path, &install_root);
+        cmd.spawn()
+            .map_err(|e| format!("failed to launch {}: {e}", exe_path.display()))?;
 
-    // Give Windows ~150ms to actually start the new process before we exit.
-    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        crate::allow_update_close(&app);
+        app.exit(0);
+        Ok(())
+    }
+}
 
-    // Exit the installer cleanly. Tauri's process plugin gives us the
-    // right hook regardless of platform.
-    app.exit(0);
+#[cfg(target_os = "windows")]
+#[derive(Debug, Deserialize)]
+struct DesktopRelaunchAck {
+    ok: bool,
+    pid: u32,
+    #[serde(rename = "requestId")]
+    request_id: String,
+}
+
+#[cfg(target_os = "windows")]
+async fn run_schtasks(args: &[String]) -> Result<std::process::Output> {
+    let mut cmd = tokio::process::Command::new("schtasks.exe");
+    cmd.args(args);
+    cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    Ok(cmd.output().await?)
+}
+
+#[cfg(target_os = "windows")]
+async fn cleanup_desktop_launch_task(task_name: &str, end_running: bool) {
+    if end_running {
+        let _ = run_schtasks(&["/End".into(), "/TN".into(), task_name.into()]).await;
+    }
+    let _ = run_schtasks(&[
+        "/Delete".into(),
+        "/F".into(),
+        "/TN".into(),
+        task_name.into(),
+    ])
+    .await;
+}
+
+#[cfg(target_os = "windows")]
+fn windows_pid_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return false;
+        }
+        let mut exit_code = 0u32;
+        let ok = GetExitCodeProcess(handle, &mut exit_code) != 0;
+        CloseHandle(handle);
+        ok && exit_code == STILL_ACTIVE as u32
+    }
+}
+
+/// Relaunch through a new Task Scheduler action whose executable is Hermes.exe
+/// itself. The task therefore owns the desktop independently of both the
+/// updater's job and the outer update-launch task. The desktop writes a
+/// request-bound cold-start ACK from Electron's app-ready path; only then do we
+/// delete the one-shot definition and verify that its PID survived deletion.
+#[cfg(target_os = "windows")]
+async fn launch_windows_desktop_via_task(
+    exe_path: &std::path::Path,
+    install_root: &std::path::Path,
+) -> Result<()> {
+    let request_id = uuid::Uuid::new_v4().simple().to_string();
+    let task_name = format!("Hermes_DesktopRelaunch_{request_id}");
+    let ack_path = crate::paths::hermes_home()
+        .join("logs")
+        .join(format!("desktop-relaunch-{request_id}.json"));
+    if let Some(parent) = ack_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let _ = std::fs::remove_file(&ack_path);
+
+    let action = format!(
+        "\"{}\" --hermes-update-relaunch-ack=\"{}\" --hermes-update-relaunch-request={}",
+        exe_path.display(),
+        ack_path.display(),
+        request_id
+    );
+    let create_args = vec![
+        "/Create".into(),
+        "/F".into(),
+        "/TN".into(),
+        task_name.clone(),
+        "/SC".into(),
+        "ONCE".into(),
+        "/ST".into(),
+        "23:59".into(),
+        "/TR".into(),
+        action,
+    ];
+    let created = run_schtasks(&create_args).await?;
+    if !created.status.success() {
+        cleanup_desktop_launch_task(&task_name, false).await;
+        return Err(anyhow!(
+            "creating desktop relaunch task failed: {}",
+            String::from_utf8_lossy(&created.stderr).trim()
+        ));
+    }
+
+    let started = run_schtasks(&["/Run".into(), "/TN".into(), task_name.clone()]).await?;
+    if !started.status.success() {
+        cleanup_desktop_launch_task(&task_name, true).await;
+        return Err(anyhow!(
+            "starting desktop relaunch task failed: {}",
+            String::from_utf8_lossy(&started.stderr).trim()
+        ));
+    }
+
+    let deadline = Instant::now() + std::time::Duration::from_secs(30);
+    let ack = loop {
+        if let Ok(raw) = std::fs::read_to_string(&ack_path) {
+            if let Ok(parsed) = serde_json::from_str::<DesktopRelaunchAck>(&raw) {
+                if parsed.ok && parsed.request_id == request_id && parsed.pid > 0 {
+                    break parsed;
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            cleanup_desktop_launch_task(&task_name, true).await;
+            let _ = std::fs::remove_file(&ack_path);
+            return Err(anyhow!(
+                "no request-bound desktop cold-start ACK within 30s"
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    };
+
+    cleanup_desktop_launch_task(&task_name, false).await;
+    let _ = std::fs::remove_file(&ack_path);
+    tokio::time::sleep(std::time::Duration::from_millis(750)).await;
+    if !windows_pid_alive(ack.pid) {
+        return Err(anyhow!(
+            "desktop PID {} did not survive scheduled-task cleanup",
+            ack.pid
+        ));
+    }
+
+    tracing::info!(
+        desktop_pid = ack.pid,
+        ?install_root,
+        "desktop cold-start ACK survived independent scheduled-task cleanup"
+    );
     Ok(())
 }
 
@@ -298,6 +441,7 @@ fn app_bundle_for_exe(exe: &std::path::Path) -> Option<PathBuf> {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 fn desktop_launch_command(
     exe_path: &std::path::Path,
     install_root: &std::path::Path,
@@ -348,8 +492,12 @@ async fn run_bootstrap(
     let kind = ScriptKind::for_current_os();
 
     let pin = Pin {
-        commit: args.commit.or_else(|| option_env_string("BUILD_PIN_COMMIT")),
-        branch: args.branch.or_else(|| option_env_string("BUILD_PIN_BRANCH")),
+        commit: args
+            .commit
+            .or_else(|| option_env_string("BUILD_PIN_COMMIT")),
+        branch: args
+            .branch
+            .or_else(|| option_env_string("BUILD_PIN_BRANCH")),
     };
 
     tracing::info!(
@@ -443,20 +591,21 @@ async fn run_bootstrap(
         return Err(anyhow!(err));
     }
 
-    let manifest: Manifest = powershell::parse_manifest(&manifest_result.stdout).ok_or_else(|| {
-        let err = format!(
-            "install.ps1 -Manifest produced no parseable JSON payload\n{}",
-            truncate(&manifest_result.stdout, 4000)
-        );
-        emit_event(
-            &app,
-            BootstrapEvent::Failed {
-                stage: None,
-                error: err.clone(),
-            },
-        );
-        anyhow!(err)
-    })?;
+    let manifest: Manifest =
+        powershell::parse_manifest(&manifest_result.stdout).ok_or_else(|| {
+            let err = format!(
+                "install.ps1 -Manifest produced no parseable JSON payload\n{}",
+                truncate(&manifest_result.stdout, 4000)
+            );
+            emit_event(
+                &app,
+                BootstrapEvent::Failed {
+                    stage: None,
+                    error: err.clone(),
+                },
+            );
+            anyhow!(err)
+        })?;
 
     emit_event(
         &app,
@@ -650,7 +799,10 @@ async fn run_bootstrap(
     // we're already running from that path. Best-effort — a failure here must
     // not fail an otherwise-successful install.
     if let Err(err) = crate::paths::copy_self_to_hermes_home() {
-        tracing::warn!(?err, "failed to copy installer into HERMES_HOME (non-fatal)");
+        tracing::warn!(
+            ?err,
+            "failed to copy installer into HERMES_HOME (non-fatal)"
+        );
         emit_log(&format!(
             "[bootstrap] warning: could not stage updater binary: {err}"
         ));
@@ -821,8 +973,8 @@ fn truncate(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
     use std::path::Path;
+    use std::path::PathBuf;
 
     fn unique_tmp_dir(tag: &str) -> PathBuf {
         let base = std::env::temp_dir().join(format!(

--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -277,10 +277,13 @@ async fn launch_windows_desktop_via_task(
     }
     let _ = std::fs::remove_file(&ack_path);
 
+    // Keep /TR comfortably below schtasks.exe's 261-character limit. The
+    // desktop derives the request-bound ACK path from HERMES_HOME + request_id,
+    // so repeating the full ACK path here is unnecessary and can make an
+    // otherwise normal Windows install impossible to relaunch.
     let action = format!(
-        "\"{}\" --hermes-update-relaunch-ack=\"{}\" --hermes-update-relaunch-request={}",
+        "\"{}\" --hermes-update-relaunch-request={}",
         exe_path.display(),
-        ack_path.display(),
         request_id
     );
     let create_args = vec![

--- a/apps/bootstrap-installer/src-tauri/src/lib.rs
+++ b/apps/bootstrap-installer/src-tauri/src/lib.rs
@@ -11,11 +11,13 @@
 mod bootstrap;
 mod events;
 mod install_script;
-mod powershell;
 mod paths;
+mod powershell;
 mod update;
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use tauri::Manager;
 use tokio::sync::Mutex;
 
 /// How the installer was invoked. Resolved once from the process args in
@@ -74,6 +76,10 @@ pub struct AppState {
     /// How this process was launched (install vs update). Immutable for the
     /// lifetime of the process; read by the `get_mode` command.
     pub mode: AppMode,
+    /// Native close gate for update mode. Starts blocked before the webview or
+    /// frontend store exists and opens only after a verified desktop relaunch
+    /// or a terminal error.
+    pub update_close_allowed: AtomicBool,
 }
 
 impl AppState {
@@ -81,8 +87,18 @@ impl AppState {
         Self {
             bootstrap: Mutex::new(None),
             mode,
+            update_close_allowed: AtomicBool::new(mode != AppMode::Update),
         }
     }
+}
+
+fn should_prevent_window_close(mode: AppMode, update_close_allowed: bool) -> bool {
+    mode == AppMode::Update && !update_close_allowed
+}
+
+pub(crate) fn allow_update_close(app: &tauri::AppHandle) {
+    let state = app.state::<Arc<AppState>>();
+    state.update_close_allowed.store(true, Ordering::SeqCst);
 }
 
 /// Frontend → Rust: which flow should the UI render?
@@ -111,6 +127,18 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
         .manage(Arc::new(AppState::new(mode)))
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let state = window.state::<Arc<AppState>>();
+                if should_prevent_window_close(
+                    state.mode,
+                    state.update_close_allowed.load(Ordering::SeqCst),
+                ) {
+                    tracing::warn!("ignored close request while update/relaunch is still active");
+                    api.prevent_close();
+                }
+            }
+        })
         .setup(move |app| {
             use tauri::Manager;
             // Launcher fast path (macOS only): a bare ("Install") launch when
@@ -160,7 +188,9 @@ pub fn run() {
                     }
                 }
                 None => {
-                    tracing::error!("main installer window not found; installer UI will not appear");
+                    tracing::error!(
+                        "main installer window not found; installer UI will not appear"
+                    );
                 }
             }
             Ok(())
@@ -187,7 +217,7 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::{force_setup_from_args, AppMode};
+    use super::{force_setup_from_args, should_prevent_window_close, AppMode};
 
     #[test]
     fn bare_args_are_install() {
@@ -228,5 +258,12 @@ mod tests {
             AppMode::from_args(["--update", "--reinstall"]),
             AppMode::Update
         );
+    }
+
+    #[test]
+    fn native_update_close_gate_covers_startup_and_relaunch_windows() {
+        assert!(should_prevent_window_close(AppMode::Update, false));
+        assert!(!should_prevent_window_close(AppMode::Update, true));
+        assert!(!should_prevent_window_close(AppMode::Install, false));
     }
 }

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -245,7 +245,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
 
     emit_stage(&app, "update", StageState::Running, None, None);
     let started = Instant::now();
-    let mut update = run_streamed(
+    let update = run_streamed(
         &app,
         &hermes,
         &update_args,
@@ -255,37 +255,11 @@ async fn run_update(app: AppHandle) -> Result<()> {
     )
     .await?;
 
-    // Retry-once for the update-boundary crash. `hermes update` lazily imports
-    // the FRESHLY PULLED modules, but the dependency-install step still runs the
-    // already-in-memory pre-pull code for one invocation. A release that changed
-    // an updater-path contract across that boundary (e.g. #39780's `_UvResult`,
-    // whose `__iter__` injected a bool into the argv and crashed Windows
-    // `list2cmdline` with `TypeError: sequence item 1: expected str instance,
-    // bool found`, fixed in #39820) therefore kills the FIRST update on the
-    // parked population — even though the fix is already on disk by then. A
-    // second `hermes update` runs clean because the now-current module is loaded
-    // from the start. Rather than make the parked user click Update twice (and
-    // stare at a scary crash first), retry once automatically. Skip the retry
-    // for the concurrent-instance guard (exit 2) — that's a "close Hermes" state
-    // a retry can't fix.
-    if !matches!(update.exit_code, Some(0) | Some(UPDATE_EXIT_CONCURRENT)) {
-        emit_log(
-            &app,
-            Some("update"),
-            LogStream::Stdout,
-            "[update] first update attempt failed; retrying once (the fix it just \
-             pulled loads on the second run)…",
-        );
-        update = run_streamed(
-            &app,
-            &hermes,
-            &update_args,
-            &install_root,
-            &child_env,
-            Some("update"),
-        )
-        .await?;
-    }
+    // Never replay a generic update failure. Git conflicts, dependency errors,
+    // build failures and post-pull validation failures are deterministic until
+    // their cause changes; blindly running them twice only expands the mutation
+    // boundary. A future retry must use an explicit CLI boundary-change result
+    // that proves the repository is safe and that the loaded updater changed.
     let update_ms = started.elapsed().as_millis() as u64;
 
     match update.exit_code {
@@ -316,10 +290,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
             let msg = format!(
                 "hermes update failed (exit {:?}). See {} for details.",
                 other,
-                crate::paths::hermes_home()
-                    .join("logs")
-                    .join("update.log")
-                    .display()
+                crate::paths::log_path().display()
             );
             emit_stage(
                 &app,
@@ -345,7 +316,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
     emit_stage(&app, "rebuild", StageState::Running, None, None);
     let started = Instant::now();
     let rebuild_args: Vec<String> = vec!["desktop".into(), "--build-only".into()];
-    let mut rebuild = run_streamed(
+    let rebuild = run_streamed(
         &app,
         &hermes,
         &rebuild_args,
@@ -355,32 +326,6 @@ async fn run_update(app: AppHandle) -> Result<()> {
     )
     .await?;
 
-    // Retry-once: the first `--build-only` can return nonzero on a still-settling
-    // post-update tree or a network-blocked Electron fetch that our self-heal
-    // repaired mid-run. A second attempt then builds clean off the healed dist
-    // (the content-hash stamp makes it a near-no-op when the first actually
-    // succeeded). Without this the updater bails here and never reaches the
-    // relaunch below — the app updates but doesn't restart. Matches the
-    // retry-once `hermes update` already does above, and `hermes update`'s own
-    // desktop rebuild in cmd_update.
-    if rebuild_needs_retry(rebuild.exit_code) {
-        emit_log(
-            &app,
-            Some("rebuild"),
-            LogStream::Stdout,
-            "[rebuild] first desktop rebuild failed; retrying once (a self-healed \
-             Electron download builds clean on the second run)…",
-        );
-        rebuild = run_streamed(
-            &app,
-            &hermes,
-            &rebuild_args,
-            &install_root,
-            &child_env,
-            Some("rebuild"),
-        )
-        .await?;
-    }
     let rebuild_ms = started.elapsed().as_millis() as u64;
 
     if rebuild.exit_code != Some(0) {
@@ -621,14 +566,6 @@ fn is_locked(path: &Path) -> bool {
         Ok(_) => false,
         Err(_) => true,
     }
-}
-
-/// Whether the `desktop --build-only` rebuild should be retried once. Any
-/// non-success exit qualifies: the common cause is a transient first-attempt
-/// failure (still-settling tree / self-healed Electron download) that a clean
-/// second run resolves.
-fn rebuild_needs_retry(exit_code: Option<i32>) -> bool {
-    exit_code != Some(0)
 }
 
 /// Spawn `hermes <args>` from `cwd`, stream stdout/stderr as Log events on the
@@ -1176,16 +1113,6 @@ mod tests {
             with_install.len(),
             base.len() + 1,
             "include_install adds exactly one stage"
-        );
-    }
-
-    #[test]
-    fn rebuild_retries_only_on_failure() {
-        assert!(!rebuild_needs_retry(Some(0)), "a clean rebuild must not retry");
-        assert!(rebuild_needs_retry(Some(1)), "a failed rebuild retries once");
-        assert!(
-            rebuild_needs_retry(None),
-            "a killed/signalled rebuild (no exit code) retries once"
         );
     }
 

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -92,6 +92,7 @@ pub async fn start_update(app: AppHandle) -> Result<(), String> {
                     error: format!("{err:#}"),
                 },
             );
+            crate::allow_update_close(&app);
         }
         UPDATE_RUNNING.store(false, Ordering::SeqCst);
     });
@@ -455,6 +456,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
 
     if let Some(target_app) = launch_target {
         if let Err(err) = launch_macos_app_and_exit(&app, &target_app).await {
+            crate::allow_update_close(&app);
             emit_log(
                 &app,
                 None,
@@ -465,6 +467,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
     } else if let Err(err) =
         crate::bootstrap::launch_hermes_desktop(app.clone(), install_root.to_string_lossy().into_owned()).await
     {
+        crate::allow_update_close(&app);
         // Launch failed: don't hard-fail the update (it succeeded); surface a
         // log line so the success screen can still tell the user to launch
         // manually.

--- a/apps/bootstrap-installer/src/app.tsx
+++ b/apps/bootstrap-installer/src/app.tsx
@@ -1,11 +1,14 @@
 import { useStore } from '@nanostores/react'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { message } from '@tauri-apps/plugin-dialog'
 import { useEffect } from 'react'
 
 import Failure from './routes/failure'
 import Progress from './routes/progress'
 import Success from './routes/success'
 import Welcome from './routes/welcome'
-import { $bootstrap, $route, initialize } from './store'
+import { $bootstrap, $mode, $route, initialize } from './store'
+import { shouldBlockUpdateClose } from './update-close-guard'
 
 /*
  * App shell — Hermes Setup.
@@ -21,6 +24,46 @@ export default function App() {
 
   useEffect(() => {
     void initialize()
+  }, [])
+
+  useEffect(() => {
+    let disposed = false
+    let noticeOpen = false
+    let unlisten: () => void = () => undefined
+
+    void getCurrentWindow()
+      .onCloseRequested(event => {
+        const state = $bootstrap.get()
+
+        if (!shouldBlockUpdateClose($mode.get(), state.status)) {
+          return
+        }
+
+        event.preventDefault()
+
+        if (!noticeOpen) {
+          noticeOpen = true
+          void message('Hermes is still updating and will restart automatically. Keep this window open.', {
+            kind: 'info',
+            title: 'Update in progress'
+          }).finally(() => {
+            noticeOpen = false
+          })
+        }
+      })
+      .then(stop => {
+        if (disposed) {
+          stop()
+        } else {
+          unlisten = stop
+        }
+      })
+      .catch(() => undefined)
+
+    return () => {
+      disposed = true
+      unlisten()
+    }
   }, [])
 
   return (

--- a/apps/bootstrap-installer/src/routes/progress.tsx
+++ b/apps/bootstrap-installer/src/routes/progress.tsx
@@ -160,10 +160,13 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
           <ChevronRight className={clsx('transition-transform', showLogs && 'rotate-90')} size={12} />
         </button>
 
-        {bootstrap.status === 'running' && (
+        {bootstrap.status === 'running' && !isUpdate && (
           <Button onClick={() => void cancelInstall()} size="sm" variant="outline">
             Cancel
           </Button>
+        )}
+        {bootstrap.status === 'running' && isUpdate && (
+          <span className="text-xs text-muted-foreground">Keep this window open — Hermes restarts automatically.</span>
         )}
       </div>
     </div>

--- a/apps/bootstrap-installer/src/update-close-guard.test.ts
+++ b/apps/bootstrap-installer/src/update-close-guard.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldBlockUpdateClose } from './update-close-guard'
+
+describe('update close guard', () => {
+  it('blocks user close only while an update is running', () => {
+    expect(shouldBlockUpdateClose('update', 'running')).toBe(true)
+    expect(shouldBlockUpdateClose('update', 'completed')).toBe(false)
+    expect(shouldBlockUpdateClose('update', 'failed')).toBe(false)
+    expect(shouldBlockUpdateClose('install', 'running')).toBe(false)
+  })
+})

--- a/apps/bootstrap-installer/src/update-close-guard.ts
+++ b/apps/bootstrap-installer/src/update-close-guard.ts
@@ -1,0 +1,6 @@
+export function shouldBlockUpdateClose(
+  mode: 'install' | 'update',
+  status: 'completed' | 'failed' | 'idle' | 'running'
+): boolean {
+  return mode === 'update' && status === 'running'
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -116,7 +116,7 @@ import {
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
-import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
+import { clearUpdateMarkerIfOwnedBy, readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
 import {
   buildRelaunchScript,
@@ -129,6 +129,9 @@ import {
 } from './update-relaunch'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import { spawnUpdaterProcess } from './updater-process'
+import { launchUpdaterViaScheduledTask } from './windows-update-launch'
+import { acknowledgeUpdateRelaunch } from './windows-update-relaunch'
+import { collectProcessTreePids, parseWindowsProcessList } from './windows-update-runtime'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import {
   computeWindowOptions,
@@ -2424,26 +2427,107 @@ function isShimLocked(shimPath) {
 // Force-kill the entire process TREE rooted at each PID. Node's child.kill()
 // only signals the direct child, so on Windows a backend `hermes.exe` that
 // spawned its own grandchildren (a `hermes` REPL, a pty terminal session, the
-// gateway) would survive and keep the venv shim locked. taskkill /T /F reaps
-// the whole tree synchronously. Windows-only: this is called solely from the
-// Windows shim-unlock path, and the backend is NOT spawned detached (so it's
-// not a process-group leader — a POSIX negative-pgid kill would be meaningless
-// here anyway). POSIX teardown stays with the existing before-quit SIGTERM.
-function forceKillProcessTree(pid) {
+// gateway) would survive and keep the venv shim locked. Windows-only: this is
+// called solely from the Windows shim-unlock path, and the backend is NOT
+// spawned detached (so it's not a process-group leader — a POSIX negative-pgid
+// kill would be meaningless here anyway). POSIX teardown stays with the
+// existing before-quit SIGTERM.
+//
+// NOT `taskkill /T`: taskkill builds its tree from raw ParentProcessId links
+// with no creation-time check. Our own dead launcher-parent PID gets recycled
+// by short-lived backend grandchildren, at which point taskkill /T counts the
+// DESKTOP as a descendant of the backend and kills us mid-handoff (that was
+// the "all Hermes processes die within 1s of Update now" failure). Instead we
+// enumerate the tree from a CIM inventory with our own pid hard-excluded and
+// kill each pid individually.
+function forceKillProcessTree(pid, processes = null) {
   if (!IS_WINDOWS) {
     return
   }
 
-  if (!Number.isInteger(pid) || pid <= 0) {
+  if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) {
     return
   }
 
-  try {
-    execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], hiddenWindowsChildOptions({ stdio: 'ignore' }))
-  } catch {
-    // Already gone, or no permission — best effort; the unlock wait below is
-    // the real gate.
+  const expectedRootCreationTimeMs = desktopOwnedWindowsProcessCreationTimes.get(pid)
+
+  if (!expectedRootCreationTimeMs) {
+    rememberLog(`[process] refusing tree-kill for untracked or identity-unknown PID ${pid}`)
+    return
   }
+
+  const inventory = processes || listWindowsProcessesForUpdate()
+  const tree = collectProcessTreePids(inventory, pid, {
+    excludePids: [process.pid],
+    expectedRootCreationTimeMs
+  })
+  // No fallback to the bare PID: when the tracked child has already exited,
+  // Windows may have recycled its PID for an unrelated process. The live
+  // inventory (including creation times) is the identity/lineage gate.
+  const targets = tree
+
+  for (const target of targets) {
+    if (target === process.pid) {
+      continue
+    }
+
+    try {
+      execFileSync('taskkill', ['/PID', String(target), '/F'], hiddenWindowsChildOptions({ stdio: 'ignore' }))
+    } catch {
+      // Already gone, or no permission — best effort; the unlock wait below is
+      // the real gate.
+    }
+  }
+}
+
+// Inventory Windows processes through CIM so the update handoff can reap every
+// process whose executable lives under this install's venv (the same set the
+// hermes update holder guard refuses to race). Fail-closed: empty inventory.
+function listWindowsProcessesForUpdate() {
+  if (!IS_WINDOWS) {
+    return []
+  }
+
+  const powershell = windowsPowerShellPath() || 'powershell.exe'
+  const script =
+    '$OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::new(); ' +
+    'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,@{Name="CreationTimeMs";Expression={([DateTimeOffset]$_.CreationDate).ToUnixTimeMilliseconds()}},ExecutablePath,CommandLine | ConvertTo-Json -Compress -Depth 3'
+
+  try {
+    const raw = execFileSync(
+      powershell,
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      hiddenWindowsChildOptions({
+        encoding: 'utf8',
+        maxBuffer: 4 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+    )
+
+    return parseWindowsProcessList(raw)
+  } catch (err) {
+    rememberLog(`[updates] managed runtime inventory unavailable; holder guard remains active: ${err.message}`)
+    return []
+  }
+}
+
+const desktopOwnedWindowsProcessCreationTimes = new Map<number, number>()
+
+function trackDesktopOwnedWindowsProcess(child) {
+  if (!IS_WINDOWS || !Number.isInteger(child?.pid)) {
+    return
+  }
+
+  const pid = child.pid
+  const info = listWindowsProcessesForUpdate().find(candidate => candidate.pid === pid)
+
+  if (info?.creationTimeMs) {
+    desktopOwnedWindowsProcessCreationTimes.set(pid, info.creationTimeMs)
+  } else {
+    rememberLog(`[process] could not establish creation-time identity for Desktop child PID ${pid}`)
+  }
+
+  child.once('exit', () => desktopOwnedWindowsProcessCreationTimes.delete(pid))
 }
 
 // Before handing off the update on Windows, the desktop MUST stop every backend
@@ -2504,11 +2588,15 @@ async function releaseBackendLock(updateRoot, tag) {
     }
   }
 
+  traceUpdateHandoff(`${tag}: sigterm sent; stopping pool backends`)
   stopAllPoolBackends()
+  traceUpdateHandoff(`${tag}: pool stopped; tree-killing ${pids.length} backend pid(s)`)
 
   for (const pid of pids) {
     forceKillProcessTree(pid)
   }
+
+  traceUpdateHandoff(`${tag}: owned backend tree-kills done; waiting for shim unlock`)
 
   const shim = venvHermesShimPath(updateRoot)
   const deadlineMs = Date.now() + 15000
@@ -2556,6 +2644,21 @@ async function releaseBackendLock(updateRoot, tag) {
   )
 
   return { unlocked: false }
+}
+
+// Hand-off phase trace — appendFileSync straight to disk, because desktop.log
+// only flushes the in-memory ring buffer: a hand-off that dies mid-flight
+// leaves no evidence there, which is exactly what made the one-click failures
+// so hard to diagnose. One line per phase; the updater side has its own logs.
+function traceUpdateHandoff(step) {
+  try {
+    fs.appendFileSync(
+      path.join(HERMES_HOME, 'logs', 'update-handoff.log'),
+      `${new Date().toISOString()} pid=${process.pid} ${step}\n`
+    )
+  } catch {
+    void 0
+  }
 }
 
 // applyUpdates — hand off to the installer's --update flow, then exit.
@@ -2642,11 +2745,19 @@ async function applyUpdates(opts = {}) {
 
     const venvBin = path.join(updateRoot, 'venv', IS_WINDOWS ? 'Scripts' : 'bin')
 
+    // Latch handoff BEFORE tearing down the backend. The renderer reconnect
+    // path otherwise respawns serve and re-locks the venv before the updater runs.
+    isQuittingForHandoff = true
+    traceUpdateHandoff('applyUpdates: handoff latched')
+    writeUpdateMarker(HERMES_HOME, process.pid)
+    traceUpdateHandoff('applyUpdates: marker written (desktop pid placeholder)')
+
     // Stop our own backend(s) and wait for the venv shim to unlock BEFORE we
     // spawn the updater. Without this the updater races a still-locked
     // hermes.exe (held by the backend child / its grandchildren) and the update
     // bricks. See releaseBackendLockForUpdate for the full failure analysis.
     const lock = await releaseBackendLockForUpdate(updateRoot)
+    traceUpdateHandoff(`applyUpdates: backend lock released unlocked=${lock.unlocked}`)
 
     if (!lock.unlocked) {
       // Something OUTSIDE this app holds the venv (a second window, a user
@@ -2659,23 +2770,68 @@ async function applyUpdates(opts = {}) {
         '(a second Hermes window or a terminal running hermes?). Close it and retry.'
 
       emitUpdateProgress({ stage: 'error', message, percent: null })
+      clearUpdateMarkerIfOwnedBy(HERMES_HOME, process.pid)
+      isQuittingForHandoff = false
       startHermes().catch(() => {})
 
       return { ok: false, error: message }
     }
 
-    // Detached so the updater outlives this process — it needs us GONE before
-    // `hermes update` will run (the venv shim is locked while we live).
-    const child = spawnUpdaterProcess(updater, updaterArgs, {
-      cwd: HERMES_HOME,
-      env: {
-        ...process.env,
-        HERMES_HOME,
-        PATH: pathWithHermesManagedNode(venvBin)
-      },
-      detached: true,
-      stdio: 'ignore'
-    })
+    const updaterEnvPath = pathWithHermesManagedNode(venvBin)
+    let updaterPid: number | null = null
+    let launchVehicle = IS_WINDOWS ? 'scheduled-task' : 'spawn'
+
+    if (IS_WINDOWS) {
+      // The desktop usually runs inside a Job Object with KILL_ON_JOB_CLOSE
+      // (scheduled-task launchers, the bootstrap chain), and Node's
+      // `detached: true` does NOT set CREATE_BREAKAWAY_FROM_JOB — a directly
+      // spawned updater stays in our job and dies the moment we quit for the
+      // hand-off. That was the one-click-update failure: bootstrap-installer.log
+      // stopped after its init line. Launch through a one-shot scheduled task
+      // instead (the Task Scheduler service creates the process outside our
+      // job) and wait for the launcher's ACK so the hand-off is confirmed
+      // before we quit.
+      traceUpdateHandoff('applyUpdates: launching updater via scheduled task')
+      const launch = await launchUpdaterViaScheduledTask({
+        updaterPath: updater,
+        updaterArgs,
+        hermesHome: HERMES_HOME,
+        pathEnv: updaterEnvPath
+      })
+      traceUpdateHandoff(`applyUpdates: scheduled-task launch ok=${launch.ok} pid=${launch.updaterPid} err=${launch.error || '-'}`)
+
+      if (launch.ok) {
+        updaterPid = launch.updaterPid
+      } else {
+        const message = `Update handoff failed safely: ${launch.error || 'Task Scheduler did not confirm the updater.'}`
+
+        rememberLog(`[updates] ${message}`)
+        emitUpdateProgress({ stage: 'error', message, percent: null })
+        clearUpdateMarkerIfOwnedBy(HERMES_HOME, process.pid)
+        isQuittingForHandoff = false
+        startHermes().catch(() => {})
+
+        return { ok: false, error: message }
+      }
+    }
+
+    if (!IS_WINDOWS) {
+      // Detached so the updater outlives this process — it needs us GONE before
+      // `hermes update` will run (the venv shim is locked while we live). On
+      // Windows this is only the fallback path: detached does not escape the job.
+      const child = spawnUpdaterProcess(updater, updaterArgs, {
+        cwd: HERMES_HOME,
+        env: {
+          ...process.env,
+          HERMES_HOME,
+          PATH: updaterEnvPath
+        },
+        detached: true,
+        stdio: 'ignore'
+      })
+
+      updaterPid = Number.isInteger(child.pid) ? child.pid : null
+    }
 
     // Write the update-in-progress marker IMMEDIATELY — before the 2.5s
     // quit dwell. The Tauri updater won't write its own marker for several
@@ -2684,19 +2840,25 @@ async function applyUpdates(opts = {}) {
     // the venv. By writing the marker ourselves the renderer's
     // waitForUpdateToFinish() gate sees a live update and parks instead.
     // The updater overwrites this with its own PID later; same format.
-    if (Number.isInteger(child.pid)) {
-      writeUpdateMarker(HERMES_HOME, child.pid)
+    if (Number.isInteger(updaterPid)) {
+      writeUpdateMarker(HERMES_HOME, updaterPid)
     }
 
-    rememberLog(`[updates] launched updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release venv shim`)
+    rememberLog(
+      `[updates] launched updater via ${launchVehicle}: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release venv shim`
+    )
+
+    app.once('before-quit', () => traceUpdateHandoff('applyUpdates: before-quit fired'))
+    process.once('exit', code => traceUpdateHandoff(`applyUpdates: process exit code=${code}`))
 
     // Linger on the "updating — don't reopen" overlay long enough for the user
     // to actually read it (and to bridge the gap until the updater's own window
     // appears), THEN quit to release the venv shim. The updater rebuilds and
     // relaunches us when it's done. (#50419 — a 600ms quit looked like a crash
     // and lured users into the #50238 relaunch loop.)
-    isQuittingForHandoff = true
+    traceUpdateHandoff(`applyUpdates: dwell started (vehicle=${launchVehicle}); quitting in ${UPDATE_HANDOFF_DWELL_MS}ms`)
     setTimeout(() => {
+      traceUpdateHandoff('applyUpdates: app.quit()')
       app.quit()
     }, UPDATE_HANDOFF_DWELL_MS)
 
@@ -2739,28 +2901,43 @@ async function handOffWindowsBootstrapRecovery(reason) {
 
   const updaterArgs = chooseUpdaterArgs(haveRealInstall, branch)
 
-  await releaseBackendLockForUpdate(updateRoot)
+  const lock = await releaseBackendLockForUpdate(updateRoot)
 
-  const child = spawnUpdaterProcess(updater, updaterArgs, {
-    cwd: HERMES_HOME,
-    env: {
-      ...process.env,
-      HERMES_HOME,
-      PATH: pathWithHermesManagedNode(venvBin)
-    },
-    detached: true,
-    stdio: 'ignore'
+  if (!lock.unlocked) {
+    rememberLog(`[bootstrap] ${reason} recovery aborted: an external process still holds the Hermes venv`)
+
+    return false
+  }
+
+  // Same Job-Object problem as applyUpdates: a detached spawn dies with our
+  // job when we quit. Require the scheduled-task launch (outside the job, with
+  // a positive ACK); an ambiguous status fails closed without a second updater.
+  const updaterEnvPath = pathWithHermesManagedNode(venvBin)
+
+  const launch = await launchUpdaterViaScheduledTask({
+    updaterPath: updater,
+    updaterArgs,
+    hermesHome: HERMES_HOME,
+    pathEnv: updaterEnvPath
   })
+
+  if (!launch.ok || !Number.isInteger(launch.updaterPid)) {
+    rememberLog(`[bootstrap] scheduled-task launch failed safely: ${launch.error || 'missing updater pid'}`)
+
+    return false
+  }
+
+  const updaterPid = launch.updaterPid
 
   // Same marker pre-write as applyUpdates — see comment there. The recovery
   // hand-off has the same window where the renderer can respawn a backend
   // before the updater writes its own marker.
-  if (Number.isInteger(child.pid)) {
-    writeUpdateMarker(HERMES_HOME, child.pid)
+  if (Number.isInteger(updaterPid)) {
+    writeUpdateMarker(HERMES_HOME, updaterPid)
   }
 
   rememberLog(
-    `[bootstrap] handed off ${reason} recovery to updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release app.asar`
+    `[bootstrap] handed off ${reason} recovery to updater via scheduled-task: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release app.asar`
   )
   // Same dwell as the in-app update hand-off (#50419): give the updater's
   // window time to appear before we vanish, so the recovery doesn't look like
@@ -6786,6 +6963,8 @@ async function spawnPoolBackend(profile, entry) {
     })
   )
 
+  trackDesktopOwnedWindowsProcess(child)
+
   entry.process = child
   entry.token = token
 
@@ -7035,6 +7214,8 @@ async function startHermes() {
         stdio: ['ignore', 'pipe', 'pipe']
       })
     )
+
+    trackDesktopOwnedWindowsProcess(hermesProcess)
 
     const processOwner = backendConnectionState.attachProcess(connectionAttempt, hermesProcess)
 
@@ -9458,6 +9639,7 @@ app.whenReady().then(() => {
   configureSpellChecker()
   registerPowerResumeListeners()
   createWindow()
+  acknowledgeUpdateRelaunch(process.argv, HERMES_HOME)
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
   const _coldStartLink = _extractDeepLink(process.argv)

--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -20,6 +20,7 @@ import path from 'path'
 import { test } from 'vitest'
 
 import {
+  clearUpdateMarkerIfOwnedBy,
   isPidAlive,
   markerPath,
   readLiveUpdateMarker,
@@ -127,4 +128,16 @@ test('writeUpdateMarker + dead pid => self-heals on read', () => {
   const res = readLiveUpdateMarker(home, { kill: DEAD })
   assert.equal(res, null, 'a dead-pid marker from writeUpdateMarker self-heals')
   assert.ok(!fs.existsSync(markerPath(home)), 'marker file is pruned')
+})
+
+test('pre-handoff cleanup removes only the desktop-owned provisional marker', () => {
+  const home = tmpHome('owned-cleanup')
+
+  writeMarker(home, 4242, Math.floor(Date.now() / 1000))
+  assert.equal(clearUpdateMarkerIfOwnedBy(home, 4242), true)
+  assert.ok(!fs.existsSync(markerPath(home)))
+
+  writeMarker(home, 7777, Math.floor(Date.now() / 1000))
+  assert.equal(clearUpdateMarkerIfOwnedBy(home, 4242), false)
+  assert.ok(fs.existsSync(markerPath(home)), 'an updater-owned replacement marker must survive desktop cleanup')
 })

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -136,3 +136,32 @@ export function writeUpdateMarker(hermesHome, pid, { now = Date.now } = {}) {
     // updater will write its own when it reaches run_update.
   }
 }
+
+/** Remove only the desktop's provisional marker after a pre-handoff failure. */
+export function clearUpdateMarkerIfOwnedBy(hermesHome, expectedPid) {
+  const file = markerPath(hermesHome)
+  let raw
+
+  try {
+    raw = fs.readFileSync(file, 'utf8')
+  } catch {
+    return false
+  }
+
+  const [pidLine] = String(raw).split('\n')
+  const markerPid = Number.parseInt((pidLine || '').trim(), 10)
+
+  // The updater may already have replaced our placeholder with its own PID.
+  // In that case leave the real marker intact so backend startup stays parked.
+  if (!Number.isInteger(expectedPid) || markerPid !== expectedPid) {
+    return false
+  }
+
+  try {
+    fs.unlinkSync(file)
+
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/electron/windows-update-handoff-regression.test.ts
+++ b/apps/desktop/electron/windows-update-handoff-regression.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildUpdateLaunchScript, schtasksCreateArgs } from './windows-update-launch'
+import { collectProcessTreePids } from './windows-update-runtime'
+
+describe('Windows one-click update handoff regression', () => {
+  it('launches through a hidden scheduled task and waits for an updater ACK', () => {
+    const script = buildUpdateLaunchScript({
+      updaterPath: 'C:\\Hermes\\hermes-setup.exe',
+      updaterArgs: ['--update', '--branch', 'main'],
+      hermesHome: 'C:\\Hermes',
+      pathEnv: 'C:\\Hermes\\venv\\Scripts',
+      ackPath: 'C:\\Hermes\\logs\\ack.json',
+      logPath: 'C:\\Hermes\\logs\\launch.log',
+      requestId: 'request-1'
+    })
+
+    expect(schtasksCreateArgs('Hermes_UpdateLaunch', 'C:\\Hermes\\update-launch.ps1', '12:34').join(' '))
+      .toContain('-WindowStyle Hidden')
+    expect(script).toContain('Set-Content -LiteralPath $ack')
+    expect(script).toContain('Wait-Process -Id $p.Id')
+  })
+
+  it('never includes the desktop itself when a recycled parent PID creates a false cycle', () => {
+    const processes = [
+      {
+        pid: 200,
+        parentPid: 100,
+        creationTimeMs: 2_000,
+        executablePath: 'C:\\Hermes\\venv\\Scripts\\hermes.exe',
+        commandLine: ''
+      },
+      {
+        pid: 100,
+        parentPid: 200,
+        creationTimeMs: 1_000,
+        executablePath: 'C:\\Hermes\\Hermes.exe',
+        commandLine: ''
+      }
+    ]
+
+    expect(
+      collectProcessTreePids(processes, 200, { excludePids: [100], expectedRootCreationTimeMs: 2_000 })
+    ).toEqual([200])
+  })
+})

--- a/apps/desktop/electron/windows-update-launch.test.ts
+++ b/apps/desktop/electron/windows-update-launch.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for electron/windows-update-launch.ts — the one-shot scheduled-task
+ * launch that gets the Windows updater OUT of the desktop's Job Object.
+ *
+ * What this locks:
+ *   1. The generated PowerShell launcher embeds env, updater path/args, ACK
+ *      path and request id with correct single-quote escaping, guards against
+ *      duplicate firings, and self-deletes the task.
+ *   2. schtasks argv shape: forced one-shot creation plus explicit /Run.
+ *   3. ACK parsing is bound to the request id and fail-closed on garbage.
+ *   4. The full launch flow ACKs the updater PID (happy path), surfaces
+ *      launcher-reported failures, and times out instead of hanging.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import {
+  buildUpdateLaunchScript,
+  launchUpdaterViaScheduledTask,
+  nextStartTime,
+  parseLaunchAck,
+  schtasksCreateArgs,
+  schtasksDeleteArgs,
+  schtasksEndArgs,
+  schtasksRunArgs,
+  UPDATE_LAUNCH_TASK_NAME,
+  updateLaunchPaths
+} from './windows-update-launch'
+
+const SCRIPT_ARGS = {
+  updaterPath: 'C:\\Users\\o\'brien\\AppData\\Local\\hermes\\hermes-setup.exe',
+  updaterArgs: ['--update', '--branch', 'main'],
+  hermesHome: 'C:\\Users\\o\'brien\\AppData\\Local\\hermes',
+  pathEnv: 'C:\\venv\\Scripts;C:\\Windows\\system32',
+  ackPath: 'C:\\Users\\o\'brien\\AppData\\Local\\hermes\\logs\\update-launch-ack.json',
+  logPath: 'C:\\Users\\o\'brien\\AppData\\Local\\hermes\\logs\\update-launch.log',
+  requestId: 'req-123'
+}
+
+test('launcher script embeds env, updater, ack and request id with escaped quotes', () => {
+  const script = buildUpdateLaunchScript(SCRIPT_ARGS)
+
+  assert.ok(script.includes(`$env:HERMES_HOME = 'C:\\Users\\o''brien\\AppData\\Local\\hermes'`))
+  assert.ok(script.includes(`$env:PATH = 'C:\\venv\\Scripts;C:\\Windows\\system32'`))
+  assert.ok(script.includes(`-FilePath 'C:\\Users\\o''brien\\AppData\\Local\\hermes\\hermes-setup.exe'`))
+  assert.ok(script.includes(`@('--update', '--branch', 'main')`))
+  assert.ok(script.includes(`$requestId = 'req-123'`))
+  assert.ok(script.includes(`$ack = 'C:\\Users\\o''brien\\AppData\\Local\\hermes\\logs\\update-launch-ack.json'`))
+})
+
+test('launcher script guards duplicates, waits for the updater, and self-deletes the task', () => {
+  const script = buildUpdateLaunchScript(SCRIPT_ARGS)
+
+  // Duplicate-firing guard is bound to the request id and exits early.
+  assert.ok(script.includes(`$existing.requestId -eq $requestId`))
+  assert.ok(script.includes('duplicate invocation ignored'))
+  // Keeps the task instance alive while the updater runs (IgnoreNew shield).
+  assert.ok(script.includes('Wait-Process -Id $p.Id'))
+  // Cleans up its own one-shot task definition.
+  assert.ok(script.includes(`schtasks.exe /Delete /F /TN '${UPDATE_LAUNCH_TASK_NAME}'`))
+  // Failure path still writes a (negative) ACK so the desktop can react.
+  assert.ok(script.includes('ok = $false'))
+})
+
+test('schtasks argv: forced one-shot create and explicit run', () => {
+  const create = schtasksCreateArgs('Hermes_UpdateLaunch', 'C:\\hh\\update-launch.ps1', '12:34')
+
+  assert.deepEqual(create.slice(0, 8), ['/Create', '/F', '/TN', 'Hermes_UpdateLaunch', '/SC', 'ONCE', '/ST', '12:34'])
+  assert.equal(create[8], '/TR')
+  assert.ok(create[9].startsWith('powershell.exe -NoProfile -ExecutionPolicy Bypass'))
+  assert.ok(create[9].endsWith('-File "C:\\hh\\update-launch.ps1"'))
+
+  assert.deepEqual(schtasksRunArgs('Hermes_UpdateLaunch'), ['/Run', '/TN', 'Hermes_UpdateLaunch'])
+  assert.deepEqual(schtasksEndArgs('Hermes_UpdateLaunch'), ['/End', '/TN', 'Hermes_UpdateLaunch'])
+  assert.deepEqual(schtasksDeleteArgs('Hermes_UpdateLaunch'), ['/Delete', '/F', '/TN', 'Hermes_UpdateLaunch'])
+})
+
+test('nextStartTime pads and wraps around midnight', () => {
+  assert.equal(nextStartTime(new Date(2026, 6, 17, 9, 5, 0)), '09:07')
+  assert.equal(nextStartTime(new Date(2026, 6, 17, 23, 59, 0)), '00:01')
+})
+
+test('parseLaunchAck accepts only the matching request id and sane pids', () => {
+  const ok = parseLaunchAck('﻿{"ok":true,"requestId":"r1","updaterPid":4321}', 'r1')
+
+  assert.ok(ok)
+  assert.equal(ok.ok, true)
+  assert.equal(ok.updaterPid, 4321)
+
+  const failed = parseLaunchAck('{"ok":false,"requestId":"r1","error":"boom"}', 'r1')
+
+  assert.ok(failed)
+  assert.equal(failed.ok, false)
+  assert.equal(failed.error, 'boom')
+
+  assert.equal(parseLaunchAck('{"ok":true,"requestId":"other","updaterPid":1}', 'r1'), null)
+  assert.equal(parseLaunchAck('not json', 'r1'), null)
+  assert.equal(parseLaunchAck('', 'r1'), null)
+  assert.equal(parseLaunchAck('{"ok":true,"requestId":"r1","updaterPid":"4242junk"}', 'r1')?.updaterPid, null)
+})
+
+function tempHome(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-update-launch-'))
+}
+
+test('launch flow: writes launcher script, fires task, returns ACKed updater pid', async () => {
+  const home = tempHome()
+  const calls: string[][] = []
+
+  const result = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update', '--branch', 'main'],
+    hermesHome: home,
+    pathEnv: 'C:\\x',
+    timeoutMs: 3000,
+    pollMs: 10,
+    runCommand: async (file, args) => {
+      calls.push([file, ...args])
+
+      if (args[0] === '/Run') {
+        // Simulate the launcher: read the request id back out of the script
+        // the flow just wrote, then ACK with an updater pid.
+        const scriptPath = calls[0][calls[0].indexOf('/TR') + 1].match(/-File "([^"]+)"/)?.[1] ?? ''
+
+        const paths = {
+          scriptPath,
+          ackPath: fs
+            .readFileSync(scriptPath, 'utf8')
+            .match(/\$ack = '([^']+)'/)?.[1]
+            .replace(/''/g, "'") ?? ''
+        }
+
+        const script = fs.readFileSync(paths.scriptPath, 'utf8')
+        const requestId = /\$requestId = '([^']+)'/.exec(script)?.[1] ?? ''
+
+        fs.writeFileSync(paths.ackPath, JSON.stringify({ ok: true, requestId, updaterPid: 777 }))
+      }
+
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  assert.deepEqual(result, { ok: true, updaterPid: 777, error: null })
+  assert.equal(calls.length, 2)
+  assert.equal(calls[0][0], 'schtasks.exe')
+  assert.equal(calls[0][1], '/Create')
+  assert.ok(calls[0].includes('ONCE'))
+  assert.match(calls[0][calls[0].indexOf('/TN') + 1], /^Hermes_UpdateLaunch_[a-f0-9]+$/)
+  assert.equal(calls[1][1], '/Run')
+})
+
+test('launch flow: surfaces schtasks create failure without firing the task', async () => {
+  const home = tempHome()
+  const calls: string[][] = []
+
+  const result = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update'],
+    hermesHome: home,
+    pathEnv: 'C:\\x',
+    runCommand: async (_file, args) => {
+      calls.push(args)
+
+      return { code: 1, stdout: '', stderr: 'ERROR: Access is denied.' }
+    }
+  })
+
+  assert.equal(result.ok, false)
+  assert.match(result.error ?? '', /schtasks create failed/)
+  assert.equal(calls.length, 2)
+  assert.equal(calls[1][0], '/Delete')
+})
+
+test('launch flow: surfaces launcher-reported failure and stale-ack timeout', async () => {
+  const home = tempHome()
+
+  const reported = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update'],
+    hermesHome: home,
+    pathEnv: 'C:\\x',
+    timeoutMs: 3000,
+    pollMs: 10,
+    runCommand: async (_file, args) => {
+      if (args[0] === '/Run') {
+        const scriptPath = fs
+          .readdirSync(home)
+          .map(name => path.join(home, name))
+          .find(candidate => candidate.endsWith('.ps1')) ?? ''
+
+        const paths = {
+          scriptPath,
+          ackPath: fs
+            .readFileSync(scriptPath, 'utf8')
+            .match(/\$ack = '([^']+)'/)?.[1]
+            .replace(/''/g, "'") ?? ''
+        }
+
+        const script = fs.readFileSync(paths.scriptPath, 'utf8')
+        const requestId = /\$requestId = '([^']+)'/.exec(script)?.[1] ?? ''
+
+        fs.writeFileSync(paths.ackPath, JSON.stringify({ ok: false, requestId, error: 'spawn denied' }))
+      }
+
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  assert.equal(reported.ok, false)
+  assert.match(reported.error ?? '', /spawn denied/)
+
+  // An ACK from a PREVIOUS request must not satisfy this run: the flow
+  // deletes stale ACKs up front and re-checks the embedded request id.
+  const staleHome = tempHome()
+  const stalePaths = updateLaunchPaths(staleHome)
+
+  fs.mkdirSync(path.dirname(stalePaths.ackPath), { recursive: true })
+  fs.writeFileSync(stalePaths.ackPath, JSON.stringify({ ok: true, requestId: 'stale', updaterPid: 1 }))
+
+  const timedOut = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update'],
+    hermesHome: staleHome,
+    pathEnv: 'C:\\x',
+    timeoutMs: 100,
+    pollMs: 10,
+    runCommand: async () => ({ code: 0, stdout: '', stderr: '' })
+  })
+
+  assert.equal(timedOut.ok, false)
+  assert.match(timedOut.error ?? '', /no launcher ACK/)
+})
+
+test('launch flow ends and deletes the one-shot task after run failure or ACK timeout', async () => {
+  const runFailureCalls: string[][] = []
+
+  const runFailed = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update'],
+    hermesHome: tempHome(),
+    pathEnv: 'C:\\x',
+    runCommand: async (_file, args) => {
+      runFailureCalls.push(args)
+
+      return args[0] === '/Run'
+        ? { code: 1, stdout: '', stderr: 'run failed' }
+        : { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  assert.equal(runFailed.ok, false)
+  assert.deepEqual(
+    runFailureCalls.map(args => args[0]),
+    ['/Create', '/Run', '/End', '/Delete']
+  )
+
+  const timeoutCalls: string[][] = []
+
+  const timedOut = await launchUpdaterViaScheduledTask({
+    updaterPath: 'C:\\hh\\hermes-setup.exe',
+    updaterArgs: ['--update'],
+    hermesHome: tempHome(),
+    pathEnv: 'C:\\x',
+    timeoutMs: 25,
+    pollMs: 5,
+    runCommand: async (_file, args) => {
+      timeoutCalls.push(args)
+
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  assert.equal(timedOut.ok, false)
+  assert.deepEqual(
+    timeoutCalls.map(args => args[0]),
+    ['/Create', '/Run', '/End', '/Delete']
+  )
+})

--- a/apps/desktop/electron/windows-update-launch.ts
+++ b/apps/desktop/electron/windows-update-launch.ts
@@ -1,0 +1,339 @@
+/**
+ * windows-update-launch.ts
+ *
+ * Launch the staged Windows updater OUTSIDE the desktop's Job Object.
+ *
+ * Why: the desktop process usually lives inside a Windows Job Object with
+ * KILL_ON_JOB_CLOSE (scheduled-task launchers, the Tauri bootstrap chain).
+ * Node's `detached: true` does NOT set CREATE_BREAKAWAY_FROM_JOB, so a
+ * directly spawned hermes-setup.exe stays in that job and dies together with
+ * the desktop when it quits for the hand-off — bootstrap-installer.log then
+ * shows only the init line and the update never runs. Processes started by
+ * the Task Scheduler service are not part of the desktop's job, so a
+ * one-shot task is used as the launch vehicle.
+ *
+ * The launcher script writes an ACK file once the updater process is running;
+ * the desktop waits for that ACK before quitting, turning the hand-off from
+ * fire-and-forget into a positively confirmed exchange. Ambiguous launch
+ * status fails closed; callers must never start a second updater in parallel.
+ */
+
+import { execFile } from 'node:child_process'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { hiddenWindowsChildOptions } from './windows-child-options'
+
+export const UPDATE_LAUNCH_TASK_NAME = 'Hermes_UpdateLaunch'
+
+export type UpdateLaunchPaths = {
+  scriptPath: string
+  ackPath: string
+  logPath: string
+}
+
+export function updateLaunchPaths(hermesHome: string, requestId = ''): UpdateLaunchPaths {
+  const logsDir = path.join(hermesHome, 'logs')
+  const suffix = requestId ? `-${requestId.replace(/[^a-z0-9]/gi, '')}` : ''
+
+  return {
+    scriptPath: path.join(hermesHome, `update-launch${suffix}.ps1`),
+    ackPath: path.join(logsDir, `update-launch-ack${suffix}.json`),
+    logPath: path.join(logsDir, 'update-launch.log')
+  }
+}
+
+// Single-quoted PowerShell string literal: only ' needs doubling.
+function psQuote(value: string): string {
+  return `'${String(value).replace(/'/g, "''")}'`
+}
+
+export type LaunchScriptArgs = {
+  updaterPath: string
+  updaterArgs: string[]
+  hermesHome: string
+  pathEnv: string
+  ackPath: string
+  logPath: string
+  requestId: string
+  taskName?: string
+}
+
+/**
+ * Build the PowerShell launcher the one-shot task executes. It runs outside
+ * the desktop's job, starts the updater, writes the ACK (with the updater
+ * PID), then stays alive until the updater exits so Task Scheduler's
+ * IgnoreNew instance policy shields against duplicate firings, and finally
+ * removes the one-shot task definition.
+ */
+export function buildUpdateLaunchScript(args: LaunchScriptArgs): string {
+  const taskName = args.taskName || UPDATE_LAUNCH_TASK_NAME
+  const updaterArgsList = args.updaterArgs.map(psQuote).join(', ')
+
+  return [
+    `$ErrorActionPreference = 'Stop'`,
+    `$ack = ${psQuote(args.ackPath)}`,
+    `$log = ${psQuote(args.logPath)}`,
+    `$requestId = ${psQuote(args.requestId)}`,
+    `function Write-LaunchLog([string]$m) {`,
+    `  try { Add-Content -Path $log -Value ("{0} [{1}] {2}" -f (Get-Date).ToString('o'), $requestId, $m) } catch {}`,
+    `}`,
+    `# Duplicate-invocation guard: the schedule (a past-tense one-shot) should`,
+    `# never fire on its own, but if it ever does, the ACK for this request id`,
+    `# marks the work as already claimed.`,
+    `if (Test-Path -LiteralPath $ack) {`,
+    `  $existing = $null`,
+    `  try { $existing = Get-Content -LiteralPath $ack -Raw | ConvertFrom-Json } catch {}`,
+    `  if ($existing -and $existing.requestId -eq $requestId) {`,
+    `    Write-LaunchLog 'duplicate invocation ignored'`,
+    `    exit 0`,
+    `  }`,
+    `}`,
+    `try {`,
+    `  $env:HERMES_HOME = ${psQuote(args.hermesHome)}`,
+    `  $env:PATH = ${psQuote(args.pathEnv)}`,
+    `  Write-LaunchLog 'launcher started (outside desktop job object)'`,
+    `  $p = Start-Process -FilePath ${psQuote(args.updaterPath)} -ArgumentList @(${updaterArgsList}) -WorkingDirectory $env:HERMES_HOME -PassThru`,
+    `  $payload = @{ ok = $true; requestId = $requestId; updaterPid = $p.Id; startedAt = (Get-Date).ToString('o') } | ConvertTo-Json -Compress`,
+    `  Set-Content -LiteralPath $ack -Value $payload -Encoding UTF8`,
+    `  Write-LaunchLog ("updater started pid=" + $p.Id)`,
+    `  try { Wait-Process -Id $p.Id -ErrorAction SilentlyContinue } catch {}`,
+    `  Write-LaunchLog 'updater exited; removing one-shot task'`,
+    `} catch {`,
+    `  $err = @{ ok = $false; requestId = $requestId; error = $_.Exception.Message } | ConvertTo-Json -Compress`,
+    `  try { Set-Content -LiteralPath $ack -Value $err -Encoding UTF8 } catch {}`,
+    `  Write-LaunchLog ("launcher failed: " + $_.Exception.Message)`,
+    `} finally {`,
+    `  try { schtasks.exe /Delete /F /TN ${psQuote(taskName)} | Out-Null } catch {}`,
+    `}`,
+    ``
+  ].join('\r\n')
+}
+
+/**
+ * Next /ST value (HH:mm, locale-independent) a couple of minutes ahead, so
+ * schtasks never warns about a start time in the past. The schedule itself is
+ * irrelevant — the task is triggered explicitly via /Run and the launcher's
+ * request-id guard ignores any stray timed firing.
+ */
+export function nextStartTime(now: Date = new Date(), minutesAhead = 2): string {
+  const t = new Date(now.getTime() + minutesAhead * 60_000)
+  const hh = String(t.getHours()).padStart(2, '0')
+  const mm = String(t.getMinutes()).padStart(2, '0')
+
+  return `${hh}:${mm}`
+}
+
+export function schtasksCreateArgs(taskName: string, scriptPath: string, startTime: string): string[] {
+  const action = `powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "${scriptPath}"`
+
+  return ['/Create', '/F', '/TN', taskName, '/SC', 'ONCE', '/ST', startTime, '/TR', action]
+}
+
+export function schtasksRunArgs(taskName: string): string[] {
+  return ['/Run', '/TN', taskName]
+}
+
+export function schtasksEndArgs(taskName: string): string[] {
+  return ['/End', '/TN', taskName]
+}
+
+export function schtasksDeleteArgs(taskName: string): string[] {
+  return ['/Delete', '/F', '/TN', taskName]
+}
+
+export type LaunchAck = {
+  ok: boolean
+  requestId: string
+  updaterPid: number | null
+  error: string | null
+}
+
+export function parseLaunchAck(raw: unknown, requestId: string): LaunchAck | null {
+  const text = String(raw ?? '')
+    .replace(/^\uFEFF/, '')
+    .trim()
+
+  if (!text) {
+    return null
+  }
+
+  let parsed: any
+
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return null
+  }
+
+  if (!parsed || parsed.requestId !== requestId) {
+    return null
+  }
+
+  const pid = Number(parsed.updaterPid)
+
+  return {
+    ok: parsed.ok === true,
+    requestId,
+    updaterPid: Number.isInteger(pid) && pid > 0 ? pid : null,
+    error: typeof parsed.error === 'string' ? parsed.error : null
+  }
+}
+
+export type RunCommand = (file: string, args: string[]) => Promise<{ code: number; stdout: string; stderr: string }>
+
+function defaultRunCommand(file: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise(resolve => {
+    execFile(
+      file,
+      args,
+      hiddenWindowsChildOptions({ encoding: 'utf8' }),
+      (error: any, stdout: any, stderr: any) => {
+        resolve({
+          code: error ? (typeof error.code === 'number' ? error.code : 1) : 0,
+          stdout: String(stdout ?? ''),
+          stderr: String(stderr ?? '')
+        })
+      }
+    )
+  })
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export type LaunchResult = { ok: boolean; updaterPid: number | null; error: string | null }
+
+function launchFailure(error: string): LaunchResult {
+  return { ok: false, updaterPid: null, error }
+}
+
+/**
+ * Full launch flow: write the launcher script, register + fire the one-shot
+ * task, then wait for the launcher's ACK. Never throws — callers use the
+ * error result to keep the desktop alive and report the failed handoff.
+ */
+export async function launchUpdaterViaScheduledTask(opts: {
+  updaterPath: string
+  updaterArgs: string[]
+  hermesHome: string
+  pathEnv: string
+  taskName?: string
+  runCommand?: RunCommand
+  timeoutMs?: number
+  pollMs?: number
+  now?: Date
+}): Promise<LaunchResult> {
+  const runCommand = opts.runCommand || defaultRunCommand
+  const timeoutMs = opts.timeoutMs ?? 30_000
+  const pollMs = opts.pollMs ?? 250
+  const requestId = crypto.randomUUID()
+  const taskName = opts.taskName || `${UPDATE_LAUNCH_TASK_NAME}_${requestId.replaceAll('-', '')}`
+  const paths = updateLaunchPaths(opts.hermesHome, requestId)
+
+  const cleanupFiles = (): void => {
+    try {
+      fs.rmSync(paths.scriptPath, { force: true })
+      fs.rmSync(paths.ackPath, { force: true })
+    } catch {
+      // Best effort; request-specific filenames make leftovers inert.
+    }
+  }
+
+  const cleanupTask = async (endRunning: boolean): Promise<void> => {
+    if (endRunning) {
+      try {
+        await runCommand('schtasks.exe', schtasksEndArgs(taskName))
+      } catch {
+        // Best effort. Deleting the definition below is still required even
+        // when Task Scheduler cannot confirm that the action has ended.
+      }
+    }
+
+    try {
+      await runCommand('schtasks.exe', schtasksDeleteArgs(taskName))
+    } catch {
+      // Best effort. The unique task name prevents collision with a later
+      // request even if Task Scheduler is temporarily unavailable.
+    }
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(paths.ackPath), { recursive: true })
+    fs.rmSync(paths.ackPath, { force: true })
+    fs.writeFileSync(
+      paths.scriptPath,
+      buildUpdateLaunchScript({
+        updaterPath: opts.updaterPath,
+        updaterArgs: opts.updaterArgs,
+        hermesHome: opts.hermesHome,
+        pathEnv: opts.pathEnv,
+        ackPath: paths.ackPath,
+        logPath: paths.logPath,
+        requestId,
+        taskName
+      }),
+      'utf8'
+    )
+  } catch (err: any) {
+    return launchFailure(`launcher script write failed: ${err.message}`)
+  }
+
+  const create = await runCommand('schtasks.exe', schtasksCreateArgs(taskName, paths.scriptPath, nextStartTime(opts.now)))
+
+  if (create.code !== 0) {
+    await cleanupTask(false)
+    cleanupFiles()
+
+    return launchFailure(`schtasks create failed (${create.code}): ${(create.stderr || create.stdout).trim()}`)
+  }
+
+  const run = await runCommand('schtasks.exe', schtasksRunArgs(taskName))
+
+  if (run.code !== 0) {
+    await cleanupTask(true)
+    cleanupFiles()
+
+    return launchFailure(`schtasks run failed (${run.code}): ${(run.stderr || run.stdout).trim()}`)
+  }
+
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    let raw: string | null = null
+
+    try {
+      raw = fs.readFileSync(paths.ackPath, 'utf8')
+    } catch {
+      // ACK not written yet.
+    }
+
+    const ack = raw === null ? null : parseLaunchAck(raw, requestId)
+
+    if (ack) {
+      if (ack.ok && ack.updaterPid !== null) {
+        cleanupFiles()
+
+        return { ok: true, updaterPid: ack.updaterPid, error: null }
+      }
+
+      await cleanupTask(true)
+      cleanupFiles()
+
+      return launchFailure(`launcher reported failure: ${ack.error || 'missing updater pid'}`)
+    }
+
+    await sleep(pollMs)
+  }
+
+  // Remove the scheduled definition so it cannot fire at its nominal time
+  // after /Run failed or was delayed. Never start a fallback updater here: if
+  // the task already started but its ACK was inaccessible, the live desktop
+  // makes it fail on the holder guard instead of racing a second mutator.
+  await cleanupTask(true)
+  cleanupFiles()
+
+  return launchFailure(`no launcher ACK within ${timeoutMs}ms`)
+}

--- a/apps/desktop/electron/windows-update-relaunch.test.ts
+++ b/apps/desktop/electron/windows-update-relaunch.test.ts
@@ -6,7 +6,7 @@ import { test } from 'vitest'
 
 import { acknowledgeUpdateRelaunch, parseUpdateRelaunchAckRequest } from './windows-update-relaunch'
 
-test('accepts only a request-bound ACK path below HERMES_HOME logs', () => {
+test('accepts an explicit safe ACK path and derives it when omitted', () => {
   const home = path.join('C:\\Users\\damian', 'hermes')
   const ack = path.join(home, 'logs', 'desktop-relaunch-abc.json')
   const id = 'a'.repeat(32)
@@ -18,6 +18,10 @@ test('accepts only a request-bound ACK path below HERMES_HOME logs', () => {
     ),
     { ackPath: path.resolve(ack), requestId: id }
   )
+  assert.deepEqual(parseUpdateRelaunchAckRequest([`--hermes-update-relaunch-request=${id}`], home), {
+    ackPath: path.resolve(home, 'logs', `desktop-relaunch-${id}.json`),
+    requestId: id
+  })
   assert.equal(
     parseUpdateRelaunchAckRequest(
       ['--hermes-update-relaunch-ack=C:\\Temp\\owned.json', `--hermes-update-relaunch-request=${id}`],
@@ -30,15 +34,11 @@ test('accepts only a request-bound ACK path below HERMES_HOME logs', () => {
 
 test('writes the cold-start PID ACK for the updater', () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-relaunch-'))
-  const ack = path.join(home, 'logs', 'desktop-relaunch.json')
   const id = 'b'.repeat(32)
+  const ack = path.join(home, 'logs', `desktop-relaunch-${id}.json`)
 
   assert.equal(
-    acknowledgeUpdateRelaunch(
-      [`--hermes-update-relaunch-ack=${ack}`, `--hermes-update-relaunch-request=${id}`],
-      home,
-      4242
-    ),
+    acknowledgeUpdateRelaunch([`--hermes-update-relaunch-request=${id}`], home, 4242),
     true
   )
   assert.deepEqual(JSON.parse(fs.readFileSync(ack, 'utf8')), {

--- a/apps/desktop/electron/windows-update-relaunch.test.ts
+++ b/apps/desktop/electron/windows-update-relaunch.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+
+import { acknowledgeUpdateRelaunch, parseUpdateRelaunchAckRequest } from './windows-update-relaunch'
+
+test('accepts only a request-bound ACK path below HERMES_HOME logs', () => {
+  const home = path.join('C:\\Users\\damian', 'hermes')
+  const ack = path.join(home, 'logs', 'desktop-relaunch-abc.json')
+  const id = 'a'.repeat(32)
+
+  assert.deepEqual(
+    parseUpdateRelaunchAckRequest(
+      [`--hermes-update-relaunch-ack=${ack}`, `--hermes-update-relaunch-request=${id}`],
+      home
+    ),
+    { ackPath: path.resolve(ack), requestId: id }
+  )
+  assert.equal(
+    parseUpdateRelaunchAckRequest(
+      ['--hermes-update-relaunch-ack=C:\\Temp\\owned.json', `--hermes-update-relaunch-request=${id}`],
+      home
+    ),
+    null
+  )
+  assert.equal(parseUpdateRelaunchAckRequest([`--hermes-update-relaunch-ack=${ack}`], home), null)
+})
+
+test('writes the cold-start PID ACK for the updater', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-relaunch-'))
+  const ack = path.join(home, 'logs', 'desktop-relaunch.json')
+  const id = 'b'.repeat(32)
+
+  assert.equal(
+    acknowledgeUpdateRelaunch(
+      [`--hermes-update-relaunch-ack=${ack}`, `--hermes-update-relaunch-request=${id}`],
+      home,
+      4242
+    ),
+    true
+  )
+  assert.deepEqual(JSON.parse(fs.readFileSync(ack, 'utf8')), {
+    ok: true,
+    pid: 4242,
+    requestId: id,
+    readyAt: JSON.parse(fs.readFileSync(ack, 'utf8')).readyAt
+  })
+})

--- a/apps/desktop/electron/windows-update-relaunch.ts
+++ b/apps/desktop/electron/windows-update-relaunch.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ACK_ARG = '--hermes-update-relaunch-ack='
+const REQUEST_ARG = '--hermes-update-relaunch-request='
+
+export type UpdateRelaunchAckRequest = { ackPath: string; requestId: string }
+
+export function parseUpdateRelaunchAckRequest(argv: string[], hermesHome: string): UpdateRelaunchAckRequest | null {
+  const rawAck = argv.find(arg => arg.startsWith(ACK_ARG))?.slice(ACK_ARG.length).trim()
+  const requestId = argv.find(arg => arg.startsWith(REQUEST_ARG))?.slice(REQUEST_ARG.length).trim()
+
+  if (!rawAck || !requestId || !/^[a-f0-9]{32}$/i.test(requestId)) {
+    return null
+  }
+
+  const ackPath = path.resolve(rawAck)
+  const logsRoot = path.resolve(hermesHome, 'logs')
+  const relativeAckPath = path.relative(logsRoot, ackPath)
+
+  if (
+    !relativeAckPath ||
+    relativeAckPath === '..' ||
+    relativeAckPath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeAckPath)
+  ) {
+    return null
+  }
+
+  return { ackPath, requestId }
+}
+
+/** Cold-start ACK consumed by the updater before it exits its own job chain. */
+export function acknowledgeUpdateRelaunch(argv: string[], hermesHome: string, pid = process.pid): boolean {
+  const request = parseUpdateRelaunchAckRequest(argv, hermesHome)
+
+  if (!request || !Number.isInteger(pid) || pid <= 0) {
+    return false
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(request.ackPath), { recursive: true })
+    fs.writeFileSync(
+      request.ackPath,
+      JSON.stringify({ ok: true, pid, requestId: request.requestId, readyAt: new Date().toISOString() }),
+      'utf8'
+    )
+
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/electron/windows-update-relaunch.ts
+++ b/apps/desktop/electron/windows-update-relaunch.ts
@@ -10,12 +10,14 @@ export function parseUpdateRelaunchAckRequest(argv: string[], hermesHome: string
   const rawAck = argv.find(arg => arg.startsWith(ACK_ARG))?.slice(ACK_ARG.length).trim()
   const requestId = argv.find(arg => arg.startsWith(REQUEST_ARG))?.slice(REQUEST_ARG.length).trim()
 
-  if (!rawAck || !requestId || !/^[a-f0-9]{32}$/i.test(requestId)) {
+  if (!requestId || !/^[a-f0-9]{32}$/i.test(requestId)) {
     return null
   }
 
-  const ackPath = path.resolve(rawAck)
   const logsRoot = path.resolve(hermesHome, 'logs')
+  const ackPath = rawAck
+    ? path.resolve(rawAck)
+    : path.resolve(logsRoot, `desktop-relaunch-${requestId}.json`)
   const relativeAckPath = path.relative(logsRoot, ackPath)
 
   if (

--- a/apps/desktop/electron/windows-update-runtime.ts
+++ b/apps/desktop/electron/windows-update-runtime.ts
@@ -1,0 +1,168 @@
+export type WindowsProcessInfo = {
+  pid: number | null
+  parentPid: number | null
+  creationTimeMs: number | null
+  executablePath: string
+  commandLine: string
+}
+
+function parsedCreationTimeMs(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value
+  }
+
+  const text = String(value ?? '').trim()
+
+  if (!text) {
+    return null
+  }
+
+  const numeric = Number(text)
+
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return numeric
+  }
+
+  const parsed = Date.parse(text)
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function normalizedProcessInfo(value: any): WindowsProcessInfo {
+  const rawPid = value?.pid ?? value?.ProcessId
+  const numericPid = Number(rawPid)
+  const rawParent = value?.parentPid ?? value?.ParentProcessId
+  const numericParent = Number(rawParent)
+
+  return {
+    pid: Number.isInteger(numericPid) && numericPid > 0 ? numericPid : null,
+    parentPid: Number.isInteger(numericParent) && numericParent > 0 ? numericParent : null,
+    creationTimeMs: parsedCreationTimeMs(value?.creationTimeMs ?? value?.CreationTimeMs ?? value?.CreationDate),
+    executablePath: String(value?.executablePath ?? value?.ExecutablePath ?? ''),
+    commandLine: String(value?.commandLine ?? value?.CommandLine ?? '')
+  }
+}
+
+export function parseWindowsProcessList(raw: unknown): WindowsProcessInfo[] {
+  const text = String(raw ?? '')
+    .replace(/^\uFEFF/, '')
+    .trim()
+
+  if (!text) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(text)
+    const rows = Array.isArray(parsed) ? parsed : [parsed]
+    return rows.map(normalizedProcessInfo)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Enumerate a process tree from a live inventory instead of `taskkill /T`.
+ *
+ * taskkill /T builds its tree from bare ParentProcessId links with no
+ * creation-time validation. The desktop's own parent (the task-launcher
+ * PowerShell) dies immediately after boot, so its PID gets recycled — and
+ * when a process in the tree being killed recycles it, taskkill considers
+ * the DESKTOP a descendant and kills it mid-handoff (observed: the whole
+ * Electron tree died within 1s of the backend tree-kill). This walk has the
+ * parent/child edge is accepted only when both creation times exist and the
+ * parent predates the child. That rejects stale ParentProcessId links after
+ * PID reuse. Callers MUST additionally pass their own pid (and anything else
+ * that must survive) in excludePids: excluded pids are neither killed nor
+ * expanded.
+ */
+export function collectProcessTreePids(
+  processes: Array<WindowsProcessInfo | Record<string, unknown>>,
+  rootPid: number,
+  {
+    excludePids = [],
+    expectedRootCreationTimeMs
+  }: { excludePids?: number[]; expectedRootCreationTimeMs: number }
+): number[] {
+  if (
+    !Number.isInteger(rootPid) ||
+    rootPid <= 0 ||
+    !Number.isFinite(expectedRootCreationTimeMs) ||
+    expectedRootCreationTimeMs <= 0
+  ) {
+    return []
+  }
+
+  const excluded = new Set(excludePids.filter(pid => Number.isInteger(pid) && pid > 0))
+
+  if (excluded.has(rootPid)) {
+    return []
+  }
+
+  const infoByPid = new Map<number, WindowsProcessInfo>()
+
+  for (const value of processes || []) {
+    const info = normalizedProcessInfo(value)
+
+    if (info.pid === null) {
+      continue
+    }
+
+    infoByPid.set(info.pid, info)
+  }
+
+  // The root must still exist in this exact inventory. If the tracked child
+  // already exited, do not kill a newly recycled PID with the same number.
+  if (infoByPid.get(rootPid)?.creationTimeMs !== expectedRootCreationTimeMs) {
+    return []
+  }
+
+  const childrenByParent = new Map<number, number[]>()
+
+  for (const info of infoByPid.values()) {
+    if (info.parentPid === null || info.creationTimeMs === null) {
+      continue
+    }
+
+    const parent = infoByPid.get(info.parentPid)
+
+    if (parent?.creationTimeMs === null || parent?.creationTimeMs === undefined) {
+      continue
+    }
+
+    // A real parent was already alive when its child started. If the current
+    // process carrying parentPid was created later, the PPID is a stale link
+    // through a recycled PID and must not be traversed.
+    if (parent.creationTimeMs > info.creationTimeMs) {
+      continue
+    }
+
+    const siblings = childrenByParent.get(info.parentPid) || []
+
+    siblings.push(info.pid as number)
+    childrenByParent.set(info.parentPid, siblings)
+  }
+
+  const tree: number[] = []
+  const seen = new Set<number>([rootPid])
+  const queue = [rootPid]
+
+  while (queue.length) {
+    const pid = queue.shift() as number
+
+    if (excluded.has(pid)) {
+      continue
+    }
+
+    tree.push(pid)
+
+    for (const child of childrenByParent.get(pid) || []) {
+      if (!seen.has(child)) {
+        seen.add(child)
+        queue.push(child)
+      }
+    }
+  }
+
+  return tree
+}

--- a/apps/desktop/electron/windows-update-tree.test.ts
+++ b/apps/desktop/electron/windows-update-tree.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for collectProcessTreePids in electron/windows-update-runtime.ts —
+ * the taskkill-/T-replacement that enumerates a kill tree from a CIM
+ * inventory with the caller's own pid hard-excluded.
+ *
+ * What this locks:
+ *   1. Plain descendant enumeration (children + grandchildren, no strays).
+ *   2. The PID-reuse self-kill guard: when a process in the tree has recycled
+ *      the desktop's dead launcher-parent PID, the desktop (excluded) and its
+ *      Electron children are NOT collected — the exact "all Hermes processes
+ *      die within 1s of Update now" incident.
+ *   3. Robustness: cycles terminate, excluded root yields nothing.
+ */
+
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import { collectProcessTreePids } from './windows-update-runtime'
+
+function proc(pid: number, parentPid: number, creationTimeMs = pid): Record<string, number> {
+  return { ProcessId: pid, ParentProcessId: parentPid, CreationTimeMs: creationTimeMs }
+}
+
+test('collects the root and all transitive descendants', () => {
+  const inventory = [proc(100, 1), proc(200, 100), proc(201, 100), proc(300, 200), proc(999, 1)]
+
+  assert.deepEqual(collectProcessTreePids(inventory, 100, { expectedRootCreationTimeMs: 100 }).sort(), [100, 200, 201, 300])
+})
+
+test('recycled launcher-parent pid cannot pull the excluded desktop into the kill tree', () => {
+  // Desktop 5000 was started by launcher 4000 (dead). Backend 100 spawned a
+  // short-lived child that recycled pid 4000 — raw ppid links now claim the
+  // desktop descends from the backend. taskkill /T would kill 5000 + its
+  // Electron children; the exclude guard must keep them all out.
+  const inventory = [
+    proc(100, 5000, 1_000), // backend (child of desktop)
+    proc(4000, 100, 2_000), // backend child that RECYCLED the dead launcher pid
+    proc(5000, 4000, 500), // desktop is older: current 4000 cannot be its real parent
+    proc(5001, 5000, 600), // Electron renderer
+    proc(5002, 5000, 700) // Electron gpu
+  ]
+
+  const tree = collectProcessTreePids(inventory, 100, {
+    excludePids: [5000],
+    expectedRootCreationTimeMs: 1_000
+  })
+
+  assert.deepEqual(tree.sort(), [100, 4000])
+  assert.ok(!tree.includes(5000))
+  assert.ok(!tree.includes(5001))
+  assert.ok(!tree.includes(5002))
+})
+
+test('parent-link cycles terminate and excluded root returns empty', () => {
+  const cycle = [proc(10, 20), proc(20, 10)]
+
+  assert.deepEqual(collectProcessTreePids(cycle, 10, { expectedRootCreationTimeMs: 10 }).sort(), [10, 20])
+  assert.deepEqual(
+    collectProcessTreePids(cycle, 10, { excludePids: [10], expectedRootCreationTimeMs: 10 }),
+    []
+  )
+  assert.deepEqual(collectProcessTreePids([], 0, { expectedRootCreationTimeMs: 1 }), [])
+})
+
+test('missing creation evidence never expands a raw PPID edge or kills a recycled root', () => {
+  const missingTimes = [
+    { ProcessId: 100, ParentProcessId: 1 },
+    { ProcessId: 200, ParentProcessId: 100 }
+  ]
+
+  assert.deepEqual(collectProcessTreePids(missingTimes, 100, { expectedRootCreationTimeMs: 1_000 }), [])
+  assert.deepEqual(
+    collectProcessTreePids([proc(200, 100, 2_000)], 100, { expectedRootCreationTimeMs: 1_000 }),
+    []
+  )
+})
+
+test('a recycled root PID is rejected unless its creation time matches the tracked child', () => {
+  const recycled = [proc(100, 1, 9_000), proc(200, 100, 9_100)]
+
+  assert.deepEqual(collectProcessTreePids(recycled, 100, { expectedRootCreationTimeMs: 1_000 }), [])
+  assert.deepEqual(collectProcessTreePids(recycled, 100, { expectedRootCreationTimeMs: 9_000 }), [100, 200])
+})

--- a/apps/desktop/src/app/contrib/hooks/use-update-continuation.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-update-continuation.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { type UpdateContinuation, updateContinuationToken } from '@/store/update-continuation'
+
+import { deliverUpdateContinuation } from './use-update-continuation'
+
+const continuation: UpdateContinuation = {
+  armedAt: 1_000,
+  requestId: 'a'.repeat(32),
+  sessionId: 'stored-1'
+}
+
+describe('deliverUpdateContinuation', () => {
+  it('submits once only after the durable transcript check', async () => {
+    const loadMessages = vi.fn().mockResolvedValue({ messages: [] })
+    const submitText = vi.fn().mockResolvedValue(true)
+    const markAttempt = vi.fn()
+
+    await expect(
+      deliverUpdateContinuation(continuation, loadMessages, submitText, { markAttempt })
+    ).resolves.toBe('submitted')
+    expect(loadMessages).toHaveBeenCalledWith('stored-1')
+    expect(markAttempt).toHaveBeenCalledOnce()
+    expect(submitText).toHaveBeenCalledOnce()
+    expect(submitText.mock.calls[0][0]).toContain(updateContinuationToken(continuation.requestId))
+  })
+
+  it('treats an existing request token as the idempotent gateway acknowledgement', async () => {
+    const submitText = vi.fn()
+
+    const loadMessages = vi.fn().mockResolvedValue({
+      messages: [{ role: 'user', text: `done ${updateContinuationToken(continuation.requestId)}` }]
+    })
+
+    await expect(deliverUpdateContinuation(continuation, loadMessages, submitText)).resolves.toBe('already-present')
+    expect(submitText).not.toHaveBeenCalled()
+  })
+
+  it('never retries within the same delivery run after an ambiguous submit timeout', async () => {
+    const loadMessages = vi.fn().mockResolvedValue({ messages: [] })
+    const submitText = vi.fn().mockRejectedValueOnce(new Error('request timed out'))
+
+    await expect(
+      deliverUpdateContinuation(continuation, loadMessages, submitText, {
+        sleep: vi.fn().mockResolvedValue(undefined)
+      })
+    ).resolves.toBe(false)
+    expect(loadMessages).toHaveBeenCalledOnce()
+    expect(submitText).toHaveBeenCalledOnce()
+  })
+
+  it('keeps an explicitly rejected marker for a later confirmed idle phase', async () => {
+    const noWait = vi.fn().mockResolvedValue(undefined)
+    const submitText = vi.fn().mockResolvedValue(false)
+
+    await expect(
+      deliverUpdateContinuation(continuation, vi.fn().mockResolvedValue({ messages: [] }), submitText, {
+        sleep: noWait
+      })
+    ).resolves.toBe(false)
+    expect(submitText).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-update-continuation.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-update-continuation.ts
@@ -1,0 +1,159 @@
+import { type RefObject, useEffect, useRef } from 'react'
+
+import { getSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
+import {
+  clearUpdateContinuation,
+  markUpdateContinuationAttempt,
+  readUpdateContinuation,
+  type UpdateContinuation,
+  updateContinuationPrompt,
+  updateContinuationToken
+} from '@/store/update-continuation'
+
+import type { GatewayRequester } from '../types'
+
+interface UpdateContinuationParams {
+  activeSessionId: null | string
+  awaitingResponse: boolean
+  busy: boolean
+  gatewayState: string
+  routedSessionId: null | string
+  runtimeIdByStoredSessionIdRef: RefObject<Map<string, string>>
+  selectedStoredSessionId: null | string
+  requestGateway: GatewayRequester
+}
+
+type DeliveryResult = 'already-present' | 'submitted' | false
+type MessagesLoader = (sessionId: string) => Promise<{ messages: unknown[] }>
+type ContinuationSubmitter = (text: string) => Promise<unknown> | unknown
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export async function deliverUpdateContinuation(
+  continuation: UpdateContinuation,
+  loadMessages: MessagesLoader,
+  submitContinuation: ContinuationSubmitter,
+  opts: { markAttempt?: () => void; now?: () => number; sleep?: (ms: number) => Promise<void> } = {}
+): Promise<DeliveryResult> {
+  const wait = opts.sleep ?? sleep
+
+  // A prior renderer may have died after prompt.submit reached the gateway but
+  // before localStorage was cleared. Give persistence a moment, then use the
+  // request token in the stored transcript as the idempotency acknowledgement.
+  if (continuation.attemptedAt) {
+    const remaining = 3_000 - ((opts.now ?? Date.now)() - continuation.attemptedAt)
+
+    if (remaining > 0) {
+      await wait(remaining)
+    }
+  }
+
+  const token = updateContinuationToken(continuation.requestId)
+  const prompt = updateContinuationPrompt(continuation.requestId)
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const transcript = await loadMessages(continuation.sessionId)
+
+      if (JSON.stringify(transcript.messages).includes(token)) {
+        return 'already-present'
+      }
+    } catch {
+      // Without the transcript check we cannot distinguish a retry from a
+      // prompt accepted just before a renderer crash. Fail closed and retry
+      // the read on a bounded backoff.
+      await wait(750 * (attempt + 1))
+
+      continue
+    }
+
+    opts.markAttempt?.()
+
+    try {
+      const accepted = await submitContinuation(prompt)
+
+      if (accepted !== false) {
+        return 'submitted'
+      }
+    } catch {
+      // A transport timeout is ambiguous: prompt.submit may already have
+      // reached the gateway before its user message is durable. Keep the
+      // marker and stop this delivery run. A later, freshly confirmed idle
+      // phase (or next launch) re-enters through the transcript check above.
+    }
+
+    return false
+  }
+
+  return false
+}
+
+/** Continue only after the normal route-resume loaded the exact, idle chat. */
+export function useUpdateContinuation({
+  activeSessionId,
+  awaitingResponse,
+  busy,
+  gatewayState,
+  routedSessionId,
+  runtimeIdByStoredSessionIdRef,
+  selectedStoredSessionId,
+  requestGateway
+}: UpdateContinuationParams): void {
+  const inFlightRequestRef = useRef<null | string>(null)
+
+  useEffect(() => {
+    const continuation = readUpdateContinuation()
+
+    const runtimeId = continuation
+      ? runtimeIdByStoredSessionIdRef.current.get(continuation.sessionId) ?? null
+      : null
+
+    const exactIdleSessionReady =
+      continuation !== null &&
+      gatewayState === 'open' &&
+      routedSessionId === continuation.sessionId &&
+      selectedStoredSessionId === continuation.sessionId &&
+      runtimeId !== null &&
+      runtimeId === activeSessionId &&
+      !busy &&
+      !awaitingResponse
+
+    if (!exactIdleSessionReady || inFlightRequestRef.current === continuation.requestId) {
+      return
+    }
+
+    inFlightRequestRef.current = continuation.requestId
+    void deliverUpdateContinuation(
+      continuation,
+      sessionId => getSessionMessages(sessionId),
+      prompt =>
+        requestGateway(
+          'prompt.submit',
+          { session_id: runtimeId, text: prompt },
+          PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+        ),
+      {
+        markAttempt: () => markUpdateContinuationAttempt(continuation)
+      }
+    )
+      .then(delivered => {
+        if (delivered) {
+          clearUpdateContinuation()
+        }
+      })
+      .finally(() => {
+        inFlightRequestRef.current = null
+      })
+  }, [
+    activeSessionId,
+    awaitingResponse,
+    busy,
+    gatewayState,
+    routedSessionId,
+    runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionId,
+    requestGateway
+  ])
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -34,6 +34,8 @@ import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActi
 import { $startWorkSessionRequest, followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
 import {
   $activeSessionId,
+  $awaitingResponse,
+  $busy,
   $connection,
   $currentCwd,
   $freshDraftReady,
@@ -98,6 +100,7 @@ import { useBackgroundSync } from './hooks/use-background-sync'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
 import { usePetBridge } from './hooks/use-pet-bridge'
 import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
+import { useUpdateContinuation } from './hooks/use-update-continuation'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
@@ -131,6 +134,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   const gatewayState = useStore($gatewayState)
   const activeSessionId = useStore($activeSessionId)
+  const awaitingResponse = useStore($awaitingResponse)
+  const busy = useStore($busy)
   const currentCwd = useStore($currentCwd)
   const freshDraftReady = useStore($freshDraftReady)
   const resumeFailedSessionId = useStore($resumeFailedSessionId)
@@ -535,6 +540,17 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     startFreshSessionDraft,
     sttEnabled,
     updateSessionState
+  })
+
+  useUpdateContinuation({
+    activeSessionId,
+    awaitingResponse,
+    busy,
+    gatewayState,
+    routedSessionId,
+    runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionId,
+    requestGateway
   })
 
   // Runs outside the selected ChatBar so queues belonging to background

--- a/apps/desktop/src/store/update-continuation.test.ts
+++ b/apps/desktop/src/store/update-continuation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  armUpdateContinuation,
+  clearUpdateContinuation,
+  continuationSessionId,
+  readUpdateContinuation,
+  type UpdateContinuationStorage
+} from './update-continuation'
+
+function memoryStorage(): UpdateContinuationStorage {
+  const values = new Map<string, string>()
+
+  return {
+    getItem: key => values.get(key) ?? null,
+    removeItem: key => values.delete(key),
+    setItem: (key, value) => values.set(key, value)
+  }
+}
+
+describe('update continuation handoff', () => {
+  it('arms only for an in-flight turn and prefers the durable stored id', () => {
+    expect(
+      continuationSessionId({ activeStoredSessionId: 'stored-1', selectedStoredSessionId: 'selected-1', busy: true })
+    ).toBe('stored-1')
+    expect(
+      continuationSessionId({ activeStoredSessionId: null, selectedStoredSessionId: 'selected-1', busy: false })
+    ).toBeNull()
+  })
+
+  it('keeps the handoff durable until delivery is explicitly acknowledged', () => {
+    const storage = memoryStorage()
+
+    armUpdateContinuation('stored-1', { now: 1_000, storage })
+
+    expect(readUpdateContinuation({ now: 2_000, storage })?.sessionId).toBe('stored-1')
+    expect(readUpdateContinuation({ now: 2_001, storage })?.sessionId).toBe('stored-1')
+    clearUpdateContinuation(storage)
+    expect(readUpdateContinuation({ now: 2_002, storage })).toBeNull()
+  })
+
+  it('drops stale handoffs instead of reviving an old task', () => {
+    const storage = memoryStorage()
+
+    armUpdateContinuation('stored-1', { now: 1_000, storage })
+
+    expect(readUpdateContinuation({ maxAgeMs: 500, now: 2_000, storage })).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/update-continuation.ts
+++ b/apps/desktop/src/store/update-continuation.ts
@@ -1,0 +1,130 @@
+const UPDATE_CONTINUATION_KEY = 'hermes.desktop.update-continuation'
+const DEFAULT_MAX_AGE_MS = 2 * 60 * 60 * 1000
+
+const UPDATE_CONTINUATION_PROMPT_BASE =
+  'Hermes wurde für das Update neu gestartet. Setze die zuvor unterbrochene Aufgabe in diesem Chat fort. ' +
+  'Prüfe zuerst, ob Update und Laufzeit gesund sind, und beende dann den ursprünglichen Auftrag. ' +
+  'Starte keinen weiteren Update-Lauf, wenn der aktuelle bereits erfolgreich war.'
+
+export interface UpdateContinuationStorage {
+  getItem: (key: string) => null | string
+  removeItem: (key: string) => void
+  setItem: (key: string, value: string) => void
+}
+
+export interface UpdateContinuation {
+  armedAt: number
+  attemptedAt?: number
+  requestId: string
+  sessionId: string
+}
+
+function newRequestId(): string {
+  return globalThis.crypto?.randomUUID?.().replaceAll('-', '') ?? `${Date.now()}${Math.random()}`.replace(/\D/g, '')
+}
+
+export function updateContinuationPrompt(requestId: string): string {
+  return `${UPDATE_CONTINUATION_PROMPT_BASE}\n\n<!-- hermes-update-continuation:${requestId} -->`
+}
+
+export function updateContinuationToken(requestId: string): string {
+  return `hermes-update-continuation:${requestId}`
+}
+
+function browserStorage(): null | UpdateContinuationStorage {
+  return typeof globalThis.localStorage === 'undefined' ? null : globalThis.localStorage
+}
+
+export function continuationSessionId(input: {
+  activeStoredSessionId: null | string
+  selectedStoredSessionId: null | string
+  busy: boolean
+  awaitingResponse?: boolean
+}): null | string {
+  if (!input.busy && !input.awaitingResponse) {
+    return null
+  }
+
+  return input.activeStoredSessionId || input.selectedStoredSessionId || null
+}
+
+export function armUpdateContinuation(
+  sessionId: string,
+  opts: { now?: number; storage?: null | UpdateContinuationStorage } = {}
+): boolean {
+  const storage = opts.storage === undefined ? browserStorage() : opts.storage
+  const normalized = sessionId.trim()
+
+  if (!storage || !normalized) {
+    return false
+  }
+
+  storage.setItem(
+    UPDATE_CONTINUATION_KEY,
+    JSON.stringify({
+      armedAt: opts.now ?? Date.now(),
+      requestId: newRequestId(),
+      sessionId: normalized
+    } satisfies UpdateContinuation)
+  )
+
+  return true
+}
+
+export function clearUpdateContinuation(storage: null | UpdateContinuationStorage = browserStorage()): void {
+  storage?.removeItem(UPDATE_CONTINUATION_KEY)
+}
+
+export function markUpdateContinuationAttempt(
+  continuation: UpdateContinuation,
+  opts: { now?: number; storage?: null | UpdateContinuationStorage } = {}
+): void {
+  const storage = opts.storage === undefined ? browserStorage() : opts.storage
+
+  storage?.setItem(
+    UPDATE_CONTINUATION_KEY,
+    JSON.stringify({ ...continuation, attemptedAt: opts.now ?? Date.now() } satisfies UpdateContinuation)
+  )
+}
+
+export function readUpdateContinuation(
+  opts: { maxAgeMs?: number; now?: number; storage?: null | UpdateContinuationStorage } = {}
+): null | UpdateContinuation {
+  const storage = opts.storage === undefined ? browserStorage() : opts.storage
+
+  if (!storage) {
+    return null
+  }
+
+  const raw = storage.getItem(UPDATE_CONTINUATION_KEY)
+
+  if (!raw) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<UpdateContinuation>
+    const sessionId = typeof parsed.sessionId === 'string' ? parsed.sessionId.trim() : ''
+    const requestId = typeof parsed.requestId === 'string' ? parsed.requestId.trim() : ''
+    const armedAt = Number(parsed.armedAt)
+    const attemptedAt = parsed.attemptedAt === undefined ? undefined : Number(parsed.attemptedAt)
+    const age = (opts.now ?? Date.now()) - armedAt
+
+    if (
+      !sessionId ||
+      !/^[a-z0-9]{16,64}$/i.test(requestId) ||
+      !Number.isFinite(armedAt) ||
+      (attemptedAt !== undefined && !Number.isFinite(attemptedAt)) ||
+      age < 0 ||
+      age > (opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS)
+    ) {
+      storage.removeItem(UPDATE_CONTINUATION_KEY)
+      return null
+    }
+
+    return { armedAt, ...(attemptedAt === undefined ? {} : { attemptedAt }), requestId, sessionId }
+  } catch {
+    storage.removeItem(UPDATE_CONTINUATION_KEY)
+    return null
+  }
+}

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -17,7 +17,18 @@ import { checkHermesUpdate, getActionStatus, updateHermes } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { persistString, storedString } from '@/lib/storage'
 import { dismissNotification, notify } from '@/store/notifications'
-import { $connection } from '@/store/session'
+import {
+  $activeSessionStoredId,
+  $awaitingResponse,
+  $busy,
+  $connection,
+  $selectedStoredSessionId
+} from '@/store/session'
+import {
+  armUpdateContinuation,
+  clearUpdateContinuation,
+  continuationSessionId
+} from '@/store/update-continuation'
 import type { BackendUpdateCheckResponse } from '@/types/hermes'
 
 export interface UpdateApplyState {
@@ -372,8 +383,25 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
   dismissNotification(UPDATE_TOAST_ID)
   $updateApply.set({ ...IDLE, applying: true, stage: 'prepare', message: 'Starting update…' })
 
+  const continuationId = continuationSessionId({
+    activeStoredSessionId: $activeSessionStoredId.get(),
+    awaitingResponse: $awaitingResponse.get(),
+    busy: $busy.get(),
+    selectedStoredSessionId: $selectedStoredSessionId.get()
+  })
+
+  if (continuationId) {
+    armUpdateContinuation(continuationId)
+  } else {
+    clearUpdateContinuation()
+  }
+
   try {
     const result = await bridge.apply(opts)
+
+    if (!result?.handedOff) {
+      clearUpdateContinuation()
+    }
 
     // CLI install with no staged updater: not an error — the user just runs
     // `hermes update` themselves. Land on a dedicated manual state so the
@@ -458,6 +486,7 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
 
     return result
   } catch (error) {
+    clearUpdateContinuation()
     const message = error instanceof Error ? error.message : String(error)
     $updateApply.set({ ...$updateApply.get(), applying: false, stage: 'error', error: 'apply-failed', message })
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9646,6 +9646,31 @@ def _discard_lockfile_churn(git_cmd, repo_root):
         pass
 
 
+def _preserve_local_update_commits(git_cmd, repo_root) -> bool:
+    """Whether this checkout keeps its local patch stack across updates.
+
+    This is an install-local Git setting rather than a tracked config value so
+    a managed downstream patch can protect the very update code that performs
+    the rebase.  The default stays compatible with ordinary managed installs;
+    operators opt in with::
+
+        git config hermes.updatePreserveLocalCommits true
+    """
+    try:
+        result = subprocess.run(
+            git_cmd
+            + ["config", "--bool", "--get", "hermes.updatePreserveLocalCommits"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except Exception:
+        return False
+
+    return result.returncode == 0 and result.stdout.strip().lower() == "true"
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -10123,26 +10148,56 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True,
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
-                )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
+                # ff-only failed — local and remote have diverged. Managed
+                # downstream installs may carry a deliberately-maintained
+                # local patch stack. Rebase that stack when the install-local
+                # guard is enabled; fail closed on conflicts so an update can
+                # never silently delete the fix that launched it.
+                if _preserve_local_update_commits(git_cmd, PROJECT_ROOT):
                     print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        "  ⚠ Fast-forward not possible. Preserving local commits "
+                        "and rebasing them onto the update..."
                     )
-                    sys.exit(1)
+                    rebase_result = subprocess.run(
+                        git_cmd + ["rebase", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if rebase_result.returncode != 0:
+                        subprocess.run(
+                            git_cmd + ["rebase", "--abort"],
+                            cwd=PROJECT_ROOT,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                        )
+                        print("✗ Local update patches conflict with the new version.")
+                        print("  Update stopped without discarding local commits.")
+                        if rebase_result.stderr.strip():
+                            print(f"  {rebase_result.stderr.strip().splitlines()[0]}")
+                        sys.exit(1)
+                else:
+                    # Historical managed-install behavior for upstream history
+                    # rewrites: local working changes are already stashed, so
+                    # reset to match the remote exactly.
+                    print(
+                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    )
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print(
+                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        )
+                        sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9671,6 +9671,543 @@ def _preserve_local_update_commits(git_cmd, repo_root) -> bool:
     return result.returncode == 0 and result.stdout.strip().lower() == "true"
 
 
+def _git_update_commit_sha(
+    git_cmd: list[str], repo_root: Path, ref: str
+) -> Optional[str]:
+    """Resolve *ref* to a commit without raising out of the update flow."""
+    result = subprocess.run(
+        git_cmd + ["rev-parse", "--verify", f"{ref}^{{commit}}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def _git_update_merge_base(
+    git_cmd: list[str], repo_root: Path, left: str, right: str
+) -> Optional[str]:
+    result = subprocess.run(
+        git_cmd + ["merge-base", left, right],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    merge_base = result.stdout.strip()
+    return merge_base or None
+
+
+def _first_git_error(result: subprocess.CompletedProcess) -> str:
+    text = (result.stderr or result.stdout or "").strip()
+    return text.splitlines()[0] if text else f"git exited {result.returncode}"
+
+
+def _ensure_update_merge_base(
+    git_cmd: list[str],
+    repo_root: Path,
+    branch: str,
+    original_head: str,
+    target_sha: str,
+) -> dict:
+    """Return a stable merge base, deepening an official shallow clone.
+
+    The remote target is pinned by the caller.  Every history fetch verifies
+    that ``origin/<branch>`` still resolves to that exact commit; a moving
+    boundary is an abort condition, never a reason to rebase a different
+    target than the one whose update was counted.
+    """
+    outcome = {"merge_base": None, "error": None, "fetch_steps": []}
+    merge_base = _git_update_merge_base(
+        git_cmd, repo_root, original_head, target_sha
+    )
+    if merge_base:
+        outcome["merge_base"] = merge_base
+        return outcome
+
+    shallow = subprocess.run(
+        git_cmd + ["rev-parse", "--is-shallow-repository"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if shallow.returncode != 0:
+        outcome["error"] = f"Could not inspect repository depth: {_first_git_error(shallow)}"
+        return outcome
+    if shallow.stdout.strip().lower() != "true":
+        outcome["error"] = (
+            "No merge base exists between the local checkout and the pinned "
+            "upstream target; histories are unrelated. No reset or rebase was attempted."
+        )
+        return outcome
+
+    fetch_steps: list[tuple[str, list[str]]] = [
+        ("--deepen=32", ["fetch", "--deepen=32", "origin", branch]),
+        ("--deepen=128", ["fetch", "--deepen=128", "origin", branch]),
+        ("--deepen=512", ["fetch", "--deepen=512", "origin", branch]),
+        ("--deepen=2048", ["fetch", "--deepen=2048", "origin", branch]),
+    ]
+
+    for label, args in fetch_steps:
+        fetch = subprocess.run(
+            git_cmd + args,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        outcome["fetch_steps"].append(label)
+        if fetch.returncode != 0:
+            outcome["error"] = f"History repair failed at {label}: {_first_git_error(fetch)}"
+            return outcome
+        current_target = _git_update_commit_sha(
+            git_cmd, repo_root, f"origin/{branch}"
+        )
+        if current_target != target_sha:
+            outcome["error"] = (
+                f"UpdaterBoundaryChanged: origin/{branch} moved while history "
+                "was being repaired. Retry the update against a fresh pinned target."
+            )
+            return outcome
+        merge_base = _git_update_merge_base(
+            git_cmd, repo_root, original_head, target_sha
+        )
+        if merge_base:
+            outcome["merge_base"] = merge_base
+            return outcome
+
+        depth_state = subprocess.run(
+            git_cmd + ["rev-parse", "--is-shallow-repository"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if depth_state.returncode == 0 and depth_state.stdout.strip().lower() != "true":
+            break
+
+    depth_state = subprocess.run(
+        git_cmd + ["rev-parse", "--is-shallow-repository"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if depth_state.returncode == 0 and depth_state.stdout.strip().lower() == "true":
+        fetch = subprocess.run(
+            git_cmd + ["fetch", "--unshallow", "origin", branch],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        outcome["fetch_steps"].append("--unshallow")
+        if fetch.returncode != 0:
+            outcome["error"] = f"History repair failed at --unshallow: {_first_git_error(fetch)}"
+            return outcome
+        current_target = _git_update_commit_sha(
+            git_cmd, repo_root, f"origin/{branch}"
+        )
+        if current_target != target_sha:
+            outcome["error"] = (
+                f"UpdaterBoundaryChanged: origin/{branch} moved while history "
+                "was being repaired. Retry the update against a fresh pinned target."
+            )
+            return outcome
+        merge_base = _git_update_merge_base(
+            git_cmd, repo_root, original_head, target_sha
+        )
+        if merge_base:
+            outcome["merge_base"] = merge_base
+            return outcome
+
+    outcome["error"] = (
+        "No merge base exists after bounded history repair. "
+        "No reset or rebase was attempted."
+    )
+    return outcome
+
+
+def _git_update_operation_paths(git_cmd: list[str], repo_root: Path) -> list[str]:
+    """List active merge/rebase/sequencer state paths for update verification."""
+    active: list[str] = []
+    for name in (
+        "rebase-apply",
+        "rebase-merge",
+        "MERGE_HEAD",
+        "CHERRY_PICK_HEAD",
+        "REVERT_HEAD",
+        "sequencer",
+    ):
+        resolved = subprocess.run(
+            git_cmd + ["rev-parse", "--git-path", name],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if resolved.returncode != 0 or not resolved.stdout.strip():
+            continue
+        path = Path(resolved.stdout.strip())
+        if not path.is_absolute():
+            path = repo_root / path
+        if path.exists():
+            active.append(name)
+    return active
+
+
+def _create_update_recovery_ref(
+    git_cmd: list[str], repo_root: Path, branch: str, pre_update_sha: str
+) -> Optional[str]:
+    branch_key = "".join(
+        ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in branch
+    )[:40]
+    token = f"{_time.time_ns()}-{os.getpid()}"
+    recovery_ref = f"refs/hermes/update-recovery/{branch_key}-{token}"
+    created = subprocess.run(
+        git_cmd + ["update-ref", recovery_ref, pre_update_sha],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return recovery_ref if created.returncode == 0 else None
+
+
+def _delete_update_recovery_ref(
+    git_cmd: list[str], repo_root: Path, recovery_ref: Optional[str]
+) -> bool:
+    if not recovery_ref:
+        return True
+    if not recovery_ref.startswith("refs/hermes/update-recovery/"):
+        return False
+    deleted = subprocess.run(
+        git_cmd + ["update-ref", "-d", recovery_ref],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return deleted.returncode == 0
+
+
+def _restore_original_update_checkout(
+    git_cmd: list[str],
+    repo_root: Path,
+    original_branch: str,
+    original_head: str,
+) -> bool:
+    current_head = _git_update_commit_sha(git_cmd, repo_root, "HEAD")
+    current_branch_result = subprocess.run(
+        git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    current_branch = current_branch_result.stdout.strip()
+    if current_head == original_head and current_branch == original_branch:
+        return True
+
+    checkout_args = (
+        ["checkout", "--detach", original_head]
+        if original_branch == "HEAD"
+        else ["checkout", original_branch]
+    )
+    checkout = subprocess.run(
+        git_cmd + checkout_args,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if checkout.returncode != 0:
+        return False
+    return (
+        _git_update_commit_sha(git_cmd, repo_root, "HEAD") == original_head
+        and not _git_update_operation_paths(git_cmd, repo_root)
+    )
+
+
+def _prepare_update_checkout_for_stash(
+    git_cmd: list[str],
+    repo_root: Path,
+    *,
+    original_branch: str,
+    original_head: str,
+    updated_branch: str,
+    update_succeeded: bool,
+) -> bool:
+    """Put the worktree on the checkout that owns the pending autostash.
+
+    A successful update that started on the target branch must remain on the
+    new target HEAD.  A no-op, failure, feature-branch, or detached-HEAD run
+    instead returns to the exact original commit before applying the stash.
+    """
+    if update_succeeded and original_branch == updated_branch:
+        current_branch = subprocess.run(
+            git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if current_branch.returncode != 0:
+            return False
+        if current_branch.stdout.strip() != updated_branch:
+            checkout = subprocess.run(
+                git_cmd + ["checkout", updated_branch],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if checkout.returncode != 0:
+                return False
+        return (
+            _git_update_commit_sha(git_cmd, repo_root, "HEAD") is not None
+            and not _git_update_operation_paths(git_cmd, repo_root)
+        )
+
+    return _restore_original_update_checkout(
+        git_cmd, repo_root, original_branch, original_head
+    )
+
+
+def _rollback_pinned_git_update(
+    git_cmd: list[str],
+    repo_root: Path,
+    *,
+    branch: str,
+    pre_update_sha: str,
+    recovery_ref: str,
+    original_branch: str,
+    original_head: str,
+) -> bool:
+    """Restore the exact pre-update branch/HEAD and clear operation state."""
+    if _git_update_commit_sha(git_cmd, repo_root, recovery_ref) != pre_update_sha:
+        return False
+
+    active_operations = _git_update_operation_paths(git_cmd, repo_root)
+    active_rebase = any(
+        name in active_operations for name in ("rebase-apply", "rebase-merge")
+    )
+    if active_rebase:
+        abort = subprocess.run(
+            git_cmd + ["rebase", "--abort"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if abort.returncode != 0:
+            return False
+    elif active_operations:
+        # This updater only starts a rebase.  An unrelated merge, cherry-pick,
+        # revert, or sequencer state must never be force-cleared here.
+        return False
+
+    if _git_update_operation_paths(git_cmd, repo_root):
+        return False
+
+    current_branch_result = subprocess.run(
+        git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if current_branch_result.returncode != 0:
+        return False
+    if current_branch_result.stdout.strip() != branch:
+        checkout = subprocess.run(
+            git_cmd + ["checkout", branch],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if checkout.returncode != 0:
+            return False
+
+    if _git_update_commit_sha(git_cmd, repo_root, branch) != pre_update_sha:
+        # ``--keep`` refuses rather than overwriting local work.  A hard reset
+        # (or checkout -f) could delete an ignored/untracked in-the-way path
+        # that was intentionally outside the updater's autostash.
+        reset = subprocess.run(
+            git_cmd + ["reset", "--keep", recovery_ref],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if reset.returncode != 0:
+            return False
+    if _git_update_commit_sha(git_cmd, repo_root, branch) != pre_update_sha:
+        return False
+    if not _restore_original_update_checkout(
+        git_cmd, repo_root, original_branch, original_head
+    ):
+        return False
+    if _git_update_operation_paths(git_cmd, repo_root):
+        return False
+    status = subprocess.run(
+        git_cmd + ["status", "--porcelain", "--untracked-files=all"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return status.returncode == 0 and not status.stdout.strip()
+
+
+def _apply_pinned_git_update(
+    git_cmd: list[str],
+    repo_root: Path,
+    *,
+    branch: str,
+    pre_update_sha: str,
+    target_sha: str,
+    merge_base: Optional[str],
+    preserve_local_commits: bool,
+    original_branch: str,
+    original_head: str,
+) -> dict:
+    """Apply exactly *target_sha*, preserving only merge-base..OriginalHEAD."""
+    outcome = {
+        "success": False,
+        "safe_to_restore_stash": False,
+        "recovery_ref": None,
+        "used_rebase": False,
+        "error": None,
+    }
+    current_branch = subprocess.run(
+        git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if (
+        current_branch.returncode != 0
+        or current_branch.stdout.strip() != branch
+        or _git_update_commit_sha(git_cmd, repo_root, "HEAD") != pre_update_sha
+    ):
+        outcome["error"] = "Local branch changed after the update target was pinned."
+        return outcome
+
+    if _git_update_commit_sha(git_cmd, repo_root, f"origin/{branch}") != target_sha:
+        outcome["safe_to_restore_stash"] = True
+        outcome["error"] = (
+            f"UpdaterBoundaryChanged: origin/{branch} no longer matches the "
+            "pinned update target. No Git mutation was attempted."
+        )
+        return outcome
+
+    recovery_ref = _create_update_recovery_ref(
+        git_cmd, repo_root, branch, pre_update_sha
+    )
+    outcome["recovery_ref"] = recovery_ref
+    if not recovery_ref:
+        outcome["safe_to_restore_stash"] = True
+        outcome["error"] = "Could not create the update recovery ref; no update was attempted."
+        return outcome
+
+    fast_forward = subprocess.run(
+        git_cmd + ["merge", "--ff-only", target_sha],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if fast_forward.returncode != 0:
+        if preserve_local_commits:
+            if not merge_base:
+                outcome["safe_to_restore_stash"] = True
+                outcome["error"] = "No merge base was provided; no rebase was attempted."
+                return outcome
+            rebase = subprocess.run(
+                git_cmd
+                + ["rebase", "--onto", target_sha, merge_base, branch],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            outcome["used_rebase"] = True
+            if rebase.returncode != 0:
+                safe = _rollback_pinned_git_update(
+                    git_cmd,
+                    repo_root,
+                    branch=branch,
+                    pre_update_sha=pre_update_sha,
+                    recovery_ref=recovery_ref,
+                    original_branch=original_branch,
+                    original_head=original_head,
+                )
+                outcome["safe_to_restore_stash"] = safe
+                outcome["error"] = (
+                    "Local update patches conflict with the pinned upstream target: "
+                    f"{_first_git_error(rebase)}"
+                )
+                return outcome
+        else:
+            reset = subprocess.run(
+                git_cmd + ["reset", "--hard", target_sha],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if reset.returncode != 0:
+                safe = _rollback_pinned_git_update(
+                    git_cmd,
+                    repo_root,
+                    branch=branch,
+                    pre_update_sha=pre_update_sha,
+                    recovery_ref=recovery_ref,
+                    original_branch=original_branch,
+                    original_head=original_head,
+                )
+                outcome["safe_to_restore_stash"] = safe
+                outcome["error"] = f"Pinned reset failed: {_first_git_error(reset)}"
+                return outcome
+
+    verify_target = subprocess.run(
+        git_cmd + ["merge-base", "--is-ancestor", target_sha, "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if verify_target.returncode != 0 or _git_update_operation_paths(
+        git_cmd, repo_root
+    ):
+        safe = _rollback_pinned_git_update(
+            git_cmd,
+            repo_root,
+            branch=branch,
+            pre_update_sha=pre_update_sha,
+            recovery_ref=recovery_ref,
+            original_branch=original_branch,
+            original_head=original_head,
+        )
+        outcome["safe_to_restore_stash"] = safe
+        outcome["error"] = "Pinned update verification failed after Git mutation."
+        return outcome
+
+    outcome["success"] = True
+    outcome["safe_to_restore_stash"] = True
+    return outcome
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -9875,8 +10412,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _resume_windows_gateways_after_update(_windows_gateway_resume)
             sys.exit(2)
 
-    # Try git-based update first, fall back to ZIP download on Windows
-    # when git file I/O is broken (antivirus, NTFS filter drivers, etc.)
+    # A checkout without Git metadata can still use the Windows ZIP updater.
+    # Once a Git update starts, however, errors never fall through to ZIP:
+    # overwriting source after a stash/rebase/dependency failure can destroy
+    # the exact local state the recovery logic is preserving.
     use_zip_update = False
     git_dir = PROJECT_ROOT / ".git"
 
@@ -9943,7 +10482,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _resume_windows_gateways_after_update(_windows_gateway_resume)
         return
 
-    # Fetch and pull
+    # Fetch and pull. Lifecycle variables are initialized outside the try so
+    # the single failure boundary can safely restore any pre-mutation stash.
+    auto_stash_ref: Optional[str] = None
+    stash_handled = True
+    branch: Optional[str] = None
+    current_branch: Optional[str] = None
+    original_checkout_sha: Optional[str] = None
+    recovery_ref: Optional[str] = None
     try:
 
         # Resolve the target branch up front so the fetch can be scoped to it.
@@ -9986,6 +10532,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
             check=True,
         )
         current_branch = result.stdout.strip()
+        original_checkout_sha = _git_update_commit_sha(
+            git_cmd, PROJECT_ROOT, "HEAD"
+        )
+        if original_checkout_sha is None:
+            print("✗ Could not pin the original checkout before updating.")
+            sys.exit(1)
 
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical
@@ -10019,10 +10571,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     text=True,
                 )
                 if track_result.returncode != 0:
-                    # Restore the user's prior branch + stash before bailing
-                    # so we don't leave them stranded in a weird state.
-                    if auto_stash_ref is not None:
-                        _restore_stashed_changes(
+                    # Restore the exact original checkout before touching the
+                    # stash; a failed checkout -B may otherwise leave HEAD on
+                    # a different branch than the work represented by it.
+                    checkout_safe = _restore_original_update_checkout(
+                        git_cmd,
+                        PROJECT_ROOT,
+                        current_branch,
+                        original_checkout_sha,
+                    )
+                    stash_restored = auto_stash_ref is None
+                    if auto_stash_ref is not None and checkout_safe:
+                        stash_restored = _restore_stashed_changes(
                             git_cmd,
                             PROJECT_ROOT,
                             auto_stash_ref,
@@ -10032,9 +10592,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(f"✗ Branch '{branch}' does not exist locally or on origin.")
                     if track_result.stderr.strip():
                         print(f"  {track_result.stderr.strip().splitlines()[0]}")
+                    if auto_stash_ref is not None and (
+                        not checkout_safe or not stash_restored
+                    ):
+                        print(
+                            f"  Local changes remain preserved in stash {auto_stash_ref}."
+                        )
                     sys.exit(1)
         else:
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
+
+        stash_handled = auto_stash_ref is None
 
         prompt_for_restore = (
             auto_stash_ref is not None
@@ -10042,9 +10610,78 @@ def _cmd_update_impl(args, gateway_mode: bool):
             and (gateway_mode or (sys.stdin.isatty() and sys.stdout.isatty()))
         )
 
+        preserve_local_commits = _preserve_local_update_commits(
+            git_cmd, PROJECT_ROOT
+        )
+        pinned_target_sha: Optional[str] = None
+        pinned_pre_update_sha: Optional[str] = None
+        pinned_merge_base: Optional[str] = None
+        if preserve_local_commits:
+            pinned_target_sha = _git_update_commit_sha(
+                git_cmd, PROJECT_ROOT, f"origin/{branch}"
+            )
+            pinned_pre_update_sha = _git_update_commit_sha(
+                git_cmd, PROJECT_ROOT, "HEAD"
+            )
+            if not pinned_target_sha or not pinned_pre_update_sha:
+                checkout_safe = _restore_original_update_checkout(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    current_branch,
+                    original_checkout_sha,
+                )
+                if auto_stash_ref is not None and checkout_safe:
+                    _restore_stashed_changes(
+                        git_cmd,
+                        PROJECT_ROOT,
+                        auto_stash_ref,
+                        prompt_user=False,
+                        input_fn=gw_input_fn,
+                    )
+                print("✗ Could not pin the local and upstream update commits.")
+                sys.exit(1)
+
+            base_result = _ensure_update_merge_base(
+                git_cmd,
+                PROJECT_ROOT,
+                branch,
+                pinned_pre_update_sha,
+                pinned_target_sha,
+            )
+            pinned_merge_base = base_result["merge_base"]
+            if not pinned_merge_base:
+                checkout_safe = _restore_original_update_checkout(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    current_branch,
+                    original_checkout_sha,
+                )
+                stash_restored = auto_stash_ref is None
+                if auto_stash_ref is not None and checkout_safe:
+                    stash_restored = _restore_stashed_changes(
+                        git_cmd,
+                        PROJECT_ROOT,
+                        auto_stash_ref,
+                        prompt_user=False,
+                        input_fn=gw_input_fn,
+                    )
+                print(f"✗ {base_result['error']}")
+                if auto_stash_ref is not None and (
+                    not checkout_safe or not stash_restored
+                ):
+                    print(
+                        f"  Local changes remain preserved in stash {auto_stash_ref}."
+                    )
+                sys.exit(1)
+
         # Check if there are updates
+        update_range = (
+            f"{pinned_pre_update_sha}..{pinned_target_sha}"
+            if preserve_local_commits
+            else f"HEAD..origin/{branch}"
+        )
         result = subprocess.run(
-            git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
+            git_cmd + ["rev-list", update_range, "--count"],
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True,
@@ -10059,23 +10696,32 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if is_fork and branch == "main":
                 _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
 
-            # Restore stash and switch back to original branch if we moved
-            if auto_stash_ref is not None:
-                _restore_stashed_changes(
+            # The stash belongs to the checkout on which it was created.  Go
+            # back there first; applying it to the update target can conflict
+            # or silently move feature-branch work onto main.
+            checkout_ready = _prepare_update_checkout_for_stash(
+                git_cmd,
+                PROJECT_ROOT,
+                original_branch=current_branch,
+                original_head=original_checkout_sha,
+                updated_branch=branch,
+                update_succeeded=False,
+            )
+            stash_restored = auto_stash_ref is None
+            if auto_stash_ref is not None and checkout_ready:
+                stash_restored = _restore_stashed_changes(
                     git_cmd,
                     PROJECT_ROOT,
                     auto_stash_ref,
                     prompt_user=prompt_for_restore,
                     input_fn=gw_input_fn,
                 )
-            if current_branch not in {branch, "HEAD"}:
-                subprocess.run(
-                    git_cmd + ["checkout", current_branch],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
+            if not checkout_ready or not stash_restored:
+                print("✗ Could not restore the original checkout after the update check.")
+                if auto_stash_ref is not None:
+                    print(f"  Local changes remain preserved in stash {auto_stash_ref}.")
+                _resume_windows_gateways_after_update(_windows_gateway_resume)
+                sys.exit(1)
 
             # A current checkout does NOT imply a healthy install: a previous
             # dependency sync may have failed partway (classic on Windows,
@@ -10134,50 +10780,54 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         print("→ Pulling updates...")
         update_succeeded = False
+        git_state_safe = False
+        recovery_ref: Optional[str] = None
         # Capture the pre-pull SHA so we can auto-roll-back if the new code
         # has a syntax error in a critical-path file (PR #28452 incident:
         # orphan merge-conflict markers in hermes_cli/config.py bricked
         # every user who ran ``hermes update`` for the 7 minutes between
         # the bad commit and the fix landing).
-        pre_pull_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
+        pre_pull_sha = (
+            pinned_pre_update_sha
+            if preserve_local_commits
+            else _capture_head_sha(git_cmd, PROJECT_ROOT)
+        )
         try:
-            pull_result = subprocess.run(
-                git_cmd + ["pull", "--ff-only", "origin", branch],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True,
-            )
-            if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged. Managed
-                # downstream installs may carry a deliberately-maintained
-                # local patch stack. Rebase that stack when the install-local
-                # guard is enabled; fail closed on conflicts so an update can
-                # never silently delete the fix that launched it.
-                if _preserve_local_update_commits(git_cmd, PROJECT_ROOT):
-                    print(
-                        "  ⚠ Fast-forward not possible. Preserving local commits "
-                        "and rebasing them onto the update..."
-                    )
-                    rebase_result = subprocess.run(
-                        git_cmd + ["rebase", f"origin/{branch}"],
-                        cwd=PROJECT_ROOT,
-                        capture_output=True,
-                        text=True,
-                    )
-                    if rebase_result.returncode != 0:
-                        subprocess.run(
-                            git_cmd + ["rebase", "--abort"],
-                            cwd=PROJECT_ROOT,
-                            capture_output=True,
-                            text=True,
-                            check=False,
+            if preserve_local_commits:
+                print(
+                    "  Preserving the pinned local patch stack across the update..."
+                )
+                pinned_update = _apply_pinned_git_update(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    branch=branch,
+                    pre_update_sha=pinned_pre_update_sha,
+                    target_sha=pinned_target_sha,
+                    merge_base=pinned_merge_base,
+                    preserve_local_commits=True,
+                    original_branch=current_branch,
+                    original_head=original_checkout_sha,
+                )
+                recovery_ref = pinned_update["recovery_ref"]
+                git_state_safe = pinned_update["safe_to_restore_stash"]
+                if not pinned_update["success"]:
+                    print(f"✗ {pinned_update['error']}")
+                    if recovery_ref:
+                        print(f"  Recovery ref: {recovery_ref}")
+                    if not git_state_safe:
+                        print(
+                            "  Automatic rollback could not be fully verified; "
+                            "no further Git mutation will be attempted."
                         )
-                        print("✗ Local update patches conflict with the new version.")
-                        print("  Update stopped without discarding local commits.")
-                        if rebase_result.stderr.strip():
-                            print(f"  {rebase_result.stderr.strip().splitlines()[0]}")
-                        sys.exit(1)
-                else:
+                    sys.exit(1)
+            else:
+                pull_result = subprocess.run(
+                    git_cmd + ["pull", "--ff-only", "origin", branch],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                )
+                if pull_result.returncode != 0:
                     # Historical managed-install behavior for upstream history
                     # rewrites: local working changes are already stashed, so
                     # reset to match the remote exactly.
@@ -10220,20 +10870,40 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 if pre_pull_sha:
                     print()
                     print(f"→ Rolling back to {pre_pull_sha[:10]}...")
-                    rollback_result = subprocess.run(
-                        git_cmd + ["reset", "--hard", pre_pull_sha],
-                        cwd=PROJECT_ROOT,
-                        capture_output=True,
-                        text=True,
-                    )
-                    if rollback_result.returncode == 0:
+                    if preserve_local_commits and recovery_ref:
+                        rollback_ok = _rollback_pinned_git_update(
+                            git_cmd,
+                            PROJECT_ROOT,
+                            branch=branch,
+                            pre_update_sha=pre_pull_sha,
+                            recovery_ref=recovery_ref,
+                            original_branch=current_branch,
+                            original_head=original_checkout_sha,
+                        )
+                        rollback_error = ""
+                    else:
+                        rollback_result = subprocess.run(
+                            git_cmd + ["reset", "--hard", pre_pull_sha],
+                            cwd=PROJECT_ROOT,
+                            capture_output=True,
+                            text=True,
+                        )
+                        rollback_ok = rollback_result.returncode == 0
+                        rollback_error = rollback_result.stderr.strip()
+                    git_state_safe = rollback_ok
+                    if rollback_ok:
                         print("  ✓ Rollback complete — your install is unchanged.")
                         print("  Try ``hermes update`` again later once a fix lands.")
                     else:
                         print("  ✗ Rollback failed. Recover manually with:")
-                        print(f"    cd {PROJECT_ROOT} && git reset --hard {pre_pull_sha}")
-                        if rollback_result.stderr.strip():
-                            print(f"    ({rollback_result.stderr.strip().splitlines()[0]})")
+                        if recovery_ref:
+                            print(f"    Recovery ref: {recovery_ref}")
+                        else:
+                            print(
+                                f"    cd {PROJECT_ROOT} && git reset --hard {pre_pull_sha}"
+                            )
+                        if rollback_error:
+                            print(f"    ({rollback_error.splitlines()[0]})")
                 else:
                     print()
                     print("  Could not capture pre-pull SHA — recover manually with:")
@@ -10241,11 +10911,35 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 sys.exit(1)
 
             update_succeeded = True
+            git_state_safe = True
         finally:
+            checkout_ready = False
+            if update_succeeded or git_state_safe:
+                checkout_ready = _prepare_update_checkout_for_stash(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    original_branch=current_branch,
+                    original_head=original_checkout_sha,
+                    updated_branch=branch,
+                    update_succeeded=update_succeeded,
+                )
+
+            stash_handled = auto_stash_ref is None
             if auto_stash_ref is not None:
-                # Don't attempt stash restore if the code update itself failed —
-                # working tree is in an unknown state.
-                if not update_succeeded:
+                if not checkout_ready:
+                    print(
+                        f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
+                    )
+                    print("  Restore manually after returning to the original checkout.")
+                elif not update_succeeded and git_state_safe:
+                    stash_handled = _restore_stashed_changes(
+                        git_cmd,
+                        PROJECT_ROOT,
+                        auto_stash_ref,
+                        prompt_user=False,
+                        input_fn=gw_input_fn,
+                    )
+                elif not update_succeeded:
                     print(
                         f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
                     )
@@ -10254,19 +10948,50 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     # Non-interactive update + user opted into discarding local
                     # source edits (updates.non_interactive_local_changes:
                     # discard). Throw the stash away instead of re-applying it.
-                    _discard_stashed_changes(
+                    stash_handled = _discard_stashed_changes(
                         git_cmd,
                         PROJECT_ROOT,
                         auto_stash_ref,
                     )
                 else:
-                    _restore_stashed_changes(
+                    stash_handled = _restore_stashed_changes(
                         git_cmd,
                         PROJECT_ROOT,
                         auto_stash_ref,
                         prompt_user=prompt_for_restore,
                         input_fn=gw_input_fn,
                     )
+
+            if recovery_ref:
+                if (
+                    not update_succeeded
+                    and git_state_safe
+                    and checkout_ready
+                    and stash_handled
+                ):
+                    if not _delete_update_recovery_ref(
+                        git_cmd, PROJECT_ROOT, recovery_ref
+                    ):
+                        print(f"  ⚠ Could not remove recovery ref {recovery_ref}.")
+                    else:
+                        recovery_ref = None
+                elif not update_succeeded:
+                    print(f"  Recovery ref retained: {recovery_ref}")
+
+            if update_succeeded and not checkout_ready:
+                update_succeeded = False
+                print("✗ Update completed, but the original checkout could not be restored.")
+                if recovery_ref:
+                    print(f"  Recovery ref retained: {recovery_ref}")
+                sys.exit(1)
+
+        if auto_stash_ref is not None and not stash_handled:
+            print("✗ Update stopped because local changes could not be restored safely.")
+            print(f"  Local changes remain preserved in stash {auto_stash_ref}.")
+            if recovery_ref:
+                print(f"  Recovery ref retained: {recovery_ref}")
+            _resume_windows_gateways_after_update(_windows_gateway_resume)
+            sys.exit(1)
 
         _invalidate_update_cache()
 
@@ -11458,19 +12183,56 @@ def _cmd_update_impl(args, gateway_mode: bool):
         else:
             _kill_stale_dashboard_processes()
 
+        # Keep the recovery ref through dependency, desktop-build, migration,
+        # and restart stages.  A late failure must never trigger a second
+        # source-update path, and the pinned pre-update commit remains an
+        # explicit recovery anchor until all critical work has completed.
+        if recovery_ref and update_succeeded and stash_handled:
+            if _delete_update_recovery_ref(git_cmd, PROJECT_ROOT, recovery_ref):
+                recovery_ref = None
+            else:
+                print()
+                print(f"  ⚠ Could not remove recovery ref {recovery_ref}.")
+
         print()
         print("Tip: You can now select a provider and model:")
         print("  hermes model              # Select provider and model")
 
     except subprocess.CalledProcessError as e:
-        if sys.platform == "win32":
-            print(f"⚠ Git update failed: {e}")
-            print("→ Falling back to ZIP download...")
-            print()
-            _update_via_zip(args)
-        else:
-            print(f"✗ Update failed: {e}")
-            sys.exit(1)
+        # Never reinterpret a dependency/build/post-pull failure as a Git
+        # failure and then overwrite the checkout with a ZIP.  Restore only a
+        # still-pending autostash whose original checkout can be verified.
+        if (
+            auto_stash_ref is not None
+            and not stash_handled
+            and current_branch is not None
+            and original_checkout_sha is not None
+        ):
+            checkout_ready = _prepare_update_checkout_for_stash(
+                git_cmd,
+                PROJECT_ROOT,
+                original_branch=current_branch,
+                original_head=original_checkout_sha,
+                updated_branch=branch or current_branch,
+                update_succeeded=False,
+            )
+            if checkout_ready:
+                stash_handled = _restore_stashed_changes(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    auto_stash_ref,
+                    prompt_user=False,
+                    input_fn=gw_input_fn,
+                )
+
+        print(f"✗ Update failed (exit {e.returncode}).")
+        print("  No ZIP fallback was attempted; the checkout was not overwritten.")
+        if auto_stash_ref is not None and not stash_handled:
+            print(f"  Local changes remain preserved in stash {auto_stash_ref}.")
+        if recovery_ref:
+            print(f"  Recovery ref retained: {recovery_ref}")
+        _resume_windows_gateways_after_update(_windows_gateway_resume)
+        sys.exit(1)
 
 
 def _coalesce_session_name_args(argv: list) -> list:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1577,7 +1577,7 @@ function Install-Repository {
                                 }
                             }
                             Write-Host ""
-                            Write-Info "Your stashed changes are preserved — nothing is lost."
+                            Write-Info "Your stashed changes are preserved -- nothing is lost."
                             Write-Info "  Stash ref: $autostashRef"
                             git -c windows.appendAtomically=false reset --hard HEAD 2>$null | Out-Null
                             Write-Info "Working tree reset to clean state."

--- a/tests/agent/test_coding_context_home_project_facts.py
+++ b/tests/agent/test_coding_context_home_project_facts.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import shutil
+import subprocess
+
+from agent import coding_context as cc
+
+
+def test_project_facts_ignore_dotfiles_repo_at_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "main.py").write_text("print('hi')\n")
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+        "HOME": str(home),
+    }
+
+    for args in (
+        ["init", "-q", "-b", "main"],
+        ["add", "-A"],
+        ["commit", "-q", "-m", "init"],
+    ):
+        subprocess.run([shutil.which("git"), "-C", str(home), *args], check=True, env=env)
+
+    monkeypatch.setattr(Path, "home", lambda: home)
+    workspace = home / "scratch"
+    workspace.mkdir()
+
+    assert cc.project_facts_for(workspace) is None

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -1,9 +1,24 @@
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 from subprocess import CalledProcessError
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+
+# The canonical runner intentionally starts from an almost-empty environment.
+# Windows' ``Path.home()`` needs USERPROFILE, which that runner does not carry;
+# give module import a harmless test-only Hermes root outside the checkout until
+# fixtures replace it with their per-test directories. Keeping this under the
+# OS temp root also prevents an interrupted test run from dirtying the repo.
+_MODULE_TEST_ROOT = Path(tempfile.gettempdir()) / f"hermes-update-tests-{os.getpid()}"
+os.environ.setdefault("HERMES_HOME", str(_MODULE_TEST_ROOT / "hermes-home"))
+os.environ.setdefault("LOCALAPPDATA", str(_MODULE_TEST_ROOT / "local-appdata"))
+os.environ.setdefault("USERPROFILE", str(_MODULE_TEST_ROOT / "user-profile"))
 
 from hermes_cli import config as hermes_config
 from hermes_cli import main as hermes_main
@@ -387,8 +402,20 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     """Common setup for cmd_update tests."""
     (tmp_path / ".git").mkdir()
     monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    # A unit test must never inspect or restart the machine's real Windows
+    # gateway/autostart tasks. Keep the updater lifecycle inside this process;
+    # dedicated gateway tests cover pause/resume separately.
+    monkeypatch.setattr(
+        hermes_main, "_pause_windows_gateways_for_update", lambda: None
+    )
+    monkeypatch.setattr(
+        hermes_main, "_resume_windows_gateways_after_update", lambda _token: None
+    )
     monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
     monkeypatch.setattr(hermes_main, "_restore_stashed_changes", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        hermes_main, "_git_update_commit_sha", lambda *a, **kw: "abc123"
+    )
     monkeypatch.setattr(hermes_config, "get_missing_env_vars", lambda required_only=True: [])
     monkeypatch.setattr(hermes_config, "get_missing_config_fields", lambda: [])
     monkeypatch.setattr(hermes_config, "check_config_version", lambda: (5, 5))
@@ -407,13 +434,13 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
 
     def fake_run(cmd, **kwargs):
         recorded.append(cmd)
-        if cmd == ["git", "fetch", "origin", "main"]:
+        if cmd[-3:] == ["fetch", "origin", "main"]:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
-        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+        if cmd[-3:] == ["rev-parse", "--abbrev-ref", "HEAD"]:
             return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
-        if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
+        if cmd[-3:] == ["rev-list", "HEAD..origin/main", "--count"]:
             return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
-        if cmd == ["git", "pull", "--ff-only", "origin", "main"]:
+        if cmd[-4:] == ["pull", "--ff-only", "origin", "main"]:
             return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
         if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[all]"]:
             raise CalledProcessError(returncode=1, cmd=cmd)
@@ -456,13 +483,13 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
 
     def fake_run(cmd, **kwargs):
         recorded.append(cmd)
-        if cmd == ["git", "fetch", "origin", "main"]:
+        if cmd[-3:] == ["fetch", "origin", "main"]:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
-        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+        if cmd[-3:] == ["rev-parse", "--abbrev-ref", "HEAD"]:
             return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
-        if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
+        if cmd[-3:] == ["rev-list", "HEAD..origin/main", "--count"]:
             return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
-        if cmd == ["git", "pull", "--ff-only", "origin", "main"]:
+        if cmd[-4:] == ["pull", "--ff-only", "origin", "main"]:
             return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -597,15 +624,38 @@ def test_cmd_update_rebases_local_patch_stack_when_preservation_is_enabled(
         "_preserve_local_update_commits",
         lambda *args: True,
     )
+    monkeypatch.setattr(
+        hermes_main,
+        "_ensure_update_merge_base",
+        lambda *args: {"merge_base": "base123", "error": None, "fetch_steps": []},
+    )
+    applied = []
+
+    def fake_apply(*args, **kwargs):
+        applied.append(kwargs)
+        return {
+            "success": True,
+            "safe_to_restore_stash": True,
+            "recovery_ref": "refs/hermes/update-recovery/test",
+            "used_rebase": True,
+            "error": None,
+        }
+
+    monkeypatch.setattr(hermes_main, "_apply_pinned_git_update", fake_apply)
+    monkeypatch.setattr(
+        hermes_main, "_delete_update_recovery_ref", lambda *args: True
+    )
 
     side_effect, recorded = _make_update_side_effect(ff_only_fails=True)
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
     hermes_main.cmd_update(SimpleNamespace())
 
-    assert any(call[-2:] == ["rebase", "origin/main"] for call in recorded)
+    assert len(applied) == 1
+    assert applied[0]["target_sha"] == "abc123"
+    assert applied[0]["merge_base"] == "base123"
     assert not any("reset" in call and "--hard" in call for call in recorded)
-    assert "Preserving local commits" in capsys.readouterr().out
+    assert "Preserving the pinned local patch stack" in capsys.readouterr().out
 
 
 def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
@@ -620,6 +670,32 @@ def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
 
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
     assert len(reset_calls) == 0
+
+
+def test_post_git_failure_never_falls_back_to_zip(monkeypatch, tmp_path, capsys):
+    """A late dependency/build failure must not overwrite the updated checkout."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    zip_calls = []
+    monkeypatch.setattr(
+        hermes_main, "_update_via_zip", lambda *a, **kw: zip_calls.append(1)
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_refresh_active_lazy_features",
+        lambda: (_ for _ in ()).throw(
+            CalledProcessError(returncode=17, cmd=["post-git-stage"])
+        ),
+    )
+    side_effect, _ = _make_update_side_effect()
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert zip_calls == []
+    out = capsys.readouterr().out
+    assert "No ZIP fallback was attempted" in out
 
 
 # ---------------------------------------------------------------------------
@@ -671,10 +747,16 @@ def test_cmd_update_restores_stash_and_branch_when_already_up_to_date(monkeypatc
         hermes_main, "_stash_local_changes_if_needed",
         lambda *a, **kw: "abc123deadbeef",
     )
-    restore_calls = []
+    events = []
+    checkout_calls = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_prepare_update_checkout_for_stash",
+        lambda *a, **kw: checkout_calls.append(kw) or events.append("checkout") or True,
+    )
     monkeypatch.setattr(
         hermes_main, "_restore_stashed_changes",
-        lambda *a, **kw: restore_calls.append(1) or True,
+        lambda *a, **kw: events.append("stash") or True,
     )
 
     side_effect, recorded = _make_update_side_effect(
@@ -684,15 +766,158 @@ def test_cmd_update_restores_stash_and_branch_when_already_up_to_date(monkeypatc
 
     hermes_main.cmd_update(SimpleNamespace())
 
-    # Stash should have been restored
-    assert len(restore_calls) == 1
-
-    # Should have checked out back to the original branch
-    checkout_back = [c for c in recorded if "checkout" in c and "fix/something" in c]
-    assert len(checkout_back) == 1
+    assert events == ["checkout", "stash"]
+    assert checkout_calls[0]["original_branch"] == "fix/something"
+    assert checkout_calls[0]["updated_branch"] == "main"
+    assert checkout_calls[0]["update_succeeded"] is False
 
     out = capsys.readouterr().out
     assert "Already up to date" in out
+
+
+def test_cmd_update_success_restores_feature_checkout_before_stash(
+    monkeypatch, tmp_path
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        hermes_main,
+        "_stash_local_changes_if_needed",
+        lambda *a, **kw: "abc123deadbeef",
+    )
+    events = []
+    checkout_calls = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_prepare_update_checkout_for_stash",
+        lambda *a, **kw: checkout_calls.append(kw) or events.append("checkout") or True,
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_restore_stashed_changes",
+        lambda *a, **kw: events.append("stash") or True,
+    )
+    side_effect, _ = _make_update_side_effect(current_branch="fix/something")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert events == ["checkout", "stash"]
+    assert checkout_calls[0]["original_branch"] == "fix/something"
+    assert checkout_calls[0]["updated_branch"] == "main"
+    assert checkout_calls[0]["update_succeeded"] is True
+
+
+def test_cmd_update_boundary_change_restores_checkout_before_stash(
+    monkeypatch, tmp_path
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        hermes_main,
+        "_stash_local_changes_if_needed",
+        lambda *a, **kw: "abc123deadbeef",
+    )
+    monkeypatch.setattr(
+        hermes_main, "_preserve_local_update_commits", lambda *a, **kw: True
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_ensure_update_merge_base",
+        lambda *a, **kw: {"merge_base": "base123", "error": None, "fetch_steps": []},
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_apply_pinned_git_update",
+        lambda *a, **kw: {
+            "success": False,
+            "safe_to_restore_stash": True,
+            "recovery_ref": "refs/hermes/update-recovery/boundary",
+            "used_rebase": False,
+            "error": "UpdaterBoundaryChanged: pinned target moved",
+        },
+    )
+    monkeypatch.setattr(
+        hermes_main, "_delete_update_recovery_ref", lambda *a, **kw: True
+    )
+    events = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_prepare_update_checkout_for_stash",
+        lambda *a, **kw: events.append("checkout") or True,
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_restore_stashed_changes",
+        lambda *a, **kw: events.append("stash") or True,
+    )
+    side_effect, _ = _make_update_side_effect(current_branch="fix/something")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert events == ["checkout", "stash"]
+
+
+def test_cmd_update_stops_before_dependencies_when_stash_restore_fails(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        hermes_main,
+        "_stash_local_changes_if_needed",
+        lambda *a, **kw: "abc123deadbeef",
+    )
+    monkeypatch.setattr(
+        hermes_main, "_preserve_local_update_commits", lambda *a, **kw: True
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_ensure_update_merge_base",
+        lambda *a, **kw: {"merge_base": "base123", "error": None, "fetch_steps": []},
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_apply_pinned_git_update",
+        lambda *a, **kw: {
+            "success": True,
+            "safe_to_restore_stash": True,
+            "recovery_ref": "refs/hermes/update-recovery/stash-conflict",
+            "used_rebase": True,
+            "error": None,
+        },
+    )
+    monkeypatch.setattr(
+        hermes_main, "_prepare_update_checkout_for_stash", lambda *a, **kw: True
+    )
+    monkeypatch.setattr(
+        hermes_main, "_restore_stashed_changes", lambda *a, **kw: False
+    )
+    deleted_refs = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_delete_update_recovery_ref",
+        lambda *a, **kw: deleted_refs.append(1) or True,
+    )
+    post_git_stages = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_refresh_active_lazy_features",
+        lambda: post_git_stages.append(1),
+    )
+    side_effect, _ = _make_update_side_effect()
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert deleted_refs == []
+    assert post_git_stages == []
+    out = capsys.readouterr().out
+    assert "could not be restored safely" in out
+    assert "Recovery ref retained" in out
 
 
 def test_cmd_update_no_checkout_when_already_on_main(monkeypatch, tmp_path):
@@ -722,8 +947,8 @@ def test_cmd_update_fetch_is_scoped_to_target_branch(monkeypatch, tmp_path):
     hermes_main.cmd_update(SimpleNamespace())
 
     fetch_calls = [c for c in recorded if "fetch" in c]
-    assert fetch_calls == [["git", "fetch", "origin", "main"]]
-    assert ["git", "fetch", "origin"] not in recorded
+    assert [c[-3:] for c in fetch_calls] == [["fetch", "origin", "main"]]
+    assert not any(c[-2:] == ["fetch", "origin"] for c in recorded)
 
 
 # ---------------------------------------------------------------------------
@@ -923,3 +1148,214 @@ def test_bootstrap_marker_not_autostashed_by_update(tmp_path):
         ["git", "status", "--porcelain"], cwd=tmp_path, capture_output=True, text=True
     ).stdout
     assert ".hermes-bootstrap-complete" not in status
+
+
+# ---------------------------------------------------------------------------
+# Real shallow-clone update topology
+# ---------------------------------------------------------------------------
+
+
+def _fixture_git(cwd: Path, *args: str, check: bool = True):
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _configure_fixture_repo(repo: Path) -> None:
+    _fixture_git(repo, "config", "user.email", "hermes-update-test@example.invalid")
+    _fixture_git(repo, "config", "user.name", "Fixture User")
+    _fixture_git(repo, "config", "core.autocrlf", "false")
+
+
+def _make_shallow_update_fixture(
+    tmp_path: Path,
+    *,
+    remote_commit_count: int = 40,
+    conflict: bool = False,
+):
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    client = tmp_path / "client"
+    _fixture_git(tmp_path, "init", "--bare", str(remote))
+    _fixture_git(tmp_path, "init", "-b", "main", str(seed))
+    _configure_fixture_repo(seed)
+    (seed / "shared.txt").write_text("base\n", encoding="utf-8")
+    (seed / "dirty.bin").write_bytes(b"clean\x00base\n")
+    _fixture_git(seed, "add", "-A")
+    _fixture_git(seed, "commit", "-m", "base")
+    _fixture_git(seed, "remote", "add", "origin", remote.as_uri())
+    _fixture_git(seed, "push", "-u", "origin", "main")
+
+    _fixture_git(
+        tmp_path,
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        "main",
+        remote.as_uri(),
+        str(client),
+    )
+    _configure_fixture_repo(client)
+    (client / ".gitignore").write_text("ignored-runtime.bin\n", encoding="utf-8")
+    if conflict:
+        (client / "shared.txt").write_text("local\n", encoding="utf-8")
+    else:
+        (client / "local-patch.txt").write_text("local patch\n", encoding="utf-8")
+    _fixture_git(client, "add", "-A")
+    _fixture_git(client, "commit", "-m", "local patch")
+
+    for index in range(remote_commit_count):
+        if conflict and index == 0:
+            (seed / "shared.txt").write_text("remote\n", encoding="utf-8")
+        else:
+            (seed / f"remote-{index:03}.txt").write_text(
+                f"remote {index}\n", encoding="utf-8"
+            )
+        _fixture_git(seed, "add", "-A")
+        _fixture_git(seed, "commit", "-m", f"remote {index}")
+    _fixture_git(seed, "push", "origin", "main")
+
+    # Match an updater that starts from the official depth-1 install and has
+    # fetched only the new tip. The local patch remains connected to the old
+    # shallow boundary, while origin/main is a second shallow island.
+    _fixture_git(client, "fetch", "--depth", "1", "origin", "main")
+    original_head = _fixture_git(client, "rev-parse", "HEAD").stdout.strip()
+    target_head = _fixture_git(client, "rev-parse", "origin/main").stdout.strip()
+    assert (
+        _fixture_git(
+            client, "merge-base", original_head, target_head, check=False
+        ).returncode
+        != 0
+    )
+    return client, original_head, target_head
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_pinned_update_repairs_depth_one_history_and_restores_dirty_files(tmp_path):
+    client, original_head, target_head = _make_shallow_update_fixture(tmp_path)
+    dirty = client / "dirty.bin"
+    untracked = client / "untracked.bin"
+    dirty.write_bytes(b"dirty\x00tracked\r\n")
+    untracked.write_bytes(b"untracked\x00payload\xff")
+    expected = (_digest(dirty), _digest(untracked))
+
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], client)
+    assert stash_ref
+    base = hermes_main._ensure_update_merge_base(
+        ["git"], client, "main", original_head, target_head
+    )
+    assert base["merge_base"]
+    assert base["error"] is None
+    assert base["fetch_steps"][:2] == ["--deepen=32", "--deepen=128"]
+
+    outcome = hermes_main._apply_pinned_git_update(
+        ["git"],
+        client,
+        branch="main",
+        pre_update_sha=original_head,
+        target_sha=target_head,
+        merge_base=base["merge_base"],
+        preserve_local_commits=True,
+        original_branch="main",
+        original_head=original_head,
+    )
+    assert outcome["success"], outcome
+    assert outcome["used_rebase"]
+    assert hermes_main._restore_stashed_changes(
+        ["git"], client, stash_ref, prompt_user=False
+    )
+    assert hermes_main._delete_update_recovery_ref(
+        ["git"], client, outcome["recovery_ref"]
+    )
+
+    assert _fixture_git(client, "rev-list", f"{target_head}..HEAD", "--count").stdout.strip() == "1"
+    assert _fixture_git(client, "log", "-1", "--format=%s").stdout.strip() == "local patch"
+    assert _fixture_git(client, "merge-base", target_head, "HEAD").stdout.strip() == target_head
+    assert (_digest(dirty), _digest(untracked)) == expected
+    assert not hermes_main._git_update_operation_paths(["git"], client)
+    assert not _fixture_git(client, "diff", "--name-only", "--diff-filter=U").stdout
+
+
+def test_pinned_update_conflict_rolls_back_before_restoring_autostash(tmp_path):
+    client, original_head, target_head = _make_shallow_update_fixture(
+        tmp_path, remote_commit_count=1, conflict=True
+    )
+    dirty = client / "dirty.bin"
+    untracked = client / "untracked.bin"
+    ignored = client / "ignored-runtime.bin"
+    dirty.write_bytes(b"dirty before conflict\x00")
+    untracked.write_bytes(b"untracked before conflict\xff")
+    ignored.write_bytes(b"ignored runtime sentinel\x00\xfe")
+    expected = (_digest(dirty), _digest(untracked), _digest(ignored))
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], client)
+    assert stash_ref
+
+    base = hermes_main._ensure_update_merge_base(
+        ["git"], client, "main", original_head, target_head
+    )
+    assert base["merge_base"]
+    outcome = hermes_main._apply_pinned_git_update(
+        ["git"],
+        client,
+        branch="main",
+        pre_update_sha=original_head,
+        target_sha=target_head,
+        merge_base=base["merge_base"],
+        preserve_local_commits=True,
+        original_branch="main",
+        original_head=original_head,
+    )
+
+    assert not outcome["success"]
+    assert outcome["safe_to_restore_stash"]
+    assert outcome["used_rebase"]
+    assert outcome["recovery_ref"]
+    assert "conflict" in outcome["error"].lower()
+    assert _fixture_git(client, "rev-parse", "HEAD").stdout.strip() == original_head
+    assert _fixture_git(client, "branch", "--show-current").stdout.strip() == "main"
+    assert not hermes_main._git_update_operation_paths(["git"], client)
+    assert hermes_main._restore_stashed_changes(
+        ["git"], client, stash_ref, prompt_user=False
+    )
+    assert (_digest(dirty), _digest(untracked), _digest(ignored)) == expected
+    assert not _fixture_git(client, "diff", "--name-only", "--diff-filter=U").stdout
+    assert hermes_main._delete_update_recovery_ref(
+        ["git"], client, outcome["recovery_ref"]
+    )
+
+
+def test_unrelated_full_histories_abort_without_head_mutation(tmp_path):
+    local = tmp_path / "local"
+    other = tmp_path / "other"
+    _fixture_git(tmp_path, "init", "-b", "main", str(local))
+    _fixture_git(tmp_path, "init", "-b", "main", str(other))
+    for repo, content in ((local, "local\n"), (other, "other\n")):
+        _configure_fixture_repo(repo)
+        (repo / "history.txt").write_text(content, encoding="utf-8")
+        _fixture_git(repo, "add", "-A")
+        _fixture_git(repo, "commit", "-m", content.strip())
+    original_head = _fixture_git(local, "rev-parse", "HEAD").stdout.strip()
+    target_head = _fixture_git(other, "rev-parse", "HEAD").stdout.strip()
+    _fixture_git(local, "remote", "add", "origin", other.as_uri())
+    _fixture_git(local, "fetch", "origin", "main")
+
+    result = hermes_main._ensure_update_merge_base(
+        ["git"], local, "main", original_head, target_head
+    )
+
+    assert result["merge_base"] is None
+    assert "no merge base" in result["error"].lower()
+    assert result["fetch_steps"] == []
+    assert _fixture_git(local, "rev-parse", "HEAD").stdout.strip() == original_head
+    assert not hermes_main._git_update_operation_paths(["git"], local)

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -580,10 +580,32 @@ def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path
 
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
     assert len(reset_calls) == 1
-    assert reset_calls[0] == ["git", "reset", "--hard", "origin/main"]
+    assert reset_calls[0][-3:] == ["reset", "--hard", "origin/main"]
 
     out = capsys.readouterr().out
     assert "Fast-forward not possible" in out
+
+
+def test_cmd_update_rebases_local_patch_stack_when_preservation_is_enabled(
+    monkeypatch, tmp_path, capsys
+):
+    """A managed local fix must survive the update that it launches."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        hermes_main,
+        "_preserve_local_update_commits",
+        lambda *args: True,
+    )
+
+    side_effect, recorded = _make_update_side_effect(ff_only_fails=True)
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert any(call[-2:] == ["rebase", "origin/main"] for call in recorded)
+    assert not any("reset" in call and "--hard" in call for call in recorded)
+    assert "Preserving local commits" in capsys.readouterr().out
 
 
 def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

The Windows update relaunch path keeps a scheduled-task PowerShell runner alive for the full update duration: the user sees a terminal window that "runs forever", closes it, and the update dies mid-mutation (bootstrap log ends without "Update complete!").

## Root cause

- The relaunch task (`windows-update-relaunch.ts` + `bootstrap.rs`) used a long-lived interactive PowerShell task instead of a short, self-terminating one.

## Fix

- Keep the Windows relaunch task short: arm a minimal one-shot relaunch and let the updater own the long work; terminate the helper after the desktop exits instead of waiting through the update.
- Adjust the relaunch test expectations to the short-task contract.

## Validation

- `apps/desktop/electron/windows-update-relaunch.test.ts` — updated.
- E2E on Windows: no lingering console window during the update; relaunch happens via the short task; update completes with exit 0.

## Stack

Part 4 of 4. Base: `dolverin/installer-keep-windows-powershell-parsin` (part 3).
