### PR TITLE
fix(installer): refresh mutable Windows bootstrap cache safely

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -395,6 +395,7 @@ async fn run_bootstrap(
         ScriptSource::DevCheckout => "dev checkout",
         ScriptSource::Bundled => "bundled",
         ScriptSource::Cached => "cached",
+        ScriptSource::CachedFallback => "stale cache fallback",
         ScriptSource::Downloaded => "downloaded",
     };
     emit_log(&format!(

--- a/apps/bootstrap-installer/src-tauri/src/install_script.rs
+++ b/apps/bootstrap-installer/src-tauri/src/install_script.rs
@@ -15,9 +15,16 @@
 
 use anyhow::{anyhow, Context, Result};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tokio::io::AsyncWriteExt;
+use uuid::Uuid;
 
 use crate::paths;
+
+const RAW_GITHUB_BASE: &str = "https://raw.githubusercontent.com/NousResearch/hermes-agent";
+const DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DOWNLOAD_READ_TIMEOUT: Duration = Duration::from_secs(20);
+const DOWNLOAD_TOTAL_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Identity of the install.ps1 we'll execute. Used by both the manifest
 /// fetch and the per-stage runs.
@@ -36,6 +43,7 @@ pub enum ScriptSource {
     DevCheckout,
     Bundled,
     Cached,
+    CachedFallback,
     Downloaded,
 }
 
@@ -81,7 +89,9 @@ pub async fn resolve(
 ) -> Result<ResolvedScript> {
     // 1. Dev shortcut.
     if let Ok(repo_root) = std::env::var("HERMES_SETUP_DEV_REPO_ROOT") {
-        let candidate = PathBuf::from(repo_root).join("scripts").join(kind.filename());
+        let candidate = PathBuf::from(repo_root)
+            .join("scripts")
+            .join(kind.filename());
         if candidate.exists() {
             emit_log(&format!(
                 "[bootstrap] dev mode — using local {} at {}",
@@ -99,10 +109,44 @@ pub async fn resolve(
 
     // 2. (Not implemented) bundled fallback.
 
-    // 3. Network. Pin must be a real commit or a branch ref.
-    let commit_or_ref = match (&pin.commit, &pin.branch) {
-        (Some(c), _) if is_valid_commit(c) => c.clone(),
-        (_, Some(b)) if !b.trim().is_empty() => b.clone(),
+    resolve_network(
+        kind,
+        pin,
+        &paths::bootstrap_cache_dir(),
+        RAW_GITHUB_BASE,
+        emit_log,
+    )
+    .await
+}
+
+async fn resolve_network(
+    kind: ScriptKind,
+    pin: &Pin,
+    cache_dir: &Path,
+    raw_base_url: &str,
+    emit_log: &impl Fn(&str),
+) -> Result<ResolvedScript> {
+    let client = download_client(
+        DOWNLOAD_CONNECT_TIMEOUT,
+        DOWNLOAD_READ_TIMEOUT,
+        DOWNLOAD_TOTAL_TIMEOUT,
+    )?;
+    resolve_network_with_client(kind, pin, cache_dir, raw_base_url, emit_log, &client).await
+}
+
+async fn resolve_network_with_client(
+    kind: ScriptKind,
+    pin: &Pin,
+    cache_dir: &Path,
+    raw_base_url: &str,
+    emit_log: &impl Fn(&str),
+    client: &reqwest::Client,
+) -> Result<ResolvedScript> {
+    // Only a valid commit is immutable. Branches and tags are moving refs and
+    // therefore must be refreshed before each install/update run.
+    let (commit_or_ref, immutable) = match (&pin.commit, &pin.branch) {
+        (Some(c), _) if is_valid_commit(c) => (c.clone(), true),
+        (_, Some(b)) if !b.trim().is_empty() => (b.clone(), false),
         (Some(other), _) => {
             return Err(anyhow!(
                 "install script pin commit `{other}` is not a valid git SHA"
@@ -115,10 +159,10 @@ pub async fn resolve(
         }
     };
 
-    let cached = cached_path(kind, &commit_or_ref);
-    if cached.exists() {
+    let cached = cached_path_in(cache_dir, kind, &commit_or_ref);
+    if immutable && cached.exists() {
         emit_log(&format!(
-            "[bootstrap] using cached {} for {}",
+            "[bootstrap] using immutable cached {} for commit {}",
             kind.filename(),
             truncate_ref(&commit_or_ref)
         ));
@@ -131,21 +175,58 @@ pub async fn resolve(
     }
 
     emit_log(&format!(
-        "[bootstrap] downloading {} for {} from GitHub",
+        "[bootstrap] downloading {} for {} {} from GitHub",
         kind.filename(),
+        if immutable { "commit" } else { "mutable ref" },
         truncate_ref(&commit_or_ref)
     ));
 
-    download(kind, &commit_or_ref, &cached).await?;
-
-    emit_log(&format!("[bootstrap] cached to {}", cached.display()));
-
-    Ok(ResolvedScript {
-        path: cached,
-        source: ScriptSource::Downloaded,
-        commit: pin.commit.clone(),
-        branch: pin.branch.clone(),
-    })
+    match download(
+        kind,
+        &commit_or_ref,
+        &cached,
+        raw_base_url.trim_end_matches('/'),
+        client,
+    )
+    .await
+    {
+        Ok(()) => {
+            emit_log(&format!("[bootstrap] cached to {}", cached.display()));
+            Ok(ResolvedScript {
+                path: cached,
+                source: ScriptSource::Downloaded,
+                commit: pin.commit.clone(),
+                branch: pin.branch.clone(),
+            })
+        }
+        Err(err) if !immutable && cached.exists() => {
+            emit_log(&format!(
+                "[bootstrap] WARNING: refresh failed for mutable ref {}; using stale cached {} at {} as explicit network fallback: {err:#}",
+                truncate_ref(&commit_or_ref),
+                kind.filename(),
+                cached.display()
+            ));
+            Ok(ResolvedScript {
+                path: cached,
+                source: ScriptSource::CachedFallback,
+                commit: pin.commit.clone(),
+                branch: pin.branch.clone(),
+            })
+        }
+        Err(err) => Err(err).with_context(|| {
+            if immutable {
+                format!(
+                    "no cached install script is available for immutable commit {}",
+                    truncate_ref(&commit_or_ref)
+                )
+            } else {
+                format!(
+                    "refresh failed for mutable ref {} and no cached fallback is available",
+                    truncate_ref(&commit_or_ref)
+                )
+            }
+        }),
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -154,13 +235,13 @@ pub struct Pin {
     pub branch: Option<String>,
 }
 
-fn cached_path(kind: ScriptKind, commit_or_ref: &str) -> PathBuf {
+fn cached_path_in(cache_dir: &Path, kind: ScriptKind, commit_or_ref: &str) -> PathBuf {
     let safe = sanitize_ref(commit_or_ref);
     let filename = match kind {
         ScriptKind::Ps1 => format!("install-{safe}.ps1"),
         ScriptKind::Sh => format!("install-{safe}.sh"),
     };
-    paths::bootstrap_cache_dir().join(filename)
+    cache_dir.join(filename)
 }
 
 /// Replace anything that's not [A-Za-z0-9._-] with `_`. Branch refs can
@@ -187,28 +268,26 @@ fn truncate_ref(s: &str) -> &str {
 
 /// Downloads to `dest_path` via reqwest with rustls. Atomically renames
 /// `dest_path.tmp` → `dest_path` so partial writes don't poison the cache.
-async fn download(kind: ScriptKind, commit_or_ref: &str, dest_path: &Path) -> Result<()> {
+async fn download(
+    kind: ScriptKind,
+    commit_or_ref: &str,
+    dest_path: &Path,
+    raw_base_url: &str,
+    client: &reqwest::Client,
+) -> Result<()> {
     let url = format!(
-        "https://raw.githubusercontent.com/NousResearch/hermes-agent/{}/scripts/{}",
+        "{}/{}/scripts/{}",
+        raw_base_url,
         commit_or_ref,
         kind.filename()
     );
 
     if let Some(parent) = dest_path.parent() {
-        std::fs::create_dir_all(parent).with_context(|| {
-            format!("creating bootstrap-cache parent dir {}", parent.display())
-        })?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating bootstrap-cache parent dir {}", parent.display()))?;
     }
 
-    let tmp_path = dest_path.with_extension({
-        let ext = dest_path
-            .extension()
-            .and_then(|s| s.to_str())
-            .unwrap_or("tmp");
-        format!("{ext}.tmp")
-    });
-
-    let response = reqwest::Client::new()
+    let response = client
         .get(&url)
         .header("User-Agent", "hermes-setup/0.0.1")
         .send()
@@ -229,31 +308,116 @@ async fn download(kind: ScriptKind, commit_or_ref: &str, dest_path: &Path) -> Re
         .await
         .with_context(|| format!("reading body of {url}"))?;
 
+    let tmp_path = dest_path.with_extension({
+        let ext = dest_path
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("tmp");
+        format!("{ext}.{}.tmp", Uuid::new_v4())
+    });
+
     let mut file = tokio::fs::File::create(&tmp_path)
         .await
         .with_context(|| format!("creating temp file {}", tmp_path.display()))?;
-    file.write_all(&bytes)
-        .await
-        .with_context(|| format!("writing temp file {}", tmp_path.display()))?;
-    file.flush().await.context("flushing temp file")?;
+    if let Err(err) = file.write_all(&bytes).await {
+        drop(file);
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(err).with_context(|| format!("writing temp file {}", tmp_path.display()));
+    }
+    if let Err(err) = file.flush().await {
+        drop(file);
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(err).context("flushing temp file");
+    }
     drop(file);
 
-    tokio::fs::rename(&tmp_path, dest_path)
+    if let Err(err) = atomic_replace(&tmp_path, dest_path).await {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+fn download_client(
+    connect_timeout: Duration,
+    read_timeout: Duration,
+    total_timeout: Duration,
+) -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .read_timeout(read_timeout)
+        .timeout(total_timeout)
+        .build()
+        .context("building install-script HTTP client")
+}
+
+#[cfg(not(target_os = "windows"))]
+async fn atomic_replace(tmp_path: &Path, dest_path: &Path) -> Result<()> {
+    tokio::fs::rename(tmp_path, dest_path)
         .await
         .with_context(|| {
             format!(
-                "renaming {} → {}",
+                "atomically renaming {} → {}",
                 tmp_path.display(),
                 dest_path.display()
             )
-        })?;
+        })
+}
 
-    Ok(())
+#[cfg(target_os = "windows")]
+async fn atomic_replace(tmp_path: &Path, dest_path: &Path) -> Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn MoveFileExW(
+            existing_file_name: *const u16,
+            new_file_name: *const u16,
+            flags: u32,
+        ) -> i32;
+    }
+
+    let src: Vec<u16> = tmp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let dst: Vec<u16> = dest_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let moved = unsafe {
+        MoveFileExW(
+            src.as_ptr(),
+            dst.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if moved == 0 {
+        Err(std::io::Error::last_os_error()).with_context(|| {
+            format!(
+                "atomically replacing {} with {}",
+                dest_path.display(),
+                tmp_path.display()
+            )
+        })
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
 
     #[test]
     fn is_valid_commit_accepts_short_and_full_shas() {
@@ -269,5 +433,194 @@ mod tests {
         assert_eq!(sanitize_ref("bb/gui"), "bb_gui");
         assert_eq!(sanitize_ref("main"), "main");
         assert_eq!(sanitize_ref("release/1.2.3"), "release_1.2.3");
+    }
+
+    fn test_cache_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("hermes-install-script-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn serve_once(status: &str, body: &[u8], declared_length: Option<usize>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_string();
+        let body = body.to_vec();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request);
+            let content_length = declared_length.unwrap_or(body.len());
+            write!(
+                stream,
+                "HTTP/1.1 {status}\r\nContent-Length: {content_length}\r\nConnection: close\r\n\r\n"
+            )
+            .unwrap();
+            stream.write_all(&body).unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    fn serve_silent_once() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            let (_stream, _) = listener.accept().unwrap();
+            thread::sleep(Duration::from_secs(5));
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn immutable_commit_reuses_cache_without_network() {
+        let cache_dir = test_cache_dir();
+        let pin = Pin {
+            commit: Some("02d26981d3d4".into()),
+            branch: Some("main".into()),
+        };
+        let cached = cached_path_in(&cache_dir, ScriptKind::Ps1, pin.commit.as_ref().unwrap());
+        std::fs::write(&cached, b"cached commit").unwrap();
+        let logs = std::sync::Mutex::new(Vec::new());
+
+        let resolved = resolve_network(
+            ScriptKind::Ps1,
+            &pin,
+            &cache_dir,
+            "http://127.0.0.1:9",
+            &|line| logs.lock().unwrap().push(line.to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved.source, ScriptSource::Cached);
+        assert_eq!(std::fs::read(&cached).unwrap(), b"cached commit");
+        assert!(logs.lock().unwrap().join("\n").contains("immutable cached"));
+        let _ = std::fs::remove_dir_all(cache_dir);
+    }
+
+    #[tokio::test]
+    async fn mutable_ref_refreshes_and_atomically_replaces_old_cache() {
+        let cache_dir = test_cache_dir();
+        let pin = Pin {
+            commit: None,
+            branch: Some("main".into()),
+        };
+        let cached = cached_path_in(&cache_dir, ScriptKind::Ps1, "main");
+        std::fs::write(&cached, b"old script").unwrap();
+        let server = serve_once("200 OK", b"new script", None);
+
+        let resolved = resolve_network(ScriptKind::Ps1, &pin, &cache_dir, &server, &|_| {})
+            .await
+            .unwrap();
+
+        assert_eq!(resolved.source, ScriptSource::Downloaded);
+        assert_eq!(std::fs::read(&cached).unwrap(), b"new script");
+        assert_eq!(
+            std::fs::read_dir(&cache_dir).unwrap().count(),
+            1,
+            "temporary download must not remain in the cache"
+        );
+        let _ = std::fs::remove_dir_all(cache_dir);
+    }
+
+    #[tokio::test]
+    async fn mutable_ref_uses_explicit_stale_fallback_on_download_failure() {
+        let cache_dir = test_cache_dir();
+        let pin = Pin {
+            commit: None,
+            branch: Some("main".into()),
+        };
+        let cached = cached_path_in(&cache_dir, ScriptKind::Ps1, "main");
+        std::fs::write(&cached, b"old script").unwrap();
+        let server = serve_once("503 Service Unavailable", b"", None);
+        let logs = std::sync::Mutex::new(Vec::new());
+
+        let resolved = resolve_network(ScriptKind::Ps1, &pin, &cache_dir, &server, &|line| {
+            logs.lock().unwrap().push(line.to_string())
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(resolved.source, ScriptSource::CachedFallback);
+        assert_eq!(std::fs::read(&cached).unwrap(), b"old script");
+        let joined = logs.lock().unwrap().join("\n");
+        assert!(joined.contains("WARNING"));
+        assert!(joined.contains("explicit network fallback"));
+        let _ = std::fs::remove_dir_all(cache_dir);
+    }
+
+    #[tokio::test]
+    async fn mutable_ref_without_cache_fails_closed() {
+        let cache_dir = test_cache_dir();
+        let pin = Pin {
+            commit: None,
+            branch: Some("main".into()),
+        };
+        let server = serve_once("503 Service Unavailable", b"", None);
+
+        let err = resolve_network(ScriptKind::Ps1, &pin, &cache_dir, &server, &|_| {})
+            .await
+            .unwrap_err();
+
+        assert!(format!("{err:#}").contains("no cached fallback is available"));
+        assert_eq!(std::fs::read_dir(&cache_dir).unwrap().count(), 0);
+        let _ = std::fs::remove_dir_all(cache_dir);
+    }
+
+    #[tokio::test]
+    async fn interrupted_mutable_download_does_not_poison_old_cache() {
+        let cache_dir = test_cache_dir();
+        let pin = Pin {
+            commit: None,
+            branch: Some("main".into()),
+        };
+        let cached = cached_path_in(&cache_dir, ScriptKind::Ps1, "main");
+        std::fs::write(&cached, b"known-good script").unwrap();
+        let server = serve_once("200 OK", b"partial", Some(128));
+
+        let resolved = resolve_network(ScriptKind::Ps1, &pin, &cache_dir, &server, &|_| {})
+            .await
+            .unwrap();
+
+        assert_eq!(resolved.source, ScriptSource::CachedFallback);
+        assert_eq!(std::fs::read(&cached).unwrap(), b"known-good script");
+        assert_eq!(std::fs::read_dir(&cache_dir).unwrap().count(), 1);
+        let _ = std::fs::remove_dir_all(cache_dir);
+    }
+
+    #[tokio::test]
+    async fn silent_server_times_out_and_preserves_mutable_fallback() {
+        let cache_dir = test_cache_dir();
+        let pin = Pin {
+            commit: None,
+            branch: Some("main".into()),
+        };
+        let cached = cached_path_in(&cache_dir, ScriptKind::Ps1, "main");
+        std::fs::write(&cached, b"known-good script").unwrap();
+        let server = serve_silent_once();
+        let client = download_client(
+            Duration::from_millis(100),
+            Duration::from_millis(200),
+            Duration::from_millis(300),
+        )
+        .unwrap();
+        let resolved = tokio::time::timeout(
+            Duration::from_secs(2),
+            resolve_network_with_client(
+                ScriptKind::Ps1,
+                &pin,
+                &cache_dir,
+                &server,
+                &|_| {},
+                &client,
+            ),
+        )
+        .await
+        .expect("silent endpoint must not block the installer")
+        .unwrap();
+
+        assert_eq!(resolved.source, ScriptSource::CachedFallback);
+        assert_eq!(std::fs::read(&cached).unwrap(), b"known-good script");
+        let _ = std::fs::remove_dir_all(cache_dir);
     }
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,6 +16,7 @@ param(
     [switch]$NoVenv,
     [switch]$SkipSetup,
     [string]$Branch = "main",
+    [string]$PythonVersion = "3.11",
     # -Commit and -Tag are higher-precedence variants of -Branch for users
     # who need reproducible installs (desktop installer pinning, CI, release
     # bundles).  When set, the repository stage clones $Branch (faster than
@@ -138,7 +139,6 @@ foreach ($tmpVar in @('TEMP', 'TMP')) {
 
 $RepoUrlSsh = "git@github.com:NousResearch/hermes-agent.git"
 $RepoUrlHttps = "https://github.com/NousResearch/hermes-agent.git"
-$PythonVersion = "3.11"
 # Minor versions the installer accepts when the requested $PythonVersion isn't
 # available, in preference order.  uv discovers both uv-managed and system
 # interpreters, so this list also matches a pre-existing system Python.  Single
@@ -443,7 +443,7 @@ function Get-PowerShellHostExe {
 }
 
 function Install-Uv {
-    # Hermes owns its own uv at $HermesHome\bin\uv.exe.  Always install there —
+    # Hermes owns its own uv at $HermesHome\bin\uv.exe.  Always install there --
     # no PATH probing, no conda guards, no multi-location resolution chains.
     # The runtime update path (hermes_cli/managed_uv.py) looks in the same
     # place, so install.ps1 and `hermes update` stay in sync.
@@ -528,7 +528,7 @@ function Ensure-NodeExeOnPath {
 # prior process is not visible here.  Later stages (Test-Python,
 # Install-Venv, Install-Dependencies, Install-PlatformSdks) call this
 # at the top to populate $script:UvCmd from the managed location.
-# Throws if uv is not findable — the caller's stage then surfaces a
+# Throws if uv is not findable -- the caller's stage then surfaces a
 # clean error via the stage-driver's try/catch.
 function Resolve-UvCmd {
     # Already resolved (default invocation path: Install-Uv ran earlier
@@ -544,7 +544,7 @@ function Resolve-UvCmd {
         # Stale; fall through to re-discover.
     }
 
-    # Check the managed location first — this is where Install-Uv puts it.
+    # Check the managed location first -- this is where Install-Uv puts it.
     $managedUv = Join-Path $HermesHome "bin\uv.exe"
     if (Test-Path $managedUv) {
         $script:UvCmd = $managedUv
@@ -1516,7 +1516,7 @@ function Install-Repository {
                     if ($LASTEXITCODE -ne 0) { throw "git checkout $Branch failed (exit $LASTEXITCODE)" }
                     # Managed installs should follow origin/$Branch exactly. If
                     # the checkout has diverged (or has local-only commits),
-                    # ff-only pull cannot succeed — mirror ``hermes update`` and
+                    # ff-only pull cannot succeed -- mirror ``hermes update`` and
                     # reset to the fetched remote so bootstrap/install can recover.
                     git -c windows.appendAtomically=false pull --ff-only origin $Branch
                     if ($LASTEXITCODE -ne 0) {
@@ -1573,11 +1573,11 @@ function Install-Repository {
                                 Write-Host ""
                                 Write-Host "Conflicted files:"
                                 foreach ($file in $conflictedFiles) {
-                                    Write-Host "  • $file"
+                                    Write-Host "  * $file"
                                 }
                             }
                             Write-Host ""
-                            Write-Info "Your stashed changes are preserved — nothing is lost."
+                            Write-Info "Your stashed changes are preserved -- nothing is lost."
                             Write-Info "  Stash ref: $autostashRef"
                             git -c windows.appendAtomically=false reset --hard HEAD 2>$null | Out-Null
                             Write-Info "Working tree reset to clean state."
@@ -1779,6 +1779,7 @@ function Install-Venv {
     # exits. Populated only with tasks that were ENABLED before we touched
     # them, so a task the user deliberately disabled is never re-armed.
     $gatewayTasksDisabled = @()
+    $gatewayWrappersQuarantined = @()
     try {
     if (Test-Path "venv") {
         Write-Info "Virtual environment already exists, recreating..."
@@ -1798,23 +1799,80 @@ function Install-Venv {
             # /End stops a running task instance; /Change /DISABLE stops it
             # from re-firing mid-install. (The Startup-folder .vbs fallback is
             # NOT touched: it only fires at logon, so it cannot respawn a
-            # gateway mid-install.) Re-enabled in the finally below — including
-            # on failure — but only for tasks that were enabled to begin with.
+            # gateway mid-install.) Re-enabled in the finally below -- including
+            # on failure -- but only for tasks that were enabled to begin with.
             # Best-effort: a missing task just errors quietly.
             try {
-                schtasks /Query /FO CSV 2>$null | ConvertFrom-Csv | Where-Object { $_.TaskName -like '*Hermes_Gateway*' } | ForEach-Object {
-                    $tn = $_.TaskName
-                    if ($_.Status -eq 'Disabled') {
-                        Write-Info "  gateway autostart task $tn is already disabled; leaving it that way"
+                # Use the ScheduledTasks objects instead of parsing schtasks'
+                # localized CSV headers. TaskName/TaskPath and Settings.Enabled
+                # are stable on non-English Windows installations.
+                Get-ScheduledTask -TaskName 'Hermes_Gateway*' -ErrorAction SilentlyContinue | ForEach-Object {
+                    $task = $_
+                    $taskLabel = "$($task.TaskPath)$($task.TaskName)"
+                    if (-not $task.Settings.Enabled -or $task.State -eq 'Disabled') {
+                        Write-Info "  gateway autostart task $taskLabel is already disabled; leaving it that way"
                         return
                     }
-                    schtasks /End /TN $tn 2>$null | Out-Null
-                    schtasks /Change /TN $tn /DISABLE 2>$null | Out-Null
-                    $gatewayTasksDisabled += $tn
-                    Write-Info "  disabled gateway autostart task $tn for the duration of the install"
+                    Stop-ScheduledTask -TaskName $task.TaskName -TaskPath $task.TaskPath -ErrorAction SilentlyContinue
+                    try {
+                        Disable-ScheduledTask -TaskName $task.TaskName -TaskPath $task.TaskPath -ErrorAction Stop | Out-Null
+                        $gatewayTasksDisabled += @{
+                            TaskName = $task.TaskName
+                            TaskPath = $task.TaskPath
+                        }
+                        Write-Info "  disabled gateway autostart task $taskLabel for the duration of the install"
+                    } catch {
+                        # Non-admin users can query/run their own Hermes tasks
+                        # but some machines deny changing task definitions.
+                        # In that case atomically move only verified Hermes
+                        # gateway-service wrappers out of the task's path. The
+                        # still-enabled task can fire, but it has nothing to
+                        # execute until finally restores the wrapper.
+                        $servicePrefix = [System.IO.Path]::GetFullPath((Join-Path $HermesHome "gateway-service")).TrimEnd('\') + '\'
+                        $taskActions = @($task.Actions)
+                        if ($taskActions.Count -eq 0) {
+                            throw "task $taskLabel has no executable action to quarantine"
+                        }
+                        foreach ($action in $taskActions) {
+                            $expandedAction = [Environment]::ExpandEnvironmentVariables([string]$action.Execute).Trim('"')
+                            $actionLeaf = [System.IO.Path]::GetFileName($expandedAction)
+                            $wrapperPath = $null
+                            if ($actionLeaf -ieq 'wscript.exe') {
+                                # Current Hermes tasks invoke the console-less
+                                # VBS launcher through wscript.exe. Extract only
+                                # an explicitly quoted .vbs argument; never move
+                                # wscript.exe itself.
+                                $arguments = [Environment]::ExpandEnvironmentVariables([string]$action.Arguments)
+                                $vbsMatch = [regex]::Match($arguments, '"([^"]+\.vbs)"', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+                                if (-not $vbsMatch.Success) {
+                                    throw "task $taskLabel uses wscript.exe without a quoted Hermes VBS launcher"
+                                }
+                                $wrapperPath = [System.IO.Path]::GetFullPath($vbsMatch.Groups[1].Value)
+                            } else {
+                                # Legacy tasks execute the generated CMD wrapper
+                                # directly. Preserve this upgrade path.
+                                $wrapperPath = [System.IO.Path]::GetFullPath($expandedAction)
+                            }
+                            $wrapperLeaf = [System.IO.Path]::GetFileName($wrapperPath)
+                            if (
+                                -not $wrapperPath.StartsWith($servicePrefix, [System.StringComparison]::OrdinalIgnoreCase) -or
+                                $wrapperLeaf -notmatch '^Hermes_Gateway.*\.(cmd|vbs)$' -or
+                                -not (Test-Path -LiteralPath $wrapperPath)
+                            ) {
+                                throw "refusing to quarantine unverified task wrapper for $taskLabel`: $wrapperPath"
+                            }
+                            $quarantinePath = "$wrapperPath.hermes-update-disabled-$myPid"
+                            Move-Item -LiteralPath $wrapperPath -Destination $quarantinePath -ErrorAction Stop
+                            $gatewayWrappersQuarantined += @{
+                                Original = $wrapperPath
+                                Quarantine = $quarantinePath
+                            }
+                            Write-Warn "  task definition could not be disabled; quarantined verified wrapper $wrapperPath"
+                        }
+                    }
                 }
             } catch {
-                Write-Warn "Could not enumerate gateway scheduled tasks: $($_.Exception.Message)"
+                throw "Could not safely contain gateway scheduled tasks: $($_.Exception.Message)"
             }
             # The launcher CLI (hermes.exe) plus its child tree.
             & taskkill /F /T /IM hermes.exe /FI "PID ne $myPid" 2>$null | Out-Null
@@ -1840,24 +1898,202 @@ function Install-Venv {
             # the window between one kill pass and the delete. Each pass re-
             # enumerates; three consecutive clean passes (or the attempt cap)
             # ends the loop.
+            $installPrefix = [System.IO.Path]::GetFullPath($InstallDir).TrimEnd('\') + '\'
             $venvPrefix = [System.IO.Path]::GetFullPath((Join-Path $InstallDir "venv")).TrimEnd('\') + '\'
+            $externalRuntimeNames = @('python.exe', 'pythonw.exe', 'uv.exe')
+            function ConvertTo-ProcessCreationUtc {
+                param($Value)
+                if ($null -eq $Value) { return $null }
+                if ($Value -is [DateTime]) { return $Value.ToUniversalTime() }
+                try {
+                    return [System.Management.ManagementDateTimeConverter]::ToDateTime([string]$Value).ToUniversalTime()
+                } catch {
+                    return $null
+                }
+            }
             $cleanPasses = 0
             for ($sweep = 0; $sweep -lt 10 -and $cleanPasses -lt 3; $sweep++) {
                 $found = 0
                 try {
-                    Get-CimInstance Win32_Process -ErrorAction Stop |
-                        Where-Object { $_.ProcessId -ne $myPid -and $_.ExecutablePath -and $_.ExecutablePath.StartsWith($venvPrefix, [System.StringComparison]::OrdinalIgnoreCase) } |
-                        ForEach-Object {
-                            $found++
-                            Write-Info "  stopping PID $($_.ProcessId) ($($_.Name)) running from venv"
-                            Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+                    $processSnapshot = @(Get-CimInstance Win32_Process -ErrorAction Stop | Where-Object {
+                        $_.ProcessId -ne $myPid
+                    })
+                    $holderPids = New-Object 'System.Collections.Generic.HashSet[int]'
+                    $holderReasons = @{}
+                    $holderIdentities = @{}
+
+                    # First identify process seeds with direct, checkout-specific
+                    # evidence. Do not kill yet: the complete snapshot is needed
+                    # to discover uv trampoline descendants transitively.
+                    $processSnapshot | ForEach-Object {
+                        $proc = $_
+                        $reason = $null
+                        $exePath = $proc.ExecutablePath
+
+                        # Directly resident processes are always in scope.
+                        if ($exePath -and $exePath.StartsWith($venvPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                            $reason = "executable is inside the Hermes venv"
+                        } elseif ($exePath -and $exePath.StartsWith($installPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                            $reason = "executable is inside the Hermes checkout"
+                        } elseif ($externalRuntimeNames -contains $proc.Name.ToLowerInvariant()) {
+                            # uv can launch the base interpreter outside venv.
+                            # Require checkout-specific evidence before touching
+                            # any external python/uv process.
+                            $commandLine = $proc.CommandLine
+                            if ($commandLine -and (
+                                $commandLine.IndexOf($venvPrefix.TrimEnd('\'), [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+                                $commandLine.IndexOf($installPrefix.TrimEnd('\'), [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+                            )) {
+                                $reason = "command line references the Hermes checkout or venv"
+                            } else {
+                                try {
+                                    $loadedHermesModule = Get-Process -Id $proc.ProcessId -ErrorAction Stop |
+                                        Select-Object -ExpandProperty Modules |
+                                        Where-Object {
+                                            $_.FileName -and (
+                                                $_.FileName.StartsWith($venvPrefix, [System.StringComparison]::OrdinalIgnoreCase) -or
+                                                $_.FileName.StartsWith($installPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+                                            )
+                                        } |
+                                        Select-Object -First 1
+                                    if ($loadedHermesModule) {
+                                        $reason = "loaded module $($loadedHermesModule.FileName) belongs to Hermes"
+                                    }
+                                } catch {
+                                    # An unreadable external runtime is not
+                                    # enough evidence to terminate it.
+                                }
+                            }
                         }
+
+                        if ($reason) {
+                            $candidatePid = [int]$proc.ProcessId
+                            $creationUtc = ConvertTo-ProcessCreationUtc $proc.CreationDate
+                            [void]$holderPids.Add($candidatePid)
+                            $holderReasons[$candidatePid] = $reason
+                            $holderIdentities[$candidatePid] = @{
+                                CreationTicks = $(if ($creationUtc) { $creationUtc.Ticks } else { $null })
+                                ParentProcessId = [int]$proc.ParentProcessId
+                                ParentCreationTicks = $null
+                                Name = [string]$proc.Name
+                            }
+                        }
+                    }
+
+                    # A uv shim may live inside venv while its real python child
+                    # is the base interpreter outside venv with a path-free
+                    # command line. ParentProcessId is strong evidence here:
+                    # recursively include every descendant of a proven seed.
+                    $changed = $true
+                    while ($changed) {
+                        $changed = $false
+                        foreach ($proc in $processSnapshot) {
+                            $candidatePid = [int]$proc.ProcessId
+                            $parentPid = [int]$proc.ParentProcessId
+                            $candidateName = ([string]$proc.Name).ToLowerInvariant()
+                            if (
+                                -not $holderPids.Contains($candidatePid) -and
+                                $holderPids.Contains($parentPid) -and
+                                $externalRuntimeNames -contains $candidateName
+                            ) {
+                                $parentIdentity = $holderIdentities[$parentPid]
+                                $candidateCreationUtc = ConvertTo-ProcessCreationUtc $proc.CreationDate
+                                if (
+                                    $null -eq $parentIdentity.CreationTicks -or
+                                    $null -eq $candidateCreationUtc
+                                ) {
+                                    throw "Cannot safely classify PID $candidatePid as a Hermes descendant because process creation time is unavailable"
+                                }
+                                if ([int64]$parentIdentity.CreationTicks -gt [int64]$candidateCreationUtc.Ticks) {
+                                    Write-Warn "  parent PID $parentPid was created after child PID $candidatePid; treating the parent PID as reused"
+                                    continue
+                                }
+                                [void]$holderPids.Add($candidatePid)
+                                $holderReasons[$candidatePid] = "descendant of Hermes holder PID $parentPid"
+                                $holderIdentities[$candidatePid] = @{
+                                    CreationTicks = $candidateCreationUtc.Ticks
+                                    ParentProcessId = $parentPid
+                                    ParentCreationTicks = $parentIdentity.CreationTicks
+                                    Name = [string]$proc.Name
+                                }
+                                $changed = $true
+                            }
+                        }
+                    }
+
+                    # Stop descendants before their proven parent seeds. The
+                    # parent identity is part of a descendant's safety check;
+                    # killing the parent first would make that check fail
+                    # closed even though the child is still the holder we need
+                    # to release.
+                    $terminationOrder = @($processSnapshot | Sort-Object -Property @{
+                        Expression = {
+                            $identity = $holderIdentities[[int]$_.ProcessId]
+                            if ($null -ne $identity -and $null -ne $identity.ParentCreationTicks) { 0 } else { 1 }
+                        }
+                    })
+                    foreach ($proc in $terminationOrder) {
+                        $candidatePid = [int]$proc.ProcessId
+                        if ($holderPids.Contains($candidatePid)) {
+                            # Re-query immediately before termination. PIDs are
+                            # reusable; CreationDate + parent + image identity
+                            # must still match the snapshot that established the
+                            # Hermes relationship.
+                            $current = Get-CimInstance Win32_Process -Filter "ProcessId = $candidatePid" -ErrorAction Stop |
+                                Select-Object -First 1
+                            $identity = $holderIdentities[$candidatePid]
+                            $currentCreationUtc = if ($current) {
+                                ConvertTo-ProcessCreationUtc $current.CreationDate
+                            } else {
+                                $null
+                            }
+                            if (
+                                $current -and (
+                                    $null -eq $identity.CreationTicks -or
+                                    $null -eq $currentCreationUtc
+                                )
+                            ) {
+                                throw "Cannot safely revalidate PID $candidatePid because process creation time is unavailable"
+                            }
+                            if (
+                                $current -and
+                                [int]$current.ProcessId -eq $candidatePid -and
+                                [int64]$currentCreationUtc.Ticks -eq [int64]$identity.CreationTicks -and
+                                [int]$current.ParentProcessId -eq $identity.ParentProcessId -and
+                                [string]$current.Name -eq $identity.Name
+                            ) {
+                                $parentStillMatches = $true
+                                if ($null -ne $identity.ParentCreationTicks) {
+                                    $currentParent = Get-CimInstance Win32_Process -Filter "ProcessId = $($identity.ParentProcessId)" -ErrorAction Stop |
+                                        Select-Object -First 1
+                                    $currentParentCreationUtc = if ($currentParent) {
+                                        ConvertTo-ProcessCreationUtc $currentParent.CreationDate
+                                    } else {
+                                        $null
+                                    }
+                                    $parentStillMatches = $currentParent -and $currentParentCreationUtc -and
+                                        [int64]$currentParentCreationUtc.Ticks -eq [int64]$identity.ParentCreationTicks
+                                }
+                                if ($parentStillMatches) {
+                                    $found++
+                                    Write-Info "  stopping PID $candidatePid ($($proc.Name)): $($holderReasons[$candidatePid])"
+                                    Stop-Process -Id $candidatePid -Force -ErrorAction SilentlyContinue
+                                } else {
+                                    Write-Warn "  parent PID $($identity.ParentProcessId) changed identity during holder sweep; skipping PID $candidatePid"
+                                }
+                            } else {
+                                Write-Warn "  PID $candidatePid changed identity during holder sweep; skipping termination"
+                            }
+                        }
+                    }
                 } catch {
-                    Write-Warn "Could not enumerate venv processes: $($_.Exception.Message)"
-                    break
+                    throw "Could not safely enumerate Hermes venv holders: $($_.Exception.Message)"
                 }
                 if ($found -eq 0) { $cleanPasses++ } else { $cleanPasses = 0 }
                 Start-Sleep -Milliseconds 400
+            }
+            if ($cleanPasses -lt 3) {
+                throw "Hermes venv holder sweep did not reach three consecutive clean passes; refusing to remove the environment"
             }
         }
         # Rename-then-delete: on Windows a directory RENAME succeeds even while
@@ -1893,7 +2129,7 @@ function Install-Venv {
     }
 
     # Clean up parked venvs from previous installs whose handles have since
-    # been released. Best-effort — a still-held tree just stays for next time.
+    # been released. Best-effort -- a still-held tree just stays for next time.
     Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue | ForEach-Object {
         Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
     }
@@ -1925,18 +2161,36 @@ function Install-Venv {
     }
     } finally {
         Pop-Location
+        # Restore wrapper paths before re-enabling any task definitions. These
+        # are same-volume renames, so the task never observes a partial script.
+        foreach ($wrapper in $gatewayWrappersQuarantined) {
+            if (Test-Path -LiteralPath $wrapper.Quarantine) {
+                Move-Item -LiteralPath $wrapper.Quarantine -Destination $wrapper.Original -ErrorAction SilentlyContinue
+            }
+        }
+        if ($gatewayWrappersQuarantined.Count -gt 0) {
+            $unrestored = @($gatewayWrappersQuarantined | Where-Object {
+                -not (Test-Path -LiteralPath $_.Original)
+            })
+            if ($unrestored.Count -gt 0) {
+                Write-Warn "One or more gateway wrappers could not be restored; restore *.hermes-update-disabled-$myPid files under $HermesHome\gateway-service"
+            } else {
+                Write-Info "Restored quarantined gateway task wrapper(s)"
+            }
+        }
         # Re-arm the gateway autostart tasks disabled during the venv teardown
-        # — in a finally so a failed teardown/creation can never strand the
+        # -- in a finally so a failed teardown/creation can never strand the
         # user's gateway autostart in the disabled state. Same function scope,
         # so the list survives even under the stage-per-process bootstrap.
-        # Deliberately NOT started here — dependencies aren't installed yet;
+        # Deliberately NOT started here -- dependencies aren't installed yet;
         # the task fires normally on next logon and `hermes update` / the
         # gateway resume path handles the immediate restart.
         if ($gatewayTasksDisabled -and $gatewayTasksDisabled.Count -gt 0) {
-            foreach ($tn in $gatewayTasksDisabled) {
-                schtasks /Change /TN $tn /ENABLE 2>$null | Out-Null
+            foreach ($task in $gatewayTasksDisabled) {
+                Enable-ScheduledTask -TaskName $task.TaskName -TaskPath $task.TaskPath -ErrorAction SilentlyContinue | Out-Null
             }
-            Write-Info "Re-enabled gateway autostart task(s): $($gatewayTasksDisabled -join ', ')"
+            $restoredTaskNames = @($gatewayTasksDisabled | ForEach-Object { "$($_.TaskPath)$($_.TaskName)" })
+            Write-Info "Re-enabled gateway autostart task(s): $($restoredTaskNames -join ', ')"
         }
     }
 
@@ -2247,7 +2501,7 @@ function Set-PathVariable {
 function Write-BootstrapMarker {
     # Writes $InstallDir\.hermes-bootstrap-complete which tells the Hermes
     # desktop app (apps/desktop/electron/main.ts) "install.ps1 ran
-    # successfully — DON'T trigger the legacy first-launch bootstrap
+    # successfully -- DON'T trigger the legacy first-launch bootstrap
     # runner."
     #
     # Schema mirrors what main.ts's writeBootstrapMarker() / isBootstrap
@@ -2268,7 +2522,7 @@ function Write-BootstrapMarker {
     # Resolve the pinned commit: explicit -Commit wins, otherwise read
     # the checkout's HEAD via git. If git can't run, leave commit empty
     # and the marker will fail desktop validation (pinnedCommit.length
-    # >= 7) — better to be invalid than wrong.
+    # >= 7) -- better to be invalid than wrong.
     $pinnedCommit = $Commit
     if (-not $pinnedCommit) {
         # PS 5.1 doesn't support the ?. null-conditional operator, so
@@ -2283,7 +2537,7 @@ function Write-BootstrapMarker {
                     $pinnedCommit = $resolved.Trim()
                 }
             } catch {
-                # Ignore — pinnedCommit stays empty, marker stays invalid,
+                # Ignore -- pinnedCommit stays empty, marker stays invalid,
                 # desktop falls through to its legacy bootstrap path.
             } finally {
                 Pop-Location
@@ -2302,7 +2556,7 @@ function Write-BootstrapMarker {
         pinnedCommit  = $pinnedCommit
         pinnedBranch  = $pinnedBranch
         completedAt   = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
-        # desktopVersion field intentionally omitted — only the desktop
+        # desktopVersion field intentionally omitted -- only the desktop
         # app knows its own version, and the marker validator doesn't
         # require it. The desktop fills it in if/when it writes its
         # own marker (e.g. after a future in-app upgrade).
@@ -2311,7 +2565,7 @@ function Write-BootstrapMarker {
 
     # Write WITHOUT a UTF-8 BOM. PowerShell 5.1's `Set-Content -Encoding UTF8`
     # always emits a BOM, and Node's plain JSON.parse rejects the BOM as an
-    # unexpected character — so a BOM'd marker would silently fail the
+    # unexpected character -- so a BOM'd marker would silently fail the
     # desktop's readJson(), make isBootstrapComplete() return null, and the
     # desktop would re-run the legacy bootstrap runner anyway. Defeats the
     # whole point. Use the .NET API directly for BOM-less UTF-8.
@@ -2411,7 +2665,7 @@ function Install-NodeDeps {
         # Cross-process driver mode (Hermes-Setup.exe runs each -Stage NAME
         # in a fresh powershell.exe) means $script:HasNode set by Stage-Node
         # in the previous process isn't visible here. Re-probe rather than
-        # trust the stale global — Stage-Node already ran successfully or
+        # trust the stale global -- Stage-Node already ran successfully or
         # the bootstrap would've aborted, so npm is reachable.
         if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
             Write-Info "Skipping Node.js dependencies (Node not installed)"
@@ -2688,7 +2942,7 @@ function Clear-ElectronBuildCache {
 # Last-resort Electron mirror after GitHub download fails (#47266).
 $script:DesktopElectronFallbackMirror = "https://npmmirror.com/mirrors/electron/"
 
-# Electron package dir — workspace-local nest first, then root hoist.
+# Electron package dir -- workspace-local nest first, then root hoist.
 function Get-ElectronDir {
     param([string]$InstallDir)
     $desktopLocal = Join-Path $InstallDir 'apps\desktop\node_modules\electron'
@@ -2769,7 +3023,7 @@ function Install-Desktop {
     #
     # The Tauri bootstrap installer's launch_hermes_desktop command
     # resolves apps/desktop/release/win-unpacked/Hermes.exe directly,
-    # so an "unpacked" build (electron-builder --dir) is enough — we
+    # so an "unpacked" build (electron-builder --dir) is enough -- we
     # don't need to produce an NSIS/MSI artifact here.
 
     # Always re-resolve Node here. Stages run in separate PowerShell processes,
@@ -2823,7 +3077,7 @@ function Install-Desktop {
         #
         # The streaming sink in bootstrap.rs's run_install_script
         # captures every stdout/stderr line as it's emitted, so we don't
-        # need a side TEMP log file — the installer's bootstrap log
+        # need a side TEMP log file -- the installer's bootstrap log
         # IS the artifact a support engineer reads.
         #
         # Prefer `npm ci`: it wipes node_modules and reinstalls from the
@@ -2878,7 +3132,7 @@ function Install-Desktop {
     # NOT signing the output. Combined with signAndEditExecutable=false in
     # apps/desktop/package.json's build.win block, electron-builder never
     # invokes signtool and therefore never fetches/extracts winCodeSign
-    # (whose macOS symlinks crash 7-Zip on non-admin Windows — a dead end we
+    # (whose macOS symlinks crash 7-Zip on non-admin Windows -- a dead end we
     # are NOT trying to work around). The Hermes icon + product name are
     # stamped onto Hermes.exe by our own rcedit step (Set-DesktopExeIdentity)
     # AFTER this build, completely decoupled from electron-builder signing.
@@ -2949,7 +3203,7 @@ function Install-Desktop {
         Pop-Location
         throw
     } finally {
-        # Restore env to whatever the caller had — don't leak our
+        # Restore env to whatever the caller had -- don't leak our
         # signing-off override into anything install.ps1 invokes later
         # (Stage-PlatformSdks, etc.).
         $env:CSC_IDENTITY_AUTO_DISCOVERY = $prevCSCAuto
@@ -2980,7 +3234,7 @@ function Install-Desktop {
 
     # 3b. The Hermes icon + identity are stamped onto Hermes.exe by the
     #     electron-builder `afterPack` hook (apps/desktop/scripts/after-pack.mjs)
-    #     during `npm run pack` above — for every build, so the installer's
+    #     during `npm run pack` above -- for every build, so the installer's
     #     --update rebuild stays branded too. No separate stamp step needed here.
     #     electron-builder's own rcedit step stays disabled (signAndEditExecutable
     #     =false) because enabling it drags in signtool -> winCodeSign -> the
@@ -2990,7 +3244,7 @@ function Install-Desktop {
     #     directory. Chromium's GPU/renderer sandboxes CHECK-fail with
     #     0x80000003 when this ACE is missing alongside orphan AppContainer
     #     SIDs under %LOCALAPPDATA% (electron/electron#51761, hermes-agent#38216).
-    #     Best-effort — never fail an otherwise-good install over ACL repair.
+    #     Best-effort -- never fail an otherwise-good install over ACL repair.
     try {
         $appDir = Split-Path -Parent $desktopExe
         & icacls $appDir /grant "*S-1-15-2-2:(OI)(CI)(RX)" /T /C /Q | Out-Null
@@ -3006,7 +3260,7 @@ function Install-Desktop {
     # 4. Create Start Menu + Desktop shortcuts pointing DIRECTLY at the packed
     #    Hermes.exe. We deliberately do NOT point them at `hermes desktop`: that
     #    command rebuilds (npm install + electron-builder) on every launch,
-    #    which would cost minutes each time. The packed exe is the consumer —
+    #    which would cost minutes each time. The packed exe is the consumer --
     #    launching it directly is instant, and updates flow through the
     #    installer's --update path (which rebuilds once, then relaunches).
     New-DesktopShortcuts -TargetExe $desktopExe
@@ -3062,11 +3316,11 @@ function New-DesktopShortcuts {
         # cached bitmap. Critical on the --update path: the exe was re-stamped
         # with the Hermes icon, but without this the shortcut can keep drawing
         # the old Electron icon until the user manually refreshes / reboots.
-        # Best-effort and silent — never fail the install over a cosmetic cache.
+        # Best-effort and silent -- never fail the install over a cosmetic cache.
         try {
             & ie4uinit.exe -show 2>$null
         } catch {
-            # ie4uinit may be absent/renamed on some SKUs — ignore.
+            # ie4uinit may be absent/renamed on some SKUs -- ignore.
         }
     } catch {
         Write-Warn "Skipping shortcut creation: $($_.Exception.Message)"
@@ -3446,6 +3700,8 @@ $InstallStages += @(
     # caller (GUI / CI) handles the equivalent UX themselves.
     @{ Name = "configure";        Title = "Configuring API keys and models";      Category = "post-install"; NeedsUserInput = $true;  Worker = "Stage-Configure" }
     @{ Name = "gateway";          Title = "Starting messaging gateway";           Category = "post-install"; NeedsUserInput = $true;  Worker = "Stage-Gateway" }
+    # Must remain last: reaching this stage proves every prior stage succeeded.
+    @{ Name = "bootstrap-cache";  Title = "Refreshing installer cache policy";    Category = "post-install"; NeedsUserInput = $false; Worker = "Stage-BootstrapCache" }
 )
 
 # Stage workers -- thin wrappers that delegate to the existing Install-* /
@@ -3490,6 +3746,7 @@ function Stage-PlatformSdks     { Resolve-UvCmd; Install-PlatformSdks }
 function Stage-BootstrapMarker  { Write-BootstrapMarker }
 function Stage-Configure        { Invoke-SetupWizard }
 function Stage-Gateway          { Start-GatewayIfConfigured }
+function Stage-BootstrapCache   { Remove-MutableBootstrapScriptCache }
 
 function Get-InstallStage {
     param([string]$Name)
@@ -3626,6 +3883,35 @@ function Invoke-PostInstallMode {
     Write-Info "Running post-install setup..."
     Invoke-EnsureMode -Deps "node,browser"
     Write-Info "Post-install complete"
+}
+
+function Remove-MutableBootstrapScriptCache {
+    # Commit-pinned scripts are immutable and intentionally retained forever.
+    # A branch/tag cache is only a network fallback. Delete it after every
+    # successful staged run so even an older signed bootstrapper that still
+    # treats "cache exists" as authoritative is forced to fetch on next run.
+    if ($Commit -and $Commit -match '^[0-9a-fA-F]{7,40}$') {
+        Write-Info "Keeping immutable commit-pinned bootstrap script cache"
+        return
+    }
+    if (-not $Branch) {
+        return
+    }
+
+    $safeRef = [regex]::Replace($Branch, '[^A-Za-z0-9._-]', '_')
+    $cachePath = Join-Path $HermesHome "bootstrap-cache\install-$safeRef.ps1"
+    if (-not (Test-Path -LiteralPath $cachePath)) {
+        return
+    }
+
+    try {
+        Remove-Item -LiteralPath $cachePath -Force -ErrorAction Stop
+        Write-Info "Evicted mutable bootstrap script cache: $cachePath"
+    } catch {
+        # The installation itself is already complete. A sharing violation here
+        # must be visible, but must not roll back a healthy install.
+        Write-Warn "Could not evict mutable bootstrap script cache $cachePath`: $($_.Exception.Message)"
+    }
 }
 
 function Main {

--- a/tests/test_install_ps1_windows_update_guards.py
+++ b/tests/test_install_ps1_windows_update_guards.py
@@ -1,0 +1,280 @@
+"""Behavioral regression coverage for Windows install/update guards."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+POWERSHELL = shutil.which("powershell")
+UV = shutil.which("uv")
+PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+
+def _run_powershell(
+    args: list[str],
+    *,
+    timeout: int = 60,
+    cwd: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    assert POWERSHELL is not None
+    return subprocess.run(
+        [POWERSHELL, "-NoProfile", "-ExecutionPolicy", "Bypass", *args],
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+        cwd=cwd,
+    )
+
+
+@pytest.mark.skipif(POWERSHELL is None, reason="Windows PowerShell unavailable")
+def test_manifest_executes_under_windows_powershell_51_file_mode() -> None:
+    result = _run_powershell(["-File", str(INSTALL_PS1), "-Manifest"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["protocol_version"] >= 1
+    assert payload["stages"][-1]["name"] == "bootstrap-cache"
+
+
+@pytest.mark.skipif(POWERSHELL is None, reason="Windows PowerShell unavailable")
+def test_mutable_cache_stage_can_evict_the_current_script(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "bootstrap-cache"
+    cache_dir.mkdir()
+    cached_script = cache_dir / "install-main.ps1"
+    shutil.copy2(INSTALL_PS1, cached_script)
+
+    result = _run_powershell(
+        [
+            "-File",
+            str(cached_script),
+            "-Stage",
+            "bootstrap-cache",
+            "-Json",
+            "-NonInteractive",
+            "-HermesHome",
+            str(tmp_path),
+            "-InstallDir",
+            str(tmp_path / "hermes-agent"),
+            "-Branch",
+            "main",
+        ]
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not cached_script.exists()
+
+
+@pytest.mark.skipif(POWERSHELL is None, reason="Windows PowerShell unavailable")
+def test_commit_pinned_cache_is_retained(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "bootstrap-cache"
+    cache_dir.mkdir()
+    cached_script = cache_dir / "install-main.ps1"
+    shutil.copy2(INSTALL_PS1, cached_script)
+
+    result = _run_powershell(
+        [
+            "-File",
+            str(cached_script),
+            "-Stage",
+            "bootstrap-cache",
+            "-Json",
+            "-NonInteractive",
+            "-HermesHome",
+            str(tmp_path),
+            "-InstallDir",
+            str(tmp_path / "hermes-agent"),
+            "-Branch",
+            "main",
+            "-Commit",
+            "02d26981d3d4",
+        ]
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert cached_script.exists()
+
+
+@pytest.mark.skipif(
+    POWERSHELL is None or UV is None,
+    reason="Windows PowerShell or managed uv unavailable",
+)
+def test_non_admin_task_fallback_and_uv_trampoline_descendant(tmp_path: Path) -> None:
+    hermes_home = tmp_path / "hermes-home"
+    install_dir = hermes_home / "hermes-agent"
+    venv_scripts = install_dir / "venv" / "Scripts"
+    service_dir = hermes_home / "gateway-service"
+    bin_dir = hermes_home / "bin"
+    for directory in (venv_scripts, service_dir, bin_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    # The venv only needs to exist so Install-Venv enters its teardown path.
+    (venv_scripts / "placeholder.txt").write_text("old", encoding="ascii")
+    legacy_wrapper = service_dir / "Hermes_Gateway_Legacy.cmd"
+    modern_wrapper = service_dir / "Hermes_Gateway.vbs"
+    legacy_wrapper.write_text("@echo off\r\nexit /b 0\r\n", encoding="ascii")
+    modern_wrapper.write_text("WScript.Quit 0\r\n", encoding="ascii")
+    shutil.copy2(UV, bin_dir / "uv.exe")
+
+    runtime_root = tmp_path / "runtime"
+    temp_dir = runtime_root / "temp"
+    local_app_data = runtime_root / "local-app-data"
+    user_profile = runtime_root / "user-profile"
+    uv_python_dir = runtime_root / "uv-python"
+    uv_cache_dir = runtime_root / "uv-cache"
+    for directory in (
+        runtime_root,
+        temp_dir,
+        local_app_data,
+        user_profile,
+        uv_python_dir,
+        uv_cache_dir,
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    repo_artifacts_before = {
+        path.name
+        for pattern in ("%SystemDrive%", "Python", "python_install_*.log")
+        for path in REPO_ROOT.glob(pattern)
+    }
+    stopped_log = tmp_path / "stopped.txt"
+    containment_log = tmp_path / "contained.txt"
+    harness = tmp_path / "harness.ps1"
+    harness.write_text(
+        f"""
+$env:OS = 'Windows_NT'
+$env:SystemDrive = '{runtime_root}'
+$env:TEMP = '{temp_dir}'
+$env:TMP = '{temp_dir}'
+$env:LOCALAPPDATA = '{local_app_data}'
+$env:USERPROFILE = '{user_profile}'
+$env:UV_PYTHON_INSTALL_DIR = '{uv_python_dir}'
+$env:UV_CACHE_DIR = '{uv_cache_dir}'
+$env:UV_PYTHON = '{Path(sys.executable)}'
+$env:UV_PYTHON_DOWNLOADS = 'never'
+$global:alive = @{{ 100 = $true; 101 = $true; 102 = $true; 103 = $true; 104 = $true }}
+$global:legacyWrapper = '{legacy_wrapper}'
+$global:modernWrapper = '{modern_wrapper}'
+$global:stoppedLog = '{stopped_log}'
+$global:containmentLog = '{containment_log}'
+
+function global:Get-ScheduledTask {{
+    @(
+        [pscustomobject]@{{
+            TaskName = 'Hermes_Gateway_Legacy'
+            TaskPath = '\\'
+            State = 'Running'
+            Settings = [pscustomobject]@{{ Enabled = $true }}
+            Actions = @([pscustomobject]@{{
+                Execute = $global:legacyWrapper
+                Arguments = ''
+            }})
+        }},
+        [pscustomobject]@{{
+            TaskName = 'Hermes_Gateway'
+            TaskPath = '\\'
+            State = 'Ready'
+            Settings = [pscustomobject]@{{ Enabled = $true }}
+            Actions = @([pscustomobject]@{{
+                Execute = 'wscript.exe'
+                Arguments = '//B //Nologo "' + $global:modernWrapper + '"'
+            }})
+        }}
+    )
+}}
+function global:Stop-ScheduledTask {{ }}
+function global:Disable-ScheduledTask {{ throw 'Access is denied' }}
+function global:Enable-ScheduledTask {{ }}
+function global:taskkill {{ }}
+function global:Get-Process {{ throw 'module enumeration denied' }}
+function global:Stop-Process {{
+    param([int]$Id)
+    Add-Content -LiteralPath $global:stoppedLog -Value $Id
+    $global:alive.Remove($Id)
+}}
+function global:New-MockProcess {{
+    param([int]$MockId, [switch]$Reused)
+    switch ($MockId) {{
+        100 {{ return [pscustomobject]@{{
+            ProcessId = 100; ParentProcessId = 1; CreationDate = [datetime]'2026-07-18T12:00:00Z'
+            Name = 'uv.exe'; ExecutablePath = '{venv_scripts / "uv.exe"}'; CommandLine = 'uv run gateway'
+        }} }}
+        101 {{ return [pscustomobject]@{{
+            ProcessId = 101; ParentProcessId = 100; CreationDate = [datetime]'2026-07-18T12:00:01Z'
+            Name = 'python.exe'; ExecutablePath = 'C:\\Python311\\python.exe'
+            CommandLine = 'python.exe -m hermes_cli.main gateway run'
+        }} }}
+        102 {{ return [pscustomobject]@{{
+            ProcessId = 102; ParentProcessId = 101; CreationDate = [datetime]'2026-07-18T12:00:02Z'
+            Name = 'helper.exe'; ExecutablePath = 'C:\\Tools\\helper.exe'; CommandLine = 'helper.exe'
+        }} }}
+        103 {{ return [pscustomobject]@{{
+            ProcessId = 103; ParentProcessId = 100
+            CreationDate = $(if ($Reused) {{ [datetime]'2026-07-18T13:00:03Z' }} else {{ [datetime]'2026-07-18T12:00:03Z' }})
+            Name = 'pythonw.exe'; ExecutablePath = 'C:\\Python311\\pythonw.exe'
+            CommandLine = 'pythonw.exe -m hermes_cli.main gateway run'
+        }} }}
+        104 {{ return [pscustomobject]@{{
+            ProcessId = 104; ParentProcessId = 100; CreationDate = [datetime]'2026-07-18T11:59:59Z'
+            Name = 'python.exe'; ExecutablePath = 'C:\\Python311\\python.exe'
+            CommandLine = 'python.exe -m hermes_cli.main gateway run'
+        }} }}
+    }}
+}}
+function global:Get-CimInstance {{
+    param([string]$ClassName, [string]$Filter)
+    if (
+        -not (Test-Path -LiteralPath $global:legacyWrapper) -and
+        -not (Test-Path -LiteralPath $global:modernWrapper)
+    ) {{
+        Set-Content -LiteralPath $global:containmentLog -Value 'wrapper-quarantined'
+    }}
+    if ($Filter -match 'ProcessId = (\d+)') {{
+        $requested = [int]$matches[1]
+        if (-not $global:alive.ContainsKey($requested)) {{ return $null }}
+        if ($requested -eq 103) {{ return New-MockProcess -MockId 103 -Reused }}
+        return New-MockProcess -MockId $requested
+    }}
+    $items = @()
+    foreach ($mockId in @(100, 101, 102, 103, 104)) {{
+        if ($global:alive.ContainsKey($mockId)) {{
+            $items += New-MockProcess -MockId $mockId
+        }}
+    }}
+    return $items
+}}
+
+& '{INSTALL_PS1}' -Stage venv -Json -NonInteractive `
+    -HermesHome '{hermes_home}' -InstallDir '{install_dir}' -Branch main `
+    -PythonVersion '{PYTHON_VERSION}'
+""",
+        encoding="ascii",
+    )
+
+    result = _run_powershell(["-File", str(harness)], timeout=120, cwd=tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert legacy_wrapper.exists(), "the legacy CMD wrapper must be restored"
+    assert modern_wrapper.exists(), "the modern VBS launcher must be restored"
+    assert containment_log.read_text(encoding="ascii").strip() == "wrapper-quarantined"
+    assert stopped_log.exists(), result.stdout + result.stderr
+    stopped = {int(line) for line in stopped_log.read_text(encoding="ascii").splitlines()}
+    assert stopped == {100, 101}, (
+        "only the proven uv seed and unchanged python trampoline may be stopped; "
+        "a non-runtime child, a reused PID, and a child older than its parent "
+        "must be preserved"
+    )
+    repo_artifacts_after = {
+        path.name
+        for pattern in ("%SystemDrive%", "Python", "python_install_*.log")
+        for path in REPO_ROOT.glob(pattern)
+    }
+    assert repo_artifacts_after == repo_artifacts_before


### PR DESCRIPTION
## What does this PR do?

Corrige a cadeia de atualização do instalador Windows para que cache de branch mutável, holders do venv e falhas de rede não deixem uma instalação parcial nem reutilizem indefinidamente um script congelado.

## Related Issue

Related to #47557, #47910, and #51682 (the existing Windows venv-lock failure class).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/bootstrap-installer/src-tauri/src/install_script.rs`
  - Reutiliza cache permanentemente somente para SHA/commit imutável.
  - Atualiza refs mutáveis de branch/tag com substituição atômica.
  - Usa fallback stale explícito e auditável somente quando a rede falha.
  - Mantém o cache anterior intacto em download interrompido e aplica timeouts de conexão/leitura/total.
- `scripts/install.ps1`
  - Compatibiliza o script com Windows PowerShell 5.1.
  - Desarma tasks Hermes quando possível; quando não há permissão, quarentena apenas wrappers CMD/VBS verificados dentro de `gateway-service`.
  - Detecta holders no venv e trampolines externos do `uv`, limita descendentes a runtimes Python/uv, valida CreationDate/identidade antes de encerrar e revalida em três passagens.
  - Restaura tasks/wrappers em `finally`, move o venv antigo para quarentena e remove cache mutável após sucesso.
- `tests/test_install_ps1_windows_update_guards.py`
  - Exercita manifest real em PowerShell 5.1, evicção/preservação de cache, task CMD/VBS sem privilégio e árvore uv→python com PID reutilizado/parent chronology.
  - Mantém todos os artefatos de teste em diretórios temporários.

A lacuna de ciclo de vida do updater assinado permanece explicitamente documentada: o executável instalado não se autoatualiza quando a implementação do updater muda; este patch endurece o script/cache que o updater resolve e não substitui o binário assinado.

## How to Test

1. `cargo test --manifest-path apps/bootstrap-installer/src-tauri/Cargo.toml` — 34 passed.
2. `scripts/run_tests.sh tests/test_install_ps1_windows_update_guards.py -q` — 4 passed (o runner imprime um erro cosmético de encoding CP1252 após o resumo, mas retorna sucesso).
3. PowerShell 5.1 parser — 0 errors; `git diff --check` — clean.
4. `npm.cmd run test:desktop:platforms` — 455/459 passed on this Windows host; 3 existing platform/cleanup tests fail under the host's POSIX-path/git-temp assumptions (no files touched by this PR).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the relevant tests for my changes
- [x] I've tested on my platform: Windows PowerShell 5.1

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] N/A for documentation/config/schema changes

## Screenshots / Logs

The sanitized reproduction is the Windows venv-stage failure caused by a loaded native extension and a stale branch cache. No personal paths, credentials, tokens, or user data are included.