### PR TITLE
fix: resolve kimi-k3 context length to 1M on canonical Kimi Coding endpoint

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -540,7 +540,13 @@ def _is_known_provider_base_url(base_url: str) -> bool:
 
 
 def _endpoint_scoped_context_length(model: str, base_url: str) -> Optional[int]:
-    """Return metadata confirmed only for one provider endpoint."""
+    """Return metadata confirmed only for the Kimi Coding endpoint.
+
+    Kimi Coding serves K3 under the bare slug ``k3``, but users may also
+    configure or select the public-facing aliases ``kimi-k3`` and
+    ``kimi-k3-cot``. Only canonical ``https://api.kimi.com/coding`` endpoints
+    (legacy Moonshot keys do not serve K3) get the 1 Mi context window.
+    """
     normalized = _normalize_base_url(base_url)
     try:
         parsed = urlparse(normalized)
@@ -556,7 +562,7 @@ def _endpoint_scoped_context_length(model: str, base_url: str) -> Optional[int]:
         and parsed.path.rstrip("/") in {"/coding", "/coding/v1"}
         and not parsed.query
         and not parsed.fragment
-        and model.strip().lower() == "k3"
+        and model.strip().lower() in {"k3", "kimi-k3", "kimi-k3-cot"}
     ):
         return 1_048_576
     return None

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -199,14 +199,16 @@ class TestDefaultContextLengths:
             )
 
             for base_url in accepted_urls:
-                assert get_model_context_length(
-                    "k3", provider="kimi-coding", base_url=base_url
-                ) == 1_048_576
+                for model in ("k3", "kimi-k3", "kimi-k3-cot"):
+                    assert get_model_context_length(
+                        model, provider="kimi-coding", base_url=base_url
+                    ) == 1_048_576
 
             for base_url in rejected_urls:
-                assert get_model_context_length(
-                    "k3", provider="kimi-coding", base_url=base_url
-                ) != 1_048_576
+                for model in ("k3", "kimi-k3", "kimi-k3-cot"):
+                    assert get_model_context_length(
+                        model, provider="kimi-coding", base_url=base_url
+                    ) != 1_048_576
 
     def test_grok_substring_matching(self):
         # Longest-first substring matching must resolve the real xAI model


### PR DESCRIPTION
## Problem

When using the public-facing model slug `kimi-k3` with the `kimi-coding` provider, Hermes resolves the context window to the generic `kimi` catch-all (262,144 tokens) instead of the 1,048,576 tokens that K3 supports.

This is because the endpoint-scoped override in `_endpoint_scoped_context_length` only keyed on the bare Kimi Coding slug `k3`. Users who select or configure `kimi-k3` fall through to the 262k default.

## Fix

- Extend `_endpoint_scoped_context_length` to recognize `kimi-k3` and `kimi-k3-cot` as aliases for the K3 model.
- The endpoint guard still restricts the 1M value to canonical `https://api.kimi.com/coding` endpoints, so legacy Moonshot keys do not get a false 1M window.
- Update the existing test to cover all three aliases.

## Verification

```python
from agent.model_metadata import get_model_context_length

# Before: 262144  After: 1048576
print(get_model_context_length('kimi-k3', provider='kimi-coding', base_url='https://api.kimi.com/coding/v1'))

# Legacy Moonshot endpoint remains 262144
print(get_model_context_length('kimi-k3', provider='kimi-coding', base_url='https://api.moonshot.ai/v1'))
```

All 122 tests in `tests/agent/test_model_metadata.py` pass.

Closes #67115