### PR TITLE
fix(kanban): gate children on explicit approval

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -310,6 +310,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
+    p_create.add_argument(
+        "--approval-parent", action="append", default=[],
+        help="Review parent whose edge requires structured approved=true "
+             "before this task can run (repeatable)",
+    )
     p_create.add_argument("--workspace", default="scratch",
                           help="scratch | worktree | worktree:<path> | dir:<path> "
                                "(default: scratch)")
@@ -500,6 +505,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_link = sub.add_parser("link", help="Add a parent->child dependency")
     p_link.add_argument("parent_id")
     p_link.add_argument("child_id")
+    p_link.add_argument(
+        "--gate", choices=sorted(kb.VALID_GATE_TYPES), default=None,
+        help="Typed dependency gate. 'approval' fails closed until the parent "
+             "has an unambiguous approved review run.",
+    )
     p_unlink = sub.add_parser("unlink", help="Remove a parent->child dependency")
     p_unlink.add_argument("parent_id")
     p_unlink.add_argument("child_id")
@@ -1363,6 +1373,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             tenant=args.tenant,
             priority=args.priority,
             parents=tuple(args.parent or ()),
+            approval_parents=tuple(getattr(args, "approval_parent", None) or ()),
             triage=bool(getattr(args, "triage", False)),
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
@@ -1822,8 +1833,12 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
 
 def _cmd_link(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
-        kb.link_tasks(conn, args.parent_id, args.child_id)
-    print(f"Linked {args.parent_id} -> {args.child_id}")
+        kb.link_tasks(
+            conn, args.parent_id, args.child_id,
+            gate_type=getattr(args, "gate", None),
+        )
+    suffix = f" [gate={args.gate}]" if getattr(args, "gate", None) else ""
+    print(f"Linked {args.parent_id} -> {args.child_id}{suffix}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -102,6 +102,13 @@ _log = logging.getLogger(__name__)
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 
+# Declarative dependency-edge contracts. NULL remains the ordinary v1
+# dependency semantics; ``approval`` is fail-closed and requires a terminal
+# parent review run with unambiguous structured approval metadata.
+APPROVAL_GATE = "approval"
+VALID_GATE_TYPES = {APPROVAL_GATE}
+APPROVED_VERDICTS = {"APPROVED", "FINAL APPROVED", "PASS", "FINAL PASS"}
+
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
 # instead of all landing in one undifferentiated ``blocked`` bucket that a cron
@@ -1182,6 +1189,7 @@ CREATE TABLE IF NOT EXISTS tasks (
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
+    gate_type  TEXT,
     PRIMARY KEY (parent_id, child_id)
 );
 
@@ -1855,6 +1863,18 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
 
     Called by ``init_db`` so opening an old DB is always safe.
     """
+    link_table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'task_links'"
+    ).fetchone() is not None
+    if link_table_exists:
+        link_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_links)")
+        }
+        if "gate_type" not in link_cols:
+            _add_column_if_missing(
+                conn, "task_links", "gate_type", "gate_type TEXT"
+            )
+
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     if "tenant" not in cols:
         _add_column_if_missing(conn, "tasks", "tenant", "tenant TEXT")
@@ -2397,6 +2417,7 @@ def create_task(
     tenant: Optional[str] = None,
     priority: int = 0,
     parents: Iterable[str] = (),
+    approval_parents: Iterable[str] = (),
     triage: bool = False,
     idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
@@ -2421,6 +2442,11 @@ def create_task(
     same key already exists, returns the existing task's id instead of
     creating a duplicate. Useful for retried webhooks / automation that
     should not double-write.
+
+    ``approval_parents`` creates typed, fail-closed dependency edges. Those
+    parents must finish with unambiguous structured ``approved: true`` review
+    metadata before this task can become runnable. Parents listed in both
+    arguments are treated as approval parents.
 
     ``max_runtime_seconds`` caps how long a worker may run before the
     dispatcher SIGTERMs (then SIGKILLs after a grace window) and
@@ -2490,7 +2516,12 @@ def create_task(
                 # ``<repo>/.worktrees/<task-id>`` dir keyed on the new task id.
                 project_repo = str(project_obj.primary_path)
 
-    parents = tuple(p for p in parents if p)
+    ordinary_parents = tuple(dict.fromkeys(p for p in parents if p))
+    approval_parent_ids = tuple(dict.fromkeys(p for p in approval_parents if p))
+    approval_parent_set = set(approval_parent_ids)
+    parents = tuple(
+        dict.fromkeys((*ordinary_parents, *approval_parent_ids))
+    )
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
     # (preserving order). Refuse commas inside a single name so we don't
@@ -2598,11 +2629,18 @@ def create_task(
                             raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
                         # If any parent is not yet done, we're todo.
                         rows = conn.execute(
-                            "SELECT status FROM tasks WHERE id IN "
+                            "SELECT id, status FROM tasks WHERE id IN "
                             "(" + ",".join("?" * len(parents)) + ")",
                             parents,
                         ).fetchall()
-                        if any(r["status"] != "done" for r in rows):
+                        if any(
+                            (
+                                _approval_gate_state(conn, row["id"]) != "approved"
+                                if row["id"] in approval_parent_set
+                                else row["status"] != "done"
+                            )
+                            for row in rows
+                        ):
                             task_status = "todo"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
@@ -2664,8 +2702,13 @@ def create_task(
                 )
                 for pid in parents:
                     conn.execute(
-                        "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
-                        (pid, task_id),
+                        "INSERT OR IGNORE INTO task_links "
+                        "(parent_id, child_id, gate_type) VALUES (?, ?, ?)",
+                        (
+                            pid,
+                            task_id,
+                            APPROVAL_GATE if pid in approval_parent_set else None,
+                        ),
                     )
                 _append_event(
                     conn,
@@ -2675,6 +2718,7 @@ def create_task(
                         "assignee": assignee,
                         "status": task_status,
                         "parents": list(parents),
+                        "approval_parents": list(approval_parent_ids) or None,
                         "tenant": tenant,
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
@@ -2811,7 +2855,17 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
 # Links
 # ---------------------------------------------------------------------------
 
-def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+def link_tasks(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    child_id: str,
+    *,
+    gate_type: Optional[str] = None,
+) -> None:
+    if gate_type is not None:
+        gate_type = str(gate_type).strip().lower() or None
+    if gate_type not in {None, *VALID_GATE_TYPES}:
+        raise ValueError(f"gate_type must be one of {sorted(VALID_GATE_TYPES)}")
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
     with write_txn(conn):
@@ -2822,22 +2876,30 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             raise ValueError(
                 f"linking {parent_id} -> {child_id} would create a cycle"
             )
-        conn.execute(
-            "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
-            (parent_id, child_id),
+        inserted = conn.execute(
+            "INSERT OR IGNORE INTO task_links "
+            "(parent_id, child_id, gate_type) VALUES (?, ?, ?)",
+            (parent_id, child_id, gate_type),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
+        if inserted.rowcount == 0 and gate_type is not None:
             conn.execute(
-                "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
+                "UPDATE task_links SET gate_type = ? "
+                "WHERE parent_id = ? AND child_id = ?",
+                (gate_type, parent_id, child_id),
+            )
+        # A newly linked or newly typed edge must immediately invalidate a
+        # stale-ready child when its dependency contract is not satisfied.
+        blockers = dependency_blockers(conn, child_id)
+        if blockers:
+            conn.execute(
+                "UPDATE tasks SET status = 'todo' "
+                "WHERE id = ? AND status = 'ready'",
                 (child_id,),
             )
+            _append_approval_gate_held_events(conn, child_id, blockers)
         _append_event(
             conn, child_id, "linked",
-            {"parent": parent_id, "child": child_id},
+            {"parent": parent_id, "child": child_id, "gate_type": gate_type},
         )
 
 
@@ -3352,6 +3414,152 @@ def _synthesize_ended_run(
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
 
+
+def _approval_gate_state(
+    conn: sqlite3.Connection,
+    parent_id: str,
+) -> str:
+    """Return the fail-closed state of one approval-gated parent.
+
+    Approval is declarative and structured: prose, comments, titles, and result
+    text are never parsed. The latest terminal run must belong unambiguously to
+    the parent's assigned reviewer and carry ``approved`` as a real JSON bool.
+    An optional verdict may only use the explicit successful verdict vocabulary;
+    contradictory or novel values remain held for an operator to resolve.
+    """
+    parent = conn.execute(
+        "SELECT status, assignee FROM tasks WHERE id = ?", (parent_id,)
+    ).fetchone()
+    if parent is None or parent["status"] not in ("done", "archived"):
+        return "parent_pending"
+
+    run = conn.execute(
+        "SELECT profile, outcome, metadata, ended_at FROM task_runs "
+        "WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+        (parent_id,),
+    ).fetchone()
+    if run is None or run["ended_at"] is None or run["outcome"] != "completed":
+        return "terminal_run_missing"
+
+    reviewer = parent["assignee"]
+    run_profile = run["profile"]
+    if not reviewer or not run_profile or reviewer != run_profile:
+        return "identity_ambiguous"
+
+    raw_metadata = run["metadata"]
+    if raw_metadata is None:
+        return "approval_missing"
+    try:
+        metadata = json.loads(raw_metadata)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return "metadata_malformed"
+    if not isinstance(metadata, dict):
+        return "metadata_malformed"
+
+    for key in ("reviewer", "reviewer_id", "reviewer_profile"):
+        declared = metadata.get(key)
+        if declared is not None and declared != run_profile:
+            return "identity_ambiguous"
+
+    if "approved" not in metadata:
+        return "approval_missing"
+    approved = metadata["approved"]
+    if not isinstance(approved, bool):
+        return "approval_invalid"
+    if not approved:
+        return "rejected"
+
+    if "verdict" in metadata:
+        verdict = metadata["verdict"]
+        if not isinstance(verdict, str):
+            return "verdict_invalid"
+        if verdict.strip().upper() not in APPROVED_VERDICTS:
+            return "verdict_conflict"
+    return "approved"
+
+
+def dependency_blockers(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> list[dict[str, Optional[str]]]:
+    """Return sanitized parent/gate states that currently hold ``task_id``.
+
+    Untyped v1 links preserve their existing terminal semantics. Typed approval
+    links require an explicit successful review; only parent id, gate type, and
+    state escape this helper so result/summary metadata cannot leak into events
+    or dashboard diagnostics.
+    """
+    blockers: list[dict[str, Optional[str]]] = []
+    rows = conn.execute(
+        "SELECT p.id AS parent_id, p.status, l.gate_type "
+        "FROM task_links l JOIN tasks p ON p.id = l.parent_id "
+        "WHERE l.child_id = ? ORDER BY p.id",
+        (task_id,),
+    ).fetchall()
+    for row in rows:
+        gate_type = row["gate_type"]
+        if gate_type is None:
+            if row["status"] not in ("done", "archived"):
+                blockers.append(
+                    {
+                        "parent_id": row["parent_id"],
+                        "gate_type": None,
+                        "gate_state": "parent_pending",
+                    }
+                )
+            continue
+        if gate_type != APPROVAL_GATE:
+            state = "gate_type_invalid"
+        else:
+            state = _approval_gate_state(conn, row["parent_id"])
+        if state != "approved":
+            blockers.append(
+                {
+                    "parent_id": row["parent_id"],
+                    "gate_type": gate_type,
+                    "gate_state": state,
+                }
+            )
+    return blockers
+
+
+def _append_approval_gate_held_events(
+    conn: sqlite3.Connection,
+    task_id: str,
+    blockers: Iterable[dict[str, Optional[str]]],
+) -> None:
+    """Emit one sanitized event per distinct held gate state, without tick spam."""
+    latest_by_gate: dict[tuple[Optional[str], Optional[str]], Optional[str]] = {}
+    previous_rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? "
+        "AND kind = 'approval_gate_held' ORDER BY id DESC",
+        (task_id,),
+    ).fetchall()
+    for row in previous_rows:
+        try:
+            previous = json.loads(row["payload"] or "null")
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+        if not isinstance(previous, dict):
+            continue
+        key = (previous.get("parent_id"), previous.get("gate_type"))
+        latest_by_gate.setdefault(key, previous.get("gate_state"))
+
+    for blocker in blockers:
+        if blocker.get("gate_type") is None:
+            continue
+        payload = {
+            "parent_id": blocker["parent_id"],
+            "gate_type": blocker["gate_type"],
+            "gate_state": blocker["gate_state"],
+        }
+        key = (payload["parent_id"], payload["gate_type"])
+        if latest_by_gate.get(key) == payload["gate_state"]:
+            continue
+        _append_event(conn, task_id, "approval_gate_held", payload)
+        latest_by_gate[key] = payload["gate_state"]
+
+
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return True when ``task_id`` is sticky-blocked by an explicit
     worker/operator ``kanban_block`` call (#28712).
@@ -3438,40 +3646,35 @@ def recompute_ready(
                 # legitimate exit (it emits ``"unblocked"`` which flips
                 # this predicate back).
                 continue
-            parents = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
-                if cur_status == "blocked":
-                    # Don't auto-recover tasks that have hit the
-                    # circuit-breaker failure limit.  Without this
-                    # guard, a task that repeatedly exhausts its
-                    # iteration budget would cycle forever:
-                    # block → auto-recover → respawn → budget
-                    # exhausted → block → …  The counter must also
-                    # be preserved so the breaker can accumulate
-                    # across recovery cycles.
-                    failures = int(row["consecutive_failures"] or 0)
-                    task_limit = row["max_retries"]
-                    effective_limit = (
-                        int(task_limit) if task_limit is not None
-                        else int(failure_limit)
-                    )
-                    if failures >= effective_limit:
-                        continue
-                    conn.execute(
-                        "UPDATE tasks SET status = 'ready' "
-                        "WHERE id = ? AND status = 'blocked'",
-                        (task_id,),
-                    )
-                else:
-                    conn.execute(
-                        "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
-                        (task_id,),
-                    )
+            blockers = dependency_blockers(conn, task_id)
+            if blockers:
+                _append_approval_gate_held_events(conn, task_id, blockers)
+                continue
+            if cur_status == "blocked":
+                # Don't auto-recover tasks that have hit the
+                # circuit-breaker failure limit. Without this guard, a task
+                # that repeatedly exhausts its iteration budget would cycle
+                # forever. Preserve the counter across recovery cycles.
+                failures = int(row["consecutive_failures"] or 0)
+                task_limit = row["max_retries"]
+                effective_limit = (
+                    int(task_limit) if task_limit is not None
+                    else int(failure_limit)
+                )
+                if failures >= effective_limit:
+                    continue
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'ready' "
+                    "WHERE id = ? AND status = 'blocked'",
+                    (task_id,),
+                )
+            else:
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'ready' "
+                    "WHERE id = ? AND status = 'todo'",
+                    (task_id,),
+                )
+            if cur.rowcount == 1:
                 _append_event(conn, task_id, "promoted", None)
                 promoted += 1
     return promoted
@@ -3505,22 +3708,22 @@ def claim_task(
         # 'todo' here — recompute_ready will re-promote when the parents
         # actually finish. See RCA at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone = conn.execute(
-            "SELECT 1 FROM task_links l "
-            "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
-            (task_id,),
-        ).fetchone()
-        if undone:
+        blockers = dependency_blockers(conn, task_id)
+        if blockers:
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "
                 "WHERE id = ? AND status = 'ready'",
                 (task_id,),
             )
-            _append_event(
-                conn, task_id, "claim_rejected",
-                {"reason": "parents_not_done"},
-            )
+            _append_approval_gate_held_events(conn, task_id, blockers)
+            payload: dict[str, Any] = {"reason": "parents_not_satisfied"}
+            approval_gates = [
+                blocker for blocker in blockers
+                if blocker.get("gate_type") is not None
+            ]
+            if approval_gates:
+                payload["approval_gates"] = approval_gates
+            _append_event(conn, task_id, "claim_rejected", payload)
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
@@ -3824,6 +4027,13 @@ def release_stale_claims(
             )
             if cur.rowcount != 1:
                 continue
+            blockers = dependency_blockers(conn, row["id"])
+            if blockers:
+                conn.execute(
+                    "UPDATE tasks SET status = 'todo' WHERE id = ?",
+                    (row["id"],),
+                )
+                _append_approval_gate_held_events(conn, row["id"], blockers)
             run_id = _end_run(
                 conn, row["id"],
                 outcome="reclaimed", status="reclaimed",
@@ -3896,6 +4106,13 @@ def reclaim_task(
         )
         if cur.rowcount != 1:
             return False
+        blockers = dependency_blockers(conn, task_id)
+        if blockers:
+            conn.execute(
+                "UPDATE tasks SET status = 'todo' WHERE id = ?",
+                (task_id,),
+            )
+            _append_approval_gate_held_events(conn, task_id, blockers)
         run_id = _end_run(
             conn, task_id,
             outcome="reclaimed", status="reclaimed",
@@ -5121,22 +5338,18 @@ def promote_task(
             f"'todo' or 'blocked'"
         )
 
-    if not force:
-        parents = conn.execute(
-            "SELECT t.id, t.status FROM tasks t "
-            "JOIN task_links l ON l.parent_id = t.id "
-            "WHERE l.child_id = ?",
-            (task_id,),
-        ).fetchall()
-        unsatisfied = [
-            p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
-        ]
-        if unsatisfied:
-            return False, (
-                f"unsatisfied parent dependencies: "
-                f"{', '.join(unsatisfied)} (use --force to override)"
-            )
+    blockers = dependency_blockers(conn, task_id)
+    approval_blockers = [
+        blocker for blocker in blockers if blocker.get("gate_type") is not None
+    ]
+    if approval_blockers or (blockers and not force):
+        active = approval_blockers if approval_blockers else blockers
+        rendered = ", ".join(
+            f"{blocker['parent_id']} ({blocker['gate_state']})"
+            for blocker in active
+        )
+        suffix = "" if approval_blockers else " (use --force to override)"
+        return False, f"unsatisfied parent dependencies: {rendered}{suffix}"
 
     if dry_run:
         return True, None
@@ -5193,13 +5406,9 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # if parents are still in progress the task must wait in 'todo'
         # until recompute_ready picks it up. RCA: Bug 2 at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone_parents = conn.execute(
-            "SELECT 1 FROM task_links l "
-            "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
-            (task_id,),
-        ).fetchone()
-        new_status = "todo" if undone_parents else "ready"
+        blockers = dependency_blockers(conn, task_id)
+        new_status = "todo" if blockers else "ready"
+        _append_approval_gate_held_events(conn, task_id, blockers)
         # NOTE: deliberately does NOT touch ``block_recurrences`` or
         # ``block_kind``. Resetting the recurrence counter on unblock is exactly
         # the amnesia that let a cron unblock → worker re-block loop run

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -352,15 +352,14 @@ def _warnings_summary_from_diagnostics(
     }
 
 
-def _links_for(conn: sqlite3.Connection, task_id: str) -> dict[str, list[str]]:
-    """Return {'parents': [...], 'children': [...]} for a task."""
-    parents = [
-        r["parent_id"]
-        for r in conn.execute(
-            "SELECT parent_id FROM task_links WHERE child_id = ? ORDER BY parent_id",
-            (task_id,),
-        )
-    ]
+def _links_for(conn: sqlite3.Connection, task_id: str) -> dict[str, Any]:
+    """Return legacy link ids plus typed parent-edge diagnostics."""
+    parent_rows = conn.execute(
+        "SELECT parent_id, gate_type FROM task_links "
+        "WHERE child_id = ? ORDER BY parent_id",
+        (task_id,),
+    ).fetchall()
+    parents = [row["parent_id"] for row in parent_rows]
     children = [
         r["child_id"]
         for r in conn.execute(
@@ -368,7 +367,28 @@ def _links_for(conn: sqlite3.Connection, task_id: str) -> dict[str, list[str]]:
             (task_id,),
         )
     ]
-    return {"parents": parents, "children": children}
+    blockers = {
+        blocker["parent_id"]: blocker
+        for blocker in kanban_db.dependency_blockers(conn, task_id)
+    }
+    parent_links = [
+        {
+            "parent_id": row["parent_id"],
+            "gate_type": row["gate_type"],
+            "gate_state": (
+                blockers[row["parent_id"]]["gate_state"]
+                if row["parent_id"] in blockers
+                else "approved" if row["gate_type"] == kanban_db.APPROVAL_GATE
+                else "satisfied"
+            ),
+        }
+        for row in parent_rows
+    ]
+    return {
+        "parents": parents,
+        "children": children,
+        "parent_links": parent_links,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -602,6 +622,7 @@ class CreateTaskBody(BaseModel):
     workspace_kind: str = "scratch"
     workspace_path: Optional[str] = None
     parents: list[str] = Field(default_factory=list)
+    approval_parents: list[str] = Field(default_factory=list)
     triage: bool = False
     idempotency_key: Optional[str] = None
     max_runtime_seconds: Optional[int] = None
@@ -626,6 +647,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             tenant=payload.tenant,
             priority=payload.priority,
             parents=payload.parents,
+            approval_parents=payload.approval_parents,
             triage=payload.triage,
             idempotency_key=payload.idempotency_key,
             max_runtime_seconds=payload.max_runtime_seconds,
@@ -879,14 +901,16 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     blockers = _parents_blocking_ready(conn, task_id)
                     if blockers:
                         names = ", ".join(
-                            f"{p['title']!r} ({p['id']}, status={p['status']})"
+                            f"{p['title']!r} ({p['id']}, status={p['status']}, "
+                            f"gate={p['gate_type'] or 'ordinary'}, "
+                            f"state={p['gate_state']})"
                             for p in blockers
                         )
                         raise HTTPException(
                             status_code=409,
                             detail=(
-                                f"Cannot move to 'ready': blocked by parent(s) "
-                                f"not done — {names}"
+                                "Cannot move to 'ready': parent dependency "
+                                f"contract not satisfied — {names}"
                             ),
                         )
                 raise HTTPException(
@@ -956,23 +980,25 @@ def delete_task(task_id: str, board: Optional[str] = Query(None)):
 def _parents_blocking_ready(
     conn: sqlite3.Connection, task_id: str,
 ) -> list:
-    """Return parent rows (``id``, ``title``, ``status``) that aren't ``done``
-    and therefore prevent ``task_id`` from being promoted to ``ready``.
-
-    Used to enrich the 409 response from :func:`update_task` so the
-    dashboard can show an actionable toast (#26744) instead of a silent
-    no-op.  Returns ``[]`` when nothing blocks the transition (e.g. no
-    parents, or all parents already done).
-    """
+    """Return sanitized parent rows that currently block ``ready``."""
+    blockers = kanban_db.dependency_blockers(conn, task_id)
+    if not blockers:
+        return []
+    by_id = {blocker["parent_id"]: blocker for blocker in blockers}
+    placeholders = ",".join("?" for _ in by_id)
     rows = conn.execute(
-        "SELECT t.id, t.title, t.status FROM tasks t "
-        "JOIN task_links l ON l.parent_id = t.id "
-        "WHERE l.child_id = ? AND t.status != 'done'",
-        (task_id,),
+        f"SELECT id, title, status FROM tasks WHERE id IN ({placeholders})",
+        tuple(by_id),
     ).fetchall()
     return [
-        {"id": r["id"], "title": r["title"], "status": r["status"]}
-        for r in rows
+        {
+            "id": row["id"],
+            "title": row["title"],
+            "status": row["status"],
+            "gate_type": by_id[row["id"]]["gate_type"],
+            "gate_state": by_id[row["id"]]["gate_state"],
+        }
+        for row in sorted(rows, key=lambda item: item["id"])
     ]
 
 
@@ -1002,15 +1028,11 @@ def _set_status_direct(
         # Prevents the dispatcher from spawning a child whose upstream work
         # hasn't completed (e.g. T4 dispatched while T3 is still blocked).
         if new_status == "ready":
-            parent_statuses = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if parent_statuses and not all(
-                p["status"] == "done" for p in parent_statuses
-            ):
+            blockers = kanban_db.dependency_blockers(conn, task_id)
+            if blockers:
+                kanban_db._append_approval_gate_held_events(
+                    conn, task_id, blockers
+                )
                 return False
 
         was_running = prev["status"] == "running"
@@ -1111,6 +1133,7 @@ def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query
 class LinkBody(BaseModel):
     parent_id: str
     child_id: str
+    gate_type: Optional[str] = None
 
 
 @router.post("/links")
@@ -1118,8 +1141,13 @@ def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        kanban_db.link_tasks(conn, payload.parent_id, payload.child_id)
-        return {"ok": True}
+        kanban_db.link_tasks(
+            conn,
+            payload.parent_id,
+            payload.child_id,
+            gate_type=payload.gate_type,
+        )
+        return {"ok": True, "gate_type": payload.gate_type}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     finally:

--- a/tests/hermes_cli/test_kanban_approval_gates.py
+++ b/tests/hermes_cli/test_kanban_approval_gates.py
@@ -1,0 +1,419 @@
+"""Approval-gated Kanban dependency invariants."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _make_gate(conn):
+    parent = kb.create_task(conn, title="independent review", assignee="otto")
+    child = kb.create_task(conn, title="release candidate", assignee="release")
+    kb.link_tasks(conn, parent, child, gate_type=kb.APPROVAL_GATE)
+    return parent, child
+
+
+def _complete_review(conn, parent, metadata):
+    assert kb.claim_task(conn, parent, claimer="reviewer") is not None
+    assert kb.complete_task(
+        conn,
+        parent,
+        summary="structured review verdict",
+        metadata=metadata,
+    )
+
+
+def _task(conn, task_id) -> kb.Task:
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    return task
+
+
+def _latest_run(conn, task_id) -> kb.Run:
+    run = kb.latest_run(conn, task_id)
+    assert run is not None
+    return run
+
+
+def test_fresh_schema_declares_typed_task_link_column(kanban_home):
+    with kb.connect() as conn:
+        columns = {
+            row["name"]: row
+            for row in conn.execute("PRAGMA table_info(task_links)").fetchall()
+        }
+    assert columns["gate_type"]["type"] == "TEXT"
+
+
+def test_connect_migrates_legacy_task_links_idempotently(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = home / "legacy.db"
+    conn = sqlite3.connect(db_path)
+    legacy_schema = kb.SCHEMA_SQL.replace("    gate_type  TEXT,\n", "")
+    conn.executescript(legacy_schema)
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('p', 'parent', 'done', 1)"
+    )
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('c', 'child', 'todo', 2)"
+    )
+    conn.execute("INSERT INTO task_links (parent_id, child_id) VALUES ('p', 'c')")
+    conn.commit()
+    conn.close()
+
+    for _ in range(2):
+        with kb.connect(db_path) as migrated:
+            columns = {
+                row["name"]
+                for row in migrated.execute("PRAGMA table_info(task_links)").fetchall()
+            }
+            link = migrated.execute(
+                "SELECT parent_id, child_id, gate_type FROM task_links"
+            ).fetchone()
+            assert columns >= {"parent_id", "child_id", "gate_type"}
+            assert dict(link) == {"parent_id": "p", "child_id": "c", "gate_type": None}
+
+
+def test_concurrent_connects_migrate_legacy_task_links_once(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = home / "legacy-concurrent.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(kb.SCHEMA_SQL.replace("    gate_type  TEXT,\n", ""))
+    conn.commit()
+    conn.close()
+
+    def connect_and_read_columns():
+        with kb.connect(db_path) as migrated:
+            return {
+                row["name"]
+                for row in migrated.execute("PRAGMA table_info(task_links)")
+            }
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        columns = list(pool.map(lambda _: connect_and_read_columns(), range(16)))
+
+    assert all("gate_type" in names for names in columns)
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected_state"),
+    [
+        ({"approved": False, "verdict": "FINAL NEEDS_WORK"}, "rejected"),
+        ({"verdict": "APPROVED"}, "approval_missing"),
+        ({"approved": "true", "verdict": "APPROVED"}, "approval_invalid"),
+        (["not", "an", "object"], "metadata_malformed"),
+        ({"approved": True, "verdict": "FINAL NEEDS_WORK"}, "verdict_conflict"),
+        ({"approved": True, "verdict": 1}, "verdict_invalid"),
+    ],
+)
+def test_approval_gate_holds_rejected_missing_malformed_or_conflicting_review(
+    kanban_home, metadata, expected_state
+):
+    with kb.connect() as conn:
+        parent, child = _make_gate(conn)
+        _complete_review(conn, parent, metadata)
+
+        assert _task(conn, parent).status == "done"
+        assert _task(conn, child).status == "todo"
+        assert kb.claim_task(conn, child, claimer="must-not-run") is None
+        assert kb.list_runs(conn, child) == []
+
+        blockers = kb.dependency_blockers(conn, child)
+        assert blockers == [
+            {
+                "parent_id": parent,
+                "gate_type": kb.APPROVAL_GATE,
+                "gate_state": expected_state,
+            }
+        ]
+        held = [event for event in kb.list_events(conn, child) if event.kind == "approval_gate_held"]
+        assert held[-1].payload == {
+            "parent_id": parent,
+            "gate_type": kb.APPROVAL_GATE,
+            "gate_state": expected_state,
+        }
+
+        # Repeated dispatcher ticks remain held without event spam.
+        before = len(held)
+        assert kb.recompute_ready(conn) == 0
+        assert kb.recompute_ready(conn) == 0
+        held = [event for event in kb.list_events(conn, child) if event.kind == "approval_gate_held"]
+        assert len(held) == before
+
+
+def test_approval_gate_holds_ambiguous_reviewer_identity(kanban_home):
+    with kb.connect() as conn:
+        parent, child = _make_gate(conn)
+        _complete_review(conn, parent, {"approved": True, "verdict": "APPROVED"})
+        conn.execute("UPDATE tasks SET assignee = 'different-reviewer' WHERE id = ?", (parent,))
+        conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (child,))
+        assert kb.recompute_ready(conn) == 0
+        assert kb.dependency_blockers(conn, child)[0]["gate_state"] == "identity_ambiguous"
+        assert kb.claim_task(conn, child) is None
+        assert kb.list_runs(conn, child) == []
+
+
+def test_approved_gate_promotes_once_and_preserves_review_metadata(kanban_home):
+    metadata = {
+        "approved": True,
+        "verdict": "FINAL APPROVED",
+        "exact_head": "abc123",
+        "exact_tree": "def456",
+    }
+    with kb.connect() as conn:
+        parent, child = _make_gate(conn)
+        _complete_review(conn, parent, metadata)
+
+        assert _task(conn, child).status == "ready"
+        assert kb.dependency_blockers(conn, child) == []
+        assert kb.recompute_ready(conn) == 0
+        assert _latest_run(conn, parent).metadata == metadata
+
+        first = kb.claim_task(conn, child, claimer="winner")
+        second = kb.claim_task(conn, child, claimer="loser")
+        assert first is not None
+        assert second is None
+        assert len(kb.list_runs(conn, child)) == 1
+
+
+def test_archived_approved_parent_remains_satisfied(kanban_home):
+    with kb.connect() as conn:
+        parent, child = _make_gate(conn)
+        _complete_review(conn, parent, {"approved": True, "verdict": "APPROVED"})
+        assert kb.archive_task(conn, parent)
+        conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (child,))
+
+        assert kb.recompute_ready(conn) == 1
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "ready"
+        assert kb.dependency_blockers(conn, child) == []
+
+
+def test_untyped_remediation_promotes_while_typed_release_stays_held(kanban_home):
+    with kb.connect() as conn:
+        review = kb.create_task(conn, title="review", assignee="otto")
+        release = kb.create_task(conn, title="release", assignee="release")
+        remediation = kb.create_task(conn, title="remediation", assignee="rog")
+        kb.link_tasks(conn, review, release, gate_type=kb.APPROVAL_GATE)
+        kb.link_tasks(conn, review, remediation)
+
+        _complete_review(
+            conn,
+            review,
+            {"approved": False, "verdict": "FINAL NEEDS_WORK"},
+        )
+
+        assert _task(conn, release).status == "todo"
+        assert _task(conn, remediation).status == "ready"
+        assert kb.claim_task(conn, release) is None
+        assert kb.claim_task(conn, remediation) is not None
+
+
+def test_mixed_parent_fan_in_requires_done_ordinary_and_approved_gate(kanban_home):
+    with kb.connect() as conn:
+        review = kb.create_task(conn, title="review", assignee="otto")
+        build = kb.create_task(conn, title="build", assignee="rog")
+        release = kb.create_task(conn, title="release", assignee="release")
+        kb.link_tasks(conn, review, release, gate_type=kb.APPROVAL_GATE)
+        kb.link_tasks(conn, build, release)
+
+        _complete_review(conn, review, {"approved": True, "verdict": "APPROVED"})
+        assert _task(conn, release).status == "todo"
+        assert kb.dependency_blockers(conn, release) == [
+            {"parent_id": build, "gate_type": None, "gate_state": "parent_pending"}
+        ]
+
+        assert kb.complete_task(conn, build, summary="build complete")
+        assert _task(conn, release).status == "ready"
+
+
+def test_claim_and_manual_promote_recheck_gate_after_racy_ready_write(kanban_home):
+    with kb.connect() as conn:
+        parent, child = _make_gate(conn)
+        _complete_review(
+            conn,
+            parent,
+            {"approved": False, "verdict": "FINAL NEEDS_WORK"},
+        )
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child,))
+
+        assert kb.claim_task(conn, child, claimer="racy-dispatch") is None
+        assert _task(conn, child).status == "todo"
+        assert kb.list_runs(conn, child) == []
+
+        promoted, reason = kb.promote_task(
+            conn,
+            child,
+            actor="operator",
+            reason="must remain gated",
+        )
+        assert promoted is False
+        assert reason is not None
+        assert parent in reason
+        assert "rejected" in reason
+        assert kb.list_runs(conn, child) == []
+
+
+@pytest.mark.parametrize("reclaim_mode", ["manual", "stale"])
+def test_reclaim_and_retry_remain_held_if_approval_is_revoked(
+    kanban_home, reclaim_mode
+):
+    with kb.connect() as conn:
+        parent, child = _make_gate(conn)
+        _complete_review(conn, parent, {"approved": True, "verdict": "APPROVED"})
+        assert kb.claim_task(conn, child, claimer="candidate-worker") is not None
+
+        parent_run = kb.latest_run(conn, parent)
+        assert parent_run is not None
+        conn.execute(
+            "UPDATE task_runs SET metadata = ? WHERE id = ?",
+            (
+                json.dumps(
+                    {"approved": False, "verdict": "FINAL NEEDS_WORK"},
+                    separators=(",", ":"),
+                ),
+                parent_run.id,
+            ),
+        )
+
+        if reclaim_mode == "manual":
+            assert kb.reclaim_task(conn, child, reason="review corrected") is True
+        else:
+            conn.execute(
+                "UPDATE tasks SET claim_expires = 0 WHERE id = ?",
+                (child,),
+            )
+            conn.execute(
+                "UPDATE task_runs SET claim_expires = 0 WHERE task_id = ? "
+                "AND ended_at IS NULL",
+                (child,),
+            )
+            assert kb.release_stale_claims(conn) == 1
+
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "todo"
+        assert kb.recompute_ready(conn) == 0
+        assert kb.claim_task(conn, child, claimer="retry") is None
+        runs = kb.list_runs(conn, child)
+        assert len(runs) == 1
+        assert runs[0].outcome == "reclaimed"
+
+
+def test_create_task_supports_explicit_approval_parent(kanban_home):
+    with kb.connect() as conn:
+        review = kb.create_task(conn, title="review", assignee="otto")
+        release = kb.create_task(
+            conn,
+            title="release",
+            assignee="release",
+            approval_parents=[review],
+        )
+        row = conn.execute(
+            "SELECT gate_type FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (review, release),
+        ).fetchone()
+        assert row["gate_type"] == kb.APPROVAL_GATE
+        assert _task(conn, release).status == "todo"
+
+
+def test_dispatcher_does_not_spawn_rejected_approval_child(
+    kanban_home, monkeypatch
+):
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _profile: True)
+    spawned = []
+    with kb.connect() as conn:
+        parent, child = _make_gate(conn)
+        _complete_review(
+            conn,
+            parent,
+            {"approved": False, "verdict": "FINAL NEEDS_WORK"},
+        )
+        # Simulate any external writer or stale dispatcher tick that left the
+        # task in ready. claim_task is the last invariant boundary before spawn.
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child,))
+
+        result = kb.dispatch_once(
+            conn,
+            max_spawn=1,
+            spawn_fn=lambda task, workspace: spawned.append((task.id, workspace)),
+        )
+
+        assert spawned == []
+        assert result.spawned == []
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "todo"
+        assert kb.list_runs(conn, child) == []
+
+
+def test_concurrent_approval_completion_and_claim_never_claims_rejected_child(
+    kanban_home,
+):
+    with kb.connect() as setup:
+        parent, child = _make_gate(setup)
+        assert kb.claim_task(setup, parent, claimer="reviewer") is not None
+
+    def complete_rejected():
+        with kb.connect() as conn:
+            return kb.complete_task(
+                conn,
+                parent,
+                summary="rejected",
+                metadata={"approved": False, "verdict": "FINAL NEEDS_WORK"},
+            )
+
+    def try_claim():
+        claimed = 0
+        for _ in range(20):
+            with kb.connect() as conn:
+                conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child,))
+                if kb.claim_task(conn, child, claimer="racer") is not None:
+                    claimed += 1
+        return claimed
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        completed = pool.submit(complete_rejected)
+        raced = pool.submit(try_claim)
+        assert completed.result() is True
+        assert raced.result() == 0
+
+    with kb.connect() as conn:
+        # One final post-completion attempt proves the second dispatcher tick
+        # also sees the rejected terminal gate rather than the earlier pending
+        # state observed by a racing tick.
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child,))
+        assert kb.claim_task(conn, child, claimer="post-completion") is None
+        assert _task(conn, child).status == "todo"
+        assert kb.list_runs(conn, child) == []
+        assert json.loads(
+            conn.execute(
+                "SELECT payload FROM task_events WHERE task_id = ? "
+                "AND kind = 'claim_rejected' ORDER BY id DESC LIMIT 1",
+                (child,),
+            ).fetchone()["payload"]
+        )["approval_gates"][0]["gate_state"] == "rejected"

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -130,6 +130,30 @@ def test_run_slash_create_with_parent_and_cascade(kanban_home):
     assert "child" in ready_list
 
 
+def test_run_slash_create_with_approval_parent_and_typed_link(kanban_home):
+    with kb.connect() as conn:
+        review = kb.create_task(conn, title="review", assignee="otto")
+
+    out = kc.run_slash(
+        f"create 'release' --assignee release --approval-parent {review}"
+    )
+    assert "todo" in out
+    import re
+    match = re.search(r"(t_[a-f0-9]+)", out)
+    assert match
+    release = match.group(1)
+    with kb.connect() as conn:
+        edge = conn.execute(
+            "SELECT gate_type FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (review, release),
+        ).fetchone()
+        assert edge["gate_type"] == kb.APPROVAL_GATE
+
+        second = kb.create_task(conn, title="second", assignee="release")
+    linked = kc.run_slash(f"link {review} {second} --gate approval")
+    assert "gate=approval" in linked
+
+
 def test_run_slash_show_includes_comments(kanban_home):
     out = kc.run_slash("create 'x'")
     import re

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -85,6 +85,70 @@ def test_board_empty(client):
 # ---------------------------------------------------------------------------
 
 
+def test_dashboard_approval_gate_api_fails_closed_and_reports_state(client):
+    review = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "review", "assignee": "otto"},
+    ).json()["task"]
+    release_response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "release",
+            "assignee": "release",
+            "approval_parents": [review["id"]],
+        },
+    )
+    assert release_response.status_code == 200
+    release = release_response.json()["task"]
+    assert release["status"] == "todo"
+
+    done = client.patch(
+        f"/api/plugins/kanban/tasks/{review['id']}",
+        json={
+            "status": "done",
+            "summary": "FINAL NEEDS_WORK",
+            "metadata": {"approved": False, "verdict": "FINAL NEEDS_WORK"},
+        },
+    )
+    assert done.status_code == 200
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{release['id']}")
+    assert detail.status_code == 200
+    assert detail.json()["links"]["parent_links"] == [
+        {
+            "parent_id": review["id"],
+            "gate_type": "approval",
+            "gate_state": "rejected",
+        }
+    ]
+
+    bypass = client.patch(
+        f"/api/plugins/kanban/tasks/{release['id']}",
+        json={"status": "ready"},
+    )
+    assert bypass.status_code == 409
+    assert review["id"] in bypass.json()["detail"]
+    assert "state=rejected" in bypass.json()["detail"]
+
+    second = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "second", "assignee": "release"},
+    ).json()["task"]
+    linked = client.post(
+        "/api/plugins/kanban/links",
+        json={
+            "parent_id": review["id"],
+            "child_id": second["id"],
+            "gate_type": "approval",
+        },
+    )
+    assert linked.status_code == 200
+    assert linked.json() == {"ok": True, "gate_type": "approval"}
+    assert client.get(
+        f"/api/plugins/kanban/tasks/{second['id']}"
+    ).json()["task"]["status"] == "todo"
+
+
 def test_create_task_appears_on_board(client):
     r = client.post(
         "/api/plugins/kanban/tasks",

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1285,6 +1285,51 @@ def test_link_rejects_self_reference(worker_env):
     assert json.loads(out).get("error")
 
 
+def test_create_and_link_support_explicit_approval_gates(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    created = json.loads(kt._handle_create({
+        "title": "release",
+        "assignee": "release",
+        "approval_parents": [worker_env],
+    }))
+    assert created["ok"] is True
+    with kb.connect() as conn:
+        row = conn.execute(
+            "SELECT gate_type FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (worker_env, created["task_id"]),
+        ).fetchone()
+        assert row["gate_type"] == kb.APPROVAL_GATE
+
+        second = kb.create_task(conn, title="second release", assignee="release")
+    linked = json.loads(kt._handle_link({
+        "parent_id": worker_env,
+        "child_id": second,
+        "gate_type": "approval",
+    }))
+    assert linked == {
+        "ok": True,
+        "parent_id": worker_env,
+        "child_id": second,
+        "gate_type": "approval",
+    }
+
+
+def test_link_rejects_unknown_gate_type(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        child = kb.create_task(conn, title="child", assignee="x")
+    out = kt._handle_link({
+        "parent_id": worker_env,
+        "child_id": child,
+        "gate_type": "prose-review",
+    })
+    assert "gate_type" in json.loads(out)["error"]
+
+
 def test_link_rejects_missing_args(worker_env):
     from tools import kanban_tools as kt
     assert json.loads(kt._handle_link({"parent_id": "x"})).get("error")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1074,6 +1074,7 @@ def _handle_create(args: dict, **kw) -> str:
         )
     body = args.get("body")
     parents = args.get("parents") or []
+    approval_parents = args.get("approval_parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
     # Stamp the originating session id when the agent loop runs under
     # ACP (which sets HERMES_SESSION_ID before invoking tools). NULL on
@@ -1117,6 +1118,13 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(
             f"parents must be a list of task ids, got {type(parents).__name__}"
         )
+    if isinstance(approval_parents, str):
+        approval_parents = [approval_parents]
+    if not isinstance(approval_parents, (list, tuple)):
+        return tool_error(
+            "approval_parents must be a list of task ids, got "
+            f"{type(approval_parents).__name__}"
+        )
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -1140,6 +1148,7 @@ def _handle_create(args: dict, **kw) -> str:
                 body=body,
                 assignee=str(assignee),
                 parents=tuple(parents),
+                approval_parents=tuple(approval_parents),
                 tenant=tenant,
                 priority=int(priority) if priority is not None else 0,
                 workspace_kind=str(workspace_kind),
@@ -1308,14 +1317,24 @@ def _handle_link(args: dict, **kw) -> str:
     """Add a parent→child dependency edge after the fact."""
     parent_id = args.get("parent_id")
     child_id = args.get("child_id")
+    gate_type = args.get("gate_type")
     if not parent_id or not child_id:
         return tool_error("both parent_id and child_id are required")
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
         try:
-            kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)
-            return _ok(parent_id=parent_id, child_id=child_id)
+            kb.link_tasks(
+                conn,
+                parent_id=parent_id,
+                child_id=child_id,
+                gate_type=gate_type,
+            )
+            return _ok(
+                parent_id=parent_id,
+                child_id=child_id,
+                gate_type=gate_type,
+            )
         finally:
             conn.close()
     except ValueError as e:
@@ -1750,11 +1769,22 @@ KANBAN_CREATE_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Parent task ids. The new task stays in 'todo' "
+                    "Ordinary parent task ids. The new task stays in 'todo' "
                     "until every parent reaches 'done'; then it "
                     "auto-promotes to 'ready'. Typical fan-in: list "
                     "all the researcher task ids when creating a "
                     "synthesizer task."
+                ),
+            },
+            "approval_parents": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Review parent task ids whose edges are explicit approval "
+                    "gates. The child remains held unless each parent has a "
+                    "terminal completed run with unambiguous structured "
+                    "approved=true metadata. Rejected, missing, malformed, or "
+                    "conflicting review metadata fails closed."
                 ),
             },
             "tenant": {
@@ -1905,6 +1935,15 @@ KANBAN_LINK_SCHEMA = {
         "properties": {
             "parent_id": {"type": "string", "description": "Parent task id."},
             "child_id":  {"type": "string", "description": "Child task id."},
+            "gate_type": {
+                "type": "string",
+                "enum": ["approval"],
+                "description": (
+                    "Optional typed edge contract. 'approval' fails closed "
+                    "until the parent has an unambiguous completed review with "
+                    "structured approved=true metadata."
+                ),
+            },
             "board": _board_schema_prop(),
         },
         "required": ["parent_id", "child_id"],


### PR DESCRIPTION
## Summary

Fixes #67132.

Kanban now supports an explicit `approval` contract on selected parent→child dependency edges. Untyped edges preserve the existing done/archived semantics, while approval-gated edges fail closed until the parent has a terminal completed run with unambiguous structured `approved: true` metadata.

This prevents rejected or ambiguous reviews from releasing candidate/release children without redefining ordinary dependencies or blocking remediation fan-out.

## What changed

- Add additive, idempotent `task_links.gate_type` SQLite migration (`NULL` keeps legacy behavior).
- Add `approval_parents` to task creation and `gate_type="approval"` to link creation across DB, CLI, model tool, and dashboard API surfaces.
- Centralize dependency evaluation in `dependency_blockers()` and enforce it in:
  - create/link/recompute
  - atomic claim immediately before spawn
  - manual promote (approval gates cannot be force-bypassed)
  - unblock and dashboard/bulk ready transitions
  - stale/manual reclaim paths
- Validate approval from structured terminal-run metadata only; never parse titles, comments, summaries, or prose verdicts.
- Fail closed for rejected, missing, malformed, non-boolean, identity-ambiguous, or contradictory verdict metadata.
- Emit deduplicated, sanitized `approval_gate_held` events with only parent ID, gate type, and gate state.
- Surface typed parent-edge state in dashboard task detail responses.

## Compatibility

- Existing databases migrate additively.
- Existing untyped links remain unchanged.
- Approved archived review parents remain satisfied.
- Untyped remediation children still run after a rejected review.
- No dependencies or runtime configuration changed.

## RED proof on pre-fix main

A temporary DB with a proposed typed marker reproduced the bug before implementation:

```text
before_parent_completion=todo
after_rejected_parent_completion=ready
claim_created=True
child_run_count=1
```

## Verification

All commands were run after rebasing onto upstream `main` at `73e32f37e7bde4f5528ab04b5b6356bcf00d0af0` and with Kanban board environment pins removed so tests used temporary databases.

```text
315 passed
  tests/hermes_cli/test_kanban_approval_gates.py
  tests/hermes_cli/test_kanban_cli.py
  tests/tools/test_kanban_tools.py
  tests/plugins/test_kanban_dashboard_plugin.py
  tests/hermes_cli/test_kanban_promote.py

447 passed
  tests/hermes_cli/test_kanban_db.py
  tests/hermes_cli/test_kanban_core_functionality.py
  tests/hermes_cli/test_kanban_goal_mode.py
  tests/hermes_cli/test_kanban_dispatch_lock.py
  tests/hermes_cli/test_kanban_block_kinds.py
  tests/plugins/test_kanban_worker_runs.py

69 passed
  migration-lock, reclaim-lock, sticky-block, lifecycle-hook,
  decomposition/default-assignee, and gateway dispatcher/watcher suites

python -m ruff check <changed files>
All checks passed!

git diff --check
passed

python -m ty check tests/hermes_cli/test_kanban_approval_gates.py
All checks passed!
```

The repository-wide type checker still reports existing diagnostics in pre-existing Kanban files outside this change (for example the known `judge_goal` tuple mismatch); this PR does not expand that unrelated scope.

## Safety

- No installed Hermes upgrade/restart.
- No live schema rollout.
- No dependency additions.
