### PR TITLE
feat(stt): add mlx_whisper as TranscriptionProvider plugin for macOS Apple Silicon

### DIFF
--- a/plugins/transcription/mlx_whisper/__init__.py
+++ b/plugins/transcription/mlx_whisper/__init__.py
@@ -1,0 +1,237 @@
+"""MLX Whisper STT provider for macOS Apple Silicon.
+
+Registers as a plugin-provided :class:`TranscriptionProvider` so users can
+set ``stt.provider: mlx_whisper`` in ``config.yaml``.  Uses Apple's MLX
+framework with GPU / Neural Engine acceleration — 3× faster than
+faster-whisper on Apple Silicon.
+
+Model selection
+---------------
+Short aliases resolve to ``mlx-community`` HF repos:
+
+    tiny           → mlx-community/whisper-tiny-mlx
+    base           → mlx-community/whisper-base-mlx      (default)
+    small          → mlx-community/whisper-small-mlx
+    medium         → mlx-community/whisper-medium-mlx
+    large / large-v3 → mlx-community/whisper-large-v3-mlx
+    turbo / large-v3-turbo → mlx-community/whisper-large-v3-turbo
+
+Any HF repo id can be passed directly as the model.
+
+Usage
+-----
+.. code-block:: bash
+
+    pip install mlx-whisper
+    hermes config set stt.provider mlx_whisper
+    # optional:
+    hermes config set stt.model mlx-community/whisper-small-mlx
+
+Setup wizard auto-detection is handled by the provider's
+:meth:`get_setup_schema` — it reports ``mlx_whisper`` as an available
+option on Darwin / arm64.
+
+References
+----------
+- https://github.com/ml-explore/mlx-examples/tree/main/whisper
+- https://huggingface.co/mlx-community
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.transcription_provider import TranscriptionProvider
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model alias map — short names → HF repo ids
+# ---------------------------------------------------------------------------
+
+_DEFAULT_MODEL = "mlx-community/whisper-base-mlx"
+
+_MODEL_ALIASES: Dict[str, str] = {
+    "tiny": "mlx-community/whisper-tiny-mlx",
+    "base": "mlx-community/whisper-base-mlx",
+    "small": "mlx-community/whisper-small-mlx",
+    "medium": "mlx-community/whisper-medium-mlx",
+    "large": "mlx-community/whisper-large-v3-mlx",
+    "large-v3": "mlx-community/whisper-large-v3-mlx",
+    "turbo": "mlx-community/whisper-large-v3-turbo",
+    "large-v3-turbo": "mlx-community/whisper-large-v3-turbo",
+}
+
+
+def _resolve_model(model: Optional[str]) -> str:
+    """Translate a short alias to a full HF repo id, or pass through."""
+    if not model:
+        return _DEFAULT_MODEL
+    key = model.strip().lower()
+    return _MODEL_ALIASES.get(key, model)
+
+
+def _is_apple_silicon() -> bool:
+    """Return True on macOS arm64 (Apple Silicon), False otherwise."""
+    return platform.system() == "Darwin" and platform.machine() == "arm64"
+
+
+def _mlx_whisper_importable() -> bool:
+    """Check whether ``mlx_whisper`` can be imported."""
+    try:
+        __import__("mlx_whisper")
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class MLXWhisperProvider(TranscriptionProvider):
+    """Speech-to-text backend using Apple MLX Whisper (local, free).
+
+    Implements the :class:`agent.transcription_provider.TranscriptionProvider`
+    protocol — attribute ``name``, :meth:`transcribe`, :meth:`is_available`,
+    :meth:`list_models`, :meth:`default_model`, and
+    :meth:`get_setup_schema`.
+
+    Users enable it by setting ``stt.provider: mlx_whisper`` in
+    ``config.yaml``.
+    """
+
+    @property
+    def name(self) -> str:
+        """Stable short identifier — ``stt.provider`` value."""
+        return "mlx_whisper"
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable label shown in ``hermes tools``."""
+        return "MLX Whisper"
+
+    def is_available(self) -> bool:
+        """Return True on Apple Silicon with mlx_whisper installed."""
+        if not _is_apple_silicon():
+            return False
+        return _mlx_whisper_importable()
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        """Expose the curated model aliases."""
+        seen: set = set()
+        models: List[Dict[str, Any]] = []
+        for alias, repo in _MODEL_ALIASES.items():
+            if repo in seen:
+                # Skip duplicates (large, large-v3 → same repo)
+                continue
+            seen.add(repo)
+            models.append({
+                "id": repo,
+                "display": f"{alias} ({repo})",
+            })
+        return models
+
+    def default_model(self) -> str:
+        return _DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        """Return provider metadata for the tools picker / setup wizard."""
+        return {
+            "name": self.display_name,
+            "badge": "free",
+            "tag": "Local MLX Whisper — Apple Silicon GPU",
+            "env_vars": [],
+        }
+
+    def transcribe(
+        self,
+        file_path: str,
+        *,
+        model: Optional[str] = None,
+        language: Optional[str] = None,
+        **extra: Any,
+    ) -> Dict[str, Any]:
+        """Transcribe *file_path* with MLX Whisper.
+
+        Returns the standard envelope on both success and failure.
+        """
+        if not self.is_available():
+            return {
+                "success": False,
+                "transcript": "",
+                "error": (
+                    "MLX Whisper requires macOS Apple Silicon and "
+                    "mlx-whisper installed (pip install mlx-whisper)"
+                ),
+                "provider": self.name,
+            }
+
+        resolved = _resolve_model(model)
+
+        try:
+            import mlx_whisper  # noqa: I001  — lazy, inside transcribe
+        except ImportError:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "mlx-whisper not installed (pip install mlx-whisper)",
+                "provider": self.name,
+            }
+
+        try:
+            result = mlx_whisper.transcribe(
+                file_path,
+                path_or_hf_repo=resolved,
+            )
+            transcript = (result.get("text") or "").strip()
+            logger.info(
+                "Transcribed %s via mlx_whisper (%s, %d chars)",
+                Path(file_path).name, resolved, len(transcript),
+            )
+            return {
+                "success": True,
+                "transcript": transcript,
+                "provider": self.name,
+            }
+        except Exception as exc:
+            logger.error(
+                "MLX Whisper transcription failed: %s", exc, exc_info=True,
+            )
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"MLX Whisper transcription failed: {exc}",
+                "provider": self.name,
+            }
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+
+def register(ctx):
+    """Register the MLX Whisper :class:`TranscriptionProvider` plugin.
+
+    Called by the Hermes plugin loader during discovery.  The provider
+    is only registered on macOS (darwin) — on other platforms the
+    registration is silently skipped.
+    """
+    if not _is_apple_silicon():
+        logger.debug(
+            "mlx_whisper plugin: skipping registration (not macOS arm64)"
+        )
+        return
+
+    try:
+        ctx.register_transcription_provider(MLXWhisperProvider())
+        logger.info("mlx_whisper transcription provider registered")
+    except Exception as exc:
+        logger.warning(
+            "mlx_whisper plugin registration failed: %s", exc,
+        )

--- a/plugins/transcription/mlx_whisper/plugin.yaml
+++ b/plugins/transcription/mlx_whisper/plugin.yaml
@@ -1,0 +1,3 @@
+name: mlx_whisper
+version: 0.1.0
+description: "MLX Whisper STT provider for macOS Apple Silicon — local, free, GPU-accelerated"

--- a/tests/tools/test_transcription_mlx_whisper.py
+++ b/tests/tools/test_transcription_mlx_whisper.py
@@ -1,0 +1,227 @@
+"""Tests for the MLX Whisper transcription provider plugin.
+
+Covers registration, availability gating, model alias resolution,
+transcribe dispatch, and error handling.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent import transcription_registry
+from agent.transcription_provider import TranscriptionProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reload_provider_module(monkeypatch, *, apple_silicon=True, mlx_importable=True):
+    """Reload the mlx_whisper plugin module with controlled platform state."""
+    import importlib
+    import sys
+    import types
+
+    # Force re-import of the plugin module
+    for mod in list(sys.modules):
+        if mod.startswith("plugins.transcription.mlx_whisper"):
+            del sys.modules[mod]
+
+    if apple_silicon:
+        monkeypatch.setattr("platform.machine", lambda: "arm64")
+        monkeypatch.setattr("platform.system", lambda: "Darwin")
+    else:
+        monkeypatch.setattr("platform.machine", lambda: "x86_64")
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    if mlx_importable:
+        fake_mlx = types.ModuleType("mlx_whisper")
+
+        def _fake_transcribe(file_path, path_or_hf_repo=None):
+            return {"text": f"transcribed from {path_or_hf_repo or 'default'}"}
+
+        fake_mlx.transcribe = _fake_transcribe
+        monkeypatch.setitem(sys.modules, "mlx_whisper", fake_mlx)
+    else:
+        # Ensure mlx_whisper is NOT importable
+        monkeypatch.delitem(sys.modules, "mlx_whisper", raising=False)
+
+    transcription_registry._reset_for_tests()
+
+    # Import the plugin module fresh and call register()
+    spec = importlib.util.find_spec("plugins.transcription.mlx_whisper")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["plugins.transcription.mlx_whisper"] = module
+    spec.loader.exec_module(module)
+
+    # Simulate plugin discovery: call register() with a mock ctx
+    class _MockCtx:
+        pass
+
+    ctx = _MockCtx()
+    ctx.register_transcription_provider = transcription_registry.register_provider
+    module.register(ctx)
+
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMLXWhisperRegistration:
+    """Provider registration and availability."""
+
+    def test_registers_on_apple_silicon(self, monkeypatch):
+        """Provider is registered on macOS arm64 with mlx_whisper."""
+        _reload_provider_module(monkeypatch, apple_silicon=True, mlx_importable=True)
+        provider = transcription_registry.get_provider("mlx_whisper")
+        assert provider is not None
+        assert provider.name == "mlx_whisper"
+        assert isinstance(provider, TranscriptionProvider)
+
+    def test_skips_on_intel(self, monkeypatch):
+        """Registration skipped when not on Apple Silicon."""
+        _reload_provider_module(monkeypatch, apple_silicon=False, mlx_importable=True)
+        provider = transcription_registry.get_provider("mlx_whisper")
+        assert provider is None
+
+    def test_registers_but_unavailable_without_package(self, monkeypatch):
+        """Registered but is_available() returns False without mlx_whisper."""
+        _reload_provider_module(monkeypatch, apple_silicon=True, mlx_importable=False)
+        provider = transcription_registry.get_provider("mlx_whisper")
+        assert provider is not None
+        assert provider.is_available() is False
+
+
+class TestMLXWhisperModels:
+    """Model alias resolution."""
+
+    def _get_provider(self, monkeypatch):
+        _reload_provider_module(monkeypatch, apple_silicon=True, mlx_importable=True)
+        return transcription_registry.get_provider("mlx_whisper")
+
+    def test_default_model(self, monkeypatch):
+        provider = self._get_provider(monkeypatch)
+        assert provider.default_model() == "mlx-community/whisper-base-mlx"
+
+    def test_list_models_returns_entries(self, monkeypatch):
+        provider = self._get_provider(monkeypatch)
+        models = provider.list_models()
+        assert len(models) > 0
+        ids = {m["id"] for m in models}
+        assert "mlx-community/whisper-tiny-mlx" in ids
+        assert "mlx-community/whisper-base-mlx" in ids
+        assert "mlx-community/whisper-large-v3-mlx" in ids
+        # large and large-v3 map to same repo — deduped
+        assert "mlx-community/whisper-large-v3-turbo" in ids
+
+    def test_alias_resolution(self, monkeypatch):
+        """Short aliases resolve to full HF repo ids."""
+        from plugins.transcription.mlx_whisper import _resolve_model
+
+        assert _resolve_model("tiny") == "mlx-community/whisper-tiny-mlx"
+        assert _resolve_model("base") == "mlx-community/whisper-base-mlx"
+        assert _resolve_model("small") == "mlx-community/whisper-small-mlx"
+        assert _resolve_model("large") == "mlx-community/whisper-large-v3-mlx"
+        assert _resolve_model("large-v3") == "mlx-community/whisper-large-v3-mlx"
+        assert _resolve_model("turbo") == "mlx-community/whisper-large-v3-turbo"
+
+    def test_passthrough_unknown_model(self, monkeypatch):
+        """Unknown model id passes through unchanged."""
+        from plugins.transcription.mlx_whisper import _resolve_model
+
+        assert _resolve_model("custom/whisper-foo") == "custom/whisper-foo"
+
+    def test_none_model_uses_default(self, monkeypatch):
+        from plugins.transcription.mlx_whisper import _resolve_model
+
+        assert _resolve_model(None) == "mlx-community/whisper-base-mlx"
+
+
+class TestMLXWhisperTranscribe:
+    """Transcription dispatch."""
+
+    def _get_provider(self, monkeypatch):
+        _reload_provider_module(monkeypatch, apple_silicon=True, mlx_importable=True)
+        return transcription_registry.get_provider("mlx_whisper")
+
+    def test_transcribe_success(self, monkeypatch, tmp_path):
+        """Successful transcription returns the standard envelope."""
+        provider = self._get_provider(monkeypatch)
+        audio = tmp_path / "audio.wav"
+        audio.write_bytes(b"\x00" * 1024)
+
+        result = provider.transcribe(str(audio))
+        assert result["success"] is True
+        assert "transcribed from" in result["transcript"]
+        assert result["provider"] == "mlx_whisper"
+
+    def test_transcribe_unavailable(self, monkeypatch, tmp_path):
+        """Returns error envelope when mlx_whisper package is missing."""
+        _reload_provider_module(monkeypatch, apple_silicon=True, mlx_importable=False)
+        provider = transcription_registry.get_provider("mlx_whisper")
+        audio = tmp_path / "audio.wav"
+        audio.write_bytes(b"\x00" * 1024)
+
+        result = provider.transcribe(str(audio))
+        assert result["success"] is False
+        assert result["transcript"] == ""
+        assert "requires" in result["error"].lower()
+        assert result["provider"] == "mlx_whisper"
+
+    def test_transcribe_with_model_alias(self, monkeypatch, tmp_path):
+        """Alias resolves to full HF repo id."""
+        provider = self._get_provider(monkeypatch)
+        audio = tmp_path / "audio.wav"
+        audio.write_bytes(b"\x00" * 1024)
+
+        result = provider.transcribe(str(audio), model="tiny")
+        assert result["success"] is True
+        assert "mlx-community/whisper-tiny-mlx" in result["transcript"]
+
+    def test_transcribe_exception_becomes_error_envelope(self, monkeypatch, tmp_path):
+        """Provider exceptions are caught and returned as error envelope."""
+        import sys
+
+        provider = self._get_provider(monkeypatch)
+        audio = tmp_path / "audio.wav"
+        audio.write_bytes(b"\x00" * 1024)
+
+        # Make the fake mlx_whisper.transcribe raise
+        fake_mlx = sys.modules["mlx_whisper"]
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("fake GPU error")
+
+        fake_mlx.transcribe = _raise
+
+        result = provider.transcribe(str(audio))
+        assert result["success"] is False
+        assert "fake GPU error" in result["error"]
+        assert result["provider"] == "mlx_whisper"
+
+    def test_transcribe_not_apple_silicon(self, monkeypatch, tmp_path):
+        """Returns error on non-Apple-Silicon."""
+        _reload_provider_module(monkeypatch, apple_silicon=False, mlx_importable=True)
+        # On intel, the plugin doesn't register at all
+        provider = transcription_registry.get_provider("mlx_whisper")
+        assert provider is None
+
+
+class TestMLXWhisperSetupSchema:
+    """Provider setup schema for tools picker."""
+
+    def _get_provider(self, monkeypatch):
+        _reload_provider_module(monkeypatch, apple_silicon=True, mlx_importable=True)
+        return transcription_registry.get_provider("mlx_whisper")
+
+    def test_schema_structure(self, monkeypatch):
+        provider = self._get_provider(monkeypatch)
+        schema = provider.get_setup_schema()
+        assert schema["name"] == "MLX Whisper"
+        assert schema["badge"] == "free"
+        assert isinstance(schema["env_vars"], list)
+        assert len(schema["env_vars"]) == 0


### PR DESCRIPTION
## What

Add MLX Whisper STT as a plugin-registered `TranscriptionProvider` — the correct integration surface per @teknium1 review of #3498. Users enable via `stt.provider: mlx_whisper` in config.yaml.

**3× faster than faster-whisper** on Apple Silicon (3.9s vs 12s per transcription).

## Changes

- **`plugins/transcription/mlx_whisper/__init__.py`** — `MLXWhisperProvider(TranscriptionProvider)` with:
  - Model alias resolution (tiny/base/small/medium/large/turbo → HF repos)
  - `is_available()` gate: macOS arm64 + mlx_whisper importable
  - `transcribe()` with standard error envelope
  - Auto-skips registration on non-Apple-Silicon hosts
  - Graceful degradation when `mlx-whisper` not installed
- **`plugins/transcription/mlx_whisper/plugin.yaml`** — plugin manifest
- **`tests/tools/test_transcription_mlx_whisper.py`** — 14 tests covering registration, availability gating, model aliases, transcription dispatch, error handling, and setup schema

## What this does NOT touch

- Zero core changes to `tools/transcription_tools.py` — no built-in provider addition
- No `BUILTIN_STT_PROVIDERS` changes
- No dispatch logic changes — existing plugin dispatch in `_dispatch_to_plugin_provider` handles this automatically

## Testing

```
14 passed in 1.12s
57 existing transcription tests pass (zero regressions)
```

## References

- Original PR: #3498 (stale, wrong integration surface)
- Feature request: #3491
- Technium review guidance: use `TranscriptionProvider` plugin, not core patch
- Benchmark: mlx-whisper base 3.9s vs faster-whisper 12s (from #3491 comments)

Closes #3491