### PR TITLE
fix(doctor): normalize model IDs during config repair

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -959,9 +959,17 @@ def run_doctor(args):
 
         # Validate model.provider and model.default values
         try:
-            # Raw-file diagnostic: inspects what the user actually wrote.
-            from hermes_cli.config import read_user_config_raw
-            cfg = read_user_config_raw(config_path)
+            import yaml as _yaml
+            cfg = _yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            migrated_root_model_keys = False
+            normalized_native_model = False
+            if should_fix:
+                from hermes_cli.config import _normalize_root_model_keys
+
+                normalized_cfg = _normalize_root_model_keys(cfg)
+                if normalized_cfg != cfg:
+                    cfg = normalized_cfg
+                    migrated_root_model_keys = True
             model_section = cfg.get("model") or {}
             provider_raw = (model_section.get("provider") or "").strip()
             provider = provider_raw.lower()
@@ -1100,14 +1108,38 @@ def run_doctor(args):
                 and provider_policy_id
                 and not provider_accepts_vendor_slug
             ):
-                check_warn(
-                    f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider_raw}'",
-                    "(vendor-prefixed slugs belong to aggregators like openrouter)",
-                )
-                issues.append(
-                    f"model.default '{default_model}' is vendor-prefixed but model.provider is '{provider_raw}'. "
-                    "Either set model.provider to 'openrouter', or drop the vendor prefix."
-                )
+                if should_fix:
+                    from hermes_cli.model_normalize import normalize_model_for_provider
+
+                    normalized_model = normalize_model_for_provider(
+                        default_model, provider_policy_id
+                    )
+                    if normalized_model != default_model:
+                        model_section["default"] = normalized_model
+                        cfg["model"] = model_section
+                        normalized_native_model = True
+                if not normalized_native_model:
+                    check_warn(
+                        f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider_raw}'",
+                        "(vendor-prefixed slugs belong to aggregators like openrouter)",
+                    )
+                    issues.append(
+                        f"model.default '{default_model}' is vendor-prefixed but model.provider is '{provider_raw}'. "
+                        "Either set model.provider to 'openrouter', or drop the vendor prefix."
+                    )
+
+            if should_fix and (migrated_root_model_keys or normalized_native_model):
+                from hermes_cli.config import atomic_config_write
+
+                atomic_config_write(config_path, cfg)
+                if migrated_root_model_keys:
+                    check_ok("Migrated stale root-level keys into model section")
+                    fixed_count += 1
+                if normalized_native_model:
+                    check_ok(
+                        f"Normalized model.default for native provider '{provider_raw}'"
+                    )
+                    fixed_count += 1
 
             # Check credentials for the configured provider.
             # Limit to API-key providers in PROVIDER_REGISTRY — other provider

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -492,6 +492,87 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
 
 
 @pytest.mark.parametrize(
+    ("provider", "model", "expected_model", "extra_config"),
+    [
+        ("openai-codex", "openai-codex/gpt-5.6-sol", "gpt-5.6-sol", ""),
+        ("openrouter", "openai/gpt-5.6-sol", "openai/gpt-5.6-sol", ""),
+        (
+            "custom:hpc-ai",
+            "deepseek/deepseek-v4-flash",
+            "deepseek/deepseek-v4-flash",
+            "custom_providers:\\n"
+            "  - name: hpc-ai\\n"
+            "    base_url: https://hpc-ai.example/v1\\n"
+            "    api_key: test-key\\n",
+        ),
+    ],
+)
+def test_doctor_fix_canonicalizes_legacy_model_config(
+    monkeypatch, tmp_path, provider, model, expected_model, extra_config
+):
+    """One repair pass canonicalizes safely and remains idempotent."""
+    import yaml
+
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        f"model: {model}\\n"
+        f"provider: {provider}\\n"
+        f"{extra_config}",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    from hermes_cli import auth as _auth_mod
+
+    monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+
+    from hermes_cli import config as config_mod
+
+    writes = 0
+    real_atomic_config_write = config_mod.atomic_config_write
+
+    def count_atomic_write(*args, **kwargs):
+        nonlocal writes
+        writes += 1
+        return real_atomic_config_write(*args, **kwargs)
+
+    monkeypatch.setattr(config_mod, "atomic_config_write", count_atomic_write)
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        doctor_mod.run_doctor(Namespace(fix=True))
+
+    repaired_text = (home / "config.yaml").read_text(encoding="utf-8")
+    repaired = yaml.safe_load(repaired_text)
+    assert repaired["model"] == {
+        "default": expected_model,
+        "provider": provider,
+    }
+    assert "provider" not in repaired
+    assert writes == 1
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        doctor_mod.run_doctor(Namespace(fix=True))
+
+    assert (home / "config.yaml").read_text(encoding="utf-8") == repaired_text
+    assert writes == 1
+
+
+@pytest.mark.parametrize(
     ("provider", "default_model"),
     [
         ("ai-gateway", "anthropic/claude-sonnet-4.6"),


### PR DESCRIPTION
## Summary

- Migrate stale root-level model keys (provider, base_url, context_length) into the model section before validation during `hermes doctor --fix`
- Normalize vendor-prefixed model IDs (e.g. `openai-codex/gpt-5.6-sol` → `gpt-5.6-sol`) for native providers using the existing `normalize_model_for_provider()` function
- Preserve slash-form IDs for aggregators, custom providers, and unmatched vendor prefixes
- Apply combined migration + normalization in a single fail-closed atomic config write
- Verify repair is idempotent

## Reproduction

Given:

```yaml
model: openai-codex/gpt-5.6-sol
provider: openai-codex
```

`hermes doctor --fix` previously migrated the structure but retained the vendor-prefixed model ID. A subsequent Doctor run then reported another issue.

## Result

One repair pass now produces:

```yaml
model:
  default: gpt-5.6-sol
  provider: openai-codex
```

## Change

- `hermes_cli/doctor.py`: Migrate root-level keys before validation; normalize vendor-prefixed model IDs during `--fix`; write combined changes atomically
- `tests/hermes_cli/test_doctor.py`: Add parametrized regression test covering root migration + model normalization + aggregator/custom provider preservation + idempotency

Closes #67106