### PR TITLE
feat(desktop): native Admin hub + Kanban board (API-only, no SPA embed)

### DIFF
--- a/apps/desktop/src/app/admin/index.tsx
+++ b/apps/desktop/src/app/admin/index.tsx
@@ -1,0 +1,113 @@
+/**
+ * Native Admin hub — deep-links into existing Desktop surfaces (settings,
+ * messaging, skills/MCP) plus the native Kanban board. No web SPA embed.
+ */
+import type * as React from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { Codicon } from '@/components/ui/codicon'
+import { cn } from '@/lib/utils'
+
+import {
+  KANBAN_ROUTE,
+  MESSAGING_ROUTE,
+  SETTINGS_ROUTE,
+  SKILLS_ROUTE
+} from '../routes'
+
+interface AdminViewProps extends React.ComponentProps<'section'> {}
+
+interface AdminCard {
+  title: string
+  description: string
+  codicon: string
+  path: string
+  keywords?: string
+}
+
+const CARDS: AdminCard[] = [
+  {
+    title: 'Kanban board',
+    description: 'Multi-agent task board — create, inspect, and move tasks (native API client).',
+    codicon: 'project',
+    path: KANBAN_ROUTE,
+    keywords: 'tasks workers dispatch'
+  },
+  {
+    title: 'Model & config',
+    description: 'Provider, model, agent, terminal, and display settings.',
+    codicon: 'settings-gear',
+    path: `${SETTINGS_ROUTE}?tab=config:model`
+  },
+  {
+    title: 'API keys',
+    description: 'Manage credentials and env keys for tools and providers.',
+    codicon: 'key',
+    path: `${SETTINGS_ROUTE}?tab=keys`
+  },
+  {
+    title: 'Messaging channels',
+    description: 'Telegram, Discord, Slack, and other gateway platforms.',
+    codicon: 'comment-discussion',
+    path: MESSAGING_ROUTE
+  },
+  {
+    title: 'MCP servers',
+    description: 'Browse catalog, enable servers, and test connections.',
+    codicon: 'server-process',
+    path: `${SKILLS_ROUTE}?tab=mcp`
+  },
+  {
+    title: 'Plugins',
+    description: 'Desktop / agent plugins and extensions.',
+    codicon: 'extensions',
+    path: `${SETTINGS_ROUTE}?tab=plugins`
+  },
+  {
+    title: 'Gateway & connection',
+    description: 'Local vs remote backend, gateway status, reconnect.',
+    codicon: 'globe',
+    path: `${SETTINGS_ROUTE}?tab=gateway`
+  },
+  {
+    title: 'Appearance',
+    description: 'Theme, density, and desktop chrome.',
+    codicon: 'symbol-color',
+    path: `${SETTINGS_ROUTE}?tab=config:appearance`
+  }
+]
+
+export function AdminView({ className, ...rest }: AdminViewProps) {
+  const navigate = useNavigate()
+
+  return (
+    <section className={cn('flex h-full min-h-0 flex-col overflow-y-auto bg-(--ui-editor-background)', className)} {...rest}>
+      <header className="border-b border-(--ui-border) px-5 py-4">
+        <h1 className="text-base font-semibold text-foreground">Admin</h1>
+        <p className="mt-1 max-w-2xl text-xs text-(--ui-text-secondary)">
+          Machine management without leaving Desktop. These open native panes and call the same
+          backend HTTP APIs as the web dashboard — no browser UI is embedded.
+        </p>
+      </header>
+      <div className="grid gap-3 p-5 sm:grid-cols-2 xl:grid-cols-3">
+        {CARDS.map(card => (
+          <button
+            className={cn(
+              'flex flex-col items-start gap-2 rounded-lg border border-(--ui-border) bg-(--ui-sidebar-surface-background)/35 p-4 text-left',
+              'transition-colors hover:border-(--ui-focus-border) hover:bg-(--ui-control-hover-background)'
+            )}
+            key={card.path + card.title}
+            onClick={() => navigate(card.path)}
+            type="button"
+          >
+            <div className="flex items-center gap-2">
+              <Codicon className="text-(--ui-text-secondary)" name={card.codicon as never} />
+              <span className="text-sm font-semibold text-foreground">{card.title}</span>
+            </div>
+            <p className="text-xs leading-relaxed text-(--ui-text-secondary)">{card.description}</p>
+          </button>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -100,7 +100,9 @@ import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/st
 
 import {
   type AppView,
+  ADMIN_ROUTE,
   ARTIFACTS_ROUTE,
+  KANBAN_ROUTE,
   MESSAGING_ROUTE,
   SIDEBAR_NAV_AREA,
   type SidebarNavContribution,
@@ -167,6 +169,20 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     icon: props => <Codicon name="files" {...props} />,
     route: ARTIFACTS_ROUTE,
     keybindActionId: 'nav.artifacts'
+  },
+  {
+    id: 'admin',
+    label: '',
+    icon: props => <Codicon name="settings" {...props} />,
+    route: ADMIN_ROUTE,
+    keybindActionId: 'nav.admin'
+  },
+  {
+    id: 'kanban',
+    label: '',
+    icon: props => <Codicon name="project" {...props} />,
+    route: KANBAN_ROUTE,
+    keybindActionId: 'nav.kanban'
   }
 ]
 
@@ -1105,6 +1121,8 @@ export function ChatSidebar({
                   (item.id === 'skills' && currentView === 'skills') ||
                   (item.id === 'messaging' && currentView === 'messaging') ||
                   (item.id === 'artifacts' && currentView === 'artifacts') ||
+                  (item.id === 'admin' && currentView === 'admin') ||
+                  (item.id === 'kanban' && currentView === 'kanban') ||
                   // Contributed rows light up at their own route.
                   (Boolean(item.route) && pathname === item.route)
 

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -27,6 +27,7 @@ import {
   Info,
   KeyRound,
   Layers3,
+  LayoutDashboard,
   MessageCircle,
   Monitor,
   Moon,
@@ -64,10 +65,12 @@ import { type ThemeMode, useTheme } from '@/themes/context'
 import { isUserTheme, resolveTheme } from '@/themes/user-themes'
 
 import {
+  ADMIN_ROUTE,
   AGENTS_ROUTE,
   ARTIFACTS_ROUTE,
   COMMAND_CENTER_ROUTE,
   CRON_ROUTE,
+  KANBAN_ROUTE,
   MESSAGING_ROUTE,
   NEW_CHAT_ROUTE,
   PROFILES_ROUTE,
@@ -449,6 +452,22 @@ export function CommandPalette() {
             id: 'nav-artifacts',
             label: cc.nav.artifacts.title,
             run: go(ARTIFACTS_ROUTE)
+          },
+          {
+            action: 'nav.admin',
+            icon: LayoutDashboard,
+            id: 'nav-admin',
+            keywords: ['admin', 'config', 'keys', 'mcp', 'channels', 'settings', 'management'],
+            label: 'Admin',
+            run: go(ADMIN_ROUTE)
+          },
+          {
+            action: 'nav.kanban',
+            icon: Layers3,
+            id: 'nav-kanban',
+            keywords: ['kanban', 'board', 'tasks', 'workers', 'multi-agent'],
+            label: 'Kanban board',
+            run: go(KANBAN_ROUTE)
           },
           {
             action: 'nav.cron',

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -33,6 +33,8 @@ import type { SidebarActions, WiringActions } from './types'
 const ArtifactsView = lazy(async () => ({ default: (await import('../artifacts')).ArtifactsView }))
 const MessagingView = lazy(async () => ({ default: (await import('../messaging')).MessagingView }))
 const SkillsView = lazy(async () => ({ default: (await import('../skills')).SkillsView }))
+const AdminView = lazy(async () => ({ default: (await import('../admin')).AdminView }))
+const KanbanView = lazy(async () => ({ default: (await import('../kanban')).KanbanView }))
 
 export function LegacySessionRedirect() {
   const { sessionId } = useParams()
@@ -180,6 +182,8 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
       <Route element={page(<SkillsView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="skills" />
       <Route element={page(<MessagingView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="messaging" />
       <Route element={page(<ArtifactsView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="artifacts" />
+      <Route element={page(<AdminView />)} path="admin" />
+      <Route element={page(<KanbanView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="kanban" />
       <Route element={null} path="agents" />
       <Route element={null} path="command-center" />
       <Route element={null} path="cron" />

--- a/apps/desktop/src/app/kanban/api.test.ts
+++ b/apps/desktop/src/app/kanban/api.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { columnMap, KANBAN_COLUMNS, statusLabel, type KanbanBoard } from './api'
+
+describe('kanban columnMap', () => {
+  it('fills every known column even when board is empty', () => {
+    const map = columnMap(null)
+    for (const name of KANBAN_COLUMNS) {
+      expect(map[name]).toEqual([])
+    }
+  })
+
+  it('places tasks under their column names', () => {
+    const board: KanbanBoard = {
+      columns: [
+        { name: 'todo', tasks: [{ id: 'a', title: 'A', status: 'todo' }] },
+        { name: 'ready', tasks: [{ id: 'b', title: 'B', status: 'ready' }] }
+      ]
+    }
+    const map = columnMap(board)
+    expect(map.todo).toHaveLength(1)
+    expect(map.ready[0]?.id).toBe('b')
+    expect(map.done).toEqual([])
+  })
+})
+
+describe('statusLabel', () => {
+  it('capitalizes status keys', () => {
+    expect(statusLabel('ready')).toBe('Ready')
+    expect(statusLabel('')).toBe('')
+  })
+})

--- a/apps/desktop/src/app/kanban/api.ts
+++ b/apps/desktop/src/app/kanban/api.ts
@@ -1,0 +1,123 @@
+/**
+ * Native Desktop client for the kanban plugin REST API
+ * (`/api/plugins/kanban/*`) via `pluginRest` — no web dashboard SPA.
+ */
+import { pluginRest } from '@/hermes'
+
+export const KANBAN_PLUGIN_ID = 'kanban'
+
+/** Board columns left→right (matches plugins/kanban/dashboard/plugin_api.py). */
+export const KANBAN_COLUMNS = [
+  'triage',
+  'todo',
+  'scheduled',
+  'ready',
+  'running',
+  'blocked',
+  'review',
+  'done'
+] as const
+
+export type KanbanStatus = (typeof KANBAN_COLUMNS)[number]
+
+export interface KanbanTask {
+  id: string
+  title: string
+  body?: string | null
+  status: string
+  assignee?: string | null
+  tenant?: string | null
+  priority?: number
+  comment_count?: number
+  age?: string | number | null
+  latest_summary?: string | null
+  link_counts?: { parents: number; children: number }
+  progress?: { done: number; total: number } | null
+}
+
+export interface KanbanColumn {
+  name: string
+  tasks: KanbanTask[]
+}
+
+export interface KanbanBoard {
+  board?: string
+  columns: KanbanColumn[]
+  tenants?: string[]
+  assignees?: string[]
+  latest_event_id?: number
+}
+
+export interface KanbanTaskDetail {
+  task: KanbanTask
+  comments?: Array<{ id?: number; author?: string; body?: string; created_at?: string }>
+  events?: Array<{ id?: number; kind?: string; message?: string; created_at?: string }>
+}
+
+function qs(board?: string | null): string {
+  if (!board) return ''
+  return `?board=${encodeURIComponent(board)}`
+}
+
+export async function fetchKanbanBoard(board?: string | null): Promise<KanbanBoard> {
+  return pluginRest<KanbanBoard>(KANBAN_PLUGIN_ID, `/board${qs(board)}`)
+}
+
+export async function fetchKanbanTask(taskId: string, board?: string | null): Promise<KanbanTaskDetail> {
+  return pluginRest<KanbanTaskDetail>(KANBAN_PLUGIN_ID, `/tasks/${encodeURIComponent(taskId)}${qs(board)}`)
+}
+
+export async function createKanbanTask(
+  input: {
+    title: string
+    body?: string
+    assignee?: string
+    priority?: number
+    triage?: boolean
+  },
+  board?: string | null
+): Promise<{ task: KanbanTask | null; warning?: string }> {
+  return pluginRest(KANBAN_PLUGIN_ID, `/tasks${qs(board)}`, {
+    method: 'POST',
+    body: input
+  })
+}
+
+export async function updateKanbanTask(
+  taskId: string,
+  patch: {
+    status?: string
+    assignee?: string | null
+    priority?: number
+    title?: string
+    body?: string
+    block_reason?: string
+    summary?: string
+  },
+  board?: string | null
+): Promise<{ task?: KanbanTask }> {
+  return pluginRest(KANBAN_PLUGIN_ID, `/tasks/${encodeURIComponent(taskId)}${qs(board)}`, {
+    method: 'PATCH',
+    body: patch
+  })
+}
+
+/** Flatten board columns into a status → tasks map (missing cols → []). */
+export function columnMap(board: KanbanBoard | null | undefined): Record<string, KanbanTask[]> {
+  const map: Record<string, KanbanTask[]> = {}
+  for (const name of KANBAN_COLUMNS) {
+    map[name] = []
+  }
+  if (!board?.columns) {
+    return map
+  }
+  for (const col of board.columns) {
+    map[col.name] = Array.isArray(col.tasks) ? col.tasks : []
+  }
+  return map
+}
+
+export function statusLabel(status: string): string {
+  if (!status) return ''
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}

--- a/apps/desktop/src/app/kanban/index.tsx
+++ b/apps/desktop/src/app/kanban/index.tsx
@@ -1,0 +1,307 @@
+/**
+ * Native Kanban board — talks to `/api/plugins/kanban` only.
+ * No web dashboard SPA / webview / serve-UI coupling.
+ */
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import type * as React from 'react'
+import { useCallback, useMemo, useState } from 'react'
+
+import { PageLoader } from '@/components/page-loader'
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
+import { notify, notifyError } from '@/store/notifications'
+
+import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
+import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
+
+import {
+  columnMap,
+  createKanbanTask,
+  fetchKanbanBoard,
+  fetchKanbanTask,
+  KANBAN_COLUMNS,
+  statusLabel,
+  type KanbanTask,
+  updateKanbanTask
+} from './api'
+
+interface KanbanViewProps extends React.ComponentProps<'section'> {
+  setStatusbarItemGroup?: SetStatusbarItemGroup
+}
+
+const COLUMN_TONE: Record<string, string> = {
+  triage: 'text-amber-300/90',
+  todo: 'text-(--ui-text-secondary)',
+  scheduled: 'text-sky-300/90',
+  ready: 'text-emerald-300/90',
+  running: 'text-violet-300/90',
+  blocked: 'text-red-300/90',
+  review: 'text-orange-300/90',
+  done: 'text-(--ui-text-tertiary)'
+}
+
+export function KanbanView({ className, setStatusbarItemGroup: _setStatusbar, ...rest }: KanbanViewProps) {
+  const qc = useQueryClient()
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [assignee, setAssignee] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [busyId, setBusyId] = useState<string | null>(null)
+
+  const boardQuery = useQuery({
+    queryKey: ['kanban', 'board'],
+    queryFn: () => fetchKanbanBoard(),
+    refetchInterval: 15_000
+  })
+
+  const detailQuery = useQuery({
+    queryKey: ['kanban', 'task', selectedId],
+    queryFn: () => fetchKanbanTask(selectedId!),
+    enabled: Boolean(selectedId)
+  })
+
+  const refresh = useCallback(() => {
+    void qc.invalidateQueries({ queryKey: ['kanban'] })
+  }, [qc])
+
+  useRefreshHotkey(refresh)
+
+  const columns = useMemo(() => columnMap(boardQuery.data), [boardQuery.data])
+
+  const onCreate = async () => {
+    const t = title.trim()
+    if (!t || creating) return
+    setCreating(true)
+    try {
+      const res = await createKanbanTask({
+        title: t,
+        body: body.trim() || undefined,
+        assignee: assignee.trim() || undefined
+      })
+      setTitle('')
+      setBody('')
+      setAssignee('')
+      if (res.warning) {
+        notify({ message: res.warning, kind: 'warning' })
+      } else {
+        notify({ message: 'Task created', kind: 'success' })
+      }
+      if (res.task?.id) setSelectedId(res.task.id)
+      refresh()
+    } catch (err) {
+      notifyError(err, 'Failed to create task')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const moveTask = async (task: KanbanTask, status: string) => {
+    if (task.status === status) return
+    setBusyId(task.id)
+    try {
+      await updateKanbanTask(task.id, {
+        status,
+        block_reason: status === 'blocked' ? 'Blocked from Desktop board' : undefined
+      })
+      notify({ message: `Moved to ${statusLabel(status)}`, kind: 'success' })
+      refresh()
+      if (selectedId === task.id) {
+        void qc.invalidateQueries({ queryKey: ['kanban', 'task', task.id] })
+      }
+    } catch (err) {
+      notifyError(err, 'Failed to update task status')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  if (boardQuery.isLoading && !boardQuery.data) {
+    return <PageLoader label="Loading kanban board…" />
+  }
+
+  if (boardQuery.isError && !boardQuery.data) {
+    return (
+      <section className={cn('flex h-full flex-col items-center justify-center gap-3 p-8', className)} {...rest}>
+        <p className="max-w-md text-center text-sm text-(--ui-text-secondary)">
+          Could not load the kanban board. The backend must expose the kanban plugin API
+          (`/api/plugins/kanban/board`).
+        </p>
+        <Button onClick={() => void boardQuery.refetch()} size="sm" variant="secondary">
+          Retry
+        </Button>
+      </section>
+    )
+  }
+
+  const selected = detailQuery.data?.task
+  const comments = detailQuery.data?.comments ?? []
+
+  return (
+    <section className={cn('flex h-full min-h-0 flex-col bg-(--ui-editor-background)', className)} {...rest}>
+      <header className="flex shrink-0 flex-wrap items-end gap-2 border-b border-(--ui-border) px-3 py-2">
+        <div className="mr-auto min-w-0">
+          <h1 className="text-sm font-semibold text-foreground">Kanban</h1>
+          <p className="text-[11px] text-(--ui-text-tertiary)">
+            Native board · same `/api/plugins/kanban` store as CLI & web
+          </p>
+        </div>
+        <Button onClick={refresh} size="sm" variant="ghost">
+          <Codicon className="mr-1" name="refresh" />
+          Refresh
+        </Button>
+      </header>
+
+      <div className="flex shrink-0 flex-wrap items-end gap-2 border-b border-(--ui-border) px-3 py-2">
+        <Input
+          className="min-w-[12rem] flex-1"
+          onChange={e => setTitle(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              void onCreate()
+            }
+          }}
+          placeholder="New task title"
+          value={title}
+        />
+        <Input
+          className="w-36"
+          onChange={e => setAssignee(e.target.value)}
+          placeholder="Assignee profile"
+          value={assignee}
+        />
+        <Textarea
+          className="min-h-[2.25rem] min-w-[14rem] flex-[1.5] resize-y"
+          onChange={e => setBody(e.target.value)}
+          placeholder="Optional body"
+          rows={1}
+          value={body}
+        />
+        <Button disabled={!title.trim() || creating} onClick={() => void onCreate()} size="sm">
+          {creating ? 'Creating…' : 'Add task'}
+        </Button>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        <div className="flex min-h-0 min-w-0 flex-1 gap-2 overflow-x-auto p-2">
+          {KANBAN_COLUMNS.map(col => {
+            const tasks = columns[col] ?? []
+            return (
+              <div
+                className="flex w-56 shrink-0 flex-col rounded-md border border-(--ui-border) bg-(--ui-sidebar-surface-background)/40"
+                key={col}
+              >
+                <div className="flex items-center justify-between gap-2 border-b border-(--ui-border) px-2 py-1.5">
+                  <span className={cn('text-[11px] font-semibold uppercase tracking-wide', COLUMN_TONE[col])}>
+                    {statusLabel(col)}
+                  </span>
+                  <span className="rounded bg-(--ui-bg-quinary) px-1.5 py-0.5 font-mono text-[10px] text-(--ui-text-tertiary)">
+                    {tasks.length}
+                  </span>
+                </div>
+                <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-1.5">
+                  {tasks.length === 0 ? (
+                    <p className="px-1 py-3 text-center text-[11px] text-(--ui-text-tertiary)">Empty</p>
+                  ) : (
+                    tasks.map(task => (
+                      <button
+                        className={cn(
+                          'rounded border border-transparent bg-(--ui-editor-background) px-2 py-1.5 text-left transition-colors',
+                          'hover:border-(--ui-border) hover:bg-(--ui-control-hover-background)',
+                          selectedId === task.id && 'border-(--ui-focus-border) bg-(--ui-list-active-selection-background)'
+                        )}
+                        disabled={busyId === task.id}
+                        key={task.id}
+                        onClick={() => setSelectedId(task.id)}
+                        type="button"
+                      >
+                        <div className="line-clamp-2 text-xs font-medium text-foreground">{task.title}</div>
+                        <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px] text-(--ui-text-tertiary)">
+                          {task.assignee ? <span className="font-mono">@{task.assignee}</span> : null}
+                          {typeof task.priority === 'number' && task.priority > 0 ? (
+                            <span>P{task.priority}</span>
+                          ) : null}
+                          {task.comment_count ? <span>{task.comment_count}💬</span> : null}
+                        </div>
+                        {task.latest_summary ? (
+                          <p className="mt-1 line-clamp-2 text-[10px] text-(--ui-text-tertiary)">{task.latest_summary}</p>
+                        ) : null}
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <aside className="flex w-72 shrink-0 flex-col border-l border-(--ui-border) bg-(--ui-sidebar-surface-background)/30">
+          {!selectedId ? (
+            <div className="flex flex-1 items-center justify-center p-4 text-center text-xs text-(--ui-text-tertiary)">
+              Select a task to inspect and move
+            </div>
+          ) : detailQuery.isLoading && !selected ? (
+            <div className="p-4 text-xs text-(--ui-text-tertiary)">Loading…</div>
+          ) : selected ? (
+            <>
+              <div className="border-b border-(--ui-border) px-3 py-2">
+                <div className="text-[10px] font-mono text-(--ui-text-tertiary)">{selected.id}</div>
+                <h2 className="mt-0.5 text-sm font-semibold text-foreground">{selected.title}</h2>
+                <div className="mt-1 text-[11px] text-(--ui-text-secondary)">
+                  {statusLabel(selected.status)}
+                  {selected.assignee ? ` · @${selected.assignee}` : ''}
+                </div>
+              </div>
+              {selected.body ? (
+                <pre className="max-h-40 overflow-auto whitespace-pre-wrap border-b border-(--ui-border) px-3 py-2 text-[11px] text-(--ui-text-secondary)">
+                  {selected.body}
+                </pre>
+              ) : null}
+              <div className="border-b border-(--ui-border) px-3 py-2">
+                <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-(--ui-text-tertiary)">
+                  Move to
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {KANBAN_COLUMNS.map(col => (
+                    <Button
+                      disabled={busyId === selected.id || selected.status === col || col === 'running'}
+                      key={col}
+                      onClick={() => void moveTask(selected, col)}
+                      size="sm"
+                      variant={selected.status === col ? 'secondary' : 'ghost'}
+                    >
+                      {statusLabel(col)}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+              <div className="min-h-0 flex-1 overflow-y-auto px-3 py-2">
+                <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-(--ui-text-tertiary)">
+                  Comments
+                </div>
+                {comments.length === 0 ? (
+                  <p className="text-[11px] text-(--ui-text-tertiary)">No comments</p>
+                ) : (
+                  <ul className="space-y-2">
+                    {comments.map((c, i) => (
+                      <li className="rounded bg-(--ui-bg-quinary)/50 px-2 py-1.5 text-[11px]" key={c.id ?? i}>
+                        <div className="font-mono text-[10px] text-(--ui-text-tertiary)">{c.author || 'unknown'}</div>
+                        <div className="whitespace-pre-wrap text-(--ui-text-secondary)">{c.body}</div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </>
+          ) : (
+            <div className="p-4 text-xs text-red-300/90">Task not found</div>
+          )}
+        </aside>
+      </div>
+    </section>
+  )
+}

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -14,8 +14,13 @@ export const CRON_ROUTE = '/cron'
 export const PROFILES_ROUTE = '/profiles'
 export const AGENTS_ROUTE = '/agents'
 export const STARMAP_ROUTE = '/starmap'
+/** Native admin hub (deep-links to settings / messaging / kanban). */
+export const ADMIN_ROUTE = '/admin'
+/** Native kanban board (plugin REST client). */
+export const KANBAN_ROUTE = '/kanban'
 
 export type AppView =
+  | 'admin'
   | 'agents'
   | 'artifacts'
   | 'chat'
@@ -26,6 +31,7 @@ export type AppView =
   // so the sidebar kept a session highlighted and the titlebar kept the
   // session-title dropdown while a plugin page was showing.
   | 'extension'
+  | 'kanban'
   | 'messaging'
   | 'profiles'
   | 'settings'
@@ -33,10 +39,12 @@ export type AppView =
   | 'starmap'
 
 export type AppRouteId =
+  | 'admin'
   | 'agents'
   | 'artifacts'
   | 'command-center'
   | 'cron'
+  | 'kanban'
   | 'messaging'
   | 'new'
   | 'profiles'
@@ -60,7 +68,9 @@ export const APP_ROUTES = [
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },
   { id: 'profiles', path: PROFILES_ROUTE, view: 'profiles' },
   { id: 'agents', path: AGENTS_ROUTE, view: 'agents' },
-  { id: 'starmap', path: STARMAP_ROUTE, view: 'starmap' }
+  { id: 'starmap', path: STARMAP_ROUTE, view: 'starmap' },
+  { id: 'admin', path: ADMIN_ROUTE, view: 'admin' },
+  { id: 'kanban', path: KANBAN_ROUTE, view: 'kanban' }
 ] as const satisfies readonly AppRoute[]
 
 const APP_VIEW_BY_PATH = new Map<string, AppView>(APP_ROUTES.map(route => [route.path, route.view]))

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -123,7 +123,15 @@ export type CommandDispatchResponse =
   | SendCommandDispatchResponse
   | PrefillCommandDispatchResponse
 
-export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
+export type SidebarNavId =
+  | 'admin'
+  | 'artifacts'
+  | 'command-center'
+  | 'kanban'
+  | 'messaging'
+  | 'new-session'
+  | 'settings'
+  | 'skills'
 
 export interface SidebarNavItem {
   /** Built-in view id, or a contributed row's namespaced contribution id. */


### PR DESCRIPTION
## What does this PR do?

**Re-scoped after review** on the first revision.

Delivers Desktop admin parity **without** embedding the web dashboard SPA and **without** changing the headless `hermes serve` contract.

### Native surfaces
1. **`/admin` hub** — cards that deep-link into existing Desktop panes (settings model/config/keys/plugins/gateway, messaging channels, skills MCP) plus Kanban.
2. **`/kanban` board** — native React board that calls `/api/plugins/kanban/*` via existing `pluginRest` (list columns, create task, inspect, move status).

### Explicitly removed from v1 approach
- ~~`HERMES_SERVE_UI` / SPA on `serve`~~
- ~~Electron webview of dashboard frontend~~
- ~~Desktop runtime dependency on `hermes_cli/web_dist`~~

## Related Issue

- Fixes / advances #67144 (native path)
- Advances #41222 (Kanban in Desktop)
- Addresses https://github.com/NousResearch/hermes-agent/pull/67155#issuecomment-5013498795

## Type of Change

- [x] ✨ New feature

## How to Test

1. Run Desktop from this branch against a backend with the kanban plugin API available.
2. Sidebar **Admin** (settings icon) → hub cards open settings / messaging / MCP / kanban.
3. Sidebar **Kanban** (project icon) or Admin → Kanban board:
   - Board columns load from `GET /api/plugins/kanban/board`
   - Create a task
   - Select a task, move status via buttons
4. Confirm `hermes serve` is still headless (no SPA) — this PR does not touch `web_server` SPA mounting.
5. `cd apps/desktop && npx vitest run src/app/kanban/api.test.ts`

## Checklist

- [x] No serve/SPA boundary change
- [x] No dashboard frontend dependency
- [x] Uses established Desktop HTTP/`pluginRest` APIs
- [x] Tests for column mapping helpers
- [x] Windows 11 implementation host

## Notes

Config/keys/MCP/channels already had native Desktop UIs; this PR adds the missing **Kanban** board and a single **Admin** entry point so users do not need the browser for day-to-day ops.