### PR TITLE
feat(desktop): terminal execution backend picker with health probes in Capabilities

### DIFF
--- a/apps/desktop/src/app/settings/terminal-backend-panel.test.tsx
+++ b/apps/desktop/src/app/settings/terminal-backend-panel.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { TerminalBackendsResponse } from '@/types/hermes'
+
+const getTerminalBackends = vi.fn()
+const selectTerminalBackend = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getTerminalBackends: () => getTerminalBackends(),
+  selectTerminalBackend: (backend: string) => selectTerminalBackend(backend)
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+function backends(overrides: Partial<TerminalBackendsResponse> = {}): TerminalBackendsResponse {
+  return {
+    active: 'local',
+    backends: [
+      {
+        name: 'local',
+        label: 'Local',
+        description: 'Run commands directly on this machine. No isolation.',
+        active: true,
+        status: 'ready',
+        detail: ''
+      },
+      {
+        name: 'docker',
+        label: 'Docker',
+        description: 'Run commands in an isolated Docker container.',
+        active: false,
+        status: 'needs_setup',
+        detail: 'Docker daemon not reachable — start Docker and retry.'
+      },
+      {
+        name: 'ssh',
+        label: 'SSH',
+        description: 'Run commands on a remote host over SSH.',
+        active: false,
+        status: 'ready',
+        detail: 'hermes@devbox'
+      }
+    ],
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  getTerminalBackends.mockResolvedValue(backends())
+  selectTerminalBackend.mockResolvedValue({ ok: true, backend: 'ssh' })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('TerminalBackendPanel', () => {
+  it('lists backends with status pills from the backends endpoint', async () => {
+    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
+    render(<TerminalBackendPanel onConfiguredChange={vi.fn()} />)
+
+    expect(await screen.findByText('Local')).toBeTruthy()
+    expect(screen.getByText('Docker')).toBeTruthy()
+    expect(screen.getByText('SSH')).toBeTruthy()
+    // Ready backends show the Ready pill; needs_setup shows the warn pill.
+    expect(screen.getAllByText('Ready').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByText('Needs setup')).toBeTruthy()
+    expect(getTerminalBackends).toHaveBeenCalled()
+  })
+
+  it('shows setup guidance detail for a needs_setup backend', async () => {
+    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
+    render(<TerminalBackendPanel onConfiguredChange={vi.fn()} />)
+
+    expect(await screen.findByText(/Docker daemon not reachable/)).toBeTruthy()
+  })
+
+  it('marks the active backend with an In use pill', async () => {
+    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
+    render(<TerminalBackendPanel onConfiguredChange={vi.fn()} />)
+
+    const local = await screen.findByRole('button', { name: /Local/ })
+    expect(local.getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByText('In use')).toBeTruthy()
+  })
+
+  it('selects a backend when clicked and reports the change', async () => {
+    const onConfiguredChange = vi.fn()
+    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
+    render(<TerminalBackendPanel onConfiguredChange={onConfiguredChange} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /SSH/ }))
+
+    await waitFor(() => expect(selectTerminalBackend).toHaveBeenCalledWith('ssh'))
+    await waitFor(() => expect(onConfiguredChange).toHaveBeenCalled())
+    // Active highlight moves without a refetch.
+    const ssh = screen.getByRole('button', { name: /SSH/ })
+    expect(ssh.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('allows selecting a needs_setup backend (guidance instead of blocking)', async () => {
+    selectTerminalBackend.mockResolvedValue({ ok: true, backend: 'docker' })
+    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
+    render(<TerminalBackendPanel onConfiguredChange={vi.fn()} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Docker/ }))
+
+    await waitFor(() => expect(selectTerminalBackend).toHaveBeenCalledWith('docker'))
+    // The guidance detail stays visible on the now-active row.
+    expect(screen.getByText(/Docker daemon not reachable/)).toBeTruthy()
+  })
+
+  it('does not re-select the already active backend', async () => {
+    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
+    render(<TerminalBackendPanel onConfiguredChange={vi.fn()} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Local/ }))
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(selectTerminalBackend).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/settings/terminal-backend-panel.tsx
+++ b/apps/desktop/src/app/settings/terminal-backend-panel.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { getTerminalBackends, selectTerminalBackend } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { AlertTriangle, Check, Loader2, RefreshCw } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { notify, notifyError } from '@/store/notifications'
+import type { TerminalBackendInfo, TerminalBackendsResponse } from '@/types/hermes'
+
+import { Pill } from './primitives'
+
+interface TerminalBackendPanelProps {
+  /** Re-read the parent toolset list after a backend change so any derived
+   *  pills stay in sync. */
+  onConfiguredChange?: () => void
+}
+
+function StatusPill({ backend }: { backend: TerminalBackendInfo }) {
+  const { t } = useI18n()
+  const copy = t.settings.toolsets.terminalBackend
+
+  if (backend.status === 'ready') {
+    return (
+      <Pill tone="primary">
+        <Check className="size-3" />
+        {copy.ready}
+      </Pill>
+    )
+  }
+
+  return (
+    <Pill tone="muted">
+      <AlertTriangle className="size-3" />
+      {backend.status === 'needs_setup' ? copy.needsSetup : copy.unavailable}
+    </Pill>
+  )
+}
+
+/**
+ * Terminal execution backend picker — the Capabilities-tab counterpart of the
+ * `terminal.backend` config enum. Each backend row carries a live health probe
+ * (Docker daemon reachable, SSH host configured, Modal/Daytona credentials
+ * present) so users see Ready / Needs-setup guidance instead of a bare
+ * dropdown. Selecting a needs-setup backend is allowed — the row shows what's
+ * missing rather than blocking, matching the CLI configurator.
+ */
+export function TerminalBackendPanel({ onConfiguredChange }: TerminalBackendPanelProps) {
+  const { t } = useI18n()
+  const copy = t.settings.toolsets.terminalBackend
+  const [data, setData] = useState<TerminalBackendsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [selecting, setSelecting] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+
+    try {
+      setData(await getTerminalBackends())
+    } catch (err) {
+      notifyError(err, copy.failedLoad)
+    } finally {
+      setLoading(false)
+    }
+  }, [copy.failedLoad])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  async function handleSelect(backend: TerminalBackendInfo) {
+    if (backend.active || selecting) {
+      return
+    }
+
+    setSelecting(backend.name)
+
+    try {
+      await selectTerminalBackend(backend.name)
+      // Mirror the backend write locally so the active highlight tracks the
+      // new selection without a refetch (probes are unchanged by a select).
+      setData(current =>
+        current
+          ? {
+              ...current,
+              active: backend.name,
+              backends: current.backends.map(b => ({ ...b, active: b.name === backend.name }))
+            }
+          : current
+      )
+      notify({ kind: 'success', title: copy.selectedTitle, message: copy.selectedMessage(backend.label) })
+      onConfiguredChange?.()
+    } catch (err) {
+      notifyError(err, copy.failedSelect(backend.label))
+    } finally {
+      setSelecting(null)
+    }
+  }
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center gap-2 px-1 text-xs text-muted-foreground">
+        <Loader2 className="size-3.5 animate-spin" />
+        {copy.loading}
+      </div>
+    )
+  }
+
+  if (!data) {
+    return null
+  }
+
+  return (
+    <div className="grid gap-1.5">
+      <div className="flex items-baseline justify-between gap-2 px-0.5">
+        <span className="text-[0.72rem] font-medium">{copy.sectionTitle}</span>
+        <Button disabled={loading} onClick={() => void refresh()} size="sm" variant="text">
+          <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
+        </Button>
+      </div>
+      <div className="grid gap-1">
+        {data.backends.map(backend => (
+          <button
+            aria-pressed={backend.active}
+            className={cn(
+              'grid gap-0.5 rounded-lg border px-2.5 py-2 text-left transition',
+              backend.active
+                ? 'border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary)'
+                : 'border-transparent bg-background/55 hover:bg-accent/40'
+            )}
+            disabled={selecting !== null}
+            key={backend.name}
+            onClick={() => void handleSelect(backend)}
+            type="button"
+          >
+            <span className="flex flex-wrap items-center gap-2">
+              <span className="text-xs font-medium">{backend.label}</span>
+              <StatusPill backend={backend} />
+              {backend.active && (
+                <Pill tone="primary">
+                  <Check className="size-3" />
+                  {copy.inUse}
+                </Pill>
+              )}
+              {selecting === backend.name && <Loader2 className="size-3 animate-spin" />}
+            </span>
+            <span className="text-[0.68rem] text-muted-foreground">{backend.description}</span>
+            {backend.status !== 'ready' && backend.detail && (
+              <span className="flex items-start gap-1 text-[0.68rem] text-amber-600 dark:text-amber-300">
+                <AlertTriangle className="mt-0.5 size-3 shrink-0" />
+                {backend.detail}
+                {backend.active && ` ${copy.needsSetupHint}`}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -48,6 +48,7 @@ import { PanelEmpty, PanelPill } from '../overlays/panel'
 import { PageSearchShell } from '../page-search-shell'
 import { ComputerUsePanel } from '../settings/computer-use-panel'
 import { asText, includesQuery, prettyName, toolNames, toolsetDisplayLabel } from '../settings/helpers'
+import { TerminalBackendPanel } from '../settings/terminal-backend-panel'
 import { ToolsetConfigPanel } from '../settings/toolset-config-panel'
 import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 
@@ -783,6 +784,7 @@ function ToolsetDetail({
         </div>
       )}
       {toolset.name === 'computer_use' && <ComputerUsePanel onConfiguredChange={onConfiguredChange} />}
+      {toolset.name === 'terminal' && <TerminalBackendPanel onConfiguredChange={onConfiguredChange} />}
       <ToolsetConfigPanel key={toolset.name} onConfiguredChange={onConfiguredChange} toolset={toolset.name} />
     </>
   )

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -52,6 +52,7 @@ import type {
   SkillInfo,
   StarmapGraph,
   StatusResponse,
+  TerminalBackendsResponse,
   ToolsetConfig,
   ToolsetInfo,
   ToolsetModelsResponse
@@ -824,6 +825,22 @@ export function runToolsetPostSetup(name: string, key: string): Promise<ActionRe
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/post-setup`,
     method: 'POST',
     body: { key }
+  })
+}
+
+export function getTerminalBackends(): Promise<TerminalBackendsResponse> {
+  return window.hermesDesktop.api<TerminalBackendsResponse>({
+    ...profileScoped(),
+    path: '/api/tools/terminal/backends'
+  })
+}
+
+export function selectTerminalBackend(backend: string): Promise<{ ok: boolean; backend: string }> {
+  return window.hermesDesktop.api<{ ok: boolean; backend: string }>({
+    ...profileScoped(),
+    path: '/api/tools/terminal/backend',
+    method: 'PUT',
+    body: { backend }
   })
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -839,7 +839,20 @@ export const en: Translations = {
       modelInactiveHint: 'Select this backend first to change its model.',
       modelSelectedTitle: 'Model selected',
       modelSelectedMessage: model => `${model} applies to new sessions.`,
-      failedSelectModel: model => `Failed to select ${model}`
+      failedSelectModel: model => `Failed to select ${model}`,
+      terminalBackend: {
+        sectionTitle: 'Execution backend',
+        loading: 'Checking execution backends…',
+        failedLoad: 'Could not load terminal backends',
+        ready: 'Ready',
+        needsSetup: 'Needs setup',
+        unavailable: 'Unavailable',
+        inUse: 'In use',
+        selectedTitle: 'Backend selected',
+        selectedMessage: backend => `Terminal commands now run via ${backend}. Applies to new sessions.`,
+        failedSelect: backend => `Failed to select ${backend}`,
+        needsSetupHint: 'You can select this backend now — commands will fail until setup is complete.'
+      }
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -864,7 +864,20 @@ export const ja = defineLocale({
       postSetupCompleteMessage: step => `${step} をインストールしました。`,
       postSetupErrorTitle: 'セットアップはエラーで終了しました',
       postSetupErrorMessage: step => `${step} のログを確認してください。`,
-      postSetupFailed: step => `${step} のセットアップの実行に失敗しました`
+      postSetupFailed: step => `${step} のセットアップの実行に失敗しました`,
+      terminalBackend: {
+        sectionTitle: '実行バックエンド',
+        loading: '実行バックエンドを確認中…',
+        failedLoad: 'ターミナルバックエンドの読み込みに失敗しました',
+        ready: '準備完了',
+        needsSetup: 'セットアップが必要',
+        unavailable: '利用不可',
+        inUse: '使用中',
+        selectedTitle: 'バックエンドを選択しました',
+        selectedMessage: backend => `ターミナルコマンドは ${backend} で実行されます。新しいセッションに適用されます。`,
+        failedSelect: backend => `${backend} の選択に失敗しました`,
+        needsSetupHint: 'このバックエンドは今すぐ選択できますが、セットアップが完了するまでコマンドは失敗します。'
+      }
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -728,6 +728,19 @@ export interface Translations {
       modelSelectedTitle: string
       modelSelectedMessage: (model: string) => string
       failedSelectModel: (model: string) => string
+      terminalBackend: {
+        sectionTitle: string
+        loading: string
+        failedLoad: string
+        ready: string
+        needsSetup: string
+        unavailable: string
+        inUse: string
+        selectedTitle: string
+        selectedMessage: (backend: string) => string
+        failedSelect: (backend: string) => string
+        needsSetupHint: string
+      }
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -836,7 +836,20 @@ export const zhHant = defineLocale({
       postSetupCompleteMessage: step => `已安裝 ${step}。`,
       postSetupErrorTitle: '設定完成但有錯誤',
       postSetupErrorMessage: step => `請檢查 ${step} 日誌。`,
-      postSetupFailed: step => `執行 ${step} 設定失敗`
+      postSetupFailed: step => `執行 ${step} 設定失敗`,
+      terminalBackend: {
+        sectionTitle: '執行後端',
+        loading: '正在檢查執行後端…',
+        failedLoad: '無法載入終端後端',
+        ready: '就緒',
+        needsSetup: '需要設定',
+        unavailable: '不可用',
+        inUse: '使用中',
+        selectedTitle: '已選擇後端',
+        selectedMessage: backend => `終端命令現在透過 ${backend} 執行。將套用於新工作階段。`,
+        failedSelect: backend => `選擇 ${backend} 失敗`,
+        needsSetupHint: '現在即可選擇此後端——但在完成設定前命令將會失敗。'
+      }
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1023,7 +1023,20 @@ export const zh: Translations = {
       modelInactiveHint: '请先选择此后端，然后再更改其模型。',
       modelSelectedTitle: '模型已选择',
       modelSelectedMessage: model => `${model} 将应用于新会话。`,
-      failedSelectModel: model => `选择 ${model} 失败`
+      failedSelectModel: model => `选择 ${model} 失败`,
+      terminalBackend: {
+        sectionTitle: '执行后端',
+        loading: '正在检查执行后端…',
+        failedLoad: '无法加载终端后端',
+        ready: '就绪',
+        needsSetup: '需要设置',
+        unavailable: '不可用',
+        inUse: '使用中',
+        selectedTitle: '已选择后端',
+        selectedMessage: backend => `终端命令现在通过 ${backend} 运行。将应用于新会话。`,
+        failedSelect: backend => `选择 ${backend} 失败`,
+        needsSetupHint: '现在即可选择此后端——但在完成设置前命令将会失败。'
+      }
     }
   },
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -707,6 +707,30 @@ export interface ToolsetConfig {
   active_provider: string | null
 }
 
+/** Health status of a terminal execution backend row.
+ *
+ *  `ready` — usable now; `needs_setup` — selectable but missing a dependency
+ *  or credential (detail says which); `unavailable` — the probe itself failed. */
+export type TerminalBackendStatus = 'ready' | 'needs_setup' | 'unavailable'
+
+/** One row from `GET /api/tools/terminal/backends`. */
+export interface TerminalBackendInfo {
+  name: string
+  label: string
+  description: string
+  /** True when this backend is the current `terminal.backend` config value. */
+  active: boolean
+  status: TerminalBackendStatus
+  /** Setup guidance / probe detail for non-ready rows (empty when ready). */
+  detail: string
+}
+
+/** Shape of `GET /api/tools/terminal/backends`. */
+export interface TerminalBackendsResponse {
+  active: string
+  backends: TerminalBackendInfo[]
+}
+
 /** One model row from a toolset backend's catalog (image/video gen). */
 export interface ToolsetModel {
   id: string

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14451,6 +14451,236 @@ async def run_toolset_post_setup(
 
 
 # ---------------------------------------------------------------------------
+# Terminal execution backend picker — the GUI counterpart of terminal.backend
+# in config.yaml. Each row carries a fast, defensive health probe (Docker
+# daemon reachable, SSH host configured, Modal/Daytona credentials present) so
+# the Capabilities panel can render Ready / Needs setup guidance instead of a
+# bare enum (issues #57738 / #63783). Probes must never raise — a probe
+# failure renders as a status, not a 500.
+# ---------------------------------------------------------------------------
+
+# Table-driven backend metadata — kept in sync with the dispatch ladder in
+# tools/terminal_tool.py::_create_environment and the terminal.backend enum
+# surfaced in the desktop raw-config settings.
+_TERMINAL_BACKENDS: List[Dict[str, str]] = [
+    {
+        "name": "local",
+        "label": "Local",
+        "description": "Run commands directly on this machine. No isolation.",
+    },
+    {
+        "name": "docker",
+        "label": "Docker",
+        "description": "Run commands in an isolated Docker container with a persistent workspace.",
+    },
+    {
+        "name": "singularity",
+        "label": "Singularity / Apptainer",
+        "description": "Run commands in a Singularity/Apptainer container (HPC-friendly, rootless).",
+    },
+    {
+        "name": "modal",
+        "label": "Modal",
+        "description": "Run commands in a Modal cloud sandbox.",
+    },
+    {
+        "name": "daytona",
+        "label": "Daytona",
+        "description": "Run commands in a Daytona cloud sandbox.",
+    },
+    {
+        "name": "ssh",
+        "label": "SSH",
+        "description": "Run commands on a remote host over SSH.",
+    },
+]
+
+_TERMINAL_BACKEND_NAMES = {row["name"] for row in _TERMINAL_BACKENDS}
+
+
+def _terminal_cfg_value(terminal_cfg: dict, key: str, env_var: str) -> str:
+    """Read a terminal.* setting from config.yaml, falling back to its env var."""
+    value = terminal_cfg.get(key)
+    if value is not None and str(value).strip():
+        return str(value).strip()
+    try:
+        from hermes_cli.config import get_env_value
+
+        return (get_env_value(env_var) or "").strip()
+    except Exception:
+        return ""
+
+
+def _probe_docker_backend() -> tuple:
+    if not shutil.which("docker"):
+        return (
+            "needs_setup",
+            "Docker CLI not found — install Docker Desktop or docker-ce.",
+        )
+    try:
+        proc = subprocess.run(
+            ["docker", "info", "--format", "{{.ServerVersion}}"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if proc.returncode == 0:
+            return ("ready", "")
+        return (
+            "needs_setup",
+            "Docker daemon not reachable — start Docker and retry.",
+        )
+    except subprocess.TimeoutExpired:
+        return ("needs_setup", "Docker daemon not responding (timed out).")
+    except Exception as exc:
+        return ("unavailable", f"Docker probe failed: {exc}")
+
+
+def _probe_singularity_backend() -> tuple:
+    if shutil.which("singularity") or shutil.which("apptainer"):
+        return ("ready", "")
+    return (
+        "needs_setup",
+        "Neither singularity nor apptainer found on PATH.",
+    )
+
+
+def _probe_ssh_backend(terminal_cfg: dict) -> tuple:
+    host = _terminal_cfg_value(terminal_cfg, "ssh_host", "TERMINAL_SSH_HOST")
+    user = _terminal_cfg_value(terminal_cfg, "ssh_user", "TERMINAL_SSH_USER")
+    missing = []
+    if not host:
+        missing.append("terminal.ssh_host")
+    if not user:
+        missing.append("terminal.ssh_user")
+    if missing:
+        return (
+            "needs_setup",
+            f"Set {' and '.join(missing)} in config.yaml (or the matching TERMINAL_SSH_* env vars).",
+        )
+    return ("ready", f"{user}@{host}")
+
+
+def _probe_modal_backend() -> tuple:
+    try:
+        from tools.tool_backend_helpers import has_direct_modal_credentials
+
+        if has_direct_modal_credentials():
+            return ("ready", "")
+    except Exception:
+        pass
+    try:
+        from hermes_cli.config import get_env_value
+
+        if get_env_value("MODAL_TOKEN_ID") and get_env_value("MODAL_TOKEN_SECRET"):
+            return ("ready", "")
+    except Exception:
+        pass
+    return (
+        "needs_setup",
+        "Modal credentials not found — set MODAL_TOKEN_ID and MODAL_TOKEN_SECRET (or run `modal setup`).",
+    )
+
+
+def _probe_daytona_backend() -> tuple:
+    try:
+        from hermes_cli.config import get_env_value
+
+        if get_env_value("DAYTONA_API_KEY"):
+            return ("ready", "")
+    except Exception:
+        pass
+    return ("needs_setup", "Set DAYTONA_API_KEY to use the Daytona backend.")
+
+
+def _probe_terminal_backend(name: str, terminal_cfg: dict) -> tuple:
+    """Return ``(status, detail)`` for one backend. Never raises."""
+    try:
+        if name == "local":
+            return ("ready", "")
+        if name == "docker":
+            return _probe_docker_backend()
+        if name == "singularity":
+            return _probe_singularity_backend()
+        if name == "ssh":
+            return _probe_ssh_backend(terminal_cfg)
+        if name == "modal":
+            return _probe_modal_backend()
+        if name == "daytona":
+            return _probe_daytona_backend()
+        return ("unavailable", f"Unknown backend: {name}")
+    except Exception as exc:  # pragma: no cover — belt-and-braces guard
+        return ("unavailable", f"Probe failed: {exc}")
+
+
+@app.get("/api/tools/terminal/backends")
+async def get_terminal_backends(profile: Optional[str] = None):
+    """Terminal execution backend rows with health probes for the picker panel.
+
+    Returns ``{active, backends: [{name, label, description, active, status,
+    detail}]}`` where ``status`` is ``ready`` / ``needs_setup`` /
+    ``unavailable`` and ``detail`` carries setup guidance for non-ready rows.
+    Probes are fast (<~2s each) and defensive — a probe failure surfaces as a
+    status, never an error response.
+    """
+    with _profile_scope(profile):
+        config = load_config()
+        terminal_cfg = config.get("terminal")
+        if not isinstance(terminal_cfg, dict):
+            terminal_cfg = {}
+        active = str(terminal_cfg.get("backend") or "local").strip().lower()
+        if active not in _TERMINAL_BACKEND_NAMES:
+            active = "local"
+
+        backends = []
+        for row in _TERMINAL_BACKENDS:
+            status, detail = _probe_terminal_backend(row["name"], terminal_cfg)
+            backends.append({
+                "name": row["name"],
+                "label": row["label"],
+                "description": row["description"],
+                "active": row["name"] == active,
+                "status": status,
+                "detail": detail,
+            })
+    return {"active": active, "backends": backends}
+
+
+class TerminalBackendSelect(BaseModel):
+    backend: str
+    profile: Optional[str] = None
+
+
+@app.put("/api/tools/terminal/backend")
+async def select_terminal_backend(
+    body: TerminalBackendSelect, profile: Optional[str] = None
+):
+    """Persist ``terminal.backend`` in config.yaml.
+
+    Validates against the known backend set (the same enum the raw-config
+    settings row exposes). Selecting a backend that still needs setup is
+    allowed — the picker shows guidance instead of blocking, matching the CLI.
+    """
+    backend = (body.backend or "").strip().lower()
+    if backend not in _TERMINAL_BACKEND_NAMES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown terminal backend: {body.backend!r}. "
+            f"Use one of: {', '.join(sorted(_TERMINAL_BACKEND_NAMES))}",
+        )
+
+    with _profile_scope(body.profile or profile):
+        config = load_config()
+        terminal_cfg = config.setdefault("terminal", {})
+        if not isinstance(terminal_cfg, dict):
+            terminal_cfg = {}
+            config["terminal"] = terminal_cfg
+        terminal_cfg["backend"] = backend
+        save_config(config)
+    return {"ok": True, "backend": backend}
+
+
+# ---------------------------------------------------------------------------
 # Computer Use (cua-driver) — cross-platform readiness + macOS permission grant
 #
 # cua-driver runs on macOS, Windows, and Linux. The desktop card reflects

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5007,6 +5007,165 @@ class TestNewEndpoints:
         )
         assert resp.status_code == 400
 
+    # -- Terminal execution backend picker ---------------------------------
+
+    def test_get_terminal_backends_shape_and_local_ready(self, monkeypatch):
+        """GET .../backends returns one row per backend; local is always ready."""
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda name: None)
+
+        resp = self.client.get("/api/tools/terminal/backends")
+        assert resp.status_code == 200
+        body = resp.json()
+        names = [row["name"] for row in body["backends"]]
+        assert names == ["local", "docker", "singularity", "modal", "daytona", "ssh"]
+        assert body["active"] in set(names)
+        for row in body["backends"]:
+            assert row["status"] in {"ready", "needs_setup", "unavailable"}
+            assert isinstance(row["label"], str) and row["label"]
+            assert isinstance(row["description"], str)
+            assert isinstance(row["detail"], str)
+            assert isinstance(row["active"], bool)
+        local = body["backends"][0]
+        assert local["status"] == "ready"
+        # Exactly one backend is flagged active, matching the summary field.
+        active_rows = [r["name"] for r in body["backends"] if r["active"]]
+        assert active_rows == [body["active"]]
+
+    def test_terminal_docker_probe_missing_cli(self, monkeypatch):
+        """No docker binary on PATH -> needs_setup with install guidance."""
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda name: None)
+
+        body = self.client.get("/api/tools/terminal/backends").json()
+        docker = next(r for r in body["backends"] if r["name"] == "docker")
+        assert docker["status"] == "needs_setup"
+        assert "not found" in docker["detail"]
+
+    def test_terminal_docker_probe_daemon_down(self, monkeypatch):
+        """docker CLI present but daemon unreachable -> needs_setup."""
+        import subprocess as subprocess_mod
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            web_server.shutil,
+            "which",
+            lambda name: "/usr/bin/docker" if name == "docker" else None,
+        )
+        monkeypatch.setattr(
+            web_server.subprocess,
+            "run",
+            lambda cmd, **kw: subprocess_mod.CompletedProcess(cmd, 1, stdout="", stderr="daemon down"),
+        )
+
+        body = self.client.get("/api/tools/terminal/backends").json()
+        docker = next(r for r in body["backends"] if r["name"] == "docker")
+        assert docker["status"] == "needs_setup"
+        assert "daemon" in docker["detail"].lower()
+
+    def test_terminal_docker_probe_daemon_ready(self, monkeypatch):
+        """docker CLI + reachable daemon -> ready."""
+        import subprocess as subprocess_mod
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            web_server.shutil,
+            "which",
+            lambda name: "/usr/bin/docker" if name in {"docker", "singularity"} else None,
+        )
+        monkeypatch.setattr(
+            web_server.subprocess,
+            "run",
+            lambda cmd, **kw: subprocess_mod.CompletedProcess(cmd, 0, stdout="27.0\n", stderr=""),
+        )
+
+        body = self.client.get("/api/tools/terminal/backends").json()
+        rows = {r["name"]: r for r in body["backends"]}
+        assert rows["docker"]["status"] == "ready"
+        # singularity resolves via which() too
+        assert rows["singularity"]["status"] == "ready"
+
+    def test_terminal_probe_failure_is_a_status_not_a_500(self, monkeypatch):
+        """A probe that raises must surface as a status row, never an error."""
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            web_server.shutil,
+            "which",
+            lambda name: "/usr/bin/docker" if name == "docker" else None,
+        )
+
+        def boom(cmd, **kw):
+            raise OSError("exec format error")
+
+        monkeypatch.setattr(web_server.subprocess, "run", boom)
+
+        resp = self.client.get("/api/tools/terminal/backends")
+        assert resp.status_code == 200
+        docker = next(r for r in resp.json()["backends"] if r["name"] == "docker")
+        assert docker["status"] == "unavailable"
+        assert "probe failed" in docker["detail"].lower()
+
+    def test_terminal_ssh_probe_reports_missing_keys(self, monkeypatch):
+        """SSH without host/user config lists the missing terminal.* keys."""
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda name: None)
+
+        body = self.client.get("/api/tools/terminal/backends").json()
+        ssh = next(r for r in body["backends"] if r["name"] == "ssh")
+        assert ssh["status"] == "needs_setup"
+        assert "terminal.ssh_host" in ssh["detail"]
+
+    def test_terminal_ssh_probe_ready_when_configured(self, monkeypatch):
+        """SSH host + user in config.yaml -> ready."""
+        import hermes_cli.web_server as web_server
+        from hermes_cli.config import load_config, save_config
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda name: None)
+        config = load_config()
+        config.setdefault("terminal", {})
+        config["terminal"]["ssh_host"] = "devbox.example.com"
+        config["terminal"]["ssh_user"] = "hermes"
+        save_config(config)
+
+        body = self.client.get("/api/tools/terminal/backends").json()
+        ssh = next(r for r in body["backends"] if r["name"] == "ssh")
+        assert ssh["status"] == "ready"
+        assert "hermes@devbox.example.com" in ssh["detail"]
+
+    def test_select_terminal_backend_persists_config(self, monkeypatch):
+        """PUT .../backend writes terminal.backend and the list reflects it."""
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda name: None)
+
+        resp = self.client.put(
+            "/api/tools/terminal/backend", json={"backend": "docker"}
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "backend": "docker"}
+
+        from hermes_cli.config import load_config
+        assert load_config()["terminal"]["backend"] == "docker"
+
+        body = self.client.get("/api/tools/terminal/backends").json()
+        assert body["active"] == "docker"
+        docker = next(r for r in body["backends"] if r["name"] == "docker")
+        assert docker["active"] is True
+        # Selecting a needs-setup backend is allowed; the row still carries
+        # its guidance detail.
+        assert docker["status"] == "needs_setup"
+
+    def test_select_terminal_backend_unknown_returns_400(self):
+        resp = self.client.put(
+            "/api/tools/terminal/backend", json={"backend": "kubernetes"}
+        )
+        assert resp.status_code == 400
+        assert "Unknown terminal backend" in resp.json()["detail"]
+
     def test_get_toolset_models_no_catalog_toolset(self):
         """Toolsets without a model catalog report has_models: false."""
         resp = self.client.get("/api/tools/toolsets/web/models")


### PR DESCRIPTION
## Summary
The Desktop Capabilities tab gets a first-class terminal execution backend picker — local / docker / ssh / modal / daytona / singularity — with per-backend health probes and setup guidance, replacing the bare enum buried in raw config settings.

Closes #57738. Addresses the execution-environment half of #63783.

## Changes
- `hermes_cli/web_server.py`: `GET /api/tools/terminal/backends` (table-driven metadata + fast defensive probes: docker CLI+daemon, ssh config keys, modal/daytona credentials, singularity/apptainer binary) and `PUT /api/tools/terminal/backend` (validates, persists `terminal.backend` via the same pattern as the toolset provider PUT, profile-scoped)
- `apps/desktop/src/app/settings/terminal-backend-panel.tsx`: new panel following the computer-use-panel precedent; status pills (Ready / Needs setup with detail text); selecting a needs_setup backend allowed with guidance shown
- Wired into `ToolsetDetail` for `toolset.name === 'terminal'`; API client fns in `hermes.ts`; i18n strings in all locales
- Raw config enum row untouched (additive)

Probes never 500 — every failure renders as a status.

## Validation
- Python: endpoint tests with mocked probes (no live docker dependency)
- Vitest: 6/6 panel tests pass; sibling panel tests still green (20/20)
- eslint + tsc --noEmit clean on changed files

## Infographic

![backend-select](https://v3b.fal.media/files/b/0aa2ce05/35OorGt0tGzkss_0GDHB1_QznVd1py.png)
