### PR TITLE
fix(mcp): re-register tools after parked server revival (#67187)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2361,6 +2361,12 @@ class MCPServerTask:
                     self._mark_lifecycle_started()
                     await self._discover_tools()
                     self._ready.set()
+                    # Tools may have been discovered before _ready was set
+                    # (e.g. _ready.clear() at line ~2934), which causes
+                    # _register_discovered_tools_if_needed() to return early.
+                    # Re-invoke so the newly-discovered tools are registered
+                    # even on the post-clear reconnect path (#67187).
+                    self._register_discovered_tools_if_needed()
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
@@ -2656,6 +2662,12 @@ class MCPServerTask:
                     self.session = session
                     await self._discover_tools()
                     self._ready.set()
+                    # Tools may have been discovered before _ready was set
+                    # (e.g. _ready.clear() at line ~2934), which causes
+                    # _register_discovered_tools_if_needed() to return early.
+                    # Re-invoke so the newly-discovered tools are registered
+                    # even on the post-clear reconnect path (#67187).
+                    self._register_discovered_tools_if_needed()
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
@@ -2713,6 +2725,8 @@ class MCPServerTask:
                         self.session = session
                         await self._discover_tools()
                         self._ready.set()
+                        # Re-register after _ready.set() — see #67187.
+                        self._register_discovered_tools_if_needed()
                         # Session is live again: clear any breaker state from
                         # a prior outage so the first call after recovery
                         # isn't gated on a stale failure count (#16788).
@@ -2745,6 +2759,8 @@ class MCPServerTask:
                     self.session = session
                     await self._discover_tools()
                     self._ready.set()
+                    # Re-register after _ready.set() — see #67187.
+                    self._register_discovered_tools_if_needed()
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
@@ -5143,8 +5159,14 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         _server_connect_errors.pop(name, None)
         _servers[name] = server
 
-    registered_names = _register_server_tools(name, server, config)
-    server._registered_tool_names = list(registered_names)
+    # If the server task already registered tools through its own
+    # _register_discovered_tools_if_needed() call (added post _ready.set()
+    # for #67187), skip double-registration here.
+    if not server._registered_tool_names:
+        registered_names = _register_server_tools(name, server, config)
+        server._registered_tool_names = list(registered_names)
+    else:
+        registered_names = server._registered_tool_names
 
     transport_type = "HTTP" if "url" in config else "stdio"
     logger.info(


### PR DESCRIPTION
## Summary

Fixes #67187 — When a parked MCP server revives after reconnect exhaustion, its tools are not re-registered in the Hermes tool registry. The transport reconnects successfully, discovery runs, but the tool registration is silently skipped.

## Root Cause

`_register_discovered_tools_if_needed()` gates on `_ready.is_set()`. The clean-reconnect path at `run()` line ~2934 calls `_ready.clear()` before re-entering `_run_http()` / `_run_stdio()`. These methods call `_discover_tools()` → `_register_discovered_tools_if_needed()` while `_ready` is still False, so registration returns early. `_ready.set()` happens afterward with no second registration call.

Sequence:
1. `_ready.clear()` — cleans stale readiness state
2. `_discover_tools()` runs → `_register_discovered_tools_if_needed()` returns early (`_ready` is False)
3. `_ready.set()` — readiness restored, but no tool registration
4. Result: transport healthy, tool registry empty for this server

## Fix

Added a post-`_ready.set()` call to `_register_discovered_tools_if_needed()` in all four transport paths:

| Path | Location |
|------|----------|
| stdio (`_run_stdio`) | after `_ready.set()` / `_reset_server_error` |
| SSE (`_run_http`) | after `_ready.set()` / `_reset_server_error` |
| Streamable HTTP new API (`_run_http`) | after `_ready.set()` / `_reset_server_error` |
| Streamable HTTP legacy API (`_run_http`) | after `_ready.set()` / `_reset_server_error` |

Also added a guard in `_discover_and_register_server()` to avoid double-registration on initial startup, since the task now registers tools through the post-`_ready.set()` call before `_discover_and_register_server()` runs its own `_register_server_tools()`.

## Change

```diff
# In all 4 transport paths, after _ready.set():
+ self._register_discovered_tools_if_needed()

# In _discover_and_register_server():
- registered_names = _register_server_tools(name, server, config)
- server._registered_tool_names = list(registered_names)
+ if not server._registered_tool_names:
+     registered_names = _register_server_tools(name, server, config)
+     server._registered_tool_names = list(registered_names)
+ else:
+     registered_names = server._registered_tool_names
```

## Verification

- All 214 existing `test_mcp_tool.py` tests pass
- `test_mcp_parked_self_probe.py` passes
- `test_mcp_capability_gating.py` (22 tests) pass
- `test_mcp_list_pagination.py` (8 tests) pass
- The existing parked-self-probe test already asserts `revived_registration >= 1`, validating this path

/cc @fpagent
