### PR TITLE
fix(gateway): route profile callbacks to owning adapter

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -27,9 +27,9 @@ AnythingLLM, NextChat, ChatBox, etc.) can connect to hermes-agent
 through this adapter by pointing at http://localhost:8642/v1 and
 authenticating with API_SERVER_KEY.
 
-When ``gateway.multiplex_profiles`` is on, the default profile owns this
-listener and secondary profiles are reached via a URL prefix — same contract
-as the webhook adapter:
+When ``gateway.multiplex_profiles`` is on, the process-primary profile owns
+this listener and every other profile is reached via a URL prefix — same
+contract as the webhook adapter:
 
     GET  /p/<profile>/v1/models
     POST /p/<profile>/v1/chat/completions
@@ -59,7 +59,7 @@ from typing import Any, Dict, List, Optional
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
-# (no prefix / multiplexing off → handle as the default profile).
+# (no prefix / multiplexing off → handle through the process-primary profile).
 _PROFILE_REJECTED = object()
 
 # Profile selected by the /p/<profile>/ URL prefix for the current request.
@@ -946,6 +946,11 @@ class APIServerAdapter(BasePlatformAdapter):
             raw_port = os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))
         self._port: int = _coerce_port(raw_port, DEFAULT_PORT)
         self._api_key: str = extra.get("key", os.getenv("API_SERVER_KEY", ""))
+        # ``runner.adapters`` belongs to the profile that created this shared
+        # listener. Capture it before profile-prefix middleware scopes each
+        # request, because a request scope must not redefine the primary map's
+        # owner.
+        self._primary_profile = self._resolve_primary_profile_name()
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
         )
@@ -1126,6 +1131,30 @@ class APIServerAdapter(BasePlatformAdapter):
         return max(0, value)
 
     @staticmethod
+    def _resolve_primary_profile_name() -> str:
+        """Return the process profile that owns this API server's primary map.
+
+        ``get_hermes_home()`` follows the request-local override installed by
+        prefix middleware. The shared listener's ownership is process-level,
+        however, so derive it from the launch home and never from a request
+        scope.
+        """
+        try:
+            from hermes_constants import get_default_hermes_root, get_process_hermes_home
+            from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+            process_home = get_process_hermes_home().resolve()
+            profiles_root = (get_default_hermes_root() / "profiles").resolve()
+            relative = process_home.relative_to(profiles_root)
+            if len(relative.parts) == 1:
+                profile = normalize_profile_name(relative.parts[0])
+                validate_profile_name(profile)
+                return profile
+        except Exception:
+            pass
+        return "default"
+
+    @staticmethod
     def _resolve_model_name(explicit: str) -> str:
         """Derive the advertised model name for /v1/models.
 
@@ -1286,7 +1315,16 @@ class APIServerAdapter(BasePlatformAdapter):
             return adapter
 
         runner = self.gateway_runner or request.app.get("gateway_runner")
-        adapters = getattr(runner, "adapters", None)
+        request_profile = _api_request_profile.get()
+        primary_profile = getattr(self, "_primary_profile", "default") or "default"
+        if request_profile and request_profile != primary_profile:
+            # A named profile prefix is an isolation boundary. If its adapter
+            # is absent (for example, disconnected or still reconnecting), do
+            # not send its callback through the primary profile's credentials.
+            profile_adapters = getattr(runner, "_profile_adapters", None) or {}
+            adapters = profile_adapters.get(request_profile)
+        else:
+            adapters = getattr(runner, "adapters", None)
         if not adapters:
             return None
 
@@ -1397,7 +1435,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Returns:
           - ``None`` when no profile prefix is present, or multiplexing is off
-            (the prefix is ignored; request handled as the default profile).
+            (the prefix is ignored; request handled through the process-primary
+            profile).
           - the profile name (str) when present, multiplexing is on, and the
             profile is one this gateway serves.
           - ``_PROFILE_REJECTED`` when a prefix is present but the profile is
@@ -1422,13 +1461,12 @@ class APIServerAdapter(BasePlatformAdapter):
             return _PROFILE_REJECTED
         return profile
 
-    @staticmethod
-    def _profile_scope(profile: Optional[str]):
+    def _profile_scope(self, profile: Optional[str]):
         """Enter the multiplex profile runtime scope, or a no-op when unset.
 
         When no ``/p/<profile>/`` prefix was given AND multiplexing is active,
-        enter the DEFAULT profile's scope instead of a no-op: api_server is a
-        port-binding platform that lives on the default profile, and with
+        enter the process-primary profile's scope instead of a no-op: api_server
+        is a port-binding platform that lives on that profile, and with
         multiplex fail-closed ``get_secret`` active, an unscoped agent run
         raises ``UnscopedSecretError`` on its first credential read (#61276).
         Single-profile gateways keep the no-op — ``get_secret`` falls through
@@ -1440,9 +1478,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 if is_multiplex_active():
                     from gateway.run import _profile_runtime_scope
-                    from hermes_constants import get_hermes_home
+                    from hermes_cli.profiles import get_profile_dir
 
-                    return _profile_runtime_scope(get_hermes_home())
+                    return _profile_runtime_scope(
+                        get_profile_dir(self._primary_profile)
+                    )
             except Exception:
                 pass
             return nullcontext()
@@ -1599,7 +1639,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Under multiplex ``/p/<profile>/`` requests the profile runtime scope
         redirects ``get_hermes_home()``, so each profile gets its own DB —
-        never the default profile's file.
+        never the process-primary profile's file.
         """
         # Explicit override (tests / manual wiring) wins. Production never sets
         # this externally, so the per-home cache below is the live path — and
@@ -1904,8 +1944,8 @@ class APIServerAdapter(BasePlatformAdapter):
         """GET /v1/models — list hermes-agent and any configured model_routes aliases.
 
         Under ``/p/<profile>/v1/models`` (multiplex on) the advertised primary
-        model id follows that profile's name/config, not the default adapter's
-        cached ``_model_name``.
+        model id follows that profile's name/config, not the process-primary
+        adapter's cached ``_model_name``.
         """
         auth_err = self._check_auth(request)
         if auth_err:

--- a/tests/gateway/test_api_server_multiplex_secret_scope.py
+++ b/tests/gateway/test_api_server_multiplex_secret_scope.py
@@ -2,11 +2,8 @@
 
 When gateway.multiplex_profiles is on, get_secret fails closed without a
 profile secret scope. Requests with a ``/p/<profile>/`` prefix are scoped by
-``_profile_scope(profile)``, but plain requests on the default listener used
-to get ``nullcontext()`` — so agent runs crashed with UnscopedSecretError on
-their first credential read (e.g. OPENROUTER_BASE_URL). ``_profile_scope``
-now enters the DEFAULT profile's runtime scope when multiplex is active and
-no profile was requested.
+``_profile_scope(profile)``, while plain requests must be scoped to the
+process-primary profile that owns the shared listener.
 
 Adapted from PR #61283 by @giggling-ginger (originally targeting a
 pre-``_profile_scope`` helper); no live gateway or network.
@@ -33,7 +30,7 @@ def adapter():
     return APIServerAdapter(PlatformConfig(enabled=True))
 
 
-class TestProfileScopeDefaultFallback:
+class TestProfileScopePrimaryFallback:
     def test_noop_when_multiplex_off(self, adapter, monkeypatch):
         monkeypatch.setenv("OPENROUTER_BASE_URL", "https://from-environ.example/v1")
         with adapter._profile_scope(None):
@@ -41,15 +38,14 @@ class TestProfileScopeDefaultFallback:
             assert ss.get_secret("OPENROUTER_BASE_URL") == "https://from-environ.example/v1"
         assert ss.current_secret_scope() is None
 
-    def test_default_scope_installed_under_multiplex(self, adapter, tmp_path, monkeypatch):
-        """No /p/ prefix + multiplex active → default profile scope, not nullcontext."""
+    def test_primary_scope_installed_under_multiplex(self, adapter, tmp_path, monkeypatch):
+        """No /p/ prefix + multiplex active → primary profile scope, not nullcontext."""
         (tmp_path / ".env").write_text(
             "OPENROUTER_BASE_URL=https://openrouter.ai/api/v1\n",
             encoding="utf-8",
         )
         monkeypatch.setattr(
-            "hermes_constants.get_hermes_home",
-            lambda: tmp_path,
+            "hermes_cli.profiles.get_profile_dir", lambda name: tmp_path
         )
         monkeypatch.setenv("OPENROUTER_BASE_URL", "https://leak.example/v1")
         ss.set_multiplex_active(True)
@@ -79,3 +75,38 @@ class TestProfileScopeDefaultFallback:
         with adapter._profile_scope("worker"):
             assert ss.get_secret("OPENROUTER_BASE_URL") == "https://worker.example/v1"
         assert ss.current_secret_scope() is None
+
+    def test_unprefixed_named_primary_uses_primary_scope(self, tmp_path, monkeypatch):
+        """The unprefixed shared listener must use its named primary's secrets."""
+        default_home = tmp_path
+        coder_home = tmp_path / "profiles" / "coder"
+        for home, url in (
+            (default_home, "https://default.example/v1"),
+            (coder_home, "https://coder.example/v1"),
+        ):
+            home.mkdir(parents=True, exist_ok=True)
+            (home / ".env").write_text(
+                f"OPENROUTER_BASE_URL={url}\n", encoding="utf-8"
+            )
+
+        process_root = tmp_path
+        with pytest.MonkeyPatch.context() as scoped:
+            scoped.setattr(
+                "hermes_constants.get_process_hermes_home", lambda: coder_home
+            )
+            scoped.setattr(
+                "hermes_constants.get_default_hermes_root", lambda: process_root
+            )
+            adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        try:
+            assert adapter._primary_profile == "coder"
+            monkeypatch.setattr(
+                "hermes_cli.profiles.get_profile_dir",
+                lambda name: {"default": default_home, "coder": coder_home}[name],
+            )
+            ss.set_multiplex_active(True)
+
+            with adapter._profile_scope(None):
+                assert ss.get_secret("OPENROUTER_BASE_URL") == "https://coder.example/v1"
+        finally:
+            adapter._response_store.close()

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -1,12 +1,20 @@
 """Multiplex /p/<profile>/ routing for the api_server adapter.
 
-Mirrors ``test_multiplex_http_routing.py`` (webhook): the default listener
-owns the port, and secondary profiles are reached via a URL prefix when
-``gateway.multiplex_profiles`` is on.
+Mirrors ``test_multiplex_http_routing.py`` (webhook): the process-primary
+listener owns the port, and every other profile is reached via a URL prefix
+when ``gateway.multiplex_profiles`` is on.
 """
 from __future__ import annotations
 
-from gateway.config import GatewayConfig, PlatformConfig
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     _PROFILE_REJECTED,
@@ -14,9 +22,26 @@ from gateway.platforms.api_server import (
 )
 
 
-def _make_adapter(multiplex: bool = True) -> APIServerAdapter:
+def _make_adapter(
+    multiplex: bool = True,
+    *,
+    primary_profile: str = "default",
+) -> APIServerAdapter:
     cfg = PlatformConfig(enabled=True, extra={"host": "127.0.0.1", "port": 8642, "key": "test-key"})
-    adapter = APIServerAdapter(cfg)
+    process_root = Path("/process-hermes")
+    process_home = (
+        process_root
+        if primary_profile == "default"
+        else process_root / "profiles" / primary_profile
+    )
+    with patch(
+        "hermes_constants.get_process_hermes_home",
+        return_value=process_home,
+    ), patch(
+        "hermes_constants.get_default_hermes_root",
+        return_value=process_root,
+    ):
+        adapter = APIServerAdapter(cfg)
 
     class _Runner:
         config = GatewayConfig(multiplex_profiles=multiplex)
@@ -28,6 +53,52 @@ def _make_adapter(multiplex: bool = True) -> APIServerAdapter:
 class _FakeReq:
     def __init__(self, profile=None):
         self.match_info = {"profile": profile} if profile is not None else {}
+
+
+class _FakeHttpEventAdapter:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.verify_headers: list[str] = []
+        self.payloads: list[dict] = []
+
+    def verify_http_event_request(self, authorization: str) -> tuple[bool, str]:
+        self.verify_headers.append(authorization)
+        return True, ""
+
+    async def dispatch_http_event(self, payload: dict) -> dict:
+        self.payloads.append(payload)
+        return {"adapter": self.name}
+
+
+def _install_multiplex_profiles(monkeypatch, tmp_path) -> None:
+    default_home = tmp_path / "default"
+    coder_home = tmp_path / "profiles" / "coder"
+    for home in (default_home, coder_home):
+        home.mkdir(parents=True)
+        (home / ".env").write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex: [("default", default_home), ("coder", coder_home)],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: {"default": default_home, "coder": coder_home}[name],
+    )
+
+
+def _callback_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[adapter._make_profile_prefix_middleware()])
+    app.router.add_post(
+        "/api/platforms/{platform}/events",
+        adapter._handle_platform_event_callback,
+    )
+    app.router.add_post(
+        "/p/{profile}/api/platforms/{platform}/events",
+        adapter._handle_platform_event_callback,
+    )
+    return app
 
 
 class TestApiServerProfileResolution:
@@ -84,3 +155,256 @@ class TestApiServerModelsUnderProfile:
             assert adapter._resolve_model_name("") == "coder"
         finally:
             _api_request_profile.reset(token_prof)
+
+
+class TestApiServerPlatformCallbacksUnderProfile:
+    def test_primary_profile_resolution_ignores_request_scope(self, tmp_path, monkeypatch):
+        """Process-level ownership must not follow a request-local profile."""
+        default_home = tmp_path / "hermes"
+        coder_home = default_home / "profiles" / "coder"
+        for home in (default_home, coder_home):
+            home.mkdir(parents=True)
+            (home / ".env").write_text("", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(coder_home))
+
+        from gateway.run import _profile_runtime_scope
+
+        with _profile_runtime_scope(default_home):
+            assert APIServerAdapter._resolve_primary_profile_name() == "coder"
+
+    def test_primary_profile_is_captured_before_request_scope(self, tmp_path, monkeypatch):
+        """The shared listener's map owner must outlive request-local scope."""
+        default_home = tmp_path / "hermes"
+        coder_home = default_home / "profiles" / "coder"
+        for home in (default_home, coder_home):
+            home.mkdir(parents=True)
+            (home / ".env").write_text("", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(coder_home))
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        try:
+            assert adapter._primary_profile == "coder"
+
+            from gateway.run import _profile_runtime_scope
+            from hermes_cli.profiles import get_active_profile_name
+
+            with _profile_runtime_scope(default_home):
+                assert get_active_profile_name() == "default"
+                assert adapter._primary_profile == "coder"
+        finally:
+            adapter._response_store.close()
+
+    @pytest.mark.asyncio
+    async def test_nonprimary_profile_callback_uses_its_profile_adapter(
+        self, tmp_path, monkeypatch
+    ):
+        _install_multiplex_profiles(monkeypatch, tmp_path)
+        platform = Platform("google_chat")
+        default = _FakeHttpEventAdapter("default")
+        coder = _FakeHttpEventAdapter("coder")
+        adapter = _make_adapter(multiplex=True)
+        adapter.gateway_runner = SimpleNamespace(
+            config=GatewayConfig(multiplex_profiles=True),
+            adapters={platform: default},
+            _profile_adapters={"coder": {platform: coder}},
+        )
+
+        try:
+            async with TestClient(TestServer(_callback_app(adapter))) as client:
+                response = await client.post(
+                    "/p/coder/api/platforms/google_chat/events",
+                    headers={"Authorization": "Bearer x"},
+                    json={"type": "MESSAGE"},
+                )
+                body = await response.json()
+
+            assert response.status == 200
+            assert body == {"adapter": "coder"}
+            assert coder.verify_headers == ["Bearer x"]
+            assert coder.payloads == [{"type": "MESSAGE"}]
+            assert default.verify_headers == []
+            assert default.payloads == []
+        finally:
+            adapter._response_store.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("profile_adapters", [{}, {"coder": {}}])
+    async def test_nonprimary_profile_callback_does_not_fallback_to_primary_adapter(
+        self,
+        tmp_path,
+        monkeypatch,
+        profile_adapters,
+    ):
+        _install_multiplex_profiles(monkeypatch, tmp_path)
+        platform = Platform("google_chat")
+        default = _FakeHttpEventAdapter("default")
+        adapter = _make_adapter(multiplex=True)
+        adapter.gateway_runner = SimpleNamespace(
+            config=GatewayConfig(multiplex_profiles=True),
+            adapters={platform: default},
+            _profile_adapters=profile_adapters,
+        )
+
+        try:
+            async with TestClient(TestServer(_callback_app(adapter))) as client:
+                response = await client.post(
+                    "/p/coder/api/platforms/google_chat/events",
+                    headers={"Authorization": "Bearer x"},
+                    json={"type": "MESSAGE"},
+                )
+                body = await response.json()
+
+            assert response.status == 503
+            assert body["error"]["code"] == "platform_unavailable"
+            assert default.verify_headers == []
+            assert default.payloads == []
+        finally:
+            adapter._response_store.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/platforms/google_chat/events",
+            "/p/default/api/platforms/google_chat/events",
+        ],
+    )
+    async def test_primary_profile_callback_keeps_primary_adapter(
+        self, tmp_path, monkeypatch, path
+    ):
+        _install_multiplex_profiles(monkeypatch, tmp_path)
+        platform = Platform("google_chat")
+        default = _FakeHttpEventAdapter("default")
+        coder = _FakeHttpEventAdapter("coder")
+        adapter = _make_adapter(multiplex=True)
+        adapter.gateway_runner = SimpleNamespace(
+            config=GatewayConfig(multiplex_profiles=True),
+            adapters={platform: default},
+            _profile_adapters={"coder": {platform: coder}},
+        )
+
+        try:
+            async with TestClient(TestServer(_callback_app(adapter))) as client:
+                response = await client.post(
+                    path,
+                    headers={"Authorization": "Bearer x"},
+                    json={"type": "MESSAGE"},
+                )
+                body = await response.json()
+
+            assert response.status == 200
+            assert body == {"adapter": "default"}
+            assert default.verify_headers == ["Bearer x"]
+            assert default.payloads == [{"type": "MESSAGE"}]
+            assert coder.verify_headers == []
+            assert coder.payloads == []
+        finally:
+            adapter._response_store.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/platforms/google_chat/events",
+            "/p/coder/api/platforms/google_chat/events",
+        ],
+    )
+    async def test_named_primary_profile_callback_uses_primary_adapter(
+        self, tmp_path, monkeypatch, path
+    ):
+        _install_multiplex_profiles(monkeypatch, tmp_path)
+        platform = Platform("google_chat")
+        coder = _FakeHttpEventAdapter("coder")
+        default = _FakeHttpEventAdapter("default")
+        adapter = _make_adapter(multiplex=True, primary_profile="coder")
+        adapter.gateway_runner = SimpleNamespace(
+            config=GatewayConfig(multiplex_profiles=True),
+            adapters={platform: coder},
+            _profile_adapters={"default": {platform: default}},
+        )
+
+        try:
+            async with TestClient(TestServer(_callback_app(adapter))) as client:
+                response = await client.post(
+                    path,
+                    headers={"Authorization": "Bearer x"},
+                    json={"type": "MESSAGE"},
+                )
+                body = await response.json()
+
+            assert response.status == 200
+            assert body == {"adapter": "coder"}
+            assert coder.verify_headers == ["Bearer x"]
+            assert coder.payloads == [{"type": "MESSAGE"}]
+            assert default.verify_headers == []
+            assert default.payloads == []
+        finally:
+            adapter._response_store.close()
+
+    @pytest.mark.asyncio
+    async def test_default_callback_under_named_primary_uses_profile_adapter(
+        self, tmp_path, monkeypatch
+    ):
+        _install_multiplex_profiles(monkeypatch, tmp_path)
+        platform = Platform("google_chat")
+        coder = _FakeHttpEventAdapter("coder")
+        default = _FakeHttpEventAdapter("default")
+        adapter = _make_adapter(multiplex=True, primary_profile="coder")
+        adapter.gateway_runner = SimpleNamespace(
+            config=GatewayConfig(multiplex_profiles=True),
+            adapters={platform: coder},
+            _profile_adapters={"default": {platform: default}},
+        )
+
+        try:
+            async with TestClient(TestServer(_callback_app(adapter))) as client:
+                response = await client.post(
+                    "/p/default/api/platforms/google_chat/events",
+                    headers={"Authorization": "Bearer x"},
+                    json={"type": "MESSAGE"},
+                )
+                body = await response.json()
+
+            assert response.status == 200
+            assert body == {"adapter": "default"}
+            assert default.verify_headers == ["Bearer x"]
+            assert default.payloads == [{"type": "MESSAGE"}]
+            assert coder.verify_headers == []
+            assert coder.payloads == []
+        finally:
+            adapter._response_store.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("profile_adapters", [{}, {"default": {}}])
+    async def test_default_callback_under_named_primary_does_not_fallback(
+        self,
+        tmp_path,
+        monkeypatch,
+        profile_adapters,
+    ):
+        _install_multiplex_profiles(monkeypatch, tmp_path)
+        platform = Platform("google_chat")
+        coder = _FakeHttpEventAdapter("coder")
+        adapter = _make_adapter(multiplex=True, primary_profile="coder")
+        adapter.gateway_runner = SimpleNamespace(
+            config=GatewayConfig(multiplex_profiles=True),
+            adapters={platform: coder},
+            _profile_adapters=profile_adapters,
+        )
+
+        try:
+            async with TestClient(TestServer(_callback_app(adapter))) as client:
+                response = await client.post(
+                    "/p/default/api/platforms/google_chat/events",
+                    headers={"Authorization": "Bearer x"},
+                    json={"type": "MESSAGE"},
+                )
+                body = await response.json()
+
+            assert response.status == 503
+            assert body["error"]["code"] == "platform_unavailable"
+            assert coder.verify_headers == []
+            assert coder.payloads == []
+        finally:
+            adapter._response_store.close()


### PR DESCRIPTION
## What does this PR do?

Fixes profile-scoped generic platform HTTP callbacks in multiplexed gateways. The shared API Server listener owns the process-primary adapter registry, but request-prefix middleware can temporarily scope a request to another profile. Previously, callback resolution could treat the literal `default` as primary or follow request-local state, allowing callbacks to select the wrong same-platform adapter or fail incorrectly when the process-primary profile was named.

The resolver now preserves the ownership boundary: a callback uses `runner.adapters` only for the process-primary profile and uses only `runner._profile_adapters[profile]` for every other profile. Missing target adapters retain the established `503 platform_unavailable` failure rather than crossing the profile boundary.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Root Cause

`GatewayRunner.adapters` belongs to the profile that launched the shared listener, not permanently to the literal `default` profile. A named launch profile, such as `coder`, owns that map while `default` is held in `_profile_adapters`.

`get_hermes_home()` deliberately follows the request-local profile override installed by prefix middleware. It therefore cannot identify the process-primary owner once a request has entered `/p/<profile>/`. The API Server now derives and captures that owner from the process launch home before request middleware runs, then uses the captured identity for callback lookup and unprefixed secret scope.

## Changes Made

- **Callback ownership:** resolves `runner.adapters` only for the process-primary profile; a non-primary `/p/<profile>/api/platforms/<platform>/events` lookup reads only that profile's live `_profile_adapters` map.
- **Fail-closed behavior:** missing non-primary maps or platform entries retain `503 platform_unavailable`; no primary verifier or dispatcher is used as fallback.
- **Primary scope consistency:** unprefixed API Server requests enter the captured process-primary profile scope while multiplexing is active, keeping secret/session resolution aligned with the listener's adapter registry.
- **Regression coverage:** adds real `aiohttp` middleware-path callback tests for default-primary and named-primary layouts, request-scope isolation, live process-home resolution, missing-adapter isolation, and named-primary unprefixed secret scope.

## Before / After

| Scenario | Before | After |
|---|---|---|
| `/p/coder/...` when `coder` is process-primary | Looked for a secondary `coder` map and could return 503 | Uses the process-primary adapter map |
| `/p/default/...` when `coder` is process-primary | Could use the `coder` adapter | Uses only the `default` profile map |
| A request-local profile scope | Could influence primary-owner detection | Cannot redefine process-primary ownership |
| Missing target profile adapter | Could cross profile boundaries | Returns `503 platform_unavailable` without cross-profile calls |
| Unprefixed API request under named-primary multiplexing | Could scope secrets through the wrong home | Uses the named primary's profile scope |

## Design and Invariants

- `runner.adapters` is owned by the process-primary profile; `_profile_adapters` contains every other served profile, including `default` when a named profile is primary.
- Process-primary identity is derived from `get_process_hermes_home()` and captured before request-local profile overrides exist.
- Registry lookup remains live per request, so reconnect replacement and cleanup are visible without caching stale adapters.
- Existing explicit aiohttp app-level adapter injection precedence is unchanged.

## Infographic

![Routing matrix showing callback setup followed by separate primary and non-primary profile rows: each row selects only its owning adapter registry, dispatches through that adapter when found, and returns 503 platform_unavailable without cross-profile fallback when missing](https://raw.githubusercontent.com/StellarisW/hermes-agent/b65c6395b56bc97bd546f9a211931ca58c806ee1/pr/67147/profile-callback-routing-v3.png)

The layout separates request setup, registry selection, and found/missing outcomes so every profile boundary remains explicit and independently readable.

## Compatibility and Migration

- No route, configuration, callback envelope, API-server authentication, or platform verifier contract changes.
- Default-primary and single-profile behavior remain unchanged. `/p/default/...` continues to use `runner.adapters` when `default` is primary.
- Deployments that relied on an unintended cross-profile fallback now receive an explicit `503` until the intended profile adapter is connected; this is the intended safe failure mode.
- Reverting this focused commit restores the prior callback routing behavior and its isolation risk.

## Not in This PR

- Platform adapters with independent HTTP listeners are unchanged; this targets only the API Server generic HTTP-event interface.
- No changes to secondary adapter startup, reconnect, teardown, URL registration, or port-binding policy.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_multiplex_api_server_routing.py tests/gateway/test_api_server.py tests/gateway/test_multiplex_profile_authz.py tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_multiplex_lifecycle.py tests/gateway/test_multiplex_phase0.py tests/gateway/test_api_server_multiplex_secret_scope.py tests/gateway/test_google_chat.py tests/test_hermes_constants.py -q` — 607 passed.
2. `ruff check gateway/platforms/api_server.py tests/gateway/test_multiplex_api_server_routing.py tests/gateway/test_api_server_multiplex_secret_scope.py`; `python -m py_compile` for the same files; and `git diff --check origin/main...HEAD` — passed.
3. Full `pytest tests/ -q` was not run locally; the focused API Server, generic callback, profile registry/authz/lifecycle, secret-scope, Google Chat, and process-home matrix covers the changed boundary.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused local matrix run; full suite not run
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (local targeted tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated API Server/profile-scope docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Python-only profile helper use; no platform-specific path or shell behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
