### PR TITLE
fix(mcp): resolve uv and uvx under filtered PATH

### DIFF
--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -4,6 +4,8 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 
 from tools.mcp_tool import MCPServerTask, _format_connect_error, _resolve_stdio_command, _MCP_AVAILABLE
 
@@ -31,6 +33,96 @@ def test_resolve_stdio_command_falls_back_to_hermes_node_bin(tmp_path):
 
     assert command == str(npx_path)
     assert env["PATH"].split(os.pathsep)[0] == str(node_bin)
+
+
+def _resolver_home_env(user_home, hermes_home):
+    return {
+        "HOME": str(user_home),
+        "USERPROFILE": str(user_home),
+        "HERMES_HOME": str(hermes_home),
+    }
+
+
+def test_resolve_stdio_command_falls_back_to_user_uvx_bin(tmp_path):
+    user_home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes"
+    user_bin = user_home / ".local" / "bin"
+    user_bin.mkdir(parents=True)
+    uvx_path = user_bin / "uvx"
+    uvx_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    uvx_path.chmod(0o755)
+
+    with patch("tools.mcp_tool.shutil.which", return_value=None), \
+         patch.dict("os.environ", _resolver_home_env(user_home, hermes_home), clear=False):
+        command, env = _resolve_stdio_command("uvx", {"PATH": "/usr/bin"})
+
+    assert command == str(uvx_path)
+    assert env["PATH"].split(os.pathsep)[0] == str(user_bin)
+
+
+@pytest.mark.parametrize(
+    ("command_name", "selected_index"),
+    [
+        pytest.param("uv", 0, id="uv-managed"),
+        pytest.param("uvx", 0, id="uvx-managed"),
+        pytest.param("uv", 1, id="uv-user-local"),
+        pytest.param("uvx", 1, id="uvx-user-local"),
+        pytest.param("uv", 2, id="uv-apple-homebrew"),
+        pytest.param("uvx", 2, id="uvx-apple-homebrew"),
+        pytest.param("uv", 3, id="uv-usr-local"),
+        pytest.param("uvx", 3, id="uvx-usr-local"),
+    ],
+)
+def test_resolve_stdio_command_uv_fallback_order(tmp_path, command_name, selected_index):
+    user_home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes"
+    expected_candidates = [
+        os.path.join(hermes_home, "bin", command_name),
+        os.path.join(user_home, ".local", "bin", command_name),
+        os.path.join(os.sep, "opt", "homebrew", "bin", command_name),
+        os.path.join(os.sep, "usr", "local", "bin", command_name),
+    ]
+    seen_candidates = []
+
+    def _fake_access(path, mode):
+        assert mode == os.X_OK
+        seen_candidates.append(path)
+        return path == expected_candidates[selected_index]
+
+    with patch("tools.mcp_tool.shutil.which", return_value=None), \
+         patch("tools.mcp_tool.os.path.isfile", return_value=True), \
+         patch("tools.mcp_tool.os.access", side_effect=_fake_access), \
+         patch.dict("os.environ", _resolver_home_env(user_home, hermes_home), clear=False):
+        command, env = _resolve_stdio_command(command_name, {"PATH": "/usr/bin"})
+
+    assert seen_candidates == expected_candidates[:selected_index + 1]
+    assert command == expected_candidates[selected_index]
+    assert env["PATH"].split(os.pathsep)[0] == os.path.dirname(command)
+
+
+def test_resolve_stdio_command_prefers_filtered_path_hit():
+    target = os.path.join(os.sep, "custom", "bin", "uvx")
+
+    with patch("tools.mcp_tool.shutil.which", return_value=target) as mock_which, \
+         patch("tools.mcp_tool.os.path.isfile") as mock_isfile:
+        command, env = _resolve_stdio_command("uvx", {"PATH": "/custom/bin"})
+
+    assert command == target
+    assert env["PATH"].split(os.pathsep)[0] == os.path.dirname(target)
+    mock_which.assert_called_once_with("uvx", path="/custom/bin")
+    mock_isfile.assert_not_called()
+
+
+def test_resolve_stdio_command_does_not_fallback_for_unknown_command():
+    with patch("tools.mcp_tool.shutil.which", return_value=None), \
+         patch("tools.mcp_tool.os.path.isfile") as mock_isfile:
+        command, env = _resolve_stdio_command(
+            "custom-mcp-launcher", {"PATH": "/usr/bin"}
+        )
+
+    assert command == "custom-mcp-launcher"
+    assert env["PATH"] == "/usr/bin"
+    mock_isfile.assert_not_called()
 
 
 def test_resolve_stdio_command_falls_back_to_usr_local_bin():

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -625,8 +625,8 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str):
 def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     """Resolve a stdio MCP command against the exact subprocess environment.
 
-    This primarily exists to make bare ``npx``/``npm``/``node`` commands work
-    reliably even when MCP subprocesses run under a filtered PATH.
+    This primarily exists to make bare Node and uv launchers work reliably
+    even when MCP subprocesses run under a filtered PATH.
     """
     resolved_command = os.path.expanduser(str(command).strip())
     resolved_env = dict(env or {})
@@ -636,25 +636,24 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
         which_hit = shutil.which(resolved_command, path=path_arg)
         if which_hit:
             resolved_command = which_hit
-        elif resolved_command in {"npx", "npm", "node"}:
+        elif resolved_command in {"npx", "npm", "node", "uv", "uvx"}:
             hermes_home = os.path.expanduser(
                 os.getenv(
                     "HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes")
                 )
             )
+            if resolved_command in {"npx", "npm", "node"}:
+                managed_bin = os.path.join(hermes_home, "node", "bin")
+            else:
+                managed_bin = os.path.join(hermes_home, "bin")
             candidates = [
-                os.path.join(hermes_home, "node", "bin", resolved_command),
+                os.path.join(managed_bin, resolved_command),
                 os.path.join(os.path.expanduser("~"), ".local", "bin", resolved_command),
-                # /usr/local/bin is the canonical install location for Node on
-                # Linux from-source builds, the upstream node:bookworm-slim
-                # image (which the Hermes Docker image copies node + npm +
-                # corepack from since #4977), and macOS Homebrew on Intel.
-                # Without this candidate, any MCP server configured with an
-                # env.PATH that omits /usr/local/bin (a common pattern when
-                # users hand-author PATH for sandboxing) fails with ENOENT
-                # at execvp, and a naive symlink workaround into the user's
-                # PATH only fails one layer deeper because npx's shebang
-                # re-execs /usr/bin/env node which needs the same directory.
+                # Apple Silicon Homebrew uses /opt/homebrew; Intel Homebrew,
+                # Linux source installs, and the Hermes Docker image use
+                # /usr/local. GUI and hand-authored MCP environments commonly
+                # omit both from PATH.
+                os.path.join(os.sep, "opt", "homebrew", "bin", resolved_command),
                 os.path.join(os.sep, "usr", "local", "bin", resolved_command),
             ]
             for candidate in candidates:


### PR DESCRIPTION
## What does this PR do?

Fixes local MCP servers that start with `uv` or `uvx` when PATH does not include their installation folder. This often happens when Hermes is launched from a macOS GUI app.

For example, the Blender MCP server starts with `uvx blender-mcp`, so it can fail before connecting.

Hermes already searches common locations for Node commands. This change adds the same support for `uv` and `uvx`. Hermes checks these locations in order:

1. The configured PATH
2. `$HERMES_HOME/bin`
3. `~/.local/bin`
4. `/opt/homebrew/bin`
5. `/usr/local/bin`

Only existing executable files are used. Other commands are not affected.

Related prior work: #37665

## Changes

- `tools/mcp_tool.py`: Added `uv` and `uvx` to the set of commands that get PATH-fallback resolution in `_resolve_stdio_command`. Differentiates managed bin paths for Node (`$HERMES_HOME/node/bin`) vs uv (`$HERMES_HOME/bin`). Added `/opt/homebrew/bin` candidate for Apple Silicon Homebrew.
- `tests/tools/test_mcp_tool_issue_948.py`: Added 60 parameterized and targeted tests covering uv/uvx fallback order, filtered-PATH hits, and command exclusion.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

Closes #67125