### PR TITLE
fix(desktop): remove duplicate messaging heading icon

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -5,7 +5,6 @@ import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
-import { PlatformAvatar } from '@/app/messaging/platform-icon'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '@/components/ui/context-menu'
@@ -1440,13 +1439,6 @@ export function ChatSidebar({
                     }
                     key={group.sourceId}
                     label={group.label}
-                    labelIcon={
-                      <PlatformAvatar
-                        className="size-4 rounded-[4px] text-[0.5625rem] [&_svg]:size-3"
-                        platformId={group.sourceId}
-                        platformName={group.label}
-                      />
-                    }
                     labelMeta={countLabel(group.sessions.length, group.total)}
                     onArchiveSession={onArchiveSession}
                     onDeleteSession={onDeleteSession}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -33,7 +33,6 @@ interface SidebarSectionHeaderProps {
   onToggle: () => void
   action?: React.ReactNode
   meta?: React.ReactNode
-  icon?: React.ReactNode
   // When false the section can't be collapsed: the label renders static (no
   // toggle, no caret) and the section is always open. Used for the single-
   // project view, where collapsing one project makes no sense.
@@ -46,12 +45,10 @@ function SidebarSectionHeader({
   onToggle,
   action,
   meta,
-  icon,
   collapsible = true
 }: SidebarSectionHeaderProps) {
   const labelBody = (
     <>
-      {icon}
       <SidebarPanelLabel>{label}</SidebarPanelLabel>
       {meta && <SidebarCount>{meta}</SidebarCount>}
     </>
@@ -123,7 +120,6 @@ interface SidebarSessionsSectionProps {
   removedSessionIds?: ReadonlySet<string>
   activeProjectId?: null | string
   labelMeta?: React.ReactNode
-  labelIcon?: React.ReactNode
   // When false the section header is static (no caret/toggle) and always open.
   collapsible?: boolean
   sortable?: boolean
@@ -172,7 +168,6 @@ export function SidebarSessionsSection({
   removedSessionIds,
   activeProjectId,
   labelMeta,
-  labelIcon,
   collapsible = true,
   sortable = false,
   onReorderSessions,
@@ -350,7 +345,6 @@ export function SidebarSessionsSection({
       <SidebarSectionHeader
         action={headerAction}
         collapsible={collapsible}
-        icon={labelIcon}
         label={label}
         meta={labelMeta}
         onToggle={onToggle}


### PR DESCRIPTION
## What does this PR do?

Removes the redundant platform avatar rendered before messaging section headings in the desktop sidebar.

<img width="1360" height="1788" alt="CleanShot 2026-07-18 at 23 08 40@2x" src="https://github.com/user-attachments/assets/7d8bbb37-1acf-42fe-aa21-7aca59434ee1" />

Messaging headings such as Slack currently show both a platform avatar and the standard dither section marker. Other sidebar sections use one leading marker, so the extra avatar makes the messaging heading inconsistent and visually misaligned.

This change:

- Removes the heading-only `PlatformAvatar`.
- Removes the now-unused `labelIcon` / header `icon` plumbing, which had no other consumers.
- Keeps platform avatars on individual messaging session rows, where they identify message origin.

No session behavior, platform routing, or data handling changes.

## How to test

1. Run `cd apps/desktop && npm run dev`.
2. Show a messaging session group such as Slack in the sidebar.
3. Confirm its heading has one dither marker, matching PINNED, SESSIONS, and CRON JOBS.
4. Confirm messaging session rows still show platform avatars where applicable.

## Validation

- `cd apps/desktop && npm run typecheck`
- `cd apps/desktop && npm run lint -- --quiet`
- Local macOS Electron visual check