### PR TITLE
fix(mcp): register tools on parked-server revival when _ready is cleared

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2799,7 +2799,7 @@ class MCPServerTask:
         revival must publish the freshly discovered tools again — otherwise
         the transport comes back alive with zero registered tools.
         """
-        if not self._ready.is_set() or self._registered_tool_names:
+        if self._registered_tool_names:
             return
         self._registered_tool_names = _register_server_tools(
             self.name, self, self._config


### PR DESCRIPTION
## Problem

When a Streamable HTTP MCP server exhausts reconnect attempts, Hermes parks it and deregisters its tools. A later self-probe can successfully reconnect and negotiate a new MCP session, but the server's tools remain absent from the Hermes tool registry.

The root cause is the guard in `_register_discovered_tools_if_needed()`:

```python
if not self._ready.is_set() or self._registered_tool_names:
    return
```

`not self._ready.is_set()` returns True when `_ready` has been cleared during a reconnect cycle (via `_signal_reconnect_and_wait()` or the park→revival path in `run()`). Since `_discover_tools()` runs before `_ready.set()` in the transport methods, the registration is skipped and never retried.

## Fix

Remove the `_ready.is_set()` check. The remaining guard on `_registered_tool_names` is sufficient:

- **Initial connect**: `_discover_and_register_server` handles registration externally, so the extra call from `_register_discovered_tools_if_needed()` is a harmless same-toolset overwrite in the registry.
- **Reconnect after parking**: `_registered_tool_names` is empty (cleared by `_deregister_tools()`), so tools are properly re-registered.
- **Planned reconnect** (OAuth recovery): `_registered_tool_names` still has old entries, so registration is correctly skipped.

## Testing

- `tests/tools/test_mcp_parked_self_probe.py` — passes
- `tests/tools/test_mcp_tool.py` — all 214 tests pass
- Module imports cleanly

Closes #67187