### PR TITLE
fix(doctor): strip vendor prefixes from native-provider model IDs on config migration

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6815,6 +6815,20 @@ def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
         model.pop("model", None)
         model.pop("name", None)
 
+    # Normalize model.default for native providers (issue #67106).
+    # When the root-level model string carries a vendor prefix
+    # (e.g. openai-codex/gpt-5.6-sol) AND the provider is a native
+    # one (e.g. openai-codex), strip the prefix so config.yaml is
+    # canonical on first load — no second repair pass required.
+    if model.get("default") and model.get("provider"):
+        try:
+            from hermes_cli.model_normalize import normalize_model_for_provider
+            model["default"] = normalize_model_for_provider(
+                model["default"], model["provider"]
+            )
+        except Exception:
+            pass
+
     return config
 
 


### PR DESCRIPTION
## Problem

`hermes doctor --fix` migrates legacy root-level model/provider configuration via `_normalize_root_model_keys`, but leaves `model.default` vendor-prefixed for native providers.

Example input:
```yaml
model: openai-codex/gpt-5.6-sol
provider: openai-codex
```

**Before this fix**, after `hermes doctor --fix`:
```yaml
model:
  default: openai-codex/gpt-5.6-sol
  provider: openai-codex
```

A subsequent `hermes doctor` run warns that the model is vendor-prefixed, requiring a separate `hermes config set` command to repair.

## Fix

After `_normalize_root_model_keys` populates both `model.default` and `model.provider`, call `normalize_model_for_provider()` on `model.default` to strip vendor prefixes where appropriate (native providers like openai-codex, anthropic, deepseek, zai, etc.) while preserving them for aggregators (openrouter, nous) and custom providers.

**After this fix**, a single `hermes doctor --fix` produces:
```yaml
model:
  default: gpt-5.6-sol
  provider: openai-codex
```

## What changed

- **`hermes_cli/config.py`** — `_normalize_root_model_keys`: Added normalization of `model.default` via `normalize_model_for_provider` when both `model.default` and `model.provider` are populated

## Verification

- All 80 model_normalize tests pass
- All 155 config tests pass  
- Manual testing confirms correct behavior for native providers (openai-codex, anthropic, deepseek), aggregators (openrouter), custom providers, and idempotent re-runs

Closes #67106