### PR TITLE
feat(desktop): surface config-defined TTS/STT providers + xAI TTS params (salvage #62459, #56724)

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -384,7 +384,13 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     },
     xai: {
       voiceId: 'xAI (Grok) Voice',
-      language: 'xAI Language'
+      language: 'xAI Language',
+      speed: 'Playback Speed',
+      autoSpeechTags: 'Auto Speech Tags',
+      textNormalization: 'Text Normalization',
+      optimizeStreamingLatency: 'Streaming Latency Optimization',
+      sampleRate: 'Sample Rate',
+      bitRate: 'Bit Rate'
     },
     minimax: {
       model: 'MiniMax TTS Model',
@@ -491,7 +497,13 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   tts: {
     xai: {
       voiceId: 'xAI voice ID (e.g. eve) or a custom voice ID.',
-      language: 'Spoken language code, e.g. en.'
+      language: 'Spoken language code (e.g. en, pt-BR) or "auto" for auto-detection.',
+      speed: 'Playback speed. 0.7 = slower, 1.0 = normal, 1.5 = faster.',
+      autoSpeechTags: 'Let an LLM insert expressive audio tags ([laughing], [sighs]) into the script before synthesis.',
+      textNormalization: 'Convert numbers, abbreviations, and symbols to spoken form before synthesis.',
+      optimizeStreamingLatency: 'Latency vs. quality trade-off. 0 = best quality, 2 = lowest latency.',
+      sampleRate: 'Audio sample rate in Hz. Higher = better quality, larger files.',
+      bitRate: 'MP3 bitrate in bps. Only applies when codec is mp3.'
     },
     neutts: {
       device: 'Local inference device for NeuTTS.'
@@ -592,6 +604,12 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.elevenlabs.model_id',
       'tts.xai.voice_id',
       'tts.xai.language',
+      'tts.xai.speed',
+      'tts.xai.auto_speech_tags',
+      'tts.xai.text_normalization',
+      'tts.xai.optimize_streaming_latency',
+      'tts.xai.sample_rate',
+      'tts.xai.bit_rate',
       'tts.minimax.model',
       'tts.minimax.voice_id',
       'tts.mistral.model',

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -387,7 +387,6 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
       language: 'xAI Language',
       speed: 'xAI Playback Speed',
       autoSpeechTags: 'xAI Auto Speech Tags',
-      textNormalization: 'xAI Text Normalization',
       optimizeStreamingLatency: 'xAI Streaming Latency Optimization',
       sampleRate: 'xAI Sample Rate',
       bitRate: 'xAI Bit Rate'
@@ -500,7 +499,6 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
       language: 'Spoken language code (e.g. en, pt-BR) or "auto" for auto-detection.',
       speed: 'Playback speed. 0.7 = slower, 1.0 = normal, 1.5 = faster.',
       autoSpeechTags: 'Let an LLM insert expressive audio tags ([laughing], [sighs]) into the script before synthesis.',
-      textNormalization: 'Convert numbers, abbreviations, and symbols to spoken form before synthesis.',
       optimizeStreamingLatency: 'Latency vs. quality trade-off. 0 = best quality, 2 = lowest latency.',
       sampleRate: 'Audio sample rate in Hz. Higher = better quality, larger files.',
       bitRate: 'MP3 bitrate in bps. Only applies when codec is mp3.'
@@ -606,7 +604,6 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.xai.language',
       'tts.xai.speed',
       'tts.xai.auto_speech_tags',
-      'tts.xai.text_normalization',
       'tts.xai.optimize_streaming_latency',
       'tts.xai.sample_rate',
       'tts.xai.bit_rate',

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -385,12 +385,12 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     xai: {
       voiceId: 'xAI (Grok) Voice',
       language: 'xAI Language',
-      speed: 'Playback Speed',
-      autoSpeechTags: 'Auto Speech Tags',
-      textNormalization: 'Text Normalization',
-      optimizeStreamingLatency: 'Streaming Latency Optimization',
-      sampleRate: 'Sample Rate',
-      bitRate: 'Bit Rate'
+      speed: 'xAI Playback Speed',
+      autoSpeechTags: 'xAI Auto Speech Tags',
+      textNormalization: 'xAI Text Normalization',
+      optimizeStreamingLatency: 'xAI Streaming Latency Optimization',
+      sampleRate: 'xAI Sample Rate',
+      bitRate: 'xAI Bit Rate'
     },
     minimax: {
       model: 'MiniMax TTS Model',

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -205,6 +205,99 @@ describe('settings helpers', () => {
       expect(opts).toContain('my-custom-command-tts')
       expect(opts).toContain('xai')
     })
+
+    it('surfaces user-defined command-type TTS providers (canonical providers nesting + legacy)', () => {
+      const withCustom: HermesConfigRecord = {
+        tts: {
+          provider: 'neutts',
+          // canonical location the runtime resolves first: tts.providers.<name>
+          providers: {
+            higgs8: { type: 'command', command: 'curl …' },
+            indextts2: { type: 'command', command: 'curl …' },
+            // `type:` is optional at runtime — a bare command block still qualifies
+            typeless: { command: 'curl …' },
+            // misconfigured: type:command but no command → NOT a runtime provider
+            noop: { type: 'command' }
+          },
+          // back-compat: a top-level tts.<name> command block still resolves at runtime
+          mylegacy: { type: 'command', command: 'curl …' },
+          // a non-command block (built-in config) must NOT be offered as a provider
+          edge: { voice: 'en-US-JennyNeural' }
+        }
+      }
+
+      const opts = enumOptionsFor('tts.provider', 'neutts', withCustom)
+      expect(opts).toContain('higgs8') // canonical providers.<name>
+      expect(opts).toContain('indextts2') // canonical providers.<name>
+      expect(opts).toContain('typeless') // command block with no type: still surfaced
+      expect(opts).toContain('mylegacy') // legacy top-level tts.<name>
+      expect(opts).toContain('elevenlabs') // built-ins preserved
+      expect(opts).not.toContain('noop') // type:command with no command is excluded
+      // 'edge' appears once (the built-in), not duplicated by the config block
+      expect(opts!.filter(o => o === 'edge')).toHaveLength(1)
+      // the 'providers' container itself is never offered as a provider name
+      expect(opts).not.toContain('providers')
+    })
+
+    it('surfaces command-type STT providers too (canonical providers nesting)', () => {
+      const withCustom: HermesConfigRecord = {
+        stt: {
+          provider: 'local',
+          providers: { myasr: { type: 'command', command: 'curl …' } }
+        }
+      }
+
+      const opts = enumOptionsFor('stt.provider', 'local', withCustom)
+      expect(opts).toContain('myasr')
+      expect(opts).toContain('local')
+      expect(opts).not.toContain('providers')
+    })
+
+    // The runtime rejects a built-in name as a command provider before any config
+    // lookup, so such a block must never be offered — including the names the
+    // display list omits (`deepinfra` for TTS; `deepinfra`/`local_command` for
+    // STT), where filtering on ENUM_OPTIONS instead of the runtime's built-in set
+    // would wrongly offer a provider that can never dispatch.
+    it('never offers a built-in name as a command provider, even one absent from the dropdown list', () => {
+      const shadowing: HermesConfigRecord = {
+        tts: {
+          provider: 'edge',
+          providers: {
+            // built-in and absent from ENUM_OPTIONS['tts.provider']
+            deepinfra: { type: 'command', command: 'curl …' },
+            // built-in guard is case-insensitive at runtime (provider.lower())
+            EDGE: { type: 'command', command: 'curl …' },
+            // a genuine custom provider alongside them still surfaces
+            higgs8: { type: 'command', command: 'curl …' }
+          }
+        }
+      }
+
+      const opts = enumOptionsFor('tts.provider', 'edge', shadowing)
+      expect(opts).not.toContain('deepinfra')
+      expect(opts).not.toContain('EDGE')
+      expect(opts).toContain('higgs8')
+      expect(opts!.filter(o => o === 'edge')).toHaveLength(1)
+    })
+
+    it('never offers a built-in STT name absent from the dropdown list as a command provider', () => {
+      const shadowing: HermesConfigRecord = {
+        stt: {
+          provider: 'local',
+          providers: {
+            // both are built-in STT names omitted from ENUM_OPTIONS['stt.provider']
+            local_command: { type: 'command', command: 'curl …' },
+            deepinfra: { type: 'command', command: 'curl …' },
+            myasr: { type: 'command', command: 'curl …' }
+          }
+        }
+      }
+
+      const opts = enumOptionsFor('stt.provider', 'local', shadowing)
+      expect(opts).not.toContain('local_command')
+      expect(opts).not.toContain('deepinfra')
+      expect(opts).toContain('myasr')
+    })
   })
 
   describe('sectionFieldEntries', () => {

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -1,4 +1,4 @@
-import { asText } from '@/lib/text'
+import { asText, normalize } from '@/lib/text'
 import type { ConfigFieldSchema, HermesConfigRecord, ToolsetInfo } from '@/types/hermes'
 
 import { BUILTIN_PERSONALITIES, ENUM_OPTIONS, PROVIDER_GROUPS, SECTIONS } from './constants'
@@ -166,13 +166,119 @@ function personalityOptions(config: HermesConfigRecord): string[] {
   return [...new Set(['', ...BUILTIN_PERSONALITIES, ...customNames])]
 }
 
+// Built-in provider names, mirroring `tts_tool.py:BUILTIN_TTS_PROVIDERS` and
+// `transcription_tools.py:BUILTIN_STT_PROVIDERS`. The runtime rejects a built-in
+// name as a command provider before any config lookup
+// (`_resolve_command_provider_config`: `key = provider.lower().strip()`, then
+// `if key in BUILTIN_*_PROVIDERS: return None`), so a ``providers.edge`` block
+// declaring ``type: command`` still dispatches to native Edge.
+//
+// These are deliberately NOT derived from `ENUM_OPTIONS`, which is a *display*
+// list and already drifts from the runtime sets: it omits `deepinfra` (TTS) and
+// `deepinfra`/`local_command` (STT). Filtering on the display list would offer
+// those names as command providers that the runtime would never honour.
+const BUILTIN_TTS_PROVIDERS = new Set([
+  'edge',
+  'elevenlabs',
+  'openai',
+  'minimax',
+  'xai',
+  'mistral',
+  'gemini',
+  'neutts',
+  'kittentts',
+  'piper',
+  'deepinfra'
+])
+
+const BUILTIN_STT_PROVIDERS = new Set([
+  'local',
+  'local_command',
+  'groq',
+  'openai',
+  'mistral',
+  'xai',
+  'elevenlabs',
+  'deepinfra'
+])
+
+// A user-declared command provider, mirroring the runtime discriminator
+// (`tts_tool.py:_is_command_provider_config` / `transcription_tools.py`): `type`
+// is OPTIONAL and case/space-insensitive (absent or normalizing to "command"),
+// and `command` MUST be a non-empty string. So a canonical block written as just
+// ``{ command: "curl …" }`` with no ``type:`` — a fully valid runtime provider
+// under ``providers.*`` — qualifies too, while built-in blocks (which carry
+// ``voice``/``model`` and no ``command``) and the ``providers`` container itself
+// (no ``command``) are skipped.
+function isCommandProvider(value: unknown): boolean {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const record = value as Record<string, unknown>
+  const type = normalize(record.type)
+
+  if (type !== '' && type !== 'command') {
+    return false
+  }
+
+  return typeof record.command === 'string' && record.command.trim() !== ''
+}
+
+// Names of user-defined command providers, so the settings dropdown can offer
+// them alongside the built-ins instead of only whichever one is currently active
+// (otherwise, once you switch away from a custom provider it drops off the list
+// and can only be reselected by hand-editing config.yaml).
+//
+// Mirrors the runtime's dual resolution (`tts_tool.py:_get_named_provider_config`,
+// `transcription_tools.py`): the CANONICAL location is nested —
+// ``tts.providers.<name>`` / ``stt.providers.<name>`` — with a back-compat
+// fallback to a top-level ``tts.<name>`` / ``stt.<name>`` block. We enumerate
+// both (deduped), keeping only sections that satisfy isCommandProvider and whose
+// name the runtime would actually resolve as a command provider — built-ins are
+// excluded case-insensitively, matching the runtime's `provider.lower().strip()`
+// guard, so a ``providers.EDGE`` command block is not offered.
+function commandProviderNames(config: HermesConfigRecord, section: 'tts' | 'stt'): string[] {
+  const builtins = section === 'tts' ? BUILTIN_TTS_PROVIDERS : BUILTIN_STT_PROVIDERS
+  const names = new Set<string>()
+
+  for (const path of [`${section}.providers`, section]) {
+    const block = getNested(config, path)
+
+    if (!block || typeof block !== 'object' || Array.isArray(block)) {
+      continue
+    }
+
+    for (const [name, value] of Object.entries(block as Record<string, unknown>)) {
+      if (isCommandProvider(value) && !builtins.has(normalize(name))) {
+        names.add(name)
+      }
+    }
+  }
+
+  return [...names]
+}
+
 export function enumOptionsFor(
   key: string,
   value: unknown,
   config: HermesConfigRecord,
   dynamicOptions?: string[]
 ): string[] | undefined {
-  const opts = dynamicOptions ?? (key === 'display.personality' ? personalityOptions(config) : ENUM_OPTIONS[key])
+  let opts = dynamicOptions ?? (key === 'display.personality' ? personalityOptions(config) : ENUM_OPTIONS[key])
+
+  // Merge in user-defined command-type providers so custom local TTS/STT
+  // backends declared in config.yaml are selectable, not just the built-ins.
+  // The `includes` guard keeps the list duplicate-free should the display list
+  // ever carry a name we also enumerate.
+  if (!dynamicOptions && opts && (key === 'tts.provider' || key === 'stt.provider')) {
+    const section = key.slice(0, 3) as 'tts' | 'stt'
+    const custom = commandProviderNames(config, section).filter(name => !opts!.includes(name))
+
+    if (custom.length > 0) {
+      opts = [...opts, ...custom]
+    }
+  }
 
   if (!opts) {
     return undefined

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -465,7 +465,13 @@ export const ja = defineLocale({
         },
         xai: {
           voiceId: 'xAI (Grok) 音声',
-          language: 'xAI 言語'
+          language: 'xAI 言語',
+          speed: '再生速度',
+          autoSpeechTags: '自動音声タグ',
+          textNormalization: 'テキスト正規化',
+          optimizeStreamingLatency: 'ストリーミング遅延最適化',
+          sampleRate: 'サンプルレート',
+          bitRate: 'ビットレート'
         },
         minimax: {
           model: 'MiniMax TTS モデル',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -468,7 +468,6 @@ export const ja = defineLocale({
           language: 'xAI 言語',
           speed: '再生速度',
           autoSpeechTags: '自動音声タグ',
-          textNormalization: 'テキスト正規化',
           optimizeStreamingLatency: 'ストリーミング遅延最適化',
           sampleRate: 'サンプルレート',
           bitRate: 'ビットレート'

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -457,7 +457,6 @@ export const zhHant = defineLocale({
           language: 'xAI 語言',
           speed: '播放速度',
           autoSpeechTags: '自動語音標籤',
-          textNormalization: '文字正規化',
           optimizeStreamingLatency: '串流延遲最佳化',
           sampleRate: '取樣率',
           bitRate: '位元率'

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -454,7 +454,13 @@ export const zhHant = defineLocale({
         },
         xai: {
           voiceId: 'xAI (Grok) 語音',
-          language: 'xAI 語言'
+          language: 'xAI 語言',
+          speed: '播放速度',
+          autoSpeechTags: '自動語音標籤',
+          textNormalization: '文字正規化',
+          optimizeStreamingLatency: '串流延遲最佳化',
+          sampleRate: '取樣率',
+          bitRate: '位元率'
         },
         minimax: {
           model: 'MiniMax TTS 模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -565,7 +565,13 @@ export const zh: Translations = {
         },
         xai: {
           voiceId: 'xAI (Grok) 语音',
-          language: 'xAI 语言'
+          language: 'xAI 语言',
+          speed: '播放速度',
+          autoSpeechTags: '自动语音标签',
+          textNormalization: '文本规范化',
+          optimizeStreamingLatency: '流式延迟优化',
+          sampleRate: '采样率',
+          bitRate: '比特率'
         },
         minimax: {
           model: 'MiniMax TTS 模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -568,7 +568,6 @@ export const zh: Translations = {
           language: 'xAI 语言',
           speed: '播放速度',
           autoSpeechTags: '自动语音标签',
-          textNormalization: '文本规范化',
           optimizeStreamingLatency: '流式延迟优化',
           sampleRate: '采样率',
           bitRate: '比特率'

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2187,7 +2187,6 @@ DEFAULT_CONFIG = {
             "language": "en",  # BCP-47 code ("en", "pt-BR") or "auto"
             "speed": 1.0,  # 0.7–1.5, playback speed
             "auto_speech_tags": False,  # insert expressive audio tags via LLM rewrite
-            "text_normalization": False,  # normalize numbers/abbreviations/symbols to spoken form
             "optimize_streaming_latency": 0,  # 0–2, trades quality for lower latency
             "sample_rate": 24000,  # 22050 / 24000 / 44100 / 48000
             "bit_rate": 128000,  # MP3 bitrate; only applies when codec=mp3

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2184,9 +2184,13 @@ DEFAULT_CONFIG = {
         },
         "xai": {
             "voice_id": "eve",  # or custom voice ID — see https://docs.x.ai/developers/model-capabilities/audio/custom-voices
-            "language": "en",
-            "sample_rate": 24000,
-            "bit_rate": 128000,
+            "language": "en",  # BCP-47 code ("en", "pt-BR") or "auto"
+            "speed": 1.0,  # 0.7–1.5, playback speed
+            "auto_speech_tags": False,  # insert expressive audio tags via LLM rewrite
+            "text_normalization": False,  # normalize numbers/abbreviations/symbols to spoken form
+            "optimize_streaming_latency": 0,  # 0–2, trades quality for lower latency
+            "sample_rate": 24000,  # 22050 / 24000 / 44100 / 48000
+            "bit_rate": 128000,  # MP3 bitrate; only applies when codec=mp3
         },
         "mistral": {
             "model": "voxtral-mini-tts-2603",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -668,7 +668,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "neutts"],
+        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"],
     },
     "stt.provider": {
         "type": "select",


### PR DESCRIPTION
## Summary
Salvage of two voice-provider desktop PRs onto current main: #62459 by @laurinaitis (config-defined command TTS/STT providers appear in the settings dropdowns) and #56724 by @Cdddo (all xAI TTS params surfaced in the desktop GUI with xAI-prefixed labels).

Contributor commits cherry-picked verbatim — rebase-merge to preserve authorship.

## Changes
- laurinaitis: `enumOptionsFor` merges `tts.providers.<name>` / STT command providers into the dropdowns (guard sets verified against current runtime: `BUILTIN_TTS_PROVIDERS` 11 names, `BUILTIN_STT_PROVIDERS` 8 names; dual-location config resolution matches `_get_named_provider_config`)
- Cdddo (2 commits): xAI TTS params in desktop settings + xAI-prefixed field labels
- Ours on top: drop `tts.xai.text_normalization` — key is not honored by the xAI TTS backend on current main (dead knob cross-check)
- `contributors/emails/carlos.dddo@gmail.com` mapping added; laurinaitis is id+login noreply (auto-resolved)

## Validation
- vitest: `helpers.test.ts` + voice-field visibility tests pass
- Every surfaced `tts.xai.*` key cross-checked against `DEFAULT_CONFIG`
- eslint clean on changed files

Closes #62459, closes #56724 (salvaged with authorship preserved). Partially addresses #46337 (custom local STT/TTS half).

## Infographic

![voice-providers](https://v3b.fal.media/files/b/0aa2ce12/uPzV74NQQleEBNpjGZei-_XTsBOJ4C.png)
