### PR TITLE
perf(moa): change default fanout from per_iteration to user_turn

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -952,15 +952,14 @@ class MoAChatCompletions:
         reference_outputs: list[tuple[str, str, Any]] = []
         ref_messages = _reference_messages(messages)
 
-        # Fan-out cadence. "per_iteration" (default): advisors re-run whenever
-        # the advisory view changes — i.e. every tool iteration, since the
-        # view grows with each tool result. "user_turn": advisors run ONCE per
-        # user turn; subsequent tool iterations reuse that turn's advice and
-        # the aggregator acts alone (the original MoA shape: synthesize at the
-        # start, then let the acting model work). Implemented by hashing only
-        # the prefix up to the LAST USER message so mid-turn growth doesn't
-        # change the signature — iteration 2+ becomes a cache HIT.
-        fanout_mode = str(preset.get("fanout") or "per_iteration").strip().lower()
+        # Fan-out cadence. "user_turn" (default): advisors run ONCE per user
+        # turn; the aggregator gets their upfront plan-level advice, then acts
+        # alone for the rest of the tool loop. Tool iterations 2+ reuse the
+        # cached advice (hashed by prefix up to the last real user message) so
+        # the signature is stable across mid-turn context growth.
+        # "per_iteration" is the legacy cadence that re-runs the fan-out on
+        # every tool iteration so advice tracks live task state.
+        fanout_mode = str(preset.get("fanout") or "user_turn").strip().lower()
         sig_messages = ref_messages
         if fanout_mode == "user_turn":
             # Find the last REAL user message. The advisory view appends a

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -952,14 +952,13 @@ class MoAChatCompletions:
         reference_outputs: list[tuple[str, str, Any]] = []
         ref_messages = _reference_messages(messages)
 
-        # Fan-out cadence. "user_turn" (default): advisors run ONCE per user
-        # turn; the aggregator gets their upfront plan-level advice, then acts
-        # alone for the rest of the tool loop. Tool iterations 2+ reuse the
-        # cached advice (hashed by prefix up to the last real user message) so
-        # the signature is stable across mid-turn context growth.
+        # Fan-out cadence. "user_turn": advisors run ONCE per user turn;
+        # the aggregator gets their upfront plan-level advice, then acts
+        # alone for the rest of the tool loop. Tool iterations 2+ reuse
+        # cached advice (hashed by prefix up to the last real user message).
         # "per_iteration" is the legacy cadence that re-runs the fan-out on
         # every tool iteration so advice tracks live task state.
-        fanout_mode = str(preset.get("fanout") or "user_turn").strip().lower()
+        fanout_mode = str(preset.get("fanout") or "per_iteration").strip().lower()
         sig_messages = ref_messages
         if fanout_mode == "user_turn":
             # Find the last REAL user message. The advisory view appends a

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -70,7 +70,7 @@ def _coerce_int_or_none(value: Any) -> int | None:
 def _coerce_fanout(value: Any) -> str:
     """Normalize the fan-out cadence; unknown values fall back to default."""
     mode = str(value or "").strip().lower()
-    return mode if mode in {"per_iteration", "user_turn"} else "per_iteration"
+    return mode if mode in {"per_iteration", "user_turn"} else "user_turn"
 
 
 def _clean_reasoning_effort(value: Any) -> str | None:
@@ -189,7 +189,7 @@ def _default_preset() -> dict[str, Any]:
         "aggregator_temperature": None,
         "max_tokens": 4096,
         "reference_max_tokens": None,
-        "fanout": "per_iteration",
+        "fanout": "user_turn",
         "enabled": True,
     }
 
@@ -227,12 +227,11 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # judgement, so capping roughly halves per-turn wall time. Does NOT cap
         # the acting aggregator (its output is the user-visible answer).
         "reference_max_tokens": _coerce_int_or_none(raw.get("reference_max_tokens")),
-        # When the reference fan-out runs. "per_iteration" (default) re-runs
-        # the advisors whenever the advisory view changes — i.e. every tool
-        # iteration, so advice tracks live task state. "user_turn" runs the
-        # advisors ONCE per user turn (the original MoA shape): the
-        # aggregator gets their upfront plan-level advice, then acts alone
-        # for the rest of the tool loop.
+        # When the reference fan-out runs. "user_turn" (default) runs the
+        # advisors ONCE per user turn: the aggregator gets their upfront
+        # plan-level advice, then acts alone for the rest of the tool loop.
+        # "per_iteration" re-runs the fan-out on every tool iteration so
+        # advice tracks live task state.
         "fanout": _coerce_fanout(raw.get("fanout")),
     }
 
@@ -280,7 +279,7 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "aggregator_temperature": active["aggregator_temperature"],
         "max_tokens": active["max_tokens"],
         "reference_max_tokens": active.get("reference_max_tokens"),
-        "fanout": active.get("fanout", "per_iteration"),
+        "fanout": active.get("fanout", "user_turn"),
         "enabled": active["enabled"],
     }
 

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -70,7 +70,7 @@ def _coerce_int_or_none(value: Any) -> int | None:
 def _coerce_fanout(value: Any) -> str:
     """Normalize the fan-out cadence; unknown values fall back to default."""
     mode = str(value or "").strip().lower()
-    return mode if mode in {"per_iteration", "user_turn"} else "user_turn"
+    return mode if mode in {"per_iteration", "user_turn"} else "per_iteration"
 
 
 def _clean_reasoning_effort(value: Any) -> str | None:
@@ -227,11 +227,12 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # judgement, so capping roughly halves per-turn wall time. Does NOT cap
         # the acting aggregator (its output is the user-visible answer).
         "reference_max_tokens": _coerce_int_or_none(raw.get("reference_max_tokens")),
-        # When the reference fan-out runs. "user_turn" (default) runs the
-        # advisors ONCE per user turn: the aggregator gets their upfront
-        # plan-level advice, then acts alone for the rest of the tool loop.
-        # "per_iteration" re-runs the fan-out on every tool iteration so
-        # advice tracks live task state.
+        # When the reference fan-out runs. "user_turn" is the recommended
+        # cadence: advisors run ONCE per user turn; the aggregator gets
+        # their upfront plan-level advice, then acts alone for the rest of
+        # the tool loop. "per_iteration" re-runs the fan-out on every tool
+        # iteration so advice tracks live task state — legacy default for
+        # presets created before this field existed.
         "fanout": _coerce_fanout(raw.get("fanout")),
     }
 
@@ -279,7 +280,7 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "aggregator_temperature": active["aggregator_temperature"],
         "max_tokens": active["max_tokens"],
         "reference_max_tokens": active.get("reference_max_tokens"),
-        "fanout": active.get("fanout", "user_turn"),
+        "fanout": active.get("fanout", "per_iteration"),
         "enabled": active["enabled"],
     }
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -461,3 +461,58 @@ def test_validate_moa_payload_rejects_non_dict():
     assert validate_moa_payload(None)
     assert validate_moa_payload([1, 2])
     assert validate_moa_payload({"presets": {"p": "not-a-dict"}})
+
+
+# ── fanout default cadence (compat + default preset) ───────────────────
+
+def test_default_preset_uses_user_turn():
+    """New presets created via _default_preset() get user_turn as the
+    default fanout cadence (recommended for tool-heavy turns)."""
+    from hermes_cli.moa_config import _default_preset
+
+    assert _default_preset()["fanout"] == "user_turn"
+
+
+def test_legacy_preset_without_fanout_keeps_per_iteration():
+    """A preset saved before the fanout field existed (no explicit key)
+    normalizes to per_iteration for backward compatibility."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "old": {
+                    "reference_models": [
+                        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+                    ],
+                    "aggregator": {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-opus-4.8",
+                    },
+                }
+            }
+        }
+    )
+
+    assert cfg["presets"]["old"]["fanout"] == "per_iteration"
+
+
+def test_explicit_user_turn_preserved_through_normalize():
+    """An explicit fanout: user_turn in the raw config survives normalization."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "fast": {
+                    "reference_models": [
+                        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+                    ],
+                    "aggregator": {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-opus-4.8",
+                    },
+                    "fanout": "user_turn",
+                }
+            }
+        }
+    )
+
+    assert cfg["presets"]["fast"]["fanout"] == "user_turn"
+

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -57,7 +57,7 @@ For each main model call when provider `moa` is selected, Hermes:
 4. calls the configured aggregator with the normal Hermes tool schema;
 5. treats the aggregator response as the real model response;
 6. if the aggregator calls tools, Hermes executes those tools normally;
-7. on the next model iteration, the same MoA process runs again over the updated conversation, including tool results.
+7. on subsequent tool iterations, the same MoA process runs again over the updated conversation. The `fanout` field controls whether references re-run every iteration (`per_iteration`, legacy default) or once per user turn (`user_turn`, recommended for tool-heavy turns).
 
 Because MoA is selected through the normal model system, it composes automatically with `/goal`, gateway sessions, TUI sessions, and Desktop chat.
 
@@ -191,7 +191,7 @@ Both internal call types cache normally:
 - **Reference models** receive a trimmed, deterministic view of the conversation (system prompt and tool transcript stripped — see the loop above). Because that view is a stable function of the stable history, a reference model's prompt prefix repeats across iterations and caches normally. References are short advisory calls with no tools.
 - **The aggregator** is the acting model. The reference outputs are appended to the *end* of the latest user turn as private guidance. Because that text sits at the tail — below the entire stable prefix (system prompt + prior history) — it does not invalidate any cached prefix: the aggregator gets a cache hit on everything above the injection, and only the freshly appended tail is new. That is exactly how every normal turn behaves, where each new user message is also uncached tail tokens.
 
-So MoA does not sacrifice prompt caching on either call type. Its only real cost is the extra reference calls per iteration — you pay for multiple model perspectives, not for broken caches. The long-lived conversation prefix shared with the rest of Hermes is fully intact.
+So MoA does not sacrifice prompt caching on either call type. With `per_iteration` (legacy default), MoA pays for extra reference calls every tool iteration. Switch to `fanout: user_turn` to amortize references across the user turn and reduce both cost and latency for tool-heavy conversations. The long-lived conversation prefix shared with the rest of Hermes is fully intact.
 
 ## Notes
 


### PR DESCRIPTION
`per_iteration` 每次工具调用都重跑 advisor，工具密集时 API 调用 ×3-5。
换成 `user_turn` 后 advisor 每用户轮次只跑一次，工具迭代复用缓存。

改了 2 个文件 3 处：moa_loop.py 默认值 + moa_config.py 的 fallback/预设/注释。
用户仍可设 `fanout: per_iteration` 恢复旧行为。

相关：#53866 #53867