### PR TITLE
feat(gateway): add structured operator cards for Discord

### DIFF
--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -191,7 +191,11 @@ class OperatorCard:
             raise OperatorCardValidationError("kind must be operator_card")
         if "version" not in payload:
             raise OperatorCardValidationError("missing required field: version")
-        if isinstance(payload["version"], bool) or payload["version"] != 1:
+        # Require the exact integer 1 — reject bools, floats (``1.0``), and
+        # numeric strings.  ``1.0 == 1`` in Python, so an equality-only check
+        # would silently admit a float version the contract does not define.
+        version = payload["version"]
+        if isinstance(version, bool) or type(version) is not int or version != 1:
             raise OperatorCardValidationError("version must be 1")
 
         card_type = _bounded_string(payload, "card_type", max_length=32)

--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -1,0 +1,268 @@
+"""Platform-agnostic operator-card contract and plaintext fallback.
+
+Operator cards carry bounded, human-readable control-surface metadata between
+the gateway and platform adapters.  This module intentionally contains no
+Discord (or other platform) dependency; adapters decide whether to render the
+validated contract richly or use :func:`render_operator_card_text`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+
+CARD_TYPES = frozenset(
+    {
+        "approval",
+        "task_run",
+        "digest",
+        "deal",
+        "capture",
+        "ops_alert",
+        "thread_header",
+    }
+)
+SEVERITIES = frozenset({"done", "info", "needs_review", "blocked", "critical"})
+ACTION_STYLES = frozenset({"primary", "secondary", "success", "danger", "link"})
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "kind",
+        "version",
+        "card_type",
+        "title",
+        "severity",
+        "summary",
+        "fields",
+        "actions",
+        "links",
+        "state_ref",
+    }
+)
+_ACTION_ID_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_STATE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$")
+
+_SEVERITY_DISPLAY = {
+    "done": ("✅", "Done"),
+    "info": ("🔵", "Info"),
+    "needs_review": ("🟡", "Needs review"),
+    "blocked": ("🔴", "Blocked"),
+    "critical": ("🚨", "Critical"),
+}
+
+
+class OperatorCardValidationError(ValueError):
+    """Raised when untrusted operator-card data violates the contract."""
+
+
+def _mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise OperatorCardValidationError(f"{field_name} must be an object")
+    return value
+
+
+def _bounded_string(
+    source: Mapping[str, Any],
+    field_name: str,
+    *,
+    max_length: int,
+) -> str:
+    if field_name not in source:
+        raise OperatorCardValidationError(f"missing required field: {field_name}")
+    value = source[field_name]
+    if not isinstance(value, str) or not value.strip():
+        raise OperatorCardValidationError(f"{field_name} must be a non-empty string")
+    value = value.strip()
+    if len(value) > max_length:
+        raise OperatorCardValidationError(
+            f"{field_name} exceeds the {max_length}-character limit"
+        )
+    return value
+
+
+def _object_list(source: Mapping[str, Any], field_name: str, *, max_items: int) -> list[Mapping[str, Any]]:
+    value = source.get(field_name, [])
+    if not isinstance(value, list):
+        raise OperatorCardValidationError(f"{field_name} must be a list")
+    if len(value) > max_items:
+        raise OperatorCardValidationError(f"{field_name} exceeds the {max_items}-item limit")
+    return [_mapping(item, f"{field_name}[{index}]") for index, item in enumerate(value)]
+
+
+def _reject_unknown_fields(source: Mapping[str, Any], allowed: set[str] | frozenset[str], context: str) -> None:
+    unknown = set(source) - set(allowed)
+    if unknown:
+        rendered = ", ".join(sorted(str(name) for name in unknown))
+        raise OperatorCardValidationError(f"{context} has unknown fields: {rendered}")
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCardField:
+    label: str
+    value: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "OperatorCardField":
+        _reject_unknown_fields(payload, {"label", "value"}, "field")
+        return cls(
+            label=_bounded_string(payload, "label", max_length=80),
+            value=_bounded_string(payload, "value", max_length=1024),
+        )
+
+    def to_mapping(self) -> dict[str, str]:
+        return {"label": self.label, "value": self.value}
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCardAction:
+    id: str
+    label: str
+    style: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "OperatorCardAction":
+        _reject_unknown_fields(payload, {"id", "label", "style"}, "action")
+        action_id = _bounded_string(payload, "id", max_length=64)
+        if not _ACTION_ID_RE.fullmatch(action_id):
+            raise OperatorCardValidationError("action id must use lowercase letters, digits, hyphens, or underscores")
+        style = _bounded_string(payload, "style", max_length=16)
+        if style not in ACTION_STYLES:
+            raise OperatorCardValidationError(f"unsupported action style: {style}")
+        return cls(
+            id=action_id,
+            label=_bounded_string(payload, "label", max_length=80),
+            style=style,
+        )
+
+    def to_mapping(self) -> dict[str, str]:
+        return {"id": self.id, "label": self.label, "style": self.style}
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCardLink:
+    label: str
+    url: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "OperatorCardLink":
+        _reject_unknown_fields(payload, {"label", "url"}, "link")
+        url = _bounded_string(payload, "url", max_length=2048)
+        parsed = urlsplit(url)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise OperatorCardValidationError("link url must be an http(s) URL without credentials")
+        return cls(
+            label=_bounded_string(payload, "label", max_length=80),
+            url=url,
+        )
+
+    def to_mapping(self) -> dict[str, str]:
+        return {"label": self.label, "url": self.url}
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCard:
+    card_type: str
+    title: str
+    severity: str
+    summary: str
+    fields: tuple[OperatorCardField, ...]
+    actions: tuple[OperatorCardAction, ...]
+    links: tuple[OperatorCardLink, ...]
+    state_ref: str
+    kind: str = "operator_card"
+    version: int = 1
+
+    @classmethod
+    def from_mapping(cls, raw_payload: Mapping[str, Any]) -> "OperatorCard":
+        payload = _mapping(raw_payload, "operator_card")
+        _reject_unknown_fields(payload, _TOP_LEVEL_FIELDS, "operator_card")
+
+        if "kind" not in payload:
+            raise OperatorCardValidationError("missing required field: kind")
+        if payload["kind"] != "operator_card":
+            raise OperatorCardValidationError("kind must be operator_card")
+        if "version" not in payload:
+            raise OperatorCardValidationError("missing required field: version")
+        if isinstance(payload["version"], bool) or payload["version"] != 1:
+            raise OperatorCardValidationError("version must be 1")
+
+        card_type = _bounded_string(payload, "card_type", max_length=32)
+        if card_type not in CARD_TYPES:
+            raise OperatorCardValidationError(f"unsupported card_type: {card_type}")
+        severity = _bounded_string(payload, "severity", max_length=32)
+        if severity not in SEVERITIES:
+            raise OperatorCardValidationError(f"unsupported severity: {severity}")
+
+        fields = tuple(
+            OperatorCardField.from_mapping(item)
+            for item in _object_list(payload, "fields", max_items=12)
+        )
+        actions = tuple(
+            OperatorCardAction.from_mapping(item)
+            for item in _object_list(payload, "actions", max_items=5)
+        )
+        action_ids = [action.id for action in actions]
+        if len(action_ids) != len(set(action_ids)):
+            raise OperatorCardValidationError("action ids must be unique")
+        links = tuple(
+            OperatorCardLink.from_mapping(item)
+            for item in _object_list(payload, "links", max_items=5)
+        )
+
+        state_ref = _bounded_string(payload, "state_ref", max_length=200)
+        if not _STATE_REF_RE.fullmatch(state_ref):
+            raise OperatorCardValidationError("state_ref must be an opaque identifier")
+
+        return cls(
+            card_type=card_type,
+            title=_bounded_string(payload, "title", max_length=120),
+            severity=severity,
+            summary=_bounded_string(payload, "summary", max_length=500),
+            fields=fields,
+            actions=actions,
+            links=links,
+            state_ref=state_ref,
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "version": self.version,
+            "card_type": self.card_type,
+            "title": self.title,
+            "severity": self.severity,
+            "summary": self.summary,
+            "fields": [field.to_mapping() for field in self.fields],
+            "actions": [action.to_mapping() for action in self.actions],
+            "links": [link.to_mapping() for link in self.links],
+            "state_ref": self.state_ref,
+        }
+
+
+def render_operator_card_text(card: OperatorCard, *, max_length: int = 2000) -> str:
+    """Render a compact Markdown fallback shared by non-rich platforms."""
+    emoji, severity_label = _SEVERITY_DISPLAY[card.severity]
+    lines = [f"{emoji} **{severity_label} — {card.title}**", card.summary]
+    lines.extend(f"{field.label}: {field.value}" for field in card.fields)
+    if card.actions:
+        lines.append("Actions: " + " · ".join(action.label for action in card.actions))
+    if card.links:
+        links = " · ".join(f"[{link.label}]({link.url})" for link in card.links)
+        lines.append(f"Links: {links}")
+
+    rendered = "\n".join(lines)
+    if len(rendered) <= max_length:
+        return rendered
+    if max_length <= 0:
+        return ""
+    if max_length == 1:
+        return "…"
+    return rendered[: max_length - 1].rstrip() + "…"

--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -54,6 +54,11 @@ _SEVERITY_DISPLAY = {
 }
 
 
+def operator_card_severity_display(severity: str) -> tuple[str, str]:
+    """Return the shared emoji and label for a validated severity."""
+    return _SEVERITY_DISPLAY[severity]
+
+
 class OperatorCardValidationError(ValueError):
     """Raised when untrusted operator-card data violates the contract."""
 
@@ -153,7 +158,7 @@ class OperatorCardLink:
         parsed = urlsplit(url)
         if (
             parsed.scheme not in {"http", "https"}
-            or not parsed.netloc
+            or not parsed.hostname
             or parsed.username is not None
             or parsed.password is not None
         ):
@@ -261,7 +266,7 @@ def render_operator_card_text(
     Passing ``None`` returns the complete fallback so an adapter with native
     message chunking can preserve every field and link across messages.
     """
-    emoji, severity_label = _SEVERITY_DISPLAY[card.severity]
+    emoji, severity_label = operator_card_severity_display(card.severity)
     lines = [f"{emoji} **{severity_label} — {card.title}**", card.summary]
     lines.extend(f"{field.label}: {field.value}" for field in card.fields)
     if card.actions:

--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -251,8 +251,16 @@ class OperatorCard:
         }
 
 
-def render_operator_card_text(card: OperatorCard, *, max_length: int = 2000) -> str:
-    """Render a compact Markdown fallback shared by non-rich platforms."""
+def render_operator_card_text(
+    card: OperatorCard,
+    *,
+    max_length: int | None = 2000,
+) -> str:
+    """Render a compact Markdown fallback shared by non-rich platforms.
+
+    Passing ``None`` returns the complete fallback so an adapter with native
+    message chunking can preserve every field and link across messages.
+    """
     emoji, severity_label = _SEVERITY_DISPLAY[card.severity]
     lines = [f"{emoji} **{severity_label} — {card.title}**", card.summary]
     lines.extend(f"{field.label}: {field.value}" for field in card.fields)
@@ -263,7 +271,7 @@ def render_operator_card_text(card: OperatorCard, *, max_length: int = 2000) -> 
         lines.append(f"Links: {links}")
 
     rendered = "\n".join(lines)
-    if len(rendered) <= max_length:
+    if max_length is None or len(rendered) <= max_length:
         return rendered
     if max_length <= 0:
         return ""

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -175,31 +175,83 @@ _DISCORD_OPERATOR_CARD_SEVERITY_LABELS = {
     "critical": "Critical",
 }
 
+# Discord embed budgets, measured in UTF-16 code units (Discord's own unit for
+# these limits).  A contract-valid operator card can still exceed them — e.g.
+# up to 12 fields at the 1024-char field ceiling, or a link block wider than a
+# single field — and Discord rejects an oversized embed wholesale (HTTP 400,
+# error code 50035), which would drop the entire message.  We bound each part
+# and stop once the running aggregate would overflow.
+_DISCORD_EMBED_TITLE_LIMIT = 256
+_DISCORD_EMBED_DESCRIPTION_LIMIT = 4096
+_DISCORD_EMBED_FOOTER_LIMIT = 2048
+_DISCORD_EMBED_FIELD_NAME_LIMIT = 256
+_DISCORD_EMBED_FIELD_VALUE_LIMIT = 1024
+_DISCORD_EMBED_TOTAL_LIMIT = 6000
+_DISCORD_EMBED_MAX_FIELDS = 25
+
 
 def _build_operator_card_embed(card: OperatorCard) -> Any:
-    """Render a validated operator card as a bounded Discord embed."""
-    embed = discord.Embed(
-        title=card.title,
-        description=card.summary,
-        color=_DISCORD_OPERATOR_CARD_COLORS[card.severity],
+    """Render a validated operator card as an embed bounded to Discord's limits.
+
+    Every part is truncated to its per-element ceiling and fields are dropped
+    once the running aggregate would exceed Discord's 6000-code-unit budget, so
+    the embed is always API-valid.  Nothing the operator needs is lost: the
+    plaintext fallback (``render_operator_card_text``) still carries the full
+    card as the message content alongside this embed.
+    """
+    title = _truncate_discord_component_text(card.title, _DISCORD_EMBED_TITLE_LIMIT)
+    description = _truncate_discord_component_text(
+        card.summary, _DISCORD_EMBED_DESCRIPTION_LIMIT
     )
-    for field in card.fields:
-        embed.add_field(name=field.label, value=field.value, inline=False)
-    if card.actions:
-        embed.add_field(
-            name="Actions",
-            value=" · ".join(action.label for action in card.actions),
-            inline=False,
-        )
-    if card.links:
-        embed.add_field(
-            name="Links",
-            value="\n".join(f"[{link.label}]({link.url})" for link in card.links),
-            inline=False,
-        )
     card_type_label = card.card_type.replace("_", " ").title()
     severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[card.severity]
-    embed.set_footer(text=f"{card_type_label} · {severity_label}")
+    footer = _truncate_discord_component_text(
+        f"{card_type_label} · {severity_label}", _DISCORD_EMBED_FOOTER_LIMIT
+    )
+
+    embed = discord.Embed(
+        title=title,
+        description=description,
+        color=_DISCORD_OPERATOR_CARD_COLORS[card.severity],
+    )
+
+    # Title, description, and footer always count against the 6000 aggregate.
+    remaining = _DISCORD_EMBED_TOTAL_LIMIT - (
+        utf16_len(title) + utf16_len(description) + utf16_len(footer)
+    )
+
+    def _add_bounded_field(name: str, value: str) -> None:
+        nonlocal remaining
+        if len(embed.fields) >= _DISCORD_EMBED_MAX_FIELDS or remaining <= 0:
+            return
+        name = _truncate_discord_component_text(
+            name, min(_DISCORD_EMBED_FIELD_NAME_LIMIT, remaining)
+        )
+        if not name:
+            return
+        remaining -= utf16_len(name)
+        if remaining <= 0:
+            return
+        value = _truncate_discord_component_text(
+            value, min(_DISCORD_EMBED_FIELD_VALUE_LIMIT, remaining)
+        )
+        if not value:
+            return
+        remaining -= utf16_len(value)
+        embed.add_field(name=name, value=value, inline=False)
+
+    for field in card.fields:
+        _add_bounded_field(field.label, field.value)
+    if card.actions:
+        _add_bounded_field(
+            "Actions", " · ".join(action.label for action in card.actions)
+        )
+    if card.links:
+        _add_bounded_field(
+            "Links", "\n".join(f"[{link.label}]({link.url})" for link in card.links)
+        )
+
+    embed.set_footer(text=footer)
     return embed
 
 
@@ -2889,9 +2941,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
                     operator_card.severity
                 ]
-                operator_card_thread_name = (
-                    f"{severity_label} — {operator_card.title}"
-                )[:100]
+                # Discord's 100-char thread-name cap is measured in UTF-16 code
+                # units; a naive ``[:100]`` slice counts code points and can
+                # emit a name Discord rejects.  Use the shared UTF-16-aware
+                # component truncator like every other Discord label.
+                operator_card_thread_name = _truncate_discord_component_text(
+                    f"{severity_label} — {operator_card.title}", 100
+                )
 
             # Determine target channel: thread_id in metadata takes precedence.
             thread_id = None

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -141,6 +141,31 @@ def _truncate_discord_component_text(text: str, limit: int) -> str:
     return _prefix_within_utf16_limit(str(text or ""), max(0, limit))
 
 
+def _chunk_discord_lossless_text(text: str, limit: int) -> list[str]:
+    """Split text on Discord's UTF-16 budget without changing its content.
+
+    Operator-card fallbacks are evidence-bearing data.  Generic message
+    chunking adds page indicators and trims boundary whitespace, which can
+    corrupt a long URL.  These chunks intentionally omit presentation markers
+    so joining them reproduces the exact validated fallback.
+    """
+    text = str(text or "")
+    limit = max(1, int(limit))
+    if utf16_len(text) <= limit:
+        return [text]
+
+    chunks: list[str] = []
+    remaining = text
+    while utf16_len(remaining) > limit:
+        chunk = _prefix_within_utf16_limit(remaining, limit)
+        if not chunk:  # Defensive only: Discord's real limit is 2,000 units.
+            chunk = remaining[0]
+        chunks.append(chunk)
+        remaining = remaining[len(chunk):]
+    chunks.append(remaining)
+    return chunks
+
+
 def _abort_discord_websocket_transport(websocket: Any) -> bool:
     """Abort the active aiohttp transport after a bounded close times out."""
     socket = getattr(websocket, "socket", None)
@@ -2978,6 +3003,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     content,
                     embed=operator_card_embed,
                     thread_name=operator_card_thread_name,
+                    preserve_content=operator_card is not None,
                 )
                 await asyncio.to_thread(
                     self._record_discord_response,
@@ -2990,7 +3016,11 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Format and split message if needed
             formatted = self.format_message(content)
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            chunks = (
+                _chunk_discord_lossless_text(formatted, self.MAX_MESSAGE_LENGTH)
+                if operator_card is not None
+                else self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            )
 
             message_ids = []
             reference = None
@@ -3084,6 +3114,7 @@ class DiscordAdapter(BasePlatformAdapter):
         *,
         embed: Any = None,
         thread_name: Optional[str] = None,
+        preserve_content: bool = False,
     ) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
@@ -3097,7 +3128,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # module — no cross-module import needed.
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        chunks = (
+            _chunk_discord_lossless_text(formatted, self.MAX_MESSAGE_LENGTH)
+            if preserve_content
+            else self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        )
 
         thread_name = thread_name or _derive_forum_thread_name(content)
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2935,7 +2935,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 operator_card = OperatorCard.from_mapping(metadata["operator_card"])
                 content = render_operator_card_text(
                     operator_card,
-                    max_length=self.MAX_MESSAGE_LENGTH,
+                    max_length=None,
                 )
                 operator_card_embed = _build_operator_card_embed(operator_card)
                 severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
@@ -8959,13 +8959,13 @@ def _probe_is_forum_cached(chat_id: str) -> Optional[bool]:
 
 
 def _derive_forum_thread_name(message: str) -> str:
-    """Derive a thread name from the first line of the message, capped at 100 chars."""
+    """Derive a thread name within Discord's 100 UTF-16-unit limit."""
     first_line = message.strip().split("\n", 1)[0].strip()
     # Strip common markdown heading prefixes
     first_line = first_line.lstrip("#").strip()
     if not first_line:
         first_line = "New Post"
-    return first_line[:100]
+    return _truncate_discord_component_text(first_line, 100)
 
 
 def _standalone_sanitize_error(text) -> str:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -112,7 +112,11 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
-from gateway.operator_cards import OperatorCard, render_operator_card_text
+from gateway.operator_cards import (
+    OperatorCard,
+    operator_card_severity_display,
+    render_operator_card_text,
+)
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
 from utils import atomic_json_write, env_float, env_int
@@ -192,14 +196,6 @@ _DISCORD_OPERATOR_CARD_COLORS = {
     "blocked": 0xE74C3C,
     "critical": 0x992D22,
 }
-_DISCORD_OPERATOR_CARD_SEVERITY_LABELS = {
-    "done": "Done",
-    "info": "Info",
-    "needs_review": "Needs review",
-    "blocked": "Blocked",
-    "critical": "Critical",
-}
-
 # Discord embed budgets, measured in UTF-16 code units (Discord's own unit for
 # these limits).  A contract-valid operator card can still exceed them — e.g.
 # up to 12 fields at the 1024-char field ceiling, or a link block wider than a
@@ -229,7 +225,7 @@ def _build_operator_card_embed(card: OperatorCard) -> Any:
         card.summary, _DISCORD_EMBED_DESCRIPTION_LIMIT
     )
     card_type_label = card.card_type.replace("_", " ").title()
-    severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[card.severity]
+    _, severity_label = operator_card_severity_display(card.severity)
     footer = _truncate_discord_component_text(
         f"{card_type_label} · {severity_label}", _DISCORD_EMBED_FOOTER_LIMIT
     )
@@ -2963,9 +2959,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     max_length=None,
                 )
                 operator_card_embed = _build_operator_card_embed(operator_card)
-                severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
+                _, severity_label = operator_card_severity_display(
                     operator_card.severity
-                ]
+                )
                 # Discord's 100-char thread-name cap is measured in UTF-16 code
                 # units; a naive ``[:100]`` slice counts code points and can
                 # emit a name Discord rejects.  Use the shared UTF-16-aware

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -112,6 +112,7 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.operator_cards import OperatorCard, render_operator_card_text
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
 from utils import atomic_json_write, env_float, env_int
@@ -157,6 +158,49 @@ def _abort_discord_websocket_transport(websocket: Any) -> bool:
         return False
     abort()
     return True
+
+
+_DISCORD_OPERATOR_CARD_COLORS = {
+    "done": 0x2ECC71,
+    "info": 0x3498DB,
+    "needs_review": 0xF1C40F,
+    "blocked": 0xE74C3C,
+    "critical": 0x992D22,
+}
+_DISCORD_OPERATOR_CARD_SEVERITY_LABELS = {
+    "done": "Done",
+    "info": "Info",
+    "needs_review": "Needs review",
+    "blocked": "Blocked",
+    "critical": "Critical",
+}
+
+
+def _build_operator_card_embed(card: OperatorCard) -> Any:
+    """Render a validated operator card as a bounded Discord embed."""
+    embed = discord.Embed(
+        title=card.title,
+        description=card.summary,
+        color=_DISCORD_OPERATOR_CARD_COLORS[card.severity],
+    )
+    for field in card.fields:
+        embed.add_field(name=field.label, value=field.value, inline=False)
+    if card.actions:
+        embed.add_field(
+            name="Actions",
+            value=" · ".join(action.label for action in card.actions),
+            inline=False,
+        )
+    if card.links:
+        embed.add_field(
+            name="Links",
+            value="\n".join(f"[{link.label}]({link.url})" for link in card.links),
+            inline=False,
+        )
+    card_type_label = card.card_type.replace("_", " ").title()
+    severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[card.severity]
+    embed.set_footer(text=f"{card_type_label} · {severity_label}")
+    return embed
 
 
 async def _wait_for_ready_or_bot_exit(
@@ -2832,6 +2876,23 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            operator_card = None
+            operator_card_embed = None
+            operator_card_thread_name = None
+            if metadata and "operator_card" in metadata:
+                operator_card = OperatorCard.from_mapping(metadata["operator_card"])
+                content = render_operator_card_text(
+                    operator_card,
+                    max_length=self.MAX_MESSAGE_LENGTH,
+                )
+                operator_card_embed = _build_operator_card_embed(operator_card)
+                severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
+                    operator_card.severity
+                ]
+                operator_card_thread_name = (
+                    f"{severity_label} — {operator_card.title}"
+                )[:100]
+
             # Determine target channel: thread_id in metadata takes precedence.
             thread_id = None
             if metadata and metadata.get("thread_id"):
@@ -2856,7 +2917,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
-                result = await self._send_to_forum(channel, content)
+                result = await self._send_to_forum(
+                    channel,
+                    content,
+                    embed=operator_card_embed,
+                    thread_name=operator_card_thread_name,
+                )
                 await asyncio.to_thread(
                     self._record_discord_response,
                     reply_to=reply_to,
@@ -2889,10 +2955,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                    )
+                    send_kwargs: Dict[str, Any] = {
+                        "content": chunk,
+                        "reference": chunk_reference,
+                    }
+                    if i == 0 and operator_card_embed is not None:
+                        send_kwargs["embed"] = operator_card_embed
+                    msg = await channel.send(**send_kwargs)
                 except Exception as e:
                     err_text = str(e)
                     if (
@@ -2911,10 +2980,8 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )
+                        send_kwargs["reference"] = None
+                        msg = await channel.send(**send_kwargs)
                     else:
                         raise
                 message_ids.append(str(msg.id))
@@ -2954,7 +3021,14 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return result
 
-    async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
+    async def _send_to_forum(
+        self,
+        forum_channel: Any,
+        content: str,
+        *,
+        embed: Any = None,
+        thread_name: Optional[str] = None,
+    ) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
         Forum channels (type 15) don't support direct messages.  Instead we
@@ -2969,15 +3043,18 @@ class DiscordAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-        thread_name = _derive_forum_thread_name(content)
+        thread_name = thread_name or _derive_forum_thread_name(content)
 
         starter_content = chunks[0] if chunks else thread_name
 
         try:
-            thread = await forum_channel.create_thread(
-                name=thread_name,
-                content=starter_content,
-            )
+            create_kwargs: Dict[str, Any] = {
+                "name": thread_name,
+                "content": starter_content,
+            }
+            if embed is not None:
+                create_kwargs["embed"] = embed
+            thread = await forum_channel.create_thread(**create_kwargs)
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
             return SendResult(success=False, error=f"Forum thread creation failed: {e}")

--- a/tests/gateway/test_discord_operator_cards_real.py
+++ b/tests/gateway/test_discord_operator_cards_real.py
@@ -1,0 +1,60 @@
+"""Integration coverage for operator cards with the real discord.py types."""
+
+import importlib
+import sys
+
+from gateway.operator_cards import OperatorCard
+
+
+def _load_real_discord_adapter():
+    """Replace the gateway test shim with the installed discord.py package."""
+    for module_name in tuple(sys.modules):
+        if module_name == "discord" or module_name.startswith("discord."):
+            sys.modules.pop(module_name)
+    sys.modules.pop("plugins.platforms.discord.adapter", None)
+    discord_module = importlib.import_module("discord")
+    adapter_module = importlib.import_module("plugins.platforms.discord.adapter")
+    return discord_module, adapter_module
+
+
+def test_operator_card_serializes_through_real_discord_embed():
+    discord_module, adapter_module = _load_real_discord_adapter()
+    card = OperatorCard.from_mapping(
+        {
+            "kind": "operator_card",
+            "version": 1,
+            "card_type": "approval",
+            "title": "Approve source sync",
+            "severity": "needs_review",
+            "summary": "A second source is ready to normalize.",
+            "fields": [{"label": "Issue", "value": "OE-222"}],
+            "actions": [
+                {"id": "approve", "label": "Approve", "style": "success"}
+            ],
+            "links": [
+                {
+                    "label": "Open issue",
+                    "url": "https://linear.app/example/issue/OE-222",
+                }
+            ],
+            "state_ref": "oe-222:approval:1",
+        }
+    )
+
+    embed = adapter_module._build_operator_card_embed(card)
+    serialized = embed.to_dict()
+
+    assert isinstance(embed, discord_module.Embed)
+    assert serialized["title"] == "Approve source sync"
+    assert serialized["description"] == "A second source is ready to normalize."
+    assert serialized["fields"] == [
+        {"inline": False, "name": "Issue", "value": "OE-222"},
+        {"inline": False, "name": "Actions", "value": "Approve"},
+        {
+            "inline": False,
+            "name": "Links",
+            "value": "[Open issue](https://linear.app/example/issue/OE-222)",
+        },
+    ]
+    assert serialized["footer"]["text"] == "Approval · Needs review"
+    assert serialized["color"] == 0xF1C40F

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -281,6 +281,49 @@ async def test_send_operator_card_creates_forum_thread_with_embed(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_operator_card_forum_chunks_preserve_maximum_length_url(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    thread_channel = SimpleNamespace(
+        id=889,
+        send=AsyncMock(return_value=SimpleNamespace(id=7004)),
+    )
+    thread = SimpleNamespace(
+        id=889,
+        message=SimpleNamespace(id=7003),
+        thread=thread_channel,
+    )
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(return_value=thread)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    payload = _operator_card_payload()
+    payload["fields"] = [
+        {"label": f"Field {index}", "value": str(index) * 1024}
+        for index in range(3)
+    ]
+    url_prefix = "https://example.com/"
+    trailing_url = url_prefix + "u" * (2048 - len(url_prefix))
+    payload["links"] = [{"label": "Trailing link", "url": trailing_url}]
+
+    result = await adapter.send(
+        "999",
+        "ignored",
+        metadata={"operator_card": payload},
+    )
+
+    assert result.success is True
+    sent_chunks = [forum_channel.create_thread.await_args.kwargs["content"]]
+    sent_chunks.extend(call.kwargs["content"] for call in thread_channel.send.await_args_list)
+    assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in sent_chunks)
+    assert trailing_url in "".join(sent_chunks)
+
+
+@pytest.mark.asyncio
 async def test_send_rejects_invalid_operator_card_without_platform_write():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     channel = SimpleNamespace(send=AsyncMock())
@@ -366,7 +409,8 @@ async def test_send_chunks_full_operator_card_fallback_without_losing_trailing_l
         {"label": f"Field {index}", "value": str(index) * 1024}
         for index in range(3)
     ]
-    trailing_url = "https://example.com/operator-card-tail"
+    url_prefix = "https://example.com/"
+    trailing_url = url_prefix + "u" * (2048 - len(url_prefix))
     payload["links"] = [{"label": "Trailing link", "url": trailing_url}]
 
     result = await adapter.send(

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -161,6 +161,145 @@ async def test_send_does_not_retry_on_unrelated_errors():
 
 
 # ---------------------------------------------------------------------------
+# Operator card rendering
+# ---------------------------------------------------------------------------
+
+
+def _operator_card_payload():
+    return {
+        "kind": "operator_card",
+        "version": 1,
+        "card_type": "approval",
+        "title": "Approve source sync",
+        "severity": "needs_review",
+        "summary": "A second source is ready to normalize.",
+        "fields": [{"label": "Issue", "value": "OE-222"}],
+        "actions": [{"id": "approve", "label": "Approve", "style": "success"}],
+        "links": [{"label": "Open issue", "url": "https://linear.app/example/issue/OE-222"}],
+        "state_ref": "oe-222:approval:1",
+    }
+
+
+class _FakeEmbed:
+    def __init__(self, *, title, description, color):
+        self.title = title
+        self.description = description
+        self.color = color
+        self.fields = []
+        self.footer = None
+
+    def add_field(self, *, name, value, inline):
+        self.fields.append({"name": name, "value": value, "inline": inline})
+
+    def set_footer(self, *, text):
+        self.footer = text
+
+
+@pytest.mark.asyncio
+async def test_send_renders_valid_operator_card_as_embed_with_text_fallback(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7001)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    result = await adapter.send(
+        "555",
+        "untrusted presentation text",
+        metadata={"operator_card": _operator_card_payload()},
+    )
+
+    assert result.success is True
+    kwargs = channel.send.await_args.kwargs
+    assert kwargs["content"].startswith("🟡 **Needs review — Approve source sync**")
+    assert len(kwargs["content"]) <= adapter.MAX_MESSAGE_LENGTH
+    assert kwargs["embed"].title == "Approve source sync"
+    assert kwargs["embed"].description == "A second source is ready to normalize."
+    assert kwargs["embed"].fields[0] == {"name": "Issue", "value": "OE-222", "inline": False}
+    assert kwargs["embed"].footer == "Approval · Needs review"
+
+
+@pytest.mark.asyncio
+async def test_send_operator_card_targets_requested_thread(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    parent = SimpleNamespace(send=AsyncMock())
+    thread = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7002)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else parent,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    result = await adapter.send(
+        "555",
+        "ignored",
+        metadata={"thread_id": "777", "operator_card": _operator_card_payload()},
+    )
+
+    assert result.success is True
+    assert thread.send.await_count == 1
+    assert parent.send.await_count == 0
+    assert isinstance(thread.send.await_args.kwargs["embed"], _FakeEmbed)
+
+
+@pytest.mark.asyncio
+async def test_send_operator_card_creates_forum_thread_with_embed(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    thread_channel = SimpleNamespace(id=888, send=AsyncMock())
+    thread = SimpleNamespace(id=888, message=SimpleNamespace(id=7003), thread=thread_channel)
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(return_value=thread)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    result = await adapter.send(
+        "999",
+        "ignored",
+        metadata={"operator_card": _operator_card_payload()},
+    )
+
+    assert result.success is True
+    kwargs = forum_channel.create_thread.await_args.kwargs
+    assert kwargs["name"] == "Needs review — Approve source sync"
+    assert isinstance(kwargs["embed"], _FakeEmbed)
+    assert len(kwargs["content"]) <= adapter.MAX_MESSAGE_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_invalid_operator_card_without_platform_write():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    payload = _operator_card_payload()
+    payload["unexpected"] = "fail closed"
+
+    result = await adapter.send(
+        "555",
+        "must not be sent",
+        metadata={"operator_card": payload},
+    )
+
+    assert result.success is False
+    assert "unknown fields" in (result.error or "")
+    assert channel.send.await_count == 0
+
+
+# ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -42,7 +42,10 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _derive_forum_thread_name,
+)
 
 
 @pytest.mark.asyncio
@@ -329,7 +332,8 @@ async def test_send_bounds_contract_valid_but_oversized_card_to_discord_limits(m
 
     # The card is delivered (safe fallback), not dropped by a Discord 400.
     assert result.success is True
-    embed = channel.send.await_args.kwargs["embed"]
+    first_send = channel.send.await_args_list[0]
+    embed = first_send.kwargs["embed"]
     # Per-field invariants.
     assert all(len(field["value"]) <= 1024 for field in embed.fields)
     assert all(0 < len(field["name"]) <= 256 for field in embed.fields)
@@ -338,7 +342,46 @@ async def test_send_bounds_contract_valid_but_oversized_card_to_discord_limits(m
     total += sum(len(field["name"]) + len(field["value"]) for field in embed.fields)
     assert total <= 6000
     # The full card still reaches the operator via the plaintext content.
-    assert channel.send.await_args.kwargs["content"].startswith("🟡")
+    assert first_send.kwargs["content"].startswith("🟡")
+    assert "https://example.com/" in "".join(
+        call.kwargs["content"] for call in channel.send.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_chunks_full_operator_card_fallback_without_losing_trailing_links(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7010)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    payload = _operator_card_payload()
+    payload["fields"] = [
+        {"label": f"Field {index}", "value": str(index) * 1024}
+        for index in range(3)
+    ]
+    trailing_url = "https://example.com/operator-card-tail"
+    payload["links"] = [{"label": "Trailing link", "url": trailing_url}]
+
+    result = await adapter.send(
+        "555",
+        "ignored",
+        metadata={"operator_card": payload},
+    )
+
+    assert result.success is True
+    assert channel.send.await_count >= 2
+    sent_chunks = [call.kwargs["content"] for call in channel.send.await_args_list]
+    assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in sent_chunks)
+    assert trailing_url in "".join(sent_chunks)
+    assert "embed" in channel.send.await_args_list[0].kwargs
+    assert all("embed" not in call.kwargs for call in channel.send.await_args_list[1:])
 
 
 # ---------------------------------------------------------------------------
@@ -404,6 +447,15 @@ async def test_send_to_forum_creates_thread_post():
     assert result.success is True
     assert result.message_id == "500"
     forum_channel.create_thread.assert_awaited_once()
+
+
+def test_forum_thread_name_obeys_discord_utf16_limit_for_astral_text():
+    title = "🚀" * 60
+
+    thread_name = _derive_forum_thread_name(title)
+
+    assert thread_name == "🚀" * 50
+    assert len(thread_name.encode("utf-16-le")) // 2 <= 100
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -299,6 +299,48 @@ async def test_send_rejects_invalid_operator_card_without_platform_write():
     assert channel.send.await_count == 0
 
 
+@pytest.mark.asyncio
+async def test_send_bounds_contract_valid_but_oversized_card_to_discord_limits(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7009)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    # Every part below is within the operator-card contract, yet the embed it
+    # would naively produce blows past Discord's 1024 per-field and 6000
+    # aggregate ceilings (12 fields at the field limit + a wide link block).
+    payload = _operator_card_payload()
+    payload["fields"] = [{"label": f"Field {i}", "value": "x" * 1024} for i in range(12)]
+    payload["links"] = [
+        {"label": "L" * 80, "url": "https://example.com/" + "y" * 2000} for _ in range(5)
+    ]
+
+    result = await adapter.send(
+        "555",
+        "ignored",
+        metadata={"operator_card": payload},
+    )
+
+    # The card is delivered (safe fallback), not dropped by a Discord 400.
+    assert result.success is True
+    embed = channel.send.await_args.kwargs["embed"]
+    # Per-field invariants.
+    assert all(len(field["value"]) <= 1024 for field in embed.fields)
+    assert all(0 < len(field["name"]) <= 256 for field in embed.fields)
+    # Aggregate invariant: whole embed stays within the 6000 budget.
+    total = len(embed.title) + len(embed.description) + len(embed.footer or "")
+    total += sum(len(field["name"]) + len(field["value"]) for field in embed.fields)
+    assert total <= 6000
+    # The full card still reaches the operator via the plaintext content.
+    assert channel.send.await_args.kwargs["content"].startswith("🟡")
+
+
 # ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_operator_cards.py
+++ b/tests/gateway/test_operator_cards.py
@@ -84,6 +84,7 @@ def test_every_severity_has_a_mobile_readable_label(severity, label):
         ({"state_ref": ""}, "state_ref"),
         ({"actions": [{"id": "approve", "label": "Approve", "style": "neon"}]}, "style"),
         ({"links": [{"label": "Bad", "url": "javascript:alert(1)"}]}, "url"),
+        ({"links": [{"label": "Bad", "url": "https://:443"}]}, "url"),
     ],
 )
 def test_invalid_values_fail_closed(change, message):

--- a/tests/gateway/test_operator_cards.py
+++ b/tests/gateway/test_operator_cards.py
@@ -1,0 +1,129 @@
+"""Behavior contract for platform-agnostic operator cards."""
+
+import pytest
+
+from gateway.operator_cards import (
+    CARD_TYPES,
+    SEVERITIES,
+    OperatorCard,
+    OperatorCardValidationError,
+    render_operator_card_text,
+)
+
+
+def _payload(**overrides):
+    payload = {
+        "kind": "operator_card",
+        "version": 1,
+        "card_type": "approval",
+        "title": "Contract redlines",
+        "severity": "needs_review",
+        "summary": "Legal language changed in the indemnity section.",
+        "fields": [
+            {"label": "Impact", "value": "The liability boundary changed."},
+            {"label": "Next", "value": "Approve or ask for revision."},
+        ],
+        "actions": [
+            {"id": "approve", "label": "Approve", "style": "success"},
+            {"id": "revise", "label": "Revise", "style": "secondary"},
+            {"id": "escalate", "label": "Escalate", "style": "danger"},
+        ],
+        "links": [{"label": "Linear", "url": "https://linear.app/example"}],
+        "state_ref": "opaque-state-ref",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_round_trip_preserves_the_contract_without_platform_fields():
+    card = OperatorCard.from_mapping(_payload())
+
+    assert card.to_mapping() == _payload()
+    assert "discord" not in repr(card).lower()
+
+
+@pytest.mark.parametrize("card_type", sorted(CARD_TYPES))
+def test_every_card_type_uses_the_same_plaintext_contract(card_type):
+    rendered = render_operator_card_text(OperatorCard.from_mapping(_payload(card_type=card_type)))
+
+    assert "Contract redlines" in rendered
+    assert "Legal language changed" in rendered
+    assert "Impact: The liability boundary changed." in rendered
+    assert "Actions: Approve · Revise · Escalate" in rendered
+    assert "[Linear](https://linear.app/example)" in rendered
+
+
+@pytest.mark.parametrize(
+    ("severity", "label"),
+    [
+        ("done", "Done"),
+        ("info", "Info"),
+        ("needs_review", "Needs review"),
+        ("blocked", "Blocked"),
+        ("critical", "Critical"),
+    ],
+)
+def test_every_severity_has_a_mobile_readable_label(severity, label):
+    rendered = render_operator_card_text(OperatorCard.from_mapping(_payload(severity=severity)))
+
+    assert label in rendered.splitlines()[0]
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        ({"kind": "message"}, "kind"),
+        ({"version": 2}, "version"),
+        ({"card_type": "unknown"}, "card_type"),
+        ({"severity": "warning"}, "severity"),
+        ({"title": ""}, "title"),
+        ({"summary": ""}, "summary"),
+        ({"state_ref": ""}, "state_ref"),
+        ({"actions": [{"id": "approve", "label": "Approve", "style": "neon"}]}, "style"),
+        ({"links": [{"label": "Bad", "url": "javascript:alert(1)"}]}, "url"),
+    ],
+)
+def test_invalid_values_fail_closed(change, message):
+    with pytest.raises(OperatorCardValidationError, match=message):
+        OperatorCard.from_mapping(_payload(**change))
+
+
+@pytest.mark.parametrize("missing", ["kind", "version", "card_type", "title", "severity", "summary", "state_ref"])
+def test_missing_required_fields_fail_closed(missing):
+    payload = _payload()
+    payload.pop(missing)
+
+    with pytest.raises(OperatorCardValidationError, match=missing):
+        OperatorCard.from_mapping(payload)
+
+
+def test_unknown_top_level_fields_cannot_leak_to_downstream_renderers():
+    payload = _payload(provider_payload={"private": "must-not-pass"})
+
+    with pytest.raises(OperatorCardValidationError, match="unknown fields"):
+        OperatorCard.from_mapping(payload)
+
+
+def test_plaintext_renderer_is_bounded_without_splitting_the_status_header():
+    card = OperatorCard.from_mapping(
+        _payload(summary="x" * 500, fields=[{"label": "Impact", "value": "y" * 1000}])
+    )
+
+    rendered = render_operator_card_text(card, max_length=240)
+
+    assert len(rendered) <= 240
+    assert rendered.startswith("🟡 **Needs review — Contract redlines**")
+    assert rendered.endswith("…")
+
+
+def test_constant_sets_match_the_values_accepted_by_the_parser():
+    assert CARD_TYPES == {
+        "approval",
+        "task_run",
+        "digest",
+        "deal",
+        "capture",
+        "ops_alert",
+        "thread_header",
+    }
+    assert SEVERITIES == {"done", "info", "needs_review", "blocked", "critical"}

--- a/tests/gateway/test_operator_cards.py
+++ b/tests/gateway/test_operator_cards.py
@@ -74,6 +74,9 @@ def test_every_severity_has_a_mobile_readable_label(severity, label):
     [
         ({"kind": "message"}, "kind"),
         ({"version": 2}, "version"),
+        ({"version": 1.0}, "version"),
+        ({"version": True}, "version"),
+        ({"version": "1"}, "version"),
         ({"card_type": "unknown"}, "card_type"),
         ({"severity": "warning"}, "severity"),
         ({"title": ""}, "title"),
@@ -116,14 +119,23 @@ def test_plaintext_renderer_is_bounded_without_splitting_the_status_header():
     assert rendered.endswith("…")
 
 
-def test_constant_sets_match_the_values_accepted_by_the_parser():
-    assert CARD_TYPES == {
-        "approval",
-        "task_run",
-        "digest",
-        "deal",
-        "capture",
-        "ops_alert",
-        "thread_header",
-    }
-    assert SEVERITIES == {"done", "info", "needs_review", "blocked", "critical"}
+@pytest.mark.parametrize("card_type", sorted(CARD_TYPES))
+def test_every_declared_card_type_is_accepted_by_the_parser(card_type):
+    # Invariant: the accept-list constant and the parser agree — each declared
+    # card_type round-trips instead of being frozen against a literal set.
+    assert OperatorCard.from_mapping(_payload(card_type=card_type)).card_type == card_type
+
+
+@pytest.mark.parametrize("severity", sorted(SEVERITIES))
+def test_every_declared_severity_is_accepted_by_the_parser(severity):
+    assert OperatorCard.from_mapping(_payload(severity=severity)).severity == severity
+
+
+def test_parser_rejects_values_outside_the_declared_sets():
+    assert "totally-made-up" not in CARD_TYPES
+    with pytest.raises(OperatorCardValidationError, match="card_type"):
+        OperatorCard.from_mapping(_payload(card_type="totally-made-up"))
+
+    assert "totally-made-up" not in SEVERITIES
+    with pytest.raises(OperatorCardValidationError, match="severity"):
+        OperatorCard.from_mapping(_payload(severity="totally-made-up"))


### PR DESCRIPTION
## Summary

- add a strict, versioned operator-card contract with JSON parsing, validation, and plaintext rendering
- render valid operator cards as bounded Discord embeds while retaining the full plaintext fallback
- enforce exact v1 integer versions plus Discord field, aggregate, UTF-16 title, and real-host URL validation
- share severity labels across plaintext and Discord rendering to prevent drift
- exercise real `discord.py` embed construction and serialization without live credentials

## Why

Hermes operators need structured, scannable action and status cards in Discord without risking message loss when payloads exceed Discord API limits. Invalid operator-card payloads fail closed without a Discord write; ordinary messages without operator-card metadata continue through the existing plain-message path.

## Verification

At exact head `c3307506ad5258dec9f70828e7ff440c390a55b9`:

- focused operator-card/recovery slice: 119/119 passed
- full 42-file Discord gateway slice: 603/603 passed
- Ruff, bytecode compilation, Windows-footgun scan, and diff checks passed
- independent Spec and Standards reviews approved with zero findings
- the original six patches remain exactly equivalent after rebase; the seventh commit contains only the fixed-point integration hardening above

## Integration note

Rebased onto upstream `main` at `e361c5e20`. The integrated forum send path retains operator-card embeds and bounded thread names while preserving the durable-response ledger used by Discord missed-message recovery.

Fork CI remains `action_required` with zero jobs until a NousResearch maintainer approves the workflow run.