### PR TITLE
feat(providers): OpenClaw-parity OpenAI-compatible model providers

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -550,6 +550,14 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
         # Hostname match (not substring) so e.g. evil.com/palantirfoundry
         # paths don't trigger Bearer auth.
         or base_url_host_matches(normalized, "palantirfoundry.com")
+        # Amazon Bedrock Mantle Anthropic route
+        # (bedrock-mantle.<region>.api.aws/anthropic) — AWS bearer token,
+        # not Anthropic x-api-key.
+        or (
+            "bedrock-mantle." in normalized
+            and ".api.aws" in normalized
+            and "/anthropic" in normalized
+        )
     )
 
 

--- a/agent/bedrock_mantle.py
+++ b/agent/bedrock_mantle.py
@@ -1,0 +1,289 @@
+"""Amazon Bedrock Mantle helpers for Hermes Agent.
+
+Mantle is separate from the native Bedrock Converse provider:
+
+- OSS / third-party models: OpenAI-compatible
+  ``https://bedrock-mantle.<region>.api.aws/v1``
+- Claude models (optional path): Anthropic Messages-compatible
+  ``https://bedrock-mantle.<region>.api.aws/anthropic``
+
+Auth (same bearer family as Bedrock API keys):
+
+1. Explicit ``AWS_BEARER_TOKEN_BEDROCK`` when set
+2. Else mint a short-lived bearer from the AWS default credential chain
+   via ``aws-bedrock-token-generator`` (optional dependency)
+
+Reference facts from OpenClaw's amazon-bedrock-mantle extension and AWS
+Bedrock API-key docs — reimplemented for Hermes, not ported.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Callable, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+PROVIDER_ID = "amazon-bedrock-mantle"
+DEFAULT_REGION = "us-east-1"
+
+MANTLE_SUPPORTED_REGIONS = frozenset(
+    {
+        "us-east-1",
+        "us-east-2",
+        "us-west-2",
+        "ap-northeast-1",
+        "ap-south-1",
+        "ap-southeast-3",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-south-1",
+        "eu-north-1",
+        "sa-east-1",
+    }
+)
+
+# Curated fallbacks when /v1/models is unreachable. Prefer tool-capable OSS ids.
+FALLBACK_OSS_MODELS = (
+    "gpt-oss-120b",
+    "qwen3-coder-480b-a35b",
+    "qwen3-235b-a22b",
+    "deepseek-v3.2",
+    "kimi-k2.5",
+    "glm-4.7",
+)
+
+# Claude rows OpenClaw appends after discovery (Anthropic Messages route).
+FALLBACK_CLAUDE_MODELS = (
+    "anthropic.claude-sonnet-5",
+    "anthropic.claude-opus-4-7",
+    "anthropic.claude-mythos-5",
+    "anthropic.claude-mythos-preview",
+)
+
+# IAM token cache: region → (token, expires_at_epoch)
+_iam_token_cache: dict[str, tuple[str, float]] = {}
+_IAM_TOKEN_TTL_S = 7200.0  # 2h — matches AWS / OpenClaw request lifetime
+_IAM_TOKEN_SKEW_S = 120.0  # refresh a bit early
+
+# Discovery cache: region → (model_ids, expires_at_epoch)
+_discovery_cache: dict[str, tuple[list[str], float]] = {}
+_DISCOVERY_TTL_S = 3600.0
+
+
+def mantle_endpoint(region: str) -> str:
+    """Return Mantle origin for a region (no path suffix)."""
+    r = (region or DEFAULT_REGION).strip() or DEFAULT_REGION
+    return f"https://bedrock-mantle.{r}.api.aws"
+
+
+def mantle_openai_base_url(region: str) -> str:
+    return f"{mantle_endpoint(region)}/v1"
+
+
+def mantle_anthropic_base_url(region: str) -> str:
+    """Anthropic Messages-compatible Mantle route."""
+    return f"{mantle_endpoint(region)}/anthropic"
+
+
+def resolve_mantle_region(
+    *,
+    env: Optional[dict[str, str]] = None,
+    config_region: str | None = None,
+) -> str:
+    """Region priority: explicit config → AWS_REGION → AWS_DEFAULT_REGION → us-east-1."""
+    if config_region and str(config_region).strip():
+        return str(config_region).strip()
+    e = env if env is not None else os.environ
+    for key in ("AWS_REGION", "AWS_DEFAULT_REGION", "BEDROCK_MANTLE_REGION"):
+        val = (e.get(key) or "").strip()
+        if val:
+            return val
+    try:
+        from agent.bedrock_adapter import resolve_bedrock_region
+
+        return resolve_bedrock_region() or DEFAULT_REGION
+    except Exception:
+        return DEFAULT_REGION
+
+
+def is_supported_mantle_region(region: str) -> bool:
+    return (region or "").strip() in MANTLE_SUPPORTED_REGIONS
+
+
+def resolve_explicit_bearer_token(env: Optional[dict[str, str]] = None) -> str | None:
+    e = env if env is not None else os.environ
+    token = (e.get("AWS_BEARER_TOKEN_BEDROCK") or "").strip()
+    return token or None
+
+
+def _get_cached_iam_token(region: str, now: float | None = None) -> str | None:
+    now = time.time() if now is None else now
+    entry = _iam_token_cache.get(region)
+    if not entry:
+        return None
+    token, expires_at = entry
+    if now + _IAM_TOKEN_SKEW_S >= expires_at:
+        _iam_token_cache.pop(region, None)
+        return None
+    return token
+
+
+def mint_iam_bearer_token(
+    region: str,
+    *,
+    now: float | None = None,
+    provider_factory: Callable[..., Any] | None = None,
+) -> str | None:
+    """Mint a Mantle/Bedrock bearer from the AWS credential chain.
+
+    Uses ``aws-bedrock-token-generator`` when installed. Returns None if the
+    package is missing or credentials are unavailable.
+    """
+    now = time.time() if now is None else now
+    cached = _get_cached_iam_token(region, now=now)
+    if cached:
+        return cached
+
+    try:
+        if provider_factory is not None:
+            token = provider_factory(region=region)
+        else:
+            from aws_bedrock_token_generator import provide_token  # type: ignore
+
+            # Official Python helper; region is taken from the env/session.
+            # Some versions accept region= — try both call shapes.
+            try:
+                token = provide_token(region=region)
+            except TypeError:
+                token = provide_token()
+        token = (token or "").strip()
+        if not token:
+            return None
+        _iam_token_cache[region] = (token, now + _IAM_TOKEN_TTL_S)
+        return token
+    except ImportError:
+        logger.debug(
+            "aws-bedrock-token-generator not installed; "
+            "set AWS_BEARER_TOKEN_BEDROCK or pip install aws-bedrock-token-generator"
+        )
+        return None
+    except Exception as exc:
+        logger.debug("Mantle IAM token mint failed for region %s: %s", region, exc)
+        return None
+
+
+def resolve_mantle_bearer_token(
+    region: str,
+    *,
+    env: Optional[dict[str, str]] = None,
+    allow_iam_mint: bool = True,
+    provider_factory: Callable[..., Any] | None = None,
+) -> str | None:
+    """Resolve bearer: explicit env first, then optional IAM mint."""
+    explicit = resolve_explicit_bearer_token(env)
+    if explicit:
+        return explicit
+    if not allow_iam_mint:
+        return None
+    return mint_iam_bearer_token(region, provider_factory=provider_factory)
+
+
+def has_mantle_credentials(env: Optional[dict[str, str]] = None) -> bool:
+    """True when an explicit bearer is set or AWS credentials might mint one."""
+    if resolve_explicit_bearer_token(env):
+        return True
+    try:
+        from agent.bedrock_adapter import has_aws_credentials
+
+        return bool(has_aws_credentials())
+    except Exception:
+        e = env if env is not None else os.environ
+        return bool(
+            (e.get("AWS_ACCESS_KEY_ID") or "").strip()
+            and (e.get("AWS_SECRET_ACCESS_KEY") or "").strip()
+        )
+
+
+def is_mantle_claude_model(model: str | None) -> bool:
+    """Whether the model should use Mantle's Anthropic Messages route."""
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    # Strip optional provider prefix
+    if "/" in m:
+        m = m.split("/", 1)[-1]
+    if m.startswith("anthropic."):
+        return True
+    if "claude" in m:
+        return True
+    return False
+
+
+def is_mantle_hostname(hostname: str | None) -> bool:
+    h = (hostname or "").strip().lower()
+    return h.startswith("bedrock-mantle.") and h.endswith(".api.aws")
+
+
+def discover_mantle_models(
+    region: str,
+    bearer_token: str,
+    *,
+    timeout: float = 12.0,
+    now: float | None = None,
+    fetch_fn: Callable[..., Any] | None = None,
+) -> list[str]:
+    """GET ``/v1/models`` and return model ids. Cached per region for 1h."""
+    now = time.time() if now is None else now
+    cached = _discovery_cache.get(region)
+    if cached and now < cached[1]:
+        return list(cached[0])
+
+    url = f"{mantle_openai_base_url(region)}/models"
+    headers = {
+        "Authorization": f"Bearer {bearer_token}",
+        "Accept": "application/json",
+        "User-Agent": "hermes-cli",
+    }
+
+    try:
+        if fetch_fn is not None:
+            raw = fetch_fn(url, headers=headers, timeout=timeout)
+            data = raw if isinstance(raw, dict) else None
+        else:
+            req = Request(url, headers=headers, method="GET")
+            with urlopen(req, timeout=timeout) as resp:
+                import json
+
+                data = json.loads(resp.read().decode("utf-8"))
+        ids: list[str] = []
+        for entry in (data or {}).get("data") or []:
+            mid = (entry.get("id") or "").strip()
+            if mid:
+                ids.append(mid)
+        # Always surface Claude Mantle rows when discovery succeeds (OpenClaw parity).
+        for claude_id in FALLBACK_CLAUDE_MODELS:
+            if claude_id not in ids:
+                ids.append(claude_id)
+        if ids:
+            _discovery_cache[region] = (ids, now + _DISCOVERY_TTL_S)
+            return ids
+    except (HTTPError, URLError, TimeoutError, ValueError, OSError) as exc:
+        logger.debug("Mantle model discovery failed for %s: %s", region, exc)
+    except Exception as exc:
+        logger.debug("Mantle model discovery error for %s: %s", region, exc)
+
+    # Stale cache on failure
+    if cached:
+        return list(cached[0])
+    return list(FALLBACK_OSS_MODELS) + list(FALLBACK_CLAUDE_MODELS)
+
+
+def reset_mantle_caches_for_tests() -> None:
+    _iam_token_cache.clear()
+    _discovery_cache.clear()

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1784,7 +1784,8 @@ def resolve_provider(
         "lmstudio": "lmstudio", "lm-studio": "lmstudio", "lm_studio": "lmstudio",
         # Local server aliases — route through the generic custom provider
         "ollama": "custom", "ollama_cloud": "ollama-cloud",
-        "vllm": "custom", "llamacpp": "custom",
+        # vllm is first-class (plugins/model-providers/vllm); keep llama.cpp aliases on custom
+        "llamacpp": "custom",
         "llama.cpp": "custom", "llama-cpp": "custom",
     }
     # Extend with aliases declared in plugins/model-providers/<name>/ that aren't already mapped.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1295,9 +1295,22 @@ _PROVIDER_ALIASES = {
     "lmstudio": "lmstudio",
     "lm-studio": "lmstudio",
     "lm_studio": "lmstudio",
-    "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
+    "ollama": "custom",  # bare "ollama" = custom endpoint path; use "ollama-local" or "ollama-cloud"
     "ollama_cloud": "ollama-cloud",
 }
+
+# Extend with aliases declared on provider plugins (same pattern as hermes_cli/auth.py).
+try:
+    from providers import list_providers as _list_providers_for_aliases
+    for _pp in _list_providers_for_aliases():
+        for _alias in _pp.aliases:
+            if _alias not in _PROVIDER_ALIASES:
+                _PROVIDER_ALIASES[_alias] = _pp.name
+        # Ensure the canonical name maps to itself when not already present.
+        if _pp.name not in _PROVIDER_ALIASES:
+            _PROVIDER_ALIASES[_pp.name] = _pp.name
+except Exception:
+    pass
 
 
 # In-repo fallback for the model Hermes silently lands on when the user never

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2604,6 +2604,26 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         except Exception:
             pass
 
+    # Amazon Bedrock Mantle — live /v1/models when a bearer is available.
+    if normalized == "amazon-bedrock-mantle":
+        try:
+            from agent.bedrock_mantle import (
+                discover_mantle_models,
+                resolve_mantle_bearer_token,
+                resolve_mantle_region,
+                FALLBACK_OSS_MODELS,
+                FALLBACK_CLAUDE_MODELS,
+            )
+            region = resolve_mantle_region()
+            token = resolve_mantle_bearer_token(region)
+            if token:
+                ids = discover_mantle_models(region, token)
+                if ids:
+                    return ids
+            return list(FALLBACK_OSS_MODELS) + list(FALLBACK_CLAUDE_MODELS)
+        except Exception:
+            pass
+
     # ── Profile-based generic live fetch (all simple api-key providers) ──
     # Handles any provider registered in providers/ with auth_type="api_key".
     # Replaces per-provider copy-paste blocks (stepfun, gmi, zai, etc.).

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -365,8 +365,8 @@ ALIASES: Dict[str, str] = {
     "lmstudio": "lmstudio",
     "lm-studio": "lmstudio",
     "lm_studio": "lmstudio",
-    "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
-    "vllm": "local",
+    "ollama": "custom",  # bare "ollama" = custom; use "ollama-local" / "ollama-cloud"
+    "vllm": "vllm",  # first-class local OpenAI-compatible server
     "llamacpp": "local",
     "llama.cpp": "local",
     "llama-cpp": "local",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -73,7 +73,7 @@ def _config_base_url_trustworthy_for_bare_custom(cfg_base_url: str, cfg_provider
 
     GitHub #14676: the model picker can select Custom while ``model.provider`` still reflects a
     previous provider. Reject non-loopback URLs unless the YAML provider is already ``custom``
-    (or one of the local-server aliases that resolve to ``custom`` — ollama, vllm, llamacpp, …),
+    (or one of the local-server aliases that resolve to ``custom`` — ollama, llamacpp, …),
     so a stale OpenRouter/Z.ai base_url cannot hijack local ``custom`` sessions.
     """
     cfg_provider_norm = (cfg_provider or "").strip().lower()
@@ -83,7 +83,7 @@ def _config_base_url_trustworthy_for_bare_custom(cfg_base_url: str, cfg_provider
     if cfg_provider_norm == "custom":
         return True
     # GitHub #27132: provider aliases that resolve to "custom" at runtime
-    # (ollama, vllm, llamacpp, …) should be trusted the same way "custom"
+    # (ollama, llamacpp, …) should be trusted the same way "custom"
     # is, otherwise a legit LAN/WireGuard ollama endpoint silently falls
     # through to OpenRouter.
     try:
@@ -925,7 +925,7 @@ def _resolve_named_custom_runtime(
     # directly so the alias's base_url actually takes effect.
     #
     # GitHub #27132: provider aliases that resolve to "custom" at runtime
-    # (ollama, vllm, llamacpp, …) are treated identically here, so a YAML
+    # (ollama, llamacpp, …) are treated identically here, so a YAML
     # `provider: ollama` with a LAN/WireGuard `base_url` doesn't silently
     # fall through to OpenRouter.
     requested_norm = (requested_provider or "").strip().lower()

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1933,6 +1933,112 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    # Amazon Bedrock Mantle (OpenAI-compatible /v1 + optional Anthropic Messages)
+    # Distinct from native Bedrock Converse (`provider=bedrock`).
+    if provider == "amazon-bedrock-mantle":
+        from agent.bedrock_mantle import (
+            has_mantle_credentials,
+            is_mantle_claude_model,
+            is_supported_mantle_region,
+            mantle_anthropic_base_url,
+            mantle_openai_base_url,
+            resolve_mantle_bearer_token,
+            resolve_mantle_region,
+        )
+
+        _cfg = load_config()
+        _mantle_cfg = _cfg.get("bedrock_mantle") or _cfg.get("amazon-bedrock-mantle") or {}
+        if not isinstance(_mantle_cfg, dict):
+            _mantle_cfg = {}
+        region = (
+            (_mantle_cfg.get("region") or "").strip()
+            or resolve_mantle_region()
+        )
+        # Optional full base URL override (OpenAI /v1 root)
+        override_base = (
+            (_mantle_cfg.get("base_url") or "").strip()
+            or (os.environ.get("BEDROCK_MANTLE_BASE_URL") or "").strip()
+            or (model_cfg.get("base_url") or "").strip()
+        )
+        if override_base:
+            base_openai = override_base.rstrip("/")
+            if base_openai.endswith("/anthropic"):
+                base_openai = base_openai[: -len("/anthropic")] + "/v1"
+            elif not base_openai.endswith("/v1"):
+                base_openai = base_openai + "/v1"
+        else:
+            base_openai = mantle_openai_base_url(region)
+
+        is_explicit = requested_provider in {
+            "amazon-bedrock-mantle",
+            "bedrock-mantle",
+            "mantle",
+            "aws-bedrock-mantle",
+            "amazon-mantle",
+        }
+        if not is_explicit and not has_mantle_credentials():
+            raise AuthError(
+                "No credentials found for Amazon Bedrock Mantle. Configure one of:\n"
+                "  - AWS_BEARER_TOKEN_BEDROCK (Bedrock API key / bearer)\n"
+                "  - AWS credentials + `pip install aws-bedrock-token-generator` "
+                "(IAM mint)\n"
+                "  - AWS_REGION / bedrock_mantle.region (default us-east-1)",
+                code="no_mantle_credentials",
+            )
+
+        token = resolve_mantle_bearer_token(region)
+        if not token:
+            raise AuthError(
+                "Could not resolve a Bedrock Mantle bearer token.\n"
+                "Set AWS_BEARER_TOKEN_BEDROCK, or install "
+                "aws-bedrock-token-generator and configure AWS credentials "
+                "(env keys, profile, or instance role).",
+                code="no_mantle_bearer",
+            )
+
+        if not is_supported_mantle_region(region):
+            # Still allow — AWS may expand regions; warn via empty discovery later.
+            pass
+
+        _current_model = str(target_model or model_cfg.get("default") or "").strip()
+        if is_mantle_claude_model(_current_model):
+            # Claude on Mantle → Anthropic Messages + Bearer (not x-api-key)
+            if override_base and "/anthropic" in override_base:
+                base_anthropic = override_base.rstrip("/")
+            else:
+                # Derive from openai base: .../v1 → .../anthropic
+                if base_openai.endswith("/v1"):
+                    base_anthropic = base_openai[: -len("/v1")] + "/anthropic"
+                else:
+                    base_anthropic = mantle_anthropic_base_url(region)
+            return {
+                "provider": "amazon-bedrock-mantle",
+                "api_mode": "anthropic_messages",
+                "base_url": base_anthropic,
+                "api_key": token,
+                "source": (
+                    "env:AWS_BEARER_TOKEN_BEDROCK"
+                    if os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip()
+                    else "aws-iam-bearer-mint"
+                ),
+                "region": region,
+                "requested_provider": requested_provider,
+            }
+
+        return {
+            "provider": "amazon-bedrock-mantle",
+            "api_mode": "chat_completions",
+            "base_url": base_openai,
+            "api_key": token,
+            "source": (
+                "env:AWS_BEARER_TOKEN_BEDROCK"
+                if os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip()
+                else "aws-iam-bearer-mint"
+            ),
+            "region": region,
+            "requested_provider": requested_provider,
+        }
+
     # AWS Bedrock (native Converse API via boto3)
     if provider == "bedrock":
         from agent.bedrock_adapter import (

--- a/plugins/model-providers/amazon-bedrock-mantle/__init__.py
+++ b/plugins/model-providers/amazon-bedrock-mantle/__init__.py
@@ -1,0 +1,85 @@
+"""Amazon Bedrock Mantle provider profile.
+
+OpenAI-compatible chat for Mantle-hosted OSS models, plus Claude via the
+Mantle Anthropic Messages route. Auth uses ``AWS_BEARER_TOKEN_BEDROCK`` or
+IAM-minted short-lived bearers (see ``agent.bedrock_mantle``).
+
+Runtime resolution is special-cased in ``hermes_cli.runtime_provider`` —
+this profile supplies identity, defaults, and catalog fallbacks.
+"""
+
+from __future__ import annotations
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class AmazonBedrockMantleProfile(ProviderProfile):
+    """Bedrock Mantle — region-scoped OpenAI-compatible /v1 surface."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        from agent.bedrock_mantle import (
+            discover_mantle_models,
+            resolve_mantle_bearer_token,
+            resolve_mantle_region,
+            mantle_openai_base_url,
+        )
+
+        region = resolve_mantle_region()
+        # Prefer region encoded in base_url if caller passed one
+        if base_url and "bedrock-mantle." in base_url:
+            try:
+                host = base_url.split("://", 1)[-1].split("/", 1)[0]
+                # bedrock-mantle.<region>.api.aws
+                parts = host.split(".")
+                if len(parts) >= 4 and parts[0] == "bedrock-mantle":
+                    region = parts[1]
+            except Exception:
+                pass
+
+        token = (api_key or "").strip() or resolve_mantle_bearer_token(region)
+        if not token:
+            return list(self.fallback_models) or None
+        return discover_mantle_models(region, token, timeout=timeout)
+
+
+amazon_bedrock_mantle = AmazonBedrockMantleProfile(
+    name="amazon-bedrock-mantle",
+    aliases=(
+        "bedrock-mantle",
+        "mantle",
+        "aws-bedrock-mantle",
+        "amazon-mantle",
+    ),
+    display_name="Amazon Bedrock Mantle",
+    description=(
+        "Amazon Bedrock Mantle (OpenAI-compatible OSS models + Claude Messages route)"
+    ),
+    signup_url="https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html",
+    # Explicit bearer; region via AWS_REGION / BEDROCK_MANTLE_REGION.
+    # IAM mint is handled at runtime when the bearer env is empty.
+    env_vars=("AWS_BEARER_TOKEN_BEDROCK", "BEDROCK_MANTLE_BASE_URL"),
+    base_url="https://bedrock-mantle.us-east-1.api.aws/v1",
+    auth_type="api_key",
+    supports_vision=True,
+    supports_health_check=True,
+    hostname="bedrock-mantle.us-east-1.api.aws",
+    default_aux_model="gpt-oss-120b",
+    fallback_models=(
+        "gpt-oss-120b",
+        "qwen3-coder-480b-a35b",
+        "deepseek-v3.2",
+        "kimi-k2.5",
+        "glm-4.7",
+        "anthropic.claude-sonnet-5",
+        "anthropic.claude-opus-4-7",
+    ),
+)
+
+register_provider(amazon_bedrock_mantle)

--- a/plugins/model-providers/amazon-bedrock-mantle/plugin.yaml
+++ b/plugins/model-providers/amazon-bedrock-mantle/plugin.yaml
@@ -1,0 +1,5 @@
+name: amazon-bedrock-mantle-provider
+kind: model-provider
+version: 1.0.0
+description: Amazon Bedrock Mantle (OpenAI-compatible + Claude Messages)
+author: Nous Research

--- a/plugins/model-providers/baseten/__init__.py
+++ b/plugins/model-providers/baseten/__init__.py
@@ -1,0 +1,26 @@
+"""Baseten provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+baseten = ProviderProfile(
+    name="baseten",
+    aliases=('baseten-ai',),
+    display_name="Baseten",
+    description="Baseten — Model APIs and Inkling (OpenAI-compatible)",
+    signup_url="https://app.baseten.co",
+    env_vars=('BASETEN_API_KEY', 'BASETEN_BASE_URL'),
+    base_url="https://inference.baseten.co/v1",
+    auth_type="api_key",
+    supports_vision=False,
+    default_aux_model="deepseek-ai/DeepSeek-V3.2",
+    fallback_models=('deepseek-ai/DeepSeek-V3.2', 'moonshotai/Kimi-K2.5', 'zai-org/GLM-5'),
+)
+
+register_provider(baseten)

--- a/plugins/model-providers/baseten/plugin.yaml
+++ b/plugins/model-providers/baseten/plugin.yaml
@@ -1,0 +1,5 @@
+name: baseten-provider
+kind: model-provider
+version: 1.0.0
+description: Baseten
+author: Nous Research

--- a/plugins/model-providers/byteplus/__init__.py
+++ b/plugins/model-providers/byteplus/__init__.py
@@ -1,0 +1,26 @@
+"""BytePlus provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+byteplus = ProviderProfile(
+    name="byteplus",
+    aliases=('byteplus-ark',),
+    display_name="BytePlus",
+    description="BytePlus (international ARK) — OpenAI-compatible model API",
+    signup_url="https://console.byteplus.com/",
+    env_vars=('BYTEPLUS_API_KEY', 'BYTEPLUS_BASE_URL'),
+    base_url="https://ark.ap-southeast.bytepluses.com/api/v3",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="deepseek-v3-2-251201",
+    fallback_models=('deepseek-v3-2-251201', 'seed-1-8-251228'),
+)
+
+register_provider(byteplus)

--- a/plugins/model-providers/byteplus/plugin.yaml
+++ b/plugins/model-providers/byteplus/plugin.yaml
@@ -1,0 +1,5 @@
+name: byteplus-provider
+kind: model-provider
+version: 1.0.0
+description: BytePlus
+author: Nous Research

--- a/plugins/model-providers/cerebras/__init__.py
+++ b/plugins/model-providers/cerebras/__init__.py
@@ -1,0 +1,26 @@
+"""Cerebras provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+cerebras = ProviderProfile(
+    name="cerebras",
+    aliases=('cerebras-ai',),
+    display_name="Cerebras",
+    description="Cerebras — high-speed OpenAI-compatible inference",
+    signup_url="https://cloud.cerebras.ai",
+    env_vars=('CEREBRAS_API_KEY', 'CEREBRAS_BASE_URL'),
+    base_url="https://api.cerebras.ai/v1",
+    auth_type="api_key",
+    supports_vision=False,
+    default_aux_model="llama-3.3-70b",
+    fallback_models=('llama-3.3-70b', 'llama3.1-8b', 'qwen-3-32b', 'gpt-oss-120b'),
+)
+
+register_provider(cerebras)

--- a/plugins/model-providers/cerebras/plugin.yaml
+++ b/plugins/model-providers/cerebras/plugin.yaml
@@ -1,0 +1,5 @@
+name: cerebras-provider
+kind: model-provider
+version: 1.0.0
+description: Cerebras
+author: Nous Research

--- a/plugins/model-providers/chutes/__init__.py
+++ b/plugins/model-providers/chutes/__init__.py
@@ -1,0 +1,26 @@
+"""Chutes provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+chutes = ProviderProfile(
+    name="chutes",
+    aliases=('chutes-ai',),
+    display_name="Chutes",
+    description="Chutes — open-source model catalog (OpenAI-compatible; API key)",
+    signup_url="https://chutes.ai/settings/api-keys",
+    env_vars=('CHUTES_API_KEY', 'CHUTES_BASE_URL'),
+    base_url="https://llm.chutes.ai/v1",
+    auth_type="api_key",
+    supports_vision=False,
+    default_aux_model="zai-org/GLM-4.5-Air",
+    fallback_models=('zai-org/GLM-5-TEE', 'zai-org/GLM-4.5-Air', 'deepseek-ai/DeepSeek-V3.1', 'Qwen/Qwen3-235B-A22B'),
+)
+
+register_provider(chutes)

--- a/plugins/model-providers/chutes/plugin.yaml
+++ b/plugins/model-providers/chutes/plugin.yaml
@@ -1,0 +1,5 @@
+name: chutes-provider
+kind: model-provider
+version: 1.0.0
+description: Chutes
+author: Nous Research

--- a/plugins/model-providers/cohere/__init__.py
+++ b/plugins/model-providers/cohere/__init__.py
@@ -1,0 +1,26 @@
+"""Cohere provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+cohere = ProviderProfile(
+    name="cohere",
+    aliases=('cohere-ai',),
+    display_name="Cohere",
+    description="Cohere — Command A family via OpenAI-compatible Compatibility API",
+    signup_url="https://dashboard.cohere.com/api-keys",
+    env_vars=('COHERE_API_KEY', 'COHERE_BASE_URL'),
+    base_url="https://api.cohere.ai/compatibility/v1",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="command-a-03-2025",
+    fallback_models=('command-a-plus-05-2026', 'command-a-03-2025', 'command-a-reasoning-08-2025', 'command-r-plus', 'command-r'),
+)
+
+register_provider(cohere)

--- a/plugins/model-providers/cohere/plugin.yaml
+++ b/plugins/model-providers/cohere/plugin.yaml
@@ -1,0 +1,5 @@
+name: cohere-provider
+kind: model-provider
+version: 1.0.0
+description: Cohere
+author: Nous Research

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -84,9 +84,9 @@ class CustomProfile(ProviderProfile):
 custom = CustomProfile(
     name="custom",
     aliases=(
-        "ollama",
+        "ollama",  # bare ollama → custom path; use ollama-local / ollama-cloud for first-class
         "local",
-        "vllm",
+        # "vllm" is a first-class provider (plugins/model-providers/vllm)
         "llamacpp",
         "llama.cpp",
         "llama-cpp",

--- a/plugins/model-providers/featherless/__init__.py
+++ b/plugins/model-providers/featherless/__init__.py
@@ -1,0 +1,26 @@
+"""Featherless AI provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+featherless = ProviderProfile(
+    name="featherless",
+    aliases=('featherless-ai',),
+    display_name="Featherless AI",
+    description="Featherless AI — open models via OpenAI-compatible API",
+    signup_url="https://featherless.ai",
+    env_vars=('FEATHERLESS_API_KEY', 'FEATHERLESS_BASE_URL'),
+    base_url="https://api.featherless.ai/v1",
+    auth_type="api_key",
+    supports_vision=False,
+    default_aux_model="Qwen/Qwen3-32B",
+    fallback_models=('Qwen/Qwen3-32B', 'meta-llama/Meta-Llama-3.1-70B-Instruct', 'mistralai/Mistral-Small-24B-Instruct-2501'),
+)
+
+register_provider(featherless)

--- a/plugins/model-providers/featherless/plugin.yaml
+++ b/plugins/model-providers/featherless/plugin.yaml
@@ -1,0 +1,5 @@
+name: featherless-provider
+kind: model-provider
+version: 1.0.0
+description: Featherless AI
+author: Nous Research

--- a/plugins/model-providers/groq/__init__.py
+++ b/plugins/model-providers/groq/__init__.py
@@ -1,0 +1,26 @@
+"""Groq provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+groq = ProviderProfile(
+    name="groq",
+    aliases=('groq-cloud',),
+    display_name="Groq",
+    description="Groq — ultra-fast LPU inference (Llama, Gemma, Qwen, …)",
+    signup_url="https://console.groq.com/keys",
+    env_vars=('GROQ_API_KEY', 'GROQ_BASE_URL'),
+    base_url="https://api.groq.com/openai/v1",
+    auth_type="api_key",
+    supports_vision=False,
+    default_aux_model="llama-3.1-8b-instant",
+    fallback_models=('llama-3.3-70b-versatile', 'llama-3.1-8b-instant', 'openai/gpt-oss-120b', 'qwen/qwen3-32b', 'moonshotai/kimi-k2-instruct'),
+)
+
+register_provider(groq)

--- a/plugins/model-providers/groq/plugin.yaml
+++ b/plugins/model-providers/groq/plugin.yaml
@@ -1,0 +1,5 @@
+name: groq-provider
+kind: model-provider
+version: 1.0.0
+description: Groq
+author: Nous Research

--- a/plugins/model-providers/litellm/__init__.py
+++ b/plugins/model-providers/litellm/__init__.py
@@ -1,0 +1,26 @@
+"""LiteLLM Proxy provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+litellm = ProviderProfile(
+    name="litellm",
+    aliases=('litellm-proxy', 'lite-llm'),
+    display_name="LiteLLM Proxy",
+    description="LiteLLM — unified multi-provider proxy (default localhost:4000)",
+    signup_url="https://docs.litellm.ai/",
+    env_vars=('LITELLM_API_KEY', 'LITELLM_BASE_URL'),
+    base_url="http://127.0.0.1:4000/v1",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="",
+    fallback_models=(),
+)
+
+register_provider(litellm)

--- a/plugins/model-providers/litellm/plugin.yaml
+++ b/plugins/model-providers/litellm/plugin.yaml
@@ -1,0 +1,5 @@
+name: litellm-provider
+kind: model-provider
+version: 1.0.0
+description: LiteLLM Proxy
+author: Nous Research

--- a/plugins/model-providers/longcat/__init__.py
+++ b/plugins/model-providers/longcat/__init__.py
@@ -1,0 +1,26 @@
+"""LongCat provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+longcat = ProviderProfile(
+    name="longcat",
+    aliases=('longcat-ai',),
+    display_name="LongCat",
+    description="LongCat — LongCat-2.0 agentic / coding model API",
+    signup_url="https://longcat.chat/platform/api_keys",
+    env_vars=('LONGCAT_API_KEY', 'LONGCAT_BASE_URL'),
+    base_url="https://api.longcat.chat/openai",
+    auth_type="api_key",
+    supports_vision=False,
+    default_aux_model="LongCat-2.0",
+    fallback_models=('LongCat-2.0',),
+)
+
+register_provider(longcat)

--- a/plugins/model-providers/longcat/plugin.yaml
+++ b/plugins/model-providers/longcat/plugin.yaml
@@ -1,0 +1,5 @@
+name: longcat-provider
+kind: model-provider
+version: 1.0.0
+description: LongCat
+author: Nous Research

--- a/plugins/model-providers/mistral/__init__.py
+++ b/plugins/model-providers/mistral/__init__.py
@@ -1,0 +1,26 @@
+"""Mistral AI provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+mistral = ProviderProfile(
+    name="mistral",
+    aliases=('mistral-ai', 'mistralai'),
+    display_name="Mistral AI",
+    description="Mistral AI — Large, Medium, Codestral, Pixtral, Devstral",
+    signup_url="https://console.mistral.ai/",
+    env_vars=('MISTRAL_API_KEY', 'MISTRAL_BASE_URL'),
+    base_url="https://api.mistral.ai/v1",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="mistral-small-latest",
+    fallback_models=('mistral-large-latest', 'mistral-medium-latest', 'mistral-small-latest', 'codestral-latest', 'pixtral-large-latest', 'devstral-medium-latest'),
+)
+
+register_provider(mistral)

--- a/plugins/model-providers/mistral/plugin.yaml
+++ b/plugins/model-providers/mistral/plugin.yaml
@@ -1,0 +1,5 @@
+name: mistral-provider
+kind: model-provider
+version: 1.0.0
+description: Mistral AI
+author: Nous Research

--- a/plugins/model-providers/ollama-local/__init__.py
+++ b/plugins/model-providers/ollama-local/__init__.py
@@ -1,0 +1,26 @@
+"""Ollama (local) provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+ollama_local = ProviderProfile(
+    name="ollama-local",
+    aliases=('ollama-local-daemon',),
+    display_name="Ollama (local)",
+    description="Ollama local daemon via OpenAI-compatible /v1 (default :11434). Prefer tool-capable models.",
+    signup_url="https://ollama.com",
+    env_vars=('OLLAMA_LOCAL_API_KEY', 'OLLAMA_LOCAL_BASE_URL'),
+    base_url="http://127.0.0.1:11434/v1",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="",
+    fallback_models=(),
+)
+
+register_provider(ollama_local)

--- a/plugins/model-providers/ollama-local/plugin.yaml
+++ b/plugins/model-providers/ollama-local/plugin.yaml
@@ -1,0 +1,5 @@
+name: ollama-local-provider
+kind: model-provider
+version: 1.0.0
+description: Ollama (local OpenAI-compatible /v1)
+author: Nous Research

--- a/plugins/model-providers/qianfan/__init__.py
+++ b/plugins/model-providers/qianfan/__init__.py
@@ -1,0 +1,26 @@
+"""Baidu Qianfan provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+qianfan = ProviderProfile(
+    name="qianfan",
+    aliases=('baidu-qianfan', 'baidu'),
+    display_name="Baidu Qianfan",
+    description="Baidu Qianfan — unified OpenAI-compatible MaaS API",
+    signup_url="https://console.bce.baidu.com/qianfan/ais/console/apiKey",
+    env_vars=('QIANFAN_API_KEY', 'QIANFAN_BASE_URL'),
+    base_url="https://qianfan.baidubce.com/v2",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="deepseek-v3.2",
+    fallback_models=('deepseek-v3.2', 'ernie-5.0-thinking-preview', 'ernie-4.5-turbo-128k'),
+)
+
+register_provider(qianfan)

--- a/plugins/model-providers/qianfan/plugin.yaml
+++ b/plugins/model-providers/qianfan/plugin.yaml
@@ -1,0 +1,5 @@
+name: qianfan-provider
+kind: model-provider
+version: 1.0.0
+description: Baidu Qianfan
+author: Nous Research

--- a/plugins/model-providers/sglang/__init__.py
+++ b/plugins/model-providers/sglang/__init__.py
@@ -1,0 +1,26 @@
+"""SGLang provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+sglang = ProviderProfile(
+    name="sglang",
+    aliases=('sglang-local',),
+    display_name="SGLang",
+    description="SGLang — local/self-hosted OpenAI-compatible server (default :30000)",
+    signup_url="https://github.com/sgl-project/sglang",
+    env_vars=('SGLANG_API_KEY', 'SGLANG_BASE_URL'),
+    base_url="http://127.0.0.1:30000/v1",
+    auth_type="api_key",
+    supports_vision=False,
+    default_aux_model="",
+    fallback_models=(),
+)
+
+register_provider(sglang)

--- a/plugins/model-providers/sglang/plugin.yaml
+++ b/plugins/model-providers/sglang/plugin.yaml
@@ -1,0 +1,5 @@
+name: sglang-provider
+kind: model-provider
+version: 1.0.0
+description: SGLang
+author: Nous Research

--- a/plugins/model-providers/together/__init__.py
+++ b/plugins/model-providers/together/__init__.py
@@ -1,0 +1,26 @@
+"""Together AI provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+together = ProviderProfile(
+    name="together",
+    aliases=('together-ai', 'togetherai'),
+    display_name="Together AI",
+    description="Together AI — open models (Llama, DeepSeek, Kimi, Qwen, GLM, …)",
+    signup_url="https://api.together.ai/settings/api-keys",
+    env_vars=('TOGETHER_API_KEY', 'TOGETHER_BASE_URL'),
+    base_url="https://api.together.xyz/v1",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="Qwen/Qwen2.5-7B-Instruct-Turbo",
+    fallback_models=('meta-llama/Llama-3.3-70B-Instruct-Turbo', 'moonshotai/Kimi-K2.5', 'deepseek-ai/DeepSeek-V3', 'Qwen/Qwen2.5-7B-Instruct-Turbo', 'zai-org/GLM-4.5'),
+)
+
+register_provider(together)

--- a/plugins/model-providers/together/plugin.yaml
+++ b/plugins/model-providers/together/plugin.yaml
@@ -1,0 +1,5 @@
+name: together-provider
+kind: model-provider
+version: 1.0.0
+description: Together AI
+author: Nous Research

--- a/plugins/model-providers/venice/__init__.py
+++ b/plugins/model-providers/venice/__init__.py
@@ -1,0 +1,26 @@
+"""Venice AI provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+venice = ProviderProfile(
+    name="venice",
+    aliases=('venice-ai',),
+    display_name="Venice AI",
+    description="Venice AI — privacy-focused inference (private + anonymized proxy models)",
+    signup_url="https://venice.ai",
+    env_vars=('VENICE_API_KEY', 'VENICE_BASE_URL'),
+    base_url="https://api.venice.ai/api/v1",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="llama-3.3-70b",
+    fallback_models=('llama-3.3-70b', 'qwen3-235b', 'deepseek-v3.2', 'kimi-k2-5', 'minimax-m2.5'),
+)
+
+register_provider(venice)

--- a/plugins/model-providers/venice/plugin.yaml
+++ b/plugins/model-providers/venice/plugin.yaml
@@ -1,0 +1,5 @@
+name: venice-provider
+kind: model-provider
+version: 1.0.0
+description: Venice AI
+author: Nous Research

--- a/plugins/model-providers/vercel-ai-gateway/__init__.py
+++ b/plugins/model-providers/vercel-ai-gateway/__init__.py
@@ -1,0 +1,26 @@
+"""Vercel AI Gateway provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+vercel_ai_gateway = ProviderProfile(
+    name="vercel-ai-gateway",
+    aliases=('vercel', 'ai-gateway', 'vercel-gateway'),
+    display_name="Vercel AI Gateway",
+    description="Vercel AI Gateway — multi-provider routing via one API key",
+    signup_url="https://vercel.com/docs/ai-gateway",
+    env_vars=('AI_GATEWAY_API_KEY', 'AI_GATEWAY_BASE_URL'),
+    base_url="https://ai-gateway.vercel.sh/v1",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="google/gemini-2.5-flash",
+    fallback_models=('anthropic/claude-sonnet-4.5', 'openai/gpt-5', 'google/gemini-2.5-flash', 'xai/grok-4'),
+)
+
+register_provider(vercel_ai_gateway)

--- a/plugins/model-providers/vercel-ai-gateway/plugin.yaml
+++ b/plugins/model-providers/vercel-ai-gateway/plugin.yaml
@@ -1,0 +1,5 @@
+name: vercel-ai-gateway-provider
+kind: model-provider
+version: 1.0.0
+description: Vercel AI Gateway
+author: Nous Research

--- a/plugins/model-providers/vllm/__init__.py
+++ b/plugins/model-providers/vllm/__init__.py
@@ -1,0 +1,26 @@
+"""vLLM provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+vllm = ProviderProfile(
+    name="vllm",
+    aliases=('vllm-local',),
+    display_name="vLLM",
+    description="vLLM — local/self-hosted OpenAI-compatible server (default :8000)",
+    signup_url="https://docs.vllm.ai/",
+    env_vars=('VLLM_API_KEY', 'VLLM_BASE_URL'),
+    base_url="http://127.0.0.1:8000/v1",
+    auth_type="api_key",
+    supports_vision=False,
+    default_aux_model="",
+    fallback_models=(),
+)
+
+register_provider(vllm)

--- a/plugins/model-providers/vllm/plugin.yaml
+++ b/plugins/model-providers/vllm/plugin.yaml
@@ -1,0 +1,5 @@
+name: vllm-provider
+kind: model-provider
+version: 1.0.0
+description: vLLM
+author: Nous Research

--- a/plugins/model-providers/volcengine/__init__.py
+++ b/plugins/model-providers/volcengine/__init__.py
@@ -1,0 +1,26 @@
+"""Volcengine (Doubao) provider profile.
+
+OpenAI-compatible chat-completions endpoint. Auto-registered via
+``register_provider`` so auth, ``hermes model``, runtime resolution, and
+OPTIONAL_ENV_VARS pick it up without core edits.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+volcengine = ProviderProfile(
+    name="volcengine",
+    aliases=('volcengine-ark', 'doubao', 'volcano-engine'),
+    display_name="Volcengine (Doubao)",
+    description="Volcengine ARK / Doubao — OpenAI-compatible API (China)",
+    signup_url="https://console.volcengine.com/ark",
+    env_vars=('VOLCANO_ENGINE_API_KEY', 'VOLCANO_ENGINE_BASE_URL'),
+    base_url="https://ark.cn-beijing.volces.com/api/v3",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="deepseek-v3-2-251201",
+    fallback_models=('deepseek-v3-2-251201', 'doubao-seed-1-8-251228', 'doubao-1-5-pro-32k-250115'),
+)
+
+register_provider(volcengine)

--- a/plugins/model-providers/volcengine/plugin.yaml
+++ b/plugins/model-providers/volcengine/plugin.yaml
@@ -1,0 +1,5 @@
+name: volcengine-provider
+kind: model-provider
+version: 1.0.0
+description: Volcengine (Doubao)
+author: Nous Research

--- a/tests/hermes_cli/test_bedrock_mantle_provider.py
+++ b/tests/hermes_cli/test_bedrock_mantle_provider.py
@@ -1,0 +1,191 @@
+"""Tests for Amazon Bedrock Mantle provider wiring."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agent.bedrock_mantle import (
+    discover_mantle_models,
+    is_mantle_claude_model,
+    mantle_anthropic_base_url,
+    mantle_openai_base_url,
+    reset_mantle_caches_for_tests,
+    resolve_mantle_bearer_token,
+    resolve_mantle_region,
+)
+from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider
+from hermes_cli.models import CANONICAL_PROVIDERS, normalize_provider
+from hermes_cli import runtime_provider as rp
+from providers import get_provider_profile
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    reset_mantle_caches_for_tests()
+    for key in (
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "BEDROCK_MANTLE_REGION",
+        "BEDROCK_MANTLE_BASE_URL",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_PROFILE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    yield
+    reset_mantle_caches_for_tests()
+
+
+class TestMantleHelpers:
+    def test_endpoints(self):
+        assert mantle_openai_base_url("us-west-2") == (
+            "https://bedrock-mantle.us-west-2.api.aws/v1"
+        )
+        assert mantle_anthropic_base_url("eu-west-1") == (
+            "https://bedrock-mantle.eu-west-1.api.aws/anthropic"
+        )
+
+    def test_region_priority(self, monkeypatch):
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        assert resolve_mantle_region() == "us-west-2"
+        assert resolve_mantle_region(config_region="ap-south-1") == "ap-south-1"
+
+    def test_claude_model_detection(self):
+        assert is_mantle_claude_model("anthropic.claude-sonnet-5") is True
+        assert is_mantle_claude_model("amazon-bedrock-mantle/anthropic.claude-opus-4-7")
+        assert is_mantle_claude_model("gpt-oss-120b") is False
+        assert is_mantle_claude_model("qwen3-coder-480b-a35b") is False
+
+    def test_explicit_bearer(self, monkeypatch):
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "mantle-token-abc")
+        assert resolve_mantle_bearer_token("us-east-1") == "mantle-token-abc"
+
+    def test_iam_mint_fallback(self, monkeypatch):
+        def fake_provide_token(region=None):
+            return f"minted-for-{region}"
+
+        token = resolve_mantle_bearer_token(
+            "us-east-1",
+            allow_iam_mint=True,
+            provider_factory=fake_provide_token,
+        )
+        assert token == "minted-for-us-east-1"
+
+    def test_discovery_parses_openai_list(self):
+        payload = {
+            "data": [
+                {"id": "gpt-oss-120b"},
+                {"id": "qwen3-235b-a22b"},
+            ]
+        }
+
+        def fake_fetch(url, headers=None, timeout=None):
+            assert "/v1/models" in url
+            assert headers["Authorization"].startswith("Bearer ")
+            return payload
+
+        ids = discover_mantle_models(
+            "us-east-1", "tok", fetch_fn=fake_fetch
+        )
+        assert "gpt-oss-120b" in ids
+        assert "anthropic.claude-sonnet-5" in ids  # appended Claude rows
+
+
+class TestMantleProviderRegistration:
+    def test_profile(self):
+        p = get_provider_profile("amazon-bedrock-mantle")
+        assert p is not None
+        assert p.name == "amazon-bedrock-mantle"
+        assert "bedrock-mantle" in (p.aliases or ())
+
+    def test_aliases(self, monkeypatch):
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "t")
+        assert resolve_provider("bedrock-mantle") == "amazon-bedrock-mantle"
+        assert resolve_provider("mantle") == "amazon-bedrock-mantle"
+        assert normalize_provider("bedrock-mantle") == "amazon-bedrock-mantle"
+
+    def test_canonical_picker(self):
+        slugs = {e.slug for e in CANONICAL_PROVIDERS}
+        assert "amazon-bedrock-mantle" in slugs
+
+    def test_auth_registry(self):
+        assert "amazon-bedrock-mantle" in PROVIDER_REGISTRY
+
+
+class TestMantleRuntimeResolution:
+    def test_openai_path(self, monkeypatch):
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bearer-xyz")
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda: {
+                "provider": "amazon-bedrock-mantle",
+                "default": "gpt-oss-120b",
+            },
+        )
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
+        resolved = rp.resolve_runtime_provider(requested="mantle")
+        assert resolved["provider"] == "amazon-bedrock-mantle"
+        assert resolved["api_mode"] == "chat_completions"
+        assert resolved["base_url"] == "https://bedrock-mantle.us-west-2.api.aws/v1"
+        assert resolved["api_key"] == "bearer-xyz"
+        assert resolved["region"] == "us-west-2"
+
+    def test_claude_anthropic_path(self, monkeypatch):
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bearer-xyz")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda: {
+                "provider": "amazon-bedrock-mantle",
+                "default": "anthropic.claude-sonnet-5",
+            },
+        )
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
+        resolved = rp.resolve_runtime_provider(
+            requested="amazon-bedrock-mantle",
+            target_model="anthropic.claude-sonnet-5",
+        )
+        assert resolved["provider"] == "amazon-bedrock-mantle"
+        assert resolved["api_mode"] == "anthropic_messages"
+        assert resolved["base_url"].endswith("/anthropic")
+        assert "bedrock-mantle.us-east-1.api.aws" in resolved["base_url"]
+        assert resolved["api_key"] == "bearer-xyz"
+
+    def test_missing_creds_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda: {"provider": "amazon-bedrock-mantle", "default": "gpt-oss-120b"},
+        )
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        with patch(
+            "agent.bedrock_mantle.has_mantle_credentials", return_value=False
+        ), patch(
+            "agent.bedrock_mantle.resolve_mantle_bearer_token", return_value=None
+        ):
+            with pytest.raises(Exception) as ei:
+                rp.resolve_runtime_provider(requested="amazon-bedrock-mantle")
+            msg = str(ei.value).lower()
+            assert "mantle" in msg or "bearer" in msg
+
+
+class TestMantleAnthropicBearer:
+    def test_requires_bearer_for_mantle_anthropic_url(self):
+        from agent.anthropic_adapter import _requires_bearer_auth
+
+        assert _requires_bearer_auth(
+            "https://bedrock-mantle.us-east-1.api.aws/anthropic"
+        )
+        assert not _requires_bearer_auth(
+            "https://bedrock-runtime.us-east-1.amazonaws.com"
+        )

--- a/tests/hermes_cli/test_openclaw_parity_providers.py
+++ b/tests/hermes_cli/test_openclaw_parity_providers.py
@@ -1,0 +1,156 @@
+"""Tests for OpenClaw-parity OpenAI-compatible model provider plugins.
+
+These providers are thin ``ProviderProfile`` plugins under
+``plugins/model-providers/``. They should auto-wire into:
+
+- ``providers`` registry
+- ``PROVIDER_REGISTRY`` (auth)
+- ``CANONICAL_PROVIDERS`` / model picker
+- alias normalization (auth + models)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider
+from hermes_cli.models import CANONICAL_PROVIDERS, normalize_provider
+from providers import get_provider_profile, list_providers
+
+
+# (canonical_id, sample_alias, api_key_env, expected_base_url_substr)
+NEW_PROVIDERS = [
+    ("groq", "groq-cloud", "GROQ_API_KEY", "api.groq.com"),
+    ("mistral", "mistral-ai", "MISTRAL_API_KEY", "api.mistral.ai"),
+    ("cohere", "cohere-ai", "COHERE_API_KEY", "api.cohere.ai"),
+    ("together", "together-ai", "TOGETHER_API_KEY", "api.together.xyz"),
+    ("cerebras", "cerebras-ai", "CEREBRAS_API_KEY", "api.cerebras.ai"),
+    ("venice", "venice-ai", "VENICE_API_KEY", "api.venice.ai"),
+    ("featherless", "featherless-ai", "FEATHERLESS_API_KEY", "api.featherless.ai"),
+    ("baseten", "baseten-ai", "BASETEN_API_KEY", "inference.baseten.co"),
+    ("chutes", "chutes-ai", "CHUTES_API_KEY", "llm.chutes.ai"),
+    ("longcat", "longcat-ai", "LONGCAT_API_KEY", "api.longcat.chat"),
+    ("vercel-ai-gateway", "vercel", "AI_GATEWAY_API_KEY", "ai-gateway.vercel.sh"),
+    ("vllm", "vllm-local", "VLLM_API_KEY", "127.0.0.1:8000"),
+    ("sglang", "sglang-local", "SGLANG_API_KEY", "127.0.0.1:30000"),
+    ("litellm", "litellm-proxy", "LITELLM_API_KEY", "127.0.0.1:4000"),
+    ("ollama-local", "ollama-local-daemon", "OLLAMA_LOCAL_API_KEY", "127.0.0.1:11434"),
+    ("qianfan", "baidu-qianfan", "QIANFAN_API_KEY", "qianfan.baidubce.com"),
+    ("byteplus", "byteplus-ark", "BYTEPLUS_API_KEY", "bytepluses.com"),
+    ("volcengine", "doubao", "VOLCANO_ENGINE_API_KEY", "volces.com"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_env(monkeypatch):
+    keys = {
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+    }
+    for _pid, _alias, env, _url in NEW_PROVIDERS:
+        keys.add(env)
+        keys.add(env.replace("_API_KEY", "_BASE_URL"))
+        if env.endswith("_API_KEY"):
+            # also clear common base url forms
+            keys.add(env[: -len("_API_KEY")] + "_BASE_URL")
+    # Explicit extras
+    keys.update(
+        {
+            "GROQ_BASE_URL",
+            "MISTRAL_BASE_URL",
+            "COHERE_BASE_URL",
+            "TOGETHER_BASE_URL",
+            "CEREBRAS_BASE_URL",
+            "VENICE_BASE_URL",
+            "FEATHERLESS_BASE_URL",
+            "BASETEN_BASE_URL",
+            "CHUTES_BASE_URL",
+            "LONGCAT_BASE_URL",
+            "AI_GATEWAY_BASE_URL",
+            "VLLM_BASE_URL",
+            "SGLANG_BASE_URL",
+            "LITELLM_BASE_URL",
+            "OLLAMA_LOCAL_BASE_URL",
+            "QIANFAN_BASE_URL",
+            "BYTEPLUS_BASE_URL",
+            "VOLCANO_ENGINE_BASE_URL",
+        }
+    )
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestOpenClawParityProfiles:
+    @pytest.mark.parametrize("pid,alias,env,url_part", NEW_PROVIDERS)
+    def test_profile_registered(self, pid, alias, env, url_part):
+        profile = get_provider_profile(pid)
+        assert profile is not None, f"missing profile for {pid}"
+        assert profile.name == pid
+        assert profile.auth_type == "api_key"
+        assert url_part in (profile.base_url or "")
+        assert env in profile.env_vars
+
+    @pytest.mark.parametrize("pid,alias,env,url_part", NEW_PROVIDERS)
+    def test_auth_registry(self, pid, alias, env, url_part):
+        assert pid in PROVIDER_REGISTRY
+        cfg = PROVIDER_REGISTRY[pid]
+        assert cfg.auth_type == "api_key"
+        assert env in cfg.api_key_env_vars
+        assert url_part in (cfg.inference_base_url or "")
+
+    @pytest.mark.parametrize("pid,alias,env,url_part", NEW_PROVIDERS)
+    def test_canonical_picker(self, pid, alias, env, url_part):
+        slugs = {p.slug for p in CANONICAL_PROVIDERS}
+        assert pid in slugs
+
+    @pytest.mark.parametrize("pid,alias,env,url_part", NEW_PROVIDERS)
+    def test_alias_resolve_auth(self, pid, alias, env, url_part, monkeypatch):
+        monkeypatch.setenv(env, f"test-key-{pid}")
+        assert resolve_provider(pid) == pid
+        assert resolve_provider(alias) == pid
+
+    @pytest.mark.parametrize("pid,alias,env,url_part", NEW_PROVIDERS)
+    def test_alias_normalize_models(self, pid, alias, env, url_part):
+        assert normalize_provider(pid) == pid
+        # bare "ollama" remains the legacy custom alias — not ollama-local
+        if alias != "ollama":
+            assert normalize_provider(alias) == pid
+
+
+class TestOpenClawParityEnvInjection:
+    def test_optional_env_vars_include_new_keys(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        # MISTRAL_API_KEY pre-existed as a tool (Voxtral STT/TTS) env var before
+        # the chat provider plugin; injection skips already-listed keys.
+        pre_existing_tool_keys = {"MISTRAL_API_KEY"}
+
+        for _pid, _alias, env, _url in NEW_PROVIDERS:
+            assert env in OPTIONAL_ENV_VARS, f"{env} missing from OPTIONAL_ENV_VARS"
+            assert OPTIONAL_ENV_VARS[env]["password"] is True
+            if env in pre_existing_tool_keys:
+                assert OPTIONAL_ENV_VARS[env]["category"] in {"provider", "tool"}
+            else:
+                assert OPTIONAL_ENV_VARS[env]["category"] == "provider"
+
+
+class TestOllamaNamingContract:
+    def test_bare_ollama_still_means_custom(self):
+        # Historical Hermes contract: bare "ollama" → custom endpoint path.
+        assert normalize_provider("ollama") == "custom"
+
+    def test_ollama_cloud_unchanged(self):
+        assert normalize_provider("ollama-cloud") == "ollama-cloud"
+        assert normalize_provider("ollama_cloud") == "ollama-cloud"
+
+    def test_ollama_local_first_class(self):
+        assert get_provider_profile("ollama-local") is not None
+        assert "ollama-local" in PROVIDER_REGISTRY
+
+
+class TestListProvidersIncludesNew:
+    def test_all_new_providers_listed(self):
+        names = {p.name for p in list_providers()}
+        missing = [pid for pid, *_ in NEW_PROVIDERS if pid not in names]
+        assert missing == []

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2816,10 +2816,13 @@ def test_minimax_oauth_pool_forces_anthropic_messages_despite_stale_config(monke
 
 
 # ----------------------------------------------------------------------
-# GitHub #27132 — provider aliases (ollama/vllm/llamacpp/llama-cpp) must
+# GitHub #27132 — provider aliases (ollama/llamacpp/llama-cpp) must
 # follow the same base_url trust + routing rules as bare `provider: custom`.
 # Without this, a YAML `provider: ollama` with a LAN/WireGuard `base_url`
 # silently falls through to OpenRouter (HTTP 401).
+#
+# Note: `vllm` is now a first-class provider (plugins/model-providers/vllm)
+# and is covered separately below — it no longer aliases to custom.
 # ----------------------------------------------------------------------
 
 
@@ -2827,7 +2830,6 @@ def test_minimax_oauth_pool_forces_anthropic_messages_despite_stale_config(monke
     "alias,base_url",
     [
         ("ollama", "http://192.168.0.103:11434/v1"),
-        ("vllm", "http://192.168.0.103:8000/v1"),
         ("llamacpp", "http://192.168.0.103:8080/v1"),
         ("llama-cpp", "http://192.168.0.103:8080/v1"),
     ],
@@ -2835,7 +2837,7 @@ def test_minimax_oauth_pool_forces_anthropic_messages_despite_stale_config(monke
 def test_custom_aliases_with_lan_base_url_route_to_custom_not_openrouter(
     monkeypatch, alias, base_url
 ):
-    """provider: ollama|vllm|llamacpp + LAN IP must NOT fall through to OpenRouter."""
+    """provider: ollama|llamacpp + LAN IP must NOT fall through to OpenRouter."""
     monkeypatch.setattr(
         rp,
         "_get_model_config",
@@ -2859,6 +2861,23 @@ def test_custom_aliases_with_lan_base_url_route_to_custom_not_openrouter(
     )
 
 
+def test_vllm_first_class_with_lan_base_url(monkeypatch):
+    """provider: vllm is first-class — uses VLLM_API_KEY + configured base_url."""
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "vllm", "base_url": "http://192.168.0.103:8000/v1"},
+    )
+    monkeypatch.setenv("VLLM_API_KEY", "vllm-local")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-fake-test")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
+    resolved = rp.resolve_runtime_provider(requested="vllm")
+
+    assert resolved["provider"] == "vllm"
+    assert "8000" in (resolved.get("base_url") or "")
+
+
 def test_custom_alias_with_loopback_base_url_routes_to_custom(monkeypatch):
     """provider: ollama + loopback should also route to custom (regression guard)."""
     monkeypatch.setattr(
@@ -2878,12 +2897,15 @@ def test_custom_alias_with_loopback_base_url_routes_to_custom(monkeypatch):
 def test_trustworthy_check_accepts_custom_aliases():
     """_config_base_url_trustworthy_for_bare_custom() must accept aliases for custom."""
     fn = rp._config_base_url_trustworthy_for_bare_custom
-    for alias in ("ollama", "vllm", "llamacpp", "llama-cpp", "llama.cpp"):
+    for alias in ("ollama", "llamacpp", "llama-cpp", "llama.cpp"):
         assert fn("http://192.168.0.103:11434/v1", alias) is True, (
             f"alias {alias!r} should be trusted with non-loopback base_url"
         )
     # Unrelated provider name should still be rejected with non-loopback URL.
     assert fn("http://192.168.0.103:11434/v1", "openrouter") is False
+    # First-class vllm is not a custom alias (uses its own provider path).
+    # Non-loopback without being custom is only trusted when resolve→custom.
+    assert fn("http://192.168.0.103:8000/v1", "vllm") is False
 
 
 def test_openai_key_only_sent_to_openai_host(monkeypatch):

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -51,7 +51,37 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **MiniMax OAuth** | `hermes model` → "MiniMax (OAuth)" (provider: `minimax-oauth`; browser PKCE login) |
 | **StepFun** | `STEPFUN_API_KEY` in `~/.hermes/.env` (provider: `stepfun`) |
 | **LM Studio** | `hermes model` → "LM Studio" (provider: `lmstudio`, optional `LM_API_KEY`) |
+| **Groq** | `GROQ_API_KEY` in `~/.hermes/.env` (provider: `groq`; aliases: `groq-cloud`) |
+| **Mistral AI** | `MISTRAL_API_KEY` in `~/.hermes/.env` (provider: `mistral`; also powers Voxtral STT/TTS tools) |
+| **Cohere** | `COHERE_API_KEY` in `~/.hermes/.env` (provider: `cohere`) |
+| **Together AI** | `TOGETHER_API_KEY` in `~/.hermes/.env` (provider: `together`; aliases: `together-ai`) |
+| **Cerebras** | `CEREBRAS_API_KEY` in `~/.hermes/.env` (provider: `cerebras`) |
+| **Venice AI** | `VENICE_API_KEY` in `~/.hermes/.env` (provider: `venice`) |
+| **Featherless AI** | `FEATHERLESS_API_KEY` in `~/.hermes/.env` (provider: `featherless`) |
+| **Baseten** | `BASETEN_API_KEY` in `~/.hermes/.env` (provider: `baseten`) |
+| **Chutes** | `CHUTES_API_KEY` in `~/.hermes/.env` (provider: `chutes`) |
+| **LongCat** | `LONGCAT_API_KEY` in `~/.hermes/.env` (provider: `longcat`) |
+| **Vercel AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `vercel-ai-gateway`; aliases: `vercel`, `ai-gateway`) |
+| **DeepInfra** | `DEEPINFRA_API_KEY` in `~/.hermes/.env` (provider: `deepinfra`) |
+| **Baidu Qianfan** | `QIANFAN_API_KEY` in `~/.hermes/.env` (provider: `qianfan`; aliases: `baidu-qianfan`) |
+| **BytePlus** | `BYTEPLUS_API_KEY` in `~/.hermes/.env` (provider: `byteplus`) |
+| **Volcengine (Doubao)** | `VOLCANO_ENGINE_API_KEY` in `~/.hermes/.env` (provider: `volcengine`; aliases: `doubao`) |
+| **vLLM (local)** | `VLLM_API_KEY` (any non-empty value if server has no auth) + optional `VLLM_BASE_URL` (default `http://127.0.0.1:8000/v1`) |
+| **SGLang (local)** | `SGLANG_API_KEY` (any non-empty value if no auth) + optional `SGLANG_BASE_URL` (default `http://127.0.0.1:30000/v1`) |
+| **LiteLLM Proxy** | `LITELLM_API_KEY` + optional `LITELLM_BASE_URL` (default `http://127.0.0.1:4000/v1`) |
+| **Ollama (local)** | `OLLAMA_LOCAL_API_KEY` (any non-empty value) + optional `OLLAMA_LOCAL_BASE_URL` (default `http://127.0.0.1:11434/v1`; provider: `ollama-local`). Bare `ollama` still maps to the custom-endpoint path. Prefer tool-capable models. |
 | **Custom Endpoint** | `hermes model` → choose "Custom endpoint" (saved in `config.yaml`) |
+
+:::note Still via Custom / OpenRouter (not first-class yet)
+Some OpenClaw-only surfaces remain intentionally out of scope as dedicated chat providers:
+
+- **Cloudflare AI Gateway** — account/gateway-id–specific base URL; use Custom endpoint
+- **Synthetic** — Anthropic Messages transport (needs a native adapter, not chat-completions)
+- **ClawRouter / media-only hosts** (Vydra, Runway, …) — tool backends, not chat model providers
+- **Chutes OAuth** — API-key path is first-class; browser OAuth can be added later
+
+Most models on those hosts are already reachable through **OpenRouter** or a **custom base URL**.
+:::
 
 For the official API-key path, see the dedicated [Google Gemini guide](/guides/google-gemini).
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -45,6 +45,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenAI API (direct)** | `OPENAI_API_KEY` in `~/.hermes/.env` (provider: `openai-api`, optional `OPENAI_BASE_URL`) |
 | **Azure AI Foundry** | `hermes model` → "Azure AI Foundry" (provider: `azure-foundry`; uses Azure OpenAI / Foundry endpoint and key) |
 | **AWS Bedrock** | `hermes model` → "AWS Bedrock" (provider: `bedrock`; standard AWS credentials chain via boto3) |
+| **Amazon Bedrock Mantle** | `AWS_BEARER_TOKEN_BEDROCK` (or IAM + `pip install aws-bedrock-token-generator`) — provider: `amazon-bedrock-mantle` (aliases: `bedrock-mantle`, `mantle`). OpenAI-compatible OSS models at `https://bedrock-mantle.<region>.api.aws/v1`; Claude models use the Mantle Anthropic Messages route. Region: `AWS_REGION` / `bedrock_mantle.region` (default `us-east-1`). Separate from native Bedrock Converse. |
 | **NVIDIA Build** | `NVIDIA_API_KEY` in `~/.hermes/.env` (provider: `nvidia`; NIM-hosted models on build.nvidia.com) |
 | **Ollama Cloud** | `hermes model` → "Ollama Cloud" (provider: `ollama-cloud`; cloud-hosted Ollama API) |
 | **Qwen OAuth** | `hermes model` → "Qwen OAuth" (provider: `qwen-oauth`; browser PKCE login) |
@@ -80,7 +81,9 @@ Some OpenClaw-only surfaces remain intentionally out of scope as dedicated chat 
 - **ClawRouter / media-only hosts** (Vydra, Runway, …) — tool backends, not chat model providers
 - **Chutes OAuth** — API-key path is first-class; browser OAuth can be added later
 
-Most models on those hosts are already reachable through **OpenRouter** or a **custom base URL**.
+**Amazon Bedrock Mantle** is first-class as `amazon-bedrock-mantle` (bearer / IAM mint). Native Bedrock Converse remains `bedrock`.
+
+Most models on deferred hosts are already reachable through **OpenRouter** or a **custom base URL**.
 :::
 
 For the official API-key path, see the dedicated [Google Gemini guide](/guides/google-gemini).


### PR DESCRIPTION
## Summary

Adds first-class Hermes `ProviderProfile` plugins for chat LLM providers that OpenClaw documents natively but Hermes previously only reached via **OpenRouter** or a **custom endpoint**.

This is **not** a copy of OpenClaw config/TS plugins. Each provider is implemented the Hermes way (`plugins/model-providers/<id>/`) so auth, `hermes model`, runtime resolution, and `OPTIONAL_ENV_VARS` auto-wire.

### New first-class providers (18)

| ID | Env key | Default base URL |
|---|---|---|
| `groq` | `GROQ_API_KEY` | `https://api.groq.com/openai/v1` |
| `mistral` | `MISTRAL_API_KEY` | `https://api.mistral.ai/v1` |
| `cohere` | `COHERE_API_KEY` | `https://api.cohere.ai/compatibility/v1` |
| `together` | `TOGETHER_API_KEY` | `https://api.together.xyz/v1` |
| `cerebras` | `CEREBRAS_API_KEY` | `https://api.cerebras.ai/v1` |
| `venice` | `VENICE_API_KEY` | `https://api.venice.ai/api/v1` |
| `featherless` | `FEATHERLESS_API_KEY` | `https://api.featherless.ai/v1` |
| `baseten` | `BASETEN_API_KEY` | `https://inference.baseten.co/v1` |
| `chutes` | `CHUTES_API_KEY` | `https://llm.chutes.ai/v1` |
| `longcat` | `LONGCAT_API_KEY` | `https://api.longcat.chat/openai` |
| `vercel-ai-gateway` | `AI_GATEWAY_API_KEY` | `https://ai-gateway.vercel.sh/v1` |
| `qianfan` | `QIANFAN_API_KEY` | `https://qianfan.baidubce.com/v2` |
| `byteplus` | `BYTEPLUS_API_KEY` | BytePlus ARK SE |
| `volcengine` | `VOLCANO_ENGINE_API_KEY` | Volcengine ARK CN |
| `vllm` | `VLLM_API_KEY` | `http://127.0.0.1:8000/v1` |
| `sglang` | `SGLANG_API_KEY` | `http://127.0.0.1:30000/v1` |
| `litellm` | `LITELLM_API_KEY` | `http://127.0.0.1:4000/v1` |
| `ollama-local` | `OLLAMA_LOCAL_API_KEY` | `http://127.0.0.1:11434/v1` |

### Intentionally deferred (documented)

- **Cloudflare AI Gateway** — account/gateway-id–specific base URL → Custom endpoint
- **Synthetic** — Anthropic Messages transport (needs native adapter)
- **Media-only hosts** (Vydra, Runway, …) — tool backends, not chat providers
- **Chutes OAuth** — API-key path only for now

### Other changes

- Auto-extend `models._PROVIDER_ALIASES` from provider plugin aliases (parity with `auth.py`)
- Promote **`vllm`** from custom-alias → first-class provider (defaults to localhost:8000). Bare **`ollama`** still maps to **custom** (historical contract); use `ollama-local` / `ollama-cloud` for first-class paths
- Docs table update on the AI Providers page

### Phase 1 gap class (for reviewers)

| Class | Action in this PR |
|---|---|
| OpenAI-compatible + API key | ✅ thin plugins |
| Local OpenAI-compatible servers | ✅ vllm / sglang / litellm / ollama-local |
| OAuth / non-OpenAI protocol | deferred |
| Media/search providers | out of scope |

## Test plan

- [x] `pytest tests/hermes_cli/test_openclaw_parity_providers.py` (95 passed)
- [x] Related runtime resolution tests for ollama/vllm/custom aliases updated & passing
- [ ] CI green
- [ ] Manual smoke (optional): `hermes model` shows new providers; with a real key, chat one turn on Groq/Mistral