### PR TITLE
fix(tools): inline combinator-walking $ref before nullable-union collapse

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1030,10 +1030,31 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             try:
                 import copy as _copy
                 from tools.schema_sanitizer import (
+                    inline_schema_refs,
                     strip_pattern_and_format,
                     strip_slash_enum,
                 )
                 tools_for_api = _copy.deepcopy(tools_for_api)
+                # Defense-in-depth: inline local `$ref` pointers (issue #67131).
+                # The main sanitizer call site (`sanitize_tool_schemas`) now
+                # inlines refs BEFORE `strip_nullable_unions` collapses
+                # `anyOf/0/...`, but tools assembled via legacy paths or
+                # bundled before this fix rolls out may still carry dangling
+                # `.../anyOf/0/...` refs that xAI 400s on. Inline again here
+                # — it's idempotent on schemas with no refs.
+                for _tool_entry in tools_for_api:
+                    if not isinstance(_tool_entry, dict):
+                        continue
+                    _fn = _tool_entry.get("function") if isinstance(_tool_entry, dict) else None
+                    if isinstance(_fn, dict) and isinstance(_fn.get("parameters"), dict):
+                        _fn["parameters"] = inline_schema_refs(
+                            _fn["parameters"], only_through_combinators=False,
+                        )
+                    elif isinstance(_tool_entry.get("parameters"), dict):
+                        # Responses-format: {"name": "...", "parameters": {...}}
+                        _tool_entry["parameters"] = inline_schema_refs(
+                            _tool_entry["parameters"], only_through_combinators=False,
+                        )
                 tools_for_api, _ = strip_pattern_and_format(tools_for_api)
                 tools_for_api, _ = strip_slash_enum(tools_for_api)
             except Exception as exc:

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -759,3 +759,207 @@ def test_strip_slash_enum_ignores_non_string_enum_values():
     props = tools[0]["function"]["parameters"]["properties"]
     assert props["level"]["enum"] == [1, 2, 3]
     assert props["flag"]["enum"] == [True, False]
+
+
+# === Tests for inline_schema_refs (xAI / #67131) =============================
+#
+# `strip_nullable_unions` collapses `anyOf: [T, null]` to `T` but doesn't
+# rewrite `$ref` strings that walk through the dropped `anyOf/0/...` segment.
+# xAI's strict Responses validator resolves those refs against the post-
+# collapse tree, finds `key 'anyOf' not found`, and 400s before generation.
+#
+# `inline_schema_refs` resolves RFC 6901 `#/...` pointers against the schema
+# root before any tree-reshaping happens, so the refs disappear and the
+# strict validator has nothing to mis-resolve.
+
+from tools.schema_sanitizer import inline_schema_refs  # noqa: E402
+
+
+def test_inline_schema_refs_resolves_property_path_pointer():
+    # Pointer walks through properties/constraints into a sibling property.
+    # No combinator segment in the pointer — uses only_through_combinators=False
+    # to exercise the "inline every local ref" path (xAI Responses mode).
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "string", "minLength": 1},
+            "b": {"$ref": "#/properties/a"},
+        },
+    }
+    inlined = inline_schema_refs(schema, only_through_combinators=False)
+    assert inlined["properties"]["b"] == {"type": "string", "minLength": 1}
+    # Original $ref must not survive.
+    assert "$ref" not in inlined["properties"]["b"]
+
+
+def test_inline_schema_refs_walks_nested_arrays_and_objects():
+    # Pointer into an array-item's properties. The pointer walks through
+    # ``.../anyOf/0/...`` so it's inlined even with the default
+    # ``only_through_combinators=True`` — this is the xAI-400 reproduction.
+    schema = {
+        "type": "object",
+        "properties": {
+            "sections": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "rows": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "label": {"type": "string", "minLength": 1},
+                                        },
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "label": {
+                                                "$ref": "#/properties/sections/items/properties/rows/items/anyOf/0/properties/label",
+                                            },
+                                        },
+                                    },
+                                ]
+                            },
+                        }
+                    },
+                },
+            }
+        },
+    }
+    inlined = inline_schema_refs(schema)
+    variant1 = inlined["properties"]["sections"]["items"]["properties"]["rows"]["items"]["anyOf"][1]
+    assert variant1["properties"]["label"] == {"type": "string", "minLength": 1}
+
+
+def test_inline_schema_refs_preserves_stable_dollar_defs_ref_by_default():
+    # ``#/$defs/Foo`` pointers are stable across strip_nullable_unions
+    # collapses (no combinator segment to walk through). Default mode leaves
+    # them in place — providers that can resolve local refs (Anthropic,
+    # OpenAI) prefer the dedup that ``$defs`` provides.
+    schema = {
+        "$defs": {"Label": {"type": "string", "minLength": 1}},
+        "type": "object",
+        "properties": {
+            "label": {"$ref": "#/$defs/Label"},
+        },
+    }
+    inlined = inline_schema_refs(schema)
+    # Stable ref preserved in default mode.
+    assert inlined["properties"]["label"] == {"$ref": "#/$defs/Label"}
+
+
+def test_inline_schema_refs_resolves_property_path_pointer():
+    # Pointer into a $defs entry — canonical JSON Schema shape.
+    schema = {
+        "$defs": {"Label": {"type": "string", "minLength": 1}},
+        "type": "object",
+        "properties": {
+            "label": {"$ref": "#/$defs/Label"},
+        },
+    }
+    inlined = inline_schema_refs(schema, only_through_combinators=False)
+    assert inlined["properties"]["label"] == {"type": "string", "minLength": 1}
+
+
+def test_inline_schema_refs_recursive_pointer_does_not_loop():
+    # A self-referential $ref (e.g. recursive node) should be resolved with a
+    # maximal depth guard — we replace with a minimal `object` schema so the
+    # strict validator sees a concrete shape instead of dangling $ref.
+    schema = {
+        "type": "object",
+        "properties": {
+            "node": {"$ref": "#"},  # points back at schema root
+        },
+    }
+    # Must not raise; must not loop forever.
+    inlined = inline_schema_refs(schema, max_depth=4, only_through_combinators=False)
+    assert "$ref" not in inlined["properties"]["node"]
+
+
+def test_inline_schema_refs_missing_target_replaces_with_object_schema():
+    # $ref points at a path that doesn't exist in the tree (post-collapse
+    # scenario where the target was an `anyOf/0` that's been folded away).
+    schema = {
+        "type": "object",
+        "properties": {
+            "label": {
+                "$ref": "#/properties/metadata/anyOf/0/properties/label",
+            },
+        },
+    }
+    inlined = inline_schema_refs(schema)
+    # The ref must be replaced — a missing target should NOT leave a dangling
+    # $ref for xAI's validator to choke on. A permissive object schema is the
+    # safe fallback (the field description is preserved if present).
+    assert "$ref" not in inlined["properties"]["label"]
+    assert inlined["properties"]["label"].get("type") == "object"
+
+
+def test_sanitize_tool_schemas_inlines_refs_before_nullable_collapse():
+    # End-to-end: the post-sanitization tree must not contain any `#/...`
+    # `$ref` strings into `anyOf/0/...` paths that were collapsed away by
+    # `strip_nullable_unions`. This is the exact xAI-400 reproduction shape
+    # from issue #67131 (Paperclip `paperclipAddComment` row.label ref).
+    tool = _tool("paperclipAddComment", {
+        "type": "object",
+        "properties": {
+            "metadata": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "sections": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "rows": {
+                                            "type": "array",
+                                            "items": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "label": {"type": "string", "nullable": True},
+                                                        },
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "label": {
+                                                                "$ref": "#/properties/metadata/anyOf/0/properties/sections/items/properties/rows/items/anyOf/0/properties/label",
+                                                            },
+                                                        },
+                                                    },
+                                                ]
+                                            },
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    },
+                    {"type": "null"},
+                ]
+            }
+        }
+    })
+    out = sanitize_tool_schemas([tool])
+    # Walk the entire sanitized tree and assert no dangling `anyOf/0/...` refs
+    # remain — every $ref must have been inlined before the union was collapsed.
+    def _has_dangling_ref(node):
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str) and "/anyOf/" in ref:
+                return True
+            return any(_has_dangling_ref(v) for v in node.values())
+        if isinstance(node, list):
+            return any(_has_dangling_ref(v) for v in node)
+        return False
+    assert not _has_dangling_ref(
+        out[0]["function"]["parameters"]
+    ), "sanitized schema still contains `anyOf/...` $ref that survives nullable-union collapse (xAI 400)"

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -84,6 +84,13 @@ def _sanitize_single_tool(tool: dict) -> dict:
             top["type"] = "object"
         if "properties" not in top or not isinstance(top.get("properties"), dict):
             top["properties"] = {}
+    # Inline local `$ref` pointers BEFORE nullable-union collapse so strict
+    # validators (xAI Responses) don't deep-resolve `.../anyOf/0/...` paths
+    # that are about to be folded away.  Issue #67131: post-collapse ref
+    # strings into the dropped `anyOf` segment cause xAI to 400 with
+    # "unresolvable $ref / key 'anyOf' not found under '...'" before any
+    # token is emitted.  Inlining first means the refs disappear entirely.
+    fn["parameters"] = inline_schema_refs(fn["parameters"])
     # Final pass: collapse nullable anyOf/oneOf unions that the recursive
     # sanitizer above leaves intact (it only handles the array-form
     # ``type: [X, "null"]``). Keep the ``nullable: true`` hint so runtime
@@ -126,6 +133,183 @@ def _strip_ref_siblings(node: Any) -> Any:
             if key in out:
                 out.pop(key, None)
     return out
+
+
+def _resolve_ref_pointer(root: Any, pointer: str) -> tuple[Any, bool]:
+    """Resolve an RFC 6901 JSON pointer ``#/path/to/target`` against ``root``.
+
+    Returns ``(target, ok)``.  ``ok=False`` means the pointer walked into a
+    missing key or an out-of-range array index — callers should treat that
+    as "the ref is dangling, replace with a safe fallback schema".
+
+    JSON pointer grammar (RFC 6901):
+
+    * ``""`` (empty) → ``root`` itself
+    * ``"/"`` → key with the empty string
+    * ``"/a/b"`` → ``root["a"]["b"]``
+    * ``"/foo~1bar"`` → ``root["foo/bar"]`` (``~1`` → ``/``, ``~0`` → ``~``)
+
+    The leading ``#`` (URI fragment marker) is stripped if present. Bare
+    pointer fragments (``"properties/a"``) are also accepted for safety.
+    """
+    raw = pointer
+    if raw.startswith("#"):
+        raw = raw[1:]
+    if raw.startswith("/"):
+        raw = raw[1:]
+    if raw == "":
+        return root, True
+    cur: Any = root
+    for segment in raw.split("/"):
+        # Unescape ~1 → / and ~0 → ~, in that order (RFC 6901 §3).
+        segment = segment.replace("~1", "/").replace("~0", "~")
+        if isinstance(cur, dict):
+            if segment not in cur:
+                return None, False
+            cur = cur[segment]
+        elif isinstance(cur, list):
+            try:
+                idx = int(segment)
+            except (TypeError, ValueError):
+                return None, False
+            if idx < 0 or idx >= len(cur):
+                return None, False
+            cur = cur[idx]
+        else:
+            return None, False
+    return cur, True
+
+
+def inline_schema_refs(
+    schema: Any,
+    *,
+    max_depth: int = 64,
+    only_through_combinators: bool = True,
+) -> Any:
+    """Inline ``$ref`` (RFC 6901 ``#/...`` pointer) nodes found in ``schema``.
+
+    Problem this solves (issue #67131):
+
+      Strict schema validators (xAI Responses) deep-resolve local ``$ref``
+      pointers **after** Hermes' ``strip_nullable_unions`` collapses
+      ``anyOf: [T, null]`` to ``T``.  A ``$ref`` string that walks through
+      the dropped ``.../anyOf/0/...`` segment then points at a path that no
+      longer exists, and xAI rejects the entire request with::
+
+          HTTP 400: unresolvable $ref '...': key 'anyOf' not found under ...
+
+      Anthropic / OpenAI / OpenRouter silently accept the same shape — only
+      xAI 400s — so the bug looks provider-specific when it's actually a
+      sanitizer tree-rewrite artifact.
+
+    What this does:
+
+      Walk the schema, replace every ``{"$ref": "#/properties/..."}`` node
+      with a deep copy of the schema fragment the pointer resolves to, then
+      recurse into the inlined fragment so transitive refs (and self-refs
+      up to ``max_depth``) are also resolved.
+
+    Bounds / contract:
+
+    * ``max_depth`` caps ref→ref chains.  A self-referential pointer
+      (``{"$ref": "#"}``) is replaced with a minimal
+      ``{"type": "object", "properties": {}}`` once the chain is exhausted,
+      so strict validators see a concrete shape instead of a dangling ref.
+    * A pointer whose target is missing in the current tree (e.g. an
+      ``.../anyOf/0/...`` pointer whose ``anyOf`` was already collapsed away
+      by an earlier sanitizer pass — defensive recovery path) is replaced
+      with the same permissive object schema, **never** left as a bare
+      ``$ref`` for a strict validator to choke on.
+    * ``only_through_combinators`` (default ``True``) restricts inlining to
+      refs whose pointer walks through an ``anyOf`` / ``oneOf`` / ``allOf``
+      array index segment — exactly the class of ref that breaks under
+      ``strip_nullable_unions`` collapse.  Other refs (``#/$defs/Foo``)
+      are left in place: they're stable across the sanitizer's tree
+      rewrites, and providers that can resolve them (Anthropic, OpenAI)
+      prefer the dedup that ``$defs`` provides.  Set ``False`` to inline
+      every local ref regardless of pointer shape — useful for the xAI
+      Responses defense-in-depth pass where any ``$ref`` may be rejected.
+    * Sibling metadata on a ``$ref`` node (``description``, ``title``)
+      is preserved on the inlined fragment when it doesn't already carry
+      that key — the refiner's prose annotation is more useful than the
+      target's own.
+
+    Args:
+        schema: A JSON-Schema fragment (dict / list / scalar).
+        max_depth: Max ref→ref chain depth before substituting a fallback.
+            Defaults to 64 — generously above any realistic schema depth.
+        only_through_combinators: If True (default), inline only refs whose
+            pointer path contains an ``anyOf`` / ``oneOf`` / ``allOf``
+            segment — the exact class that breaks under nullable-union
+            collapse.  If False, inline every local ``$ref``.
+
+    Returns:
+        A deep copy of ``schema`` with the targeted ``$ref`` nodes resolved.
+        Callers may freely mutate the result without aliasing the input.
+    """
+    _combinator_segments = ("anyOf", "oneOf", "allOf")
+
+    def _walks_through_combinator(pointer: str) -> bool:
+        # Segment check on the raw pointer string. Leading ``#``/``/`` are
+        # stripped so the first real segment is comparable.
+        raw = pointer[1:] if pointer.startswith("#") else pointer
+        raw = raw[1:] if raw.startswith("/") else raw
+        for seg in raw.split("/"):
+            seg = seg.replace("~1", "/").replace("~0", "~")
+            if seg in _combinator_segments:
+                return True
+        return False
+
+    def _walk(node: Any, chain: tuple[str, ...]) -> Any:
+        if isinstance(node, list):
+            return [_walk(item, chain) for item in node]
+        if not isinstance(node, dict):
+            return node
+
+        ref = node.get("$ref")
+        if isinstance(ref, str):
+            if only_through_combinators and not _walks_through_combinator(ref):
+                # Stable ref (e.g. ``#/$defs/Foo``) — leave in place; the
+                # combinator-walking refs are the only class that breaks
+                # under ``strip_nullable_unions`` and strict validators.
+                # ``_strip_ref_siblings`` (called separately) handles the
+                # ``default`` sibling keyword hygiene for this node.
+                return {key: _walk(value, chain) for key, value in node.items()}
+            target, ok = _resolve_ref_pointer(schema, ref)
+            if not ok or target is None:
+                # Dangling pointer (e.g. anyOf/0 path was collapsed away by
+                # a later strip_nullable_unions run on a hot path). Replace
+                # with a permissive object schema so strict validators don't
+                # see a bare $ref with no resolvable target. Preserve
+                # adjacent metadata so the model keeps the prose hint.
+                fallback: dict = {"type": "object", "properties": {}}
+                for meta in ("description", "title"):
+                    if meta in node and meta not in fallback:
+                        fallback[meta] = node[meta]
+                return fallback
+            if ref in chain or len(chain) >= max_depth:
+                # Cycle or depth cap — substitute permissive object schema.
+                fallback = {"type": "object", "properties": {}}
+                for meta in ("description", "title"):
+                    if meta in node and meta not in fallback:
+                        fallback[meta] = node[meta]
+                return fallback
+            # Recurse into the inlined target so transitive refs also resolve.
+            inlined_target = _walk(target, chain + (ref,))
+            # Preserve sibling metadata not present on the target (the ref
+            # node's description is generally more useful than the target's).
+            if isinstance(inlined_target, dict):
+                merged = copy.deepcopy(inlined_target)
+                for meta in ("description", "title"):
+                    if meta in node and meta not in merged:
+                        merged[meta] = node[meta]
+                return merged
+            return inlined_target
+
+        # No $ref at this node — recurse into values.
+        return {key: _walk(value, chain) for key, value in node.items()}
+
+    return _walk(schema, chain=())
 
 
 _TOP_LEVEL_FORBIDDEN_KEYS = ("allOf", "anyOf", "oneOf", "enum", "not")


### PR DESCRIPTION
## Problem

xAI Responses' strict schema validator deep-resolves local `` pointers **after** Hermes' `strip_nullable_unions` collapses `anyOf: [T, null]` to `T`. Refs that walk through the dropped `.../anyOf/0/...` segment then point at a path that no longer exists, and xAI rejects the entire request:

```
HTTP 400: unresolvable $ref '...': key 'anyOf' not found under ...
```

Anthropic / OpenAI / OpenRouter silently accept the same shape — only xAI 400s — so the bug looks provider-specific when it's actually a sanitizer tree-rewrite artifact.

Closes #67131

## Root cause

`inline_schema_refs`-equivalent logic was never wired into `sanitize_tool_schemas`'s pipeline. `_strip_ref_siblings` only strips sibling keywords (`default`/`description`) from a `{$ref: ...}` node — it doesn't revalidate the pointer against the post-collapse tree, so dangling `.../anyOf/0/...` strings survived to the wire.

## Fix

1. **`tools/schema_sanitizer.py`** — Add `inline_schema_refs(schema)` that walks the schema and replaces every `{$ref: "#/..."}` node with a deep copy of the resolved fragment. Recurses into the inlined target so transitive refs also resolve. Cycle / depth-cap / missing-target fallbacks always substitute a permissive `{"type": "object", "properties": {}}` — never leave a bare $ref for a strict validator to choke on. Sibling metadata (`description`, `title`) is preserved on the inlined fragment.

   Default `only_through_combinators=True` restricts inlining to refs whose pointer walks through an `anyOf` / `oneOf` / `allOf` segment — the exact class that breaks under `strip_nullable_unions`. Stable `#/$defs/Foo` refs are left in place: providers that can resolve them (Anthropic, OpenAI) prefer the dedup that `` provides. Set `False` to inline every local ref (xAI Responses mode).

2. **`tools/schema_sanitizer.py` (`sanitize_tool_schemas`)** — call `inline_schema_refs` BEFORE `strip_nullable_unions` — refs must be pointed at fragments that still exist in the tree.

3. **`agent/chat_completion_helpers.py` (xAI Responses path)** — defense-in-depth pass that re-inlines ALL local refs (`only_through_combinators=False`) immediately before dispatch. Idempotent on schemas with no refs. Catches tools assembled via legacy paths or bundled before this fix rolls out.

## Tests

- Six new unit tests covering: property-path resolution, nested arrays + objects, $defs pointer, recursive pointer (cycle / depth cap), missing target fallback, end-to-end sanitizer pipeline ordering.
- Existing 47 sanitizer tests still pass.
- 165 agent transport / xAI / sanitizer integration tests still pass.

```
============================== 53 passed in 0.60s =============================
==================== 165 passed, 5947 deselected in 14.19s =====================
```

## Repro

Issue #67131 (Paperclip `paperclipAddComment` row.label ref into `metadata.anyOf[0].sections.items.rows.items.anyOf[0].label`).

## Checklist

- [x] Branch focused on a single fix
- [x] Tests added that reproduce the bug (without fix: 3-6 fail; with fix: all pass)
- [x] Tests verify both before and after behavior where applicable
- [x] All tests pass locally
- [x] Commit message follows conventional commits
