### PR TITLE
feat(gateway): durable delivery-obligation ledger for final responses

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -1,0 +1,323 @@
+"""Durable delivery-obligation ledger for gateway final responses.
+
+A final agent response that was generated but not yet confirmed-delivered
+to the messaging platform is the one artifact the gateway can lose without
+a trace: the turn already burned its tokens, the text exists only in a
+Python local, and a crash / planned restart between finalize and platform
+ACK drops it silently (#58818, #41696, #63695).
+
+This module records a small durable row per outbound final response in the
+shared ``state.db`` (same file and conventions as
+``tools.async_delegation`` — WAL, owner pid + process-start-time liveness,
+bounded retention). The gateway writes three checkpoints around the send:
+
+    record_obligation()   state='pending'     before any send attempt
+    mark_attempting()     state='attempting'  immediately before the await
+    mark_delivered() /    state='delivered'   only on SendResult.success
+    mark_failed()         state='failed'      on a definitive rejection
+
+On startup, ``sweep_recoverable()`` claims rows whose owning process is
+dead and hands them to the gateway for redelivery. Crash semantics are
+explicit about ambiguity (the contract review of the earlier
+delivery-outbox attempt, #61790, closed it for silently resending
+ambiguous sends):
+
+- ``pending``     — the send never started: redeliver plainly, no dup risk.
+- ``attempting``  — crashed mid-await: the platform MAY already have the
+  message. Redelivered WITH a visible recovered-reply marker so the
+  contract is honest at-least-once, never a silent duplicate.
+- ``failed``      — definitively rejected once; the restart is a natural
+  retry boundary. Also carries the marker.
+- ``delivered``   — nothing to do; retention prunes.
+
+Poison rows cannot spin: attempts are capped, stale rows expire, and both
+transition to ``abandoned`` (kept briefly for inspection, then pruned).
+
+Everything here is best-effort by design: ledger failures must never block
+or delay an actual send. Callers wrap every call in try/except.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_DB_LOCK = threading.Lock()
+
+# Redelivery policy knobs (module constants; deliberately not config — the
+# ledger itself is gated by ``gateway.delivery_ledger`` and these bounds
+# only matter in the rare recovery path).
+MAX_ATTEMPTS = 3
+STALE_AFTER_SECONDS = 24 * 60 * 60
+_RETENTION_SECONDS = 7 * 24 * 60 * 60
+_MAX_ROWS = 500
+
+# Visible prefix for redeliveries that might duplicate an already-received
+# message (crash mid-send / post-rejection retry). Honest at-least-once.
+RECOVERED_MARKER = (
+    "♻️ Recovered reply — the gateway restarted during delivery, "
+    "so this may be a duplicate:\n\n"
+)
+
+
+def _db_path():
+    return get_hermes_home() / "state.db"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS delivery_obligations (
+            obligation_id TEXT PRIMARY KEY,
+            session_key TEXT NOT NULL,
+            platform TEXT NOT NULL,
+            chat_id TEXT NOT NULL,
+            thread_id TEXT,
+            content TEXT NOT NULL,
+            state TEXT NOT NULL,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            owner_pid INTEGER,
+            owner_started_at INTEGER,
+            last_error TEXT
+        )"""
+    )
+    return conn
+
+
+def _owner_stamp() -> tuple[int, Optional[int]]:
+    pid = os.getpid()
+    try:
+        from gateway.status import get_process_start_time
+
+        return pid, get_process_start_time(pid)
+    except Exception:
+        return pid, None
+
+
+def _owner_alive(pid: Any, started_at: Any) -> bool:
+    """True when the recorded owning process still exists (pid + start time)."""
+    if not pid:
+        return False
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return False
+    try:
+        from gateway.status import get_process_start_time
+
+        current_start = get_process_start_time(pid)
+    except Exception:
+        current_start = None
+    if current_start is None:
+        # No such process (or unreadable) — treat unreadable-but-extant
+        # processes as alive only if the pid exists.
+        try:
+            os.kill(pid, 0)  # windows-footgun: ok — EPERM counts as alive below
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        except OSError:
+            return False
+        return True
+    if started_at is None:
+        return True
+    try:
+        return int(current_start) == int(started_at)
+    except (TypeError, ValueError):
+        return True
+
+
+def compute_obligation_id(session_key: str, message_ref: str, content: str) -> str:
+    """Stable id: same turn + same content re-records idempotently, while
+    distinct threads/topics on the same chat can never collide (the
+    session_key carries platform, chat and thread; ``message_ref`` is the
+    triggering inbound message id, distinguishing turns in one session)."""
+    payload = f"{session_key}|{message_ref}|{content}"
+    return hashlib.sha256(payload.encode("utf-8", "replace")).hexdigest()[:24]
+
+
+def record_obligation(
+    *,
+    obligation_id: str,
+    session_key: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    content: str,
+) -> None:
+    """Record a final response as owed to the platform (state='pending')."""
+    now = time.time()
+    pid, started = _owner_stamp()
+    with _DB_LOCK, _connect() as conn:
+        conn.execute(
+            """INSERT OR REPLACE INTO delivery_obligations
+               (obligation_id, session_key, platform, chat_id, thread_id,
+                content, state, attempts, created_at, updated_at,
+                owner_pid, owner_started_at)
+               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+            (obligation_id, session_key, platform, str(chat_id),
+             str(thread_id) if thread_id else None, content, now, now,
+             pid, started),
+        )
+    _prune()
+
+
+def mark_attempting(obligation_id: str) -> None:
+    _update_state(obligation_id, "attempting")
+
+
+def mark_delivered(obligation_id: str) -> None:
+    _update_state(obligation_id, "delivered")
+
+
+def mark_failed(obligation_id: str, error: str = "") -> None:
+    _update_state(obligation_id, "failed", error=error)
+
+
+def _update_state(obligation_id: str, state: str, error: str = "") -> None:
+    with _DB_LOCK, _connect() as conn:
+        conn.execute(
+            """UPDATE delivery_obligations
+               SET state=?, updated_at=?, last_error=?
+               WHERE obligation_id=?""",
+            (state, time.time(), error[:500] if error else None, obligation_id),
+        )
+
+
+def sweep_recoverable(now: Optional[float] = None) -> List[Dict[str, Any]]:
+    """Claim undelivered rows owned by dead processes; return them for
+    redelivery.
+
+    Claiming atomically re-stamps the owner to THIS process and increments
+    ``attempts``, so a second gateway racing the same sweep cannot
+    double-claim (the UPDATE is guarded on the previous owner stamp).
+    Rows over the attempts cap or older than the stale cutoff transition to
+    'abandoned' instead of being returned.
+    """
+    now = now if now is not None else time.time()
+    pid, started = _owner_stamp()
+    claimed: List[Dict[str, Any]] = []
+    with _DB_LOCK, _connect() as conn:
+        rows = conn.execute(
+            """SELECT obligation_id, session_key, platform, chat_id, thread_id,
+                      content, state, attempts, created_at,
+                      owner_pid, owner_started_at
+               FROM delivery_obligations
+               WHERE state IN ('pending', 'attempting', 'failed')"""
+        ).fetchall()
+        for (oid, session_key, platform, chat_id, thread_id, content, state,
+             attempts, created_at, owner_pid, owner_started_at) in rows:
+            if _owner_alive(owner_pid, owner_started_at):
+                continue  # a live gateway still owns this row
+            if attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:
+                conn.execute(
+                    """UPDATE delivery_obligations
+                       SET state='abandoned', updated_at=? WHERE obligation_id=?""",
+                    (now, oid),
+                )
+                continue
+            cursor = conn.execute(
+                """UPDATE delivery_obligations
+                   SET owner_pid=?, owner_started_at=?, attempts=attempts+1,
+                       updated_at=?
+                   WHERE obligation_id=? AND (owner_pid IS ? OR owner_pid=?)""",
+                (pid, started, now, oid, owner_pid, owner_pid),
+            )
+            if cursor.rowcount:
+                claimed.append({
+                    "obligation_id": oid,
+                    "session_key": session_key,
+                    "platform": platform,
+                    "chat_id": chat_id,
+                    "thread_id": thread_id,
+                    "content": content,
+                    # pending = send never started, redeliver plainly;
+                    # attempting/failed = ambiguous or rejected, carry marker.
+                    "needs_marker": state != "pending",
+                    "attempts": attempts + 1,
+                })
+    return claimed
+
+
+def _prune(now: Optional[float] = None) -> None:
+    now = now if now is not None else time.time()
+    cutoff = now - _RETENTION_SECONDS
+    try:
+        with _connect() as conn:
+            conn.execute(
+                """DELETE FROM delivery_obligations
+                   WHERE state IN ('delivered', 'abandoned') AND updated_at < ?""",
+                (cutoff,),
+            )
+            total = conn.execute(
+                "SELECT COUNT(*) FROM delivery_obligations"
+            ).fetchone()[0]
+            excess = max(0, total - _MAX_ROWS)
+            if excess:
+                conn.execute(
+                    """DELETE FROM delivery_obligations WHERE obligation_id IN (
+                         SELECT obligation_id FROM delivery_obligations
+                         ORDER BY CASE state
+                                    WHEN 'delivered' THEN 0
+                                    WHEN 'abandoned' THEN 1
+                                    ELSE 2
+                                  END, updated_at ASC
+                         LIMIT ?)""",
+                    (excess,),
+                )
+    except Exception:
+        logger.debug("delivery ledger prune failed", exc_info=True)
+
+
+def ledger_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
+    """Read the ``gateway.delivery_ledger`` config gate (default on)."""
+    try:
+        if config is None:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        gw = config.get("gateway") or {}
+        value = gw.get("delivery_ledger", True)
+        if isinstance(value, str):
+            return value.strip().lower() not in {"false", "0", "no", "off"}
+        return bool(value)
+    except Exception:
+        return True
+
+
+def debug_rows(limit: int = 20) -> str:
+    """Human-readable dump for ad-hoc inspection (sqlite3-free path)."""
+    with _DB_LOCK, _connect() as conn:
+        rows = conn.execute(
+            """SELECT obligation_id, session_key, state, attempts,
+                      created_at, updated_at, last_error
+               FROM delivery_obligations
+               ORDER BY updated_at DESC LIMIT ?""",
+            (limit,),
+        ).fetchall()
+    return json.dumps(
+        [
+            {
+                "id": r[0], "session": r[1], "state": r[2], "attempts": r[3],
+                "created_at": r[4], "updated_at": r[5], "last_error": r[6],
+            }
+            for r in rows
+        ],
+        indent=2,
+    )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5169,6 +5169,47 @@ class BasePlatformAdapter(ABC):
                         event.source.chat_id,
                     )
                     _reply_anchor = _reply_anchor_for_event(event)
+                    # Delivery-obligation ledger: durably record the final
+                    # response BEFORE the send attempt so a gateway crash
+                    # between finalize and platform ACK can redeliver it on
+                    # the next boot instead of silently losing the turn's
+                    # output (#58818). Best-effort at every step — ledger
+                    # trouble must never block or delay the actual send.
+                    # Slash-command and ephemeral replies are cheap to
+                    # regenerate and are not recorded.
+                    _obligation_id = None
+                    if not is_ephemeral_response and not str(
+                        event.text or ""
+                    ).lstrip().startswith(("/", self.typed_command_prefix or "!")):
+                        try:
+                            from gateway.delivery_ledger import (
+                                compute_obligation_id,
+                                ledger_enabled,
+                                mark_attempting,
+                                record_obligation,
+                            )
+
+                            if ledger_enabled():
+                                _obligation_id = compute_obligation_id(
+                                    session_key,
+                                    str(getattr(event, "message_id", "") or ""),
+                                    text_content,
+                                )
+                                record_obligation(
+                                    obligation_id=_obligation_id,
+                                    session_key=session_key,
+                                    platform=str(
+                                        getattr(event.source.platform, "value",
+                                                event.source.platform)
+                                    ),
+                                    chat_id=event.source.chat_id,
+                                    thread_id=getattr(event.source, "thread_id", None),
+                                    content=text_content,
+                                )
+                                mark_attempting(_obligation_id)
+                        except Exception:
+                            logger.debug("delivery ledger record failed", exc_info=True)
+                            _obligation_id = None
                     result = await delivery_adapter._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,
@@ -5176,6 +5217,24 @@ class BasePlatformAdapter(ABC):
                         metadata=_final_thread_metadata,
                     )
                     _record_delivery(result)
+                    if _obligation_id is not None:
+                        try:
+                            from gateway.delivery_ledger import (
+                                mark_delivered,
+                                mark_failed,
+                            )
+
+                            if getattr(result, "success", False):
+                                mark_delivered(_obligation_id)
+                            else:
+                                mark_failed(
+                                    _obligation_id,
+                                    str(getattr(result, "error", "") or ""),
+                                )
+                        except Exception:
+                            logger.debug(
+                                "delivery ledger update failed", exc_info=True
+                            )
 
                     # Schedule auto-deletion on the adapter that owns the new
                     # message ID, which may be the reconnect replacement.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6851,6 +6851,104 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if drained:
             logger.info("Drained %d inbound message(s) queued during startup restore", drained)
 
+    async def _redeliver_pending_obligations(self) -> int:
+        """Redeliver final responses recorded in the delivery ledger by a
+        previous (now dead) gateway process.
+
+        Runs at startup BEFORE ``_schedule_resume_pending_sessions``. A
+        session with a recoverable obligation already produced its answer —
+        the turn completed and only delivery is owed — so this method sends
+        the stored text and clears ``resume_pending`` for that session,
+        preventing the resume path from re-running (and re-paying for) a
+        turn whose output we hold.
+
+        Crash-ambiguity contract (see gateway/delivery_ledger.py):
+        rows that were mid-send or previously rejected carry a visible
+        recovered-reply marker so a possible duplicate is labeled, never
+        silent. Returns the number of redeliveries attempted.
+        """
+        try:
+            from gateway.delivery_ledger import (
+                RECOVERED_MARKER,
+                ledger_enabled,
+                mark_delivered,
+                mark_failed,
+                sweep_recoverable,
+            )
+
+            if not ledger_enabled():
+                return 0
+            claimed = await asyncio.to_thread(sweep_recoverable)
+        except Exception:
+            logger.debug("delivery ledger sweep failed", exc_info=True)
+            return 0
+        if not claimed:
+            return 0
+
+        redelivered = 0
+        for row in claimed:
+            try:
+                platform = Platform(row["platform"])
+            except Exception:
+                logger.debug(
+                    "obligation %s: unknown platform %r",
+                    row["obligation_id"], row.get("platform"),
+                )
+                continue
+            adapter = self.adapters.get(platform)
+            if adapter is None:
+                # Platform not connected this boot — leave the row claimed;
+                # attempts cap + stale cutoff bound the retries on later boots.
+                continue
+            content = row["content"]
+            if row.get("needs_marker"):
+                content = RECOVERED_MARKER + content
+            metadata = (
+                {"thread_id": row["thread_id"]} if row.get("thread_id") else None
+            )
+            try:
+                result = await adapter.send(
+                    chat_id=row["chat_id"],
+                    content=content,
+                    metadata=metadata,
+                )
+            except Exception as send_err:
+                logger.warning(
+                    "obligation %s: redelivery send raised: %s",
+                    row["obligation_id"], send_err,
+                )
+                result = None
+            try:
+                if result is not None and getattr(result, "success", False):
+                    mark_delivered(row["obligation_id"])
+                    redelivered += 1
+                    logger.info(
+                        "Redelivered recovered final response to %s:%s "
+                        "(obligation %s, attempt %d)",
+                        row["platform"], row["chat_id"],
+                        row["obligation_id"], row["attempts"],
+                    )
+                else:
+                    mark_failed(
+                        row["obligation_id"],
+                        str(getattr(result, "error", "") or "send failed"),
+                    )
+            except Exception:
+                logger.debug("delivery ledger update failed", exc_info=True)
+
+            # The answer reached (or was owed to) this session — don't ALSO
+            # re-run the turn via the resume path.
+            session_key = row.get("session_key") or ""
+            if session_key:
+                try:
+                    await self.async_session_store.clear_resume_pending(session_key)
+                except Exception:
+                    logger.debug(
+                        "clear_resume_pending failed for %s", session_key,
+                        exc_info=True,
+                    )
+        return redelivered
+
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
 
@@ -7685,6 +7783,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
         # by the normal successful-turn path, so a failed auto-resume remains
         # visible for manual recovery on the next user message.
+        #
+        # Delivery-obligation redelivery runs FIRST: a session whose final
+        # response was generated but never confirmed-delivered has its answer
+        # in the ledger — redelivering it (and clearing resume_pending for
+        # that session) is strictly cheaper and more correct than re-running
+        # the whole turn.
+        await self._redeliver_pending_obligations()
         self._schedule_resume_pending_sessions()
         await self._finish_startup_restore()
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2964,6 +2964,15 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        # Durable delivery-obligation ledger: final agent responses are
+        # recorded in state.db around the platform send, and a gateway that
+        # died between finalize and platform ACK redelivers the stored
+        # response on the next boot (ambiguous cases carry a visible
+        # "recovered reply — may be a duplicate" marker; honest
+        # at-least-once). Disable to lose in-flight final responses on
+        # crash/restart, as before.
+        "delivery_ledger": True,
+
         # Seconds the gateway waits for a single messaging platform to finish
         # connecting during startup (and on reconnect). Discord in particular
         # can blow past the old fixed 30s when an account has many slash

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -1,0 +1,283 @@
+"""Tests for the gateway delivery-obligation ledger (gateway/delivery_ledger.py).
+
+State machine, dead-owner claiming, attempts cap, stale cutoff, retention,
+id stability, and the startup redelivery sweep's contract:
+- pending rows redeliver plainly (send never started, no dup risk)
+- attempting/failed rows carry the recovered-reply marker (honest
+  at-least-once; ambiguity is labeled, never silently resent)
+- rows owned by a LIVE process are never claimed
+- poison rows abandon at the attempts cap / stale cutoff
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway import delivery_ledger as dl
+
+
+@pytest.fixture(autouse=True)
+def _fresh_db(tmp_path, monkeypatch):
+    """Isolated state.db per test (autouse HERMES_HOME isolation already
+    redirects get_hermes_home; make the redirect explicit and per-test)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(dl, "_db_path", lambda: home / "state.db")
+    yield
+
+
+def _record(oid="ob-1", session_key="agent:main:slack:channel:C1", **kw):
+    dl.record_obligation(
+        obligation_id=oid,
+        session_key=session_key,
+        platform=kw.get("platform", "slack"),
+        chat_id=kw.get("chat_id", "C1"),
+        thread_id=kw.get("thread_id", "171.001"),
+        content=kw.get("content", "the final answer"),
+    )
+
+
+def _row(oid):
+    with dl._connect() as conn:
+        r = conn.execute(
+            """SELECT state, attempts, owner_pid, content
+               FROM delivery_obligations WHERE obligation_id=?""",
+            (oid,),
+        ).fetchone()
+    return None if r is None else {
+        "state": r[0], "attempts": r[1], "owner_pid": r[2], "content": r[3],
+    }
+
+
+def _orphan(oid):
+    """Make the row look like it belongs to a dead process."""
+    with dl._connect() as conn:
+        conn.execute(
+            "UPDATE delivery_obligations SET owner_pid=999999999, "
+            "owner_started_at=1 WHERE obligation_id=?",
+            (oid,),
+        )
+
+
+class TestStateMachine:
+    def test_record_starts_pending(self):
+        _record()
+        assert _row("ob-1")["state"] == "pending"
+
+    def test_full_happy_path(self):
+        _record()
+        dl.mark_attempting("ob-1")
+        assert _row("ob-1")["state"] == "attempting"
+        dl.mark_delivered("ob-1")
+        assert _row("ob-1")["state"] == "delivered"
+
+    def test_failed_records_error(self):
+        _record()
+        dl.mark_attempting("ob-1")
+        dl.mark_failed("ob-1", "chat_not_found")
+        assert _row("ob-1")["state"] == "failed"
+
+    def test_rerecord_same_id_is_idempotent(self):
+        _record()
+        dl.mark_attempting("ob-1")
+        _record()  # INSERT OR REPLACE resets to pending — same turn re-record
+        assert _row("ob-1")["state"] == "pending"
+
+
+class TestObligationId:
+    def test_stable_and_distinct(self):
+        a = dl.compute_obligation_id("sk1", "msg1", "hello")
+        assert a == dl.compute_obligation_id("sk1", "msg1", "hello")
+        # Different thread (baked into session_key) → different id. This is
+        # the cron-topic collision class from the earlier outbox attempt.
+        assert a != dl.compute_obligation_id("sk1:threadB", "msg1", "hello")
+        assert a != dl.compute_obligation_id("sk1", "msg2", "hello")
+        assert a != dl.compute_obligation_id("sk1", "msg1", "other")
+        assert len(a) == 24
+
+
+class TestSweep:
+    def test_live_owner_rows_never_claimed(self):
+        _record()  # owner = this (live) process
+        assert dl.sweep_recoverable() == []
+
+    def test_dead_owner_pending_claimed_without_marker(self):
+        _record()
+        _orphan("ob-1")
+        claimed = dl.sweep_recoverable()
+        assert len(claimed) == 1
+        assert claimed[0]["needs_marker"] is False
+        assert claimed[0]["attempts"] == 1
+        # Claim re-stamps ownership: a second sweep in the same (live)
+        # process must not double-claim.
+        assert dl.sweep_recoverable() == []
+
+    def test_dead_owner_attempting_needs_marker(self):
+        _record()
+        dl.mark_attempting("ob-1")
+        _orphan("ob-1")
+        claimed = dl.sweep_recoverable()
+        assert claimed[0]["needs_marker"] is True
+
+    def test_dead_owner_failed_needs_marker(self):
+        _record()
+        dl.mark_failed("ob-1", "boom")
+        _orphan("ob-1")
+        claimed = dl.sweep_recoverable()
+        assert claimed[0]["needs_marker"] is True
+
+    def test_delivered_rows_ignored(self):
+        _record()
+        dl.mark_delivered("ob-1")
+        _orphan("ob-1")
+        assert dl.sweep_recoverable() == []
+
+    def test_attempts_cap_abandons(self):
+        _record()
+        _orphan("ob-1")
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET attempts=? WHERE obligation_id=?",
+                (dl.MAX_ATTEMPTS, "ob-1"),
+            )
+        assert dl.sweep_recoverable() == []
+        assert _row("ob-1")["state"] == "abandoned"
+
+    def test_stale_cutoff_abandons(self):
+        _record()
+        _orphan("ob-1")
+        future = time.time() + dl.STALE_AFTER_SECONDS + 60
+        assert dl.sweep_recoverable(now=future) == []
+        assert _row("ob-1")["state"] == "abandoned"
+
+
+class TestPrune:
+    def test_old_delivered_rows_pruned(self):
+        _record()
+        dl.mark_delivered("ob-1")
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET updated_at=? WHERE obligation_id=?",
+                (time.time() - dl._RETENTION_SECONDS - 60, "ob-1"),
+            )
+        dl._prune()
+        assert _row("ob-1") is None
+
+    def test_undelivered_rows_survive_retention(self):
+        _record()
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET updated_at=? WHERE obligation_id=?",
+                (time.time() - dl._RETENTION_SECONDS - 60, "ob-1"),
+            )
+        dl._prune()
+        assert _row("ob-1") is not None
+
+
+class TestLedgerEnabled:
+    def test_default_on(self):
+        assert dl.ledger_enabled({}) is True
+        assert dl.ledger_enabled({"gateway": {}}) is True
+
+    def test_explicit_off(self):
+        assert dl.ledger_enabled({"gateway": {"delivery_ledger": False}}) is False
+        assert dl.ledger_enabled({"gateway": {"delivery_ledger": "off"}}) is False
+
+    def test_truthy_strings(self):
+        assert dl.ledger_enabled({"gateway": {"delivery_ledger": "true"}}) is True
+
+
+class TestGatewayRedeliverySweep:
+    """Drive the real GatewayRunner._redeliver_pending_obligations."""
+
+    @staticmethod
+    def _runner(adapter=None):
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {Platform.SLACK: adapter} if adapter else {}
+        _store = MagicMock()
+        _store.clear_resume_pending = AsyncMock()
+        _store._store = None
+        runner.session_store = None
+        runner._async_session_store = _store
+        return runner
+
+    @staticmethod
+    def _adapter(success=True):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=MagicMock(success=success, error="" if success else "nope")
+        )
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_pending_redelivers_plain_and_clears_resume(self):
+        _record()  # pending
+        _orphan("ob-1")
+        adapter = self._adapter()
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 1
+        sent = adapter.send.call_args.kwargs
+        assert sent["content"] == "the final answer"  # no marker
+        assert sent["metadata"] == {"thread_id": "171.001"}
+        assert _row("ob-1")["state"] == "delivered"
+        runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
+            "agent:main:slack:channel:C1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_attempting_redelivers_with_marker(self):
+        _record()
+        dl.mark_attempting("ob-1")
+        _orphan("ob-1")
+        adapter = self._adapter()
+        runner = self._runner(adapter)
+
+        await runner._redeliver_pending_obligations()
+
+        sent = adapter.send.call_args.kwargs
+        assert sent["content"].startswith(dl.RECOVERED_MARKER)
+        assert sent["content"].endswith("the final answer")
+
+    @pytest.mark.asyncio
+    async def test_send_failure_marks_failed_for_next_boot(self):
+        _record()
+        _orphan("ob-1")
+        runner = self._runner(self._adapter(success=False))
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 0
+        assert _row("ob-1")["state"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_missing_adapter_leaves_row_recoverable(self):
+        _record()
+        _orphan("ob-1")
+        runner = self._runner(adapter=None)  # slack not connected
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 0
+        # Row still claimed by us but NOT delivered/abandoned — a later boot
+        # (attempts cap permitting) can retry once the platform connects.
+        assert _row("ob-1")["state"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_disabled_gate_short_circuits(self):
+        _record()
+        _orphan("ob-1")
+        adapter = self._adapter()
+        runner = self._runner(adapter)
+        with patch.object(dl, "ledger_enabled", return_value=False), patch(
+            "gateway.delivery_ledger.ledger_enabled", return_value=False
+        ):
+            n = await runner._redeliver_pending_obligations()
+        assert n == 0
+        adapter.send.assert_not_awaited()

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -1,0 +1,168 @@
+"""Producer-hook tests: _process_message_background records delivery
+obligations around the final send (gateway/platforms/base.py).
+
+Contract: obligation recorded (pending→attempting) BEFORE the send await,
+delivered/failed by SendResult afterward; slash commands, ephemeral
+replies, and empty responses are never recorded; ledger failures never
+block the send.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway import delivery_ledger as dl
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _fresh_db(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(dl, "_db_path", lambda: home / "state.db")
+    yield
+
+
+class _Adapter(BasePlatformAdapter):  # type: ignore[misc]
+    """Minimal concrete adapter driving the real base-class pipeline."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True), Platform.SLACK)
+        self.sent = []
+
+    async def connect(self, *, is_reconnect: bool = False):  # pragma: no cover
+        return True
+
+    async def disconnect(self):  # pragma: no cover - unused
+        return None
+
+    async def get_chat_info(self, chat_id):  # pragma: no cover - unused
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(content)
+        return SendResult(success=True, message_id="m1")
+
+
+def _event(text="hello agent"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.SLACK, chat_id="C1", chat_type="channel"
+        ),
+        message_id="msg-42",
+    )
+
+
+def _rows():
+    with dl._connect() as conn:
+        return conn.execute(
+            "SELECT obligation_id, state, content FROM delivery_obligations"
+        ).fetchall()
+
+
+async def _run(adapter, event, response="final answer"):
+    adapter._message_handler = AsyncMock(return_value=response)
+    session_key = "agent:main:slack:channel:C1"
+    adapter._active_sessions[session_key] = asyncio.Event()
+    await adapter._process_message_background(event, session_key)
+
+
+class TestProducerHook:
+    @pytest.mark.asyncio
+    async def test_normal_turn_records_and_delivers(self):
+        adapter = _Adapter()
+        await _run(adapter, _event())
+
+        assert adapter.sent == ["final answer"]
+        rows = _rows()
+        assert len(rows) == 1
+        assert rows[0][1] == "delivered"
+        assert rows[0][2] == "final answer"
+
+    @pytest.mark.asyncio
+    async def test_send_failure_leaves_failed_row(self):
+        adapter = _Adapter()
+        adapter.send = AsyncMock(
+            return_value=SendResult(success=False, error="chat_not_found")
+        )
+        await _run(adapter, _event())
+
+        rows = _rows()
+        assert len(rows) == 1
+        assert rows[0][1] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_slash_command_not_recorded(self):
+        adapter = _Adapter()
+        await _run(adapter, _event(text="/status"))
+        assert adapter.sent  # reply still sent
+        assert _rows() == []
+
+    @pytest.mark.asyncio
+    async def test_typed_prefix_command_not_recorded(self):
+        adapter = _Adapter()
+        # Platforms like Slack rewrite native slash commands to a typed "!"
+        # prefix; declare it so the hook's prefix check exercises that lane.
+        adapter.typed_command_prefix = "!"
+        await _run(adapter, _event(text="!status"))
+        assert _rows() == []
+
+    @pytest.mark.asyncio
+    async def test_empty_response_not_recorded(self):
+        adapter = _Adapter()
+        await _run(adapter, _event(), response="")
+        assert adapter.sent == []
+        assert _rows() == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_gate_skips_recording_but_sends(self):
+        adapter = _Adapter()
+        with patch("gateway.delivery_ledger.ledger_enabled", return_value=False):
+            await _run(adapter, _event())
+        assert adapter.sent == ["final answer"]
+        assert _rows() == []
+
+    @pytest.mark.asyncio
+    async def test_ledger_crash_never_blocks_send(self):
+        adapter = _Adapter()
+        with patch(
+            "gateway.delivery_ledger.record_obligation",
+            side_effect=RuntimeError("disk full"),
+        ):
+            await _run(adapter, _event())
+        assert adapter.sent == ["final answer"]
+
+    @pytest.mark.asyncio
+    async def test_crash_between_attempting_and_ack_is_recoverable(self):
+        """The core scenario (#58818): process dies mid-send. The row must
+        be claimable by a later process and carry the ambiguity marker."""
+        adapter = _Adapter()
+
+        async def _dies_mid_send(chat_id, content, reply_to=None, metadata=None):
+            raise ConnectionError("gateway killed mid-await")
+
+        adapter.send = _dies_mid_send
+        # _send_with_retry raising propagates; the background task catches
+        # broadly — drive only through the send block by tolerating the error.
+        try:
+            await _run(adapter, _event())
+        except Exception:
+            pass
+
+        rows = _rows()
+        assert len(rows) == 1
+        # Row is stuck in 'attempting' (or failed if retry wrapper caught it):
+        # either way it is non-delivered and recoverable.
+        assert rows[0][1] in ("attempting", "failed")
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET owner_pid=999999999, owner_started_at=1"
+            )
+        claimed = dl.sweep_recoverable()
+        assert len(claimed) == 1
+        assert claimed[0]["needs_marker"] is True

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -213,6 +213,27 @@ platform network disconnect as an event-loop failure.
 
 Sessions persist across messages until they reset. The agent remembers your conversation context.
 
+### Delivery Reliability
+
+Final agent responses are recorded in a durable **delivery ledger**
+(`state.db`) around each platform send. If the gateway crashes or restarts
+between producing a response and the platform confirming receipt, the next
+boot redelivers the stored response instead of losing it — or re-running the
+whole turn.
+
+Semantics are honest at-least-once:
+
+- A response whose send **never started** is redelivered as-is.
+- A response that was **mid-send** when the gateway died (the platform may or
+  may not have received it) is redelivered with a visible
+  "♻️ Recovered reply — … may be a duplicate" prefix. Ambiguity is labeled,
+  never silently resent.
+- Redelivery is bounded: 3 attempts, 24-hour freshness, then the row is
+  abandoned. Delivered rows are pruned after 7 days.
+
+Disable with `gateway.delivery_ledger: false` in `config.yaml` (restores the
+old behavior: in-flight responses are lost on crash).
+
 ### Reset Policies
 
 **By default sessions never auto-reset** — context lives until you `/reset`


### PR DESCRIPTION
## Summary
A final agent response generated but not confirmed-delivered now survives gateway death: it's recorded in a durable ledger around the platform send and redelivered on the next boot — closing the silent-loss window behind #58818 (P1), #41696, and the gateway half of #63695.

## Changes
- `gateway/delivery_ledger.py` (new): `delivery_obligations` table in `state.db`, same conventions as the async-delegation ledger (#63494) — WAL, owner pid + process-start-time liveness, atomic claim, bounded retention. States: `pending → attempting → delivered | failed`, with `abandoned` for poison rows (3 attempts / 24h)
- `gateway/platforms/base.py`: producer hook in `_process_message_background` — obligation recorded **before** the first send attempt, `delivered`/`failed` by `SendResult`; slash-command/ephemeral/empty responses skipped; every ledger call best-effort (can never block a send)
- `gateway/run.py`: `_redeliver_pending_obligations()` startup sweep, runs **before** `_schedule_resume_pending_sessions` and clears `resume_pending` for redelivered sessions — the resume path never re-runs (re-pays for) a turn whose answer the ledger holds
- `hermes_cli/config.py`: `gateway.delivery_ledger` (default on, opt-out; no version bump — deep-merge handles new keys)
- Docs: "Delivery Reliability" section in messaging/index.md

## Contract (the #61790 review lessons, encoded)
| #61790 defect | This design |
|---|---|
| Ambiguous timeouts marked "definitely failed" → silent dup sends | Mid-send crash rows redeliver with a visible "♻️ Recovered reply — may be a duplicate" prefix; honest at-least-once, never silent |
| Cron delivery IDs collided across thread/topic targets | ID = hash(session_key \| inbound message id \| content); session_key carries platform+chat+thread |
| Unknown records had no recovery or retention | Startup sweep with atomic dead-owner claim; 3-attempt cap + 24h stale cutoff → `abandoned`; 7-day retention, 500-row cap |
| Separate SQLite store outside established state | Reuses `state.db` and the merged #63494 ledger conventions |
| Covered only one delivery path | Hook sits at the base-adapter chokepoint every platform's final send flows through; cron/proactive stays on DeliveryRouter by design (#64085/#16645 own that lane) |

Also reconciles with turn-level recovery: a session with a recoverable obligation completed its turn — only delivery is owed — so redelivery clears `resume_pending` (complements #30030).

## Validation
| | Result |
|---|---|
| Ledger + producer tests (new) | 30 passed — state machine, dead-owner claim, marker rules, attempts cap, stale cutoff, prune, id anti-collision, send-never-blocked |
| Blast-radius sweep (all test files touching `_process_message_background` / `_record_delivery`) | 352 passed across 14 files |
| Config | 155 config tests passed |
| Cross-process E2E | real process A records mid-send and dies → fresh process B sweeps same `state.db`: claims row, `needs_marker=true`, attempts=1, second sweep empty, delivered |

## Infographic

![delivery-ledger](https://v3b.fal.media/files/b/0aa2cc4b/nCW-MPG8AN7T-NXh8-muC_R6rvCFXc.png)
