### PR TITLE
test: fix Windows memory test isolation

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -77,6 +77,20 @@ fi
 # ── Run in hermetic env ──────────────────────────────────────────────────────
 # env -i: start with empty environment, opt-in only what we need.
 # No credential var can leak — you'd have to explicitly add it here.
+#
+# On Windows, Python's pathlib.Path.home() does not use the POSIX HOME alias;
+# it resolves USERPROFILE or HOMEDRIVE+HOMEPATH. Preserve only those non-secret
+# home-resolution variables so env -i remains hermetic without creating a
+# literal '~' path or breaking Windows tests.
+WINDOWS_HOME_ENV=()
+if [[ -n "${USERPROFILE:-}" || -n "${HOMEDRIVE:-}${HOMEPATH:-}" ]]; then
+  for name in USERPROFILE HOMEDRIVE HOMEPATH; do
+    if [[ -n "${!name:-}" ]]; then
+      WINDOWS_HOME_ENV+=("$name=${!name}")
+    fi
+  done
+fi
+
 echo "▶ running per-file parallel test suite via run_tests_parallel.py"
 echo "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)"
 
@@ -94,6 +108,7 @@ echo "▶ launching test runner"
 exec env -i \
   PATH="$PATH" \
   HOME="$HOME" \
+  "${WINDOWS_HOME_ENV[@]}" \
   TZ=UTC \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -10,6 +10,7 @@ import os
 import re
 import stat
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -36,8 +37,8 @@ from plugins.memory.hindsight import (
 
 
 @pytest.fixture(autouse=True)
-def _clean_env(monkeypatch):
-    """Ensure no stale env vars leak between tests."""
+def _clean_env(tmp_path, monkeypatch):
+    """Ensure no stale env vars or Windows home state leak between tests."""
     for key in (
         "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
         "HINDSIGHT_BUDGET", "HINDSIGHT_MODE", "HINDSIGHT_TIMEOUT",
@@ -47,6 +48,12 @@ def _clean_env(monkeypatch):
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
     ):
         monkeypatch.delenv(key, raising=False)
+
+    # On Windows pathlib.Path.home() resolves USERPROFILE/HOMEDRIVE+HOMEPATH,
+    # not the POSIX HOME alias that these tests historically monkeypatched.
+    # Patch the actual API and keep all legacy profile writes in tmp_path.
+    isolated_home = tmp_path / "user-home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: isolated_home))
 
 
 def _make_mock_client():

--- a/tests/test_run_tests_shell_env.py
+++ b/tests/test_run_tests_shell_env.py
@@ -1,0 +1,15 @@
+"""Windows regression tests for the canonical hermetic runner."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows home resolution is the behavior under test")
+def test_runner_preserves_windows_home_resolution():
+    """Path.home() must resolve when run under scripts/run_tests.sh."""
+    actual = Path.home()
+    expected = os.environ.get("USERPROFILE")
+    assert expected, "canonical runner dropped USERPROFILE"
+    assert actual == Path(expected)


### PR DESCRIPTION
## Summary

- Preserve Windows `USERPROFILE`, `HOMEDRIVE`, and `HOMEPATH` when `scripts/run_tests.sh` launches its `env -i` subprocesses.
- Add a behavioral regression test proving `pathlib.Path.home()` resolves under the canonical runner on Windows.
- Isolate Hindsight legacy-home tests by patching the actual `Path.home()` API and keeping test writes below `tmp_path`.

## Root cause

On Windows, `pathlib.Path.home()` resolves through `USERPROFILE` or `HOMEDRIVE` + `HOMEPATH`; it does not use the POSIX `HOME` alias. The canonical runner discarded those variables with `env -i`, producing false Hindsight/Mem0 failures and even a literal repo-local `~/` artifact.

## Verification

- RED observed: the new runner behavior test failed with `RuntimeError: Could not determine home directory` before the runner fix.
- Final canonical smoke on `origin/main` base `614dc194ea7d853d39f9e84582ec62156f41a475`: **145 passed, 0 failed**.
- Direct Hindsight suite: **115 passed, 1 skipped**.
- Mem0 setup: **20/20 clean canonical runs**, each **29 passed, 0 failed**.
- `tests/plugins/memory/` excluding the pre-existing symlink test: **443 passed, 0 failed**.
- The complete memory suite has one unrelated Windows environment failure in `test_holographic_store.py`: `WinError 1314` because this runner lacks symlink creation privilege.
- Real `~/.hindsight` profile SHA-256 manifest was unchanged before and after all runs.
- No production memory implementation, user configuration, credentials, or installed Hermes checkout was changed.

## Scope

This PR is limited to Windows test-runner and test isolation behavior. It does not add retries or change production memory logic.
