### PR TITLE
fix(mcp): re-register tools during parked revival

### DIFF
--- a/tests/tools/test_mcp_parked_self_probe.py
+++ b/tests/tools/test_mcp_parked_self_probe.py
@@ -8,8 +8,37 @@ revival probe on its own.
 """
 
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+
+def test_revival_discovery_registers_tools_while_ready_is_cleared(monkeypatch):
+    """A managed server revival must publish tools before readiness is reset."""
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    server = MCPServerTask("srv")
+    server._config = {"url": "https://example.test/mcp"}
+    server.session = SimpleNamespace(
+        list_tools=AsyncMock(
+            return_value=SimpleNamespace(
+                tools=[SimpleNamespace(name="send_message")],
+            )
+        )
+    )
+    server._ready.clear()
+    server._registered_tool_names = []
+    monkeypatch.setitem(mcp_tool._servers, server.name, server)
+
+    register = MagicMock(return_value=["srv__send_message"])
+    monkeypatch.setattr(mcp_tool, "_register_server_tools", register)
+
+    asyncio.run(server._discover_tools())
+
+    register.assert_called_once_with(server.name, server, server._config)
+    assert server._registered_tool_names == ["srv__send_message"]
 
 
 @pytest.mark.no_isolate

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2793,14 +2793,18 @@ class MCPServerTask:
         """Re-register tools after a post-ready reconnect if needed.
 
         Initial registration is performed by ``_discover_and_register_server``
-        after ``start()`` completes. During a later reconnect, however,
-        ``_ready`` remains set; if outage handling previously deregistered
-        stale tools (parking calls ``_deregister_tools``), a successful
-        revival must publish the freshly discovered tools again — otherwise
-        the transport comes back alive with zero registered tools.
+        after ``start()`` completes. During a later reconnect, outage handling
+        may clear ``_ready`` before discovery and may deregister stale tools.
+        A managed server can still be identified by its entry in ``_servers``;
+        publish its freshly discovered tools before transport readiness is
+        restored so a successful revival cannot come back with zero tools.
         """
-        if not self._ready.is_set() or self._registered_tool_names:
+        if self._registered_tool_names:
             return
+        if not self._ready.is_set():
+            with _lock:
+                if _servers.get(self.name) is not self:
+                    return
         self._registered_tool_names = _register_server_tools(
             self.name, self, self._config
         )


### PR DESCRIPTION
## Summary

- Re-publish MCP tools when a managed server revives while its readiness flag is still cleared.
- Preserve the existing initial-start registration flow for servers that are not yet present in the managed server registry.
- Add a regression test for the real discovery-before-ready ordering.

## Root Cause

`_discover_tools()` invokes `_register_discovered_tools_if_needed()` before the transport sets `_ready`. After outage handling clears readiness and parking deregisters the tools, the helper returned early even though the server was an already-managed revival. The transport recovered, but its tools stayed absent from the registry.

## Tests

- `scripts/run_tests.sh tests/tools/test_mcp_parked_self_probe.py tests/tools/test_mcp_circuit_breaker.py tests/tools/test_mcp_reconnect_retry_reset.py tests/tools/test_mcp_list_pagination.py tests/tools/test_mcp_tool.py -q` — 231 passed
- `python -m pytest tests/tools/test_mcp_stability.py -q -k 'not kill_orphaned_handles_dead_pids'` — 23 passed, 1 deselected
- `python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_parked_self_probe.py`
- `git diff --check`

The deselected stability test is an existing local baseline: it sends `SIGTERM` to a deliberately nonexistent PID and is blocked by the repository live-system guard on unchanged `main` as well.

Fixes #67187