### PR TITLE
fix(desktop): isolate fresh draft scopes

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -66,6 +66,7 @@ export function ChatBar({
   cwd,
   disabled,
   focusKey,
+  freshDraftKey,
   gateway,
   maxRecordingSeconds = 120,
   queueSessionKey,
@@ -111,7 +112,7 @@ export function ChatBar({
   // would discard a question the user may want to come back to. The blocking
   // prompt owns its own dismissal (Skip, Reject, dialog close).
   const awaitingInput = useStore(scope.$awaitingInput)
-  const activeQueueSessionKey = queueSessionKey || sessionId || null
+  const activeQueueSessionKey = queueSessionKey || sessionId || freshDraftKey || null
 
   // Status items (subagents, background processes) are keyed by the RUNTIME
   // session id — gateway events and process.list both speak that id. Only the

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -35,6 +35,8 @@ export interface ChatBarProps {
   busy: boolean
   disabled: boolean
   focusKey?: string | null
+  /** Durable scope for the current sessionless new-chat lifecycle. */
+  freshDraftKey?: string
   maxRecordingSeconds?: number
   state: ChatBarState
   gateway?: HermesGateway | null

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -26,6 +26,7 @@ import { $petOverlayActive } from '@/store/pet-overlay'
 import { $gatewaySwapTarget, $profiles } from '@/store/profile'
 import {
   $contextSuggestions,
+  $freshDraftKey,
   $freshDraftReady,
   $gatewayState,
   $introPersonality,
@@ -262,6 +263,7 @@ export function ChatView({
   const petOverlayActive = useStore($petOverlayActive)
   const petPresent = petActive || petOverlayActive
   const freshDraftReady = useStore($freshDraftReady)
+  const freshDraftKey = useStore($freshDraftKey)
   const gatewayState = useStore($gatewayState)
   const gatewaySwapTarget = useStore($gatewaySwapTarget)
   const gatewayOpen = gatewayState === 'open'
@@ -509,6 +511,7 @@ export function ChatView({
               cwd={currentCwd}
               disabled={!gatewayOpen}
               focusKey={activeSessionId}
+              freshDraftKey={freshDraftKey}
               gateway={gateway}
               maxRecordingSeconds={maxVoiceRecordingSeconds}
               onAddContextRef={onAddContextRef}

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -21,7 +21,7 @@ interface HarnessProps {
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: null | string
   selectedStoredSessionIdRef: MutableRefObject<null | string>
-  startFreshSessionDraft: (focus: boolean) => unknown
+  startFreshSessionDraft: (options: boolean | { replaceRoute?: boolean; rotateFreshDraftKey?: boolean }) => unknown
 }
 
 function RouteResumeHarness({ resumeFailedSessionId = null, resumeExhaustedSessionId = null, ...props }: HarnessProps) {
@@ -73,11 +73,11 @@ describe('useRouteResume', () => {
         activeSessionIdRef={activeSessionIdRef}
         creatingSessionRef={creatingSessionRef}
         currentView="chat"
-        freshDraftReady
+        freshDraftReady={false}
         gatewayState="open"
-        locationPathname="/session-1"
+        locationPathname="/new"
         resumeSession={resumeSession}
-        routedSessionId="session-1"
+        routedSessionId={null}
         runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
         selectedStoredSessionId={null}
         selectedStoredSessionIdRef={selectedStoredSessionIdRef}

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -27,7 +27,7 @@ interface RouteResumeOptions {
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: string | null
   selectedStoredSessionIdRef: MutableRefObject<string | null>
-  startFreshSessionDraft: (focus: boolean) => unknown
+  startFreshSessionDraft: (options: boolean | { replaceRoute?: boolean; rotateFreshDraftKey?: boolean }) => unknown
 }
 
 // Bounded auto-retry for a stranded session window. A resume can fail terminally
@@ -159,7 +159,7 @@ export function useRouteResume({
       (selectedStoredSessionId || activeSessionId || !freshDraftReady) &&
       !rawHashLooksLikeSession()
     ) {
-      startFreshSessionDraft(true)
+      startFreshSessionDraft({ replaceRoute: true, rotateFreshDraftKey: false })
     }
   }, [
     activeSessionId,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -10,6 +10,7 @@ import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
   $currentCwd,
+  $freshDraftKey,
   $messages,
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
@@ -967,5 +968,17 @@ describe('createBackendSessionForSend workspace target', () => {
     )
 
     expect(params).toMatchObject({ cwd: '/clicked-workspace' })
+  })
+
+  it('can preserve the current fresh draft key when explicitly requested', async () => {
+    let handle: HarnessHandle | null = null
+    const requestGateway = vi.fn(async () => ({} as never))
+
+    render(<Harness onReady={h => (handle = h)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const before = $freshDraftKey.get()
+    await handle!.startFreshSessionDraft({ replaceRoute: true, rotateFreshDraftKey: false })
+    expect($freshDraftKey.get()).toBe(before)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -25,6 +25,7 @@ import {
   $sessions,
   $yoloActive,
   type NewChatWorkspaceTarget,
+  rotateFreshDraftKey,
   sessionPinId,
   setActiveSessionId,
   setAwaitingResponse,
@@ -233,6 +234,7 @@ export function useSessionActions({
         ? normalizeNewChatWorkspaceTarget(draftOptions.workspaceTarget)
         : undefined
 
+      rotateFreshDraftKey()
       resetViewSync()
       busyRef.current = false
       setBusy(false)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -166,6 +166,7 @@ async function desktopSessionCreateParams(cwd: string): Promise<Record<string, u
 
 interface FreshSessionDraftOptions {
   replaceRoute?: boolean
+  rotateFreshDraftKey?: boolean
   workspaceTarget?: NewChatWorkspaceTarget
 }
 
@@ -234,7 +235,10 @@ export function useSessionActions({
         ? normalizeNewChatWorkspaceTarget(draftOptions.workspaceTarget)
         : undefined
 
-      rotateFreshDraftKey()
+      if (draftOptions.rotateFreshDraftKey !== false) {
+        rotateFreshDraftKey()
+      }
+
       resetViewSync()
       busyRef.current = false
       setBusy(false)

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -73,6 +73,14 @@ describe('session drafts', () => {
     expect(takeSessionDraft('session-a').text).toBe('session draft')
   })
 
+  it('keeps separate fresh-chat lifecycle drafts isolated', () => {
+    stashSessionDraft('__new__:first', 'first unsent chat', [])
+    stashSessionDraft('__new__:second', 'second unsent chat', [])
+
+    expect(takeSessionDraft('__new__:first').text).toBe('first unsent chat')
+    expect(takeSessionDraft('__new__:second').text).toBe('second unsent chat')
+  })
+
   it('persists draft text (not attachments) to localStorage', () => {
     stashSessionDraft('session-a', 'survives reload', [attachment({ id: 'file:a' })])
 

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -8,10 +8,12 @@ import {
   $activeSessionId,
   $connection,
   $currentCwd,
+  $freshDraftKey,
   $selectedStoredSessionId,
   $unreadFinishedSessionIds,
   applyConfiguredDefaultProjectDir,
   mergeSessionPage,
+  rotateFreshDraftKey,
   sessionPinId,
   setCurrentCwd,
   setSelectedStoredSessionId,
@@ -41,6 +43,19 @@ const session = (over: Partial<SessionInfo>): SessionInfo => ({
   title: null,
   tool_call_count: 0,
   ...over
+})
+
+describe('fresh draft identity', () => {
+  it('rotates for each new-chat lifecycle and persists the current key', () => {
+    const previous = $freshDraftKey.get()
+    const first = rotateFreshDraftKey()
+    const second = rotateFreshDraftKey()
+
+    expect(first).not.toBe(previous)
+    expect(second).not.toBe(first)
+    expect($freshDraftKey.get()).toBe(second)
+    expect(window.localStorage.getItem('hermes.desktop.freshDraftKey')).toBe(second)
+  })
 })
 
 describe('computed $attentionSessionIds', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -34,6 +34,16 @@ export const setRememberedSessionId = (id: null | string) => persistString(LAST_
 // relaunch lands back where you were instead of a bare new-chat.
 const LAST_ROUTE_KEY = 'hermes.desktop.lastRoute'
 
+// Stable only for the lifetime of the current sessionless chat. Persisting the
+// key (rather than just its text) lets a reload restore that exact fresh draft;
+// starting another new chat rotates the key so abandoned unsent drafts cannot
+// bleed into the next lifecycle.
+const FRESH_DRAFT_KEY = 'hermes.desktop.freshDraftKey'
+const LEGACY_FRESH_DRAFT_SCOPE = '__new__'
+
+const createFreshDraftKey = (): string =>
+  `__new__:${globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`}`
+
 export const getRememberedRoute = (): null | string => storedString(LAST_ROUTE_KEY)
 export const setRememberedRoute = (path: null | string) => persistString(LAST_ROUTE_KEY, path)
 
@@ -265,6 +275,7 @@ export const $messagesEmpty = computed($messages, messages => messages.length ==
 export const $lastVisibleMessageIsUser = computed($messages, lastVisibleMessageIsUser)
 
 export const $freshDraftReady = atom(false)
+export const $freshDraftKey = atom(storedString(FRESH_DRAFT_KEY) ?? LEGACY_FRESH_DRAFT_SCOPE)
 export const $busy = atom(false)
 export const $awaitingResponse = atom(false)
 // Stored-session id whose most recent resume FAILED terminally (the gateway RPC
@@ -344,6 +355,15 @@ export const setSelectedStoredSessionId = (next: Updater<string | null>) => {
 
 export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($messages, next)
 export const setFreshDraftReady = (next: Updater<boolean>) => updateAtom($freshDraftReady, next)
+
+export const rotateFreshDraftKey = (): string => {
+  const key = createFreshDraftKey()
+  $freshDraftKey.set(key)
+  persistString(FRESH_DRAFT_KEY, key)
+
+  return key
+}
+
 export const setResumeFailedSessionId = (next: Updater<string | null>) => updateAtom($resumeFailedSessionId, next)
 export const setResumeExhaustedSessionId = (next: Updater<string | null>) => updateAtom($resumeExhaustedSessionId, next)
 export const setBusy = (next: Updater<boolean>) => updateAtom($busy, next)


### PR DESCRIPTION
## Summary
- give each fresh new-chat lifecycle its own persisted draft key
- rotate that key when starting a new session so abandoned unsent drafts don't bleed into the next blank chat
- keep session-scoped drafts intact and preserve the current fresh draft across reloads

## Verification
- vitest run src/store/composer.test.ts src/store/session.test.ts --reporter=dot ✅
- git diff --check ✅
- eslint on touched files ✅
- typecheck attempted, but the current workspace install is missing several repo dependencies/types, so it fails before reaching these changes
