### PR TITLE
fix(desktop): truthful per-provider readiness in Capabilities (no more false Ready)

### DIFF
--- a/apps/desktop/src/app/settings/primitives.tsx
+++ b/apps/desktop/src/app/settings/primitives.tsx
@@ -20,8 +20,10 @@ export function SettingsContent({ children, bare = false }: { children: ReactNod
   )
 }
 
-export function Pill({ tone = 'muted', children }: { tone?: 'muted' | 'primary'; children: ReactNode }) {
-  return <Badge variant={tone === 'primary' ? 'default' : 'muted'}>{children}</Badge>
+const PILL_VARIANT = { muted: 'muted', primary: 'default', warn: 'warn' } as const
+
+export function Pill({ tone = 'muted', children }: { tone?: keyof typeof PILL_VARIANT; children: ReactNode }) {
+  return <Badge variant={PILL_VARIANT[tone]}>{children}</Badge>
 }
 
 export function SectionHeading({ icon: Icon, title, meta }: { icon: IconComponent; title: string; meta?: string }) {

--- a/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
@@ -358,4 +358,140 @@ describe('ToolsetConfigPanel', () => {
       timeout: 4000
     })
   })
+
+  describe('readiness pills', () => {
+    it('renders the server status instead of assuming keyless rows are Ready', async () => {
+      // The false-Ready bug: a logged-out Nous Subscription row and a
+      // never-installed local TTS both have zero env vars — the old client
+      // heuristic pilled every such row "Ready". The server now sends an
+      // honest per-provider status; the pill must follow it.
+      getToolsetConfig.mockResolvedValue(
+        config({
+          providers: [
+            {
+              name: 'Microsoft Edge TTS',
+              badge: 'free',
+              tag: 'No API key needed',
+              env_vars: [],
+              post_setup: null,
+              requires_nous_auth: false,
+              is_active: true,
+              status: 'ready'
+            },
+            {
+              name: 'Nous Subscription',
+              badge: 'subscription',
+              tag: 'Managed OpenAI TTS',
+              env_vars: [],
+              post_setup: null,
+              requires_nous_auth: true,
+              is_active: false,
+              status: 'needs_auth'
+            },
+            {
+              name: 'KittenTTS',
+              badge: 'local · free',
+              tag: 'Lightweight local ONNX TTS',
+              env_vars: [],
+              post_setup: 'kittentts',
+              requires_nous_auth: false,
+              is_active: false,
+              status: 'needs_setup'
+            }
+          ]
+        })
+      )
+
+      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+      render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
+
+      await screen.findByText('Microsoft Edge TTS')
+      // Exactly one Ready pill — the genuinely keyless Edge TTS row.
+      expect(screen.getAllByText('Ready')).toHaveLength(1)
+      expect(screen.getByText('Needs sign-in')).toBeTruthy()
+      expect(screen.getByText('Needs setup')).toBeTruthy()
+    })
+
+    it('shows no Ready pill for a keyed provider the server marks needs_keys', async () => {
+      getToolsetConfig.mockResolvedValue(
+        config({
+          providers: [
+            {
+              name: 'ElevenLabs',
+              badge: 'paid',
+              tag: 'Most natural voices',
+              env_vars: [
+                { key: 'ELEVENLABS_API_KEY', prompt: 'ElevenLabs API key', url: 'https://x', default: null, is_set: false }
+              ],
+              post_setup: null,
+              requires_nous_auth: false,
+              is_active: false,
+              status: 'needs_keys'
+            }
+          ]
+        })
+      )
+
+      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+      render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
+
+      await screen.findByText('ElevenLabs')
+      expect(screen.queryByText('Ready')).toBeNull()
+      // Missing keys are signalled by the env-var fields, not a warn pill.
+      expect(screen.queryByText('Needs sign-in')).toBeNull()
+      expect(screen.queryByText('Needs setup')).toBeNull()
+    })
+
+    it('falls back to the env-var heuristic when the backend sends no status', async () => {
+      // Older backend (no `status` field): keyless rows keep the legacy
+      // Ready pill, keyed-and-unset rows keep no pill. Narrow compat path —
+      // desktop and backend update on separate clocks.
+      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+      render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
+
+      await screen.findByText('Microsoft Edge TTS')
+      // Default config(): keyless Edge TTS (ready) + unset ElevenLabs (not).
+      expect(screen.getAllByText('Ready')).toHaveLength(1)
+      expect(screen.queryByText('Needs sign-in')).toBeNull()
+      expect(screen.queryByText('Needs setup')).toBeNull()
+    })
+
+    it('flips a needs_keys provider to Ready locally after its key is saved', async () => {
+      getToolsetConfig.mockResolvedValue(
+        config({
+          active_provider: 'ElevenLabs',
+          providers: [
+            {
+              name: 'ElevenLabs',
+              badge: 'paid',
+              tag: 'Most natural voices',
+              env_vars: [
+                { key: 'ELEVENLABS_API_KEY', prompt: 'ElevenLabs API key', url: 'https://x', default: null, is_set: false }
+              ],
+              post_setup: null,
+              requires_nous_auth: false,
+              is_active: true,
+              status: 'needs_keys'
+            }
+          ]
+        })
+      )
+
+      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+      render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
+
+      expect(await screen.findByText('ELEVENLABS_API_KEY')).toBeTruthy()
+      expect(screen.queryByText('Ready')).toBeNull()
+
+      // Save a key: the pill must go Ready from the local envState patch even
+      // though the (now stale) server status still says needs_keys.
+      const trigger = await screen.findByRole('button', { name: /Actions for ELEVENLABS_API_KEY/ })
+      fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerType: 'mouse' })
+      fireEvent.click(await screen.findByRole('menuitem', { name: 'Set' }))
+      fireEvent.change(await screen.findByPlaceholderText('ElevenLabs API key'), { target: { value: 'sk-live' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+      await waitFor(() => expect(screen.getByText('Ready')).toBeTruthy())
+    })
+  })
 })

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -22,6 +22,7 @@ import type {
   ActionStatusResponse,
   ToolEnvVar,
   ToolProvider,
+  ToolProviderStatus,
   ToolsetConfig,
   ToolsetModelsResponse
 } from '@/types/hermes'
@@ -46,6 +47,28 @@ function providerConfigured(provider: ToolProvider, envState: Record<string, boo
   }
 
   return provider.env_vars.every(ev => envState[ev.key])
+}
+
+/**
+ * Resolve the readiness pill state for a provider row. Prefers the honest
+ * server-computed `status` (keys ∧ Nous entitlement ∧ post-setup install
+ * state). Older backends don't send `status` — fall back to the legacy
+ * env-var heuristic, mapped onto the same state space (`ready` /
+ * `needs_keys`), so the pill still renders against an outdated runtime.
+ */
+function providerStatus(provider: ToolProvider, envState: Record<string, boolean>): ToolProviderStatus {
+  if (provider.status) {
+    // Env-var edits patch envState locally without a refetch — a stale
+    // server `status` must not keep saying "needs keys" (or "ready") after
+    // the user just saved (or cleared) a key in this panel.
+    if (provider.env_vars.length > 0) {
+      return provider.env_vars.every(ev => envState[ev.key]) ? 'ready' : 'needs_keys'
+    }
+
+    return provider.status
+  }
+
+  return providerConfigured(provider, envState) ? 'ready' : 'needs_keys'
 }
 
 interface EnvVarFieldProps {
@@ -538,7 +561,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
     <div className="grid gap-2">
       {providers.map(provider => {
         const isActive = activeProvider === provider.name
-        const configured = providerConfigured(provider, envState)
+        const status = providerStatus(provider, envState)
 
         return (
           <div className="overflow-hidden rounded-xl bg-background/60" key={provider.name}>
@@ -554,12 +577,14 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
               <span className="flex min-w-0 items-center gap-2">
                 <span className="truncate text-sm font-medium">{provider.name}</span>
                 {provider.badge && <Pill>{provider.badge}</Pill>}
-                {configured && (
+                {status === 'ready' && (
                   <Pill tone="primary">
                     <Check className="size-3" />
                     {copy.ready}
                   </Pill>
                 )}
+                {status === 'needs_auth' && <Pill tone="warn">{copy.needsSignIn}</Pill>}
+                {status === 'needs_setup' && <Pill tone="warn">{copy.needsSetup}</Pill>}
               </span>
               {selecting === provider.name && <Loader2 className="size-3.5 shrink-0 animate-spin" />}
             </button>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -819,6 +819,8 @@ export const en: Translations = {
       noProviderOptions: 'This toolset has no provider options — enable it and it works with your current setup.',
       noProviders: 'No providers are available for this toolset right now.',
       ready: 'Ready',
+      needsSignIn: 'Needs sign-in',
+      needsSetup: 'Needs setup',
       nousIncluded: 'Included with a Nous subscription — sign in to Nous Portal to activate.',
       noApiKeyRequired: 'No API key required.',
       postSetupHint: step =>

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -853,6 +853,8 @@ export const ja = defineLocale({
         'このツールセットにはプロバイダーのオプションがありません。有効にすれば現在の設定で動作します。',
       noProviders: '現在このツールセットに利用可能なプロバイダーがありません。',
       ready: '準備完了',
+      needsSignIn: 'サインインが必要',
+      needsSetup: 'セットアップが必要',
       nousIncluded: 'Nous サブスクリプションに含まれています。有効にするには Nous Portal にサインインしてください。',
       noApiKeyRequired: 'API キーは不要です。',
       postSetupHint: step =>

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -708,6 +708,8 @@ export interface Translations {
       noProviderOptions: string
       noProviders: string
       ready: string
+      needsSignIn: string
+      needsSetup: string
       nousIncluded: string
       noApiKeyRequired: string
       postSetupHint: (step: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -826,6 +826,8 @@ export const zhHant = defineLocale({
       noProviderOptions: '此工具集沒有提供方選項；啟用後即可使用目前設定。',
       noProviders: '此工具集目前沒有可用提供方。',
       ready: '就緒',
+      needsSignIn: '需要登入',
+      needsSetup: '需要安裝',
       nousIncluded: '包含在 Nous 訂閱中；登入 Nous Portal 即可啟用。',
       noApiKeyRequired: '不需要 API 金鑰。',
       postSetupHint: step => `此後端需要一次性安裝 (${step})。將在此機器上執行，可能需要幾分鐘。`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1004,6 +1004,8 @@ export const zh: Translations = {
       noProviderOptions: '此工具集没有提供方选项；启用后即可使用当前配置。',
       noProviders: '此工具集当前没有可用提供方。',
       ready: '就绪',
+      needsSignIn: '需要登录',
+      needsSetup: '需要安装',
       nousIncluded: '包含在 Nous 订阅中；登录 Nous Portal 即可激活。',
       noApiKeyRequired: '不需要 API 密钥。',
       postSetupHint: step => `此后端需要一次性安装 (${step})。将在此机器上执行，可能需要几分钟。`,

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -687,6 +687,10 @@ export interface ToolEnvVar {
   is_set: boolean
 }
 
+/** Server-computed readiness for a provider picker row. Absent on older
+ *  backends that predate the truthful-readiness endpoint. */
+export type ToolProviderStatus = 'ready' | 'needs_setup' | 'needs_auth' | 'needs_keys'
+
 export interface ToolProvider {
   name: string
   badge: string
@@ -697,6 +701,9 @@ export interface ToolProvider {
   /** True when this is the provider currently written to config (mirrors the
    *  CLI `hermes tools` active-provider detection). */
   is_active: boolean
+  /** Honest readiness computed server-side (keys ∧ Nous entitlement ∧
+   *  post-setup install state). Optional for older backends. */
+  status?: ToolProviderStatus
 }
 
 export interface ToolsetConfig {

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -25,6 +25,7 @@ from hermes_cli.config import (
 )
 from hermes_cli.colors import Colors, color
 from hermes_cli.nous_subscription import (
+    MANAGED_FEATURE_COVERAGE_CATEGORY,
     apply_nous_managed_defaults,
     get_nous_subscription_features,
 )
@@ -126,6 +127,8 @@ def _xai_credentials_present() -> bool:
     ``XAI_API_KEY``. Does NOT hit the network — only inspects the local
     auth store and environment. The tool's runtime ``check_fn`` still
     gates schema registration if creds later expire or get revoked.
+    Also reused by ``provider_readiness_status`` for ``post_setup:
+    "xai_grok"`` picker rows (xAI TTS, Grok OAuth x_search).
     """
     try:
         from hermes_cli.auth import _read_xai_oauth_tokens
@@ -2599,6 +2602,118 @@ def _post_setup_already_installed(post_setup_key: str) -> bool:
         return bool(predicate())
     except Exception:
         return True
+
+
+def _module_installed(module_name: str) -> bool:
+    """Cheap importable-without-importing check (no heavy side effects)."""
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except Exception:
+        return False
+
+
+def _agent_browser_installed() -> bool:
+    from hermes_cli.nous_subscription import _has_agent_browser
+
+    return _has_agent_browser()
+
+
+# post_setup_key -> predicate(): True when the install side-effect is already
+# satisfied. Used by ``provider_readiness_status`` to decide whether a keyless
+# post_setup row (KittenTTS, Piper, Local Browser, …) is honestly "ready" or
+# still "needs_setup". Mirrors the installed-checks ``_run_post_setup`` itself
+# performs before installing. ``xai_grok`` is intentionally absent — it is a
+# credential bootstrap, not an install, and is handled as an auth check.
+_POST_SETUP_READY: dict = {
+    "kittentts": lambda: _module_installed("kittentts"),
+    "piper": lambda: _module_installed("piper"),
+    "ddgs": lambda: _module_installed("ddgs"),
+    "langfuse": lambda: _module_installed("langfuse"),
+    "agent_browser": _agent_browser_installed,
+    "cua_driver": lambda: bool(shutil.which(_cua_driver_cmd())),
+}
+
+
+def provider_readiness_status(
+    provider: dict,
+    config: dict,
+    *,
+    features=None,
+    is_active: Optional[bool] = None,
+) -> str:
+    """Compute an honest readiness state for a provider picker row.
+
+    Returns one of:
+
+    - ``"ready"``       — usable as-is (keys set / entitled / installed).
+    - ``"needs_keys"``  — declares env vars and at least one is unset.
+    - ``"needs_auth"``  — needs a sign-in: Nous Portal login/entitlement for
+      managed Tool Gateway rows, or xAI Grok OAuth / XAI_API_KEY for
+      ``post_setup: "xai_grok"`` rows.
+    - ``"needs_setup"`` — keyless row whose ``post_setup`` install hook has
+      verifiably not run yet (see ``_POST_SETUP_READY``).
+
+    Keyless ≠ usable: this is the server-side truth the GUI "Ready" pill
+    renders from (the old client-side heuristic showed Ready for every
+    zero-env-var row, including logged-out Nous Subscription rows).
+
+    ``features`` (a ``NousSubscriptionFeatures``) can be passed to avoid
+    re-fetching portal state per row. ``is_active`` is the completed-setup
+    fallback signal for post_setup hooks with no registered installed-check
+    (selecting a row runs its hook, so the active row has been set up).
+    """
+    env_vars = provider.get("env_vars", [])
+    if env_vars:
+        if all(get_env_value(e["key"]) for e in env_vars):
+            return "ready"
+        return "needs_keys"
+
+    managed_feature = provider.get("managed_nous_feature")
+    if provider.get("requires_nous_auth") or managed_feature:
+        if features is None:
+            features = get_nous_subscription_features(config)
+        if not features.nous_auth_present:
+            return "needs_auth"
+        if managed_feature:
+            # Same per-category entitlement gate the CLI applies at selection
+            # time (free tool-pool users get image gen but not video gen).
+            acct = features.account_info
+            category = MANAGED_FEATURE_COVERAGE_CATEGORY.get(managed_feature)
+            entitled = bool(
+                acct
+                and acct.logged_in
+                and (
+                    acct.tool_gateway_entitled_for(category)
+                    if category
+                    else acct.tool_gateway_entitled
+                )
+            )
+            if not entitled:
+                return "needs_auth"
+        # Signed in and entitled — fall through: a managed row may still
+        # carry a local install hook (e.g. the managed browser row needs
+        # the agent-browser CLI on this machine).
+
+    post_setup = provider.get("post_setup")
+    if post_setup:
+        if post_setup == "xai_grok":
+            return "ready" if _xai_credentials_present() else "needs_auth"
+        predicate = _POST_SETUP_READY.get(post_setup)
+        if predicate is not None:
+            try:
+                return "ready" if predicate() else "needs_setup"
+            except Exception:
+                # Flaky detection must not manufacture a warning state.
+                return "ready"
+        # No reliable installed-check registered → treat the active-provider
+        # signal as "setup completed" (selecting the row runs the hook).
+        if is_active is None:
+            is_active = _is_provider_active(provider, config)
+        return "ready" if is_active else "needs_setup"
+
+    return "ready"
 
 
 def _toolset_needs_configuration_prompt(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14081,8 +14081,10 @@ async def get_toolset_config(name: str, profile: Optional[str] = None):
         _get_effective_configurable_toolsets,
         _is_provider_active,
         _visible_providers,
+        provider_readiness_status,
     )
     from hermes_cli.config import get_env_value
+    from hermes_cli.nous_subscription import get_nous_subscription_features
 
     valid = {ts_key for ts_key, _, _ in _get_effective_configurable_toolsets()}
     if name not in valid:
@@ -14094,6 +14096,10 @@ async def get_toolset_config(name: str, profile: Optional[str] = None):
         providers = []
         active_provider = None
         if cat:
+            # Fetch portal/entitlement state once for the whole matrix — the
+            # per-provider readiness computation below reuses it instead of
+            # re-probing per row.
+            features = get_nous_subscription_features(config, force_fresh=True)
             for prov in _visible_providers(cat, config, force_fresh=True):
                 env_vars = [
                     {
@@ -14120,6 +14126,13 @@ async def get_toolset_config(name: str, profile: Optional[str] = None):
                     "post_setup": prov.get("post_setup"),
                     "requires_nous_auth": bool(prov.get("requires_nous_auth")),
                     "is_active": is_active,
+                    # Honest server-side readiness. The GUI's old client-side
+                    # heuristic showed "Ready" for every zero-env-var row —
+                    # including logged-out Nous Subscription rows and never-run
+                    # post_setup installs (see provider_readiness_status).
+                    "status": provider_readiness_status(
+                        prov, config, features=features, is_active=is_active
+                    ),
                 })
     return {
         "name": name,

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -24,6 +24,7 @@ from hermes_cli.tools_config import (
     TOOL_CATEGORIES,
     gui_toolset_label,
     _visible_providers,
+    provider_readiness_status,
     tools_command,
 )
 
@@ -1830,3 +1831,118 @@ def test_save_platform_tools_disabling_a_toolset_does_not_touch_disabled_toolset
     assert "todo" not in config["platform_toolsets"]["cli"]
     # disabled_toolsets is untouched by a disable action.
     assert config["agent"]["disabled_toolsets"] == ["memory"]
+
+
+# ─── provider_readiness_status ────────────────────────────────────────────────
+#
+# Server-side truth for the GUI "Ready" pill (issue: Capabilities tab showed
+# Ready for every zero-env-var provider row, including logged-out Nous
+# Subscription rows and never-installed KittenTTS/Piper).
+
+
+def _fake_features(*, logged_in: bool, paid: bool = True):
+    account = (
+        NousPortalAccountInfo(
+            logged_in=True, source="jwt", fresh=False, paid_service_access=paid
+        )
+        if logged_in
+        else NousPortalAccountInfo(
+            logged_in=False, source="none", fresh=False, paid_service_access=None
+        )
+    )
+    return SimpleNamespace(nous_auth_present=logged_in, account_info=account)
+
+
+def test_provider_readiness_env_vars_gate_keys(monkeypatch):
+    provider = {"name": "ElevenLabs", "env_vars": [{"key": "ELEVENLABS_API_KEY"}]}
+
+    monkeypatch.setattr("hermes_cli.tools_config.get_env_value", lambda key: None)
+    assert provider_readiness_status(provider, {}) == "needs_keys"
+
+    monkeypatch.setattr("hermes_cli.tools_config.get_env_value", lambda key: "sk-x")
+    assert provider_readiness_status(provider, {}) == "ready"
+
+
+def test_provider_readiness_keyless_ungated_row_is_ready():
+    # Edge TTS: no env vars, no post_setup, no nous auth → genuinely free.
+    provider = {"name": "Microsoft Edge TTS", "env_vars": [], "tts_provider": "edge"}
+    assert provider_readiness_status(provider, {}) == "ready"
+
+
+def test_provider_readiness_managed_nous_row_needs_auth_when_logged_out():
+    provider = {
+        "name": "Nous Subscription",
+        "env_vars": [],
+        "requires_nous_auth": True,
+        "managed_nous_feature": "tts",
+    }
+    status = provider_readiness_status(
+        provider, {}, features=_fake_features(logged_in=False)
+    )
+    assert status == "needs_auth"
+
+
+def test_provider_readiness_managed_nous_row_ready_when_entitled():
+    provider = {
+        "name": "Nous Subscription",
+        "env_vars": [],
+        "requires_nous_auth": True,
+        "managed_nous_feature": "tts",
+    }
+    status = provider_readiness_status(
+        provider, {}, features=_fake_features(logged_in=True, paid=True)
+    )
+    assert status == "ready"
+
+
+def test_provider_readiness_managed_nous_row_needs_auth_when_unentitled():
+    # Logged in but unpaid and no free tool pool → still gated.
+    provider = {
+        "name": "Nous Subscription",
+        "env_vars": [],
+        "requires_nous_auth": True,
+        "managed_nous_feature": "video_gen",
+    }
+    status = provider_readiness_status(
+        provider, {}, features=_fake_features(logged_in=True, paid=False)
+    )
+    assert status == "needs_auth"
+
+
+def test_provider_readiness_xai_grok_row_tracks_credentials(monkeypatch):
+    provider = {"name": "xAI TTS", "env_vars": [], "post_setup": "xai_grok"}
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._xai_credentials_present", lambda: False
+    )
+    assert provider_readiness_status(provider, {}) == "needs_auth"
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._xai_credentials_present", lambda: True
+    )
+    assert provider_readiness_status(provider, {}) == "ready"
+
+
+def test_provider_readiness_local_install_rows_track_module_presence(monkeypatch):
+    kitten = {"name": "KittenTTS", "env_vars": [], "post_setup": "kittentts"}
+    piper = {"name": "Piper", "env_vars": [], "post_setup": "piper"}
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._module_installed", lambda name: False
+    )
+    assert provider_readiness_status(kitten, {}) == "needs_setup"
+    assert provider_readiness_status(piper, {}) == "needs_setup"
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._module_installed", lambda name: True
+    )
+    assert provider_readiness_status(kitten, {}) == "ready"
+    assert provider_readiness_status(piper, {}) == "ready"
+
+
+def test_provider_readiness_unknown_post_setup_falls_back_to_is_active():
+    # A post_setup hook with no registered installed-check: selecting the row
+    # runs the hook, so is_active is the completed-setup signal.
+    provider = {"name": "Mystery", "env_vars": [], "post_setup": "mystery_hook"}
+    assert provider_readiness_status(provider, {}, is_active=True) == "ready"
+    assert provider_readiness_status(provider, {}, is_active=False) == "needs_setup"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4940,6 +4940,56 @@ class TestNewEndpoints:
         else:
             assert data["active_provider"] is None
 
+    def test_get_toolset_config_reports_truthful_provider_status(self, monkeypatch):
+        """Each provider row carries a server-computed readiness `status`.
+
+        Regression: the GUI pilled every zero-env-var row "Ready" — including
+        logged-out Nous Subscription rows, xAI TTS without Grok OAuth, and
+        never-installed KittenTTS/Piper. The endpoint now reports the honest
+        state so keyless ≠ ready.
+        """
+        import hermes_cli.tools_config as tools_config
+        from hermes_cli.nous_account import NousPortalAccountInfo
+
+        # Logged out of Nous Portal → managed subscription rows need sign-in.
+        monkeypatch.setattr(
+            "hermes_cli.nous_subscription.get_nous_portal_account_info",
+            lambda *a, **k: NousPortalAccountInfo(
+                logged_in=False, source="none", fresh=False, paid_service_access=None
+            ),
+        )
+        # No xAI credentials → the Grok OAuth-backed row needs sign-in.
+        monkeypatch.setattr(tools_config, "_xai_credentials_present", lambda: False)
+        # Local TTS engines not installed → their rows need setup.
+        monkeypatch.setattr(tools_config, "_module_installed", lambda name: False)
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+
+        resp = self.client.get("/api/tools/toolsets/tts/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        by_name = {p["name"]: p for p in data["providers"]}
+
+        valid = {"ready", "needs_keys", "needs_auth", "needs_setup"}
+        assert all(p["status"] in valid for p in data["providers"])
+        # Genuinely-free keyless row stays Ready.
+        assert by_name["Microsoft Edge TTS"]["status"] == "ready"
+        # Keyless ≠ ready for gated rows:
+        assert by_name["Nous Subscription"]["status"] == "needs_auth"
+        assert by_name["xAI TTS"]["status"] == "needs_auth"
+        assert by_name["KittenTTS"]["status"] == "needs_setup"
+        assert by_name["Piper"]["status"] == "needs_setup"
+        # Keyed row with the key unset:
+        assert by_name["ElevenLabs"]["status"] == "needs_keys"
+
+    def test_get_toolset_config_status_ready_when_key_set(self, monkeypatch):
+        """A keyed provider flips to status=ready once its env var is set."""
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "sk-test")
+
+        resp = self.client.get("/api/tools/toolsets/tts/config")
+        assert resp.status_code == 200
+        by_name = {p["name"]: p for p in resp.json()["providers"]}
+        assert by_name["ElevenLabs"]["status"] == "ready"
+
     def test_get_toolset_config_reflects_selected_provider(self):
         """Selecting a provider is reflected in the next /config read.
 


### PR DESCRIPTION
## Summary
Desktop Capabilities provider rows now show truthful readiness: the backend computes a per-provider `status` (`ready` / `needs_keys` / `needs_auth` / `needs_setup`) instead of the frontend guessing "Ready" from an empty env-var list.

Root cause: `providerConfigured()` in `toolset-config-panel.tsx` returned true for any provider with zero `env_vars` — so Nous Subscription rows (logged out), xAI TTS (no Grok OAuth), and KittenTTS/Piper (no local install) all showed a false "Ready" pill.

## Changes
- `hermes_cli/tools_config.py`: new `provider_readiness_status()` — env-key check, Nous entitlement check (`get_nous_subscription_features`), post-setup installed-detection table (`_POST_SETUP_READY`) for kittentts/piper/xai_grok/agent-browser
- `hermes_cli/web_server.py`: `GET /api/tools/toolsets/{name}/config` adds an additive per-provider `status` field; subscription features fetched once per request
- `apps/desktop/src/app/settings/toolset-config-panel.tsx`: renders server status — Ready / "Needs sign-in" (warn) / "Needs setup" (warn); falls back to old env-var logic against older backends
- `apps/desktop/src/app/settings/primitives.tsx`: Pill gains `warn` tone
- i18n: `needsSignIn` / `needsSetup` added to en, zh, zh-hant, ja
- Keyed rows still derive ready/needs_keys locally so saving a key updates the pill without a refetch

## Validation
| | Before | After |
|---|---|---|
| Nous rows, logged out | Ready ✓ | Needs sign-in |
| xAI TTS, no OAuth | Ready ✓ | Needs setup |
| KittenTTS/Piper, not installed | Ready ✓ | Needs setup |
| Edge TTS (genuinely free) | Ready ✓ | Ready ✓ |

8 unit tests (status computation) + 2 endpoint tests + panel vitest — all pass.

## Infographic

![truthful-readiness](https://v3b.fal.media/files/b/0aa2ce0c/XtTzks6b8k5PzExwUAbO9_1z1Seivo.png)
