### PR TITLE
fix(gateway): resolve adapters for standalone profiles

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -62,8 +62,12 @@ class GatewayAuthorizationMixin:
         if not platform:
             return None
         profile_name = (profile or "").strip() or None
-        if profile_name and profile_name != "default":
-            profile_adapters = getattr(self, "_profile_adapters", None) or {}
+        profile_adapters = getattr(self, "_profile_adapters", None) or {}
+        multiplexed = bool(
+            getattr(getattr(self, "config", None), "multiplex_profiles", False)
+            or (profile_name and profile_name in profile_adapters)
+        )
+        if multiplexed and profile_name and profile_name != "default":
             if profile_name in profile_adapters:
                 return profile_adapters[profile_name].get(platform)
             # Fail closed: a stamped secondary profile with no registry entry

--- a/tests/gateway/test_profile_adapter_resolution.py
+++ b/tests/gateway/test_profile_adapter_resolution.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+class _Runner(GatewayAuthorizationMixin):
+    config: object
+    adapters: dict
+    _profile_adapters: dict
+
+
+def _source(profile: str) -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        user_id="user-1",
+        chat_id="chat-1",
+        profile=profile,
+    )
+
+
+def test_named_standalone_profile_resolves_its_primary_adapter():
+    adapter = object()
+    runner = _Runner()
+    runner.config = SimpleNamespace(multiplex_profiles=False)
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {}
+
+    assert runner._adapter_for_source(_source("project-alpha")) is adapter
+
+
+def test_multiplex_secondary_profile_does_not_fall_back_to_default_adapter():
+    default_adapter = object()
+    runner = _Runner()
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    runner.adapters = {Platform.DISCORD: default_adapter}
+    runner._profile_adapters = {"project-alpha": {}}
+
+    assert runner._adapter_for_source(_source("project-alpha")) is None
+
+
+def test_multiplex_missing_secondary_registry_does_not_fall_back():
+    default_adapter = object()
+    runner = _Runner()
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    runner.adapters = {Platform.DISCORD: default_adapter}
+    runner._profile_adapters = {}
+
+    assert runner._adapter_for_source(_source("project-alpha")) is None
+
+
+def test_multiplex_default_profile_resolves_primary_adapter():
+    adapter = object()
+    runner = _Runner()
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"project-alpha": {Platform.DISCORD: object()}}
+
+    assert runner._adapter_for_source(_source("default")) is adapter


### PR DESCRIPTION
## Withdrawn

This PR is closed because the proposed regression constructed an unsupported state.

After tracing the concrete ingress path, I confirmed that standalone sources do not receive a named `SessionSource.profile` stamp. That field is multiplex-routing state, so changing adapter resolution for a non-multiplexed named stamp would weaken the intentional fail-closed boundary without demonstrating a valid production path.

The observed approval-delivery failure needs a new reproduction that captures the actual source and adapter state before any replacement fix is proposed.
