### PR TITLE
test(cron): add coverage for pre-set stop event

### DIFF
--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -206,6 +206,32 @@ def test_inprocess_provider_stop_is_noop():
 
     assert InProcessCronScheduler().stop() is None
 
+def test_inprocess_provider_exits_when_stop_event_already_set():
+    """If the stop event is already set before start(), the provider exits
+    immediately without calling cron.scheduler.tick()."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    calls = []
+    stop = threading.Event()
+    stop.set()
+
+    provider = InProcessCronScheduler()
+
+    with patch(
+        "cron.scheduler.tick",
+        side_effect=lambda *args, **kwargs: calls.append(kwargs),
+    ):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={"interval": 0},
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=2)
+
+    assert not thread.is_alive()
+    assert calls == []
 
 # ── Phase 2: config key, discovery, resolver ─────────────────────────────────
 


### PR DESCRIPTION
Adds a unit test covering the edge case where the in-process cron scheduler is started with an already-set stop event.

The test verifies that the scheduler exits cleanly without continuing background work when shutdown has already been requested. This improves test coverage around the scheduler lifecycle without modifying production code.

Related to #67102

- [x] ✅ Tests (adding or improving test coverage)


- Added a new unit test in `tests/cron/test_scheduler_provider.py`.
- Covered the scenario where `InProcessCronScheduler` starts with the stop event already set.
- No production code was modified.

1. Run the cron scheduler test suite.
2. Verify the new test executes successfully.
3. Confirm existing cron scheduler tests continue to pass.