### PR TITLE
fix(gateway): preserve transformed final after reconnect

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21531,17 +21531,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _sc_msg_id = _sc.message_id
                 if _sc_msg_id:
                     try:
-                        await _sc.adapter.edit_message(
-                            chat_id=source.chat_id,
+                        _edit_result = await _sc._edit_message(
                             message_id=_sc_msg_id,
                             content=response["final_response"],
                             finalize=True,
                         )
-                        response["already_sent"] = True
-                        logger.info(
-                            "Edited streamed message %s for session %s to include plugin-transformed content.",
-                            _sc_msg_id, session_key or "?",
-                        )
+                        if getattr(_edit_result, "success", False):
+                            response["already_sent"] = True
+                            logger.info(
+                                "Edited streamed message %s for session %s to include plugin-transformed content.",
+                                _sc_msg_id, session_key or "?",
+                            )
+                        else:
+                            logger.warning(
+                                "Failed to edit streamed message %s for session %s; keeping normal final send enabled.",
+                                _sc_msg_id,
+                                session_key or "?",
+                            )
                     except Exception as _edit_err:
                         logger.warning(
                             "Failed to edit streamed message for session %s: %s",

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
@@ -12,7 +13,7 @@ import pytest
 import gateway.platforms.base as base_platform
 from gateway.config import Platform, PlatformConfig, StreamingConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
-from gateway.session import SessionSource
+from gateway.session import SessionSource, build_session_key
 
 
 class ProgressCaptureAdapter(BasePlatformAdapter):
@@ -112,6 +113,54 @@ class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
                 "metadata": metadata,
             }
         )
+        return SendResult(success=True, message_id=message_id)
+
+
+class ReconnectTransformCaptureAdapter(MetadataEditProgressCaptureAdapter):
+    """Capture a streamed preview, then model a disconnected edit target."""
+
+    def __init__(self, *, preview_sent: threading.Event, platform=Platform.DISCORD):
+        super().__init__(platform=platform)
+        self.preview_sent = preview_sent
+        self.connected = True
+        self.edit_results = []
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        if not self.connected:
+            return SendResult(success=False, error="Not connected")
+        result = await super().send(
+            chat_id,
+            content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        self.preview_sent.set()
+        return result
+
+    async def edit_message(
+        self,
+        chat_id,
+        message_id,
+        content,
+        *,
+        finalize: bool = False,
+        metadata=None,
+    ) -> SendResult:
+        error = None if self.connected else "Not connected"
+        self.edit_results.append((content, self.connected, error))
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "metadata": metadata,
+            }
+        )
+        if error:
+            return SendResult(success=False, error=error)
         return SendResult(success=True, message_id=message_id)
 
 
@@ -1039,6 +1088,30 @@ class TransformedStreamAgent:
         }
 
 
+class BlockingTransformedStreamAgent:
+    """Hold the turn open after preview delivery so the adapter can be replaced."""
+
+    preview_sent: threading.Event
+    release_agent: threading.Event
+
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        assert self.stream_delta_callback is not None
+        self.stream_delta_callback("original answer")
+        assert type(self).preview_sent.wait(5), "stream preview never reached old adapter"
+        assert type(self).release_agent.wait(5), "test did not release transformed final"
+        return {
+            "final_response": "original answer\n\n[plugin appended this]",
+            "response_previewed": True,
+            "response_transformed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 @pytest.mark.asyncio
 async def test_transformed_response_edits_streamed_message_in_place(monkeypatch, tmp_path):
     """When a transform_llm_output hook modifies the response after streaming,
@@ -1066,10 +1139,101 @@ async def test_transformed_response_edits_streamed_message_in_place(monkeypatch,
     assert result.get("already_sent") is True
     # The transformed final text reached the user — appended portion is present
     # in an edit_message call (not just in the streamed sends).
-    edited_texts = [e["content"] for e in adapter.edits]
-    assert any("[plugin appended this]" in text for text in edited_texts), (
-        f"expected transformed text in adapter.edits, got: {edited_texts!r}"
+    transformed_edits = [
+        edit for edit in adapter.edits if "[plugin appended this]" in edit["content"]
+    ]
+    assert transformed_edits, (
+        f"expected transformed text in adapter.edits, got: {adapter.edits!r}"
     )
+    assert transformed_edits[-1]["metadata"] == {"thread_id": "$thread"}
+
+
+@pytest.mark.asyncio
+async def test_transformed_stream_failed_old_edit_falls_back_to_replacement_adapter(
+    monkeypatch, tmp_path
+):
+    preview_sent = threading.Event()
+    release_agent = threading.Event()
+    BlockingTransformedStreamAgent.preview_sent = preview_sent
+    BlockingTransformedStreamAgent.release_agent = release_agent
+
+    fake_dotenv = types.ModuleType("dotenv")
+    setattr(fake_dotenv, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    fake_run_agent = types.ModuleType("run_agent")
+    setattr(fake_run_agent, "AIAgent", BlockingTransformedStreamAgent)
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    old_adapter = ReconnectTransformCaptureAdapter(preview_sent=preview_sent)
+    replacement = ReconnectTransformCaptureAdapter(preview_sent=threading.Event())
+    runner = _make_runner(old_adapter)
+    runner.config.streaming = StreamingConfig.from_dict(
+        {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1}
+    )
+    old_adapter.gateway_runner = runner
+    replacement.gateway_runner = runner
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***"},
+    )
+
+    agent_results = []
+
+    async def handler(event):
+        result = await runner._run_agent(
+            message=event.text,
+            context_prompt="",
+            history=[],
+            source=event.source,
+            session_id="sess-transformed-reconnect",
+            session_key="agent:main:discord:dm:channel-1",
+        )
+        agent_results.append(result)
+        return None if result.get("already_sent") else result["final_response"]
+
+    old_adapter.set_message_handler(handler)
+    event = MessageEvent(
+        text="long-running request",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-1",
+            chat_type="dm",
+            user_id="user-1",
+            thread_id="thread-1",
+        ),
+        message_id="inbound-1",
+    )
+    task = asyncio.create_task(
+        old_adapter._process_message_background(
+            event,
+            build_session_key(event.source),
+        )
+    )
+
+    try:
+        assert await asyncio.to_thread(preview_sent.wait, 5)
+        await old_adapter.disconnect()
+        runner.adapters[Platform.DISCORD] = replacement
+        release_agent.set()
+        await asyncio.wait_for(task, timeout=5)
+    finally:
+        release_agent.set()
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    transformed = "original answer\n\n[plugin appended this]"
+    assert (transformed, False, "Not connected") in old_adapter.edit_results
+    transformed_edits = [
+        edit for edit in old_adapter.edits if edit["content"] == transformed
+    ]
+    assert transformed_edits[-1]["metadata"] == {"thread_id": "thread-1"}
+    assert agent_results[-1].get("already_sent") is not True
+    assert [call["content"] for call in replacement.sent] == [transformed]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes a Gateway delivery gap during a mid-turn adapter reconnect. When `transform_llm_output` changes a streamed final response, the stream consumer still owns the old preview message and adapter. The transformed-final path now edits through the consumer so stored thread/routing metadata is preserved, and suppresses normal final delivery only when that old-message edit reports success. If the stale edit returns `SendResult(success=False)`, the complete transformed response remains pending for delivery through the live replacement adapter.

Follow-up to merged PRs #31433 (initial transformed streamed-final delivery) and #66946 (live-replacement final-send path). Related to open #31900, which covers the same edit-result and consumer-helper contracts; this PR additionally exercises the real in-flight reconnect through final delivery on current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **Transformed streaming final:** retain the `edit_message()` result and set `already_sent` only when it reports `success=True`.
- **Thread-aware edit path:** route the old-message update through `GatewayStreamConsumer._edit_message()` so the consumer forwards its stored thread/routing metadata without moving old message-ID ownership to the replacement adapter.
- **Reconnect fallback:** on an unsuccessful old-message edit, leave final delivery pending so the existing `BasePlatformAdapter._final_delivery_adapter()` path sends the complete transformed response through the live replacement adapter.
- **Regression coverage:** add an event-coordinated in-flight reconnect test that sends a preview, disconnects the old adapter, publishes a replacement, then verifies the failed old edit retains routing metadata, does not suppress delivery, and the replacement receives the full transformed response.

## Root Cause

`GatewayStreamConsumer` captures its adapter and thread/routing metadata at turn start. This is correct for preview-message edits because a replacement adapter cannot safely own the old message ID. However, `gateway/run.py` called the adapter directly, dropping the consumer metadata, and treated completion of the `edit_message()` await as delivery confirmation without checking the returned `SendResult`. In the affected disconnect path, the old adapter can return `success=False` rather than raise, so `already_sent=True` incorrectly skipped the normal new-message final delivery path.

## Design and Invariants

- Old preview message IDs remain owned by the old adapter; this PR does not migrate or delete them through a replacement adapter.
- Old-message edits use the consumer helper so thread/routing metadata follows the preview while adapter ownership remains unchanged.
- A successful old-message edit keeps existing single-message behavior and suppresses a duplicate final send.
- A failed/unknown edit result is not delivery confirmation; the existing live-adapter final-send fallback handles the new complete message.

## Infographic

![Gateway reconnect delivery diagram showing the stream consumer preserving thread metadata while the old adapter retains preview message ownership, successful edits suppressing duplicates, and failed edits falling through to the live replacement adapter for complete final delivery](https://raw.githubusercontent.com/StellarisW/hermes-agent/79a6dfd666f1ae04510b772318c0510d40b96ecd/pr/67145/v2/transformed-final-reconnect.png)

Delivery is confirmed only by a successful edit; a failed stale-adapter edit preserves the complete transformed response for a new-message send through the published replacement.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Old adapter edit succeeds | Edit succeeds and normal final send is suppressed | Unchanged |
| Threaded transformed-final edit | Direct adapter call could drop the consumer's routing metadata | Consumer helper forwards stored thread/routing metadata to the old adapter |
| Old adapter disconnects after preview; edit returns `success=False` | `already_sent=True`; transformed final is silently lost | `already_sent` stays unset; live replacement sends the full transformed final |

## Risk and Impact

- **Risk:** a replacement adapter cannot edit the old preview, so users may temporarily see the stale preview plus a new complete final message after a reconnect.
- **Mitigation:** preserving complete transformed content takes priority; the old-message ownership boundary remains intact and the regression test verifies no false delivery confirmation.
- **Residual limitation:** if no replacement adapter has been published by final-send time, the existing fallback remains best-effort; this PR does not add a reconnect wait queue.

## Not in This PR

- CLI streaming display behavior (#57269).
- Transform-result persistence/history consistency (#44239, #65921).
- The non-editable `__no_edit__` sentinel handling proposed in #31521.
- Stream-consumer adapter rebinding or message-ID migration.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_run_progress_topics.py tests/gateway/test_runner_fatal_adapter.py tests/gateway/test_duplicate_reply_suppression.py tests/gateway/test_stream_consumer.py -q` — 191 passed.
2. `scripts/run_tests.sh tests/gateway/ -q` — 489 files, 9657 passed.
3. `"$PYTHON_BIN" -m ruff check gateway/run.py tests/gateway/test_run_progress_topics.py` (managed development interpreter) — passed.
4. `"$PYTHON_BIN" -m py_compile gateway/run.py tests/gateway/test_run_progress_topics.py` (managed development interpreter) — passed.
5. `git diff --check origin/main...HEAD` — passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing issues and PRs; this is a focused follow-up to the transformed-stream and reconnect-delivery work.
- [x] My PR contains only changes related to this fix.
- [x] I've run the relevant Gateway test suite locally.
- [x] I've added a deterministic regression test.
- [x] I've tested on Linux via the hermetic canonical test runner.

### Documentation & Housekeeping

- [x] Documentation/config/architecture workflow updates — N/A; no public contract changed.
- [x] Cross-platform impact considered — stdlib result handling only; no platform-specific behavior or configuration changed.
- [x] Tool descriptions/schemas — N/A.
