### PR TITLE
fix(anthropic): abort watchdog TLS sockets from a stranger thread, close from the worker (#67142)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -569,7 +569,54 @@ def interruptible_api_call(agent, api_kwargs: dict):
         else:
             agent._close_request_openai_client(request_client, reason=reason)
 
+    # #67142: owner-aware teardown for the SHARED Anthropic client. The direct
+    # Anthropic path does not build per-request clients, so it can't reuse the
+    # OpenAI ``request_client_holder`` machinery above — but it has the identical
+    # FD-recycling hazard: the stale-call / interrupt watchdog runs on a stranger
+    # thread and previously called ``_anthropic_client.close()`` there, racing
+    # the worker's live SSL BIO and corrupting SQLite via a recycled TLS FD.
+    # ``owner_tid`` is stamped by the worker; a stranger-thread teardown only
+    # aborts sockets (unblocking the worker) and defers the close+rebuild to the
+    # worker via ``rebuild_pending``.
+    _anthropic_teardown = {"owner_tid": None, "rebuild_pending": False}
+
+    def _teardown_anthropic_client(reason: str) -> None:
+        owner_tid = _anthropic_teardown.get("owner_tid")
+        stranger_thread = (
+            owner_tid is not None and owner_tid != threading.get_ident()
+        )
+        if stranger_thread:
+            # Stranger thread → abort sockets only; the worker owns the close.
+            _anthropic_teardown["rebuild_pending"] = True
+            agent._abort_anthropic_client(reason=reason)
+            return
+        # Owning (worker) thread → full close + rebuild is FD-safe here.
+        _anthropic_teardown["rebuild_pending"] = False
+        try:
+            agent._anthropic_client.close()
+        except Exception:
+            pass
+        agent._rebuild_anthropic_client()
+
+    def _drain_pending_anthropic_rebuild() -> None:
+        # Worker-thread finalizer: if a stranger-thread watchdog aborted the
+        # Anthropic sockets, complete the deferred close+rebuild here so the FD
+        # is released from the owning thread (#67142).
+        if not _anthropic_teardown.get("rebuild_pending"):
+            return
+        _anthropic_teardown["rebuild_pending"] = False
+        try:
+            agent._anthropic_client.close()
+        except Exception:
+            pass
+        try:
+            agent._rebuild_anthropic_client()
+        except Exception:
+            pass
+
     def _call():
+        if agent.api_mode == "anthropic_messages":
+            _anthropic_teardown["owner_tid"] = threading.get_ident()
         try:
             # _set_request_client registers each per-request OpenAI client with
             # the stranger-thread abort machinery above; the shared dispatch
@@ -599,6 +646,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
             result["error"] = e
         finally:
             _close_request_client_once("request_complete")
+            _drain_pending_anthropic_rebuild()
 
     # ── Stale-call timeout (mirrors streaming stale detector) ────────
     # Non-streaming calls return nothing until the full response is
@@ -894,8 +942,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 )
             try:
                 if agent.api_mode == "anthropic_messages":
-                    agent._anthropic_client.close()
-                    agent._rebuild_anthropic_client()
+                    # #67142: stranger-thread teardown aborts sockets only; the
+                    # worker completes the close+rebuild from its own thread.
+                    _teardown_anthropic_client("stale_call_kill")
                 else:
                     _close_request_client_once("stale_call_kill")
             except Exception:
@@ -936,8 +985,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # seed future retries.
             try:
                 if agent.api_mode == "anthropic_messages":
-                    agent._anthropic_client.close()
-                    agent._rebuild_anthropic_client()
+                    # #67142: stranger-thread teardown aborts sockets only; the
+                    # worker completes the close+rebuild from its own thread.
+                    _teardown_anthropic_client("interrupt_abort")
                 else:
                     _close_request_client_once("interrupt_abort")
             except Exception:
@@ -2433,6 +2483,47 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         else:
             agent._close_request_openai_client(request_client, reason=reason)
 
+    # #67142: owner-aware teardown for the SHARED Anthropic client — streaming
+    # sibling of the non-streaming helper in ``interruptible_api_call``. The
+    # Anthropic stream runs on ``agent._anthropic_client``; the stale-stream /
+    # interrupt watchdog runs on the outer poll thread (a stranger thread) and
+    # previously called ``_anthropic_client.close()`` there, racing the worker's
+    # live SSL BIO and clobbering SQLite via a recycled TLS socket FD. A
+    # stranger-thread teardown now only aborts sockets (unblocking the worker)
+    # and defers close+rebuild to the worker via ``rebuild_pending``; the
+    # in-worker retry cleanup and the worker finally still close+rebuild from
+    # the owning thread, preserving the #28161 no-hang behavior.
+    _anthropic_teardown = {"owner_tid": None, "rebuild_pending": False}
+
+    def _teardown_anthropic_client(reason: str) -> None:
+        owner_tid = _anthropic_teardown.get("owner_tid")
+        stranger_thread = (
+            owner_tid is not None and owner_tid != threading.get_ident()
+        )
+        if stranger_thread:
+            _anthropic_teardown["rebuild_pending"] = True
+            agent._abort_anthropic_client(reason=reason)
+            return
+        _anthropic_teardown["rebuild_pending"] = False
+        try:
+            agent._anthropic_client.close()
+        except Exception:
+            pass
+        agent._rebuild_anthropic_client()
+
+    def _drain_pending_anthropic_rebuild() -> None:
+        if not _anthropic_teardown.get("rebuild_pending"):
+            return
+        _anthropic_teardown["rebuild_pending"] = False
+        try:
+            agent._anthropic_client.close()
+        except Exception:
+            pass
+        try:
+            agent._rebuild_anthropic_client()
+        except Exception:
+            pass
+
     first_delta_fired = {"done": False}
     deltas_were_sent = {"yes": False}  # Track if any deltas were fired (for fallback)
     # Wall-clock timestamp of the last real streaming chunk.  The outer
@@ -3133,6 +3224,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     def _call():
         import httpx as _httpx
 
+        if agent.api_mode == "anthropic_messages":
+            _anthropic_teardown["owner_tid"] = threading.get_ident()
+
         _max_stream_retries = env_int("HERMES_STREAM_RETRIES", 2)
 
         try:
@@ -3277,9 +3371,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         _cancel_current_stream_attempt("stream_mid_tool_retry_cleanup")
                         _close_request_client_once("stream_mid_tool_retry_cleanup")
                         if agent.api_mode == "anthropic_messages":
+                            # Worker-owned close+rebuild (#67142): runs on this
+                            # worker thread, so the FD release is safe.
                             try:
-                                agent._anthropic_client.close()
-                                agent._rebuild_anthropic_client()
+                                _teardown_anthropic_client(
+                                    "stream_mid_tool_retry_pool_cleanup"
+                                )
                             except Exception:
                                 pass
                         else:
@@ -3344,9 +3441,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             # Also rebuild the primary client to purge
                             # any dead connections from the pool.
                             if agent.api_mode == "anthropic_messages":
+                                # Worker-owned close+rebuild (#67142): runs on
+                                # this worker thread, so the FD release is safe.
                                 try:
-                                    agent._anthropic_client.close()
-                                    agent._rebuild_anthropic_client()
+                                    _teardown_anthropic_client(
+                                        "stream_retry_pool_cleanup"
+                                    )
                                 except Exception:
                                     pass
                             else:
@@ -3456,6 +3556,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             return
         finally:
             _close_request_client_once("stream_request_complete")
+            _drain_pending_anthropic_rebuild()
 
     # Provider-configured stale timeout takes priority over env default.
     _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
@@ -3589,9 +3690,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
             if agent.api_mode == "anthropic_messages":
+                # #67142: stranger-thread teardown aborts sockets only; the
+                # worker completes the close+rebuild from its own thread.
                 try:
-                    agent._anthropic_client.close()
-                    agent._rebuild_anthropic_client()
+                    _teardown_anthropic_client("stale_stream_pool_cleanup")
                 except Exception:
                     pass
             else:
@@ -3623,8 +3725,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             try:
                 _cancel_current_stream_attempt("stream_interrupt_abort")
                 if agent.api_mode == "anthropic_messages":
-                    agent._anthropic_client.close()
-                    agent._rebuild_anthropic_client()
+                    # #67142: stranger-thread teardown aborts sockets only; the
+                    # worker completes the close+rebuild from its own thread.
+                    _teardown_anthropic_client("stream_interrupt_abort")
                 else:
                     _close_request_client_once("stream_interrupt_abort")
             except Exception:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4259,6 +4259,45 @@ class AIAgent:
                 exc,
             )
 
+    def _abort_anthropic_client(self, *, reason: str) -> None:
+        """Cross-thread abort of the shared Anthropic client (#67142).
+
+        Anthropic companion to :meth:`_abort_request_openai_client`. The outer
+        stale/interrupt watchdog runs on a *stranger* thread relative to the
+        worker driving ``_anthropic_client.messages.stream(...)``. Calling
+        ``_anthropic_client.close()`` there raced the worker's still-live SSL
+        ``BIO`` and, when the kernel recycled the just-freed TLS socket FD into
+        an unrelated ``open()`` (e.g. ``cron/executions.db``), a pending 24-byte
+        TLS application-data record was flushed into that file's header —
+        corrupting a SQLite database the same way #29507 did for the OpenAI
+        path.
+
+        Here we only ``shutdown(SHUT_RDWR)`` the Anthropic client's pool sockets
+        so the owning worker's blocked ``recv``/``send`` unwinds with EOF /
+        ``EPIPE``. The worker then performs ``close()`` + ``_rebuild_anthropic_client()``
+        from its own thread, where FD release is safe — preserving the #28161
+        no-hang cleanup without releasing the FD from a stranger thread.
+        """
+        client = getattr(self, "_anthropic_client", None)
+        if client is None:
+            return
+        try:
+            shutdown_count = self._force_close_tcp_sockets(client)
+            logger.info(
+                "Anthropic client aborted (%s, tcp_force_closed=%d, "
+                "deferred_close=stranger_thread) %s",
+                reason,
+                shutdown_count,
+                self._client_log_context(),
+            )
+        except Exception as exc:
+            logger.debug(
+                "Anthropic client abort failed (%s) %s error=%s",
+                reason,
+                self._client_log_context(),
+                exc,
+            )
+
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
         """Forwarder — see ``agent.codex_runtime.run_codex_stream``."""
         from agent.codex_runtime import run_codex_stream

--- a/tests/run_agent/test_28161_anthropic_stream_pool_cleanup.py
+++ b/tests/run_agent/test_28161_anthropic_stream_pool_cleanup.py
@@ -135,8 +135,13 @@ class TestAnthropicStreamPoolCleanup:
             return _good_stream_cm()
 
         agent._anthropic_client.messages.stream.side_effect = _stream_side_effect
-        # close() on the mock Anthropic client unblocks the inner thread.
-        agent._anthropic_client.close.side_effect = unblock.set
+        # #67142: the stranger-thread stale detector now ABORTS the Anthropic
+        # sockets rather than calling close(); the abort is what unblocks the
+        # worker, and the worker performs the close()+rebuild from its own
+        # thread. Route the unblock through the abort path accordingly.
+        agent._abort_anthropic_client = MagicMock(
+            side_effect=lambda *a, **k: unblock.set()
+        )
 
         with patch.object(agent, "_rebuild_anthropic_client") as mock_rebuild:
             with patch.object(
@@ -145,6 +150,9 @@ class TestAnthropicStreamPoolCleanup:
                 agent._interruptible_streaming_api_call({})
 
         mock_replace.assert_not_called()
-        # close() and rebuild called at least once by the stale detector.
+        # The stale detector aborts from the stranger thread; the worker still
+        # closes+rebuilds the Anthropic client from its own thread (no OpenAI
+        # primary replace, no 15-minute hang — #28161 behavior preserved).
+        agent._abort_anthropic_client.assert_called()
         agent._anthropic_client.close.assert_called()
         assert mock_rebuild.call_count >= 1

--- a/tests/run_agent/test_67142_anthropic_watchdog_fd_ownership.py
+++ b/tests/run_agent/test_67142_anthropic_watchdog_fd_ownership.py
@@ -1,0 +1,312 @@
+"""Direct-Anthropic watchdog must not release the TLS socket FD from a stranger thread (#67142).
+
+Issue #29507 gave the OpenAI request path an owner-thread contract: the outer
+stale/interrupt watchdog (a *stranger* thread relative to the worker driving the
+request) only ``shutdown(SHUT_RDWR)``s the sockets, and the owning worker thread
+performs ``client.close()`` on its way out. Calling ``close()`` from the
+watchdog thread raced the worker's still-live SSL BIO; when the kernel recycled
+the just-freed TLS socket FD into an unrelated ``open()`` (e.g.
+``cron/executions.db``), a pending 24-byte TLS record was flushed into that
+file's header and corrupted a SQLite database.
+
+The direct-Anthropic path (``api_mode == "anthropic_messages"``) still closed
+``_anthropic_client`` from the outer stale/interrupt watchdog on ``origin/main``,
+so the same corruption reproduced on an Anthropic cron request.
+
+These tests prove the two properties the fix must hold:
+
+1. The outer stale/interrupt watchdog never calls ``_anthropic_client.close()``
+   from a stranger thread — it aborts sockets via ``_abort_anthropic_client``.
+2. The worker still unblocks promptly and performs the close+rebuild from its
+   OWN thread (preserving the #28161 no-hang cleanup).
+
+Plus a socket-level test that ``_abort_anthropic_client`` shuts sockets down
+without releasing the FD.
+
+Fixes #67142
+"""
+
+import socket
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_anthropic_agent(**kwargs):
+    from run_agent import AIAgent
+
+    defaults = dict(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="claude-opus-4-8",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    defaults.update(kwargs)
+    agent = AIAgent(**defaults)
+    agent.api_mode = "anthropic_messages"
+    agent._anthropic_client = MagicMock()
+    agent._anthropic_api_key = "test-anthropic-key"
+    return agent
+
+
+def _good_stream_cm():
+    """Context manager whose stream yields no events and returns a valid message."""
+    cm = MagicMock()
+    stream = MagicMock()
+    stream.__iter__ = MagicMock(return_value=iter([]))
+    msg = MagicMock()
+    msg.content = []
+    msg.stop_reason = "end_turn"
+    msg.usage = SimpleNamespace(input_tokens=10, output_tokens=5)
+    stream.get_final_message = MagicMock(return_value=msg)
+    cm.__enter__ = MagicMock(return_value=stream)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+class _FakeSock:
+    """Minimal socket stand-in that records shutdown/close separately."""
+
+    def __init__(self):
+        self.shutdown_calls = []
+        self.closed = False
+
+    def shutdown(self, how):
+        self.shutdown_calls.append(how)
+
+    def close(self):
+        self.closed = True
+
+
+def _install_fake_pool(anthropic_client, sock):
+    """Wire ``anthropic_client`` so ``_iter_pool_sockets`` finds ``sock``."""
+    stream = SimpleNamespace(_sock=sock)
+    conn = SimpleNamespace(_connection=SimpleNamespace(_network_stream=stream))
+    pool = SimpleNamespace(_connections=[conn])
+    transport = SimpleNamespace(_pool=pool)
+    anthropic_client._client = SimpleNamespace(_transport=transport)
+
+
+# ---------------------------------------------------------------------------
+# Socket-level abort contract
+# ---------------------------------------------------------------------------
+
+
+class TestAbortAnthropicClient:
+    def test_abort_shuts_down_sockets_without_releasing_fd(self):
+        """``_abort_anthropic_client`` shuts sockets down but never closes them
+        or the client — the FD release belongs to the owning worker thread."""
+        agent = _make_anthropic_agent()
+        sock = _FakeSock()
+        _install_fake_pool(agent._anthropic_client, sock)
+
+        agent._abort_anthropic_client(reason="unit")
+
+        # FIN sent so the worker's blocked recv/send unwinds …
+        assert sock.shutdown_calls == [socket.SHUT_RDWR]
+        # … but the FD is NOT released from this (stranger) thread.
+        assert sock.closed is False
+        agent._anthropic_client.close.assert_not_called()
+
+    def test_abort_is_safe_when_no_client(self):
+        agent = _make_anthropic_agent()
+        agent._anthropic_client = None
+        # Must not raise.
+        agent._abort_anthropic_client(reason="unit")
+
+
+# ---------------------------------------------------------------------------
+# Streaming path ownership contract
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingWatchdogOwnership:
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    def test_stale_stream_aborts_from_stranger_thread_and_closes_from_worker(
+        self, monkeypatch
+    ):
+        """Stale-stream detector (stranger thread) aborts; the worker thread
+        performs the Anthropic close()+rebuild."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.1")
+
+        agent = _make_anthropic_agent()
+        main_tid = threading.get_ident()
+        unblock = threading.Event()
+        attempt = [0]
+
+        abort_threads = []
+        close_threads = []
+        rebuild_threads = []
+
+        def _stream_side_effect(*args, **kwargs):
+            attempt[0] += 1
+            if attempt[0] == 1:
+                cm = MagicMock()
+                stream = MagicMock()
+
+                def _blocking_gen():
+                    unblock.wait(timeout=5.0)
+                    raise httpx.ConnectError("dropped after abort")
+                    yield  # generator so iteration triggers the wait
+
+                stream.__iter__ = MagicMock(return_value=_blocking_gen())
+                cm.__enter__ = MagicMock(return_value=stream)
+                cm.__exit__ = MagicMock(return_value=False)
+                return cm
+            return _good_stream_cm()
+
+        agent._anthropic_client.messages.stream.side_effect = _stream_side_effect
+        agent._anthropic_client.close.side_effect = (
+            lambda *a, **k: close_threads.append(threading.get_ident())
+        )
+        agent._abort_anthropic_client = MagicMock(
+            side_effect=lambda *a, **k: (
+                abort_threads.append(threading.get_ident()),
+                unblock.set(),
+            )
+        )
+
+        def _rebuild(*a, **k):
+            rebuild_threads.append(threading.get_ident())
+
+        with patch.object(agent, "_rebuild_anthropic_client", side_effect=_rebuild):
+            with patch.object(agent, "_replace_primary_openai_client") as mock_replace:
+                agent._interruptible_streaming_api_call({})
+
+        # Never the OpenAI primary client on an Anthropic-native config.
+        mock_replace.assert_not_called()
+
+        # Property 1: the stale watchdog aborted from the stranger (main) thread
+        # and never released the FD there.
+        assert main_tid in abort_threads
+        assert main_tid not in close_threads
+
+        # Property 2: the worker unblocked and performed close()+rebuild from
+        # its OWN thread.
+        assert close_threads, "worker never closed the Anthropic client"
+        assert all(tid != main_tid for tid in close_threads)
+        assert rebuild_threads and all(tid != main_tid for tid in rebuild_threads)
+
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    def test_interrupt_aborts_from_stranger_thread(self, monkeypatch):
+        """An interrupt during an Anthropic stream aborts from the poll thread
+        rather than closing the client there."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "600")
+
+        agent = _make_anthropic_agent()
+        main_tid = threading.get_ident()
+        started = threading.Event()
+        unblock = threading.Event()
+        abort_threads = []
+        close_threads = []
+
+        def _stream_side_effect(*args, **kwargs):
+            cm = MagicMock()
+            stream = MagicMock()
+
+            def _blocking_gen():
+                started.set()
+                unblock.wait(timeout=5.0)
+                raise httpx.ConnectError("dropped after abort")
+                yield
+
+            stream.__iter__ = MagicMock(return_value=_blocking_gen())
+            cm.__enter__ = MagicMock(return_value=stream)
+            cm.__exit__ = MagicMock(return_value=False)
+            return cm
+
+        agent._anthropic_client.messages.stream.side_effect = _stream_side_effect
+        agent._anthropic_client.close.side_effect = (
+            lambda *a, **k: close_threads.append(threading.get_ident())
+        )
+        agent._abort_anthropic_client = MagicMock(
+            side_effect=lambda *a, **k: (
+                abort_threads.append(threading.get_ident()),
+                unblock.set(),
+            )
+        )
+
+        def _request_interrupt():
+            started.wait(timeout=5.0)
+            agent._interrupt_requested = True
+
+        trigger = threading.Thread(target=_request_interrupt, daemon=True)
+        trigger.start()
+
+        with patch.object(agent, "_rebuild_anthropic_client"):
+            with pytest.raises(InterruptedError):
+                agent._interruptible_streaming_api_call({})
+
+        trigger.join(timeout=5.0)
+
+        # The interrupt watchdog aborted from the stranger (poll) thread and
+        # never released the FD there.
+        assert main_tid in abort_threads
+        assert main_tid not in close_threads
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming path ownership contract
+# ---------------------------------------------------------------------------
+
+
+class TestNonStreamingWatchdogOwnership:
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    def test_stale_call_aborts_from_stranger_thread_and_closes_from_worker(
+        self, monkeypatch
+    ):
+        """Non-streaming stale detector aborts from the stranger thread; the
+        worker performs the Anthropic close()+rebuild from its own thread."""
+        agent = _make_anthropic_agent()
+        main_tid = threading.get_ident()
+        unblock = threading.Event()
+        abort_threads = []
+        close_threads = []
+        rebuild_threads = []
+
+        def _blocking_create(api_kwargs):
+            unblock.wait(timeout=5.0)
+            raise httpx.ConnectError("dropped after abort")
+
+        agent._anthropic_messages_create = MagicMock(side_effect=_blocking_create)
+        agent._compute_non_stream_stale_timeout = MagicMock(return_value=0.1)
+        agent._anthropic_client.close.side_effect = (
+            lambda *a, **k: close_threads.append(threading.get_ident())
+        )
+        agent._abort_anthropic_client = MagicMock(
+            side_effect=lambda *a, **k: (
+                abort_threads.append(threading.get_ident()),
+                unblock.set(),
+            )
+        )
+
+        def _rebuild(*a, **k):
+            rebuild_threads.append(threading.get_ident())
+
+        with patch.object(agent, "_rebuild_anthropic_client", side_effect=_rebuild):
+            with pytest.raises(Exception):
+                agent._interruptible_api_call({})
+
+        # Property 1: abort from the stranger (main) thread, never close there.
+        assert main_tid in abort_threads
+        assert main_tid not in close_threads
+
+        # Property 2: worker closed + rebuilt from its own thread.
+        assert close_threads and all(tid != main_tid for tid in close_threads)
+        assert rebuild_threads and all(tid != main_tid for tid in rebuild_threads)

--- a/tests/run_agent/test_stream_stale_circuit_breaker.py
+++ b/tests/run_agent/test_stream_stale_circuit_breaker.py
@@ -116,7 +116,9 @@ class TestStreamStaleCircuitBreaker:
 
         # Every attempt blocks, trips the stale detector, and fails.
         agent._anthropic_client.messages.stream.side_effect = _stream_side_effect
-        agent._anthropic_client.close.side_effect = unblock.set
+        # #67142: the stranger-thread stale detector now ABORTS the Anthropic
+        # sockets (never ``close()``); the abort is what unblocks the worker.
+        agent._abort_anthropic_client = MagicMock(side_effect=lambda *a, **k: unblock.set())
 
         with pytest.raises(Exception):
             agent._interruptible_streaming_api_call({})


### PR DESCRIPTION
## Summary

Fixes #67142 — a direct-Anthropic cron request reproduced the same 24-byte TLS/SQLite FD-reuse corruption shape as #29507, on `api_mode == "anthropic_messages"`.

The outer stale/interrupt watchdog runs on the poll thread — a **stranger thread** relative to the worker driving `_anthropic_client.messages.stream(...)`. On `origin/main` all four outer Anthropic watchdog branches called `_anthropic_client.close()` from that stranger thread:

- `agent/chat_completion_helpers.py` non-streaming stale watchdog + interrupt
- `agent/chat_completion_helpers.py` streaming stale watchdog + interrupt

Closing the client there races the worker's still-live SSL `BIO`. When the kernel recycles the just-freed TLS socket FD into an unrelated `open()` (e.g. `cron/executions.db`), a pending 24-byte TLS application-data record is flushed into that file, clobbering SQLite header bytes 5..28 and yielding `sqlite3.DatabaseError: file is not a database`. Because `create_execution()` runs before executor dispatch, every subsequent due cron on that profile then fails at the tick boundary.

This extends the #29507 owner-thread contract to the shared Anthropic client:

- Adds `_abort_anthropic_client()` (companion to `_abort_request_openai_client`) — a stranger-thread abort that only `shutdown(SHUT_RDWR)`s the client's httpx pool sockets and **never releases the FD**.
- Both the non-streaming and streaming loops stamp the worker thread id and route every Anthropic teardown through an owner-aware helper: a stranger-thread call aborts sockets (unblocking the worker) and defers the close+rebuild; the owning worker performs `close()` + `_rebuild_anthropic_client()` from its own thread (in its retry cleanup, or a `finally` drain on interrupt), where FD release is safe.

Both properties requested in the issue hold:
1. The outer stale/interrupt watchdog never releases the active Anthropic TLS socket FD from a stranger thread.
2. The worker still unblocks promptly and performs the close/rebuild from its own thread — preserving the #28161 no-hang behavior (the abort unblocks a stuck stream, and the dead pool is still rebuilt).

The two in-worker retry-cleanup closes remain worker-owned.

## Test plan

- [x] `scripts/run_tests.sh tests/run_agent/test_67142_anthropic_watchdog_fd_ownership.py` — new suite proving the ownership contract (socket-level abort, streaming stale + interrupt, non-streaming stale).
- [x] `scripts/run_tests.sh tests/run_agent/test_28161_anthropic_stream_pool_cleanup.py tests/run_agent/test_stream_stale_circuit_breaker.py tests/run_agent/test_streaming.py` — updated regressions still assert no OpenAI-primary replace and no 15-minute hang, now via the abort path.
- [x] Broader regression: `test_tls_fd_recycle_corruption`, `test_cascading_interrupt_6600`, `test_stream_interrupt_retry`, `test_non_stream_stale_timeout`, `test_bedrock_interrupt_post_worker`, `test_cron_inline_api_call_62151`, `test_stream_single_writer_65991`, `test_partial_stream_finish_reason`, `test_stream_stale_breaker_reset`, `test_moa_streaming`, `test_create_openai_client_reuse` — all green.

## Infographic

![Anthropic watchdog TLS FD-reuse fix](https://github.com/HexLab98/hermes-agent-fork/releases/download/pr-assets-67142/hermes-67142-infographic.png)