### PR TITLE
fix(kanban): isolate restart reproduction boards

### DIFF
--- a/scripts/kanban_repro.py
+++ b/scripts/kanban_repro.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Run an ad-hoc Kanban reproduction without inheriting the live board.
+
+Dispatcher workers inherit ``HERMES_KANBAN_DB`` so every lifecycle tool stays
+on the board that claimed the task.  A reproduction launched from such a
+worker must replace that direct override; changing only ``HERMES_HOME`` or
+``HERMES_KANBAN_HOME`` is not sufficient because the DB override wins.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a Python Kanban reproduction in an isolated DB by default.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        help="Use an explicit reproduction DB instead of a temporary one.",
+    )
+    parser.add_argument(
+        "--allow-existing-db",
+        action="store_true",
+        help="DANGEROUS: allow mutation of an existing non-configured DB.",
+    )
+    parser.add_argument(
+        "--allow-configured-db",
+        action="store_true",
+        help="DANGEROUS: allow mutation of the configured/live Kanban board.",
+    )
+    parser.add_argument("script", type=Path, help="Python reproduction script to run.")
+    parser.add_argument("script_args", nargs=argparse.REMAINDER)
+    return parser
+
+
+def _resolved(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _is_configured_board(db: Path, env: dict[str, str]) -> bool:
+    """Return whether ``db`` is the active/default/named production board."""
+    direct = env.get("HERMES_KANBAN_DB", "").strip()
+    if direct and db == _resolved(Path(direct)):
+        return True
+
+    # Import lazily so argument/help handling remains lightweight.  These path
+    # helpers do not connect to or initialize the database.
+    from hermes_cli import kanban_db as kb
+
+    home = _resolved(kb.kanban_home())
+    if db == home / "kanban.db":
+        return True
+    boards = home / "kanban" / "boards"
+    return db.name == "kanban.db" and db.is_relative_to(boards)
+
+
+def _run(script: Path, script_args: list[str], db: Path, env: dict[str, str]) -> int:
+    runtime_root = db.parent
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    scoped = env.copy()
+    scoped.update({
+        "HERMES_HOME": str(runtime_root),
+        "HERMES_KANBAN_HOME": str(runtime_root),
+        "HERMES_KANBAN_DB": str(db),
+        "HERMES_KANBAN_BOARD": "default",
+        "HERMES_KANBAN_WORKSPACES_ROOT": str(runtime_root / "kanban" / "workspaces"),
+        "HERMES_KANBAN_LOGS_ROOT": str(runtime_root / "kanban" / "logs"),
+    })
+    completed = subprocess.run(
+        [sys.executable, str(script), *script_args],
+        env=scoped,
+        check=False,
+    )
+    return completed.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    script = _resolved(args.script)
+    if not script.is_file():
+        print(f"reproduction script not found: {script}", file=sys.stderr)
+        return 2
+
+    inherited = os.environ.copy()
+    if args.db is None:
+        with tempfile.TemporaryDirectory(prefix="hermes-kanban-repro-") as temp_dir:
+            return _run(
+                script,
+                args.script_args,
+                Path(temp_dir) / "kanban.db",
+                inherited,
+            )
+
+    db = _resolved(args.db)
+    if _is_configured_board(db, inherited) and not args.allow_configured_db:
+        print(
+            "refusing configured Kanban DB without --allow-configured-db: "
+            f"{db}\nUse the default temporary DB unless live-board mutation is intentional.",
+            file=sys.stderr,
+        )
+        return 2
+    if db.exists() and not (args.allow_existing_db or args.allow_configured_db):
+        print(
+            f"refusing existing Kanban DB without --allow-existing-db: {db}",
+            file=sys.stderr,
+        )
+        return 2
+    return _run(script, args.script_args, db, inherited)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_kanban_repro.py
+++ b/tests/scripts/test_kanban_repro.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPRO_RUNNER = REPO_ROOT / "scripts" / "kanban_repro.py"
+
+
+def _probe_script(tmp_path: Path) -> Path:
+    probe = tmp_path / "restart_orphan_probe.py"
+    probe.write_text(
+        """
+import json
+from hermes_cli import kanban_db as kb
+
+with kb.connect_closing() as conn:
+    task_id = kb.create_task(conn, title="restart orphan repro", assignee="a")
+print(json.dumps({"db": str(kb.kanban_db_path()), "task_id": task_id}))
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return probe
+
+
+def _runner_env(configured_db: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HERMES_KANBAN_DB"] = str(configured_db)
+    env["HERMES_KANBAN_BOARD"] = "default"
+    env["PYTHONPATH"] = os.pathsep.join([
+        str(REPO_ROOT),
+        env.get("PYTHONPATH", ""),
+    ]).rstrip(os.pathsep)
+    return env
+
+
+def _synthetic_count(db_path: Path) -> int:
+    with kb.connect(db_path) as conn:
+        return conn.execute(
+            "SELECT COUNT(*) FROM tasks "
+            "WHERE title = 'restart orphan repro' AND assignee = 'a'"
+        ).fetchone()[0]
+
+
+def test_repro_runner_uses_temporary_db_instead_of_inherited_live_board(
+    tmp_path: Path,
+) -> None:
+    live_db = tmp_path / "production" / "kanban.db"
+    with kb.connect(live_db) as conn:
+        kb.create_task(conn, title="real production task", assignee="coder")
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+    result = subprocess.run(
+        [sys.executable, str(REPRO_RUNNER), str(_probe_script(tmp_path))],
+        cwd=REPO_ROOT,
+        env=_runner_env(live_db),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert Path(payload["db"]).resolve() != live_db.resolve()
+    assert "hermes-kanban-repro-" in payload["db"]
+    with kb.connect(live_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
+    assert _synthetic_count(live_db) == 0
+
+
+def test_repro_runner_refuses_configured_db_without_dangerous_opt_in(
+    tmp_path: Path,
+) -> None:
+    live_db = tmp_path / "production" / "kanban.db"
+    with kb.connect(live_db) as conn:
+        kb.create_task(conn, title="real production task", assignee="coder")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPRO_RUNNER),
+            "--db",
+            str(live_db),
+            str(_probe_script(tmp_path)),
+        ],
+        cwd=REPO_ROOT,
+        env=_runner_env(live_db),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "refusing configured Kanban DB" in result.stderr
+    assert "--allow-configured-db" in result.stderr
+    assert _synthetic_count(live_db) == 0
+
+
+def test_repro_runner_refuses_configured_db_even_before_it_exists(
+    tmp_path: Path,
+) -> None:
+    live_db = tmp_path / "production" / "kanban.db"
+    assert not live_db.exists()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPRO_RUNNER),
+            "--db",
+            str(live_db),
+            str(_probe_script(tmp_path)),
+        ],
+        cwd=REPO_ROOT,
+        env=_runner_env(live_db),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "refusing configured Kanban DB" in result.stderr
+    assert not live_db.exists()
+
+
+def test_repro_runner_allows_configured_db_only_with_explicit_dangerous_opt_in(
+    tmp_path: Path,
+) -> None:
+    live_db = tmp_path / "production" / "kanban.db"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPRO_RUNNER),
+            "--db",
+            str(live_db),
+            "--allow-configured-db",
+            str(_probe_script(tmp_path)),
+        ],
+        cwd=REPO_ROOT,
+        env=_runner_env(live_db),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _synthetic_count(live_db) == 1

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -265,6 +265,41 @@ hermes kanban unblock  t_abc t_def
 hermes kanban block    t_abc "need input" --ids t_def t_hij
 ```
 
+### Safe restart/reclaimer reproductions
+
+Run ad-hoc Python reproductions through `scripts/kanban_repro.py`. The helper
+replaces any inherited `HERMES_KANBAN_DB` with a temporary database, so a
+reproduction launched by a Kanban worker cannot accidentally write fixtures to
+the board that dispatched it:
+
+```bash
+python scripts/kanban_repro.py /tmp/reproduce_restart_orphan.py
+```
+
+Use `--db /absolute/path/to/repro.db` to keep an isolated reproduction DB.
+Existing databases require `--allow-existing-db`. The configured default,
+active, and named-board paths are guarded more strongly and require the
+explicitly dangerous `--allow-configured-db` opt-in. Put options before the
+script path. Normal reproductions should never need either opt-in.
+
+Clean up synthetic artifacts by provenance, not by weakening the completion
+evidence policy. Record every task id created by the reproduction, then inspect
+each one with `hermes kanban show <id>`. A restart-orphan fixture is safe to
+archive only when all of the reproduction's expected markers agree. For the
+historical `restart orphan repro` fixture these are: exact title, `created_by`
+unset, the deliberately nonexistent test assignee, and a `restart_reclaimed`
+event whose payload contains the expected synthetic host/epoch values and
+`exclusive_handoff=true`. Archive the individually verified ids:
+
+```bash
+hermes kanban archive t_repro_parent t_repro_child
+```
+
+Do not complete synthetic failures merely to remove them from Ready: that
+would fabricate implementation evidence. Do not archive by assignee, status,
+age, title keyword, or `created_by` alone; any mismatch means the task may be
+real work and must be left for operator review.
+
 :::note Where an unblocked task lands
 `unblock` itself only ever moves a task to **`ready`** (all parents `done`) or
 **`todo`** (a parent is still open — the task is dependency-gated and the


### PR DESCRIPTION
## Summary
- Add `scripts/kanban_repro.py`: a restart/reclaimer reproduction runner that replaces inherited board pins with an isolated temporary DB by default
- Fail closed for configured/live board paths unless the operator passes an explicit dangerous opt-in
- Document provenance-scoped archival of synthetic artifacts without bypassing implementation completion evidence

## Changes
- **`scripts/kanban_repro.py`** (new): Ad-hoc Kanban reproduction runner. Dispatcher workers inherit `HERMES_KANBAN_DB` so every lifecycle tool stays on the board that claimed the task. A reproduction launched from such a worker must replace that direct override; changing only `HERMES_HOME` or `HERMES_KANBAN_HOME` is not sufficient because the DB override wins.
- **`tests/scripts/test_kanban_repro.py`** (new): Comprehensive test suite covering temporary DB isolation, refusal without dangerous opt-in, and allow-listed configured DB usage
- **`website/docs/user-guide/features/kanban.md`**: Document safe restart/reclaimer reproductions in the kanban user guide

## Test plan
- `python3 -m py_compile scripts/kanban_repro.py tests/scripts/test_kanban_repro.py` ✓
- `git diff origin/main...HEAD --check` (no whitespace errors)

Closes #67107