### PR TITLE
feat(cron): add deduplicated job creation (#67096)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1069,6 +1069,14 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
     )
 
 
+def job_id_for_dedup_key(dedup_key: str) -> str:
+    """Return the stable cron job ID for a caller-owned idempotency key."""
+    normalized = str(dedup_key or "").strip()
+    if not normalized:
+        raise ValueError("dedup_key must not be empty")
+    return uuid.uuid5(uuid.NAMESPACE_URL, f"hermes-cron:{normalized}").hex[:12]
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1087,6 +1095,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    dedup_key: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1128,13 +1137,28 @@ def create_job(
                 script's cwd so relative paths inside the script behave
                 predictably.
         no_agent: When True, skip the agent entirely — run ``script`` on schedule
-                and deliver its stdout directly. Empty stdout = silent (no
-                delivery). Requires ``script`` to be set. Ideal for classic
-                watchdogs and periodic alerts that don't need LLM reasoning.
+                 and deliver its stdout directly. Empty stdout = silent (no
+                 delivery). Requires ``script`` to be set. Ideal for classic
+                 watchdogs and periodic alerts that don't need LLM reasoning.
+        dedup_key: Optional caller-owned idempotency key. Repeated creates with
+                   the same key return the original job instead of adding a duplicate.
 
     Returns:
         The created job dict
     """
+    normalized_dedup_key = _normalize_job_optional_text(dedup_key)
+    if normalized_dedup_key:
+        # Fast idempotency check before schedule parsing. Replaying a durable
+        # reservation after a crash may happen after its one-shot timestamp has
+        # passed; the existing job still wins.
+        with _jobs_lock():
+            existing = next(
+                (item for item in load_jobs() if item.get("dedup_key") == normalized_dedup_key),
+                None,
+            )
+            if existing is not None:
+                return copy.deepcopy(existing)
+
     parsed_schedule = parse_schedule(schedule)
 
     # Normalize repeat: treat 0 or negative values as None (infinite)
@@ -1149,7 +1173,6 @@ def create_job(
     if deliver is None:
         deliver = "origin" if origin else "local"
 
-    job_id = uuid.uuid4().hex[:12]
     now = _hermes_now().isoformat()
 
     normalized_skills = _normalize_skill_list(skill, skills)
@@ -1163,6 +1186,8 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_dedup_key = _normalize_job_optional_text(dedup_key)
+    job_id = job_id_for_dedup_key(normalized_dedup_key) if normalized_dedup_key else uuid.uuid4().hex[:12]
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1253,6 +1278,8 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    if normalized_dedup_key:
+        job["dedup_key"] = normalized_dedup_key
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).
@@ -1261,6 +1288,13 @@ def create_job(
 
     with _jobs_lock():
         jobs = load_jobs()
+        if normalized_dedup_key:
+            existing = next((item for item in jobs if item.get("dedup_key") == normalized_dedup_key), None)
+            if existing is not None:
+                return copy.deepcopy(existing)
+            collision = next((item for item in jobs if item.get("id") == job_id), None)
+            if collision is not None:
+                raise RuntimeError(f"Cron dedup job id collision for key {normalized_dedup_key!r}")
         jobs.append(job)
         save_jobs(jobs)
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -251,6 +251,25 @@ class TestJobCRUD:
         assert fetched is not None
         assert fetched["prompt"] == "Check server status"
 
+    def test_create_with_dedup_key_is_idempotent(self, tmp_cron_dir):
+        first = create_job(
+            prompt="Recover the failed build",
+            schedule="30m",
+            name="Recovery attempt",
+            dedup_key="recovery:chain-123:1",
+        )
+        second = create_job(
+            prompt="This second payload must not create a duplicate",
+            schedule=(datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+            name="Duplicate recovery attempt",
+            dedup_key="recovery:chain-123:1",
+        )
+
+        assert second["id"] == first["id"]
+        assert second["prompt"] == first["prompt"]
+        assert first["dedup_key"] == "recovery:chain-123:1"
+        assert len(load_jobs()) == 1
+
     def test_list_jobs(self, tmp_cron_dir):
         create_job(prompt="Job 1", schedule="every 1h")
         create_job(prompt="Job 2", schedule="every 2h")


### PR DESCRIPTION
## What does this PR do?

Adds locked, idempotent cron job creation through an optional `dedup_key`.

Crash-safe schedulers and recovery workflows can retry job creation after a process interruption. Without an atomic lookup-and-create operation, the retry can enqueue duplicate continuation jobs. This change keeps the existing API unchanged for normal callers and returns the existing job when the same non-empty key is reused.

## Related Issue

Closes #67096

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add an optional `dedup_key` to `create_job()`
- Add `job_id_for_dedup_key()` helper for stable job IDs
- Serialize lookup-and-create with the existing jobs-file lock
- Return the existing job without mutating it when a duplicate key is supplied
- Preserve current behavior for callers that omit the key
- Add idempotency coverage using recovery-job fixtures

## How to Test

```bash
python3 -m pytest -q -o 'addopts=' tests/cron/test_jobs.py
# 142 passed
```

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/cron/test_jobs.py` and all tests pass
- [x] I've added tests for my changes