### PR TITLE
fix(discord): make voice auto-join profile-safe and transactional

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14188,9 +14188,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return False
 
-        chat_name = getattr(text_channel, "name", str(text_channel_id))
         guild = getattr(text_channel, "guild", None)
-        if guild is not None and getattr(guild, "name", None):
+        # Reject a linked text channel that lives in a different guild than the
+        # voice event. Auto-join wires the voice session to this text channel;
+        # if it belonged to another server we would leak the session across a
+        # guild boundary and post into a channel the voice event never touched.
+        text_guild_id = getattr(guild, "id", None)
+        try:
+            same_guild = text_guild_id is not None and int(text_guild_id) == int(guild_id)
+        except (TypeError, ValueError):
+            same_guild = False
+        if not same_guild:
+            logger.warning(
+                "Discord voice auto-join blocked: linked text channel %s is in guild %s, "
+                "not the voice event guild %s",
+                text_channel_id,
+                text_guild_id,
+                guild_id,
+            )
+            return False
+
+        chat_name = getattr(text_channel, "name", str(text_channel_id))
+        if getattr(guild, "name", None):
             chat_name = f"{guild.name} / #{chat_name}"
         parent_id = str(getattr(text_channel, "parent_id", "") or "")
         channel_prompt = None
@@ -14227,6 +14246,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             raw_message=SimpleNamespace(guild_id=int(guild_id), guild=guild),
             channel_prompt=channel_prompt,
         )
+
+        # Revalidate the user's CURRENT voice channel against the configured
+        # allowlist immediately before joining. The allowlist was checked when
+        # the voice-state event fired, but the manual join path re-resolves the
+        # user's live channel; re-checking here closes a channel-move race where
+        # the user hops to a non-allowlisted channel before the join lands, which
+        # would otherwise put the bot in a channel outside policy.
+        auto_join_cfg = getattr(adapter, "_voice_auto_join_cfg", None)
+        allowed_channels_raw = (
+            auto_join_cfg.get("allowed_voice_channel_ids")
+            if isinstance(auto_join_cfg, dict)
+            else None
+        )
+        allowed_channels = {
+            str(c)
+            for c in (
+                allowed_channels_raw
+                if isinstance(allowed_channels_raw, (set, frozenset, list, tuple))
+                else ()
+            )
+        }
+        try:
+            current_voice_channel = await adapter.get_user_voice_channel(
+                int(guild_id), str(user_id)
+            )
+        except Exception:
+            current_voice_channel = None
+        current_voice_channel_id = str(getattr(current_voice_channel, "id", "") or "")
+        if not allowed_channels or current_voice_channel_id not in allowed_channels:
+            logger.warning(
+                "Discord voice auto-join blocked: user %s current voice channel %s is not "
+                "in the configured allowlist",
+                user_id,
+                current_voice_channel_id or "<none>",
+            )
+            return False
 
         result = await self._handle_voice_channel_join(event)
         success = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14524,7 +14524,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not guild_id or not hasattr(adapter, "leave_voice_channel"):
             return "Not in a voice channel."
 
-        if not hasattr(adapter, "is_in_voice_channel") or not adapter.is_in_voice_channel(guild_id):
+        physically_in_vc = bool(
+            hasattr(adapter, "is_in_voice_channel")
+            and adapter.is_in_voice_channel(guild_id)
+        )
+
+        # A manual leave must ALSO stop an in-flight PRE-CONNECT auto-join even
+        # when no physical session exists yet. Otherwise a barrier-blocked
+        # callback that connects moments later would defeat the leave. Detect any
+        # in-flight / owned auto-join so we don't early-return past the cleanup.
+        pending = getattr(adapter, "_voice_auto_join_pending", None)
+        targets = getattr(adapter, "_voice_auto_join_targets", None)
+        retry_tasks = getattr(adapter, "_voice_auto_join_retry_tasks", None)
+        direct_tasks = getattr(adapter, "_voice_auto_join_direct_tasks", None)
+        inflight_auto_join = bool(
+            (isinstance(pending, dict) and guild_id in pending)
+            or (isinstance(targets, dict) and guild_id in targets)
+            or (isinstance(retry_tasks, dict) and guild_id in retry_tasks)
+            or (isinstance(direct_tasks, set) and direct_tasks)
+        )
+
+        if not physically_in_vc and not inflight_auto_join:
             return "Not in a voice channel."
 
         suppress_auto_join = (
@@ -14535,13 +14555,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if suppress_auto_join is not None:
             # Prefer the TRACKED target so a manual /voice leave stops the follow
             # of the configured user/channel regardless of which operator issued
-            # the command (they may differ from the followed user). Fall back to
-            # the issuer's live channel when no auto-join target is tracked.
-            targets = getattr(adapter, "_voice_auto_join_targets", None)
+            # the command (they may differ from the followed user). Before a join
+            # commits there is no target yet — fall back to the in-flight pending
+            # attempt's user/channel, then to the issuer's live channel.
             target = targets.get(guild_id) if isinstance(targets, dict) else None
             target_user = getattr(target, "user_id", None)
             target_channel = getattr(target, "voice_channel_id", None)
-            if target is not None and target_user:
+            if target is None and isinstance(pending, dict):
+                pending_entry = pending.get(guild_id)
+                if isinstance(pending_entry, dict):
+                    target_user = target_user or pending_entry.get("user_id")
+                    target_channel = target_channel or pending_entry.get("voice_channel_id")
+            if target_user:
                 suppress_auto_join(
                     guild_id,
                     user_id=str(target_user),
@@ -14569,10 +14594,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     channel_id=str(voice_channel_id) if voice_channel_id is not None else None,
                 )
 
-        # Atomic manual takeover: having recorded suppression above, drop all
-        # auto-follow ownership (target, pending, retry) so a later target
-        # leave/rejoin can never disconnect the session the user just left.
-        if hasattr(adapter, "clear_voice_auto_join_ownership"):
+        # Manual leave = "no session": FLAG any in-flight attempt cancelled (so a
+        # callback that connects moments later is torn back down by its own
+        # barrier) and drop follow ownership — WITHOUT superseding it (which a
+        # /voice JOIN takeover does). ``cancel_inflight_auto_join`` keeps the
+        # pending token intact so the late connection is recognized as cancelled
+        # rather than as a protected newer/manual owner.
+        cancel_inflight = getattr(adapter, "cancel_inflight_auto_join", None)
+        if callable(cancel_inflight):
+            cancel_inflight(guild_id)
+        elif hasattr(adapter, "clear_voice_auto_join_ownership"):
             adapter.clear_voice_auto_join_ownership(guild_id)
 
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14529,8 +14529,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 success = await adapter.join_voice_channel(
                     voice_channel, manual_owner=bool(manual), attempt_token=attempt_token
                 )
-            except TypeError:
-                # Older adapter without the manual_owner/attempt_token kwargs.
+            except TypeError as te:
+                # Fall back to the tokenless call ONLY for a genuinely older adapter
+                # that does not accept these kwargs — never for a broad/internal
+                # TypeError, which must propagate (dropping the attempt token or
+                # manual-owner flag would let a stale attempt mutate a live session).
+                msg = str(te)
+                legacy_signature = "unexpected keyword argument" in msg and (
+                    "attempt_token" in msg or "manual_owner" in msg
+                )
+                if not legacy_signature:
+                    raise
                 success = await adapter.join_voice_channel(voice_channel)
         except Exception as e:
             logger.warning("Failed to join voice channel: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14525,21 +14525,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # own and never disconnects it. The auto-follow path passes manual=False
             # plus the barrier's attempt_token, so join_voice_channel refuses to
             # move/overwrite a manual/newer-owned session for a stale attempt.
+            #
+            # Decide how to invoke join_voice_channel by INSPECTING ITS SIGNATURE
+            # BEFORE the call — never by parsing a TypeError message and never by
+            # retrying a modern call tokenless (dropping attempt_token/manual_owner
+            # would bypass the ownership gate and let a stale attempt mutate a live
+            # session). An internal TypeError from a modern adapter therefore
+            # surfaces as a single failed call (handled by the outer except).
+            _supports_gate_kwargs = True
             try:
+                _params = inspect.signature(adapter.join_voice_channel).parameters
+                _has_var_kw = any(
+                    p.kind is inspect.Parameter.VAR_KEYWORD for p in _params.values()
+                )
+                _supports_gate_kwargs = _has_var_kw or (
+                    "attempt_token" in _params and "manual_owner" in _params
+                )
+            except (TypeError, ValueError):
+                # Not introspectable (e.g. a builtin) — assume the modern contract.
+                _supports_gate_kwargs = True
+            if _supports_gate_kwargs:
                 success = await adapter.join_voice_channel(
                     voice_channel, manual_owner=bool(manual), attempt_token=attempt_token
                 )
-            except TypeError as te:
-                # Fall back to the tokenless call ONLY for a genuinely older adapter
-                # that does not accept these kwargs — never for a broad/internal
-                # TypeError, which must propagate (dropping the attempt token or
-                # manual-owner flag would let a stale attempt mutate a live session).
-                msg = str(te)
-                legacy_signature = "unexpected keyword argument" in msg and (
-                    "attempt_token" in msg or "manual_owner" in msg
-                )
-                if not legacy_signature:
-                    raise
+            else:
+                # Genuinely legacy adapter without the gate kwargs — single call.
                 success = await adapter.join_voice_channel(voice_channel)
         except Exception as e:
             logger.warning("Failed to join voice channel: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14484,7 +14484,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
         try:
-            success = await adapter.join_voice_channel(voice_channel)
+            # A MANUAL /voice join stamps manual session ownership (atomic under
+            # the adapter's guild voice lock) so a stale auto-join barrier that
+            # completes later recognizes the hand-established session is not its
+            # own and never disconnects it. The auto-follow path passes manual=False.
+            try:
+                success = await adapter.join_voice_channel(
+                    voice_channel, manual_owner=bool(manual)
+                )
+            except TypeError:
+                # Older adapter without the manual_owner kwarg.
+                success = await adapter.join_voice_channel(voice_channel)
         except Exception as e:
             logger.warning("Failed to join voice channel: %s", e)
             adapter._voice_input_callback = None
@@ -14531,18 +14541,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # A manual leave must ALSO stop an in-flight PRE-CONNECT auto-join even
         # when no physical session exists yet. Otherwise a barrier-blocked
-        # callback that connects moments later would defeat the leave. Detect any
-        # in-flight / owned auto-join so we don't early-return past the cleanup.
-        pending = getattr(adapter, "_voice_auto_join_pending", None)
-        targets = getattr(adapter, "_voice_auto_join_targets", None)
-        retry_tasks = getattr(adapter, "_voice_auto_join_retry_tasks", None)
-        direct_tasks = getattr(adapter, "_voice_auto_join_direct_tasks", None)
-        inflight_auto_join = bool(
-            (isinstance(pending, dict) and guild_id in pending)
-            or (isinstance(targets, dict) and guild_id in targets)
-            or (isinstance(retry_tasks, dict) and guild_id in retry_tasks)
-            or (isinstance(direct_tasks, set) and direct_tasks)
-        )
+        # callback that connects moments later would defeat the leave. Ask the
+        # adapter for a GUILD-SCOPED snapshot rather than reaching into its
+        # private collections — the snapshot is keyed to THIS guild, so another
+        # guild's in-flight attempt can never make this idle guild report success.
+        aj_state = None
+        snapshot_fn = getattr(adapter, "voice_auto_join_state", None)
+        if callable(snapshot_fn):
+            try:
+                aj_state = snapshot_fn(guild_id)
+            except Exception:
+                aj_state = None
+        inflight_auto_join = bool(getattr(aj_state, "inflight", False))
 
         if not physically_in_vc and not inflight_auto_join:
             return "Not in a voice channel."
@@ -14553,19 +14563,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else None
         )
         if suppress_auto_join is not None:
-            # Prefer the TRACKED target so a manual /voice leave stops the follow
-            # of the configured user/channel regardless of which operator issued
-            # the command (they may differ from the followed user). Before a join
-            # commits there is no target yet — fall back to the in-flight pending
-            # attempt's user/channel, then to the issuer's live channel.
-            target = targets.get(guild_id) if isinstance(targets, dict) else None
-            target_user = getattr(target, "user_id", None)
-            target_channel = getattr(target, "voice_channel_id", None)
-            if target is None and isinstance(pending, dict):
-                pending_entry = pending.get(guild_id)
-                if isinstance(pending_entry, dict):
-                    target_user = target_user or pending_entry.get("user_id")
-                    target_channel = target_channel or pending_entry.get("voice_channel_id")
+            # Key the manual-leave suppression off the guild snapshot: it prefers
+            # the TRACKED target (so a leave stops the follow of the configured
+            # user/channel regardless of which operator issued it), and before a
+            # join commits — when there is no target yet — falls back to the
+            # in-flight pending attempt's user/channel. The gateway never reaches
+            # into the adapter's private collections for this.
+            target_user = getattr(aj_state, "suppression_user_id", None) if aj_state else None
+            target_channel = getattr(aj_state, "suppression_channel_id", None) if aj_state else None
             if target_user:
                 suppress_auto_join(
                     guild_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3610,13 +3610,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             enabled_chats.discard(chat_id)
 
-    def _sync_voice_mode_state_to_adapter(self, adapter) -> None:
+    def _sync_voice_mode_state_to_adapter(
+        self, adapter, *, profile_name=None, profile_home=None
+    ) -> None:
         """Restore persisted /voice state into a live platform adapter.
 
         Populates three fields from config + ``self._voice_mode``:
-          - ``_auto_tts_default``: global default from ``voice.auto_tts``
+          - ``_auto_tts_default``: default from the OWNING profile's ``voice.auto_tts``
           - ``_auto_tts_enabled_chats``: chats with mode ``voice_only``/``all``
           - ``_auto_tts_disabled_chats``: chats with mode ``off``
+
+        Profile-aware: for a secondary profile only the ``profile:<name>:<platform>:``
+        keys are consulted (and stripped), and ``voice.auto_tts`` is read from the
+        owning profile's config, so two adapters for the same platform in
+        different profiles never leak each other's mode state.
         """
         platform = getattr(adapter, "platform", None)
         if not isinstance(platform, Platform):
@@ -3627,20 +3634,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not isinstance(disabled_chats, set) and not isinstance(enabled_chats, set):
             return
 
-        # Push the global voice.auto_tts default (config.yaml) onto the adapter.
+        # Push the owning profile's voice.auto_tts default onto the adapter.
         # Lazy import to avoid adding a module-level dep from gateway → hermes_cli.
+        def _read_auto_tts_default() -> bool:
+            try:
+                from hermes_cli.config import load_config as _load_full_config
+                _full_cfg = _load_full_config()
+                return bool((_full_cfg.get("voice") or {}).get("auto_tts", False))
+            except Exception:
+                return False
+
         try:
-            from hermes_cli.config import load_config as _load_full_config
-            _full_cfg = _load_full_config()
-            _auto_tts_default = bool(
-                (_full_cfg.get("voice") or {}).get("auto_tts", False)
-            )
+            if profile_home is not None:
+                with _profile_runtime_scope(profile_home):
+                    _auto_tts_default = _read_auto_tts_default()
+            else:
+                _auto_tts_default = _read_auto_tts_default()
         except Exception:
             _auto_tts_default = False
         if hasattr(adapter, "_auto_tts_default"):
             adapter._auto_tts_default = _auto_tts_default
 
-        prefix = f"{platform.value}:"
+        # ``_voice_key(platform, "", profile)`` yields the exact namespace prefix:
+        # ``platform:`` for the default profile, ``profile:<name>:platform:`` for a
+        # secondary. Only keys under this profile's namespace are consulted, so a
+        # default sync ignores secondary keys and vice versa.
+        prefix = self._voice_key(platform, "", profile=profile_name)
         if isinstance(disabled_chats, set):
             disabled_chats.clear()
             disabled_chats.update(
@@ -9458,6 +9477,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                 if success:
                     profile_map[platform] = adapter
+                    self._sync_voice_mode_state_to_adapter(
+                        adapter, profile_name=profile_name, profile_home=profile_home
+                    )
                     self._sync_voice_auto_join_state_to_adapter(
                         adapter, profile_name=profile_name
                     )
@@ -9527,7 +9549,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         profile_map = self._profile_adapters.setdefault(profile_name, {})
                         if platform not in profile_map:
                             profile_map[platform] = adapter
-                            self._sync_voice_mode_state_to_adapter(adapter)
+                            self._sync_voice_mode_state_to_adapter(
+                                adapter, profile_name=profile_name, profile_home=profile_home
+                            )
                             self._sync_voice_auto_join_state_to_adapter(
                                 adapter, profile_name=profile_name
                             )
@@ -14371,7 +14395,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         # Join the EXACT resolved channel (single resolution — no second lookup).
-        result = await self._handle_voice_channel_join(event, voice_channel=voice_channel)
+        result = await self._handle_voice_channel_join(
+            event, voice_channel=voice_channel, manual=False
+        )
 
         # Verify and record the ACTUAL connected channel, not the event's
         # (possibly stale) channel id.
@@ -14403,13 +14429,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return bool(success)
 
 
-    async def _handle_voice_channel_join(self, event: MessageEvent, *, voice_channel=None) -> str:
+    async def _handle_voice_channel_join(
+        self, event: MessageEvent, *, voice_channel=None, manual: bool = True
+    ) -> str:
         """Join the user's current Discord voice channel.
 
         ``voice_channel`` may be a channel already resolved by the caller (the
         auto-join path resolves it once and validates it against policy). When
         provided it is used verbatim — the user's live channel is NOT looked up
         again, so the channel that was validated is the channel that is joined.
+        ``manual`` marks a hand-issued ``/voice join`` (vs the auto-follow path)
+        so a manual takeover can drop stale auto-follow ownership.
         """
         adapter = self._adapter_for_source(event.source)
         if not hasattr(adapter, "join_voice_channel"):
@@ -14473,6 +14503,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id, profile=owner_profile)] = "all"
             self._save_voice_modes()
             self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+            # A MANUAL join is a takeover: drop any auto-follow ownership so a
+            # later target leave/rejoin can never disconnect or hijack this
+            # hand-established session.
+            if manual and hasattr(adapter, "clear_voice_auto_join_ownership"):
+                adapter.clear_voice_auto_join_ownership(guild_id)
             return (
                 f"Joined voice channel **{voice_channel.name}**.\n"
                 f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
@@ -14534,6 +14569,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     channel_id=str(voice_channel_id) if voice_channel_id is not None else None,
                 )
 
+        # Atomic manual takeover: having recorded suppression above, drop all
+        # auto-follow ownership (target, pending, retry) so a later target
+        # leave/rejoin can never disconnect the session the user just left.
+        if hasattr(adapter, "clear_voice_auto_join_ownership"):
+            adapter.clear_voice_auto_join_ownership(guild_id)
+
         try:
             await adapter.leave_voice_channel(guild_id)
         except Exception as e:
@@ -14566,13 +14607,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter = self._authorization_adapter(Platform.DISCORD, profile)
         self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
 
-    def _is_duplicate_voice_transcript(self, guild_id: int, user_id: int, transcript: str) -> bool:
+    def _is_duplicate_voice_transcript(
+        self, guild_id: int, user_id: int, transcript: str, *, profile=None
+    ) -> bool:
         """Suppress repeated STT outputs for the same recent utterance.
 
         Voice capture can occasionally emit the same utterance twice a few
         seconds apart, which creates a second queued agent run and overlapping
-        spoken replies. Dedup exact and near-exact repeats per guild/user over a
-        short window while allowing genuinely new turns through.
+        spoken replies. Dedup exact and near-exact repeats per profile/guild/user
+        over a short window while allowing genuinely new turns through.
+
+        The dedupe key includes the normalized owning profile so two profiles
+        sharing a guild/user (each its own bot session) never cross-suppress each
+        other's identical utterance.
         """
         from difflib import SequenceMatcher
 
@@ -14583,7 +14630,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         now = time.monotonic()
         window_seconds = 12.0
-        key = (guild_id, user_id)
+        profile_key = (str(profile).strip() if profile else "") or "default"
+        key = (profile_key, guild_id, user_id)
         recent_store = getattr(self, "_recent_voice_transcripts", None)
         if not isinstance(recent_store, dict):
             recent_store = {}
@@ -14619,7 +14667,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         default profile's.
         """
         if adapter is None:
-            adapter = self._authorization_adapter(Platform.DISCORD, profile) or self.adapters.get(Platform.DISCORD)
+            # Resolve strictly by the owning profile — NO fallback to the default
+            # adapter. A secondary-profile voice callback must never be serviced
+            # by the default bot (wrong session, wrong credentials).
+            adapter = self._authorization_adapter(Platform.DISCORD, profile)
         if not adapter:
             return
 
@@ -14652,7 +14703,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Unauthorized voice input from user %d, ignoring", user_id)
             return
 
-        if self._is_duplicate_voice_transcript(guild_id, user_id, transcript):
+        if self._is_duplicate_voice_transcript(
+            guild_id, user_id, transcript, profile=profile
+        ):
             logger.info(
                 "Suppressing duplicate voice transcript for guild=%s user=%s: %s",
                 guild_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3719,7 +3719,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if profile == "default":
             profile = None
 
-        async def _callback(*, guild_id, user_id, voice_channel_id, text_channel_id):
+        async def _callback(
+            *, guild_id, user_id, voice_channel_id, text_channel_id, attempt_token=None
+        ):
             return await self._handle_discord_voice_auto_join(
                 adapter=adapter,
                 profile=profile,
@@ -3727,6 +3729,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_id=user_id,
                 voice_channel_id=voice_channel_id,
                 text_channel_id=text_channel_id,
+                attempt_token=attempt_token,
             )
 
         adapter._voice_auto_join_callback = _callback
@@ -14228,6 +14231,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         text_channel_id: str,
         adapter=None,
         profile=None,
+        attempt_token=None,
     ) -> bool:
         """Auto-join Discord voice by reusing the manual /voice join path.
 
@@ -14395,8 +14399,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         # Join the EXACT resolved channel (single resolution — no second lookup).
+        # Thread the barrier's attempt token so join_voice_channel can refuse to
+        # move/overwrite a manual/newer-owned session on behalf of a stale attempt.
         result = await self._handle_voice_channel_join(
-            event, voice_channel=voice_channel, manual=False
+            event, voice_channel=voice_channel, manual=False, attempt_token=attempt_token
         )
 
         # Verify and record the ACTUAL connected channel, not the event's
@@ -14415,7 +14421,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         text_ok = str(
             getattr(adapter, "_voice_text_channels", {}).get(int(guild_id))
         ) == str(text_channel_id)
-        success = bool(connected_channel_id) and text_ok
+        # Only this exact attempt may mark the follow target: if the join was
+        # REJECTED for a stale attempt (a manual/newer owner holds the session),
+        # ownership will not be ours, so we never stamp a target for a session we
+        # do not own. When the adapter can't report ownership (token-less path),
+        # fall back to the connected+text check.
+        owns_session = True
+        owned_check = getattr(adapter, "_voice_session_owned_by_attempt", None)
+        if attempt_token is not None and callable(owned_check):
+            owns_session = bool(owned_check(int(guild_id), attempt_token))
+        success = bool(connected_channel_id) and text_ok and owns_session
         if success and "mark_voice_auto_join_target" in dir(adapter):
             adapter.mark_voice_auto_join_target(
                 int(guild_id),
@@ -14425,12 +14440,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 profile=profile_name,
             )
         if not success:
-            logger.debug("Discord voice auto-join did not connect: %s", result)
+            logger.debug("Discord voice auto-join did not connect/own session: %s", result)
         return bool(success)
 
 
     async def _handle_voice_channel_join(
-        self, event: MessageEvent, *, voice_channel=None, manual: bool = True
+        self, event: MessageEvent, *, voice_channel=None, manual: bool = True,
+        attempt_token=None,
     ) -> str:
         """Join the user's current Discord voice channel.
 
@@ -14439,7 +14455,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         provided it is used verbatim — the user's live channel is NOT looked up
         again, so the channel that was validated is the channel that is joined.
         ``manual`` marks a hand-issued ``/voice join`` (vs the auto-follow path)
-        so a manual takeover can drop stale auto-follow ownership.
+        so a manual takeover can drop stale auto-follow ownership. ``attempt_token``
+        is the auto-join barrier's exact token, threaded into ``join_voice_channel``
+        so the join is gated on attempt currency + session ownership under the guild
+        lock; a rejected (stale) attempt returns without applying any side effects.
         """
         adapter = self._adapter_for_source(event.source)
         if not hasattr(adapter, "join_voice_channel"):
@@ -14462,6 +14481,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # cleanup, and mode lookups act on ITS session — never the default
         # profile's adapter or voice-mode namespace.
         owner_profile = getattr(event.source, "profile", None)
+        # Snapshot the prior callback wiring so a REJECTED join (a stale auto
+        # attempt refused because a manual/newer owner holds the session) can
+        # restore it — a rejected attempt must apply NO runner-side side effects,
+        # including never rebinding disconnect/mode callbacks over the live owner's.
+        _prev_input_cb = getattr(adapter, "_voice_input_callback", None)
+        _prev_on_disconnect = getattr(adapter, "_on_voice_disconnect", None)
+        _prev_mode_getter = getattr(adapter, "_voice_mode_getter", None)
+
+        def _restore_prior_wiring():
+            if hasattr(adapter, "_voice_input_callback"):
+                adapter._voice_input_callback = _prev_input_cb
+            if hasattr(adapter, "_on_voice_disconnect"):
+                adapter._on_voice_disconnect = _prev_on_disconnect
+            if hasattr(adapter, "_voice_mode_getter"):
+                adapter._voice_mode_getter = _prev_mode_getter
+
         if hasattr(adapter, "_voice_input_callback"):
             adapter._voice_input_callback = (
                 lambda guild_id, user_id, transcript, _a=adapter, _p=owner_profile:
@@ -14487,17 +14522,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # A MANUAL /voice join stamps manual session ownership (atomic under
             # the adapter's guild voice lock) so a stale auto-join barrier that
             # completes later recognizes the hand-established session is not its
-            # own and never disconnects it. The auto-follow path passes manual=False.
+            # own and never disconnects it. The auto-follow path passes manual=False
+            # plus the barrier's attempt_token, so join_voice_channel refuses to
+            # move/overwrite a manual/newer-owned session for a stale attempt.
             try:
                 success = await adapter.join_voice_channel(
-                    voice_channel, manual_owner=bool(manual)
+                    voice_channel, manual_owner=bool(manual), attempt_token=attempt_token
                 )
             except TypeError:
-                # Older adapter without the manual_owner kwarg.
+                # Older adapter without the manual_owner/attempt_token kwargs.
                 success = await adapter.join_voice_channel(voice_channel)
         except Exception as e:
             logger.warning("Failed to join voice channel: %s", e)
-            adapter._voice_input_callback = None
+            _restore_prior_wiring()
             err_lower = str(e).lower()
             if "pynacl" in err_lower or "nacl" in err_lower or "davey" in err_lower:
                 return (
@@ -14522,8 +14559,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 f"Joined voice channel **{voice_channel.name}**.\n"
                 f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
             )
-        # Join failed — clear callback
-        adapter._voice_input_callback = None
+        # Join failed or was REJECTED (stale attempt) — restore prior wiring so no
+        # side effect leaks onto the live owner's session.
+        _restore_prior_wiring()
         return "Failed to join voice channel. Check bot permissions (Connect + Speak)."
 
     async def _handle_voice_channel_leave(self, event: MessageEvent) -> str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3672,12 +3672,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         task.add_done_callback(consume_detached_task_result)
         return False
 
-    def _sync_voice_auto_join_state_to_adapter(self, adapter) -> None:
-        """Wire Discord voice auto-join callbacks onto a live adapter."""
+    def _sync_voice_auto_join_state_to_adapter(self, adapter, *, profile_name=None) -> None:
+        """Wire Discord voice auto-join callbacks onto a live adapter.
+
+        The callback is bound to THIS adapter instance and its owning profile so
+        a multiplexed gateway (one Discord adapter per profile) routes the join
+        back to the adapter that fired the event — never blindly to the active
+        profile's adapter. ``profile_name`` is normalized to ``None`` for the
+        active/default profile, matching ``_authorization_adapter`` resolution.
+        """
         if getattr(adapter, "platform", None) != Platform.DISCORD:
             return
-        if hasattr(adapter, "_voice_auto_join_callback"):
-            adapter._voice_auto_join_callback = self._handle_discord_voice_auto_join
+        if not hasattr(adapter, "_voice_auto_join_callback"):
+            return
+        profile = (str(profile_name).strip() if profile_name else "") or None
+        if profile == "default":
+            profile = None
+
+        async def _callback(*, guild_id, user_id, voice_channel_id, text_channel_id):
+            return await self._handle_discord_voice_auto_join(
+                adapter=adapter,
+                profile=profile,
+                guild_id=guild_id,
+                user_id=user_id,
+                voice_channel_id=voice_channel_id,
+                text_channel_id=text_channel_id,
+            )
+
+        adapter._voice_auto_join_callback = _callback
 
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
         """Call adapter.disconnect() defensively, swallowing any error.
@@ -9425,6 +9447,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                 if success:
                     profile_map[platform] = adapter
+                    self._sync_voice_auto_join_state_to_adapter(
+                        adapter, profile_name=profile_name
+                    )
                     connected += 1
                     logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
                 else:
@@ -9492,6 +9517,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if platform not in profile_map:
                             profile_map[platform] = adapter
                             self._sync_voice_mode_state_to_adapter(adapter)
+                            self._sync_voice_auto_join_state_to_adapter(
+                                adapter, profile_name=profile_name
+                            )
                             logger.info(
                                 "✓ %s reconnected (profile: %s)",
                                 platform.value,
@@ -14163,10 +14191,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_id: str,
         voice_channel_id: str,
         text_channel_id: str,
+        adapter=None,
+        profile=None,
     ) -> bool:
-        """Auto-join Discord voice by reusing the manual /voice join path."""
-        adapter = self.adapters.get(Platform.DISCORD)
-        if not adapter or "get_user_voice_channel" not in dir(adapter):
+        """Auto-join Discord voice by reusing the manual /voice join path.
+
+        ``adapter``/``profile`` identify the adapter that fired the event. Only
+        the live registered adapter for that profile may drive the join — a
+        stale adapter left over from a reconnect (identity mismatch) is rejected
+        so it cannot connect on a replaced bot session.
+        """
+        profile_name = (str(profile).strip() if profile else "") or None
+        if profile_name == "default":
+            profile_name = None
+        # Ownership/identity: resolve the adapter currently registered for this
+        # profile and require it to be the exact instance that fired.
+        current_adapter = self._authorization_adapter(Platform.DISCORD, profile_name)
+        if adapter is None:
+            adapter = current_adapter
+        if current_adapter is None or current_adapter is not adapter:
+            logger.warning(
+                "Discord voice auto-join blocked: adapter identity mismatch for profile %s",
+                profile_name or "default",
+            )
+            return False
+        if "get_user_voice_channel" not in dir(adapter):
             return False
 
         text_channel = None
@@ -14237,6 +14286,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             guild_id=str(guild_id),
             parent_chat_id=parent_id or None,
         )
+        # Stamp the owning profile so the session is namespaced to this adapter's
+        # profile and the join path resolves back to the SAME adapter instance.
+        try:
+            source.profile = profile_name
+        except Exception:
+            pass
 
         from types import SimpleNamespace
         event = MessageEvent(
@@ -14247,12 +14302,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             channel_prompt=channel_prompt,
         )
 
-        # Revalidate the user's CURRENT voice channel against the configured
-        # allowlist immediately before joining. The allowlist was checked when
-        # the voice-state event fired, but the manual join path re-resolves the
-        # user's live channel; re-checking here closes a channel-move race where
-        # the user hops to a non-allowlisted channel before the join lands, which
-        # would otherwise put the bot in a channel outside policy.
+        # Resolve the user's CURRENT voice channel EXACTLY ONCE, here in the
+        # deepest join path, and validate THAT exact channel — allowlist and
+        # guild — before joining. The resolved channel is then handed to the
+        # join so it is never re-resolved (which would reopen a channel-move
+        # TOCTOU where the user hops to a disallowed channel after the check).
         auto_join_cfg = getattr(adapter, "_voice_auto_join_cfg", None)
         allowed_channels_raw = (
             auto_join_cfg.get("allowed_voice_channel_ids")
@@ -14268,41 +14322,84 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         }
         try:
-            current_voice_channel = await adapter.get_user_voice_channel(
+            voice_channel = await adapter.get_user_voice_channel(
                 int(guild_id), str(user_id)
             )
         except Exception:
-            current_voice_channel = None
-        current_voice_channel_id = str(getattr(current_voice_channel, "id", "") or "")
-        if not allowed_channels or current_voice_channel_id not in allowed_channels:
+            voice_channel = None
+        if voice_channel is None:
+            logger.warning(
+                "Discord voice auto-join blocked: user %s is not in a voice channel",
+                user_id,
+            )
+            return False
+        resolved_channel_id = str(getattr(voice_channel, "id", "") or "")
+        if not allowed_channels or resolved_channel_id not in allowed_channels:
             logger.warning(
                 "Discord voice auto-join blocked: user %s current voice channel %s is not "
                 "in the configured allowlist",
                 user_id,
-                current_voice_channel_id or "<none>",
+                resolved_channel_id or "<none>",
+            )
+            return False
+        resolved_guild_id = getattr(getattr(voice_channel, "guild", None), "id", None)
+        try:
+            channel_same_guild = (
+                resolved_guild_id is not None and int(resolved_guild_id) == int(guild_id)
+            )
+        except (TypeError, ValueError):
+            channel_same_guild = False
+        if not channel_same_guild:
+            logger.warning(
+                "Discord voice auto-join blocked: resolved voice channel %s is in guild %s, "
+                "not the voice event guild %s",
+                resolved_channel_id,
+                resolved_guild_id,
+                guild_id,
             )
             return False
 
-        result = await self._handle_voice_channel_join(event)
-        success = (
+        # Join the EXACT resolved channel (single resolution — no second lookup).
+        result = await self._handle_voice_channel_join(event, voice_channel=voice_channel)
+
+        # Verify and record the ACTUAL connected channel, not the event's
+        # (possibly stale) channel id.
+        connected_channel_id = None
+        if "connected_voice_channel_id" in dir(adapter):
+            connected_channel_id = adapter.connected_voice_channel_id(int(guild_id))
+        elif (
             "is_in_voice_channel" in dir(adapter)
             and adapter.is_in_voice_channel(int(guild_id))
-            and str(getattr(adapter, "_voice_text_channels", {}).get(int(guild_id))) == str(text_channel_id)
-        )
+        ):
+            vc = getattr(adapter, "_voice_clients", {}).get(int(guild_id))
+            connected_channel_id = str(
+                getattr(getattr(vc, "channel", None), "id", "") or ""
+            ) or None
+        text_ok = str(
+            getattr(adapter, "_voice_text_channels", {}).get(int(guild_id))
+        ) == str(text_channel_id)
+        success = bool(connected_channel_id) and text_ok
         if success and "mark_voice_auto_join_target" in dir(adapter):
             adapter.mark_voice_auto_join_target(
                 int(guild_id),
                 user_id=str(user_id),
-                voice_channel_id=str(voice_channel_id),
+                voice_channel_id=str(connected_channel_id),
                 text_channel_id=str(text_channel_id),
+                profile=profile_name,
             )
         if not success:
             logger.debug("Discord voice auto-join did not connect: %s", result)
         return bool(success)
 
 
-    async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
-        """Join the user's current Discord voice channel."""
+    async def _handle_voice_channel_join(self, event: MessageEvent, *, voice_channel=None) -> str:
+        """Join the user's current Discord voice channel.
+
+        ``voice_channel`` may be a channel already resolved by the caller (the
+        auto-join path resolves it once and validates it against policy). When
+        provided it is used verbatim — the user's live channel is NOT looked up
+        again, so the channel that was validated is the channel that is joined.
+        """
         adapter = self._adapter_for_source(event.source)
         if not hasattr(adapter, "join_voice_channel"):
             return "Voice channels are not supported on this platform."
@@ -14311,9 +14408,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not guild_id:
             return "This command only works in a Discord server."
 
-        voice_channel = await adapter.get_user_voice_channel(
-            guild_id, event.source.user_id
-        )
+        if voice_channel is None:
+            voice_channel = await adapter.get_user_voice_channel(
+                guild_id, event.source.user_id
+            )
         if not voice_channel:
             return "You need to be in a voice channel first."
 
@@ -14375,26 +14473,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else None
         )
         if suppress_auto_join is not None:
-            voice_channel_id = None
-            get_user_voice_channel = (
-                getattr(adapter, "get_user_voice_channel", None)
-                if "get_user_voice_channel" in dir(adapter)
-                else None
-            )
-            if get_user_voice_channel is not None:
-                try:
-                    voice_channel = await get_user_voice_channel(
-                        guild_id,
-                        event.source.user_id,
-                    )
-                    voice_channel_id = getattr(voice_channel, "id", None)
-                except Exception:
-                    voice_channel_id = None
-            suppress_auto_join(
-                guild_id,
-                user_id=event.source.user_id,
-                channel_id=str(voice_channel_id) if voice_channel_id is not None else None,
-            )
+            # Prefer the TRACKED target so a manual /voice leave stops the follow
+            # of the configured user/channel regardless of which operator issued
+            # the command (they may differ from the followed user). Fall back to
+            # the issuer's live channel when no auto-join target is tracked.
+            targets = getattr(adapter, "_voice_auto_join_targets", None)
+            target = targets.get(guild_id) if isinstance(targets, dict) else None
+            target_user = getattr(target, "user_id", None)
+            target_channel = getattr(target, "voice_channel_id", None)
+            if target is not None and target_user:
+                suppress_auto_join(
+                    guild_id,
+                    user_id=str(target_user),
+                    channel_id=str(target_channel) if target_channel is not None else None,
+                )
+            else:
+                voice_channel_id = None
+                get_user_voice_channel = (
+                    getattr(adapter, "get_user_voice_channel", None)
+                    if "get_user_voice_channel" in dir(adapter)
+                    else None
+                )
+                if get_user_voice_channel is not None:
+                    try:
+                        voice_channel = await get_user_voice_channel(
+                            guild_id,
+                            event.source.user_id,
+                        )
+                        voice_channel_id = getattr(voice_channel, "id", None)
+                    except Exception:
+                        voice_channel_id = None
+                suppress_auto_join(
+                    guild_id,
+                    user_id=event.source.user_id,
+                    channel_id=str(voice_channel_id) if voice_channel_id is not None else None,
+                )
 
         try:
             await adapter.leave_voice_channel(guild_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3672,6 +3672,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         task.add_done_callback(consume_detached_task_result)
         return False
 
+    def _sync_voice_auto_join_state_to_adapter(self, adapter) -> None:
+        """Wire Discord voice auto-join callbacks onto a live adapter."""
+        if getattr(adapter, "platform", None) != Platform.DISCORD:
+            return
+        if hasattr(adapter, "_voice_auto_join_callback"):
+            adapter._voice_auto_join_callback = self._handle_discord_voice_auto_join
+
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
         """Call adapter.disconnect() defensively, swallowing any error.
 
@@ -7614,6 +7621,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if success:
                     self.adapters[platform] = adapter
                     self._sync_voice_mode_state_to_adapter(adapter)
+                    self._sync_voice_auto_join_state_to_adapter(adapter)
                     connected_count += 1
                     self._update_platform_runtime_status(
                         platform.value,
@@ -8580,6 +8588,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if success:
                         self.adapters[platform] = adapter
                         self._sync_voice_mode_state_to_adapter(adapter)
+                        self._sync_voice_auto_join_state_to_adapter(adapter)
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]
                         self._update_platform_runtime_status(
@@ -14147,6 +14156,95 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return raw.guild.id
         return None
 
+    async def _handle_discord_voice_auto_join(
+        self,
+        *,
+        guild_id: int,
+        user_id: str,
+        voice_channel_id: str,
+        text_channel_id: str,
+    ) -> bool:
+        """Auto-join Discord voice by reusing the manual /voice join path."""
+        adapter = self.adapters.get(Platform.DISCORD)
+        if not adapter or "get_user_voice_channel" not in dir(adapter):
+            return False
+
+        text_channel = None
+        client = getattr(adapter, "_client", None)
+        if client is not None:
+            try:
+                text_channel = client.get_channel(int(text_channel_id))
+            except Exception:
+                text_channel = None
+            if text_channel is None and hasattr(client, "fetch_channel"):
+                try:
+                    text_channel = await client.fetch_channel(int(text_channel_id))
+                except Exception:
+                    text_channel = None
+        if text_channel is None:
+            logger.warning(
+                "Discord voice auto-join skipped: linked text channel %s is unavailable",
+                text_channel_id,
+            )
+            return False
+
+        chat_name = getattr(text_channel, "name", str(text_channel_id))
+        guild = getattr(text_channel, "guild", None)
+        if guild is not None and getattr(guild, "name", None):
+            chat_name = f"{guild.name} / #{chat_name}"
+        parent_id = str(getattr(text_channel, "parent_id", "") or "")
+        channel_prompt = None
+        if "_resolve_channel_prompt" in dir(adapter):
+            try:
+                channel_prompt = adapter._resolve_channel_prompt(str(text_channel_id), parent_id or None)
+            except Exception:
+                channel_prompt = None
+
+        source = adapter.build_source(
+            chat_id=str(text_channel_id),
+            chat_name=chat_name,
+            chat_type="group",
+            user_id=str(user_id),
+            user_name=str(user_id),
+            guild_id=str(guild_id),
+            parent_chat_id=parent_id or None,
+        ) if "build_source" in dir(adapter) else SessionSource(
+            platform=Platform.DISCORD,
+            chat_id=str(text_channel_id),
+            chat_name=chat_name,
+            chat_type="group",
+            user_id=str(user_id),
+            user_name=str(user_id),
+            guild_id=str(guild_id),
+            parent_chat_id=parent_id or None,
+        )
+
+        from types import SimpleNamespace
+        event = MessageEvent(
+            text="/voice join",
+            message_type=MessageType.COMMAND,
+            source=source,
+            raw_message=SimpleNamespace(guild_id=int(guild_id), guild=guild),
+            channel_prompt=channel_prompt,
+        )
+
+        result = await self._handle_voice_channel_join(event)
+        success = (
+            "is_in_voice_channel" in dir(adapter)
+            and adapter.is_in_voice_channel(int(guild_id))
+            and str(getattr(adapter, "_voice_text_channels", {}).get(int(guild_id))) == str(text_channel_id)
+        )
+        if success and "mark_voice_auto_join_target" in dir(adapter):
+            adapter.mark_voice_auto_join_target(
+                int(guild_id),
+                user_id=str(user_id),
+                voice_channel_id=str(voice_channel_id),
+                text_channel_id=str(text_channel_id),
+            )
+        if not success:
+            logger.debug("Discord voice auto-join did not connect: %s", result)
+        return bool(success)
+
 
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         """Join the user's current Discord voice channel."""
@@ -14215,6 +14313,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if not hasattr(adapter, "is_in_voice_channel") or not adapter.is_in_voice_channel(guild_id):
             return "Not in a voice channel."
+
+        suppress_auto_join = (
+            getattr(adapter, "suppress_voice_auto_join", None)
+            if "suppress_voice_auto_join" in dir(adapter)
+            else None
+        )
+        if suppress_auto_join is not None:
+            voice_channel_id = None
+            get_user_voice_channel = (
+                getattr(adapter, "get_user_voice_channel", None)
+                if "get_user_voice_channel" in dir(adapter)
+                else None
+            )
+            if get_user_voice_channel is not None:
+                try:
+                    voice_channel = await get_user_voice_channel(
+                        guild_id,
+                        event.source.user_id,
+                    )
+                    voice_channel_id = getattr(voice_channel, "id", None)
+                except Exception:
+                    voice_channel_id = None
+            suppress_auto_join(
+                guild_id,
+                user_id=event.source.user_id,
+                channel_id=str(voice_channel_id) if voice_channel_id is not None else None,
+            )
 
         try:
             await adapter.leave_voice_channel(guild_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3528,9 +3528,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     _VOICE_MODE_PATH = _hermes_home / "gateway_voice_mode.json"
 
-    def _voice_key(self, platform: Platform, chat_id: str) -> str:
-        """Return a platform-namespaced key for voice mode state."""
-        return f"{platform.value}:{chat_id}"
+    def _voice_key(self, platform: Platform, chat_id: str, profile: Optional[str] = None) -> str:
+        """Return a platform- (and profile-) namespaced key for voice mode state.
+
+        The active/default profile keeps the legacy ``platform:chat_id`` form so
+        existing persisted state is preserved. A secondary (multiplexed) profile
+        is namespaced as ``profile:<name>:platform:chat_id`` so two adapters for
+        the same platform in different profiles never share or overwrite each
+        other's voice-mode state.
+        """
+        name = (str(profile).strip() if profile else "") or None
+        base = f"{platform.value}:{chat_id}"
+        if name and name != "default":
+            return f"profile:{name}:{base}"
+        return base
 
     def _load_voice_modes(self) -> Dict[str, str]:
         try:
@@ -14416,16 +14427,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "You need to be in a voice channel first."
 
         # Wire callbacks BEFORE join so voice input arriving immediately
-        # after connection is not lost.
+        # after connection is not lost. Bind the OWNING adapter and profile into
+        # each callback so a secondary-profile adapter's voice input, timeout
+        # cleanup, and mode lookups act on ITS session — never the default
+        # profile's adapter or voice-mode namespace.
+        owner_profile = getattr(event.source, "profile", None)
         if hasattr(adapter, "_voice_input_callback"):
-            adapter._voice_input_callback = self._handle_voice_channel_input
+            adapter._voice_input_callback = (
+                lambda guild_id, user_id, transcript, _a=adapter, _p=owner_profile:
+                self._handle_voice_channel_input(
+                    guild_id, user_id, transcript, adapter=_a, profile=_p
+                )
+            )
         if hasattr(adapter, "_on_voice_disconnect"):
-            adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+            adapter._on_voice_disconnect = (
+                lambda chat_id, _a=adapter, _p=owner_profile:
+                self._handle_voice_timeout_cleanup(chat_id, adapter=_a, profile=_p)
+            )
         # Let the adapter's inactivity timer see the live voice-reply mode so it
         # doesn't disconnect a deliberately text-only (/voice off) session.
         if hasattr(adapter, "_voice_mode_getter"):
-            adapter._voice_mode_getter = lambda chat_id: self._voice_mode.get(
-                self._voice_key(Platform.DISCORD, str(chat_id)), "off"
+            adapter._voice_mode_getter = (
+                lambda chat_id, _p=owner_profile: self._voice_mode.get(
+                    self._voice_key(Platform.DISCORD, str(chat_id), profile=_p), "off"
+                )
             )
 
         try:
@@ -14445,7 +14470,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
             if hasattr(adapter, "_voice_sources"):
                 adapter._voice_sources[guild_id] = event.source.to_dict()
-            self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
+            self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id, profile=owner_profile)] = "all"
             self._save_voice_modes()
             self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
             return (
@@ -14514,21 +14539,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Error leaving voice channel: %s", e)
         # Always clean up state even if leave raised an exception
-        self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "off"
+        self._voice_mode[
+            self._voice_key(
+                event.source.platform,
+                event.source.chat_id,
+                profile=getattr(event.source, "profile", None),
+            )
+        ] = "off"
         self._save_voice_modes()
         self._set_adapter_auto_tts_disabled(adapter, event.source.chat_id, disabled=True)
         if hasattr(adapter, "_voice_input_callback"):
             adapter._voice_input_callback = None
         return "Left voice channel."
 
-    def _handle_voice_timeout_cleanup(self, chat_id: str) -> None:
+    def _handle_voice_timeout_cleanup(self, chat_id: str, *, adapter=None, profile=None) -> None:
         """Called by the adapter when a voice channel times out.
 
         Cleans up runner-side voice_mode state that the adapter cannot reach.
+        ``adapter``/``profile`` identify the OWNING adapter so a secondary
+        profile's timeout never clears the default adapter's auto-TTS state or
+        the wrong voice-mode namespace.
         """
-        self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "off"
+        self._voice_mode[self._voice_key(Platform.DISCORD, chat_id, profile=profile)] = "off"
         self._save_voice_modes()
-        adapter = self.adapters.get(Platform.DISCORD)
+        if adapter is None:
+            adapter = self._authorization_adapter(Platform.DISCORD, profile)
         self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
 
     def _is_duplicate_voice_transcript(self, guild_id: int, user_id: int, transcript: str) -> bool:
@@ -14573,14 +14608,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return False
 
     async def _handle_voice_channel_input(
-        self, guild_id: int, user_id: int, transcript: str
+        self, guild_id: int, user_id: int, transcript: str, *, adapter=None, profile=None
     ):
         """Handle transcribed voice from a user in a voice channel.
 
         Creates a synthetic MessageEvent and processes it through the
         adapter's full message pipeline (session, typing, agent, TTS reply).
+        ``adapter``/``profile`` identify the OWNING adapter so voice input on a
+        secondary profile is processed by ITS adapter and session, never the
+        default profile's.
         """
-        adapter = self.adapters.get(Platform.DISCORD)
+        if adapter is None:
+            adapter = self._authorization_adapter(Platform.DISCORD, profile) or self.adapters.get(Platform.DISCORD)
         if not adapter:
             return
 
@@ -14603,6 +14642,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_name=str(user_id),
                 chat_type="channel",
             )
+        # Namespace the synthetic voice turn to the owning profile so the session
+        # store, authorization, and reply routing resolve the right adapter.
+        if getattr(source, "profile", None) is None and profile:
+            source.profile = profile
 
         # Check authorization before processing voice input
         if not self._is_user_authorized(source):
@@ -14662,7 +14705,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         chat_id = event.source.chat_id
-        voice_mode = self._voice_mode.get(self._voice_key(event.source.platform, chat_id), "off")
+        voice_mode = self._voice_mode.get(
+            self._voice_key(
+                event.source.platform,
+                chat_id,
+                profile=getattr(event.source, "profile", None),
+            ),
+            "off",
+        )
         is_voice_input = (event.message_type == MessageType.VOICE)
 
         should = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14528,10 +14528,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             #
             # Decide how to invoke join_voice_channel by INSPECTING ITS SIGNATURE
             # BEFORE the call — never by parsing a TypeError message and never by
-            # retrying a modern call tokenless (dropping attempt_token/manual_owner
-            # would bypass the ownership gate and let a stale attempt mutate a live
-            # session). An internal TypeError from a modern adapter therefore
-            # surfaces as a single failed call (handled by the outer except).
+            # retrying tokenless. The ownership gate lives in these kwargs, so a
+            # callable that does not accept BOTH manual_owner and attempt_token is
+            # FAILED CLOSED (a tokenless call would bypass the gate and let a stale
+            # attempt mutate a live session). An internal TypeError from a
+            # gate-aware adapter surfaces as a single failed call (outer except).
             _supports_gate_kwargs = True
             try:
                 _params = inspect.signature(adapter.join_voice_channel).parameters
@@ -14544,13 +14545,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except (TypeError, ValueError):
                 # Not introspectable (e.g. a builtin) — assume the modern contract.
                 _supports_gate_kwargs = True
-            if _supports_gate_kwargs:
-                success = await adapter.join_voice_channel(
-                    voice_channel, manual_owner=bool(manual), attempt_token=attempt_token
+            if not _supports_gate_kwargs:
+                # Fail closed — do NOT invoke a legacy tokenless branch.
+                logger.warning(
+                    "join_voice_channel lacks the ownership-gate kwargs "
+                    "(manual_owner/attempt_token); refusing to join to avoid "
+                    "bypassing the ownership gate"
                 )
-            else:
-                # Genuinely legacy adapter without the gate kwargs — single call.
-                success = await adapter.join_voice_channel(voice_channel)
+                _restore_prior_wiring()
+                return "Failed to join voice channel: voice ownership gate unavailable."
+            success = await adapter.join_voice_channel(
+                voice_channel, manual_owner=bool(manual), attempt_token=attempt_token
+            )
         except Exception as e:
             logger.warning("Failed to join voice channel: %s", e)
             _restore_prior_wiring()

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2572,9 +2572,13 @@ class GatewaySlashCommandsMixin:
         args = event.get_command_args().strip().lower()
         chat_id = event.source.chat_id
         platform = event.source.platform
-        voice_key = self._voice_key(platform, chat_id)
+        profile = getattr(event.source, "profile", None)
+        # Namespace voice mode by owning profile and resolve the profile's own
+        # adapter, so a secondary-profile /voice command never reads/writes the
+        # default profile's voice-mode state or toggles the default adapter.
+        voice_key = self._voice_key(platform, chat_id, profile=profile)
 
-        adapter = self.adapters.get(platform)
+        adapter = self._adapter_for_source(event.source)
 
         if args in {"on", "enable"}:
             self._voice_mode[voice_key] = "voice_only"
@@ -2606,7 +2610,7 @@ class GatewaySlashCommandsMixin:
                 "all": t("gateway.voice.label_all"),
             }
             # Append voice channel info if connected
-            adapter = self.adapters.get(event.source.platform)
+            adapter = self._adapter_for_source(event.source)
             guild_id = self._get_guild_id(event)
             if guild_id and hasattr(adapter, "get_voice_channel_info"):
                 info = adapter.get_voice_channel_info(guild_id)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2582,6 +2582,21 @@ DEFAULT_CONFIG = {
         # override: DISCORD_APPROVAL_MENTIONS. Default false avoids surprise
         # pings.
         "approval_mentions": False,
+        # Voice auto-join/follow mode. OFF by default and requires explicit
+        # allowed user IDs, allowed voice-channel IDs, and a linked text
+        # channel ID. No live Discord IDs are inferred.
+        "voice_auto_join": {
+            "enabled": False,
+            "allowed_user_ids": [],
+            "allowed_voice_channel_ids": [],
+            "text_channel_id": "",
+            "idle_timeout_seconds": 300,
+            "target_leave_cleanup": True,
+            "stay_while_target_present": False,
+            "manual_leave_cooldown_seconds": 300,
+            "reconnect_cooldown_seconds": 15,
+            "failure_backoff_seconds": 60,
+        },
         # Voice-channel audio effects (the continuous mixer). OFF by default.
         # When enabled, the bot installs a software mixer on the outgoing voice
         # stream so a low ambient "thinking" bed, verbal acknowledgements, and

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -945,8 +945,14 @@ class DiscordAdapter(BasePlatformAdapter):
         # In-flight join attempts keyed by guild → {user_id, voice_channel_id,
         # cancelled}. Recorded BEFORE the network join so a target-leave event
         # racing the join can cancel it, and the post-join barrier can refuse a
-        # session the target already left.
+        # session the target already left. Each entry carries a unique
+        # generation token so an overlapping later attempt supersedes (and
+        # cannot be committed by) an earlier one.
         self._voice_auto_join_pending: Dict[int, Dict[str, Any]] = {}
+        self._voice_auto_join_gen: int = 0
+        # Direct (non-retry) in-flight barrier tasks, tracked so disconnect can
+        # cancel + await them before resources are torn down.
+        self._voice_auto_join_direct_tasks: set = set()
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -4037,21 +4043,48 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _register_pending_auto_join(
         self, guild_id: int, user_id: str, voice_channel_id: str
-    ) -> None:
-        """Record an in-flight auto-join attempt so a racing leave can cancel it."""
+    ) -> int:
+        """Record an in-flight auto-join attempt so a racing leave can cancel it.
+
+        Returns a unique generation token. Only the attempt whose token still
+        matches the current pending entry may commit — an overlapping later
+        attempt supersedes an earlier one.
+        """
         pending = getattr(self, "_voice_auto_join_pending", None)
         if not isinstance(pending, dict):
             pending = {}
             self._voice_auto_join_pending = pending
+        self._voice_auto_join_gen = int(getattr(self, "_voice_auto_join_gen", 0)) + 1
+        token = self._voice_auto_join_gen
         pending[int(guild_id)] = {
             "user_id": str(user_id),
             "voice_channel_id": str(voice_channel_id),
             "cancelled": False,
+            "token": token,
         }
+        return token
 
-    def _clear_pending_auto_join(self, guild_id: int) -> None:
+    def _current_pending_auto_join(self, guild_id: int, token: int):
+        """Return the pending entry iff it is still this attempt's (token match)."""
         pending = getattr(self, "_voice_auto_join_pending", None)
-        if isinstance(pending, dict):
+        if not isinstance(pending, dict):
+            return None
+        entry = pending.get(int(guild_id))
+        if entry is not None and entry.get("token") == token:
+            return entry
+        return None
+
+    def _clear_pending_auto_join(self, guild_id: int, token: Optional[int] = None) -> None:
+        """Drop the pending entry. With ``token`` set, only if it still matches
+        (so a superseding later attempt's entry is never clobbered)."""
+        pending = getattr(self, "_voice_auto_join_pending", None)
+        if not isinstance(pending, dict):
+            return
+        if token is None:
+            pending.pop(int(guild_id), None)
+            return
+        entry = pending.get(int(guild_id))
+        if entry is not None and entry.get("token") == token:
             pending.pop(int(guild_id), None)
 
     def _cancel_pending_auto_join_if_matches(
@@ -4106,7 +4139,11 @@ class DiscordAdapter(BasePlatformAdapter):
         callback = getattr(self, "_voice_auto_join_callback", None)
         if callback is None:
             return False
-        self._register_pending_auto_join(guild_id, user_id, voice_channel_id)
+        # Reject while disconnecting — an adapter being torn down must not
+        # establish a new voice session.
+        if getattr(self, "_disconnecting", False):
+            return False
+        token = self._register_pending_auto_join(guild_id, user_id, voice_channel_id)
         success = False
         try:
             success = bool(await callback(
@@ -4116,36 +4153,54 @@ class DiscordAdapter(BasePlatformAdapter):
                 text_channel_id=str(text_channel_id),
             ))
         except asyncio.CancelledError:
-            self._clear_pending_auto_join(guild_id)
+            self._clear_pending_auto_join(guild_id, token)
             raise
         except Exception as exc:
             logger.warning("Discord voice auto-join failed: %s", exc, exc_info=True)
             success = False
 
         if not success:
-            self._clear_pending_auto_join(guild_id)
+            self._clear_pending_auto_join(guild_id, token)
             return False
 
-        pending = getattr(self, "_voice_auto_join_pending", {}) or {}
-        entry = pending.get(int(guild_id)) or {}
-        cancelled = bool(entry.get("cancelled"))
+        # The exact pending entry for THIS attempt must still be current: a
+        # superseding later attempt (or a cancellation) invalidates this one.
+        entry = self._current_pending_auto_join(guild_id, token)
+        superseded = entry is None
+        cancelled = superseded or bool(entry.get("cancelled"))
+        disconnecting = bool(getattr(self, "_disconnecting", False))
         actual_channel = self.connected_voice_channel_id(guild_id)
         target_present = await self._voice_target_in_channel(
             guild_id, user_id, voice_channel_id
         )
-        self._clear_pending_auto_join(guild_id)
+        self._clear_pending_auto_join(guild_id, token)
 
-        if cancelled or actual_channel != str(voice_channel_id) or not target_present:
+        if (
+            cancelled
+            or disconnecting
+            or actual_channel != str(voice_channel_id)
+            or not target_present
+        ):
             logger.info(
-                "Discord voice auto-join aborted post-join (guild %s): cancelled=%s "
-                "actual=%s expected=%s target_present=%s",
-                guild_id, cancelled, actual_channel, voice_channel_id, target_present,
+                "Discord voice auto-join aborted post-join (guild %s): superseded=%s "
+                "cancelled=%s disconnecting=%s actual=%s expected=%s target_present=%s",
+                guild_id, superseded, cancelled, disconnecting,
+                actual_channel, voice_channel_id, target_present,
             )
             self._voice_auto_join_targets.pop(int(guild_id), None)
             try:
                 await self.leave_voice_channel(int(guild_id))
             except Exception:
                 pass
+            # Roll back the runner-side join side effects (voice mode / auto-TTS)
+            # via the profile-bound cleanup so an aborted join leaves no stale
+            # "voice on" state behind.
+            on_disconnect = getattr(self, "_on_voice_disconnect", None)
+            if on_disconnect and text_channel_id:
+                try:
+                    on_disconnect(str(text_channel_id))
+                except Exception:
+                    pass
             return False
         return True
 
@@ -4159,6 +4214,11 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         tasks = list(getattr(self, "_voice_auto_join_retry_tasks", {}).values())
         self._voice_auto_join_retry_tasks = {}
+        # Also cancel any DIRECT (non-retry) in-flight barrier attempts so an
+        # attempt awaiting a network join cannot commit after teardown.
+        direct = getattr(self, "_voice_auto_join_direct_tasks", None)
+        if isinstance(direct, set):
+            tasks.extend(list(direct))
         for task in tasks:
             task.cancel()
         for task in tasks:
@@ -4168,16 +4228,28 @@ class DiscordAdapter(BasePlatformAdapter):
                 pass
             except Exception:
                 logger.debug(
-                    "[%s] auto-join retry task raised during teardown",
+                    "[%s] auto-join in-flight task raised during teardown",
                     getattr(self, "name", "discord"),
                     exc_info=True,
                 )
+        self._voice_auto_join_direct_tasks = set()
         self._voice_auto_join_targets = {}
         self._voice_auto_join_pending = {}
         self._voice_auto_join_callback = None
         self._voice_input_callback = None
         self._on_voice_disconnect = None
         self._voice_mode_getter = None
+
+    def clear_voice_auto_join_ownership(self, guild_id: int) -> None:
+        """Drop all auto-follow ownership for a guild (target, pending, retry).
+
+        Called on a MANUAL /voice takeover (leave or join) so a later target
+        leave/rejoin can never disconnect or hijack the hand-established
+        session. Suppression is deliberately left intact.
+        """
+        self._voice_auto_join_targets.pop(int(guild_id), None)
+        self._clear_pending_auto_join(int(guild_id))
+        self._cancel_voice_auto_join_retry(int(guild_id))
 
     async def _voice_auto_join_retry_still_valid(
         self,
@@ -4391,10 +4463,23 @@ class DiscordAdapter(BasePlatformAdapter):
 
         if getattr(self, "_voice_auto_join_callback", None) is None:
             return False
+        if getattr(self, "_disconnecting", False):
+            return False
 
-        success = await self._run_auto_join_with_barrier(
-            guild_id, user_id, voice_channel_id, text_channel_id
+        # Run the barrier as a TRACKED task so disconnect teardown can cancel +
+        # await this direct in-flight attempt before resources are torn down.
+        task = asyncio.ensure_future(
+            self._run_auto_join_with_barrier(
+                guild_id, user_id, voice_channel_id, text_channel_id
+            )
         )
+        direct = self._voice_auto_join_direct_tasks
+        direct.add(task)
+        task.add_done_callback(lambda t: direct.discard(t))
+        try:
+            success = await task
+        except asyncio.CancelledError:
+            return False
 
         if success:
             # The join callback records the target against the ACTUAL connected
@@ -4449,11 +4534,17 @@ class DiscordAdapter(BasePlatformAdapter):
         if after_channel is not None and str(getattr(after_channel, "id", "")) == before_channel_id:
             return
 
+        target_channel_id = str(target.voice_channel_id)
         self._voice_auto_join_targets.pop(int(guild_id), None)
         # Target left the followed channel — cancel any pending rejoin retry.
         self._cancel_voice_auto_join_retry(int(guild_id))
         cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
         if not cfg.get("target_leave_cleanup", True):
+            return
+        # Only disconnect if the bot is STILL in the exact channel it was
+        # following. A manual /voice takeover may have moved the session to a
+        # different channel; never disconnect that hand-established session.
+        if self.connected_voice_channel_id(int(guild_id)) != target_channel_id:
             return
         text_ch_id = self._voice_text_channels.get(int(guild_id))
         await self.leave_voice_channel(int(guild_id))

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -25,6 +25,7 @@ import threading
 import time
 from collections import defaultdict
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Any, Tuple
 
 from agent.async_utils import (
@@ -298,6 +299,24 @@ def _clean_discord_id(entry: str) -> str:
     if entry.lower().startswith("user:"):
         entry = entry[5:]
     return entry.strip()
+
+
+@dataclass
+class VoiceAutoJoinTarget:
+    """The user/channel a guild is currently auto-following.
+
+    Carries the owning ``profile`` so a multiplexed gateway (one process, one
+    Discord adapter per profile) can prove which profile established the
+    follow. Only auto-join creates one of these — a manually established voice
+    connection has no target and is therefore never torn down by auto-follow
+    cleanup.
+    """
+
+    guild_id: int
+    user_id: str
+    voice_channel_id: str
+    text_channel_id: str
+    profile: Optional[str] = None
 
 
 def _clean_discord_channel_id(entry: str) -> str:
@@ -913,9 +932,12 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_auto_join_callback: Optional[Callable] = None  # set by run.py
         self._voice_auto_join_cfg: Dict[str, Any] = self._load_voice_auto_join_config()
         self._voice_timeout_seconds: float = self._voice_auto_join_cfg["idle_timeout_seconds"]
-        self._voice_auto_join_targets: Dict[int, Dict[str, str]] = {}
+        self._voice_auto_join_targets: Dict[int, VoiceAutoJoinTarget] = {}
         self._voice_auto_join_suppressed_until: Dict[Tuple[int, str, str], float] = {}
         self._voice_auto_join_next_attempt_at: Dict[Tuple[int, str], float] = {}
+        # One cancellable retry task per guild, scheduled after a failed
+        # auto-join so a reconnect does not require a second voice-state event.
+        self._voice_auto_join_retry_tasks: Dict[int, asyncio.Task] = {}
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -3840,10 +3862,19 @@ class DiscordAdapter(BasePlatformAdapter):
         channel_id: Optional[str] = None,
         seconds: Optional[float] = None,
     ) -> None:
-        """Suppress auto-rejoin after an intentional manual /voice leave."""
+        """Suppress auto-rejoin after an intentional manual /voice leave.
+
+        The suppression is keyed to the tracked target (guild, user, channel)
+        and retained until its monotonic deadline expires — it is NOT cleared
+        when the user later leaves and rejoins the channel, so a manual leave
+        cannot be defeated by immediately hopping back in.
+        """
         cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
         cooldown = cfg.get("manual_leave_cooldown_seconds", 300.0) if seconds is None else seconds
         cooldown = _discord_config_float(cooldown, 300.0, minimum=0.0)
+        # A manual leave always cancels any pending auto-rejoin retry, even when
+        # the cooldown itself is disabled.
+        self._cancel_voice_auto_join_retry(guild_id)
         if cooldown <= 0:
             return
 
@@ -3854,10 +3885,20 @@ class DiscordAdapter(BasePlatformAdapter):
             current_channel_id = getattr(current_channel, "id", None)
             if current_channel_id is not None:
                 channel_ids.add(str(current_channel_id))
+        # Fall back to the tracked target's channel so suppression stays keyed
+        # to the followed target even if the live connection is already gone.
+        if not channel_ids:
+            target = self._voice_auto_join_targets.get(int(guild_id))
+            if target is not None:
+                channel_ids.add(str(target.voice_channel_id))
         if not channel_ids:
             return
 
         user_ids = {str(user_id)} if user_id is not None else set()
+        if not user_ids:
+            target = self._voice_auto_join_targets.get(int(guild_id))
+            if target is not None:
+                user_ids.add(str(target.user_id))
         if not user_ids:
             user_ids.update(cfg.get("allowed_user_ids") or set())
         if not user_ids:
@@ -3880,12 +3921,6 @@ class DiscordAdapter(BasePlatformAdapter):
             return False
         return True
 
-    def _clear_voice_auto_join_suppression(self, guild_id: int, user_id: str, channel_id: str) -> None:
-        self._voice_auto_join_suppressed_until.pop(
-            (int(guild_id), str(user_id), str(channel_id)),
-            None,
-        )
-
     def mark_voice_auto_join_target(
         self,
         guild_id: int,
@@ -3893,13 +3928,16 @@ class DiscordAdapter(BasePlatformAdapter):
         user_id: str,
         voice_channel_id: str,
         text_channel_id: str,
+        profile: Optional[str] = None,
     ) -> None:
         """Record which configured user/channel this guild is following."""
-        self._voice_auto_join_targets[int(guild_id)] = {
-            "user_id": str(user_id),
-            "voice_channel_id": str(voice_channel_id),
-            "text_channel_id": str(text_channel_id),
-        }
+        self._voice_auto_join_targets[int(guild_id)] = VoiceAutoJoinTarget(
+            guild_id=int(guild_id),
+            user_id=str(user_id),
+            voice_channel_id=str(voice_channel_id),
+            text_channel_id=str(text_channel_id),
+            profile=(str(profile) if profile else None),
+        )
 
     def _voice_auto_join_target_present(self, guild_id: int) -> bool:
         target = self._voice_auto_join_targets.get(int(guild_id))
@@ -3909,12 +3947,158 @@ class DiscordAdapter(BasePlatformAdapter):
         channel = getattr(vc, "channel", None)
         if channel is None:
             return False
-        if str(getattr(channel, "id", "")) != str(target.get("voice_channel_id")):
+        if str(getattr(channel, "id", "")) != str(target.voice_channel_id):
             return False
         for member in getattr(channel, "members", []) or []:
-            if str(getattr(member, "id", "")) == str(target.get("user_id")):
+            if str(getattr(member, "id", "")) == str(target.user_id):
                 return True
         return False
+
+    def connected_voice_channel_id(self, guild_id: int) -> Optional[str]:
+        """Return the id of the voice channel the bot is actually connected to."""
+        vc = self._voice_clients.get(int(guild_id))
+        if vc is None or not getattr(vc, "is_connected", lambda: False)():
+            return None
+        channel = getattr(vc, "channel", None)
+        channel_id = getattr(channel, "id", None)
+        return str(channel_id) if channel_id is not None else None
+
+    def _schedule_voice_auto_join_retry(
+        self,
+        guild_id: int,
+        user_id: str,
+        voice_channel_id: str,
+        text_channel_id: str,
+        backoff: float,
+    ) -> None:
+        """Schedule (or replace) the single retry task for this guild."""
+        # A newer attempt/target supersedes any in-flight retry.
+        self._cancel_voice_auto_join_retry(guild_id)
+        if backoff is None or float(backoff) <= 0:
+            # No backoff configured → no unattended retry; the next voice-state
+            # event drives any further attempt.
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        gid = int(guild_id)
+        task = asyncio.ensure_future(
+            self._voice_auto_join_retry_loop(
+                gid, str(user_id), str(voice_channel_id), str(text_channel_id), float(backoff)
+            )
+        )
+        self._voice_auto_join_retry_tasks[gid] = task
+
+        def _cleanup(finished: asyncio.Task, _gid: int = gid) -> None:
+            if self._voice_auto_join_retry_tasks.get(_gid) is finished:
+                self._voice_auto_join_retry_tasks.pop(_gid, None)
+
+        task.add_done_callback(_cleanup)
+
+    def _cancel_voice_auto_join_retry(self, guild_id: int) -> None:
+        """Cancel the pending auto-join retry task for this guild, if any."""
+        tasks = getattr(self, "_voice_auto_join_retry_tasks", None)
+        if not isinstance(tasks, dict):
+            return
+        task = tasks.pop(int(guild_id), None)
+        if task is not None:
+            task.cancel()
+
+    async def _voice_auto_join_retry_still_valid(
+        self,
+        guild_id: int,
+        user_id: str,
+        voice_channel_id: str,
+    ) -> bool:
+        """Post-backoff revalidation before a retry attempt actually joins."""
+        cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+        if not cfg.get("enabled", False):
+            return False
+        allowed_users = cfg.get("allowed_user_ids") or set()
+        allowed_channels = cfg.get("allowed_voice_channel_ids") or set()
+        if str(user_id) not in allowed_users:
+            return False
+        if str(voice_channel_id) not in allowed_channels:
+            return False
+        if not cfg.get("text_channel_id"):
+            return False
+        if self._is_voice_auto_join_suppressed(guild_id, user_id, voice_channel_id):
+            return False
+        # Already connected to the target channel → nothing to retry.
+        if self.connected_voice_channel_id(guild_id) == str(voice_channel_id):
+            return False
+        # The target user must currently be in the target voice channel.
+        try:
+            current = await self.get_user_voice_channel(int(guild_id), str(user_id))
+        except Exception:
+            current = None
+        if str(getattr(current, "id", "")) != str(voice_channel_id):
+            return False
+        return True
+
+    async def _voice_auto_join_retry_loop(
+        self,
+        guild_id: int,
+        user_id: str,
+        voice_channel_id: str,
+        text_channel_id: str,
+        backoff: float,
+    ) -> None:
+        """Retry a failed auto-join without waiting for a second voice event.
+
+        Backoff is measured from the completion of the previous failed attempt.
+        Cancelled on target leave, manual leave, disconnect, or replacement.
+        """
+        try:
+            while True:
+                try:
+                    await asyncio.sleep(max(0.0, float(backoff)))
+                except asyncio.CancelledError:
+                    return
+                if not await self._voice_auto_join_retry_still_valid(
+                    guild_id, user_id, voice_channel_id
+                ):
+                    return
+                callback = getattr(self, "_voice_auto_join_callback", None)
+                if callback is None:
+                    return
+                success = False
+                try:
+                    success = bool(await callback(
+                        guild_id=int(guild_id),
+                        user_id=str(user_id),
+                        voice_channel_id=str(voice_channel_id),
+                        text_channel_id=str(text_channel_id),
+                    ))
+                except asyncio.CancelledError:
+                    return
+                except Exception as exc:
+                    logger.warning(
+                        "Discord voice auto-join retry failed: %s", exc, exc_info=True
+                    )
+                now = time.monotonic()
+                if success:
+                    if int(guild_id) not in self._voice_auto_join_targets:
+                        self.mark_voice_auto_join_target(
+                            guild_id,
+                            user_id=user_id,
+                            voice_channel_id=voice_channel_id,
+                            text_channel_id=text_channel_id,
+                        )
+                    self._voice_auto_join_next_attempt_at[
+                        (int(guild_id), str(voice_channel_id))
+                    ] = now
+                    return
+                cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+                backoff = float(cfg.get("failure_backoff_seconds", 60.0) or 0.0)
+                self._voice_auto_join_next_attempt_at[
+                    (int(guild_id), str(voice_channel_id))
+                ] = now + backoff
+                if backoff <= 0:
+                    return
+        except asyncio.CancelledError:
+            return
 
     async def _handle_voice_state_update(self, member, before, after) -> None:
         """Handle Discord voice-state changes for logging and auto-follow."""
@@ -3986,12 +4170,19 @@ class DiscordAdapter(BasePlatformAdapter):
 
         existing = self._voice_clients.get(guild_id)
         if existing and existing.is_connected() and str(getattr(existing.channel, "id", "")) == voice_channel_id:
-            self.mark_voice_auto_join_target(
-                guild_id,
-                user_id=user_id,
-                voice_channel_id=voice_channel_id,
-                text_channel_id=str(text_channel_id),
-            )
+            # Already connected to the target channel. Refresh an EXISTING
+            # auto-join target only — never adopt a manual connection into
+            # auto-follow, or target-leave cleanup would tear down a session the
+            # user established by hand.
+            current_target = self._voice_auto_join_targets.get(guild_id)
+            if current_target is not None:
+                self.mark_voice_auto_join_target(
+                    guild_id,
+                    user_id=user_id,
+                    voice_channel_id=voice_channel_id,
+                    text_channel_id=str(text_channel_id),
+                    profile=current_target.profile,
+                )
             return
 
         if self._is_voice_auto_join_suppressed(guild_id, user_id, voice_channel_id):
@@ -4001,37 +4192,66 @@ class DiscordAdapter(BasePlatformAdapter):
         now = time.monotonic()
         next_allowed = self._voice_auto_join_next_attempt_at.get(attempt_key, 0.0)
         if now < next_allowed:
+            # A retry task (if any) remains the live path back into the channel;
+            # replacement is handled when an attempt actually reschedules it.
             return
 
+        await self._attempt_voice_auto_join(
+            guild_id, user_id, voice_channel_id, str(text_channel_id)
+        )
+
+    async def _attempt_voice_auto_join(
+        self,
+        guild_id: int,
+        user_id: str,
+        voice_channel_id: str,
+        text_channel_id: str,
+    ) -> bool:
+        """Invoke the join callback once; schedule a retry on failure."""
+        cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+        attempt_key = (int(guild_id), str(voice_channel_id))
+        now = time.monotonic()
         cooldown = float(cfg.get("reconnect_cooldown_seconds", 15.0) or 0.0)
         self._voice_auto_join_next_attempt_at[attempt_key] = now + cooldown
 
         callback = getattr(self, "_voice_auto_join_callback", None)
         if callback is None:
-            return
+            return False
 
         success = False
         try:
             success = bool(await callback(
-                guild_id=guild_id,
-                user_id=user_id,
-                voice_channel_id=voice_channel_id,
+                guild_id=int(guild_id),
+                user_id=str(user_id),
+                voice_channel_id=str(voice_channel_id),
                 text_channel_id=str(text_channel_id),
             ))
         except Exception as exc:
             logger.warning("Discord voice auto-join failed: %s", exc, exc_info=True)
 
         if success:
-            self.mark_voice_auto_join_target(
-                guild_id,
-                user_id=user_id,
-                voice_channel_id=voice_channel_id,
-                text_channel_id=str(text_channel_id),
-            )
-            return
+            # The join callback records the target against the ACTUAL connected
+            # channel (and owning profile). Only synthesize one here if it did
+            # not, so we never overwrite the verified target with the event's
+            # (possibly stale) channel id.
+            if int(guild_id) not in self._voice_auto_join_targets:
+                self.mark_voice_auto_join_target(
+                    guild_id,
+                    user_id=user_id,
+                    voice_channel_id=voice_channel_id,
+                    text_channel_id=text_channel_id,
+                )
+            self._cancel_voice_auto_join_retry(guild_id)
+            return True
 
+        # Failure: measure backoff from failure completion and schedule the one
+        # retry task for this guild so a reconnect needs no second event.
         backoff = float(cfg.get("failure_backoff_seconds", 60.0) or 0.0)
-        self._voice_auto_join_next_attempt_at[attempt_key] = now + max(cooldown, backoff)
+        self._voice_auto_join_next_attempt_at[attempt_key] = time.monotonic() + max(cooldown, backoff)
+        self._schedule_voice_auto_join_retry(
+            guild_id, user_id, voice_channel_id, text_channel_id, backoff
+        )
+        return False
 
     async def _maybe_cleanup_voice_auto_join_target(
         self,
@@ -4041,19 +4261,23 @@ class DiscordAdapter(BasePlatformAdapter):
         after_channel,
     ) -> None:
         before_channel_id = str(getattr(before_channel, "id", "") or "")
-        self._clear_voice_auto_join_suppression(guild_id, user_id, before_channel_id)
+        # NB: manual-leave suppression is deliberately NOT cleared here. It is
+        # keyed to the tracked target and must survive a target leave/rejoin
+        # until its monotonic deadline expires.
 
         target = self._voice_auto_join_targets.get(int(guild_id))
         if not target:
             return
-        if str(target.get("user_id")) != str(user_id):
+        if str(target.user_id) != str(user_id):
             return
-        if str(target.get("voice_channel_id")) != before_channel_id:
+        if str(target.voice_channel_id) != before_channel_id:
             return
         if after_channel is not None and str(getattr(after_channel, "id", "")) == before_channel_id:
             return
 
         self._voice_auto_join_targets.pop(int(guild_id), None)
+        # Target left the followed channel — cancel any pending rejoin retry.
+        self._cancel_voice_auto_join_retry(int(guild_id))
         cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
         if not cfg.get("target_leave_cleanup", True):
             return
@@ -4136,6 +4360,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 task.cancel()
             self._voice_text_channels.pop(guild_id, None)
             self._voice_sources.pop(guild_id, None)
+        # Disconnecting cancels any pending auto-rejoin retry for this guild.
+        self._cancel_voice_auto_join_retry(guild_id)
 
     # Maximum seconds to wait for voice playback before giving up
     PLAYBACK_TIMEOUT = 120
@@ -4263,6 +4489,13 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_join_cfg.get("stay_while_target_present")
             and self._voice_auto_join_target_present(guild_id)
         ):
+            # Stay while the followed target is still here, but REARM the timer.
+            # Otherwise the timer dies and, once the target later leaves (and
+            # target_leave_cleanup is False, so the leave event does not
+            # disconnect), nothing would ever tear the idle session down.
+            self._voice_timeout_tasks[guild_id] = asyncio.ensure_future(
+                self._voice_timeout_handler(guild_id)
+            )
             return
         await self.leave_voice_channel(guild_id)
         # Notify the runner so it can clean up voice_mode state

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -319,6 +319,57 @@ class VoiceAutoJoinTarget:
     profile: Optional[str] = None
 
 
+# Typed outcome of a single auto-join barrier attempt. The distinction matters
+# for retry decisioning: only a genuine FAILED attempt may schedule a retry — a
+# SUPERSEDED (a newer auto-join or manual takeover claimed the slot) or CANCELLED
+# (target leave / manual leave) attempt must NOT retry, because a retry could act
+# over a session it does not own.
+AUTO_JOIN_COMMITTED = "committed"
+AUTO_JOIN_FAILED = "failed"
+AUTO_JOIN_SUPERSEDED = "superseded"
+AUTO_JOIN_CANCELLED = "cancelled"
+
+# Sentinel owner stamped on a guild's physical voice session when it was
+# established by a MANUAL /voice-join. Attempt owners are ints (generation
+# tokens), so this string never collides with one. A stale auto-join barrier that
+# finds this owner leaves the hand-established session strictly intact.
+MANUAL_VOICE_SESSION_OWNER = "manual"
+
+
+@dataclass(frozen=True)
+class VoiceAutoJoinGuildState:
+    """Guild-scoped snapshot of an adapter's auto-join state.
+
+    Lets the gateway ask a single, guild-keyed question ("is anything in flight
+    or owned for THIS guild?") instead of reaching into adapter-private
+    collections — and, being guild-scoped, prevents one guild's in-flight attempt
+    from making an unrelated idle guild's ``/voice leave`` report success.
+    """
+
+    has_pending: bool
+    has_target: bool
+    has_retry: bool
+    has_direct: bool
+    pending_user_id: Optional[str] = None
+    pending_channel_id: Optional[str] = None
+    target_user_id: Optional[str] = None
+    target_channel_id: Optional[str] = None
+
+    @property
+    def inflight(self) -> bool:
+        return bool(self.has_pending or self.has_target or self.has_retry or self.has_direct)
+
+    @property
+    def suppression_user_id(self) -> Optional[str]:
+        """User to key a manual-leave suppression on: the committed target if
+        one exists, else the in-flight pending attempt's user."""
+        return self.target_user_id or self.pending_user_id
+
+    @property
+    def suppression_channel_id(self) -> Optional[str]:
+        return self.target_channel_id or self.pending_channel_id
+
+
 def _clean_discord_channel_id(entry: str) -> str:
     """Normalize a Discord channel/voice-channel ID pasted from config."""
     entry = str(entry or "").strip()
@@ -950,9 +1001,15 @@ class DiscordAdapter(BasePlatformAdapter):
         # cannot be committed by) an earlier one.
         self._voice_auto_join_pending: Dict[int, Dict[str, Any]] = {}
         self._voice_auto_join_gen: int = 0
-        # Direct (non-retry) in-flight barrier tasks, tracked so disconnect can
-        # cancel + await them before resources are torn down.
-        self._voice_auto_join_direct_tasks: set = set()
+        # Direct (non-retry) in-flight barrier tasks, keyed BY GUILD so disconnect
+        # can cancel + await them, and so a gateway state query for one guild never
+        # observes another guild's in-flight attempt.
+        self._voice_auto_join_direct_tasks: Dict[int, set] = {}
+        # Owner of each guild's live physical voice session: an int attempt token
+        # (a committed auto-join) or ``MANUAL_VOICE_SESSION_OWNER`` (a manual
+        # /voice-join). Absent when there is no session. Read/written only under
+        # the guild voice lock so ownership and physical teardown stay atomic.
+        self._voice_session_owner: Dict[int, Any] = {}
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -4041,6 +4098,17 @@ class DiscordAdapter(BasePlatformAdapter):
         if task is not None:
             task.cancel()
 
+    def _mint_voice_gen_token(self) -> int:
+        """Return a fresh, process-monotonic voice generation token.
+
+        Shared by auto-join attempts (pending/session ownership) and manual
+        session ownership so every owner value is globally unique — an int token
+        for an attempt, never colliding with another attempt or with the manual
+        sentinel.
+        """
+        self._voice_auto_join_gen = int(getattr(self, "_voice_auto_join_gen", 0)) + 1
+        return self._voice_auto_join_gen
+
     def _register_pending_auto_join(
         self, guild_id: int, user_id: str, voice_channel_id: str
     ) -> int:
@@ -4054,8 +4122,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not isinstance(pending, dict):
             pending = {}
             self._voice_auto_join_pending = pending
-        self._voice_auto_join_gen = int(getattr(self, "_voice_auto_join_gen", 0)) + 1
-        token = self._voice_auto_join_gen
+        token = self._mint_voice_gen_token()
         pending[int(guild_id)] = {
             "user_id": str(user_id),
             "voice_channel_id": str(voice_channel_id),
@@ -4126,25 +4193,30 @@ class DiscordAdapter(BasePlatformAdapter):
         user_id: str,
         voice_channel_id: str,
         text_channel_id: str,
-    ) -> bool:
+    ) -> str:
         """Invoke the join callback under a leave-race barrier.
 
-        Tracks the attempt as pending BEFORE the (awaited) network join so a
-        concurrent target-leave event can cancel it. After a reported success we
-        require that (a) the attempt was not cancelled mid-flight, (b) the ACTUAL
-        connected channel equals the validated channel, and (c) the target is
-        still present. If any fails the freshly established session is torn down
-        rather than left following a target that is already gone.
+        Returns a TYPED outcome — ``AUTO_JOIN_COMMITTED`` / ``AUTO_JOIN_FAILED`` /
+        ``AUTO_JOIN_SUPERSEDED`` / ``AUTO_JOIN_CANCELLED`` — so the caller can tell
+        a genuine failure (retryable) from a supersession or cancellation (which
+        must NOT retry).
+
+        The attempt is tracked as pending BEFORE the (awaited) network join so a
+        concurrent leave can cancel it. The commit/abort decision AND any physical
+        teardown happen together under the guild voice lock (see
+        ``_finalize_auto_join_under_lock``), so a manual or newer join that
+        completes while we wait for the lock is observed and left intact. A stale
+        attempt whose callback created an unowned session tears that ORPHAN down;
+        it never touches a session a different (newer/manual) owner holds.
         """
         callback = getattr(self, "_voice_auto_join_callback", None)
         if callback is None:
-            return False
+            return AUTO_JOIN_FAILED
         # Reject while disconnecting — an adapter being torn down must not
         # establish a new voice session.
         if getattr(self, "_disconnecting", False):
-            return False
+            return AUTO_JOIN_FAILED
         token = self._register_pending_auto_join(guild_id, user_id, voice_channel_id)
-        success = False
         try:
             success = bool(await callback(
                 guild_id=int(guild_id),
@@ -4153,109 +4225,156 @@ class DiscordAdapter(BasePlatformAdapter):
                 text_channel_id=str(text_channel_id),
             ))
         except asyncio.CancelledError:
-            # The callback may have already applied the join side effects — a
-            # live physical voice session PLUS runner-side voice-mode/auto-TTS —
-            # before the cancellation landed. Roll them back transactionally and
-            # profile-bound, but ONLY if THIS attempt still owns the session (a
-            # newer auto-join or manual takeover that superseded our pending slot
-            # must be left intact). Shield the async rollback so the very
-            # cancellation we are propagating cannot abort it mid-teardown.
-            rollback = asyncio.ensure_future(
-                self._rollback_owned_auto_join_session(
-                    guild_id, str(voice_channel_id), str(text_channel_id), token
-                )
-            )
-            while not rollback.done():
-                try:
-                    await asyncio.shield(rollback)
-                except asyncio.CancelledError:
-                    # Another cancellation targeted the shield; keep waiting for
-                    # the shielded rollback to finish, then re-raise below.
-                    continue
-            self._clear_pending_auto_join(guild_id, token)
+            # Cancellation can land at ANY await after the callback began. The
+            # callback may have already applied the join side effects (a live
+            # session + runner voice-mode/auto-TTS). Run the shielded, lock-scoped,
+            # profile-bound cleanup — for an OWNED/ORPHAN session only — then
+            # re-raise. A newer/manual owner's session is left intact.
+            await self._shielded_cancel_cleanup(guild_id, text_channel_id, token)
             raise
         except Exception as exc:
             logger.warning("Discord voice auto-join failed: %s", exc, exc_info=True)
             success = False
 
-        if not success:
-            self._clear_pending_auto_join(guild_id, token)
-            return False
-
-        # Ownership gate: only the attempt whose pending entry is STILL current
-        # owns the freshly (reportedly) established session. If the entry is gone
-        # the attempt was SUPERSEDED — a newer auto-join replaced the pending
-        # slot, or a manual /voice-join takeover cleared it — and that newer or
-        # hand-established session must NEVER be torn down here.
-        entry = self._current_pending_auto_join(guild_id, token)
-        if entry is None:
-            logger.info(
-                "Discord voice auto-join superseded post-join (guild %s); leaving "
-                "the current (newer/manual) owner's session intact", guild_id,
+        # Every await from here on — target validation AND the lock-scoped
+        # finalize/rollback itself — is guarded: a cancellation runs the shielded
+        # owned/orphan cleanup to completion (never touching a newer/manual owner)
+        # before propagating, so no half-torn-down or dangling state survives.
+        try:
+            if not success:
+                # A failed callback may still have (partially) connected; finalize
+                # under the lock so an orphan it created cannot linger, and
+                # classify the outcome (superseded/cancelled must not retry).
+                return await self._finalize_auto_join_under_lock(
+                    guild_id, voice_channel_id, text_channel_id, token,
+                    callback_success=False, target_present=False,
+                )
+            target_present = await self._voice_target_in_channel(
+                guild_id, user_id, voice_channel_id
             )
-            return False
-
-        cancelled = bool(entry.get("cancelled"))
-        disconnecting = bool(getattr(self, "_disconnecting", False))
-        actual_channel = self.connected_voice_channel_id(guild_id)
-        target_present = await self._voice_target_in_channel(
-            guild_id, user_id, voice_channel_id
-        )
-
-        if (
-            cancelled
-            or disconnecting
-            or actual_channel != str(voice_channel_id)
-            or not target_present
-        ):
-            logger.info(
-                "Discord voice auto-join aborted post-join (guild %s): cancelled=%s "
-                "disconnecting=%s actual=%s expected=%s target_present=%s",
-                guild_id, cancelled, disconnecting,
-                actual_channel, voice_channel_id, target_present,
+            return await self._finalize_auto_join_under_lock(
+                guild_id, voice_channel_id, text_channel_id, token,
+                callback_success=True, target_present=target_present,
             )
-            # This exact attempt still owns the pending slot, so the session (if
-            # any) is OURS to tear down — including the profile-bound runner
-            # rollback. A superseded attempt already returned above.
-            await self._rollback_owned_auto_join_session(
-                guild_id, str(voice_channel_id), str(text_channel_id), token
-            )
-            self._clear_pending_auto_join(guild_id, token)
-            return False
-        self._clear_pending_auto_join(guild_id, token)
-        return True
+        except asyncio.CancelledError:
+            await self._shielded_cancel_cleanup(guild_id, text_channel_id, token)
+            raise
 
-    async def _rollback_owned_auto_join_session(
+    async def _finalize_auto_join_under_lock(
         self,
         guild_id: int,
         voice_channel_id: str,
         text_channel_id: str,
         token: int,
-    ) -> None:
-        """Transactionally tear down an aborted auto-join's side effects.
+        *,
+        callback_success: bool,
+        target_present: bool,
+    ) -> str:
+        """Decide the attempt outcome and perform any physical teardown ATOMICALLY
+        under the guild voice lock.
 
-        Runs ONLY when THIS attempt still owns the pending slot (its ``token`` is
-        still current). A superseded attempt — a newer auto-join or a manual
-        takeover replaced/cleared the slot — returns without touching anything,
-        so we never disconnect a newer or hand-established session or roll back
-        its voice mode. The runner-side rollback is profile-bound: it routes
-        through the bound ``_on_voice_disconnect`` for THIS session's linked text
-        channel, so no other profile's voice-mode / auto-TTS state is affected.
+        Holding ``_voice_locks[guild_id]`` across BOTH the ownership recheck and
+        the disconnect closes the P1-B race: a manual/newer join that completes
+        while this attempt waited for the lock will already have stamped its
+        session ownership (and superseded our pending slot), so we observe it and
+        never disconnect it. Returns the typed outcome.
         """
-        if self._current_pending_auto_join(int(guild_id), token) is None:
-            # Superseded (or already cleared) between the abort decision and here.
+        lock = self._voice_locks.setdefault(int(guild_id), asyncio.Lock())
+        async with lock:
+            entry = self._current_pending_auto_join(int(guild_id), token)
+            superseded = entry is None
+            cancelled = (not superseded) and bool(entry.get("cancelled"))
+            disconnecting = bool(getattr(self, "_disconnecting", False))
+            actual_channel = self.connected_voice_channel_id(int(guild_id))
+            committed = bool(
+                callback_success
+                and not superseded
+                and not cancelled
+                and not disconnecting
+                and actual_channel == str(voice_channel_id)
+                and target_present
+            )
+            if committed:
+                # Stamp session ownership with THIS attempt's token so a later
+                # stale rollback recognizes the session is no longer its own.
+                self._voice_session_owner[int(guild_id)] = token
+                self._clear_pending_auto_join(int(guild_id), token)
+                return AUTO_JOIN_COMMITTED
+
+            if superseded:
+                outcome = AUTO_JOIN_SUPERSEDED
+            elif cancelled:
+                outcome = AUTO_JOIN_CANCELLED
+            else:
+                outcome = AUTO_JOIN_FAILED
+            await self._teardown_owned_or_orphan_locked(
+                guild_id, text_channel_id, token
+            )
+            self._clear_pending_auto_join(int(guild_id), token)
+            return outcome
+
+    async def _teardown_owned_or_orphan_locked(
+        self, guild_id: int, text_channel_id: str, token: int
+    ) -> None:
+        """Disconnect the guild's physical session ONLY if this attempt owns it or
+        it is an ORPHAN. Caller MUST hold ``_voice_locks[guild_id]``.
+
+        Ownership is decided from ``_voice_session_owner`` under the lock:
+          - a different owner (a newer committed attempt, or a manual takeover) →
+            leave the session strictly intact;
+          - our own token, or no owner at all (an orphan a stale/cancelled
+            callback created that nobody committed) → disconnect it and run the
+            profile-bound runner rollback, so no unowned VC is ever left behind
+            (this is the only cleanup when ``idle_timeout_seconds`` is 0 and the
+            inactivity timer never fires).
+        """
+        actual_channel = self.connected_voice_channel_id(int(guild_id))
+        if actual_channel is None:
             return
+        owner = self._voice_session_owner.get(int(guild_id))
+        if owner is not None and owner != token:
+            # A newer auto-join or manual session owns the live connection.
+            return
+        await self._leave_voice_channel_locked(int(guild_id))
         self._voice_auto_join_targets.pop(int(guild_id), None)
-        try:
-            await self.leave_voice_channel(int(guild_id))
-        except Exception:
-            pass
         on_disconnect = getattr(self, "_on_voice_disconnect", None)
         if on_disconnect and text_channel_id:
             try:
                 on_disconnect(str(text_channel_id))
             except Exception:
                 pass
+
+    async def _shielded_cancel_cleanup(
+        self, guild_id: int, text_channel_id: str, token: int
+    ) -> None:
+        """Run the lock-scoped owned/orphan teardown to completion even though the
+        current task is being cancelled, then clear our pending slot.
+
+        The teardown is shielded and awaited in a loop so a second cancellation
+        cannot abort it mid-flight — the profile-bound cleanup for an owned/orphan
+        session always finishes before the cancellation propagates, and a
+        newer/manual session is left intact.
+        """
+        cleanup = asyncio.ensure_future(
+            self._finalize_cancelled_under_lock(guild_id, text_channel_id, token)
+        )
+        while not cleanup.done():
+            try:
+                await asyncio.shield(cleanup)
+            except asyncio.CancelledError:
+                continue
+
+    async def _finalize_cancelled_under_lock(
+        self, guild_id: int, text_channel_id: str, token: int
+    ) -> None:
+        """Cancellation cleanup body: owned/orphan teardown + pending clear, all
+        under the guild voice lock so it is atomic with any concurrent join."""
+        lock = self._voice_locks.setdefault(int(guild_id), asyncio.Lock())
+        async with lock:
+            await self._teardown_owned_or_orphan_locked(
+                guild_id, text_channel_id, token
+            )
+            self._clear_pending_auto_join(int(guild_id), token)
 
     async def _teardown_voice_auto_join_state(self) -> None:
         """Cancel + await every retry task and clear auto-join state.
@@ -4267,11 +4386,13 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         tasks = list(getattr(self, "_voice_auto_join_retry_tasks", {}).values())
         self._voice_auto_join_retry_tasks = {}
-        # Also cancel any DIRECT (non-retry) in-flight barrier attempts so an
-        # attempt awaiting a network join cannot commit after teardown.
+        # Also cancel any DIRECT (non-retry) in-flight barrier attempts (keyed by
+        # guild) so an attempt awaiting a network join cannot commit after teardown.
         direct = getattr(self, "_voice_auto_join_direct_tasks", None)
-        if isinstance(direct, set):
-            tasks.extend(list(direct))
+        if isinstance(direct, dict):
+            for guild_tasks in list(direct.values()):
+                if isinstance(guild_tasks, set):
+                    tasks.extend(list(guild_tasks))
         for task in tasks:
             task.cancel()
         for task in tasks:
@@ -4285,9 +4406,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     getattr(self, "name", "discord"),
                     exc_info=True,
                 )
-        self._voice_auto_join_direct_tasks = set()
+        self._voice_auto_join_direct_tasks = {}
         self._voice_auto_join_targets = {}
         self._voice_auto_join_pending = {}
+        self._voice_session_owner = {}
         self._voice_auto_join_callback = None
         self._voice_input_callback = None
         self._on_voice_disconnect = None
@@ -4340,9 +4462,39 @@ class DiscordAdapter(BasePlatformAdapter):
             had = True
         self._cancel_voice_auto_join_retry(int(guild_id))
         direct = getattr(self, "_voice_auto_join_direct_tasks", None)
-        if isinstance(direct, set) and direct:
-            had = True
+        if isinstance(direct, dict):
+            guild_direct = direct.get(int(guild_id))
+            if isinstance(guild_direct, set) and guild_direct:
+                had = True
         return had
+
+    def voice_auto_join_state(self, guild_id: int) -> VoiceAutoJoinGuildState:
+        """Return a guild-scoped snapshot of auto-join state for the gateway.
+
+        The gateway must not reach into the adapter's private collections (they
+        may change shape). This exposes exactly what a manual ``/voice leave``
+        needs — is anything in flight or owned for THIS guild, and the in-flight
+        attempt's user/channel for suppression keying — WITHOUT leaking any other
+        guild's state.
+        """
+        gid = int(guild_id)
+        pending = getattr(self, "_voice_auto_join_pending", None)
+        entry = pending.get(gid) if isinstance(pending, dict) else None
+        targets = getattr(self, "_voice_auto_join_targets", None)
+        retry = getattr(self, "_voice_auto_join_retry_tasks", None)
+        direct = getattr(self, "_voice_auto_join_direct_tasks", None)
+        guild_direct = direct.get(gid) if isinstance(direct, dict) else None
+        target = targets.get(gid) if isinstance(targets, dict) else None
+        return VoiceAutoJoinGuildState(
+            has_pending=isinstance(entry, dict),
+            has_target=target is not None,
+            has_retry=isinstance(retry, dict) and gid in retry,
+            has_direct=bool(guild_direct),
+            pending_user_id=(entry.get("user_id") if isinstance(entry, dict) else None),
+            pending_channel_id=(entry.get("voice_channel_id") if isinstance(entry, dict) else None),
+            target_user_id=(str(target.user_id) if target is not None else None),
+            target_channel_id=(str(target.voice_channel_id) if target is not None else None),
+        )
 
     async def _voice_auto_join_retry_still_valid(
         self,
@@ -4404,13 +4556,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 if getattr(self, "_voice_auto_join_callback", None) is None:
                     return
                 try:
-                    success = await self._run_auto_join_with_barrier(
+                    outcome = await self._run_auto_join_with_barrier(
                         guild_id, user_id, voice_channel_id, text_channel_id
                     )
                 except asyncio.CancelledError:
                     return
                 now = time.monotonic()
-                if success:
+                if outcome == AUTO_JOIN_COMMITTED:
                     if int(guild_id) not in self._voice_auto_join_targets:
                         self.mark_voice_auto_join_target(
                             guild_id,
@@ -4421,6 +4573,11 @@ class DiscordAdapter(BasePlatformAdapter):
                     self._voice_auto_join_next_attempt_at[
                         (int(guild_id), str(voice_channel_id))
                     ] = now
+                    return
+                if outcome in (AUTO_JOIN_SUPERSEDED, AUTO_JOIN_CANCELLED):
+                    # A newer auto-join or a manual takeover/leave claimed the
+                    # slot — stop retrying so a retry can never act over a session
+                    # this attempt does not own.
                     return
                 cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
                 delay = self._voice_auto_join_retry_delay(cfg)
@@ -4572,22 +4729,21 @@ class DiscordAdapter(BasePlatformAdapter):
         if getattr(self, "_disconnecting", False):
             return False
 
-        # Run the barrier as a TRACKED task so disconnect teardown can cancel +
-        # await this direct in-flight attempt before resources are torn down.
+        # Run the barrier as a TRACKED task (keyed by guild) so disconnect
+        # teardown can cancel + await this direct in-flight attempt before
+        # resources are torn down.
         task = asyncio.ensure_future(
             self._run_auto_join_with_barrier(
                 guild_id, user_id, voice_channel_id, text_channel_id
             )
         )
-        direct = self._voice_auto_join_direct_tasks
-        direct.add(task)
-        task.add_done_callback(lambda t: direct.discard(t))
+        self._track_direct_auto_join_task(int(guild_id), task)
         try:
-            success = await task
+            outcome = await task
         except asyncio.CancelledError:
             return False
 
-        if success:
+        if outcome == AUTO_JOIN_COMMITTED:
             # The join callback records the target against the ACTUAL connected
             # channel (and owning profile). Only synthesize one here if it did
             # not, so we never overwrite the verified target with the event's
@@ -4602,15 +4758,43 @@ class DiscordAdapter(BasePlatformAdapter):
             self._cancel_voice_auto_join_retry(guild_id)
             return True
 
-        # Failure: schedule the one retry task for this guild at the next-allowed
-        # deadline (honoring both failure backoff AND reconnect cooldown) so a
-        # reconnect needs no second event and never violates the cooldown.
+        if outcome in (AUTO_JOIN_SUPERSEDED, AUTO_JOIN_CANCELLED):
+            # Superseded/cancelled is NOT a retryable failure — a newer auto-join
+            # or a manual takeover/leave owns (or intentionally ended) the slot.
+            # Retrying could act over a session this attempt does not own.
+            return False
+
+        # Genuine failure: schedule the one retry task for this guild at the
+        # next-allowed deadline (honoring both failure backoff AND reconnect
+        # cooldown) so a reconnect needs no second event and never violates the
+        # cooldown.
         delay = self._voice_auto_join_retry_delay(cfg)
         self._voice_auto_join_next_attempt_at[attempt_key] = time.monotonic() + delay
         self._schedule_voice_auto_join_retry(
             guild_id, user_id, voice_channel_id, text_channel_id, delay
         )
         return False
+
+    def _track_direct_auto_join_task(self, guild_id: int, task: "asyncio.Task") -> None:
+        """Track an in-flight direct barrier task under its guild key."""
+        direct = self._voice_auto_join_direct_tasks
+        if not isinstance(direct, dict):
+            direct = {}
+            self._voice_auto_join_direct_tasks = direct
+        guild_tasks = direct.setdefault(int(guild_id), set())
+        guild_tasks.add(task)
+
+        def _discard(finished: "asyncio.Task", _gid: int = int(guild_id)) -> None:
+            bucket = self._voice_auto_join_direct_tasks
+            if not isinstance(bucket, dict):
+                return
+            guild_set = bucket.get(_gid)
+            if isinstance(guild_set, set):
+                guild_set.discard(finished)
+                if not guild_set:
+                    bucket.pop(_gid, None)
+
+        task.add_done_callback(_discard)
 
     async def _maybe_cleanup_voice_auto_join_target(
         self,
@@ -4660,8 +4844,15 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
-    async def join_voice_channel(self, channel) -> bool:
-        """Join a Discord voice channel. Returns True on success."""
+    async def join_voice_channel(self, channel, *, manual_owner: bool = False) -> bool:
+        """Join a Discord voice channel. Returns True on success.
+
+        ``manual_owner`` marks a hand-issued ``/voice join``: under the guild
+        voice lock (atomic with the connect/move) it stamps the session as manual-
+        owned, so a stale auto-join barrier that completes later recognizes the
+        session is not its own and never disconnects it. Auto-join leaves this
+        False — its ownership is stamped by the barrier's commit under the lock.
+        """
         if not self._client or not DISCORD_AVAILABLE:
             return False
         guild_id = channel.guild.id
@@ -4672,13 +4863,19 @@ class DiscordAdapter(BasePlatformAdapter):
             if existing and existing.is_connected():
                 if existing.channel.id == channel.id:
                     self._reset_voice_timeout(guild_id)
+                    if manual_owner:
+                        self._voice_session_owner[guild_id] = MANUAL_VOICE_SESSION_OWNER
                     return True
                 await existing.move_to(channel)
                 self._reset_voice_timeout(guild_id)
+                if manual_owner:
+                    self._voice_session_owner[guild_id] = MANUAL_VOICE_SESSION_OWNER
                 return True
 
             vc = await channel.connect()
             self._voice_clients[guild_id] = vc
+            if manual_owner:
+                self._voice_session_owner[guild_id] = MANUAL_VOICE_SESSION_OWNER
             self._reset_voice_timeout(guild_id)
 
             # Start voice receiver (Phase 2: listen to users)
@@ -4706,33 +4903,56 @@ class DiscordAdapter(BasePlatformAdapter):
     async def leave_voice_channel(self, guild_id: int) -> None:
         """Disconnect from the voice channel in a guild."""
         async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
-            # Stop voice receiver first
-            receiver = self._voice_receivers.pop(guild_id, None)
-            if receiver:
-                receiver.stop()
-            listen_task = self._voice_listen_tasks.pop(guild_id, None)
-            if listen_task:
-                listen_task.cancel()
-
-            # Tear down the mixer (stops the continuous outgoing stream).
-            if getattr(self, "_voice_mixers", None) is not None:
-                self._voice_mixers.pop(guild_id, None)
-
-            vc = self._voice_clients.pop(guild_id, None)
-            if vc and vc.is_connected():
-                try:
-                    if vc.is_playing():
-                        vc.stop()
-                except Exception:
-                    pass
-                await vc.disconnect()
-            task = self._voice_timeout_tasks.pop(guild_id, None)
-            if task:
-                task.cancel()
-            self._voice_text_channels.pop(guild_id, None)
-            self._voice_sources.pop(guild_id, None)
+            await self._leave_voice_channel_locked(guild_id)
         # Disconnecting cancels any pending auto-rejoin retry for this guild.
         self._cancel_voice_auto_join_retry(guild_id)
+
+    async def _leave_voice_channel_locked(self, guild_id: int) -> None:
+        """Physical voice teardown body. The caller MUST hold
+        ``_voice_locks[guild_id]``.
+
+        Split out so the auto-join barrier can recheck session ownership and
+        disconnect ATOMICALLY under the same lock (closing the P1-B race where a
+        manual/newer join completes while a stale rollback waits for the lock).
+        Tolerant of the lightweight fake voice clients used in tests.
+        """
+        # Stop voice receiver first
+        receiver = self._voice_receivers.pop(guild_id, None)
+        if receiver:
+            receiver.stop()
+        listen_task = self._voice_listen_tasks.pop(guild_id, None)
+        if listen_task:
+            listen_task.cancel()
+
+        # Tear down the mixer (stops the continuous outgoing stream).
+        if getattr(self, "_voice_mixers", None) is not None:
+            self._voice_mixers.pop(guild_id, None)
+
+        vc = self._voice_clients.pop(guild_id, None)
+        if vc is not None:
+            try:
+                if getattr(vc, "is_connected", lambda: False)():
+                    try:
+                        if vc.is_playing():
+                            vc.stop()
+                    except Exception:
+                        pass
+                    disconnect = getattr(vc, "disconnect", None)
+                    if disconnect is not None:
+                        result = disconnect()
+                        if asyncio.iscoroutine(result):
+                            await result
+            except Exception:
+                pass
+        task = self._voice_timeout_tasks.pop(guild_id, None)
+        if task:
+            task.cancel()
+        self._voice_text_channels.pop(guild_id, None)
+        self._voice_sources.pop(guild_id, None)
+        # A disconnected session has no owner.
+        owner_map = getattr(self, "_voice_session_owner", None)
+        if isinstance(owner_map, dict):
+            owner_map.pop(guild_id, None)
 
     # Maximum seconds to wait for voice playback before giving up
     PLAYBACK_TIMEOUT = 120

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4547,9 +4547,7 @@ class DiscordAdapter(BasePlatformAdapter):
         leave/rejoin can never disconnect or hijack the hand-established
         session. Suppression is deliberately left intact.
         """
-        self._voice_auto_join_targets.pop(int(guild_id), None)
-        self._clear_pending_auto_join(int(guild_id))
-        self._cancel_voice_auto_join_retry(int(guild_id))
+        self._drop_auto_follow_ownership(int(guild_id))
 
     def cancel_inflight_auto_join(self, guild_id: int) -> bool:
         """Cancel an in-flight auto-join on a MANUAL ``/voice leave``.
@@ -5105,7 +5103,13 @@ class DiscordAdapter(BasePlatformAdapter):
             if not restored:
                 # Rollback failed / unknown pre-move channel — deterministically
                 # tear the session down so it is never left on the wrong channel.
-                await self._leave_voice_channel_body(int(guild_id))
+                # Capture the owning text channel FIRST, then run the FULL
+                # profile-bound teardown (physical + maps + owner/target + the
+                # runner _on_voice_disconnect cleanup that clears persisted voice
+                # mode / auto-TTS) — still inside this run-to-completion unit, so it
+                # all completes before any cancellation propagates.
+                text_ch_id = self._voice_text_channels.get(int(guild_id))
+                await self._teardown_voice_session_body(int(guild_id), text_ch_id)
             return False
         self._reset_voice_timeout(int(guild_id))
         self._stamp_voice_owner_locked(int(guild_id), manual_owner, attempt_token)
@@ -5165,13 +5169,24 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         if manual_owner:
             self._voice_session_owner[int(guild_id)] = VoiceSessionOwner.manual()
-            self._clear_pending_auto_join(int(guild_id))
-            targets = getattr(self, "_voice_auto_join_targets", None)
-            if isinstance(targets, dict):
-                targets.pop(int(guild_id), None)
-            self._cancel_voice_auto_join_retry(int(guild_id))
+            self._drop_auto_follow_ownership(int(guild_id))
         elif attempt_token is not None:
             self._voice_session_owner[int(guild_id)] = VoiceSessionOwner.auto(attempt_token)
+
+    def _drop_auto_follow_ownership(self, guild_id: int) -> None:
+        """Drop ALL auto-follow ownership for a guild — pending attempt slot,
+        tracked target, and the unattended retry task — in a single, lock-safe,
+        synchronous (no-await) step. Shared by the manual /voice-join takeover
+        (``clear_voice_auto_join_ownership`` and the manual owner stamp), so the
+        pending/target/retry clearing lives in exactly one place. Suppression is
+        deliberately left intact.
+        """
+        gid = int(guild_id)
+        targets = getattr(self, "_voice_auto_join_targets", None)
+        if isinstance(targets, dict):
+            targets.pop(gid, None)
+        self._clear_pending_auto_join(gid)
+        self._cancel_voice_auto_join_retry(gid)
 
     async def leave_voice_channel(self, guild_id: int) -> None:
         """Disconnect from the voice channel in a guild (cancellation-safe).

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4424,7 +4424,8 @@ class DiscordAdapter(BasePlatformAdapter):
             ``idle_timeout_seconds`` is 0 and the inactivity timer never fires).
 
         The physical disconnect + all map cleanup + the runner rollback are
-        performed TRANSACTIONALLY (shielded) so a cancellation cannot leave a
+        performed TRANSACTIONALLY (``_teardown_voice_session_transactional`` runs
+        the whole unit to completion) so a cancellation cannot leave a
         popped-but-connected client or skip the runner cleanup.
         """
         gid = int(guild_id)
@@ -4447,9 +4448,20 @@ class DiscordAdapter(BasePlatformAdapter):
         self, guild_id: int, text_channel_id: str
     ) -> None:
         """Physical disconnect + full map cleanup + profile-bound runner cleanup,
-        as one unit that completes before any cancellation propagates. Invoked via
-        ``asyncio.shield`` by the owned/orphan and cancellation paths."""
-        await self._leave_voice_channel_locked(int(guild_id))
+        as ONE cancellation-transactional unit: every step completes before a
+        cancellation propagates (the caller need not shield it itself)."""
+        gid = int(guild_id)
+        await self._shield_to_completion(
+            lambda: self._teardown_voice_session_body(gid, text_channel_id)
+        )
+
+    async def _teardown_voice_session_body(
+        self, guild_id: int, text_channel_id: str
+    ) -> None:
+        """Raw teardown body (run to completion by
+        ``_teardown_voice_session_transactional``): physical disconnect + maps,
+        then the profile-bound runner ``_on_voice_disconnect`` cleanup."""
+        await self._leave_voice_channel_body(int(guild_id))
         on_disconnect = getattr(self, "_on_voice_disconnect", None)
         if on_disconnect and text_channel_id:
             try:
@@ -4938,31 +4950,45 @@ class DiscordAdapter(BasePlatformAdapter):
             return
 
         target_channel_id = str(target.voice_channel_id)
-        self._voice_auto_join_targets.pop(int(guild_id), None)
-        # Target left the followed channel — cancel any pending rejoin retry.
-        self._cancel_voice_auto_join_retry(int(guild_id))
+        # Capture the session owner tied to THIS follow BEFORE any await, so we can
+        # tell — under the lock — whether a NEWER auto attempt has since re-committed
+        # (and re-marked the target) on the same channel. A newer owner must be left
+        # strictly intact, along with its target.
+        owner_at_start = self._voice_session_owner.get(int(guild_id))
         cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
-        if not cfg.get("target_leave_cleanup", True):
-            return
-        # The exact-channel + owner recheck AND the physical disconnect happen in
-        # ONE guild-lock critical section, so a manual /voice-join that races this
-        # cleanup (acquiring the lock first, stamping manual ownership, moving the
-        # session) can never be disconnected: under the lock we observe either a
-        # different connected channel or a MANUAL owner and bail without touching it.
+        # The target-identity/owner recheck, the target/retry drop, AND the physical
+        # disconnect all happen in ONE guild-lock critical section, so a manual join
+        # OR a newer auto commit that races this cleanup (acquiring the lock first,
+        # stamping ownership + re-marking the target) is observed and preserved.
         lock = self._voice_locks.setdefault(int(guild_id), asyncio.Lock())
         async with lock:
+            current_owner = self._voice_session_owner.get(int(guild_id))
+            # A newer/different owner (a newer committed AUTO token, or a MANUAL
+            # takeover) took over while we waited for the lock — never touch its
+            # session or its (re-marked) target.
+            if current_owner is not None and current_owner != owner_at_start:
+                return
+            current_target = self._voice_auto_join_targets.get(int(guild_id))
+            # Only drop the target if it is STILL the exact follow that left; a
+            # newer attempt may have re-marked it (same channel) and it must survive.
+            if (
+                current_target is not None
+                and str(current_target.user_id) == str(user_id)
+                and str(current_target.voice_channel_id) == before_channel_id
+            ):
+                self._voice_auto_join_targets.pop(int(guild_id), None)
+            self._cancel_voice_auto_join_retry(int(guild_id))
+            if not cfg.get("target_leave_cleanup", True):
+                return
             if self.connected_voice_channel_id(int(guild_id)) != target_channel_id:
                 return
-            owner = self._voice_session_owner.get(int(guild_id))
-            if owner is not None and owner.is_manual:
+            if current_owner is not None and current_owner.is_manual:
                 return
             text_ch_id = self._voice_text_channels.get(int(guild_id))
             # Transactional: physical disconnect + map cleanup + the profile-bound
             # runner cleanup complete (holding the lock throughout) before any
             # cancellation can propagate.
-            await self._shield_to_completion(
-                lambda: self._teardown_voice_session_transactional(int(guild_id), text_ch_id)
-            )
+            await self._teardown_voice_session_transactional(int(guild_id), text_ch_id)
 
     async def join_voice_channel(
         self, channel, *, manual_owner: bool = False, attempt_token: Optional[int] = None
@@ -5000,11 +5026,23 @@ class DiscordAdapter(BasePlatformAdapter):
                     self._reset_voice_timeout(guild_id)
                     self._stamp_voice_owner_locked(guild_id, manual_owner, attempt_token)
                     return True
+                # Capture the pre-move channel so a mid-move supersession can be
+                # UNDONE — the physical move is an awaited mutation, and supersession
+                # (via a non-lock-holding leave/register) can land while we await it.
+                pre_move_channel = getattr(existing, "channel", None)
                 await existing.move_to(channel)
                 # Recheck currency after the awaited move before keeping/stamping.
                 if attempt_token is not None and not self._auto_attempt_current_locked(
                     guild_id, attempt_token
                 ):
+                    # Superseded/cancelled mid-move: restore the session to its
+                    # pre-move channel so a stale attempt leaves NO physical move
+                    # mutation behind, then bail without stamping.
+                    if pre_move_channel is not None:
+                        try:
+                            await existing.move_to(pre_move_channel)
+                        except Exception:
+                            pass
                     return False
                 self._reset_voice_timeout(guild_id)
                 self._stamp_voice_owner_locked(guild_id, manual_owner, attempt_token)
@@ -5092,8 +5130,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _disconnect_voice_client(self, vc) -> None:
         """Disconnect a single voice client defensively (tolerant of the fake
-        clients used in tests). The physical disconnect await lives here so
-        callers can shield exactly this step."""
+        clients used in tests). Isolates the physical-disconnect await; the caller
+        runs it inside a run-to-completion task so a cancellation cannot interrupt
+        it."""
         try:
             if getattr(vc, "is_connected", lambda: False)():
                 try:
@@ -5110,15 +5149,25 @@ class DiscordAdapter(BasePlatformAdapter):
             pass
 
     async def _leave_voice_channel_locked(self, guild_id: int) -> None:
-        """Physical voice teardown body. The caller MUST hold
+        """Cancellation-TRANSACTIONAL physical voice teardown. The caller MUST hold
         ``_voice_locks[guild_id]``.
 
-        Cancellation-safe: all per-guild maps (receiver, mixer, client, timeout,
-        text, source, owner) are cleared SYNCHRONOUSLY first — no await between
-        them — and then the ONLY await, the physical disconnect, is SHIELDED, so a
-        cancellation can never leave a popped-but-still-connected client dangling
-        or a half-cleared set of maps. Tolerant of the fake clients used in tests.
+        The full body — synchronous cleanup of every per-guild map (receiver,
+        mixer, client, timeout, text, source, owner, target) PLUS the awaited
+        physical ``disconnect()`` — runs to COMPLETION before any cancellation
+        propagates. So a cancellation landing exactly during the awaited disconnect
+        can never leave the physical client untracked-but-connected, nor a
+        half-cleared set of maps: the whole unit finishes first, then the
+        cancellation is re-raised.
         """
+        gid = int(guild_id)
+        await self._shield_to_completion(lambda: self._leave_voice_channel_body(gid))
+
+    async def _leave_voice_channel_body(self, guild_id: int) -> None:
+        """Raw physical teardown, run inside a run-to-completion task by
+        ``_leave_voice_channel_locked`` / ``_teardown_voice_session_body``. Clears
+        every per-guild map synchronously, then awaits the physical disconnect.
+        Tolerant of the fake clients used in tests."""
         gid = int(guild_id)
         # -- synchronous map teardown (uninterruptible: no await) --
         receiver = self._voice_receivers.pop(gid, None)
@@ -5142,9 +5191,9 @@ class DiscordAdapter(BasePlatformAdapter):
         targets = getattr(self, "_voice_auto_join_targets", None)
         if isinstance(targets, dict):
             targets.pop(gid, None)
-        # -- the sole await: complete the physical disconnect even under cancel --
+        # -- the physical disconnect (the caller runs this whole body to completion) --
         if vc is not None:
-            await asyncio.shield(self._disconnect_voice_client(vc))
+            await self._disconnect_voice_client(vc)
 
     # Maximum seconds to wait for voice playback before giving up
     PLAYBACK_TIMEOUT = 120
@@ -5305,9 +5354,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # profile-bound runner cleanup) under the guild lock.
         lock = self._voice_locks.setdefault(int(guild_id), asyncio.Lock())
         async with lock:
-            await self._shield_to_completion(
-                lambda: self._teardown_voice_session_transactional(int(guild_id), text_ch_id)
-            )
+            await self._teardown_voice_session_transactional(int(guild_id), text_ch_id)
         self._cancel_voice_auto_join_retry(int(guild_id))
         if text_ch_id and self._client:
             ch = self._client.get_channel(text_ch_id)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4153,6 +4153,25 @@ class DiscordAdapter(BasePlatformAdapter):
                 text_channel_id=str(text_channel_id),
             ))
         except asyncio.CancelledError:
+            # The callback may have already applied the join side effects — a
+            # live physical voice session PLUS runner-side voice-mode/auto-TTS —
+            # before the cancellation landed. Roll them back transactionally and
+            # profile-bound, but ONLY if THIS attempt still owns the session (a
+            # newer auto-join or manual takeover that superseded our pending slot
+            # must be left intact). Shield the async rollback so the very
+            # cancellation we are propagating cannot abort it mid-teardown.
+            rollback = asyncio.ensure_future(
+                self._rollback_owned_auto_join_session(
+                    guild_id, str(voice_channel_id), str(text_channel_id), token
+                )
+            )
+            while not rollback.done():
+                try:
+                    await asyncio.shield(rollback)
+                except asyncio.CancelledError:
+                    # Another cancellation targeted the shield; keep waiting for
+                    # the shielded rollback to finish, then re-raise below.
+                    continue
             self._clear_pending_auto_join(guild_id, token)
             raise
         except Exception as exc:
@@ -4163,17 +4182,25 @@ class DiscordAdapter(BasePlatformAdapter):
             self._clear_pending_auto_join(guild_id, token)
             return False
 
-        # The exact pending entry for THIS attempt must still be current: a
-        # superseding later attempt (or a cancellation) invalidates this one.
+        # Ownership gate: only the attempt whose pending entry is STILL current
+        # owns the freshly (reportedly) established session. If the entry is gone
+        # the attempt was SUPERSEDED — a newer auto-join replaced the pending
+        # slot, or a manual /voice-join takeover cleared it — and that newer or
+        # hand-established session must NEVER be torn down here.
         entry = self._current_pending_auto_join(guild_id, token)
-        superseded = entry is None
-        cancelled = superseded or bool(entry.get("cancelled"))
+        if entry is None:
+            logger.info(
+                "Discord voice auto-join superseded post-join (guild %s); leaving "
+                "the current (newer/manual) owner's session intact", guild_id,
+            )
+            return False
+
+        cancelled = bool(entry.get("cancelled"))
         disconnecting = bool(getattr(self, "_disconnecting", False))
         actual_channel = self.connected_voice_channel_id(guild_id)
         target_present = await self._voice_target_in_channel(
             guild_id, user_id, voice_channel_id
         )
-        self._clear_pending_auto_join(guild_id, token)
 
         if (
             cancelled
@@ -4182,27 +4209,53 @@ class DiscordAdapter(BasePlatformAdapter):
             or not target_present
         ):
             logger.info(
-                "Discord voice auto-join aborted post-join (guild %s): superseded=%s "
-                "cancelled=%s disconnecting=%s actual=%s expected=%s target_present=%s",
-                guild_id, superseded, cancelled, disconnecting,
+                "Discord voice auto-join aborted post-join (guild %s): cancelled=%s "
+                "disconnecting=%s actual=%s expected=%s target_present=%s",
+                guild_id, cancelled, disconnecting,
                 actual_channel, voice_channel_id, target_present,
             )
-            self._voice_auto_join_targets.pop(int(guild_id), None)
+            # This exact attempt still owns the pending slot, so the session (if
+            # any) is OURS to tear down — including the profile-bound runner
+            # rollback. A superseded attempt already returned above.
+            await self._rollback_owned_auto_join_session(
+                guild_id, str(voice_channel_id), str(text_channel_id), token
+            )
+            self._clear_pending_auto_join(guild_id, token)
+            return False
+        self._clear_pending_auto_join(guild_id, token)
+        return True
+
+    async def _rollback_owned_auto_join_session(
+        self,
+        guild_id: int,
+        voice_channel_id: str,
+        text_channel_id: str,
+        token: int,
+    ) -> None:
+        """Transactionally tear down an aborted auto-join's side effects.
+
+        Runs ONLY when THIS attempt still owns the pending slot (its ``token`` is
+        still current). A superseded attempt — a newer auto-join or a manual
+        takeover replaced/cleared the slot — returns without touching anything,
+        so we never disconnect a newer or hand-established session or roll back
+        its voice mode. The runner-side rollback is profile-bound: it routes
+        through the bound ``_on_voice_disconnect`` for THIS session's linked text
+        channel, so no other profile's voice-mode / auto-TTS state is affected.
+        """
+        if self._current_pending_auto_join(int(guild_id), token) is None:
+            # Superseded (or already cleared) between the abort decision and here.
+            return
+        self._voice_auto_join_targets.pop(int(guild_id), None)
+        try:
+            await self.leave_voice_channel(int(guild_id))
+        except Exception:
+            pass
+        on_disconnect = getattr(self, "_on_voice_disconnect", None)
+        if on_disconnect and text_channel_id:
             try:
-                await self.leave_voice_channel(int(guild_id))
+                on_disconnect(str(text_channel_id))
             except Exception:
                 pass
-            # Roll back the runner-side join side effects (voice mode / auto-TTS)
-            # via the profile-bound cleanup so an aborted join leaves no stale
-            # "voice on" state behind.
-            on_disconnect = getattr(self, "_on_voice_disconnect", None)
-            if on_disconnect and text_channel_id:
-                try:
-                    on_disconnect(str(text_channel_id))
-                except Exception:
-                    pass
-            return False
-        return True
 
     async def _teardown_voice_auto_join_state(self) -> None:
         """Cancel + await every retry task and clear auto-join state.
@@ -4250,6 +4303,46 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_auto_join_targets.pop(int(guild_id), None)
         self._clear_pending_auto_join(int(guild_id))
         self._cancel_voice_auto_join_retry(int(guild_id))
+
+    def cancel_inflight_auto_join(self, guild_id: int) -> bool:
+        """Cancel an in-flight auto-join on a MANUAL ``/voice leave``.
+
+        A manual leave means "no session at all". Unlike a manual ``/voice join``
+        takeover — which SUPERSEDES the pending slot via
+        ``clear_voice_auto_join_ownership`` so the in-flight attempt yields to the
+        newly hand-established session — a leave must instead ensure any session
+        the in-flight callback is about to establish is torn back down. So:
+
+        - the pending entry is FLAGGED cancelled and LEFT in place (token intact)
+          so a callback that connects moments later is recognized by the post-join
+          barrier as ITS OWN cancelled attempt and rolled back, and
+        - follow ownership (tracked target + unattended retry) is dropped.
+
+        The pending entry is deliberately NOT popped: popping would make the
+        attempt look SUPERSEDED, and a superseded attempt is protected from
+        teardown (it might be a newer/manual owner) — which would let the late
+        connection survive the leave. Returns True if anything was in flight or
+        owned.
+        """
+        had = False
+        pending = getattr(self, "_voice_auto_join_pending", None)
+        if isinstance(pending, dict):
+            entry = pending.get(int(guild_id))
+            if isinstance(entry, dict):
+                entry["cancelled"] = True
+                had = True
+        targets = getattr(self, "_voice_auto_join_targets", None)
+        if isinstance(targets, dict) and int(guild_id) in targets:
+            had = True
+            targets.pop(int(guild_id), None)
+        retry = getattr(self, "_voice_auto_join_retry_tasks", None)
+        if isinstance(retry, dict) and int(guild_id) in retry:
+            had = True
+        self._cancel_voice_auto_join_retry(int(guild_id))
+        direct = getattr(self, "_voice_auto_join_direct_tasks", None)
+        if isinstance(direct, set) and direct:
+            had = True
+        return had
 
     async def _voice_auto_join_retry_still_valid(
         self,
@@ -4438,8 +4531,21 @@ class DiscordAdapter(BasePlatformAdapter):
         now = time.monotonic()
         next_allowed = self._voice_auto_join_next_attempt_at.get(attempt_key, 0.0)
         if now < next_allowed:
-            # A retry task (if any) remains the live path back into the channel;
-            # replacement is handled when an attempt actually reschedules it.
+            # Inside the reconnect cooldown. A SUCCESSFUL follow leaves no retry
+            # task (success cancels retries), so a target who leaves and then
+            # rejoins the same channel mid-cooldown would otherwise be stranded:
+            # this event is refused and no unattended path back exists. Schedule a
+            # retry for the REMAINING cooldown so the rejoin is followed without
+            # requiring a further, unrelated voice-state event. If a retry task is
+            # already the live path back, leave it be.
+            if int(guild_id) not in self._voice_auto_join_retry_tasks:
+                self._schedule_voice_auto_join_retry(
+                    guild_id,
+                    user_id,
+                    voice_channel_id,
+                    str(text_channel_id),
+                    max(0.0, next_allowed - now),
+                )
             return
 
         await self._attempt_voice_auto_join(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4950,32 +4950,32 @@ class DiscordAdapter(BasePlatformAdapter):
             return
 
         target_channel_id = str(target.voice_channel_id)
-        # Capture the session owner tied to THIS follow BEFORE any await, so we can
-        # tell — under the lock — whether a NEWER auto attempt has since re-committed
-        # (and re-marked the target) on the same channel. A newer owner must be left
-        # strictly intact, along with its target.
-        owner_at_start = self._voice_session_owner.get(int(guild_id))
+        # Capture BOTH the exact target OBJECT and the session owner tied to THIS
+        # follow before any await. Under the lock we require the current target to
+        # be the SAME OBJECT and the current owner to match this follow's owner
+        # token — so ANY replacement target/session (a newer attempt re-committed
+        # and re-marked the follow, even on the SAME channel with a fresh object)
+        # is preserved rather than disconnected.
+        captured_target = target
+        captured_owner = self._voice_session_owner.get(int(guild_id))
         cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
-        # The target-identity/owner recheck, the target/retry drop, AND the physical
+        # The target-object recheck, the target/retry drop, AND the physical
         # disconnect all happen in ONE guild-lock critical section, so a manual join
         # OR a newer auto commit that races this cleanup (acquiring the lock first,
         # stamping ownership + re-marking the target) is observed and preserved.
         lock = self._voice_locks.setdefault(int(guild_id), asyncio.Lock())
         async with lock:
-            current_owner = self._voice_session_owner.get(int(guild_id))
-            # A newer/different owner (a newer committed AUTO token, or a MANUAL
-            # takeover) took over while we waited for the lock — never touch its
-            # session or its (re-marked) target.
-            if current_owner is not None and current_owner != owner_at_start:
-                return
             current_target = self._voice_auto_join_targets.get(int(guild_id))
-            # Only drop the target if it is STILL the exact follow that left; a
-            # newer attempt may have re-marked it (same channel) and it must survive.
-            if (
-                current_target is not None
-                and str(current_target.user_id) == str(user_id)
-                and str(current_target.voice_channel_id) == before_channel_id
-            ):
+            current_owner = self._voice_session_owner.get(int(guild_id))
+            # A REPLACEMENT target object (a newer follow re-marked it) — even with
+            # the same user/channel — or a newer/different session owner means this
+            # follow is no longer current: leave its target AND session intact.
+            if current_target is not None and current_target is not captured_target:
+                return
+            if current_owner is not None and current_owner != captured_owner:
+                return
+            # Still exactly this follow: drop the (unchanged) target + retry.
+            if current_target is captured_target:
                 self._voice_auto_join_targets.pop(int(guild_id), None)
             self._cancel_voice_auto_join_retry(int(guild_id))
             if not cfg.get("target_leave_cleanup", True):
@@ -5026,35 +5026,27 @@ class DiscordAdapter(BasePlatformAdapter):
                     self._reset_voice_timeout(guild_id)
                     self._stamp_voice_owner_locked(guild_id, manual_owner, attempt_token)
                     return True
-                # Capture the pre-move channel so a mid-move supersession can be
-                # UNDONE — the physical move is an awaited mutation, and supersession
-                # (via a non-lock-holding leave/register) can land while we await it.
-                pre_move_channel = getattr(existing, "channel", None)
-                await existing.move_to(channel)
-                # Recheck currency after the awaited move before keeping/stamping.
-                if attempt_token is not None and not self._auto_attempt_current_locked(
-                    guild_id, attempt_token
-                ):
-                    # Superseded/cancelled mid-move: restore the session to its
-                    # pre-move channel so a stale attempt leaves NO physical move
-                    # mutation behind, then bail without stamping.
-                    if pre_move_channel is not None:
-                        try:
-                            await existing.move_to(pre_move_channel)
-                        except Exception:
-                            pass
-                    return False
-                self._reset_voice_timeout(guild_id)
-                self._stamp_voice_owner_locked(guild_id, manual_owner, attempt_token)
-                return True
+                # Move an existing (auto/orphan-owned) session as a RUN-TO-COMPLETION
+                # unit: the awaited move + the mid-move-supersession recheck + the
+                # deterministic rollback all finish before any cancellation
+                # propagates, so a stale attempt can never leave a half-applied move.
+                return await self._shield_to_completion(
+                    lambda: self._move_existing_session_locked(
+                        existing, channel, guild_id, manual_owner, attempt_token
+                    )
+                )
 
             vc = await channel.connect()
             # Recheck AFTER the awaited connect, BEFORE publishing the client: a
-            # stale attempt must not publish an orphan; disconnect it instead.
+            # stale attempt must not publish an orphan. The vc was NOT published to
+            # ``_voice_clients``, so barrier cleanup cannot find it — disconnect it
+            # to COMPLETION (run-to-completion) before propagating any cancellation.
             if attempt_token is not None and not self._auto_attempt_current_locked(
                 guild_id, attempt_token
             ):
-                await self._disconnect_voice_client(vc)
+                await self._shield_to_completion(
+                    lambda: self._disconnect_voice_client(vc)
+                )
                 return False
             self._voice_clients[guild_id] = vc
             self._stamp_voice_owner_locked(guild_id, manual_owner, attempt_token)
@@ -5082,6 +5074,43 @@ class DiscordAdapter(BasePlatformAdapter):
 
             return True
 
+    async def _move_existing_session_locked(
+        self, existing, channel, guild_id, manual_owner, attempt_token
+    ) -> bool:
+        """Move an existing session to ``channel`` and finalize ownership, with a
+        DETERMINISTIC rollback if this attempt is superseded/cancelled mid-move.
+
+        Run to completion by ``join_voice_channel`` via ``_shield_to_completion`` so
+        neither the move nor the rollback can be interrupted by a cancellation. On
+        supersession the session is restored to its pre-move channel; if that
+        restore itself fails, the session is torn down entirely rather than left
+        stranded on the wrong channel — so no stale physical mutation can remain.
+        """
+        pre_move_channel = getattr(existing, "channel", None)
+        await existing.move_to(channel)
+        if attempt_token is not None and not self._auto_attempt_current_locked(
+            int(guild_id), attempt_token
+        ):
+            same_channel = (
+                pre_move_channel is not None
+                and getattr(pre_move_channel, "id", None) == getattr(channel, "id", None)
+            )
+            restored = same_channel
+            if pre_move_channel is not None and not same_channel:
+                try:
+                    await existing.move_to(pre_move_channel)
+                    restored = True
+                except Exception:
+                    restored = False
+            if not restored:
+                # Rollback failed / unknown pre-move channel — deterministically
+                # tear the session down so it is never left on the wrong channel.
+                await self._leave_voice_channel_body(int(guild_id))
+            return False
+        self._reset_voice_timeout(int(guild_id))
+        self._stamp_voice_owner_locked(int(guild_id), manual_owner, attempt_token)
+        return True
+
     def _auto_attempt_current_locked(self, guild_id: int, token: int) -> bool:
         """Whether the auto attempt ``token`` is still the current pending attempt
         (not cancelled) and the adapter is not disconnecting. Caller holds the lock.
@@ -5098,16 +5127,24 @@ class DiscordAdapter(BasePlatformAdapter):
         session. Caller holds the guild voice lock.
 
         Requires the attempt to be current AND that any existing live session is
-        NOT owned by a MANUAL takeover — a manual (hand-established) session is
-        never moved/overwritten by an auto attempt.
+        owned by neither a MANUAL takeover NOR a NEWER auto attempt (a strictly
+        larger token) — a manual or newer-owned session is never moved/overwritten
+        by this (older) attempt.
         """
         if not self._auto_attempt_current_locked(guild_id, token):
             return False
         existing = self._voice_clients.get(int(guild_id))
         if existing is not None and getattr(existing, "is_connected", lambda: False)():
             owner = self._voice_session_owner.get(int(guild_id))
-            if owner is not None and owner.is_manual:
-                return False
+            if owner is not None:
+                if owner.is_manual:
+                    return False
+                if (
+                    owner.kind is VoiceOwnerKind.AUTO
+                    and owner.token is not None
+                    and int(owner.token) > int(token)
+                ):
+                    return False
         return True
 
     def _stamp_voice_owner_locked(
@@ -5115,18 +5152,51 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> None:
         """Stamp typed session ownership under the guild lock: MANUAL for a manual
         join, AUTO(token) for a token-carrying auto attempt. A tokenless auto call
-        (legacy) leaves ownership for the barrier commit to stamp."""
+        (legacy) leaves ownership for the barrier commit to stamp.
+
+        A MANUAL stamp ALSO drops ALL auto-follow ownership — pending attempt slot,
+        tracked target, and the unattended retry task — ATOMICALLY under this same
+        guild lock. So the auto barrier's finalize (which acquires this lock) and
+        the retry loop both observe themselves superseded and can never commit AUTO
+        ownership, re-mark a target, or reconnect over the hand-established manual
+        session in the window before the gateway drops auto-follow ownership. (The
+        manual /voice LEAVE path keeps its distinct semantics: it FLAGS the pending
+        attempt cancelled instead, via ``cancel_inflight_auto_join``.)
+        """
         if manual_owner:
             self._voice_session_owner[int(guild_id)] = VoiceSessionOwner.manual()
+            self._clear_pending_auto_join(int(guild_id))
+            targets = getattr(self, "_voice_auto_join_targets", None)
+            if isinstance(targets, dict):
+                targets.pop(int(guild_id), None)
+            self._cancel_voice_auto_join_retry(int(guild_id))
         elif attempt_token is not None:
             self._voice_session_owner[int(guild_id)] = VoiceSessionOwner.auto(attempt_token)
 
     async def leave_voice_channel(self, guild_id: int) -> None:
-        """Disconnect from the voice channel in a guild (cancellation-safe)."""
-        async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
-            await self._leave_voice_channel_locked(guild_id)
-        # Disconnecting cancels any pending auto-rejoin retry for this guild.
-        self._cancel_voice_auto_join_retry(guild_id)
+        """Disconnect from the voice channel in a guild (cancellation-safe).
+
+        The WHOLE public leave — acquiring the guild lock, the FULL profile-bound
+        transactional teardown (physical disconnect + all maps + the runner
+        ``_on_voice_disconnect`` cleanup), AND the pending-retry cancellation —
+        runs to completion before any cancellation propagates, so a cancellation
+        during the physical disconnect can never release the lock early (letting a
+        concurrent join race the still-in-flight disconnect) or skip the retry
+        cancellation (cleared in a ``finally``).
+        """
+        await self._shield_to_completion(lambda: self._public_leave_body(int(guild_id)))
+
+    async def _public_leave_body(self, guild_id: int) -> None:
+        gid = int(guild_id)
+        try:
+            async with self._voice_locks.setdefault(gid, asyncio.Lock()):
+                text_ch_id = self._voice_text_channels.get(gid)
+                # Full profile-bound teardown: physical disconnect + maps + the
+                # bound runner cleanup, all under the held lock.
+                await self._teardown_voice_session_body(gid, text_ch_id)
+        finally:
+            # Retry state is cleaned even if teardown raised or is cancelling.
+            self._cancel_voice_auto_join_retry(gid)
 
     async def _disconnect_voice_client(self, vc) -> None:
         """Disconnect a single voice client defensively (tolerant of the fake

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -905,6 +905,10 @@ class DiscordAdapter(BasePlatformAdapter):
 
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
+    # A configured idle timeout <= 0 means "disabled" (never auto-disconnect).
+    # Any positive value is floored to this minimum so a tiny/misconfigured
+    # value cannot turn the inactivity timer into a busy zero-sleep loop.
+    VOICE_TIMEOUT_MIN = 1.0
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
@@ -938,6 +942,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # One cancellable retry task per guild, scheduled after a failed
         # auto-join so a reconnect does not require a second voice-state event.
         self._voice_auto_join_retry_tasks: Dict[int, asyncio.Task] = {}
+        # In-flight join attempts keyed by guild → {user_id, voice_channel_id,
+        # cancelled}. Recorded BEFORE the network join so a target-leave event
+        # racing the join can cancel it, and the post-join barrier can refuse a
+        # session the target already left.
+        self._voice_auto_join_pending: Dict[int, Dict[str, Any]] = {}
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -1645,6 +1654,10 @@ class DiscordAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
         self._disconnecting = True
+        # Cancel + await auto-join retry tasks and clear auto-join state BEFORE
+        # tearing down voice/client resources, so a pending retry cannot fire
+        # mid-teardown and try to reconnect on a dying adapter.
+        await self._teardown_voice_auto_join_state()
         # Cancel the liveness probe first so it can't fire a spurious fatal
         # error / reconnect while we're intentionally tearing the adapter down.
         await self._cancel_liveness_task()
@@ -3963,19 +3976,36 @@ class DiscordAdapter(BasePlatformAdapter):
         channel_id = getattr(channel, "id", None)
         return str(channel_id) if channel_id is not None else None
 
+    @staticmethod
+    def _voice_auto_join_retry_delay(cfg: Dict[str, Any]) -> float:
+        """Effective delay before the next auto-join attempt.
+
+        Honors BOTH the failure backoff and the reconnect cooldown: the next
+        attempt may not run before the later of the two deadlines, so when
+        ``reconnect_cooldown_seconds`` exceeds ``failure_backoff_seconds`` we
+        schedule at the cooldown deadline rather than the shorter backoff.
+        """
+        backoff = float((cfg or {}).get("failure_backoff_seconds", 60.0) or 0.0)
+        cooldown = float((cfg or {}).get("reconnect_cooldown_seconds", 15.0) or 0.0)
+        return max(backoff, cooldown, 0.0)
+
     def _schedule_voice_auto_join_retry(
         self,
         guild_id: int,
         user_id: str,
         voice_channel_id: str,
         text_channel_id: str,
-        backoff: float,
+        delay: float,
     ) -> None:
-        """Schedule (or replace) the single retry task for this guild."""
+        """Schedule (or replace) the single retry task for this guild.
+
+        ``delay`` is the effective next-allowed interval (max of failure backoff
+        and reconnect cooldown), so a retry never fires before the cooldown.
+        """
         # A newer attempt/target supersedes any in-flight retry.
         self._cancel_voice_auto_join_retry(guild_id)
-        if backoff is None or float(backoff) <= 0:
-            # No backoff configured → no unattended retry; the next voice-state
+        if delay is None or float(delay) <= 0:
+            # No delay configured → no unattended retry; the next voice-state
             # event drives any further attempt.
             return
         try:
@@ -3985,7 +4015,7 @@ class DiscordAdapter(BasePlatformAdapter):
         gid = int(guild_id)
         task = asyncio.ensure_future(
             self._voice_auto_join_retry_loop(
-                gid, str(user_id), str(voice_channel_id), str(text_channel_id), float(backoff)
+                gid, str(user_id), str(voice_channel_id), str(text_channel_id), float(delay)
             )
         )
         self._voice_auto_join_retry_tasks[gid] = task
@@ -4004,6 +4034,150 @@ class DiscordAdapter(BasePlatformAdapter):
         task = tasks.pop(int(guild_id), None)
         if task is not None:
             task.cancel()
+
+    def _register_pending_auto_join(
+        self, guild_id: int, user_id: str, voice_channel_id: str
+    ) -> None:
+        """Record an in-flight auto-join attempt so a racing leave can cancel it."""
+        pending = getattr(self, "_voice_auto_join_pending", None)
+        if not isinstance(pending, dict):
+            pending = {}
+            self._voice_auto_join_pending = pending
+        pending[int(guild_id)] = {
+            "user_id": str(user_id),
+            "voice_channel_id": str(voice_channel_id),
+            "cancelled": False,
+        }
+
+    def _clear_pending_auto_join(self, guild_id: int) -> None:
+        pending = getattr(self, "_voice_auto_join_pending", None)
+        if isinstance(pending, dict):
+            pending.pop(int(guild_id), None)
+
+    def _cancel_pending_auto_join_if_matches(
+        self, guild_id: int, user_id: str, voice_channel_id: str
+    ) -> None:
+        """Flag an in-flight join for (guild,user,channel) as cancelled."""
+        pending = getattr(self, "_voice_auto_join_pending", None)
+        if not isinstance(pending, dict):
+            return
+        entry = pending.get(int(guild_id))
+        if not entry:
+            return
+        if str(entry.get("user_id")) == str(user_id) and str(
+            entry.get("voice_channel_id")
+        ) == str(voice_channel_id):
+            entry["cancelled"] = True
+
+    async def _voice_target_in_channel(
+        self, guild_id: int, user_id: str, voice_channel_id: str
+    ) -> bool:
+        """Whether the target user is currently in the given voice channel."""
+        vc = self._voice_clients.get(int(guild_id))
+        channel = getattr(vc, "channel", None)
+        if channel is not None and str(getattr(channel, "id", "")) == str(voice_channel_id):
+            members = getattr(channel, "members", None)
+            if members is not None:
+                return any(
+                    str(getattr(m, "id", "")) == str(user_id) for m in members
+                )
+        try:
+            current = await self.get_user_voice_channel(int(guild_id), str(user_id))
+        except Exception:
+            current = None
+        return str(getattr(current, "id", "")) == str(voice_channel_id)
+
+    async def _run_auto_join_with_barrier(
+        self,
+        guild_id: int,
+        user_id: str,
+        voice_channel_id: str,
+        text_channel_id: str,
+    ) -> bool:
+        """Invoke the join callback under a leave-race barrier.
+
+        Tracks the attempt as pending BEFORE the (awaited) network join so a
+        concurrent target-leave event can cancel it. After a reported success we
+        require that (a) the attempt was not cancelled mid-flight, (b) the ACTUAL
+        connected channel equals the validated channel, and (c) the target is
+        still present. If any fails the freshly established session is torn down
+        rather than left following a target that is already gone.
+        """
+        callback = getattr(self, "_voice_auto_join_callback", None)
+        if callback is None:
+            return False
+        self._register_pending_auto_join(guild_id, user_id, voice_channel_id)
+        success = False
+        try:
+            success = bool(await callback(
+                guild_id=int(guild_id),
+                user_id=str(user_id),
+                voice_channel_id=str(voice_channel_id),
+                text_channel_id=str(text_channel_id),
+            ))
+        except asyncio.CancelledError:
+            self._clear_pending_auto_join(guild_id)
+            raise
+        except Exception as exc:
+            logger.warning("Discord voice auto-join failed: %s", exc, exc_info=True)
+            success = False
+
+        if not success:
+            self._clear_pending_auto_join(guild_id)
+            return False
+
+        pending = getattr(self, "_voice_auto_join_pending", {}) or {}
+        entry = pending.get(int(guild_id)) or {}
+        cancelled = bool(entry.get("cancelled"))
+        actual_channel = self.connected_voice_channel_id(guild_id)
+        target_present = await self._voice_target_in_channel(
+            guild_id, user_id, voice_channel_id
+        )
+        self._clear_pending_auto_join(guild_id)
+
+        if cancelled or actual_channel != str(voice_channel_id) or not target_present:
+            logger.info(
+                "Discord voice auto-join aborted post-join (guild %s): cancelled=%s "
+                "actual=%s expected=%s target_present=%s",
+                guild_id, cancelled, actual_channel, voice_channel_id, target_present,
+            )
+            self._voice_auto_join_targets.pop(int(guild_id), None)
+            try:
+                await self.leave_voice_channel(int(guild_id))
+            except Exception:
+                pass
+            return False
+        return True
+
+    async def _teardown_voice_auto_join_state(self) -> None:
+        """Cancel + await every retry task and clear auto-join state.
+
+        Called at the START of ``disconnect()`` — BEFORE any voice/client
+        resources are torn down — so a retry cannot fire mid-teardown and
+        reconnect on a dying adapter. Callbacks and targets/pending are cleared
+        so nothing keeps referencing this adapter after it goes away.
+        """
+        tasks = list(getattr(self, "_voice_auto_join_retry_tasks", {}).values())
+        self._voice_auto_join_retry_tasks = {}
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug(
+                    "[%s] auto-join retry task raised during teardown",
+                    getattr(self, "name", "discord"),
+                    exc_info=True,
+                )
+        self._voice_auto_join_targets = {}
+        self._voice_auto_join_pending = {}
+        self._voice_auto_join_callback = None
+        self._voice_input_callback = None
+        self._on_voice_disconnect = None
+        self._voice_mode_getter = None
 
     async def _voice_auto_join_retry_still_valid(
         self,
@@ -4043,40 +4217,33 @@ class DiscordAdapter(BasePlatformAdapter):
         user_id: str,
         voice_channel_id: str,
         text_channel_id: str,
-        backoff: float,
+        delay: float,
     ) -> None:
         """Retry a failed auto-join without waiting for a second voice event.
 
-        Backoff is measured from the completion of the previous failed attempt.
-        Cancelled on target leave, manual leave, disconnect, or replacement.
+        ``delay`` is the next-allowed interval (max of failure backoff and
+        reconnect cooldown), measured from the completion of the previous failed
+        attempt. Cancelled on target leave, manual leave, disconnect, or
+        replacement.
         """
         try:
             while True:
                 try:
-                    await asyncio.sleep(max(0.0, float(backoff)))
+                    await asyncio.sleep(max(0.0, float(delay)))
                 except asyncio.CancelledError:
                     return
                 if not await self._voice_auto_join_retry_still_valid(
                     guild_id, user_id, voice_channel_id
                 ):
                     return
-                callback = getattr(self, "_voice_auto_join_callback", None)
-                if callback is None:
+                if getattr(self, "_voice_auto_join_callback", None) is None:
                     return
-                success = False
                 try:
-                    success = bool(await callback(
-                        guild_id=int(guild_id),
-                        user_id=str(user_id),
-                        voice_channel_id=str(voice_channel_id),
-                        text_channel_id=str(text_channel_id),
-                    ))
+                    success = await self._run_auto_join_with_barrier(
+                        guild_id, user_id, voice_channel_id, text_channel_id
+                    )
                 except asyncio.CancelledError:
                     return
-                except Exception as exc:
-                    logger.warning(
-                        "Discord voice auto-join retry failed: %s", exc, exc_info=True
-                    )
                 now = time.monotonic()
                 if success:
                     if int(guild_id) not in self._voice_auto_join_targets:
@@ -4091,11 +4258,11 @@ class DiscordAdapter(BasePlatformAdapter):
                     ] = now
                     return
                 cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
-                backoff = float(cfg.get("failure_backoff_seconds", 60.0) or 0.0)
+                delay = self._voice_auto_join_retry_delay(cfg)
                 self._voice_auto_join_next_attempt_at[
                     (int(guild_id), str(voice_channel_id))
-                ] = now + backoff
-                if backoff <= 0:
+                ] = now + delay
+                if delay <= 0:
                     return
         except asyncio.CancelledError:
             return
@@ -4169,13 +4336,18 @@ class DiscordAdapter(BasePlatformAdapter):
             return
 
         existing = self._voice_clients.get(guild_id)
-        if existing and existing.is_connected() and str(getattr(existing.channel, "id", "")) == voice_channel_id:
-            # Already connected to the target channel. Refresh an EXISTING
-            # auto-join target only — never adopt a manual connection into
-            # auto-follow, or target-leave cleanup would tear down a session the
-            # user established by hand.
+        if existing and existing.is_connected():
             current_target = self._voice_auto_join_targets.get(guild_id)
-            if current_target is not None:
+            if current_target is None:
+                # A voice connection this guild already holds that auto-follow
+                # does NOT own is a MANUAL session. Refuse to touch it — whether
+                # or not the manual channel matches the event channel — so we
+                # never move it and never let target-leave cleanup disconnect a
+                # session the user established by hand.
+                return
+            connected_id = str(getattr(existing.channel, "id", ""))
+            if connected_id == voice_channel_id:
+                # Already following the target here — refresh the target.
                 self.mark_voice_auto_join_target(
                     guild_id,
                     user_id=user_id,
@@ -4183,7 +4355,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     text_channel_id=str(text_channel_id),
                     profile=current_target.profile,
                 )
-            return
+                return
+            # We own an auto-follow session but are connected to a different
+            # channel (the target moved) — fall through to follow it.
 
         if self._is_voice_auto_join_suppressed(guild_id, user_id, voice_channel_id):
             return
@@ -4207,27 +4381,20 @@ class DiscordAdapter(BasePlatformAdapter):
         voice_channel_id: str,
         text_channel_id: str,
     ) -> bool:
-        """Invoke the join callback once; schedule a retry on failure."""
+        """Invoke the join callback once (under the leave-race barrier); schedule
+        a retry on failure at the next-allowed deadline."""
         cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
         attempt_key = (int(guild_id), str(voice_channel_id))
         now = time.monotonic()
         cooldown = float(cfg.get("reconnect_cooldown_seconds", 15.0) or 0.0)
         self._voice_auto_join_next_attempt_at[attempt_key] = now + cooldown
 
-        callback = getattr(self, "_voice_auto_join_callback", None)
-        if callback is None:
+        if getattr(self, "_voice_auto_join_callback", None) is None:
             return False
 
-        success = False
-        try:
-            success = bool(await callback(
-                guild_id=int(guild_id),
-                user_id=str(user_id),
-                voice_channel_id=str(voice_channel_id),
-                text_channel_id=str(text_channel_id),
-            ))
-        except Exception as exc:
-            logger.warning("Discord voice auto-join failed: %s", exc, exc_info=True)
+        success = await self._run_auto_join_with_barrier(
+            guild_id, user_id, voice_channel_id, text_channel_id
+        )
 
         if success:
             # The join callback records the target against the ACTUAL connected
@@ -4244,12 +4411,13 @@ class DiscordAdapter(BasePlatformAdapter):
             self._cancel_voice_auto_join_retry(guild_id)
             return True
 
-        # Failure: measure backoff from failure completion and schedule the one
-        # retry task for this guild so a reconnect needs no second event.
-        backoff = float(cfg.get("failure_backoff_seconds", 60.0) or 0.0)
-        self._voice_auto_join_next_attempt_at[attempt_key] = time.monotonic() + max(cooldown, backoff)
+        # Failure: schedule the one retry task for this guild at the next-allowed
+        # deadline (honoring both failure backoff AND reconnect cooldown) so a
+        # reconnect needs no second event and never violates the cooldown.
+        delay = self._voice_auto_join_retry_delay(cfg)
+        self._voice_auto_join_next_attempt_at[attempt_key] = time.monotonic() + delay
         self._schedule_voice_auto_join_retry(
-            guild_id, user_id, voice_channel_id, text_channel_id, backoff
+            guild_id, user_id, voice_channel_id, text_channel_id, delay
         )
         return False
 
@@ -4264,6 +4432,12 @@ class DiscordAdapter(BasePlatformAdapter):
         # NB: manual-leave suppression is deliberately NOT cleared here. It is
         # keyed to the tracked target and must survive a target leave/rejoin
         # until its monotonic deadline expires.
+
+        # If a join for this exact (guild,user,channel) is in flight, the target
+        # is leaving mid-join: flag it so the post-join barrier aborts instead of
+        # committing a session the target already left. Runs even when no target
+        # is committed yet (the mark happens only after a successful join).
+        self._cancel_pending_auto_join_if_matches(guild_id, user_id, before_channel_id)
 
         target = self._voice_auto_join_targets.get(int(guild_id))
         if not target:
@@ -4453,18 +4627,39 @@ class DiscordAdapter(BasePlatformAdapter):
             return None
         return member.voice.channel
 
+    def _effective_voice_timeout_seconds(self) -> float:
+        """Resolve the idle timeout, treating <= 0 as disabled.
+
+        A configured value of ``0`` (or negative) means "never auto-disconnect".
+        Any positive value is floored to ``VOICE_TIMEOUT_MIN`` so a tiny value
+        cannot turn the timer into a busy zero-sleep rearm loop.
+        """
+        raw = float(getattr(self, "_voice_timeout_seconds", self.VOICE_TIMEOUT))
+        if raw <= 0:
+            return 0.0
+        return max(raw, self.VOICE_TIMEOUT_MIN)
+
     def _reset_voice_timeout(self, guild_id: int) -> None:
-        """Reset the auto-disconnect inactivity timer."""
+        """Reset the auto-disconnect inactivity timer.
+
+        When the idle timeout is disabled (<= 0) no timer is scheduled — the
+        session simply has no inactivity auto-disconnect.
+        """
         task = self._voice_timeout_tasks.pop(guild_id, None)
         if task:
             task.cancel()
+        if self._effective_voice_timeout_seconds() <= 0:
+            return
         self._voice_timeout_tasks[guild_id] = asyncio.ensure_future(
             self._voice_timeout_handler(guild_id)
         )
 
     async def _voice_timeout_handler(self, guild_id: int) -> None:
-        """Auto-disconnect after VOICE_TIMEOUT seconds of inactivity."""
-        timeout_seconds = float(getattr(self, "_voice_timeout_seconds", self.VOICE_TIMEOUT))
+        """Auto-disconnect after the idle timeout of inactivity."""
+        timeout_seconds = self._effective_voice_timeout_seconds()
+        if timeout_seconds <= 0:
+            # Idle timeout disabled — never auto-disconnect, never zero-sleep.
+            return
         try:
             await asyncio.sleep(timeout_seconds)
         except asyncio.CancelledError:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5203,15 +5203,18 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _public_leave_body(self, guild_id: int) -> None:
         gid = int(guild_id)
-        try:
-            async with self._voice_locks.setdefault(gid, asyncio.Lock()):
+        async with self._voice_locks.setdefault(gid, asyncio.Lock()):
+            try:
                 text_ch_id = self._voice_text_channels.get(gid)
                 # Full profile-bound teardown: physical disconnect + maps + the
                 # bound runner cleanup, all under the held lock.
                 await self._teardown_voice_session_body(gid, text_ch_id)
-        finally:
-            # Retry state is cleaned even if teardown raised or is cancelling.
-            self._cancel_voice_auto_join_retry(gid)
+            finally:
+                # Cancel the pending-retry WHILE THE GUILD LOCK IS STILL HELD (and
+                # even if teardown raised or is cancelling), so a concurrent join
+                # that is waiting for the lock can never observe a stale retry task
+                # for a session that is already torn down.
+                self._cancel_voice_auto_join_retry(gid)
 
     async def _disconnect_voice_client(self, vc) -> None:
         """Disconnect a single voice client defensively (tolerant of the fake

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -300,6 +300,52 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+def _clean_discord_channel_id(entry: str) -> str:
+    """Normalize a Discord channel/voice-channel ID pasted from config."""
+    entry = str(entry or "").strip()
+    if entry.startswith("<#") and entry.endswith(">"):
+        entry = entry[2:-1]
+    for prefix in ("channel:", "voice:", "vc:", "text:"):
+        if entry.lower().startswith(prefix):
+            entry = entry[len(prefix):]
+            break
+    return entry.strip()
+
+
+def _discord_config_id_set(value: Any, *, channel: bool = False) -> set[str]:
+    if value is None:
+        return set()
+    if isinstance(value, (list, tuple, set)):
+        entries = value
+    else:
+        entries = str(value).split(",")
+    cleaner = _clean_discord_channel_id if channel else _clean_discord_id
+    return {cleaner(str(entry)) for entry in entries if cleaner(str(entry))}
+
+
+def _discord_config_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+        return default
+    return bool(value)
+
+
+def _discord_config_float(value: Any, default: float, *, minimum: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, parsed)
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available.
 
@@ -864,6 +910,12 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
+        self._voice_auto_join_callback: Optional[Callable] = None  # set by run.py
+        self._voice_auto_join_cfg: Dict[str, Any] = self._load_voice_auto_join_config()
+        self._voice_timeout_seconds: float = self._voice_auto_join_cfg["idle_timeout_seconds"]
+        self._voice_auto_join_targets: Dict[int, Dict[str, str]] = {}
+        self._voice_auto_join_suppressed_until: Dict[Tuple[int, str, str], float] = {}
+        self._voice_auto_join_next_attempt_at: Dict[Tuple[int, str], float] = {}
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -1176,35 +1228,7 @@ class DiscordAdapter(BasePlatformAdapter):
             @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
-                # Only track channels where the bot is connected
-                bot_guild_ids = set(adapter_self._voice_clients.keys())
-                if not bot_guild_ids:
-                    return
-                guild_id = member.guild.id
-                if guild_id not in bot_guild_ids:
-                    return
-                # Ignore the bot itself
-                if member == adapter_self._client.user:
-                    return
-
-                joined = before.channel is None and after.channel is not None
-                left = before.channel is not None and after.channel is None
-                switched = (
-                    before.channel is not None
-                    and after.channel is not None
-                    and before.channel != after.channel
-                )
-
-                if joined or left or switched:
-                    logger.info(
-                        "Voice state: %s (%d) %s (guild %d)",
-                        member.display_name,
-                        member.id,
-                        "joined " + after.channel.name if joined
-                        else "left " + before.channel.name if left
-                        else f"moved {before.channel.name} -> {after.channel.name}",
-                        guild_id,
-                    )
+                await adapter_self._handle_voice_state_update(member, before, after)
 
             # Register slash commands
             if self._slash_commands:
@@ -3595,6 +3619,102 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.debug("Could not load discord.voice_fx config: %s", e)
         return defaults
 
+    def _load_voice_auto_join_config(self) -> Dict[str, Any]:
+        """Read Discord voice auto-join/follow settings from config.yaml.
+
+        Behavioral settings live under ``discord.voice_auto_join`` and are
+        disabled by default. IDs must be explicit; Hermes never infers live
+        Discord users or channels for this feature.
+        """
+        defaults: Dict[str, Any] = {
+            "enabled": False,
+            "allowed_user_ids": set(),
+            "allowed_voice_channel_ids": set(),
+            "text_channel_id": None,
+            "idle_timeout_seconds": float(self.VOICE_TIMEOUT),
+            "target_leave_cleanup": True,
+            "stay_while_target_present": False,
+            "manual_leave_cooldown_seconds": 300.0,
+            "reconnect_cooldown_seconds": 15.0,
+            "failure_backoff_seconds": 60.0,
+        }
+        raw: Dict[str, Any] = {}
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config() or {}
+            discord_cfg = cfg.get("discord") or {}
+            if isinstance(discord_cfg, dict):
+                block = discord_cfg.get("voice_auto_join") or {}
+                if isinstance(block, dict):
+                    raw.update(block)
+                # Top-level timeout alias so manual /voice joins can also use
+                # the configurable Discord voice inactivity timeout.
+                if "voice_idle_timeout_seconds" in discord_cfg:
+                    raw.setdefault(
+                        "idle_timeout_seconds",
+                        discord_cfg.get("voice_idle_timeout_seconds"),
+                    )
+        except Exception as e:
+            logger.debug("Could not load discord.voice_auto_join config: %s", e)
+
+        extra_block = {}
+        try:
+            extra_block = (getattr(self.config, "extra", {}) or {}).get("voice_auto_join") or {}
+        except Exception:
+            extra_block = {}
+        if isinstance(extra_block, dict):
+            raw.update(extra_block)
+
+        allowed_users = (
+            raw.get("allowed_user_ids")
+            if "allowed_user_ids" in raw
+            else raw.get("allowed_users")
+        )
+        allowed_vcs = (
+            raw.get("allowed_voice_channel_ids")
+            if "allowed_voice_channel_ids" in raw
+            else raw.get("allowed_voice_channels", raw.get("allowed_vcs"))
+        )
+        text_channel = raw.get(
+            "text_channel_id",
+            raw.get("linked_text_channel_id", raw.get("linked_text_channel")),
+        )
+        cleaned_text_channel = _clean_discord_channel_id(text_channel) if text_channel is not None else ""
+
+        defaults["enabled"] = _discord_config_bool(raw.get("enabled"), False)
+        defaults["allowed_user_ids"] = _discord_config_id_set(allowed_users)
+        defaults["allowed_voice_channel_ids"] = _discord_config_id_set(allowed_vcs, channel=True)
+        defaults["text_channel_id"] = cleaned_text_channel or None
+        defaults["idle_timeout_seconds"] = _discord_config_float(
+            raw.get("idle_timeout_seconds", raw.get("idle_timeout", raw.get("timeout_seconds"))),
+            defaults["idle_timeout_seconds"],
+            minimum=0.0,
+        )
+        defaults["target_leave_cleanup"] = _discord_config_bool(
+            raw.get("target_leave_cleanup"),
+            True,
+        )
+        defaults["stay_while_target_present"] = _discord_config_bool(
+            raw.get("stay_while_target_present"),
+            False,
+        )
+        defaults["manual_leave_cooldown_seconds"] = _discord_config_float(
+            raw.get("manual_leave_cooldown_seconds", raw.get("manual_leave_cooldown")),
+            defaults["manual_leave_cooldown_seconds"],
+            minimum=0.0,
+        )
+        defaults["reconnect_cooldown_seconds"] = _discord_config_float(
+            raw.get("reconnect_cooldown_seconds", raw.get("reconnect_cooldown")),
+            defaults["reconnect_cooldown_seconds"],
+            minimum=0.0,
+        )
+        defaults["failure_backoff_seconds"] = _discord_config_float(
+            raw.get("failure_backoff_seconds", raw.get("failure_backoff")),
+            defaults["failure_backoff_seconds"],
+            minimum=0.0,
+        )
+        return defaults
+
     def _get_ambient_pcm(self) -> Optional[bytes]:
         """Return decoded 48k/stereo/s16le PCM for the ambient idle bed.
 
@@ -3711,6 +3831,239 @@ class DiscordAdapter(BasePlatformAdapter):
         """True when a continuous mixer is installed for this guild."""
         mixers = getattr(self, "_voice_mixers", None)
         return bool(mixers) and mixers.get(guild_id) is not None
+
+    def suppress_voice_auto_join(
+        self,
+        guild_id: int,
+        *,
+        user_id: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        seconds: Optional[float] = None,
+    ) -> None:
+        """Suppress auto-rejoin after an intentional manual /voice leave."""
+        cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+        cooldown = cfg.get("manual_leave_cooldown_seconds", 300.0) if seconds is None else seconds
+        cooldown = _discord_config_float(cooldown, 300.0, minimum=0.0)
+        if cooldown <= 0:
+            return
+
+        channel_ids = {str(channel_id)} if channel_id is not None else set()
+        if not channel_ids:
+            current = self._voice_clients.get(int(guild_id))
+            current_channel = getattr(current, "channel", None)
+            current_channel_id = getattr(current_channel, "id", None)
+            if current_channel_id is not None:
+                channel_ids.add(str(current_channel_id))
+        if not channel_ids:
+            return
+
+        user_ids = {str(user_id)} if user_id is not None else set()
+        if not user_ids:
+            user_ids.update(cfg.get("allowed_user_ids") or set())
+        if not user_ids:
+            return
+
+        until = time.monotonic() + cooldown
+        for target_user_id in user_ids:
+            for target_channel_id in channel_ids:
+                self._voice_auto_join_suppressed_until[
+                    (int(guild_id), str(target_user_id), str(target_channel_id))
+                ] = until
+
+    def _is_voice_auto_join_suppressed(self, guild_id: int, user_id: str, channel_id: str) -> bool:
+        key = (int(guild_id), str(user_id), str(channel_id))
+        until = self._voice_auto_join_suppressed_until.get(key)
+        if until is None:
+            return False
+        if time.monotonic() >= until:
+            self._voice_auto_join_suppressed_until.pop(key, None)
+            return False
+        return True
+
+    def _clear_voice_auto_join_suppression(self, guild_id: int, user_id: str, channel_id: str) -> None:
+        self._voice_auto_join_suppressed_until.pop(
+            (int(guild_id), str(user_id), str(channel_id)),
+            None,
+        )
+
+    def mark_voice_auto_join_target(
+        self,
+        guild_id: int,
+        *,
+        user_id: str,
+        voice_channel_id: str,
+        text_channel_id: str,
+    ) -> None:
+        """Record which configured user/channel this guild is following."""
+        self._voice_auto_join_targets[int(guild_id)] = {
+            "user_id": str(user_id),
+            "voice_channel_id": str(voice_channel_id),
+            "text_channel_id": str(text_channel_id),
+        }
+
+    def _voice_auto_join_target_present(self, guild_id: int) -> bool:
+        target = self._voice_auto_join_targets.get(int(guild_id))
+        if not target:
+            return False
+        vc = self._voice_clients.get(int(guild_id))
+        channel = getattr(vc, "channel", None)
+        if channel is None:
+            return False
+        if str(getattr(channel, "id", "")) != str(target.get("voice_channel_id")):
+            return False
+        for member in getattr(channel, "members", []) or []:
+            if str(getattr(member, "id", "")) == str(target.get("user_id")):
+                return True
+        return False
+
+    async def _handle_voice_state_update(self, member, before, after) -> None:
+        """Handle Discord voice-state changes for logging and auto-follow."""
+        if self._client is not None and member == getattr(self._client, "user", None):
+            return
+
+        before_channel = getattr(before, "channel", None)
+        after_channel = getattr(after, "channel", None)
+        joined = before_channel is None and after_channel is not None
+        left = before_channel is not None and after_channel is None
+        switched = (
+            before_channel is not None
+            and after_channel is not None
+            and before_channel != after_channel
+        )
+        if not (joined or left or switched):
+            return
+
+        await self._maybe_handle_voice_auto_join(member, before_channel, after_channel)
+
+        guild = getattr(member, "guild", None)
+        guild_id = getattr(guild, "id", None)
+        if guild_id in set(getattr(self, "_voice_clients", {}).keys()):
+            before_name = getattr(before_channel, "name", "")
+            after_name = getattr(after_channel, "name", "")
+            logger.info(
+                "Voice state: %s (%d) %s (guild %d)",
+                getattr(member, "display_name", str(getattr(member, "id", ""))),
+                getattr(member, "id", 0),
+                "joined " + after_name if joined
+                else "left " + before_name if left
+                else f"moved {before_name} -> {after_name}",
+                guild_id,
+            )
+
+    async def _maybe_handle_voice_auto_join(self, member, before_channel, after_channel) -> None:
+        guild = getattr(member, "guild", None)
+        guild_id = getattr(guild, "id", None)
+        user_id = str(getattr(member, "id", "") or "")
+        if guild_id is None or not user_id:
+            return
+        guild_id = int(guild_id)
+
+        if before_channel is not None:
+            await self._maybe_cleanup_voice_auto_join_target(
+                guild_id,
+                user_id,
+                before_channel,
+                after_channel,
+            )
+
+        if after_channel is None:
+            return
+
+        cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+        if not cfg.get("enabled", False):
+            return
+
+        allowed_users = cfg.get("allowed_user_ids") or set()
+        allowed_channels = cfg.get("allowed_voice_channel_ids") or set()
+        text_channel_id = cfg.get("text_channel_id")
+        voice_channel_id = str(getattr(after_channel, "id", "") or "")
+        if not allowed_users or user_id not in allowed_users:
+            return
+        if not allowed_channels or voice_channel_id not in allowed_channels:
+            return
+        if not text_channel_id:
+            return
+
+        existing = self._voice_clients.get(guild_id)
+        if existing and existing.is_connected() and str(getattr(existing.channel, "id", "")) == voice_channel_id:
+            self.mark_voice_auto_join_target(
+                guild_id,
+                user_id=user_id,
+                voice_channel_id=voice_channel_id,
+                text_channel_id=str(text_channel_id),
+            )
+            return
+
+        if self._is_voice_auto_join_suppressed(guild_id, user_id, voice_channel_id):
+            return
+
+        attempt_key = (guild_id, voice_channel_id)
+        now = time.monotonic()
+        next_allowed = self._voice_auto_join_next_attempt_at.get(attempt_key, 0.0)
+        if now < next_allowed:
+            return
+
+        cooldown = float(cfg.get("reconnect_cooldown_seconds", 15.0) or 0.0)
+        self._voice_auto_join_next_attempt_at[attempt_key] = now + cooldown
+
+        callback = getattr(self, "_voice_auto_join_callback", None)
+        if callback is None:
+            return
+
+        success = False
+        try:
+            success = bool(await callback(
+                guild_id=guild_id,
+                user_id=user_id,
+                voice_channel_id=voice_channel_id,
+                text_channel_id=str(text_channel_id),
+            ))
+        except Exception as exc:
+            logger.warning("Discord voice auto-join failed: %s", exc, exc_info=True)
+
+        if success:
+            self.mark_voice_auto_join_target(
+                guild_id,
+                user_id=user_id,
+                voice_channel_id=voice_channel_id,
+                text_channel_id=str(text_channel_id),
+            )
+            return
+
+        backoff = float(cfg.get("failure_backoff_seconds", 60.0) or 0.0)
+        self._voice_auto_join_next_attempt_at[attempt_key] = now + max(cooldown, backoff)
+
+    async def _maybe_cleanup_voice_auto_join_target(
+        self,
+        guild_id: int,
+        user_id: str,
+        before_channel,
+        after_channel,
+    ) -> None:
+        before_channel_id = str(getattr(before_channel, "id", "") or "")
+        self._clear_voice_auto_join_suppression(guild_id, user_id, before_channel_id)
+
+        target = self._voice_auto_join_targets.get(int(guild_id))
+        if not target:
+            return
+        if str(target.get("user_id")) != str(user_id):
+            return
+        if str(target.get("voice_channel_id")) != before_channel_id:
+            return
+        if after_channel is not None and str(getattr(after_channel, "id", "")) == before_channel_id:
+            return
+
+        self._voice_auto_join_targets.pop(int(guild_id), None)
+        cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+        if not cfg.get("target_leave_cleanup", True):
+            return
+        text_ch_id = self._voice_text_channels.get(int(guild_id))
+        await self.leave_voice_channel(int(guild_id))
+        if self._on_voice_disconnect and text_ch_id:
+            try:
+                self._on_voice_disconnect(str(text_ch_id))
+            except Exception:
+                pass
 
     async def join_voice_channel(self, channel) -> bool:
         """Join a Discord voice channel. Returns True on success."""
@@ -3885,8 +4238,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _voice_timeout_handler(self, guild_id: int) -> None:
         """Auto-disconnect after VOICE_TIMEOUT seconds of inactivity."""
+        timeout_seconds = float(getattr(self, "_voice_timeout_seconds", self.VOICE_TIMEOUT))
         try:
-            await asyncio.sleep(self.VOICE_TIMEOUT)
+            await asyncio.sleep(timeout_seconds)
         except asyncio.CancelledError:
             return
         text_ch_id = self._voice_text_channels.get(guild_id)
@@ -3904,6 +4258,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     return
             except Exception:
                 pass
+        auto_join_cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+        if (
+            auto_join_cfg.get("stay_while_target_present")
+            and self._voice_auto_join_target_present(guild_id)
+        ):
+            return
         await self.leave_voice_channel(guild_id)
         # Notify the runner so it can clean up voice_mode state
         if self._on_voice_disconnect and text_ch_id:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -26,6 +26,7 @@ import time
 from collections import defaultdict
 from contextlib import suppress
 from dataclasses import dataclass
+from enum import Enum
 from typing import Callable, Dict, List, Optional, Any, Tuple
 
 from agent.async_utils import (
@@ -319,21 +320,56 @@ class VoiceAutoJoinTarget:
     profile: Optional[str] = None
 
 
-# Typed outcome of a single auto-join barrier attempt. The distinction matters
-# for retry decisioning: only a genuine FAILED attempt may schedule a retry — a
-# SUPERSEDED (a newer auto-join or manual takeover claimed the slot) or CANCELLED
-# (target leave / manual leave) attempt must NOT retry, because a retry could act
-# over a session it does not own.
-AUTO_JOIN_COMMITTED = "committed"
-AUTO_JOIN_FAILED = "failed"
-AUTO_JOIN_SUPERSEDED = "superseded"
-AUTO_JOIN_CANCELLED = "cancelled"
+class AutoJoinOutcome(Enum):
+    """Typed outcome of a single auto-join barrier attempt.
 
-# Sentinel owner stamped on a guild's physical voice session when it was
-# established by a MANUAL /voice-join. Attempt owners are ints (generation
-# tokens), so this string never collides with one. A stale auto-join barrier that
-# finds this owner leaves the hand-established session strictly intact.
-MANUAL_VOICE_SESSION_OWNER = "manual"
+    The distinction drives retry decisioning: only a genuine ``FAILED`` attempt
+    may schedule a retry. A ``SUPERSEDED`` (a newer auto-join or a manual takeover
+    claimed the slot) or ``CANCELLED`` (target leave / manual leave) attempt must
+    NOT retry, because a retry could act over a session it does not own.
+    """
+
+    COMMITTED = "committed"
+    FAILED = "failed"
+    SUPERSEDED = "superseded"
+    CANCELLED = "cancelled"
+
+
+class VoiceOwnerKind(Enum):
+    """Which kind of actor established a guild's live physical voice session."""
+
+    AUTO = "auto"      # an auto-join attempt (carries its generation token)
+    MANUAL = "manual"  # a hand-issued /voice join
+
+
+@dataclass(frozen=True)
+class VoiceSessionOwner:
+    """Immutable ownership stamp for a guild's live physical voice session.
+
+    Destructive teardown keys off this typed value (never a bare string / ``Any``):
+    an attempt may tear a session down only when it is the ORPHAN (no owner) or the
+    exact AUTO owner matching its own token; a MANUAL owner, or a different AUTO
+    token, is never disconnected by a stale attempt.
+    """
+
+    kind: VoiceOwnerKind
+    token: Optional[int] = None  # the attempt generation token for AUTO; None for MANUAL
+
+    @classmethod
+    def manual(cls) -> "VoiceSessionOwner":
+        return cls(VoiceOwnerKind.MANUAL, None)
+
+    @classmethod
+    def auto(cls, token: int) -> "VoiceSessionOwner":
+        return cls(VoiceOwnerKind.AUTO, int(token))
+
+    @property
+    def is_manual(self) -> bool:
+        return self.kind is VoiceOwnerKind.MANUAL
+
+    def is_auto_token(self, token: int) -> bool:
+        """True iff this is the AUTO owner for exactly ``token``."""
+        return self.kind is VoiceOwnerKind.AUTO and self.token == int(token)
 
 
 @dataclass(frozen=True)
@@ -1005,11 +1041,13 @@ class DiscordAdapter(BasePlatformAdapter):
         # can cancel + await them, and so a gateway state query for one guild never
         # observes another guild's in-flight attempt.
         self._voice_auto_join_direct_tasks: Dict[int, set] = {}
-        # Owner of each guild's live physical voice session: an int attempt token
-        # (a committed auto-join) or ``MANUAL_VOICE_SESSION_OWNER`` (a manual
-        # /voice-join). Absent when there is no session. Read/written only under
-        # the guild voice lock so ownership and physical teardown stay atomic.
-        self._voice_session_owner: Dict[int, Any] = {}
+        # Typed owner of each guild's live physical voice session:
+        # ``VoiceSessionOwner.auto(token)`` (a committed auto-join) or
+        # ``VoiceSessionOwner.manual()`` (a manual /voice-join). Absent when there
+        # is no session. Read/written only under the guild voice lock so ownership
+        # and physical teardown stay atomic; destructive teardown keys off this
+        # typed value, never a bare string / Any.
+        self._voice_session_owner: Dict[int, VoiceSessionOwner] = {}
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -4193,29 +4231,28 @@ class DiscordAdapter(BasePlatformAdapter):
         user_id: str,
         voice_channel_id: str,
         text_channel_id: str,
-    ) -> str:
+    ) -> AutoJoinOutcome:
         """Invoke the join callback under a leave-race barrier.
 
-        Returns a TYPED outcome — ``AUTO_JOIN_COMMITTED`` / ``AUTO_JOIN_FAILED`` /
-        ``AUTO_JOIN_SUPERSEDED`` / ``AUTO_JOIN_CANCELLED`` — so the caller can tell
-        a genuine failure (retryable) from a supersession or cancellation (which
-        must NOT retry).
+        Returns a typed :class:`AutoJoinOutcome` so the caller can tell a genuine
+        failure (retryable) from a supersession or cancellation (which must NOT
+        retry).
 
         The attempt is tracked as pending BEFORE the (awaited) network join so a
-        concurrent leave can cancel it. The commit/abort decision AND any physical
-        teardown happen together under the guild voice lock (see
-        ``_finalize_auto_join_under_lock``), so a manual or newer join that
-        completes while we wait for the lock is observed and left intact. A stale
-        attempt whose callback created an unowned session tears that ORPHAN down;
-        it never touches a session a different (newer/manual) owner holds.
+        concurrent leave can cancel it, and the EXACT attempt token is threaded
+        into the join callback so ``join_voice_channel`` can refuse to mutate a
+        manual/newer-owned session on behalf of a stale attempt. The commit/abort
+        decision AND any physical teardown happen together under the guild voice
+        lock, so a manual or newer join that completes while we wait for the lock
+        is observed and left intact.
         """
         callback = getattr(self, "_voice_auto_join_callback", None)
         if callback is None:
-            return AUTO_JOIN_FAILED
+            return AutoJoinOutcome.FAILED
         # Reject while disconnecting — an adapter being torn down must not
         # establish a new voice session.
         if getattr(self, "_disconnecting", False):
-            return AUTO_JOIN_FAILED
+            return AutoJoinOutcome.FAILED
         token = self._register_pending_auto_join(guild_id, user_id, voice_channel_id)
         try:
             success = bool(await callback(
@@ -4223,6 +4260,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 user_id=str(user_id),
                 voice_channel_id=str(voice_channel_id),
                 text_channel_id=str(text_channel_id),
+                attempt_token=token,
             ))
         except asyncio.CancelledError:
             # Cancellation can land at ANY await after the callback began. The
@@ -4242,23 +4280,54 @@ class DiscordAdapter(BasePlatformAdapter):
         # before propagating, so no half-torn-down or dangling state survives.
         try:
             if not success:
-                # A failed callback may still have (partially) connected; finalize
-                # under the lock so an orphan it created cannot linger, and
-                # classify the outcome (superseded/cancelled must not retry).
-                return await self._finalize_auto_join_under_lock(
-                    guild_id, voice_channel_id, text_channel_id, token,
-                    callback_success=False, target_present=False,
+                # A failed/rejected callback may still have (partially) connected;
+                # finalize under the lock so an orphan it created cannot linger,
+                # and classify the outcome (superseded/cancelled must not retry).
+                # Shielded-to-completion so a cancellation cannot interrupt the
+                # lock-scoped commit/teardown mid-flight.
+                return await self._shield_to_completion(
+                    lambda: self._finalize_auto_join_under_lock(
+                        guild_id, voice_channel_id, text_channel_id, token,
+                        callback_success=False, target_present=False,
+                    )
                 )
             target_present = await self._voice_target_in_channel(
                 guild_id, user_id, voice_channel_id
             )
-            return await self._finalize_auto_join_under_lock(
-                guild_id, voice_channel_id, text_channel_id, token,
-                callback_success=True, target_present=target_present,
+            return await self._shield_to_completion(
+                lambda: self._finalize_auto_join_under_lock(
+                    guild_id, voice_channel_id, text_channel_id, token,
+                    callback_success=True, target_present=target_present,
+                )
             )
         except asyncio.CancelledError:
             await self._shielded_cancel_cleanup(guild_id, text_channel_id, token)
             raise
+
+    async def _shield_to_completion(self, factory):
+        """Run ``factory()`` as a task and await it to COMPLETION even if THIS
+        coroutine is cancelled; re-raise the cancellation only after the task has
+        fully finished.
+
+        Lets a lock-scoped teardown finish atomically — physical disconnect + map
+        cleanup + profile-bound runner cleanup — before a cancellation propagates,
+        WITHOUT releasing the guild lock mid-teardown (the task, not this
+        coroutine, owns the lock, so a cancellation of this coroutine never exits
+        the ``async with`` early).
+        """
+        task = asyncio.ensure_future(factory())
+        cancelled = False
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                cancelled = True
+        if cancelled:
+            exc = task.exception()
+            if exc is not None:
+                raise exc
+            raise asyncio.CancelledError()
+        return task.result()
 
     async def _finalize_auto_join_under_lock(
         self,
@@ -4269,7 +4338,7 @@ class DiscordAdapter(BasePlatformAdapter):
         *,
         callback_success: bool,
         target_present: bool,
-    ) -> str:
+    ) -> AutoJoinOutcome:
         """Decide the attempt outcome and perform any physical teardown ATOMICALLY
         under the guild voice lock.
 
@@ -4277,7 +4346,7 @@ class DiscordAdapter(BasePlatformAdapter):
         the disconnect closes the P1-B race: a manual/newer join that completes
         while this attempt waited for the lock will already have stamped its
         session ownership (and superseded our pending slot), so we observe it and
-        never disconnect it. Returns the typed outcome.
+        never disconnect it.
         """
         lock = self._voice_locks.setdefault(int(guild_id), asyncio.Lock())
         async with lock:
@@ -4286,6 +4355,7 @@ class DiscordAdapter(BasePlatformAdapter):
             cancelled = (not superseded) and bool(entry.get("cancelled"))
             disconnecting = bool(getattr(self, "_disconnecting", False))
             actual_channel = self.connected_voice_channel_id(int(guild_id))
+            owner = self._voice_session_owner.get(int(guild_id))
             committed = bool(
                 callback_success
                 and not superseded
@@ -4293,25 +4363,51 @@ class DiscordAdapter(BasePlatformAdapter):
                 and not disconnecting
                 and actual_channel == str(voice_channel_id)
                 and target_present
+                # The live session must be an orphan we just created or already
+                # ours — never commit on top of a manual/other-token owner.
+                and (owner is None or owner.is_auto_token(token))
             )
             if committed:
-                # Stamp session ownership with THIS attempt's token so a later
-                # stale rollback recognizes the session is no longer its own.
-                self._voice_session_owner[int(guild_id)] = token
+                # Stamp typed session ownership so a later stale rollback
+                # recognizes the session is no longer its own.
+                self._voice_session_owner[int(guild_id)] = VoiceSessionOwner.auto(token)
                 self._clear_pending_auto_join(int(guild_id), token)
-                return AUTO_JOIN_COMMITTED
+                return AutoJoinOutcome.COMMITTED
 
             if superseded:
-                outcome = AUTO_JOIN_SUPERSEDED
+                outcome = AutoJoinOutcome.SUPERSEDED
             elif cancelled:
-                outcome = AUTO_JOIN_CANCELLED
+                outcome = AutoJoinOutcome.CANCELLED
             else:
-                outcome = AUTO_JOIN_FAILED
+                outcome = AutoJoinOutcome.FAILED
             await self._teardown_owned_or_orphan_locked(
                 guild_id, text_channel_id, token
             )
             self._clear_pending_auto_join(int(guild_id), token)
             return outcome
+
+    def _voice_session_owned_by_attempt(self, guild_id: int, token: int) -> bool:
+        """Whether the guild's live session is owned by exactly this AUTO token."""
+        owner = self._voice_session_owner.get(int(guild_id))
+        return owner is not None and owner.is_auto_token(token)
+
+    def _has_residual_voice_state(self, guild_id: int) -> bool:
+        """True if ANY per-guild voice map still holds state for this guild.
+
+        Used so a (retry) teardown never returns early merely because
+        ``_voice_clients`` was already popped by a partially-completed teardown —
+        the remaining maps (text/source/owner/receiver/timeout) still get cleared.
+        """
+        gid = int(guild_id)
+        for name in (
+            "_voice_clients", "_voice_text_channels", "_voice_sources",
+            "_voice_session_owner", "_voice_receivers", "_voice_listen_tasks",
+            "_voice_timeout_tasks", "_voice_mixers",
+        ):
+            m = getattr(self, name, None)
+            if isinstance(m, dict) and gid in m:
+                return True
+        return False
 
     async def _teardown_owned_or_orphan_locked(
         self, guild_id: int, text_channel_id: str, token: int
@@ -4319,24 +4415,41 @@ class DiscordAdapter(BasePlatformAdapter):
         """Disconnect the guild's physical session ONLY if this attempt owns it or
         it is an ORPHAN. Caller MUST hold ``_voice_locks[guild_id]``.
 
-        Ownership is decided from ``_voice_session_owner`` under the lock:
-          - a different owner (a newer committed attempt, or a manual takeover) →
+        Ownership is decided from the typed ``_voice_session_owner`` under the lock:
+          - a different owner (a newer committed AUTO token, or a MANUAL takeover) →
             leave the session strictly intact;
-          - our own token, or no owner at all (an orphan a stale/cancelled
-            callback created that nobody committed) → disconnect it and run the
-            profile-bound runner rollback, so no unowned VC is ever left behind
-            (this is the only cleanup when ``idle_timeout_seconds`` is 0 and the
-            inactivity timer never fires).
+          - our own token, or no owner at all (an orphan a stale/cancelled callback
+            created) → disconnect it and run the profile-bound runner rollback, so
+            no unowned VC is ever left behind (the only cleanup when
+            ``idle_timeout_seconds`` is 0 and the inactivity timer never fires).
+
+        The physical disconnect + all map cleanup + the runner rollback are
+        performed TRANSACTIONALLY (shielded) so a cancellation cannot leave a
+        popped-but-connected client or skip the runner cleanup.
         """
-        actual_channel = self.connected_voice_channel_id(int(guild_id))
-        if actual_channel is None:
+        gid = int(guild_id)
+        client = self._voice_clients.get(gid)
+        connected = client is not None and getattr(client, "is_connected", lambda: False)()
+        owner = self._voice_session_owner.get(gid)
+        if connected and owner is not None and not owner.is_auto_token(token):
+            # A newer auto-join or a manual session owns the live connection.
             return
-        owner = self._voice_session_owner.get(int(guild_id))
-        if owner is not None and owner != token:
-            # A newer auto-join or manual session owns the live connection.
+        if not connected and not self._has_residual_voice_state(gid):
+            # Nothing live and no residual state — nothing to tear down.
             return
+        # NB: the CALLER runs this whole teardown to completion (see
+        # ``_shield_to_completion`` / ``_shielded_cancel_cleanup``), so a
+        # cancellation cannot interrupt it mid-flight or release the guild lock
+        # before the physical disconnect + runner cleanup finish.
+        await self._teardown_voice_session_transactional(gid, text_channel_id)
+
+    async def _teardown_voice_session_transactional(
+        self, guild_id: int, text_channel_id: str
+    ) -> None:
+        """Physical disconnect + full map cleanup + profile-bound runner cleanup,
+        as one unit that completes before any cancellation propagates. Invoked via
+        ``asyncio.shield`` by the owned/orphan and cancellation paths."""
         await self._leave_voice_channel_locked(int(guild_id))
-        self._voice_auto_join_targets.pop(int(guild_id), None)
         on_disconnect = getattr(self, "_on_voice_disconnect", None)
         if on_disconnect and text_channel_id:
             try:
@@ -4562,7 +4675,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 except asyncio.CancelledError:
                     return
                 now = time.monotonic()
-                if outcome == AUTO_JOIN_COMMITTED:
+                if outcome == AutoJoinOutcome.COMMITTED:
                     if int(guild_id) not in self._voice_auto_join_targets:
                         self.mark_voice_auto_join_target(
                             guild_id,
@@ -4574,7 +4687,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         (int(guild_id), str(voice_channel_id))
                     ] = now
                     return
-                if outcome in (AUTO_JOIN_SUPERSEDED, AUTO_JOIN_CANCELLED):
+                if outcome in (AutoJoinOutcome.SUPERSEDED, AutoJoinOutcome.CANCELLED):
                     # A newer auto-join or a manual takeover/leave claimed the
                     # slot — stop retrying so a retry can never act over a session
                     # this attempt does not own.
@@ -4743,7 +4856,7 @@ class DiscordAdapter(BasePlatformAdapter):
         except asyncio.CancelledError:
             return False
 
-        if outcome == AUTO_JOIN_COMMITTED:
+        if outcome == AutoJoinOutcome.COMMITTED:
             # The join callback records the target against the ACTUAL connected
             # channel (and owning profile). Only synthesize one here if it did
             # not, so we never overwrite the verified target with the event's
@@ -4758,7 +4871,7 @@ class DiscordAdapter(BasePlatformAdapter):
             self._cancel_voice_auto_join_retry(guild_id)
             return True
 
-        if outcome in (AUTO_JOIN_SUPERSEDED, AUTO_JOIN_CANCELLED):
+        if outcome in (AutoJoinOutcome.SUPERSEDED, AutoJoinOutcome.CANCELLED):
             # Superseded/cancelled is NOT a retryable failure — a newer auto-join
             # or a manual takeover/leave owns (or intentionally ended) the slot.
             # Retrying could act over a session this attempt does not own.
@@ -4831,51 +4944,82 @@ class DiscordAdapter(BasePlatformAdapter):
         cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
         if not cfg.get("target_leave_cleanup", True):
             return
-        # Only disconnect if the bot is STILL in the exact channel it was
-        # following. A manual /voice takeover may have moved the session to a
-        # different channel; never disconnect that hand-established session.
-        if self.connected_voice_channel_id(int(guild_id)) != target_channel_id:
-            return
-        text_ch_id = self._voice_text_channels.get(int(guild_id))
-        await self.leave_voice_channel(int(guild_id))
-        if self._on_voice_disconnect and text_ch_id:
-            try:
-                self._on_voice_disconnect(str(text_ch_id))
-            except Exception:
-                pass
+        # The exact-channel + owner recheck AND the physical disconnect happen in
+        # ONE guild-lock critical section, so a manual /voice-join that races this
+        # cleanup (acquiring the lock first, stamping manual ownership, moving the
+        # session) can never be disconnected: under the lock we observe either a
+        # different connected channel or a MANUAL owner and bail without touching it.
+        lock = self._voice_locks.setdefault(int(guild_id), asyncio.Lock())
+        async with lock:
+            if self.connected_voice_channel_id(int(guild_id)) != target_channel_id:
+                return
+            owner = self._voice_session_owner.get(int(guild_id))
+            if owner is not None and owner.is_manual:
+                return
+            text_ch_id = self._voice_text_channels.get(int(guild_id))
+            # Transactional: physical disconnect + map cleanup + the profile-bound
+            # runner cleanup complete (holding the lock throughout) before any
+            # cancellation can propagate.
+            await self._shield_to_completion(
+                lambda: self._teardown_voice_session_transactional(int(guild_id), text_ch_id)
+            )
 
-    async def join_voice_channel(self, channel, *, manual_owner: bool = False) -> bool:
+    async def join_voice_channel(
+        self, channel, *, manual_owner: bool = False, attempt_token: Optional[int] = None
+    ) -> bool:
         """Join a Discord voice channel. Returns True on success.
 
-        ``manual_owner`` marks a hand-issued ``/voice join``: under the guild
-        voice lock (atomic with the connect/move) it stamps the session as manual-
-        owned, so a stale auto-join barrier that completes later recognizes the
-        session is not its own and never disconnects it. Auto-join leaves this
-        False — its ownership is stamped by the barrier's commit under the lock.
+        ``manual_owner`` marks a hand-issued ``/voice join``: it stamps the session
+        as manual-owned so a stale auto-join barrier can never disconnect it.
+
+        ``attempt_token`` is the auto-join barrier's exact generation token. When
+        provided, then UNDER THE GUILD VOICE LOCK and BEFORE any ``move_to`` /
+        ``connect``, the join is gated: the attempt must still be the current
+        pending attempt (not cancelled, not disconnecting) and any existing session
+        must be an orphan or already auto-owned — a MANUAL (or otherwise different)
+        owner is rejected WITHOUT mutation, so a stale/superseded auto callback can
+        never move or overwrite a hand-established or newer session. After the
+        awaited connect the currency is rechecked before the session is published
+        or stamped.
         """
         if not self._client or not DISCORD_AVAILABLE:
             return False
         guild_id = channel.guild.id
 
         async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
+            # Gate an AUTO attempt BEFORE touching the physical session.
+            if attempt_token is not None and not self._auto_attempt_may_mutate_locked(
+                guild_id, attempt_token
+            ):
+                return False
+
             # Already connected in this guild?
             existing = self._voice_clients.get(guild_id)
             if existing and existing.is_connected():
                 if existing.channel.id == channel.id:
                     self._reset_voice_timeout(guild_id)
-                    if manual_owner:
-                        self._voice_session_owner[guild_id] = MANUAL_VOICE_SESSION_OWNER
+                    self._stamp_voice_owner_locked(guild_id, manual_owner, attempt_token)
                     return True
                 await existing.move_to(channel)
+                # Recheck currency after the awaited move before keeping/stamping.
+                if attempt_token is not None and not self._auto_attempt_current_locked(
+                    guild_id, attempt_token
+                ):
+                    return False
                 self._reset_voice_timeout(guild_id)
-                if manual_owner:
-                    self._voice_session_owner[guild_id] = MANUAL_VOICE_SESSION_OWNER
+                self._stamp_voice_owner_locked(guild_id, manual_owner, attempt_token)
                 return True
 
             vc = await channel.connect()
+            # Recheck AFTER the awaited connect, BEFORE publishing the client: a
+            # stale attempt must not publish an orphan; disconnect it instead.
+            if attempt_token is not None and not self._auto_attempt_current_locked(
+                guild_id, attempt_token
+            ):
+                await self._disconnect_voice_client(vc)
+                return False
             self._voice_clients[guild_id] = vc
-            if manual_owner:
-                self._voice_session_owner[guild_id] = MANUAL_VOICE_SESSION_OWNER
+            self._stamp_voice_owner_locked(guild_id, manual_owner, attempt_token)
             self._reset_voice_timeout(guild_id)
 
             # Start voice receiver (Phase 2: listen to users)
@@ -4900,59 +5044,107 @@ class DiscordAdapter(BasePlatformAdapter):
 
             return True
 
+    def _auto_attempt_current_locked(self, guild_id: int, token: int) -> bool:
+        """Whether the auto attempt ``token`` is still the current pending attempt
+        (not cancelled) and the adapter is not disconnecting. Caller holds the lock.
+        """
+        entry = self._current_pending_auto_join(int(guild_id), token)
+        if entry is None or entry.get("cancelled"):
+            return False
+        if getattr(self, "_disconnecting", False):
+            return False
+        return True
+
+    def _auto_attempt_may_mutate_locked(self, guild_id: int, token: int) -> bool:
+        """Whether the auto attempt ``token`` may mutate the guild's physical
+        session. Caller holds the guild voice lock.
+
+        Requires the attempt to be current AND that any existing live session is
+        NOT owned by a MANUAL takeover — a manual (hand-established) session is
+        never moved/overwritten by an auto attempt.
+        """
+        if not self._auto_attempt_current_locked(guild_id, token):
+            return False
+        existing = self._voice_clients.get(int(guild_id))
+        if existing is not None and getattr(existing, "is_connected", lambda: False)():
+            owner = self._voice_session_owner.get(int(guild_id))
+            if owner is not None and owner.is_manual:
+                return False
+        return True
+
+    def _stamp_voice_owner_locked(
+        self, guild_id: int, manual_owner: bool, attempt_token: Optional[int]
+    ) -> None:
+        """Stamp typed session ownership under the guild lock: MANUAL for a manual
+        join, AUTO(token) for a token-carrying auto attempt. A tokenless auto call
+        (legacy) leaves ownership for the barrier commit to stamp."""
+        if manual_owner:
+            self._voice_session_owner[int(guild_id)] = VoiceSessionOwner.manual()
+        elif attempt_token is not None:
+            self._voice_session_owner[int(guild_id)] = VoiceSessionOwner.auto(attempt_token)
+
     async def leave_voice_channel(self, guild_id: int) -> None:
-        """Disconnect from the voice channel in a guild."""
+        """Disconnect from the voice channel in a guild (cancellation-safe)."""
         async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
             await self._leave_voice_channel_locked(guild_id)
         # Disconnecting cancels any pending auto-rejoin retry for this guild.
         self._cancel_voice_auto_join_retry(guild_id)
 
+    async def _disconnect_voice_client(self, vc) -> None:
+        """Disconnect a single voice client defensively (tolerant of the fake
+        clients used in tests). The physical disconnect await lives here so
+        callers can shield exactly this step."""
+        try:
+            if getattr(vc, "is_connected", lambda: False)():
+                try:
+                    if vc.is_playing():
+                        vc.stop()
+                except Exception:
+                    pass
+                disconnect = getattr(vc, "disconnect", None)
+                if disconnect is not None:
+                    result = disconnect()
+                    if asyncio.iscoroutine(result):
+                        await result
+        except Exception:
+            pass
+
     async def _leave_voice_channel_locked(self, guild_id: int) -> None:
         """Physical voice teardown body. The caller MUST hold
         ``_voice_locks[guild_id]``.
 
-        Split out so the auto-join barrier can recheck session ownership and
-        disconnect ATOMICALLY under the same lock (closing the P1-B race where a
-        manual/newer join completes while a stale rollback waits for the lock).
-        Tolerant of the lightweight fake voice clients used in tests.
+        Cancellation-safe: all per-guild maps (receiver, mixer, client, timeout,
+        text, source, owner) are cleared SYNCHRONOUSLY first — no await between
+        them — and then the ONLY await, the physical disconnect, is SHIELDED, so a
+        cancellation can never leave a popped-but-still-connected client dangling
+        or a half-cleared set of maps. Tolerant of the fake clients used in tests.
         """
-        # Stop voice receiver first
-        receiver = self._voice_receivers.pop(guild_id, None)
+        gid = int(guild_id)
+        # -- synchronous map teardown (uninterruptible: no await) --
+        receiver = self._voice_receivers.pop(gid, None)
         if receiver:
             receiver.stop()
-        listen_task = self._voice_listen_tasks.pop(guild_id, None)
+        listen_task = self._voice_listen_tasks.pop(gid, None)
         if listen_task:
             listen_task.cancel()
-
-        # Tear down the mixer (stops the continuous outgoing stream).
         if getattr(self, "_voice_mixers", None) is not None:
-            self._voice_mixers.pop(guild_id, None)
-
-        vc = self._voice_clients.pop(guild_id, None)
-        if vc is not None:
-            try:
-                if getattr(vc, "is_connected", lambda: False)():
-                    try:
-                        if vc.is_playing():
-                            vc.stop()
-                    except Exception:
-                        pass
-                    disconnect = getattr(vc, "disconnect", None)
-                    if disconnect is not None:
-                        result = disconnect()
-                        if asyncio.iscoroutine(result):
-                            await result
-            except Exception:
-                pass
-        task = self._voice_timeout_tasks.pop(guild_id, None)
-        if task:
-            task.cancel()
-        self._voice_text_channels.pop(guild_id, None)
-        self._voice_sources.pop(guild_id, None)
-        # A disconnected session has no owner.
+            self._voice_mixers.pop(gid, None)
+        vc = self._voice_clients.pop(gid, None)
+        timeout_task = self._voice_timeout_tasks.pop(gid, None)
+        if timeout_task:
+            timeout_task.cancel()
+        self._voice_text_channels.pop(gid, None)
+        self._voice_sources.pop(gid, None)
         owner_map = getattr(self, "_voice_session_owner", None)
         if isinstance(owner_map, dict):
-            owner_map.pop(guild_id, None)
+            owner_map.pop(gid, None)
+        # The auto-follow target is tied to the session — drop it too.
+        targets = getattr(self, "_voice_auto_join_targets", None)
+        if isinstance(targets, dict):
+            targets.pop(gid, None)
+        # -- the sole await: complete the physical disconnect even under cancel --
+        if vc is not None:
+            await asyncio.shield(self._disconnect_voice_client(vc))
 
     # Maximum seconds to wait for voice playback before giving up
     PLAYBACK_TIMEOUT = 120
@@ -5109,13 +5301,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._voice_timeout_handler(guild_id)
             )
             return
-        await self.leave_voice_channel(guild_id)
-        # Notify the runner so it can clean up voice_mode state
-        if self._on_voice_disconnect and text_ch_id:
-            try:
-                self._on_voice_disconnect(str(text_ch_id))
-            except Exception:
-                pass
+        # Transactional, cancellation-safe teardown (physical disconnect + maps +
+        # profile-bound runner cleanup) under the guild lock.
+        lock = self._voice_locks.setdefault(int(guild_id), asyncio.Lock())
+        async with lock:
+            await self._shield_to_completion(
+                lambda: self._teardown_voice_session_transactional(int(guild_id), text_ch_id)
+            )
+        self._cancel_voice_auto_join_retry(int(guild_id))
         if text_ch_id and self._client:
             ch = self._client.get_channel(text_ch_id)
             if ch:

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -95,13 +95,15 @@ class _FakeVoiceClient:
     """
 
     def __init__(self, channel, *, disconnect_gate=None, on_disconnect_start=None,
-                 move_gate=None, on_move_start=None):
+                 move_gate=None, on_move_start=None, raise_move_after=None):
         self.channel = channel
         self._connected = True
         self._disconnect_gate = disconnect_gate
         self._on_disconnect_start = on_disconnect_start
         self._move_gate = move_gate
         self._on_move_start = on_move_start
+        self._raise_move_after = raise_move_after  # raise on the (N+1)-th move_to
+        self._move_count = 0
         self.disconnected = False
 
     def is_connected(self):
@@ -118,6 +120,10 @@ class _FakeVoiceClient:
             self._on_move_start()
         if self._move_gate is not None:
             await self._move_gate.wait()
+        if self._raise_move_after is not None and self._move_count >= self._raise_move_after:
+            self._move_count += 1
+            raise RuntimeError("simulated move_to failure")
+        self._move_count += 1
         self.channel = channel
 
     async def disconnect(self):
@@ -1743,7 +1749,7 @@ class TestDiscordVoiceAutoJoin:
         assert task is not None and not task.done()
 
         adapter.suppress_voice_auto_join(111, user_id="42", channel_id="222")
-        await asyncio.sleep(0)
+        await asyncio.gather(task, return_exceptions=True)
 
         assert task.done()
         assert 111 not in adapter._voice_auto_join_retry_tasks
@@ -1776,7 +1782,7 @@ class TestDiscordVoiceAutoJoin:
             SimpleNamespace(channel=SimpleNamespace(id=222, name="General")),
             SimpleNamespace(channel=None),
         )
-        await asyncio.sleep(0)
+        await asyncio.gather(task, return_exceptions=True)
 
         assert task.done()
         assert 111 not in adapter._voice_auto_join_retry_tasks
@@ -2296,7 +2302,7 @@ class TestDiscordVoiceAutoJoin:
         assert 111 not in adapter._voice_auto_join_targets
         assert 111 not in adapter._voice_auto_join_pending
         assert 111 not in adapter._voice_auto_join_retry_tasks
-        await asyncio.sleep(0)
+        await asyncio.gather(retry, return_exceptions=True)
         assert retry.cancelled() or retry.done()
 
     # ----- Final P1 findings: attempt-scoped teardown, cancellation, leave -----
@@ -3147,24 +3153,27 @@ class TestDiscordVoiceAutoJoin:
         assert adapter._voice_auto_join_targets[111] is newer_target
 
     @pytest.mark.asyncio
-    async def test_join_broad_typeerror_never_drops_token_or_manual_owner(self, tmp_path):
-        """P1: a broad/internal TypeError from join_voice_channel must PROPAGATE
-        (no tokenless retry) so a stale attempt is never re-driven without its
-        token; only a genuine unknown-kwarg TypeError falls back."""
+    async def test_join_signature_inspected_never_parses_typeerror_or_retries_modern(self, tmp_path):
+        """P1: the gateway inspects join_voice_channel's SIGNATURE before calling —
+        it never parses a TypeError message and never retries a MODERN call
+        tokenless. A modern adapter that raises an internal TypeError makes exactly
+        ONE failed call; a genuinely legacy signature (no gate kwargs) is called
+        tokenless exactly once."""
         from gateway.config import Platform
 
-        # -- broad internal TypeError → propagates → failure, single call, no retry --
+        # -- MODERN signature (accepts the gate kwargs) that raises an internal
+        #    TypeError → propagates → single failed call, NO tokenless retry --
         runner = _make_runner(tmp_path)
         adapter = MagicMock()
         adapter.platform = Platform.DISCORD
-        adapter.get_user_voice_channel = AsyncMock(return_value=None)
-        calls = {"n": 0}
+        calls = {"n": 0, "last_kwargs": None}
 
-        async def _boom(vc, **kw):
+        async def _modern_join(channel, *, manual_owner=False, attempt_token=None):
             calls["n"] += 1
+            calls["last_kwargs"] = {"manual_owner": manual_owner, "attempt_token": attempt_token}
             raise TypeError("some internal boom unrelated to kwargs")
 
-        adapter.join_voice_channel = _boom
+        adapter.join_voice_channel = _modern_join
         adapter._voice_input_callback = None
         adapter._on_voice_disconnect = None
         adapter._voice_mode_getter = None
@@ -3177,29 +3186,21 @@ class TestDiscordVoiceAutoJoin:
         event = self._voice_event("333")
         result = await runner._handle_voice_channel_join(event, voice_channel=vch, manual=True, attempt_token=None)
         assert "failed" in result.lower()
-        assert calls["n"] == 1                       # NO tokenless retry
-        assert runner._voice_mode == {}              # no side effects
+        assert calls["n"] == 1                            # exactly one call, NO retry
+        assert calls["last_kwargs"] == {"manual_owner": True, "attempt_token": None}
+        assert runner._voice_mode == {}                   # no side effects
 
-        # -- genuine unknown-kwarg TypeError → single tokenless fallback --
+        # -- LEGACY signature (no gate kwargs, no **kwargs) → single tokenless call --
         runner2 = _make_runner(tmp_path)
         adapter2 = MagicMock()
         adapter2.platform = Platform.DISCORD
-        legacy_calls = {"with_kw": 0, "without_kw": 0}
+        legacy = {"n": 0}
 
-        async def _legacy(vc, *, manual_owner=None, attempt_token=None, **extra):
-            # Simulate an older signature: reject the new kwargs like Python would.
-            raise TypeError(
-                "join_voice_channel() got an unexpected keyword argument 'attempt_token'"
-            )
-
-        async def _legacy_dispatch(vc, **kw):
-            if "attempt_token" in kw or "manual_owner" in kw:
-                legacy_calls["with_kw"] += 1
-                return await _legacy(vc, **kw)
-            legacy_calls["without_kw"] += 1
+        async def _legacy_join(channel):   # genuinely older signature
+            legacy["n"] += 1
             return True
 
-        adapter2.join_voice_channel = _legacy_dispatch
+        adapter2.join_voice_channel = _legacy_join
         adapter2._voice_input_callback = None
         adapter2._on_voice_disconnect = None
         adapter2._voice_mode_getter = None
@@ -3215,7 +3216,7 @@ class TestDiscordVoiceAutoJoin:
         event2 = self._voice_event("333")
         result2 = await runner2._handle_voice_channel_join(event2, voice_channel=vch2, manual=True, attempt_token=None)
         assert "joined" in result2.lower()
-        assert legacy_calls == {"with_kw": 1, "without_kw": 1}  # exactly one fallback
+        assert legacy["n"] == 1                            # single tokenless call
 
     @pytest.mark.asyncio
     async def test_public_leave_holds_lock_until_disconnect_completes_under_cancel(self):
@@ -3232,23 +3233,26 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_clients[111] = vc
         adapter._voice_text_channels[111] = 333
         adapter._voice_sources[111] = {"chat_id": "333"}
-        adapter._voice_locks[111] = asyncio.Lock()
+        # A retry task must be finally-cleaned even under cancellation.
+        adapter._voice_auto_join_retry_tasks[111] = MagicMock()
+        instrumented = _InstrumentedLock()
+        adapter._voice_locks[111] = instrumented
 
         leave_task = asyncio.ensure_future(adapter.leave_voice_channel(111))
         await disconnect_started.wait()             # inside vc.disconnect(), lock held
 
-        # A contender tries to take the guild lock; it must NOT succeed while the
-        # cancelled teardown is still completing the physical disconnect.
+        # A contender tries to take the guild lock; the instrumented lock signals
+        # when it is actually BLOCKED (explicit event, no sleep-zero guess) — proof
+        # the teardown still holds the lock.
         got_lock = asyncio.Event()
 
         async def _contender():
-            async with adapter._voice_locks[111]:
+            async with instrumented:
                 got_lock.set()
 
         contender = asyncio.ensure_future(_contender())
-
         leave_task.cancel()
-        await asyncio.sleep(0)
+        await instrumented.waiter_arrived.wait()    # contender is blocked on the lock
         assert not got_lock.is_set()                # lock still held by the teardown
 
         gate.set()                                  # let the disconnect finish
@@ -3259,9 +3263,206 @@ class TestDiscordVoiceAutoJoin:
         assert 111 not in adapter._voice_clients
         assert 111 not in adapter._voice_text_channels
         assert 111 not in adapter._voice_sources
+        assert 111 not in adapter._voice_auto_join_retry_tasks   # retry finally-cleaned
         # Only now can the contender acquire the lock.
         await asyncio.wait_for(contender, timeout=1)
         assert got_lock.is_set()
+
+    @pytest.mark.asyncio
+    async def test_mid_move_rollback_failure_tears_session_down(self):
+        """P1 (1): if the mid-move supersession ROLLBACK itself fails, the session
+        is deterministically torn down rather than left stranded on the wrong
+        channel — no stale physical mutation can remain."""
+        from plugins.platforms.discord.adapter import VoiceSessionOwner
+
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222", "555"],
+            "text_channel_id": "333",
+        })
+        move_started = asyncio.Event()
+        move_gate = asyncio.Event()
+        # Existing session on 222; the FIRST move (222→555) succeeds, the SECOND
+        # (the 555→222 restore) raises.
+        existing = _FakeVoiceClient(
+            SimpleNamespace(id=222), move_gate=move_gate,
+            on_move_start=move_started.set, raise_move_after=1,
+        )
+        adapter._voice_clients[111] = existing
+        adapter._voice_session_owner[111] = VoiceSessionOwner.auto(1)
+        adapter._voice_text_channels[111] = 333
+        adapter._voice_locks[111] = asyncio.Lock()
+
+        token_a = adapter._register_pending_auto_join(111, "42", "555")
+        target_555 = _FakeVoiceChannel(555, guild_id=111, members=[SimpleNamespace(id=42)])
+        join_task = asyncio.ensure_future(
+            adapter.join_voice_channel(target_555, attempt_token=token_a)
+        )
+        await move_started.wait()
+        adapter._register_pending_auto_join(111, "42", "555")  # supersede A mid-move
+        move_gate.set()
+        result = await join_task
+
+        assert result is False
+        # Restore failed → deterministic teardown: no dangling session/maps/owner.
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_session_owner
+        assert 111 not in adapter._voice_text_channels
+
+    @pytest.mark.asyncio
+    async def test_target_leave_preserves_replacement_target_same_object_check(self):
+        """P1 (2): a REPLACEMENT target object on the SAME channel (even with an
+        unchanged owner) is preserved — the cleanup matches the exact captured
+        target object, not just channel/owner."""
+        from plugins.platforms.discord.adapter import VoiceSessionOwner, VoiceAutoJoinTarget
+
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "target_leave_cleanup": True,
+        })
+        vc = _FakeVoiceClient(SimpleNamespace(id=222))
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 333
+        adapter._voice_session_owner[111] = VoiceSessionOwner.auto(1)
+        captured = VoiceAutoJoinTarget(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+        adapter._voice_auto_join_targets[111] = captured
+        instrumented = _InstrumentedLock()
+        adapter._voice_locks[111] = instrumented
+
+        await instrumented.acquire()
+        cleanup_task = asyncio.ensure_future(
+            adapter._maybe_cleanup_voice_auto_join_target(
+                111, "42", SimpleNamespace(id=222, name="General"), None,
+            )
+        )
+        await instrumented.waiter_arrived.wait()
+
+        # A replacement target object (same user/channel, same owner token) is set.
+        replacement = VoiceAutoJoinTarget(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+        adapter._voice_auto_join_targets[111] = replacement
+        instrumented.release()
+        await cleanup_task
+
+        # The replacement target AND its session survive.
+        assert adapter._voice_auto_join_targets[111] is replacement
+        assert vc.disconnected is False
+        assert 111 in adapter._voice_clients
+
+    @pytest.mark.asyncio
+    async def test_manual_join_clears_pending_target_retry_atomically(self, tmp_path):
+        """P1 (6): a manual join clears the pending attempt, target, AND retry
+        atomically under the guild lock, so an in-flight auto finalizer cannot
+        commit AUTO ownership, re-mark a target, or reconnect over the manual
+        session in the former window."""
+        from plugins.platforms.discord.adapter import (
+            AutoJoinOutcome, VoiceOwnerKind, VoiceAutoJoinTarget,
+        )
+
+        runner = _make_runner(tmp_path)
+        adapter = self._real_join_adapter(runner, {
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+        })
+        member = SimpleNamespace(id=42)
+        # Pre-existing (stale) auto follow state that the manual join must clear.
+        adapter._voice_auto_join_targets[111] = VoiceAutoJoinTarget(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+        adapter._voice_auto_join_retry_tasks[111] = MagicMock()
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _cb(*, attempt_token=None, **_kw):
+            started.set()  # A's pending registered by the barrier
+            await release.wait()
+            ch = _FakeVoiceChannel(222, guild_id=111, members=[member])
+            return await adapter.join_voice_channel(ch, attempt_token=attempt_token)
+
+        adapter._voice_auto_join_callback = _cb
+        a_task = asyncio.ensure_future(
+            adapter._run_auto_join_with_barrier(111, "42", "222", "333")
+        )
+        await started.wait()
+        assert 111 in adapter._voice_auto_join_pending
+
+        # Manual takeover through the REAL join path.
+        manual_ch = _FakeVoiceChannel(555, guild_id=111, members=[member])
+        msg = await runner._handle_voice_channel_join(
+            self._voice_event("777"), voice_channel=manual_ch, manual=True
+        )
+        assert "joined" in msg.lower()
+        # Pending, target, and retry were cleared ATOMICALLY under the join lock.
+        assert 111 not in adapter._voice_auto_join_pending
+        assert 111 not in adapter._voice_auto_join_targets
+        assert 111 not in adapter._voice_auto_join_retry_tasks
+        assert adapter._voice_session_owner[111].kind is VoiceOwnerKind.MANUAL
+
+        # Releasing the in-flight auto attempt cannot replace/misclassify ownership.
+        release.set()
+        outcome = await a_task
+        assert outcome == AutoJoinOutcome.SUPERSEDED
+        assert adapter._voice_session_owner[111].kind is VoiceOwnerKind.MANUAL
+        assert adapter.connected_voice_channel_id(111) == "555"
+        assert 111 not in adapter._voice_auto_join_targets
+
+    @pytest.mark.asyncio
+    async def test_unpublished_connect_disconnect_completes_under_cancel(self):
+        """P1 (5): a stale-connect whose vc was never published, cancelled during
+        its disconnect, still disconnects the physical vc to completion (barrier
+        cleanup could never find an unpublished client)."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+        })
+        adapter._voice_locks[111] = asyncio.Lock()
+        token_a = adapter._register_pending_auto_join(111, "42", "222")
+
+        disconnect_started = asyncio.Event()
+        disconnect_gate = asyncio.Event()
+        connected = asyncio.Event()
+
+        def _on_connect():
+            # The attempt goes stale WHILE its connect is completing.
+            adapter._register_pending_auto_join(111, "42", "222")
+            connected.set()
+
+        fake_ch = _FakeVoiceChannel(
+            222, guild_id=111, members=[SimpleNamespace(id=42)],
+            on_connect=_on_connect,
+            vc_kwargs={"disconnect_gate": disconnect_gate,
+                       "on_disconnect_start": disconnect_started.set},
+        )
+
+        join_task = asyncio.ensure_future(
+            adapter.join_voice_channel(fake_ch, attempt_token=token_a)
+        )
+        await disconnect_started.wait()   # stale → disconnecting the unpublished vc
+        vc = fake_ch.last_vc
+        assert 111 not in adapter._voice_clients   # never published
+
+        join_task.cancel()
+        disconnect_gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await join_task
+
+        # The unpublished vc was disconnected to completion despite the cancel.
+        assert vc.disconnected is True
+        assert 111 not in adapter._voice_clients
 
 
 class TestVoiceProfileIsolation:
@@ -3407,7 +3608,7 @@ class TestVoiceProfileIsolation:
         adapter._client.get_channel = MagicMock(return_value=text_channel)
         adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
 
-        async def _join(channel):
+        async def _join(channel, **_kw):
             # The target-leave lands mid-join (cancels the pending attempt), then
             # the physical connection is established.
             adapter._cancel_pending_auto_join_if_matches(111, "42", "222")

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1571,13 +1571,16 @@ class TestDiscordVoiceAutoJoin:
     async def test_retry_task_rejoins_without_second_event(self):
         """After a failed join, the retry task re-attempts on its own — no
         second voice-state event is required."""
+        # Backoff is deliberately large; the retry loop's sleep is patched to a
+        # no-op so the test is deterministic — no real wall-clock delay and no
+        # multi-second wait_for timeout that could flake under load.
         adapter = self._make_adapter({
             "enabled": True,
             "allowed_user_ids": ["42"],
             "allowed_voice_channel_ids": ["222"],
             "text_channel_id": "333",
             "reconnect_cooldown_seconds": 0,
-            "failure_backoff_seconds": 0.01,
+            "failure_backoff_seconds": 30,
         })
         calls = {"n": 0}
 
@@ -1600,12 +1603,18 @@ class TestDiscordVoiceAutoJoin:
         adapter.get_user_voice_channel = AsyncMock(return_value=chan)
         member, before, after, _channel = self._voice_state()
 
-        await adapter._handle_voice_state_update(member, before, after)
+        with patch(
+            "plugins.platforms.discord.adapter.asyncio.sleep", new=AsyncMock()
+        ) as patched_sleep:
+            await adapter._handle_voice_state_update(member, before, after)
 
-        task = adapter._voice_auto_join_retry_tasks.get(111)
-        assert task is not None
-        await asyncio.wait_for(task, timeout=2)
+            task = adapter._voice_auto_join_retry_tasks.get(111)
+            assert task is not None
+            await asyncio.wait_for(task, timeout=1)
 
+        # The backoff was honored via a (patched, instant) sleep — proving the
+        # retry waited on the cadence rather than busy-looping.
+        patched_sleep.assert_awaited()
         assert calls["n"] >= 2
         assert 111 in adapter._voice_auto_join_targets
 
@@ -2164,6 +2173,299 @@ class TestDiscordVoiceAutoJoin:
         assert 111 not in adapter._voice_auto_join_retry_tasks
         await asyncio.sleep(0)
         assert retry.cancelled() or retry.done()
+
+    # ----- Final P1 findings: attempt-scoped teardown, cancellation, leave -----
+
+    @pytest.mark.asyncio
+    async def test_superseded_older_attempt_never_disconnects_newer_owner(self):
+        """P1 (finding 1): an older auto-join that completes AFTER a newer one has
+        established and owns the guild's voice session must not disconnect it."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222", "555"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+        })
+        adapter.leave_voice_channel = AsyncMock(
+            side_effect=lambda gid: adapter._voice_clients.pop(int(gid), None)
+        )
+
+        hold_a = asyncio.Event()
+
+        async def _cb_a(**_kw):
+            await hold_a.wait()  # A is held until B has committed and owns 555
+            return True
+
+        # Start the OLDER attempt A (channel 222); it registers pending token 1
+        # and blocks inside its callback.
+        adapter._voice_auto_join_callback = _cb_a
+        task_a = asyncio.ensure_future(
+            adapter._run_auto_join_with_barrier(111, "42", "222", "333")
+        )
+        await asyncio.sleep(0)
+        assert adapter._voice_auto_join_pending[111]["token"] == 1
+
+        # The NEWER attempt B (channel 555) runs fully, connects, and commits —
+        # superseding A's pending slot and owning the physical session on 555.
+        async def _cb_b(**_kw):
+            member = SimpleNamespace(id=42)
+            channel = SimpleNamespace(id=555, members=[member])
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True, channel=channel
+            )
+            return True
+
+        adapter._voice_auto_join_callback = _cb_b
+        ok_b = await adapter._run_auto_join_with_barrier(111, "42", "555", "333")
+        assert ok_b is True
+        adapter.mark_voice_auto_join_target(
+            111, user_id="42", voice_channel_id="555", text_channel_id="333",
+        )
+        assert adapter.connected_voice_channel_id(111) == "555"
+
+        # Release the older A: it completes late but is superseded.
+        hold_a.set()
+        ok_a = await task_a
+
+        assert ok_a is False  # A did not commit
+        # B's session and target are untouched — never disconnected.
+        adapter.leave_voice_channel.assert_not_awaited()
+        assert adapter.connected_voice_channel_id(111) == "555"
+        assert adapter._voice_auto_join_targets[111].voice_channel_id == "555"
+
+    @pytest.mark.asyncio
+    async def test_superseded_attempt_never_disconnects_manual_takeover(self):
+        """P1 (finding 1): an in-flight auto-join that completes after a manual
+        /voice-join takeover must not disconnect the hand-established session."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+        })
+        adapter.leave_voice_channel = AsyncMock(
+            side_effect=lambda gid: adapter._voice_clients.pop(int(gid), None)
+        )
+
+        hold = asyncio.Event()
+
+        async def _cb(**_kw):
+            await hold.wait()
+            return True
+
+        adapter._voice_auto_join_callback = _cb
+        task = asyncio.ensure_future(
+            adapter._run_auto_join_with_barrier(111, "42", "222", "333")
+        )
+        await asyncio.sleep(0)
+        assert 111 in adapter._voice_auto_join_pending
+
+        # A manual /voice-join takes over to channel 555 and supersedes the
+        # in-flight auto-follow ownership.
+        adapter._voice_clients[111] = SimpleNamespace(
+            is_connected=lambda: True,
+            channel=SimpleNamespace(id=555, members=[SimpleNamespace(id=42)]),
+        )
+        adapter.clear_voice_auto_join_ownership(111)
+
+        hold.set()
+        ok = await task
+
+        assert ok is False
+        adapter.leave_voice_channel.assert_not_awaited()
+        assert adapter.connected_voice_channel_id(111) == "555"  # manual session stands
+
+    @pytest.mark.asyncio
+    async def test_cancellation_after_side_effects_rolls_back_transactionally(self, tmp_path):
+        """P1 (finding 2): a real runner callback that completes its join side
+        effects and is then cancelled before the barrier commits must have those
+        side effects rolled back transactionally and profile-bound."""
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+        })
+        guild = SimpleNamespace(id=111, name="Guild")
+        text_channel = SimpleNamespace(id=333, name="voice-chat", guild=guild, parent_id=None)
+        voice_channel = SimpleNamespace(id=222, name="General", guild=guild)
+        adapter._client = SimpleNamespace(
+            user=SimpleNamespace(id=999), get_channel=lambda cid: text_channel
+        )
+        adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
+
+        def _join(vc):
+            member = SimpleNamespace(id=42)
+            channel = SimpleNamespace(id=222, members=[member])
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True, channel=channel
+            )
+            return True
+
+        adapter.join_voice_channel = AsyncMock(side_effect=_join)
+        adapter.leave_voice_channel = AsyncMock(
+            side_effect=lambda gid: adapter._voice_clients.pop(int(gid), None)
+        )
+        adapter._auto_tts_enabled_chats = set()
+        adapter._auto_tts_disabled_chats = set()
+        runner.adapters[Platform.DISCORD] = adapter
+
+        hold = asyncio.Event()
+        side_effects_applied = asyncio.Event()
+
+        async def _cb(*, guild_id, user_id, voice_channel_id, text_channel_id):
+            ok = await runner._handle_discord_voice_auto_join(
+                guild_id=guild_id,
+                user_id=user_id,
+                voice_channel_id=voice_channel_id,
+                text_channel_id=text_channel_id,
+                adapter=adapter,
+                profile=None,
+            )
+            side_effects_applied.set()
+            await hold.wait()  # cancelled here — INSIDE the callback, after side effects
+            return ok
+
+        adapter._voice_auto_join_callback = _cb
+        task = asyncio.ensure_future(
+            adapter._run_auto_join_with_barrier(111, "42", "222", "333")
+        )
+        await side_effects_applied.wait()
+
+        # Side effects are live before the cancellation.
+        assert 111 in adapter._voice_clients
+        assert runner._voice_mode["discord:333"] == "all"
+        assert adapter._auto_tts_enabled_chats == {"333"}
+        assert 111 in adapter._voice_auto_join_targets
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Transactional, profile-bound rollback.
+        assert 111 not in adapter._voice_clients              # owned VC removed
+        assert 111 not in adapter._voice_auto_join_targets    # target cleared
+        assert adapter._voice_auto_join_pending == {}         # pending cleared
+        assert runner._voice_mode["discord:333"] == "off"     # persisted mode off
+        assert "333" not in adapter._auto_tts_enabled_chats   # enabled cleared
+        assert "333" in adapter._auto_tts_disabled_chats      # disabled set
+
+    @pytest.mark.asyncio
+    async def test_manual_leave_before_preconnect_join_leaves_nothing(self, tmp_path):
+        """P1 (finding 3): a manual /voice leave issued while an auto-join is
+        barrier-blocked PRE-CONNECT must leave no connection/target/mode once the
+        callback is released."""
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+            "manual_leave_cooldown_seconds": 300,
+        })
+        adapter.leave_voice_channel = AsyncMock(
+            side_effect=lambda gid: adapter._voice_clients.pop(int(gid), None)
+        )
+        # A bound on_disconnect that records the runner-side voice mode.
+        mode = {"voice": "all"}
+        adapter._on_voice_disconnect = lambda chat_id: mode.__setitem__("voice", "off")
+        runner.adapters[Platform.DISCORD] = adapter
+        runner._adapter_for_source = lambda source: adapter
+
+        hold = asyncio.Event()
+        started = asyncio.Event()
+
+        async def _cb(**_kw):
+            started.set()  # pending is already registered by the barrier at this point
+            await hold.wait()  # blocked PRE-CONNECT while the manual leave arrives
+            member = SimpleNamespace(id=42)
+            channel = SimpleNamespace(id=222, members=[member])
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True, channel=channel
+            )
+            return True
+
+        adapter._voice_auto_join_callback = _cb
+
+        # Kick off the auto-join; it registers a pending attempt and blocks.
+        join_task = asyncio.ensure_future(
+            adapter._attempt_voice_auto_join(111, "42", "222", "333")
+        )
+        await started.wait()
+        assert adapter._voice_auto_join_pending.get(111) is not None
+        assert 111 not in adapter._voice_clients  # not connected yet
+
+        # Manual /voice leave while pre-connect (no physical VC exists).
+        source = SessionSource(chat_id="333", user_id="42", platform=MagicMock())
+        source.platform.value = "discord"
+        source.thread_id = None
+        leave_event = MessageEvent(
+            text="/voice leave", message_type=MessageType.TEXT, source=source
+        )
+        leave_event.raw_message = SimpleNamespace(guild_id=111, guild=None)
+        result = await runner._handle_voice_channel_leave(leave_event)
+        assert "left" in result.lower()
+
+        # Release the callback: it connects, but its own barrier tears it down.
+        hold.set()
+        await join_task
+
+        assert 111 not in adapter._voice_clients            # no connection survives
+        assert 111 not in adapter._voice_auto_join_targets  # no target
+        assert adapter._voice_auto_join_pending == {}       # pending cleared
+        assert mode["voice"] == "off"                       # runner mode off
+        # Suppression recorded keyed to the in-flight attempt's user/channel.
+        assert adapter._is_voice_auto_join_suppressed(111, "42", "222")
+
+    @pytest.mark.asyncio
+    async def test_target_rejoin_during_reconnect_cooldown_schedules_retry(self):
+        """A target who leaves then rejoins the same channel DURING the reconnect
+        cooldown is followed via a scheduled retry — no unrelated event needed."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 30,
+            "failure_backoff_seconds": 0,
+        })
+        adapter._voice_auto_join_callback = self._connecting_callback(adapter)
+        guild = SimpleNamespace(id=111, name="Guild")
+        chan = SimpleNamespace(
+            id=222, name="General", guild=guild, members=[SimpleNamespace(id=42)]
+        )
+        adapter.get_user_voice_channel = AsyncMock(return_value=chan)
+
+        # A prior successful follow just ended (target left): a reconnect cooldown
+        # is in force and NO retry task exists (success cancels retries).
+        adapter._voice_auto_join_next_attempt_at[(111, "222")] = time.monotonic() + 30
+
+        member, before, after, _channel = self._voice_state()  # target REJOINS 222
+
+        with patch(
+            "plugins.platforms.discord.adapter.asyncio.sleep", new=AsyncMock()
+        ):
+            await adapter._handle_voice_state_update(member, before, after)
+            task = adapter._voice_auto_join_retry_tasks.get(111)
+            assert task is not None  # a retry was scheduled for the remaining cooldown
+            await asyncio.wait_for(task, timeout=1)
+
+        # The rejoin was followed without a second voice-state event.
+        assert adapter.connected_voice_channel_id(111) == "222"
+        assert 111 in adapter._voice_auto_join_targets
 
 
 class TestVoiceProfileIsolation:
@@ -4345,3 +4647,106 @@ class TestShouldAutoTtsForChat:
         fn, adapter = self._make_adapter(default=False, enabled={"chat1"})
         assert fn(adapter, "chat1") is True
         assert fn(adapter, "chat2") is False
+
+
+class TestTwoProfileVoiceStartupIsolation:
+    """Integration: two profiles started through ``_start_one_profile_adapters``
+    with OPPOSITE voice-mode / auto-TTS settings must stay isolated, and re-derive
+    correctly on reconnect — exercised through actual adapter construction."""
+
+    @pytest.mark.asyncio
+    async def test_opposite_voice_settings_isolated_across_profiles_and_reconnect(
+        self, tmp_path
+    ):
+        from gateway.run import GatewayRunner
+        from gateway.config import Platform
+        from plugins.platforms.discord.adapter import DiscordAdapter
+
+        # Two profile homes with OPPOSITE voice.auto_tts defaults and their own
+        # DISCORD_BOT_TOKEN (distinct, so credential-dedup doesn't refuse either).
+        prof_a = tmp_path / "profA"
+        prof_b = tmp_path / "profB"
+        prof_a.mkdir()
+        prof_b.mkdir()
+        (prof_a / "config.yaml").write_text("voice:\n  auto_tts: true\n", encoding="utf-8")
+        (prof_a / ".env").write_text("DISCORD_BOT_TOKEN=token-a\n", encoding="utf-8")
+        (prof_b / "config.yaml").write_text("voice:\n  auto_tts: false\n", encoding="utf-8")
+        (prof_b / ".env").write_text("DISCORD_BOT_TOKEN=token-b\n", encoding="utf-8")
+
+        runner = object.__new__(GatewayRunner)
+        runner._profile_adapters = {}
+        runner.adapters = {}
+        runner.session_store = MagicMock()
+        runner._busy_text_mode = False
+        runner.config = SimpleNamespace(
+            multiplex_profiles=True,
+            group_sessions_per_user=False,
+            thread_sessions_per_user=False,
+        )
+        # OPPOSITE persisted per-profile voice modes (namespaced by profile).
+        runner._voice_mode = {
+            "profile:profA:discord:100": "all",   # A: auto-TTS ON for chat 100
+            "profile:profB:discord:200": "off",   # B: auto-TTS OFF for chat 200
+        }
+        runner._VOICE_MODE_PATH = tmp_path / "voice_mode.json"
+
+        # Peripheral wiring factories (unrelated to the voice-state focus).
+        runner._make_profile_message_handler = lambda p: (lambda *a, **k: None)
+        runner._make_profile_fatal_error_handler = lambda p, plat: (lambda *a, **k: None)
+        runner._make_adapter_auth_check = lambda plat, profile_name=None: (lambda *a, **k: True)
+        runner._handle_active_session_busy_message = MagicMock()
+        runner._recover_telegram_topic_thread_id = MagicMock()
+        # No live Discord: connect always "succeeds" without touching the network.
+        runner._connect_adapter_with_timeout = AsyncMock(return_value=True)
+
+        # Real adapter construction (discord.py is mocked in this suite, so the
+        # plugin registry's dependency check would refuse; build the real adapter
+        # directly while everything else in _start_one_profile_adapters runs for
+        # real — config load under profile scope, policy guard, credential dedup,
+        # _configure_profile_adapter, connect, and the two voice-sync methods).
+        def _construct(platform, config):
+            adapter = DiscordAdapter(config)
+            adapter.gateway_runner = runner
+            return adapter
+
+        runner._create_adapter = _construct
+
+        claimed = {}
+        n_a = await runner._start_one_profile_adapters("profA", prof_a, claimed)
+        n_b = await runner._start_one_profile_adapters("profB", prof_b, claimed)
+        assert n_a == 1
+        assert n_b == 1
+
+        a = runner._profile_adapters["profA"][Platform.DISCORD]
+        b = runner._profile_adapters["profB"][Platform.DISCORD]
+        assert a is not b
+
+        # Opposite auto_tts defaults, each read from its OWN profile's config.yaml.
+        assert a._auto_tts_default is True
+        assert b._auto_tts_default is False
+
+        # Per-profile enabled/disabled chats — each adapter sees ONLY its own
+        # namespace, never the other profile's mode keys.
+        assert a._auto_tts_enabled_chats == {"100"}
+        assert a._auto_tts_disabled_chats == set()
+        assert b._auto_tts_enabled_chats == set()
+        assert b._auto_tts_disabled_chats == {"200"}
+
+        # Each profile has its own bound auto-join callback (never cross-wired).
+        assert a._voice_auto_join_callback is not None
+        assert b._voice_auto_join_callback is not None
+        assert a._voice_auto_join_callback is not b._voice_auto_join_callback
+
+        # Reconnect profB: the reconnect path re-runs the same profile-scoped
+        # resync. Simulate drift, reconnect, and prove B re-derives from its OWN
+        # namespace only — no bleed from A, and A is left untouched.
+        b._auto_tts_enabled_chats.add("999")
+        b._auto_tts_disabled_chats.discard("200")
+        runner._sync_voice_mode_state_to_adapter(
+            b, profile_name="profB", profile_home=prof_b
+        )
+        runner._sync_voice_auto_join_state_to_adapter(b, profile_name="profB")
+        assert b._auto_tts_enabled_chats == set()
+        assert b._auto_tts_disabled_chats == {"200"}
+        assert b._auto_tts_default is False
+        assert a._auto_tts_enabled_chats == {"100"}

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -3153,16 +3153,16 @@ class TestDiscordVoiceAutoJoin:
         assert adapter._voice_auto_join_targets[111] is newer_target
 
     @pytest.mark.asyncio
-    async def test_join_signature_inspected_never_parses_typeerror_or_retries_modern(self, tmp_path):
+    async def test_join_signature_inspected_and_fails_closed_without_gate_kwargs(self, tmp_path):
         """P1: the gateway inspects join_voice_channel's SIGNATURE before calling —
-        it never parses a TypeError message and never retries a MODERN call
-        tokenless. A modern adapter that raises an internal TypeError makes exactly
-        ONE failed call; a genuinely legacy signature (no gate kwargs) is called
-        tokenless exactly once."""
+        it never parses a TypeError and never retries tokenless. A gate-aware
+        adapter that raises an internal TypeError makes exactly ONE failed call; an
+        adapter whose callable LACKS the gate kwargs is FAILED CLOSED (never invoked
+        tokenless, so the ownership gate can't be bypassed)."""
         from gateway.config import Platform
 
-        # -- MODERN signature (accepts the gate kwargs) that raises an internal
-        #    TypeError → propagates → single failed call, NO tokenless retry --
+        # -- gate-aware signature that raises an internal TypeError → propagates →
+        #    single failed call, NO tokenless retry --
         runner = _make_runner(tmp_path)
         adapter = MagicMock()
         adapter.platform = Platform.DISCORD
@@ -3190,13 +3190,13 @@ class TestDiscordVoiceAutoJoin:
         assert calls["last_kwargs"] == {"manual_owner": True, "attempt_token": None}
         assert runner._voice_mode == {}                   # no side effects
 
-        # -- LEGACY signature (no gate kwargs, no **kwargs) → single tokenless call --
+        # -- signature WITHOUT the gate kwargs → FAIL CLOSED: never invoked --
         runner2 = _make_runner(tmp_path)
         adapter2 = MagicMock()
         adapter2.platform = Platform.DISCORD
         legacy = {"n": 0}
 
-        async def _legacy_join(channel):   # genuinely older signature
+        async def _legacy_join(channel):   # no manual_owner / attempt_token, no **kwargs
             legacy["n"] += 1
             return True
 
@@ -3215,8 +3215,9 @@ class TestDiscordVoiceAutoJoin:
         vch2 = _FakeVoiceChannel(222, guild_id=111, members=[SimpleNamespace(id=42)])
         event2 = self._voice_event("333")
         result2 = await runner2._handle_voice_channel_join(event2, voice_channel=vch2, manual=True, attempt_token=None)
-        assert "joined" in result2.lower()
-        assert legacy["n"] == 1                            # single tokenless call
+        assert "failed" in result2.lower()
+        assert legacy["n"] == 0                            # NEVER invoked (fail closed)
+        assert runner2._voice_mode == {}                  # no side effects
 
     @pytest.mark.asyncio
     async def test_public_leave_holds_lock_until_disconnect_completes_under_cancel(self):
@@ -3269,18 +3270,29 @@ class TestDiscordVoiceAutoJoin:
         assert got_lock.is_set()
 
     @pytest.mark.asyncio
-    async def test_mid_move_rollback_failure_tears_session_down(self):
+    async def test_mid_move_rollback_failure_runs_full_profile_bound_teardown(self, tmp_path):
         """P1 (1): if the mid-move supersession ROLLBACK itself fails, the session
-        is deterministically torn down rather than left stranded on the wrong
-        channel — no stale physical mutation can remain."""
-        from plugins.platforms.discord.adapter import VoiceSessionOwner
+        is torn down via the FULL profile-bound teardown — physical + maps + owner +
+        target AND the runner cleanup (persisted voice mode off, auto-TTS enabled
+        cleared / disabled set) — all inside the run-to-completion unit."""
+        from plugins.platforms.discord.adapter import VoiceSessionOwner, VoiceAutoJoinTarget
 
+        runner = _make_runner(tmp_path)
         adapter = self._make_adapter({
             "enabled": True,
             "allowed_user_ids": ["42"],
             "allowed_voice_channel_ids": ["222", "555"],
             "text_channel_id": "333",
         })
+        adapter._auto_tts_enabled_chats = {"333"}
+        adapter._auto_tts_disabled_chats = set()
+        runner.adapters[Platform.DISCORD] = adapter
+        runner._voice_mode["discord:333"] = "all"
+        # The bound, profile-scoped runner cleanup — exactly as the join path wires.
+        adapter._on_voice_disconnect = (
+            lambda chat_id: runner._handle_voice_timeout_cleanup(chat_id, adapter=adapter, profile=None)
+        )
+
         move_started = asyncio.Event()
         move_gate = asyncio.Event()
         # Existing session on 222; the FIRST move (222→555) succeeds, the SECOND
@@ -3292,6 +3304,10 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_clients[111] = existing
         adapter._voice_session_owner[111] = VoiceSessionOwner.auto(1)
         adapter._voice_text_channels[111] = 333
+        adapter._voice_sources[111] = {"chat_id": "333"}
+        adapter._voice_auto_join_targets[111] = VoiceAutoJoinTarget(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
         adapter._voice_locks[111] = asyncio.Lock()
 
         token_a = adapter._register_pending_auto_join(111, "42", "555")
@@ -3305,17 +3321,25 @@ class TestDiscordVoiceAutoJoin:
         result = await join_task
 
         assert result is False
-        # Restore failed → deterministic teardown: no dangling session/maps/owner.
+        # Restore failed → FULL profile-bound teardown: no dangling physical/maps.
+        assert existing.disconnected is True
         assert 111 not in adapter._voice_clients
         assert 111 not in adapter._voice_session_owner
         assert 111 not in adapter._voice_text_channels
+        assert 111 not in adapter._voice_sources
+        assert 111 not in adapter._voice_auto_join_targets
+        # ...and the runner profile cleanup ran.
+        assert runner._voice_mode["discord:333"] == "off"
+        assert "333" not in adapter._auto_tts_enabled_chats
+        assert "333" in adapter._auto_tts_disabled_chats
 
     @pytest.mark.asyncio
-    async def test_target_leave_preserves_replacement_target_same_object_check(self):
-        """P1 (2): a REPLACEMENT target object on the SAME channel (even with an
-        unchanged owner) is preserved — the cleanup matches the exact captured
-        target object, not just channel/owner."""
-        from plugins.platforms.discord.adapter import VoiceSessionOwner, VoiceAutoJoinTarget
+    async def test_target_leave_preserves_replacement_target_same_channel(self):
+        """P1 (2): driven through the real voice-state/behavior path and the real
+        ``mark_voice_auto_join_target`` API — a REPLACEMENT target object on the
+        SAME channel (same user, same owner token) is preserved. The cleanup
+        matches the exact captured target OBJECT, not just channel/owner."""
+        from plugins.platforms.discord.adapter import VoiceSessionOwner
 
         adapter = self._make_adapter({
             "enabled": True,
@@ -3328,28 +3352,37 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_clients[111] = vc
         adapter._voice_text_channels[111] = 333
         adapter._voice_session_owner[111] = VoiceSessionOwner.auto(1)
-        captured = VoiceAutoJoinTarget(
-            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        # Establish the followed target through the REAL API.
+        adapter.mark_voice_auto_join_target(
+            111, user_id="42", voice_channel_id="222", text_channel_id="333",
         )
-        adapter._voice_auto_join_targets[111] = captured
+        captured = adapter._voice_auto_join_targets[111]
+
         instrumented = _InstrumentedLock()
         adapter._voice_locks[111] = instrumented
 
+        guild = SimpleNamespace(id=111, name="Guild")
+        member = SimpleNamespace(id=42, display_name="Martin", guild=guild)
+        before = SimpleNamespace(channel=SimpleNamespace(id=222, name="General"))
+        after = SimpleNamespace(channel=None)
+
+        # Hold the lock so the target-leave cleanup (driven by the real voice-state
+        # handler) blocks after capturing the original target object.
         await instrumented.acquire()
-        cleanup_task = asyncio.ensure_future(
-            adapter._maybe_cleanup_voice_auto_join_target(
-                111, "42", SimpleNamespace(id=222, name="General"), None,
-            )
+        leave_task = asyncio.ensure_future(
+            adapter._handle_voice_state_update(member, before, after)
         )
         await instrumented.waiter_arrived.wait()
 
-        # A replacement target object (same user/channel, same owner token) is set.
-        replacement = VoiceAutoJoinTarget(
-            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        # A newer follow RE-MARKS the target through the real API (new object, same
+        # user/channel/owner token).
+        adapter.mark_voice_auto_join_target(
+            111, user_id="42", voice_channel_id="222", text_channel_id="333",
         )
-        adapter._voice_auto_join_targets[111] = replacement
+        replacement = adapter._voice_auto_join_targets[111]
+        assert replacement is not captured
         instrumented.release()
-        await cleanup_task
+        await leave_task
 
         # The replacement target AND its session survive.
         assert adapter._voice_auto_join_targets[111] is replacement

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1275,6 +1275,7 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_mode_getter = None
         adapter._auto_tts_enabled_chats = set()
         adapter._auto_tts_disabled_chats = set()
+        adapter._voice_auto_join_cfg = {"allowed_voice_channel_ids": {"222"}}
         adapter.mark_voice_auto_join_target = MagicMock()
         runner.adapters[Platform.DISCORD] = adapter
 
@@ -1295,6 +1296,69 @@ class TestDiscordVoiceAutoJoin:
             voice_channel_id="222",
             text_channel_id="333",
         )
+
+    @pytest.mark.asyncio
+    async def test_runner_auto_join_rejects_cross_guild_text_channel(self, tmp_path):
+        """A linked text channel in a different guild than the voice event is rejected."""
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        # Text channel resolves into a DIFFERENT guild than the voice event (111).
+        other_guild = SimpleNamespace(id=222222, name="Other Server")
+        text_channel = SimpleNamespace(id=333, name="voice-chat", guild=other_guild, parent_id=None)
+        voice_channel = SimpleNamespace(id=222, name="General", guild=other_guild)
+        adapter = MagicMock()
+        adapter._client = MagicMock()
+        adapter._client.get_channel = MagicMock(return_value=text_channel)
+        adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
+        adapter.join_voice_channel = AsyncMock(return_value=True)
+        adapter.is_in_voice_channel = MagicMock(return_value=True)
+        adapter._voice_auto_join_cfg = {"allowed_voice_channel_ids": {"222"}}
+        adapter.mark_voice_auto_join_target = MagicMock()
+        runner.adapters[Platform.DISCORD] = adapter
+
+        success = await runner._handle_discord_voice_auto_join(
+            guild_id=111,
+            user_id="42",
+            voice_channel_id="222",
+            text_channel_id="333",
+        )
+
+        assert success is False
+        adapter.join_voice_channel.assert_not_awaited()
+        adapter.mark_voice_auto_join_target.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runner_auto_join_revalidates_current_channel_against_allowlist(self, tmp_path):
+        """A channel-move race — the user's live channel left the allowlist — is blocked."""
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        guild = SimpleNamespace(id=111, name="Guild")
+        text_channel = SimpleNamespace(id=333, name="voice-chat", guild=guild, parent_id=None)
+        # The user has moved to a channel that is NOT in the allowlist since the
+        # voice-state event that triggered auto-join fired.
+        moved_channel = SimpleNamespace(id=999, name="Private", guild=guild)
+        adapter = MagicMock()
+        adapter._client = MagicMock()
+        adapter._client.get_channel = MagicMock(return_value=text_channel)
+        adapter.get_user_voice_channel = AsyncMock(return_value=moved_channel)
+        adapter.join_voice_channel = AsyncMock(return_value=True)
+        adapter.is_in_voice_channel = MagicMock(return_value=True)
+        adapter._voice_auto_join_cfg = {"allowed_voice_channel_ids": {"222"}}
+        adapter.mark_voice_auto_join_target = MagicMock()
+        runner.adapters[Platform.DISCORD] = adapter
+
+        success = await runner._handle_discord_voice_auto_join(
+            guild_id=111,
+            user_id="42",
+            voice_channel_id="222",
+            text_channel_id="333",
+        )
+
+        assert success is False
+        adapter.join_voice_channel.assert_not_awaited()
+        adapter.mark_voice_auto_join_target.assert_not_called()
 
 
 # =====================================================================

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -95,12 +95,13 @@ class _FakeVoiceClient:
     """
 
     def __init__(self, channel, *, disconnect_gate=None, on_disconnect_start=None,
-                 move_gate=None):
+                 move_gate=None, on_move_start=None):
         self.channel = channel
         self._connected = True
         self._disconnect_gate = disconnect_gate
         self._on_disconnect_start = on_disconnect_start
         self._move_gate = move_gate
+        self._on_move_start = on_move_start
         self.disconnected = False
 
     def is_connected(self):
@@ -113,6 +114,8 @@ class _FakeVoiceClient:
         pass
 
     async def move_to(self, channel):
+        if self._on_move_start is not None:
+            self._on_move_start()
         if self._move_gate is not None:
             await self._move_gate.wait()
         self.channel = channel
@@ -2953,6 +2956,312 @@ class TestDiscordVoiceAutoJoin:
         assert runner._voice_mode["discord:333"] == "off"     # runner mode off
         assert "333" not in adapter._auto_tts_enabled_chats   # enabled cleared
         assert "333" in adapter._auto_tts_disabled_chats      # disabled set
+
+    @pytest.mark.asyncio
+    async def test_leave_voice_channel_locked_is_cancellation_transactional(self):
+        """Additional P1 (direct): cancelling _leave_voice_channel_locked EXACTLY
+        during the awaited physical disconnect still completes the disconnect and
+        clears every tracked map — no tracked or physical session state survives,
+        checked immediately after the cancellation propagates (no settling wait)."""
+        from plugins.platforms.discord.adapter import VoiceSessionOwner
+
+        adapter = self._make_adapter({"enabled": True})
+        gate = asyncio.Event()
+        disconnect_started = asyncio.Event()
+        vc = _FakeVoiceClient(
+            SimpleNamespace(id=222),
+            disconnect_gate=gate, on_disconnect_start=disconnect_started.set,
+        )
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 333
+        adapter._voice_sources[111] = {"chat_id": "333"}
+        adapter._voice_session_owner[111] = VoiceSessionOwner.manual()
+        adapter._voice_auto_join_targets[111] = SimpleNamespace(user_id="42")
+        adapter._voice_receivers[111] = SimpleNamespace(stop=lambda: None)
+        adapter._voice_locks[111] = asyncio.Lock()
+
+        async def _caller():
+            async with adapter._voice_locks[111]:
+                await adapter._leave_voice_channel_locked(111)
+
+        task = asyncio.ensure_future(_caller())
+        await disconnect_started.wait()          # blocked INSIDE vc.disconnect()
+        task.cancel()                            # cancel exactly during disconnect
+        gate.set()                               # let the physical disconnect finish
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Checked immediately — the whole unit completed before the cancel propagated.
+        assert vc.disconnected is True
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_text_channels
+        assert 111 not in adapter._voice_sources
+        assert 111 not in adapter._voice_session_owner
+        assert 111 not in adapter._voice_auto_join_targets
+        assert 111 not in adapter._voice_receivers
+
+    @pytest.mark.asyncio
+    async def test_teardown_transactional_runs_runner_cleanup_under_disconnect_cancel(self, tmp_path):
+        """Additional P1 (direct): _teardown_voice_session_transactional cancelled
+        EXACTLY during the physical disconnect still completes disconnect + all
+        maps + the profile-bound runner cleanup (mode off, auto-TTS enabled cleared
+        / disabled set)."""
+        from gateway.config import Platform
+        from plugins.platforms.discord.adapter import VoiceSessionOwner
+
+        runner = _make_runner(tmp_path)
+        adapter = self._make_adapter({"enabled": True})
+        adapter._auto_tts_enabled_chats = {"333"}
+        adapter._auto_tts_disabled_chats = set()
+        runner.adapters[Platform.DISCORD] = adapter
+        runner._voice_mode["discord:333"] = "all"
+        # Bind the profile-bound runner cleanup exactly as the join path does.
+        adapter._on_voice_disconnect = (
+            lambda chat_id: runner._handle_voice_timeout_cleanup(chat_id, adapter=adapter, profile=None)
+        )
+
+        gate = asyncio.Event()
+        disconnect_started = asyncio.Event()
+        vc = _FakeVoiceClient(
+            SimpleNamespace(id=222),
+            disconnect_gate=gate, on_disconnect_start=disconnect_started.set,
+        )
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 333
+        adapter._voice_sources[111] = {"chat_id": "333"}
+        adapter._voice_session_owner[111] = VoiceSessionOwner.auto(7)
+        adapter._voice_locks[111] = asyncio.Lock()
+
+        async def _caller():
+            async with adapter._voice_locks[111]:
+                await adapter._teardown_voice_session_transactional(111, "333")
+
+        task = asyncio.ensure_future(_caller())
+        await disconnect_started.wait()
+        task.cancel()
+        gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert vc.disconnected is True
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_text_channels
+        assert 111 not in adapter._voice_sources
+        assert 111 not in adapter._voice_session_owner
+        # Profile-bound runner cleanup ran despite the cancel-during-disconnect.
+        assert runner._voice_mode["discord:333"] == "off"
+        assert "333" not in adapter._auto_tts_enabled_chats
+        assert "333" in adapter._auto_tts_disabled_chats
+
+    @pytest.mark.asyncio
+    async def test_mid_move_supersession_undoes_physical_move(self):
+        """P1: an auto attempt superseded WHILE its move_to is awaited must not
+        leave a physical move mutation — the session is restored to its pre-move
+        channel and the stale attempt stamps nothing."""
+        from plugins.platforms.discord.adapter import VoiceSessionOwner
+
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222", "555"],
+            "text_channel_id": "333",
+        })
+        move_started = asyncio.Event()
+        move_gate = asyncio.Event()
+        # Existing auto-owned session on 222, whose move_to is gated.
+        existing = _FakeVoiceClient(
+            SimpleNamespace(id=222), move_gate=move_gate, on_move_start=move_started.set,
+        )
+        adapter._voice_clients[111] = existing
+        adapter._voice_session_owner[111] = VoiceSessionOwner.auto(1)
+        adapter._voice_locks[111] = asyncio.Lock()
+
+        # Attempt A (token minted here) wants to follow the target to 555.
+        token_a = adapter._register_pending_auto_join(111, "42", "555")
+        target_555 = _FakeVoiceChannel(555, guild_id=111, members=[SimpleNamespace(id=42)])
+        join_task = asyncio.ensure_future(
+            adapter.join_voice_channel(target_555, attempt_token=token_a)
+        )
+        await move_started.wait()  # move_to(555) is now in flight (channel not yet changed)
+
+        # A newer attempt supersedes A while the move is awaited.
+        adapter._register_pending_auto_join(111, "42", "555")
+
+        move_gate.set()
+        result = await join_task
+
+        assert result is False                       # stale attempt did not commit
+        assert existing.channel.id == 222            # physical move UNDONE (restored)
+        assert adapter.connected_voice_channel_id(111) == "222"
+        # Ownership unchanged — the stale attempt stamped nothing.
+        assert adapter._voice_session_owner[111] == VoiceSessionOwner.auto(1)
+
+    @pytest.mark.asyncio
+    async def test_target_leave_preserves_newer_auto_owner_same_channel(self):
+        """P1: when a NEWER auto attempt re-commits (and re-marks the target) on the
+        SAME channel while an older target-leave cleanup waits for the guild lock,
+        the cleanup must preserve the newer session AND its target."""
+        from plugins.platforms.discord.adapter import VoiceSessionOwner, VoiceAutoJoinTarget
+
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "target_leave_cleanup": True,
+        })
+        vc = _FakeVoiceClient(SimpleNamespace(id=222))
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 333
+        adapter._voice_session_owner[111] = VoiceSessionOwner.auto(1)  # older follow
+        adapter._voice_auto_join_targets[111] = VoiceAutoJoinTarget(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+        instrumented = _InstrumentedLock()
+        adapter._voice_locks[111] = instrumented
+
+        # Hold the lock so the cleanup blocks after capturing owner_at_start=auto(1).
+        await instrumented.acquire()
+        cleanup_task = asyncio.ensure_future(
+            adapter._maybe_cleanup_voice_auto_join_target(
+                111, "42",
+                SimpleNamespace(id=222, name="General"),
+                None,
+            )
+        )
+        await instrumented.waiter_arrived.wait()  # cleanup is blocked on the lock
+
+        # A NEWER auto attempt commits on the SAME channel and re-marks the target.
+        adapter._voice_session_owner[111] = VoiceSessionOwner.auto(2)
+        adapter._voice_auto_join_targets[111] = VoiceAutoJoinTarget(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+        newer_target = adapter._voice_auto_join_targets[111]
+        instrumented.release()
+        await cleanup_task
+
+        # The newer session, ownership, and target are all preserved.
+        assert vc.disconnected is False
+        assert 111 in adapter._voice_clients
+        assert adapter._voice_session_owner[111] == VoiceSessionOwner.auto(2)
+        assert adapter._voice_auto_join_targets[111] is newer_target
+
+    @pytest.mark.asyncio
+    async def test_join_broad_typeerror_never_drops_token_or_manual_owner(self, tmp_path):
+        """P1: a broad/internal TypeError from join_voice_channel must PROPAGATE
+        (no tokenless retry) so a stale attempt is never re-driven without its
+        token; only a genuine unknown-kwarg TypeError falls back."""
+        from gateway.config import Platform
+
+        # -- broad internal TypeError → propagates → failure, single call, no retry --
+        runner = _make_runner(tmp_path)
+        adapter = MagicMock()
+        adapter.platform = Platform.DISCORD
+        adapter.get_user_voice_channel = AsyncMock(return_value=None)
+        calls = {"n": 0}
+
+        async def _boom(vc, **kw):
+            calls["n"] += 1
+            raise TypeError("some internal boom unrelated to kwargs")
+
+        adapter.join_voice_channel = _boom
+        adapter._voice_input_callback = None
+        adapter._on_voice_disconnect = None
+        adapter._voice_mode_getter = None
+        adapter._voice_text_channels = {}
+        adapter._voice_sources = {}
+        runner.adapters[Platform.DISCORD] = adapter
+        runner._voice_mode = {}
+
+        vch = _FakeVoiceChannel(222, guild_id=111, members=[SimpleNamespace(id=42)])
+        event = self._voice_event("333")
+        result = await runner._handle_voice_channel_join(event, voice_channel=vch, manual=True, attempt_token=None)
+        assert "failed" in result.lower()
+        assert calls["n"] == 1                       # NO tokenless retry
+        assert runner._voice_mode == {}              # no side effects
+
+        # -- genuine unknown-kwarg TypeError → single tokenless fallback --
+        runner2 = _make_runner(tmp_path)
+        adapter2 = MagicMock()
+        adapter2.platform = Platform.DISCORD
+        legacy_calls = {"with_kw": 0, "without_kw": 0}
+
+        async def _legacy(vc, *, manual_owner=None, attempt_token=None, **extra):
+            # Simulate an older signature: reject the new kwargs like Python would.
+            raise TypeError(
+                "join_voice_channel() got an unexpected keyword argument 'attempt_token'"
+            )
+
+        async def _legacy_dispatch(vc, **kw):
+            if "attempt_token" in kw or "manual_owner" in kw:
+                legacy_calls["with_kw"] += 1
+                return await _legacy(vc, **kw)
+            legacy_calls["without_kw"] += 1
+            return True
+
+        adapter2.join_voice_channel = _legacy_dispatch
+        adapter2._voice_input_callback = None
+        adapter2._on_voice_disconnect = None
+        adapter2._voice_mode_getter = None
+        adapter2._voice_text_channels = {}
+        adapter2._voice_sources = {}
+        adapter2._auto_tts_enabled_chats = set()
+        adapter2._auto_tts_disabled_chats = set()
+        runner2.adapters[Platform.DISCORD] = adapter2
+        runner2._voice_mode = {}
+        runner2._VOICE_MODE_PATH = tmp_path / "vm2.json"
+
+        vch2 = _FakeVoiceChannel(222, guild_id=111, members=[SimpleNamespace(id=42)])
+        event2 = self._voice_event("333")
+        result2 = await runner2._handle_voice_channel_join(event2, voice_channel=vch2, manual=True, attempt_token=None)
+        assert "joined" in result2.lower()
+        assert legacy_calls == {"with_kw": 1, "without_kw": 1}  # exactly one fallback
+
+    @pytest.mark.asyncio
+    async def test_public_leave_holds_lock_until_disconnect_completes_under_cancel(self):
+        """P1: public leave_voice_channel cancelled during the physical disconnect
+        must hold the guild lock and finish the physical + map cleanup before
+        propagating — a contender cannot acquire the lock until teardown completes."""
+        gate = asyncio.Event()
+        disconnect_started = asyncio.Event()
+        adapter = self._make_adapter({"enabled": True})
+        vc = _FakeVoiceClient(
+            SimpleNamespace(id=222), disconnect_gate=gate,
+            on_disconnect_start=disconnect_started.set,
+        )
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 333
+        adapter._voice_sources[111] = {"chat_id": "333"}
+        adapter._voice_locks[111] = asyncio.Lock()
+
+        leave_task = asyncio.ensure_future(adapter.leave_voice_channel(111))
+        await disconnect_started.wait()             # inside vc.disconnect(), lock held
+
+        # A contender tries to take the guild lock; it must NOT succeed while the
+        # cancelled teardown is still completing the physical disconnect.
+        got_lock = asyncio.Event()
+
+        async def _contender():
+            async with adapter._voice_locks[111]:
+                got_lock.set()
+
+        contender = asyncio.ensure_future(_contender())
+
+        leave_task.cancel()
+        await asyncio.sleep(0)
+        assert not got_lock.is_set()                # lock still held by the teardown
+
+        gate.set()                                  # let the disconnect finish
+        with pytest.raises(asyncio.CancelledError):
+            await leave_task
+
+        assert vc.disconnected is True
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_text_channels
+        assert 111 not in adapter._voice_sources
+        # Only now can the contender acquire the lock.
+        await asyncio.wait_for(contender, timeout=1)
+        assert got_lock.is_set()
 
 
 class TestVoiceProfileIsolation:

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1288,6 +1288,7 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_mixers = {}
         adapter._allowed_user_ids = set()
         adapter._disconnecting = False
+        adapter._missed_message_backfill_task = None
         return adapter
 
     @staticmethod

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -926,6 +926,25 @@ class TestVoiceChannelCommands:
         assert runner._voice_mode["discord:123"] == "off"
         mock_adapter.leave_voice_channel.assert_called_once_with(111)
 
+    @pytest.mark.asyncio
+    async def test_leave_suppresses_voice_auto_rejoin(self, runner):
+        """Manual /voice leave starts the adapter's auto-join cooldown."""
+        mock_adapter = AsyncMock()
+        mock_adapter.is_in_voice_channel = MagicMock(return_value=True)
+        mock_adapter.leave_voice_channel = AsyncMock()
+        mock_adapter.get_user_voice_channel = AsyncMock(return_value=SimpleNamespace(id=222))
+        mock_adapter.suppress_voice_auto_join = MagicMock()
+        event = self._make_discord_event("/voice leave")
+        runner.adapters[event.source.platform] = mock_adapter
+
+        await runner._handle_voice_channel_leave(event)
+
+        mock_adapter.suppress_voice_auto_join.assert_called_once_with(
+            111,
+            user_id="user1",
+            channel_id="222",
+        )
+
     # -- _handle_voice_channel_input --
 
     @pytest.mark.asyncio
@@ -1081,6 +1100,201 @@ class TestVoiceChannelCommands:
         event.raw_message = SimpleNamespace(guild_id=None, guild=None)
         result = runner._get_guild_id(event)
         assert result is None
+
+
+class TestDiscordVoiceAutoJoin:
+    """Regression coverage for Discord voice auto-join/follow mode."""
+
+    @staticmethod
+    def _make_adapter(auto_join=None):
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        from gateway.config import Platform, PlatformConfig
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={"voice_auto_join": auto_join or {}},
+        )
+        config.token = "fake-token"
+        adapter = object.__new__(DiscordAdapter)
+        adapter.platform = Platform.DISCORD
+        adapter.config = config
+        adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+        adapter._voice_clients = {}
+        adapter._voice_locks = {}
+        adapter._voice_text_channels = {}
+        adapter._voice_sources = {}
+        adapter._voice_timeout_tasks = {}
+        adapter._voice_receivers = {}
+        adapter._voice_listen_tasks = {}
+        adapter._voice_input_callback = None
+        adapter._on_voice_disconnect = None
+        adapter._voice_auto_join_callback = AsyncMock(return_value=True)
+        adapter._voice_auto_join_cfg = adapter._load_voice_auto_join_config()
+        adapter._voice_timeout_seconds = adapter._voice_auto_join_cfg["idle_timeout_seconds"]
+        adapter._voice_auto_join_targets = {}
+        adapter._voice_auto_join_suppressed_until = {}
+        adapter._voice_auto_join_next_attempt_at = {}
+        return adapter
+
+    @staticmethod
+    def _voice_state(user_id="42", channel_id=222, before_channel=None):
+        guild = SimpleNamespace(id=111, name="Guild")
+        channel = SimpleNamespace(id=channel_id, name="General", guild=guild, members=[])
+        member = SimpleNamespace(id=int(user_id), display_name="Martin", guild=guild)
+        before = SimpleNamespace(channel=before_channel)
+        after = SimpleNamespace(channel=channel)
+        return member, before, after, channel
+
+    @pytest.mark.asyncio
+    async def test_auto_join_disabled_by_default(self):
+        adapter = self._make_adapter()
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allowed_user_and_channel_auto_join(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+        })
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_awaited_once_with(
+            guild_id=111,
+            user_id="42",
+            voice_channel_id="222",
+            text_channel_id="333",
+        )
+        assert adapter._voice_auto_join_targets[111]["user_id"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_disallowed_user_or_channel_ignored(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["99"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+        })
+        member, before, after, _channel = self._voice_state(user_id="42")
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manual_leave_cooldown_blocks_immediate_rejoin(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+        })
+        adapter.suppress_voice_auto_join(111, user_id="42", channel_id="222", seconds=30)
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failure_backoff_prevents_reconnect_thrash(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 60,
+        })
+        adapter._voice_auto_join_callback = AsyncMock(return_value=False)
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_target_leave_cleanup_disconnects_and_notifies_runner(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "target_leave_cleanup": True,
+        })
+        guild = SimpleNamespace(id=111, name="Guild")
+        before_channel = SimpleNamespace(id=222, name="General", guild=guild)
+        member = SimpleNamespace(id=42, display_name="Martin", guild=guild)
+        adapter._voice_auto_join_targets[111] = {
+            "user_id": "42",
+            "voice_channel_id": "222",
+            "text_channel_id": "333",
+        }
+        adapter._voice_text_channels[111] = 333
+        adapter.leave_voice_channel = AsyncMock()
+        disconnect_calls = []
+        adapter._on_voice_disconnect = lambda chat_id: disconnect_calls.append(chat_id)
+
+        await adapter._handle_voice_state_update(
+            member,
+            SimpleNamespace(channel=before_channel),
+            SimpleNamespace(channel=None),
+        )
+
+        adapter.leave_voice_channel.assert_awaited_once_with(111)
+        assert disconnect_calls == ["333"]
+        assert 111 not in adapter._voice_auto_join_targets
+
+    @pytest.mark.asyncio
+    async def test_runner_auto_join_reuses_manual_join_wiring(self, tmp_path):
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        guild = SimpleNamespace(id=111, name="Guild")
+        text_channel = SimpleNamespace(id=333, name="voice-chat", guild=guild, parent_id=None)
+        voice_channel = SimpleNamespace(id=222, name="General", guild=guild)
+        adapter = MagicMock()
+        adapter._client = MagicMock()
+        adapter._client.get_channel = MagicMock(return_value=text_channel)
+        adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
+        adapter.join_voice_channel = AsyncMock(return_value=True)
+        adapter.is_in_voice_channel = MagicMock(return_value=True)
+        adapter._voice_text_channels = {}
+        adapter._voice_sources = {}
+        adapter._voice_input_callback = None
+        adapter._on_voice_disconnect = None
+        adapter._voice_mode_getter = None
+        adapter._auto_tts_enabled_chats = set()
+        adapter._auto_tts_disabled_chats = set()
+        adapter.mark_voice_auto_join_target = MagicMock()
+        runner.adapters[Platform.DISCORD] = adapter
+
+        success = await runner._handle_discord_voice_auto_join(
+            guild_id=111,
+            user_id="42",
+            voice_channel_id="222",
+            text_channel_id="333",
+        )
+
+        assert success is True
+        adapter.join_voice_channel.assert_awaited_once_with(voice_channel)
+        assert runner._voice_mode["discord:333"] == "all"
+        assert adapter._auto_tts_enabled_chats == {"333"}
+        adapter.mark_voice_auto_join_target.assert_called_once_with(
+            111,
+            user_id="42",
+            voice_channel_id="222",
+            text_channel_id="333",
+        )
 
 
 # =====================================================================
@@ -2023,6 +2237,48 @@ class TestVoiceTimeoutCleansRunnerState:
 
         assert 111 not in adapter._voice_clients
         assert disconnect_calls == ["999"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_uses_configured_seconds(self, adapter):
+        adapter._voice_timeout_seconds = 17
+        adapter._voice_auto_join_cfg = {}
+
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.disconnect = AsyncMock()
+        adapter._voice_clients[111] = mock_vc
+        adapter._voice_text_channels[111] = 999
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await adapter._voice_timeout_handler(111)
+
+        mock_sleep.assert_awaited_once_with(17)
+
+    @pytest.mark.asyncio
+    async def test_timeout_stays_while_auto_join_target_present(self, adapter):
+        adapter._voice_timeout_seconds = 17
+        adapter._voice_auto_join_cfg = {"stay_while_target_present": True}
+        adapter._voice_auto_join_targets = {
+            111: {
+                "user_id": "42",
+                "voice_channel_id": "222",
+                "text_channel_id": "999",
+            }
+        }
+
+        target_member = SimpleNamespace(id=42)
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.disconnect = AsyncMock()
+        mock_vc.channel = SimpleNamespace(id=222, members=[target_member])
+        adapter._voice_clients[111] = mock_vc
+        adapter._voice_text_channels[111] = 999
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await adapter._voice_timeout_handler(111)
+
+        assert 111 in adapter._voice_clients
+        mock_vc.disconnect.assert_not_called()
 
 
 # =====================================================================

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -86,6 +86,105 @@ def _make_runner(tmp_path):
     return runner
 
 
+class _FakeVoiceClient:
+    """Minimal stand-in for a discord VoiceClient that the REAL
+    ``join_voice_channel`` / ``_leave_voice_channel_locked`` paths can drive.
+
+    ``disconnect_gate`` (optional) lets a test hold the physical disconnect
+    mid-flight to drive a cancellation-exactly-during-disconnect race.
+    """
+
+    def __init__(self, channel, *, disconnect_gate=None, on_disconnect_start=None,
+                 move_gate=None):
+        self.channel = channel
+        self._connected = True
+        self._disconnect_gate = disconnect_gate
+        self._on_disconnect_start = on_disconnect_start
+        self._move_gate = move_gate
+        self.disconnected = False
+
+    def is_connected(self):
+        return self._connected
+
+    def is_playing(self):
+        return False
+
+    def stop(self):
+        pass
+
+    async def move_to(self, channel):
+        if self._move_gate is not None:
+            await self._move_gate.wait()
+        self.channel = channel
+
+    async def disconnect(self):
+        if self._on_disconnect_start is not None:
+            self._on_disconnect_start()
+        if self._disconnect_gate is not None:
+            await self._disconnect_gate.wait()
+        self._connected = False
+        self.disconnected = True
+
+
+class _FakeVoiceChannel:
+    """A discord voice channel whose ``.connect()`` yields a ``_FakeVoiceClient``.
+
+    ``connect_gate`` lets a test hold the connect mid-flight; ``on_connect`` fires
+    the moment ``connect()`` is entered (before the gate) so a test can sequence a
+    race deterministically without ``asyncio.sleep(0)`` guesses.
+    """
+
+    def __init__(self, channel_id, *, guild_id=111, members=(), connect_gate=None,
+                 on_connect=None, vc_kwargs=None):
+        self.id = int(channel_id)
+        self.name = f"chan-{channel_id}"
+        self.guild = SimpleNamespace(id=int(guild_id), name="Guild")
+        self.members = list(members)
+        self._connect_gate = connect_gate
+        self._on_connect = on_connect
+        self._vc_kwargs = vc_kwargs or {}
+        self.last_vc = None
+
+    async def connect(self):
+        if self._on_connect is not None:
+            self._on_connect()
+        if self._connect_gate is not None:
+            await self._connect_gate.wait()
+        vc = _FakeVoiceClient(
+            SimpleNamespace(id=self.id, members=self.members), **self._vc_kwargs
+        )
+        self.last_vc = vc
+        return vc
+
+
+class _InstrumentedLock:
+    """An asyncio.Lock that fires ``waiter_arrived`` when a coroutine attempts to
+    acquire it WHILE it is already held — so a lock-race test can wait for the
+    contender to actually be blocked instead of assuming scheduler order."""
+
+    def __init__(self):
+        self._lock = asyncio.Lock()
+        self.waiter_arrived = asyncio.Event()
+
+    async def acquire(self):
+        if self._lock.locked():
+            self.waiter_arrived.set()
+        return await self._lock.acquire()
+
+    def release(self):
+        self._lock.release()
+
+    def locked(self):
+        return self._lock.locked()
+
+    async def __aenter__(self):
+        await self.acquire()
+        return self
+
+    async def __aexit__(self, *exc):
+        self.release()
+
+
 # =====================================================================
 # /voice command handler
 # =====================================================================
@@ -1178,6 +1277,7 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_auto_join_direct_tasks = {}
         adapter._voice_session_owner = {}
         adapter._voice_mixers = {}
+        adapter._allowed_user_ids = set()
         adapter._disconnecting = False
         return adapter
 
@@ -1232,11 +1332,13 @@ class TestDiscordVoiceAutoJoin:
 
         await adapter._handle_voice_state_update(member, before, after)
 
+        from unittest.mock import ANY
         adapter._voice_auto_join_callback.assert_awaited_once_with(
             guild_id=111,
             user_id="42",
             voice_channel_id="222",
             text_channel_id="333",
+            attempt_token=ANY,
         )
         assert adapter._voice_auto_join_targets[111].user_id == "42"
 
@@ -1316,7 +1418,6 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_clients[111] = SimpleNamespace(
             is_connected=lambda: True, channel=SimpleNamespace(id=222)
         )
-        adapter.leave_voice_channel = AsyncMock()
         disconnect_calls = []
         adapter._on_voice_disconnect = lambda chat_id: disconnect_calls.append(chat_id)
 
@@ -1326,7 +1427,8 @@ class TestDiscordVoiceAutoJoin:
             SimpleNamespace(channel=None),
         )
 
-        adapter.leave_voice_channel.assert_awaited_once_with(111)
+        # Physical session torn down under the guild lock + runner notified.
+        assert 111 not in adapter._voice_clients
         assert disconnect_calls == ["333"]
         assert 111 not in adapter._voice_auto_join_targets
 
@@ -1368,7 +1470,7 @@ class TestDiscordVoiceAutoJoin:
         )
 
         assert success is True
-        adapter.join_voice_channel.assert_awaited_once_with(voice_channel, manual_owner=False)
+        adapter.join_voice_channel.assert_awaited_once_with(voice_channel, manual_owner=False, attempt_token=None)
         assert runner._voice_mode["discord:333"] == "all"
         assert adapter._auto_tts_enabled_chats == {"333"}
         adapter.mark_voice_auto_join_target.assert_called_once_with(
@@ -1479,7 +1581,7 @@ class TestDiscordVoiceAutoJoin:
         assert success is True
         # Exactly one resolution across the whole join path.
         assert adapter.get_user_voice_channel.await_count == 1
-        adapter.join_voice_channel.assert_awaited_once_with(voice_channel, manual_owner=False)
+        adapter.join_voice_channel.assert_awaited_once_with(voice_channel, manual_owner=False, attempt_token=None)
 
     @pytest.mark.asyncio
     async def test_secondary_profile_auto_join_binds_owning_adapter(self, tmp_path):
@@ -1528,7 +1630,7 @@ class TestDiscordVoiceAutoJoin:
         )
 
         assert success is True
-        adapter.join_voice_channel.assert_awaited_once_with(voice_channel, manual_owner=False)
+        adapter.join_voice_channel.assert_awaited_once_with(voice_channel, manual_owner=False, attempt_token=None)
         active.join_voice_channel.assert_not_awaited()
         adapter.mark_voice_auto_join_target.assert_called_once_with(
             111, user_id="42", voice_channel_id="222", text_channel_id="333", profile="coder",
@@ -2082,9 +2184,7 @@ class TestDiscordVoiceAutoJoin:
         """A later attempt supersedes an earlier one (unique tokens); a target
         leave cancels the current entry, so neither overlapping join commits and
         no orphan session is left behind."""
-        from plugins.platforms.discord.adapter import (
-            AUTO_JOIN_SUPERSEDED, AUTO_JOIN_CANCELLED,
-        )
+        from plugins.platforms.discord.adapter import AutoJoinOutcome
 
         adapter = self._make_adapter({
             "enabled": True,
@@ -2093,31 +2193,39 @@ class TestDiscordVoiceAutoJoin:
             "text_channel_id": "333",
         })
         release = asyncio.Event()
+        a_started = asyncio.Event()
+        b_started = asyncio.Event()
 
-        async def _cb(**_kw):
-            await release.wait()
-            adapter._voice_clients[111] = SimpleNamespace(
-                is_connected=lambda: True,
-                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
-            )
-            return True
+        def _make_cb(started):
+            async def _cb(**_kw):
+                started.set()  # pending already registered by the barrier here
+                await release.wait()
+                adapter._voice_clients[111] = SimpleNamespace(
+                    is_connected=lambda: True,
+                    channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
+                )
+                return True
+            return _cb
 
-        adapter._voice_auto_join_callback = _cb
+        # Start A and wait until it has registered its pending slot; only then
+        # start B so B deterministically SUPERSEDES A (no scheduler assumptions).
+        adapter._voice_auto_join_callback = _make_cb(a_started)
         task_a = asyncio.ensure_future(
             adapter._run_auto_join_with_barrier(111, "42", "222", "333")
         )
-        await asyncio.sleep(0)
+        await a_started.wait()
+        adapter._voice_auto_join_callback = _make_cb(b_started)
         task_b = asyncio.ensure_future(
             adapter._run_auto_join_with_barrier(111, "42", "222", "333")
         )
-        await asyncio.sleep(0)
+        await b_started.wait()
         # Target leaves mid-flight → flags the CURRENT (B's) pending entry.
         adapter._cancel_pending_auto_join_if_matches(111, "42", "222")
         release.set()
         outcome_a, outcome_b = await asyncio.gather(task_a, task_b)
 
-        assert outcome_a == AUTO_JOIN_SUPERSEDED  # A superseded by B's token
-        assert outcome_b == AUTO_JOIN_CANCELLED   # B cancelled by the leave
+        assert outcome_a == AutoJoinOutcome.SUPERSEDED  # A superseded by B's token
+        assert outcome_b == AutoJoinOutcome.CANCELLED   # B cancelled by the leave
         # Neither committed and the orphan connection is torn down.
         assert 111 not in adapter._voice_auto_join_targets
         assert adapter._voice_auto_join_pending == {}
@@ -2195,9 +2303,7 @@ class TestDiscordVoiceAutoJoin:
         """P1 (finding 1/B): an older auto-join that completes AFTER a newer one
         has committed and OWNS the guild's session must not disconnect it — the
         ownership check is session-token based, decided under the guild lock."""
-        from plugins.platforms.discord.adapter import (
-            AUTO_JOIN_COMMITTED, AUTO_JOIN_SUPERSEDED,
-        )
+        from plugins.platforms.discord.adapter import AutoJoinOutcome
 
         adapter = self._make_adapter({
             "enabled": True,
@@ -2211,8 +2317,10 @@ class TestDiscordVoiceAutoJoin:
             return_value=SimpleNamespace(id=555)
         )
         hold_a = asyncio.Event()
+        a_started = asyncio.Event()
 
         async def _cb_a(**_kw):
+            a_started.set()  # pending already registered by the barrier here
             await hold_a.wait()  # A held until B has committed and owns 555
             return True
 
@@ -2221,7 +2329,7 @@ class TestDiscordVoiceAutoJoin:
         task_a = asyncio.ensure_future(
             adapter._run_auto_join_with_barrier(111, "42", "222", "333")
         )
-        await asyncio.sleep(0)
+        await a_started.wait()
         assert adapter._voice_auto_join_pending[111]["token"] == 1
 
         # Newer attempt B (channel 555) runs fully, connects, and COMMITS —
@@ -2236,7 +2344,7 @@ class TestDiscordVoiceAutoJoin:
 
         adapter._voice_auto_join_callback = _cb_b
         outcome_b = await adapter._run_auto_join_with_barrier(111, "42", "555", "333")
-        assert outcome_b == AUTO_JOIN_COMMITTED
+        assert outcome_b == AutoJoinOutcome.COMMITTED
         b_owner = adapter._voice_session_owner[111]
         adapter.mark_voice_auto_join_target(
             111, user_id="42", voice_channel_id="555", text_channel_id="333",
@@ -2246,7 +2354,7 @@ class TestDiscordVoiceAutoJoin:
         hold_a.set()
         outcome_a = await task_a
 
-        assert outcome_a == AUTO_JOIN_SUPERSEDED
+        assert outcome_a == AutoJoinOutcome.SUPERSEDED
         # B's session, ownership stamp, and target are untouched.
         assert adapter.connected_voice_channel_id(111) == "555"
         assert adapter._voice_session_owner[111] == b_owner
@@ -2308,15 +2416,43 @@ class TestDiscordVoiceAutoJoin:
         assert 111 not in adapter._voice_auto_join_retry_tasks
 
     @pytest.mark.asyncio
-    async def test_stale_callback_after_manual_takeover_leaves_manual_intact(self):
-        """P1 (finding 1/A): a stale auto-join callback that MUTATES the VC after
-        a manual takeover established a manual-owned session must never disconnect
-        that manual session."""
-        from plugins.platforms.discord.adapter import (
-            AUTO_JOIN_SUPERSEDED, MANUAL_VOICE_SESSION_OWNER,
-        )
+    @staticmethod
+    def _voice_event(chat_id, *, user_id="42", guild_id=111):
+        source = SessionSource(chat_id=str(chat_id), user_id=str(user_id), platform=Platform.DISCORD)
+        source.thread_id = None
+        ev = MessageEvent(text="/voice", message_type=MessageType.TEXT, source=source)
+        ev.message_id = "m1"
+        ev.raw_message = SimpleNamespace(guild_id=int(guild_id), guild=None)
+        return ev
 
-        adapter = self._make_adapter({
+    @staticmethod
+    def _real_join_adapter(runner, cfg):
+        """A real DiscordAdapter wired for the REAL join path under ``runner``."""
+        from gateway.config import Platform
+        adapter = TestDiscordVoiceAutoJoin._make_adapter(cfg)
+        adapter._auto_tts_enabled_chats = set()
+        adapter._auto_tts_disabled_chats = set()
+        adapter._client = SimpleNamespace(
+            user=SimpleNamespace(id=999),
+            get_channel=lambda cid: SimpleNamespace(
+                id=int(cid), name=f"text-{cid}",
+                guild=SimpleNamespace(id=111, name="Guild"), parent_id=None,
+            ),
+        )
+        runner.adapters[Platform.DISCORD] = adapter
+        runner._sync_voice_auto_join_state_to_adapter(adapter, profile_name=None)
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_stale_callback_after_manual_takeover_leaves_manual_intact(self, tmp_path):
+        """P1 auto-mutation: a stale auto callback that reaches the REAL
+        ``join_voice_channel`` after a manual takeover established a manual-owned
+        session is REJECTED before ``move_to``/``connect`` — the manual channel id,
+        owner, target, voice mode, and auto-TTS all remain unchanged."""
+        from plugins.platforms.discord.adapter import AutoJoinOutcome, VoiceOwnerKind
+
+        runner = _make_runner(tmp_path)
+        adapter = self._real_join_adapter(runner, {
             "enabled": True,
             "allowed_user_ids": ["42"],
             "allowed_voice_channel_ids": ["222"],
@@ -2324,51 +2460,112 @@ class TestDiscordVoiceAutoJoin:
             "reconnect_cooldown_seconds": 0,
             "failure_backoff_seconds": 0,
         })
-        hold = asyncio.Event()
-        started = asyncio.Event()
+        member = SimpleNamespace(id=42)
 
-        async def _cb(**_kw):
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _cb(*, guild_id, user_id, voice_channel_id, text_channel_id, attempt_token=None):
+            # Stale auto attempt reaches the REAL join path with its exact token.
             started.set()
-            await hold.wait()
-            # Stale callback actually mutates the VC (as a real join would).
-            adapter._voice_clients[111] = SimpleNamespace(
-                is_connected=lambda: True,
-                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
-            )
-            return True
+            await release.wait()
+            ch = _FakeVoiceChannel(222, guild_id=111, members=[member])
+            return await adapter.join_voice_channel(ch, attempt_token=attempt_token)
 
         adapter._voice_auto_join_callback = _cb
         task = asyncio.ensure_future(
             adapter._run_auto_join_with_barrier(111, "42", "222", "333")
         )
-        await started.wait()
+        await started.wait()  # A's pending registered; A blocked before the join
 
-        # Manual /voice-join takeover: establishes a MANUAL-owned session on 555
-        # and supersedes the in-flight auto-follow ownership.
-        adapter._voice_clients[111] = SimpleNamespace(
-            is_connected=lambda: True,
-            channel=SimpleNamespace(id=555, members=[SimpleNamespace(id=42)]),
+        # MANUAL takeover through the real handler → manual-owned session on 555,
+        # runner mode 'all' + auto-TTS for the manual chat, and supersedes A.
+        manual_ch = _FakeVoiceChannel(555, guild_id=111, members=[member])
+        manual_event = self._voice_event("777")
+        msg = await runner._handle_voice_channel_join(
+            manual_event, voice_channel=manual_ch, manual=True
         )
-        adapter._voice_session_owner[111] = MANUAL_VOICE_SESSION_OWNER
-        adapter.clear_voice_auto_join_ownership(111)
+        assert "joined" in msg.lower()
+        assert runner._voice_mode["discord:777"] == "all"
+        assert adapter._auto_tts_enabled_chats == {"777"}
+        owner = adapter._voice_session_owner[111]
+        assert owner.kind is VoiceOwnerKind.MANUAL
+        manual_on_disconnect = adapter._on_voice_disconnect  # manual session's wiring
 
-        hold.set()
+        # Release the stale attempt: its real join is rejected without mutation.
+        release.set()
         outcome = await task
 
-        assert outcome == AUTO_JOIN_SUPERSEDED
-        # The manual-owned session remains (never disconnected by the stale attempt).
-        assert 111 in adapter._voice_clients
-        assert adapter._voice_session_owner[111] == MANUAL_VOICE_SESSION_OWNER
+        assert outcome == AutoJoinOutcome.SUPERSEDED
+        # Manual channel id, owner, mode, auto-TTS, and (absent) auto target all unchanged.
+        assert adapter.connected_voice_channel_id(111) == "555"
+        assert adapter._voice_session_owner[111] == owner
+        assert adapter._voice_session_owner[111].kind is VoiceOwnerKind.MANUAL
+        assert 111 not in adapter._voice_auto_join_targets
+        assert runner._voice_mode["discord:777"] == "all"
+        assert "discord:333" not in runner._voice_mode
+        assert adapter._auto_tts_enabled_chats == {"777"}
+        # The rejected stale attempt restored the manual session's callback wiring
+        # (no cross-profile rebind of _on_voice_disconnect).
+        assert adapter._on_voice_disconnect is manual_on_disconnect
+
+    @pytest.mark.asyncio
+    async def test_stale_callback_never_moves_newer_committed_session(self, tmp_path):
+        """P1 auto-mutation: a stale auto attempt's real join must not move a
+        NEWER auto-committed session (owned by a different token)."""
+        from plugins.platforms.discord.adapter import AutoJoinOutcome
+
+        runner = _make_runner(tmp_path)
+        adapter = self._real_join_adapter(runner, {
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222", "555"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+        })
+        member = SimpleNamespace(id=42)
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _cb_a(*, attempt_token=None, **_kw):
+            started.set()
+            await release.wait()
+            ch = _FakeVoiceChannel(222, guild_id=111, members=[member])
+            return await adapter.join_voice_channel(ch, attempt_token=attempt_token)
+
+        adapter._voice_auto_join_callback = _cb_a
+        task_a = asyncio.ensure_future(
+            adapter._run_auto_join_with_barrier(111, "42", "222", "333")
+        )
+        await started.wait()
+
+        # Newer attempt B commits a real session on 555 (owned by B's token),
+        # superseding A.
+        async def _cb_b(*, attempt_token=None, **_kw):
+            ch = _FakeVoiceChannel(555, guild_id=111, members=[member])
+            return await adapter.join_voice_channel(ch, attempt_token=attempt_token)
+
+        adapter._voice_auto_join_callback = _cb_b
+        outcome_b = await adapter._run_auto_join_with_barrier(111, "42", "555", "333")
+        assert outcome_b == AutoJoinOutcome.COMMITTED
+        b_owner = adapter._voice_session_owner[111]
+
+        release.set()
+        outcome_a = await task_a
+        assert outcome_a == AutoJoinOutcome.SUPERSEDED
+        # B's committed session and ownership are untouched.
+        assert adapter.connected_voice_channel_id(111) == "555"
+        assert adapter._voice_session_owner[111] == b_owner
 
     @pytest.mark.asyncio
     async def test_cancellation_after_side_effects_rolls_back_transactionally(self, tmp_path):
         """P1 (finding 2): a real runner callback that completes its join side
-        effects and is then cancelled before the barrier commits must have those
-        side effects rolled back transactionally and profile-bound."""
-        from gateway.config import Platform
-
+        effects (via the REAL join path) and is then cancelled before the barrier
+        commits must have those side effects rolled back transactionally and
+        profile-bound."""
         runner = _make_runner(tmp_path)
-        adapter = self._make_adapter({
+        adapter = self._real_join_adapter(runner, {
             "enabled": True,
             "allowed_user_ids": ["42"],
             "allowed_voice_channel_ids": ["222"],
@@ -2376,41 +2573,19 @@ class TestDiscordVoiceAutoJoin:
             "reconnect_cooldown_seconds": 0,
             "failure_backoff_seconds": 0,
         })
-        guild = SimpleNamespace(id=111, name="Guild")
-        text_channel = SimpleNamespace(id=333, name="voice-chat", guild=guild, parent_id=None)
-        voice_channel = SimpleNamespace(id=222, name="General", guild=guild)
-        adapter._client = SimpleNamespace(
-            user=SimpleNamespace(id=999), get_channel=lambda cid: text_channel
+        member = SimpleNamespace(id=42)
+        adapter.get_user_voice_channel = AsyncMock(
+            return_value=_FakeVoiceChannel(222, guild_id=111, members=[member])
         )
-        adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
-
-        def _join(vc):
-            member = SimpleNamespace(id=42)
-            channel = SimpleNamespace(id=222, members=[member])
-            adapter._voice_clients[111] = SimpleNamespace(
-                is_connected=lambda: True, channel=channel
-            )
-            return True
-
-        adapter.join_voice_channel = AsyncMock(side_effect=_join)
-        adapter.leave_voice_channel = AsyncMock(
-            side_effect=lambda gid: adapter._voice_clients.pop(int(gid), None)
-        )
-        adapter._auto_tts_enabled_chats = set()
-        adapter._auto_tts_disabled_chats = set()
-        runner.adapters[Platform.DISCORD] = adapter
 
         hold = asyncio.Event()
         side_effects_applied = asyncio.Event()
 
-        async def _cb(*, guild_id, user_id, voice_channel_id, text_channel_id):
+        async def _cb(*, guild_id, user_id, voice_channel_id, text_channel_id, attempt_token=None):
             ok = await runner._handle_discord_voice_auto_join(
-                guild_id=guild_id,
-                user_id=user_id,
-                voice_channel_id=voice_channel_id,
-                text_channel_id=text_channel_id,
-                adapter=adapter,
-                profile=None,
+                guild_id=guild_id, user_id=user_id, voice_channel_id=voice_channel_id,
+                text_channel_id=text_channel_id, adapter=adapter, profile=None,
+                attempt_token=attempt_token,
             )
             side_effects_applied.set()
             await hold.wait()  # cancelled here — INSIDE the callback, after side effects
@@ -2422,7 +2597,8 @@ class TestDiscordVoiceAutoJoin:
         )
         await side_effects_applied.wait()
 
-        # Side effects are live before the cancellation.
+        # Side effects are live before the cancellation (real join stamped AUTO
+        # ownership, so the real ownership-gated mark_target ran).
         assert 111 in adapter._voice_clients
         assert runner._voice_mode["discord:333"] == "all"
         assert adapter._auto_tts_enabled_chats == {"333"}
@@ -2436,6 +2612,7 @@ class TestDiscordVoiceAutoJoin:
         assert 111 not in adapter._voice_clients              # owned VC removed
         assert 111 not in adapter._voice_auto_join_targets    # target cleared
         assert adapter._voice_auto_join_pending == {}         # pending cleared
+        assert 111 not in adapter._voice_session_owner        # ownership cleared
         assert runner._voice_mode["discord:333"] == "off"     # persisted mode off
         assert "333" not in adapter._auto_tts_enabled_chats   # enabled cleared
         assert "333" in adapter._auto_tts_disabled_chats      # disabled set
@@ -2592,15 +2769,16 @@ class TestDiscordVoiceAutoJoin:
         assert runner._voice_mode == {}  # guild B's mode never mutated
 
     @pytest.mark.asyncio
-    async def test_concurrent_manual_takeover_during_rollback_wait(self):
+    async def test_concurrent_manual_takeover_during_rollback_wait(self, tmp_path):
         """P1 B: when a stale attempt's lock-scoped teardown must wait for the
-        guild voice lock, a manual takeover that grabs the lock first (stamping
-        manual ownership) is observed under the lock and left intact."""
-        from plugins.platforms.discord.adapter import (
-            AUTO_JOIN_CANCELLED, MANUAL_VOICE_SESSION_OWNER,
-        )
+        guild voice lock, a MANUAL takeover (real ``join_voice_channel``) that
+        grabs the lock first — stamping manual ownership — is observed under the
+        lock and left strictly intact. Driven with an instrumented lock (no
+        ``asyncio.sleep(0)`` / no private-map mutation)."""
+        from plugins.platforms.discord.adapter import AutoJoinOutcome, VoiceOwnerKind
 
-        adapter = self._make_adapter({
+        runner = _make_runner(tmp_path)
+        adapter = self._real_join_adapter(runner, {
             "enabled": True,
             "allowed_user_ids": ["42"],
             "allowed_voice_channel_ids": ["222"],
@@ -2608,60 +2786,64 @@ class TestDiscordVoiceAutoJoin:
             "reconnect_cooldown_seconds": 0,
             "failure_backoff_seconds": 0,
         })
-        guild_lock = asyncio.Lock()
-        adapter._voice_locks[111] = guild_lock
+        instrumented = _InstrumentedLock()
+        adapter._voice_locks[111] = instrumented
+        member = SimpleNamespace(id=42)
+        move_gate = asyncio.Event()
 
-        started = asyncio.Event()
-        release_cb = asyncio.Event()
+        a_connected = asyncio.Event()
+        a_proceed = asyncio.Event()
 
-        async def _cb(**_kw):
-            started.set()
-            await release_cb.wait()
-            # Stale attempt's callback connected; it will be flagged cancelled.
-            adapter._voice_clients[111] = SimpleNamespace(
-                is_connected=lambda: True,
-                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
+        async def _cb(*, attempt_token=None, **_kw):
+            # Stale attempt A really connects to 222 (stamps AUTO ownership), then
+            # pauses before returning so we can flag it cancelled + start a takeover.
+            ch = _FakeVoiceChannel(
+                222, guild_id=111, members=[member],
+                vc_kwargs={"move_gate": move_gate},
             )
-            return True
+            ok = await adapter.join_voice_channel(ch, attempt_token=attempt_token)
+            a_connected.set()
+            await a_proceed.wait()
+            return ok
 
         adapter._voice_auto_join_callback = _cb
         task = asyncio.ensure_future(
             adapter._run_auto_join_with_barrier(111, "42", "222", "333")
         )
-        await started.wait()
+        await a_connected.wait()  # A connected + owns 222
 
-        # Flag the attempt cancelled, then HOLD the guild voice lock so the
-        # barrier's lock-scoped teardown must wait for it — the window in which a
-        # concurrent takeover completes.
-        adapter._cancel_pending_auto_join_if_matches(111, "42", "222")
-        await guild_lock.acquire()
-        release_cb.set()
-        await asyncio.sleep(0)  # let the barrier reach the lock and block
-
-        # A manual takeover completes while the rollback waits: it establishes a
-        # manual-owned session on 555 (this is what the real join does under the
-        # lock it currently holds).
-        adapter._voice_clients[111] = SimpleNamespace(
-            is_connected=lambda: True,
-            channel=SimpleNamespace(id=555, members=[SimpleNamespace(id=42)]),
+        # MANUAL takeover: real join to 555. It acquires the guild lock and blocks
+        # inside move_to (move_gate), HOLDING the lock. The manual handler also
+        # supersedes A's pending slot (clear_voice_auto_join_ownership).
+        manual_ch = _FakeVoiceChannel(555, guild_id=111, members=[member])
+        manual_event = self._voice_event("777")
+        manual_task = asyncio.ensure_future(
+            runner._handle_voice_channel_join(manual_event, voice_channel=manual_ch, manual=True)
         )
-        adapter._voice_session_owner[111] = MANUAL_VOICE_SESSION_OWNER
-        guild_lock.release()
+        # Let A proceed: it returns, then its finalize contends for the lock the
+        # manual takeover now holds → the instrumented lock signals the waiter.
+        a_proceed.set()
+        await instrumented.waiter_arrived.wait()
 
+        # Now let the manual takeover finish (move + stamp MANUAL + release lock).
+        move_gate.set()
         outcome = await task
-        assert outcome == AUTO_JOIN_CANCELLED
-        # The stale rollback re-checked ownership UNDER the lock and left the
+        await manual_task
+
+        # A did not commit (superseded by the manual takeover under the lock).
+        assert outcome == AutoJoinOutcome.SUPERSEDED
+        # The stale finalize re-checked ownership UNDER the lock and left the
         # manual session strictly intact.
-        assert 111 in adapter._voice_clients
-        assert adapter._voice_session_owner[111] == MANUAL_VOICE_SESSION_OWNER
         assert adapter.connected_voice_channel_id(111) == "555"
+        assert adapter._voice_session_owner[111].kind is VoiceOwnerKind.MANUAL
 
     @pytest.mark.asyncio
-    async def test_cancellation_during_finalize_lock_wait_completes_cleanup(self):
-        """P1 B: a cancellation that lands while the barrier is blocked acquiring
-        the guild voice lock for its finalize/rollback still completes the shielded
-        owned/orphan cleanup — no half-torn-down or dangling state survives."""
-        adapter = self._make_adapter({
+    async def test_cancellation_during_finalize_lock_wait_completes_cleanup(self, tmp_path):
+        """P1 B: a cancellation landing while the barrier is blocked acquiring the
+        guild voice lock for its finalize still completes the owned/orphan cleanup.
+        Uses an instrumented lock to know exactly when finalize is blocked."""
+        runner = _make_runner(tmp_path)
+        adapter = self._real_join_adapter(runner, {
             "enabled": True,
             "allowed_user_ids": ["42"],
             "allowed_voice_channel_ids": ["222"],
@@ -2669,45 +2851,108 @@ class TestDiscordVoiceAutoJoin:
             "reconnect_cooldown_seconds": 0,
             "failure_backoff_seconds": 0,
         })
-        guild_lock = asyncio.Lock()
-        adapter._voice_locks[111] = guild_lock
-        started = asyncio.Event()
-        released = asyncio.Event()
+        instrumented = _InstrumentedLock()
+        adapter._voice_locks[111] = instrumented
+        member = SimpleNamespace(id=42)
+        a_connected = asyncio.Event()
+        a_proceed = asyncio.Event()
 
-        async def _cb(**_kw):
-            started.set()
-            await released.wait()
-            # The attempt's own (orphan) session — nobody else owns it.
-            adapter._voice_clients[111] = SimpleNamespace(
-                is_connected=lambda: True,
-                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
-            )
-            return True
+        async def _cb(*, attempt_token=None, **_kw):
+            ch = _FakeVoiceChannel(222, guild_id=111, members=[member])
+            ok = await adapter.join_voice_channel(ch, attempt_token=attempt_token)
+            a_connected.set()
+            await a_proceed.wait()
+            return ok
 
         adapter._voice_auto_join_callback = _cb
         task = asyncio.ensure_future(
             adapter._run_auto_join_with_barrier(111, "42", "222", "333")
         )
-        await started.wait()
+        await a_connected.wait()  # A connected + owns 222 (lock free again)
 
         # Hold the guild lock so the barrier's finalize must WAIT for it.
-        await guild_lock.acquire()
-        released.set()
-        await asyncio.sleep(0)  # callback connects; barrier reaches the finalize lock
+        await instrumented.acquire()
+        a_proceed.set()
+        await instrumented.waiter_arrived.wait()  # finalize is now blocked on the lock
 
-        # Cancel while finalize is blocked on the lock, then release so the
-        # SHIELDED cleanup can run to completion.
+        # Cancel while finalize is blocked, then release so its shield-to-completion
+        # cleanup can run.
         task.cancel()
-        await asyncio.sleep(0)
-        guild_lock.release()
+        instrumented.release()
 
         with pytest.raises(asyncio.CancelledError):
             await task
 
-        # The shielded owned/orphan cleanup completed despite the cancellation.
+        # The owned cleanup completed despite the cancellation.
         assert 111 not in adapter._voice_clients
         assert adapter._voice_auto_join_pending == {}
         assert 111 not in adapter._voice_session_owner
+
+    @pytest.mark.asyncio
+    async def test_cancellation_exactly_during_disconnect_completes_teardown(self, tmp_path):
+        """Additional P1: a cancellation landing EXACTLY during the physical
+        ``vc.disconnect()`` still completes the transactional teardown — the client
+        is disconnected, every per-guild map is cleared, and the profile-bound
+        runner cleanup runs (mode off, auto-TTS enabled cleared / disabled set)."""
+        runner = _make_runner(tmp_path)
+        adapter = self._real_join_adapter(runner, {
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+        })
+        member = SimpleNamespace(id=42)
+        disconnect_started = asyncio.Event()
+        disconnect_gate = asyncio.Event()
+        fake_channel = _FakeVoiceChannel(
+            222, guild_id=111, members=[member],
+            vc_kwargs={
+                "disconnect_gate": disconnect_gate,
+                "on_disconnect_start": disconnect_started.set,
+            },
+        )
+        adapter.get_user_voice_channel = AsyncMock(return_value=fake_channel)
+
+        async def _cb(*, guild_id, user_id, voice_channel_id, text_channel_id, attempt_token=None):
+            ok = await runner._handle_discord_voice_auto_join(
+                guild_id=guild_id, user_id=user_id, voice_channel_id=voice_channel_id,
+                text_channel_id=text_channel_id, adapter=adapter, profile=None,
+                attempt_token=attempt_token,
+            )
+            # Target leaves mid-join → the owned session is torn down at finalize.
+            adapter._cancel_pending_auto_join_if_matches(111, "42", "222")
+            return ok
+
+        adapter._voice_auto_join_callback = _cb
+        task = asyncio.ensure_future(
+            adapter._run_auto_join_with_barrier(111, "42", "222", "333")
+        )
+
+        # Side effects were applied by the real join; teardown has now reached the
+        # physical disconnect and is blocked inside it.
+        await disconnect_started.wait()
+        assert runner._voice_mode["discord:333"] == "all"  # still on at this instant
+        vc = fake_channel.last_vc
+
+        # Cancel EXACTLY during the disconnect, then let the disconnect finish.
+        task.cancel()
+        disconnect_gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Physical disconnect completed and the FULL transactional teardown ran.
+        assert vc.disconnected is True
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_session_owner
+        assert 111 not in adapter._voice_auto_join_targets
+        assert 111 not in adapter._voice_text_channels
+        assert 111 not in adapter._voice_sources
+        assert adapter._voice_auto_join_pending == {}
+        assert runner._voice_mode["discord:333"] == "off"     # runner mode off
+        assert "333" not in adapter._auto_tts_enabled_chats   # enabled cleared
+        assert "333" in adapter._auto_tts_disabled_chats      # disabled set
 
 
 class TestVoiceProfileIsolation:
@@ -3927,17 +4172,19 @@ class TestVoiceTimeoutCleansRunnerState:
         }
         mock_vc = MagicMock()
         mock_vc.is_connected.return_value = True
+        mock_vc.is_playing.return_value = False
         mock_vc.disconnect = AsyncMock()
         mock_vc.channel = SimpleNamespace(id=222, members=[])
         adapter._voice_clients[111] = mock_vc
         adapter._voice_text_channels[111] = 999
-        adapter.leave_voice_channel = AsyncMock()
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
             await adapter._voice_timeout_handler(111)
 
-        # Target absent → no stay/rearm; the idle timeout disconnects.
-        adapter.leave_voice_channel.assert_awaited_once_with(111)
+        # Target absent → no stay/rearm; the idle timeout disconnects the physical
+        # session (transactional teardown under the guild lock).
+        mock_vc.disconnect.assert_awaited()
+        assert 111 not in adapter._voice_clients
 
 
 # =====================================================================

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -3171,7 +3171,13 @@ class TestDiscordVoiceAutoJoin:
         async def _modern_join(channel, *, manual_owner=False, attempt_token=None):
             calls["n"] += 1
             calls["last_kwargs"] = {"manual_owner": manual_owner, "attempt_token": attempt_token}
-            raise TypeError("some internal boom unrelated to kwargs")
+            # Raise the EXACT text an unknown-kwarg TypeError produces. Because the
+            # gateway inspects the signature (which DOES accept the kwargs) and never
+            # parses TypeError text, this is a single GATED call that fails — it must
+            # NOT be misread as "legacy" and retried tokenless.
+            raise TypeError(
+                "join_voice_channel() got an unexpected keyword argument 'attempt_token'"
+            )
 
         adapter.join_voice_channel = _modern_join
         adapter._voice_input_callback = None
@@ -3234,21 +3240,34 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_clients[111] = vc
         adapter._voice_text_channels[111] = 333
         adapter._voice_sources[111] = {"chat_id": "333"}
-        # A retry task must be finally-cleaned even under cancellation.
-        adapter._voice_auto_join_retry_tasks[111] = MagicMock()
         instrumented = _InstrumentedLock()
         adapter._voice_locks[111] = instrumented
+        # A retry task must be finally-cleaned under the guild lock even when the
+        # public leave is cancelled during the physical disconnect.
+        retry_cancel_lock_state = []
+        retry_task = MagicMock()
+        retry_task.cancel.side_effect = lambda: retry_cancel_lock_state.append(
+            instrumented.locked()
+        )
+        adapter._voice_auto_join_retry_tasks[111] = retry_task
 
         leave_task = asyncio.ensure_future(adapter.leave_voice_channel(111))
         await disconnect_started.wait()             # inside vc.disconnect(), lock held
 
         # A contender tries to take the guild lock; the instrumented lock signals
         # when it is actually BLOCKED (explicit event, no sleep-zero guess) — proof
-        # the teardown still holds the lock.
+        # the teardown still holds the lock. When the contender FINALLY acquires the
+        # lock it records whether the retry was already cleared: because retry
+        # cancellation runs in a finally INSIDE the async-with (lock still held), the
+        # contender must never observe a stale retry task.
         got_lock = asyncio.Event()
+        retry_state_when_locked = {}
 
         async def _contender():
             async with instrumented:
+                retry_state_when_locked["cleared"] = (
+                    111 not in adapter._voice_auto_join_retry_tasks
+                )
                 got_lock.set()
 
         contender = asyncio.ensure_future(_contender())
@@ -3265,9 +3284,13 @@ class TestDiscordVoiceAutoJoin:
         assert 111 not in adapter._voice_text_channels
         assert 111 not in adapter._voice_sources
         assert 111 not in adapter._voice_auto_join_retry_tasks   # retry finally-cleaned
+        assert retry_cancel_lock_state == [True]                 # cleaned under lock
         # Only now can the contender acquire the lock.
         await asyncio.wait_for(contender, timeout=1)
         assert got_lock.is_set()
+        # The retry was already cleared AT THE MOMENT the contender took the lock —
+        # i.e. cancellation happened while the guild lock was still held.
+        assert retry_state_when_locked["cleared"] is True
 
     @pytest.mark.asyncio
     async def test_mid_move_rollback_failure_runs_full_profile_bound_teardown(self, tmp_path):

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -53,6 +53,7 @@ def _ensure_discord_mock():
 _ensure_discord_mock()
 
 from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.config import Platform
 
 
 # ---------------------------------------------------------------------------
@@ -1172,7 +1173,27 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_auto_join_suppressed_until = {}
         adapter._voice_auto_join_next_attempt_at = {}
         adapter._voice_auto_join_retry_tasks = {}
+        adapter._voice_auto_join_pending = {}
         return adapter
+
+    @staticmethod
+    def _connecting_callback(adapter, *, guild_id=111, channel_id=222, user_id=42):
+        """An auto-join callback that simulates a real successful connection.
+
+        The post-join barrier requires the adapter to actually be connected to
+        the validated channel with the target present, so a bare
+        ``AsyncMock(return_value=True)`` is not enough — the callback must
+        populate ``_voice_clients`` the way the real join path does.
+        """
+        def _connect(**_kw):
+            member = SimpleNamespace(id=int(user_id))
+            channel = SimpleNamespace(id=int(channel_id), members=[member])
+            adapter._voice_clients[int(guild_id)] = SimpleNamespace(
+                is_connected=lambda: True, channel=channel
+            )
+            return True
+
+        return AsyncMock(side_effect=_connect)
 
     @staticmethod
     def _voice_state(user_id="42", channel_id=222, before_channel=None):
@@ -1201,6 +1222,7 @@ class TestDiscordVoiceAutoJoin:
             "text_channel_id": "333",
             "reconnect_cooldown_seconds": 0,
         })
+        adapter._voice_auto_join_callback = self._connecting_callback(adapter)
         member, before, after, _channel = self._voice_state()
 
         await adapter._handle_voice_state_update(member, before, after)
@@ -1553,7 +1575,16 @@ class TestDiscordVoiceAutoJoin:
 
         async def _cb(**_kw):
             calls["n"] += 1
-            return calls["n"] > 1  # first attempt fails, retry succeeds
+            if calls["n"] > 1:
+                # Retry succeeds — simulate the real join populating the client so
+                # the post-join barrier can confirm the connection.
+                member = SimpleNamespace(id=42)
+                channel = SimpleNamespace(id=222, members=[member])
+                adapter._voice_clients[111] = SimpleNamespace(
+                    is_connected=lambda: True, channel=channel
+                )
+                return True
+            return False  # first attempt fails
 
         adapter._voice_auto_join_callback = _cb
         guild = SimpleNamespace(id=111, name="Guild")
@@ -1714,6 +1745,352 @@ class TestDiscordVoiceAutoJoin:
         assert cfg["allowed_voice_channel_ids"] == {"222"}
         assert cfg["text_channel_id"] == "333"
         assert cfg["reconnect_cooldown_seconds"] == 5
+
+    # ----- Gap 2: refuse auto-follow over any manual connection -----
+
+    @pytest.mark.asyncio
+    async def test_auto_follow_refused_when_manual_connection_different_channel(self):
+        """A manual connection in a DIFFERENT channel is never moved or adopted."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+        })
+        adapter._voice_auto_join_callback = self._connecting_callback(adapter)
+        # Bot is MANUALLY connected to channel 999 (NOT the allowed 222), no target.
+        manual_channel = SimpleNamespace(id=999, name="Manual")
+        manual_vc = SimpleNamespace(is_connected=lambda: True, channel=manual_channel)
+        adapter._voice_clients[111] = manual_vc
+        member, before, after, _channel = self._voice_state()  # target joins 222
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_not_called()
+        assert 111 not in adapter._voice_auto_join_targets
+        # The manual session is untouched — still connected to 999.
+        assert adapter._voice_clients[111] is manual_vc
+        assert adapter._voice_clients[111].channel.id == 999
+
+    # ----- Gap 3: post-join barrier + pending-attempt race -----
+
+    @pytest.mark.asyncio
+    async def test_join_aborted_when_target_leaves_mid_join(self):
+        """If a leave event cancels the pending attempt mid-join, the barrier
+        aborts and tears the session back down rather than committing it."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+        })
+        adapter.leave_voice_channel = AsyncMock()
+
+        async def _cb(**_kw):
+            # The target-leave event lands while the network join is in flight.
+            adapter._cancel_pending_auto_join_if_matches(111, "42", "222")
+            member = SimpleNamespace(id=42)
+            channel = SimpleNamespace(id=222, members=[member])
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True, channel=channel
+            )
+            return True
+
+        adapter._voice_auto_join_callback = _cb
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        assert 111 not in adapter._voice_auto_join_targets
+        adapter.leave_voice_channel.assert_awaited_once_with(111)
+
+    @pytest.mark.asyncio
+    async def test_join_aborted_when_actual_channel_differs(self):
+        """If the bot ends up in a different channel than validated, abort."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+        })
+        adapter.leave_voice_channel = AsyncMock()
+
+        async def _cb(**_kw):
+            # Landed in channel 999, not the validated 222.
+            channel = SimpleNamespace(id=999, members=[SimpleNamespace(id=42)])
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True, channel=channel
+            )
+            return True
+
+        adapter._voice_auto_join_callback = _cb
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        assert 111 not in adapter._voice_auto_join_targets
+        adapter.leave_voice_channel.assert_awaited_once_with(111)
+
+    @pytest.mark.asyncio
+    async def test_leave_event_cancels_in_flight_pending_join(self):
+        """A concurrent leave event flags the tracked pending attempt cancelled."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+        })
+        adapter._register_pending_auto_join(111, "42", "222")
+
+        # Target leaves channel 222 while a join for it is in flight.
+        await adapter._maybe_cleanup_voice_auto_join_target(
+            111, "42",
+            SimpleNamespace(id=222, name="General"),
+            None,
+        )
+
+        assert adapter._voice_auto_join_pending[111]["cancelled"] is True
+
+    # ----- Gap 4: disconnect teardown after failed join -----
+
+    @pytest.mark.asyncio
+    async def test_teardown_cancels_awaits_retry_and_clears_state(self):
+        """Teardown cancels+awaits the retry task and clears all auto-join state."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 30,
+        })
+        adapter._voice_auto_join_callback = AsyncMock(return_value=False)
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+        task = adapter._voice_auto_join_retry_tasks.get(111)
+        assert task is not None and not task.done()
+
+        await adapter._teardown_voice_auto_join_state()
+
+        assert task.done()
+        assert adapter._voice_auto_join_retry_tasks == {}
+        assert adapter._voice_auto_join_targets == {}
+        assert adapter._voice_auto_join_pending == {}
+        assert adapter._voice_auto_join_callback is None
+        assert adapter._voice_input_callback is None
+        assert adapter._on_voice_disconnect is None
+        assert adapter._voice_mode_getter is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_after_failed_join_tears_down_retry(self):
+        """Full disconnect() after a failed join cancels the retry before teardown."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 30,
+        })
+        adapter._voice_auto_join_callback = AsyncMock(return_value=False)
+        member, before, after, _channel = self._voice_state()
+        await adapter._handle_voice_state_update(member, before, after)
+        task = adapter._voice_auto_join_retry_tasks.get(111)
+        assert task is not None and not task.done()
+
+        # Stub the rest of disconnect()'s resource teardown.
+        adapter._disconnecting = False
+        adapter._cancel_liveness_task = AsyncMock()
+        adapter._cancel_bot_task = AsyncMock()
+        adapter._post_connect_task = None
+        adapter._ready_event = MagicMock()
+        adapter._release_platform_lock = MagicMock()
+        adapter._client = None
+
+        await adapter.disconnect()
+
+        assert task.done()
+        assert adapter._voice_auto_join_retry_tasks == {}
+        assert adapter._voice_auto_join_callback is None
+
+    # ----- Gap 5: reconnect cooldown dominates retry backoff -----
+
+    def test_retry_delay_is_max_of_backoff_and_cooldown(self):
+        adapter = self._make_adapter()
+        assert adapter._voice_auto_join_retry_delay(
+            {"failure_backoff_seconds": 5, "reconnect_cooldown_seconds": 30}
+        ) == 30
+        assert adapter._voice_auto_join_retry_delay(
+            {"failure_backoff_seconds": 60, "reconnect_cooldown_seconds": 15}
+        ) == 60
+
+    @pytest.mark.asyncio
+    async def test_retry_scheduled_at_cooldown_deadline_when_cooldown_exceeds_backoff(self):
+        """Virtual time: the retry sleeps the cooldown (30), not the backoff (5)."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 30,
+            "failure_backoff_seconds": 5,
+        })
+        adapter._voice_auto_join_callback = AsyncMock(return_value=False)
+        slept = []
+
+        async def _fake_sleep(seconds):
+            slept.append(seconds)
+            # Stop the retry loop after recording the (single) scheduled delay.
+            raise asyncio.CancelledError
+
+        member, before, after, _channel = self._voice_state()
+        with patch("asyncio.sleep", _fake_sleep):
+            await adapter._handle_voice_state_update(member, before, after)
+            task = adapter._voice_auto_join_retry_tasks.get(111)
+            assert task is not None
+            # The loop catches the CancelledError and returns cleanly.
+            await task
+
+        # Slept the cooldown (30), NOT the shorter failure backoff (5).
+        assert slept == [30]
+
+    # ----- Gap 6: zero / tiny idle timeout safety -----
+
+    def test_zero_idle_timeout_is_disabled(self):
+        adapter = self._make_adapter()
+        adapter._voice_timeout_seconds = 0
+        assert adapter._effective_voice_timeout_seconds() == 0.0
+
+    def test_tiny_positive_idle_timeout_floored(self):
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        adapter = self._make_adapter()
+        adapter._voice_timeout_seconds = 0.001
+        assert adapter._effective_voice_timeout_seconds() == DiscordAdapter.VOICE_TIMEOUT_MIN
+
+    @pytest.mark.asyncio
+    async def test_zero_idle_timeout_never_disconnects_or_zero_sleeps(self):
+        adapter = self._make_adapter({"stay_while_target_present": True})
+        adapter._voice_timeout_seconds = 0
+        adapter._voice_text_channels[111] = 999
+        adapter.leave_voice_channel = AsyncMock()
+        slept = []
+
+        async def _fake_sleep(seconds):
+            slept.append(seconds)
+
+        with patch("asyncio.sleep", _fake_sleep):
+            await adapter._voice_timeout_handler(111)
+
+        # Disabled: never sleeps, never disconnects, never rearms.
+        assert slept == []
+        adapter.leave_voice_channel.assert_not_awaited()
+        assert 111 not in adapter._voice_timeout_tasks
+
+    def test_reset_voice_timeout_disabled_schedules_nothing(self):
+        adapter = self._make_adapter()
+        adapter._voice_timeout_seconds = 0
+        adapter._reset_voice_timeout(111)
+        assert 111 not in adapter._voice_timeout_tasks
+
+
+class TestVoiceProfileIsolation:
+    """Gap 1: two simultaneous Discord adapters (default + secondary profile);
+    the secondary's voice input / cleanup / mode never touch the default."""
+
+    @staticmethod
+    def _mock_discord_adapter():
+        adapter = MagicMock()
+        adapter.platform = Platform.DISCORD
+        adapter._client = MagicMock()
+        adapter._voice_text_channels = {}
+        adapter._voice_sources = {}
+        adapter._auto_tts_enabled_chats = set()
+        adapter._auto_tts_disabled_chats = set()
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    def test_voice_key_namespaced_by_profile(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        assert runner._voice_key(Platform.DISCORD, "333") == "discord:333"
+        assert runner._voice_key(Platform.DISCORD, "333", profile="default") == "discord:333"
+        assert (
+            runner._voice_key(Platform.DISCORD, "333", profile="coder")
+            == "profile:coder:discord:333"
+        )
+        # A secondary key must differ from the default so state never collides.
+        assert runner._voice_key(Platform.DISCORD, "333", profile="coder") != runner._voice_key(
+            Platform.DISCORD, "333"
+        )
+
+    @pytest.mark.asyncio
+    async def test_voice_input_routes_to_owning_secondary_adapter(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        runner._profile_adapters = {}
+        default = self._mock_discord_adapter()
+        secondary = self._mock_discord_adapter()
+        secondary._voice_text_channels = {111: 333}
+        secondary._client.get_channel = MagicMock(
+            return_value=SimpleNamespace(send=AsyncMock())
+        )
+        runner.adapters[Platform.DISCORD] = default
+        runner._profile_adapters["coder"] = {Platform.DISCORD: secondary}
+
+        await runner._handle_voice_channel_input(
+            111, 42, "hello from the secondary profile", adapter=secondary, profile="coder"
+        )
+
+        # Only the owning (secondary) adapter processed the voice turn.
+        secondary.handle_message.assert_awaited_once()
+        default.handle_message.assert_not_awaited()
+        # The synthetic turn is stamped with the owning profile.
+        event = secondary.handle_message.call_args.args[0]
+        assert event.source.profile == "coder"
+
+    def test_timeout_cleanup_targets_owning_adapter_only(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        runner._profile_adapters = {}
+        default = self._mock_discord_adapter()
+        secondary = self._mock_discord_adapter()
+        runner.adapters[Platform.DISCORD] = default
+        runner._profile_adapters["coder"] = {Platform.DISCORD: secondary}
+
+        runner._handle_voice_timeout_cleanup("333", adapter=secondary, profile="coder")
+
+        # Secondary's auto-TTS suppression updated; default untouched.
+        assert "333" in secondary._auto_tts_disabled_chats
+        assert "333" not in default._auto_tts_disabled_chats
+        # Voice mode is written under the profile-namespaced key only.
+        assert runner._voice_mode.get("profile:coder:discord:333") == "off"
+        assert "discord:333" not in runner._voice_mode
+
+    @pytest.mark.asyncio
+    async def test_voice_command_mode_namespaced_to_owning_profile(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        runner._profile_adapters = {}
+        default = self._mock_discord_adapter()
+        secondary = self._mock_discord_adapter()
+        runner.adapters[Platform.DISCORD] = default
+        runner._profile_adapters["coder"] = {Platform.DISCORD: secondary}
+
+        source = SessionSource(
+            platform=Platform.DISCORD, chat_id="333", user_id="42", chat_type="channel",
+        )
+        source.profile = "coder"
+        event = MessageEvent(text="/voice tts", message_type=MessageType.COMMAND, source=source)
+
+        await runner._handle_voice_command(event)
+
+        # Mode written under the profile-namespaced key; default namespace clean.
+        assert runner._voice_mode.get("profile:coder:discord:333") == "all"
+        assert "discord:333" not in runner._voice_mode
+        # Only the secondary adapter's auto-TTS opt-in was touched.
+        assert "333" in secondary._auto_tts_enabled_chats
+        assert "333" not in default._auto_tts_enabled_chats
 
 
 # =====================================================================
@@ -2714,7 +3091,7 @@ class TestVoiceTimeoutCleansRunnerState:
         when target_leave_cleanup is False (no leave event tears it down)."""
         from plugins.platforms.discord.adapter import VoiceAutoJoinTarget
 
-        adapter._voice_timeout_seconds = 0
+        adapter._voice_timeout_seconds = 5
         adapter._voice_auto_join_cfg = {
             "stay_while_target_present": True,
             "target_leave_cleanup": False,

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1174,6 +1174,9 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_auto_join_next_attempt_at = {}
         adapter._voice_auto_join_retry_tasks = {}
         adapter._voice_auto_join_pending = {}
+        adapter._voice_auto_join_gen = 0
+        adapter._voice_auto_join_direct_tasks = set()
+        adapter._disconnecting = False
         return adapter
 
     @staticmethod
@@ -1306,6 +1309,11 @@ class TestDiscordVoiceAutoJoin:
             text_channel_id="333",
         )
         adapter._voice_text_channels[111] = 333
+        # The bot is still connected to the followed channel (222), so cleanup
+        # proceeds to disconnect.
+        adapter._voice_clients[111] = SimpleNamespace(
+            is_connected=lambda: True, channel=SimpleNamespace(id=222)
+        )
         adapter.leave_voice_channel = AsyncMock()
         disconnect_calls = []
         adapter._on_voice_disconnect = lambda chat_id: disconnect_calls.append(chat_id)
@@ -1997,6 +2005,166 @@ class TestDiscordVoiceAutoJoin:
         adapter._reset_voice_timeout(111)
         assert 111 not in adapter._voice_timeout_tasks
 
+    # ----- Finding 1: in-flight joins must not survive disconnect / overlap -----
+
+    @pytest.mark.asyncio
+    async def test_in_flight_join_cancelled_and_awaited_during_disconnect(self):
+        """A barrier-blocked in-flight attempt is cancelled+awaited by disconnect
+        and never commits a session on the dying adapter."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+        })
+        # Stub disconnect()'s resource-teardown deps.
+        adapter._cancel_liveness_task = AsyncMock()
+        adapter._cancel_bot_task = AsyncMock()
+        adapter._post_connect_task = None
+        adapter._ready_event = MagicMock()
+        adapter._release_platform_lock = MagicMock()
+        adapter._liveness_task = None
+        adapter._running = True
+        adapter._client = None
+        adapter.leave_voice_channel = AsyncMock()
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _cb(**_kw):
+            started.set()
+            await release.wait()  # block mid-join
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True,
+                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
+            )
+            return True
+
+        adapter._voice_auto_join_callback = _cb
+        member, before, after, _channel = self._voice_state()
+        ev_task = asyncio.ensure_future(
+            adapter._handle_voice_state_update(member, before, after)
+        )
+        await started.wait()
+        assert adapter._voice_auto_join_direct_tasks  # attempt is tracked
+
+        # Full disconnect while the join is in flight.
+        await adapter.disconnect()
+        release.set()
+        await asyncio.gather(ev_task, return_exceptions=True)
+
+        # Nothing committed; all in-flight state cleared.
+        assert 111 not in adapter._voice_auto_join_targets
+        assert adapter._voice_auto_join_pending == {}
+        assert adapter._voice_auto_join_direct_tasks == set()
+        assert adapter._voice_auto_join_callback is None
+
+    @pytest.mark.asyncio
+    async def test_two_overlapping_attempts_then_leave_neither_commits(self):
+        """A later attempt supersedes an earlier one (unique tokens); a target
+        leave cancels the current entry, so neither overlapping join commits."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+        })
+        adapter.leave_voice_channel = AsyncMock()
+        release = asyncio.Event()
+
+        async def _cb(**_kw):
+            await release.wait()
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True,
+                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
+            )
+            return True
+
+        adapter._voice_auto_join_callback = _cb
+        task_a = asyncio.ensure_future(
+            adapter._run_auto_join_with_barrier(111, "42", "222", "333")
+        )
+        await asyncio.sleep(0)
+        task_b = asyncio.ensure_future(
+            adapter._run_auto_join_with_barrier(111, "42", "222", "333")
+        )
+        await asyncio.sleep(0)
+        # Target leaves mid-flight → flags the CURRENT (B's) pending entry.
+        adapter._cancel_pending_auto_join_if_matches(111, "42", "222")
+        release.set()
+        result_a, result_b = await asyncio.gather(task_a, task_b)
+
+        assert result_a is False  # A superseded by B's token
+        assert result_b is False  # B cancelled by the leave
+        assert 111 not in adapter._voice_auto_join_targets
+        assert adapter._voice_auto_join_pending == {}
+        adapter.leave_voice_channel.assert_awaited()
+
+    # ----- Finding 2: manual takeover must not leave stale auto-follow -----
+
+    @pytest.mark.asyncio
+    async def test_cleanup_never_disconnects_a_manual_channel(self):
+        """A stale auto-follow target must not disconnect a manual session the
+        bot has since moved to (connected channel != tracked target channel)."""
+        from plugins.platforms.discord.adapter import VoiceAutoJoinTarget
+
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "target_leave_cleanup": True,
+        })
+        # Stale target for 222 remains, but the bot is now on manual channel 999.
+        adapter._voice_auto_join_targets[111] = VoiceAutoJoinTarget(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+        adapter._voice_clients[111] = SimpleNamespace(
+            is_connected=lambda: True, channel=SimpleNamespace(id=999, name="Manual")
+        )
+        adapter._voice_text_channels[111] = 333
+        adapter.leave_voice_channel = AsyncMock()
+
+        await adapter._handle_voice_state_update(
+            SimpleNamespace(id=42, guild=SimpleNamespace(id=111, name="G")),
+            SimpleNamespace(channel=SimpleNamespace(id=222, name="General")),
+            SimpleNamespace(channel=None),
+        )
+
+        # Stale target dropped, but the manual 999 session is never disconnected.
+        adapter.leave_voice_channel.assert_not_awaited()
+        assert 111 not in adapter._voice_auto_join_targets
+        assert adapter._voice_clients[111].channel.id == 999
+
+    @pytest.mark.asyncio
+    async def test_manual_takeover_clears_all_auto_follow_ownership(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "failure_backoff_seconds": 30,
+        })
+        from plugins.platforms.discord.adapter import VoiceAutoJoinTarget
+        adapter._voice_auto_join_targets[111] = VoiceAutoJoinTarget(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+        adapter._register_pending_auto_join(111, "42", "222")
+        # A live retry task exists.
+        adapter._voice_auto_join_callback = AsyncMock(return_value=False)
+        adapter._schedule_voice_auto_join_retry(111, "42", "222", "333", 30)
+        retry = adapter._voice_auto_join_retry_tasks.get(111)
+        assert retry is not None
+
+        adapter.clear_voice_auto_join_ownership(111)
+
+        assert 111 not in adapter._voice_auto_join_targets
+        assert 111 not in adapter._voice_auto_join_pending
+        assert 111 not in adapter._voice_auto_join_retry_tasks
+        await asyncio.sleep(0)
+        assert retry.cancelled() or retry.done()
+
 
 class TestVoiceProfileIsolation:
     """Gap 1: two simultaneous Discord adapters (default + secondary profile);
@@ -2091,6 +2259,113 @@ class TestVoiceProfileIsolation:
         # Only the secondary adapter's auto-TTS opt-in was touched.
         assert "333" in secondary._auto_tts_enabled_chats
         assert "333" not in default._auto_tts_enabled_chats
+
+    # ----- Finding 3: profile-aware mode synchronization -----
+
+    def test_mode_sync_isolates_opposite_default_and_secondary_states(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        default = self._mock_discord_adapter()
+        secondary = self._mock_discord_adapter()
+        # Opposite states: default chat 100 is ON ("all"); secondary chat 200 is OFF.
+        runner._voice_mode = {
+            "discord:100": "all",
+            "profile:coder:discord:200": "off",
+        }
+
+        runner._sync_voice_mode_state_to_adapter(default)
+        runner._sync_voice_mode_state_to_adapter(secondary, profile_name="coder")
+
+        # Default adapter sees ONLY its own namespace.
+        assert default._auto_tts_enabled_chats == {"100"}
+        assert default._auto_tts_disabled_chats == set()
+        # Secondary adapter sees ONLY its own namespace.
+        assert secondary._auto_tts_disabled_chats == {"200"}
+        assert secondary._auto_tts_enabled_chats == set()
+
+        # Restart/reconnect re-derives the same isolated state (idempotent).
+        runner._sync_voice_mode_state_to_adapter(secondary, profile_name="coder")
+        assert secondary._auto_tts_disabled_chats == {"200"}
+        assert "100" not in secondary._auto_tts_disabled_chats
+        assert "100" not in secondary._auto_tts_enabled_chats
+
+    # ----- Finding 4: aborted auto-join rolls back join side effects -----
+
+    @pytest.mark.asyncio
+    async def test_real_callback_midjoin_cancel_rolls_back_all_side_effects(self, tmp_path):
+        """The real runner auto-join callback, cancelled mid-join, must leave no
+        physical VC / target / pending and roll back persisted mode + auto-TTS."""
+        adapter = TestDiscordVoiceAutoJoin._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+        })
+        adapter._auto_tts_enabled_chats = set()
+        adapter._auto_tts_disabled_chats = set()
+        guild = SimpleNamespace(id=111, name="Guild")
+        text_channel = SimpleNamespace(id=333, name="voice-chat", guild=guild, parent_id=None)
+        voice_channel = SimpleNamespace(id=222, name="General", guild=guild)
+        adapter._client.get_channel = MagicMock(return_value=text_channel)
+        adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
+
+        async def _join(channel):
+            # The target-leave lands mid-join (cancels the pending attempt), then
+            # the physical connection is established.
+            adapter._cancel_pending_auto_join_if_matches(111, "42", "222")
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True,
+                is_playing=lambda: False,
+                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
+                disconnect=AsyncMock(),
+            )
+            return True
+
+        adapter.join_voice_channel = AsyncMock(side_effect=_join)
+
+        runner = _make_runner(tmp_path)
+        runner.adapters[Platform.DISCORD] = adapter
+        runner._sync_voice_auto_join_state_to_adapter(adapter)
+
+        member, before, after, _channel = TestDiscordVoiceAutoJoin._voice_state()
+        await adapter._handle_voice_state_update(member, before, after)
+
+        # Physical VC and all ownership state gone.
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_auto_join_targets
+        assert adapter._voice_auto_join_pending == {}
+        # Persisted mode rolled back to off; auto-TTS enable cleared, disable set.
+        assert runner._voice_mode.get("discord:333") == "off"
+        assert "333" not in adapter._auto_tts_enabled_chats
+        assert "333" in adapter._auto_tts_disabled_chats
+
+    # ----- Finding 5: transcript dedupe keyed by profile -----
+
+    @pytest.mark.asyncio
+    async def test_transcript_dedupe_is_per_profile(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        # Identical guild/user/transcript is accepted ONCE per profile...
+        assert runner._is_duplicate_voice_transcript(111, 42, "hello there", profile=None) is False
+        assert runner._is_duplicate_voice_transcript(111, 42, "hello there", profile="coder") is False
+        # ...and a repeat within the SAME profile is suppressed.
+        assert runner._is_duplicate_voice_transcript(111, 42, "hello there", profile=None) is True
+        assert runner._is_duplicate_voice_transcript(111, 42, "hello there", profile="coder") is True
+
+    @pytest.mark.asyncio
+    async def test_secondary_voice_input_has_no_default_adapter_fallback(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        runner._profile_adapters = {}
+        default = self._mock_discord_adapter()
+        default._voice_text_channels = {111: 333}
+        runner.adapters[Platform.DISCORD] = default
+        # Secondary profile "coder" has NO registered adapter.
+
+        await runner._handle_voice_channel_input(
+            111, 42, "orphan transcript", profile="coder"
+        )
+
+        # No fallback to the default adapter — the turn is dropped, default untouched.
+        default.handle_message.assert_not_awaited()
 
 
 # =====================================================================

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1175,7 +1175,9 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_auto_join_retry_tasks = {}
         adapter._voice_auto_join_pending = {}
         adapter._voice_auto_join_gen = 0
-        adapter._voice_auto_join_direct_tasks = set()
+        adapter._voice_auto_join_direct_tasks = {}
+        adapter._voice_session_owner = {}
+        adapter._voice_mixers = {}
         adapter._disconnecting = False
         return adapter
 
@@ -1366,7 +1368,7 @@ class TestDiscordVoiceAutoJoin:
         )
 
         assert success is True
-        adapter.join_voice_channel.assert_awaited_once_with(voice_channel)
+        adapter.join_voice_channel.assert_awaited_once_with(voice_channel, manual_owner=False)
         assert runner._voice_mode["discord:333"] == "all"
         assert adapter._auto_tts_enabled_chats == {"333"}
         adapter.mark_voice_auto_join_target.assert_called_once_with(
@@ -1477,7 +1479,7 @@ class TestDiscordVoiceAutoJoin:
         assert success is True
         # Exactly one resolution across the whole join path.
         assert adapter.get_user_voice_channel.await_count == 1
-        adapter.join_voice_channel.assert_awaited_once_with(voice_channel)
+        adapter.join_voice_channel.assert_awaited_once_with(voice_channel, manual_owner=False)
 
     @pytest.mark.asyncio
     async def test_secondary_profile_auto_join_binds_owning_adapter(self, tmp_path):
@@ -1526,7 +1528,7 @@ class TestDiscordVoiceAutoJoin:
         )
 
         assert success is True
-        adapter.join_voice_channel.assert_awaited_once_with(voice_channel)
+        adapter.join_voice_channel.assert_awaited_once_with(voice_channel, manual_owner=False)
         active.join_voice_channel.assert_not_awaited()
         adapter.mark_voice_auto_join_target.assert_called_once_with(
             111, user_id="42", voice_channel_id="222", text_channel_id="333", profile="coder",
@@ -1821,7 +1823,10 @@ class TestDiscordVoiceAutoJoin:
         await adapter._handle_voice_state_update(member, before, after)
 
         assert 111 not in adapter._voice_auto_join_targets
-        adapter.leave_voice_channel.assert_awaited_once_with(111)
+        # The unowned session the aborted attempt created is torn down (no
+        # dangling VC), and no retry is scheduled.
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_auto_join_retry_tasks
 
     @pytest.mark.asyncio
     async def test_join_aborted_when_actual_channel_differs(self):
@@ -1850,7 +1855,10 @@ class TestDiscordVoiceAutoJoin:
         await adapter._handle_voice_state_update(member, before, after)
 
         assert 111 not in adapter._voice_auto_join_targets
-        adapter.leave_voice_channel.assert_awaited_once_with(111)
+        # The unowned session the aborted attempt created is torn down (no
+        # dangling VC), and no retry is scheduled.
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_auto_join_retry_tasks
 
     @pytest.mark.asyncio
     async def test_leave_event_cancels_in_flight_pending_join(self):
@@ -2056,7 +2064,7 @@ class TestDiscordVoiceAutoJoin:
             adapter._handle_voice_state_update(member, before, after)
         )
         await started.wait()
-        assert adapter._voice_auto_join_direct_tasks  # attempt is tracked
+        assert adapter._voice_auto_join_direct_tasks.get(111)  # attempt tracked per-guild
 
         # Full disconnect while the join is in flight.
         await adapter.disconnect()
@@ -2066,20 +2074,24 @@ class TestDiscordVoiceAutoJoin:
         # Nothing committed; all in-flight state cleared.
         assert 111 not in adapter._voice_auto_join_targets
         assert adapter._voice_auto_join_pending == {}
-        assert adapter._voice_auto_join_direct_tasks == set()
+        assert adapter._voice_auto_join_direct_tasks == {}
         assert adapter._voice_auto_join_callback is None
 
     @pytest.mark.asyncio
     async def test_two_overlapping_attempts_then_leave_neither_commits(self):
         """A later attempt supersedes an earlier one (unique tokens); a target
-        leave cancels the current entry, so neither overlapping join commits."""
+        leave cancels the current entry, so neither overlapping join commits and
+        no orphan session is left behind."""
+        from plugins.platforms.discord.adapter import (
+            AUTO_JOIN_SUPERSEDED, AUTO_JOIN_CANCELLED,
+        )
+
         adapter = self._make_adapter({
             "enabled": True,
             "allowed_user_ids": ["42"],
             "allowed_voice_channel_ids": ["222"],
             "text_channel_id": "333",
         })
-        adapter.leave_voice_channel = AsyncMock()
         release = asyncio.Event()
 
         async def _cb(**_kw):
@@ -2102,13 +2114,15 @@ class TestDiscordVoiceAutoJoin:
         # Target leaves mid-flight → flags the CURRENT (B's) pending entry.
         adapter._cancel_pending_auto_join_if_matches(111, "42", "222")
         release.set()
-        result_a, result_b = await asyncio.gather(task_a, task_b)
+        outcome_a, outcome_b = await asyncio.gather(task_a, task_b)
 
-        assert result_a is False  # A superseded by B's token
-        assert result_b is False  # B cancelled by the leave
+        assert outcome_a == AUTO_JOIN_SUPERSEDED  # A superseded by B's token
+        assert outcome_b == AUTO_JOIN_CANCELLED   # B cancelled by the leave
+        # Neither committed and the orphan connection is torn down.
         assert 111 not in adapter._voice_auto_join_targets
         assert adapter._voice_auto_join_pending == {}
-        adapter.leave_voice_channel.assert_awaited()
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_session_owner
 
     # ----- Finding 2: manual takeover must not leave stale auto-follow -----
 
@@ -2178,8 +2192,13 @@ class TestDiscordVoiceAutoJoin:
 
     @pytest.mark.asyncio
     async def test_superseded_older_attempt_never_disconnects_newer_owner(self):
-        """P1 (finding 1): an older auto-join that completes AFTER a newer one has
-        established and owns the guild's voice session must not disconnect it."""
+        """P1 (finding 1/B): an older auto-join that completes AFTER a newer one
+        has committed and OWNS the guild's session must not disconnect it — the
+        ownership check is session-token based, decided under the guild lock."""
+        from plugins.platforms.discord.adapter import (
+            AUTO_JOIN_COMMITTED, AUTO_JOIN_SUPERSEDED,
+        )
+
         adapter = self._make_adapter({
             "enabled": True,
             "allowed_user_ids": ["42"],
@@ -2188,18 +2207,16 @@ class TestDiscordVoiceAutoJoin:
             "reconnect_cooldown_seconds": 0,
             "failure_backoff_seconds": 0,
         })
-        adapter.leave_voice_channel = AsyncMock(
-            side_effect=lambda gid: adapter._voice_clients.pop(int(gid), None)
+        adapter.get_user_voice_channel = AsyncMock(
+            return_value=SimpleNamespace(id=555)
         )
-
         hold_a = asyncio.Event()
 
         async def _cb_a(**_kw):
-            await hold_a.wait()  # A is held until B has committed and owns 555
+            await hold_a.wait()  # A held until B has committed and owns 555
             return True
 
-        # Start the OLDER attempt A (channel 222); it registers pending token 1
-        # and blocks inside its callback.
+        # Older attempt A (channel 222) registers pending token 1, then blocks.
         adapter._voice_auto_join_callback = _cb_a
         task_a = asyncio.ensure_future(
             adapter._run_auto_join_with_barrier(111, "42", "222", "333")
@@ -2207,38 +2224,98 @@ class TestDiscordVoiceAutoJoin:
         await asyncio.sleep(0)
         assert adapter._voice_auto_join_pending[111]["token"] == 1
 
-        # The NEWER attempt B (channel 555) runs fully, connects, and commits —
-        # superseding A's pending slot and owning the physical session on 555.
+        # Newer attempt B (channel 555) runs fully, connects, and COMMITS —
+        # superseding A's pending slot and stamping session ownership with its
+        # own token.
         async def _cb_b(**_kw):
-            member = SimpleNamespace(id=42)
-            channel = SimpleNamespace(id=555, members=[member])
             adapter._voice_clients[111] = SimpleNamespace(
-                is_connected=lambda: True, channel=channel
+                is_connected=lambda: True,
+                channel=SimpleNamespace(id=555, members=[SimpleNamespace(id=42)]),
             )
             return True
 
         adapter._voice_auto_join_callback = _cb_b
-        ok_b = await adapter._run_auto_join_with_barrier(111, "42", "555", "333")
-        assert ok_b is True
+        outcome_b = await adapter._run_auto_join_with_barrier(111, "42", "555", "333")
+        assert outcome_b == AUTO_JOIN_COMMITTED
+        b_owner = adapter._voice_session_owner[111]
         adapter.mark_voice_auto_join_target(
             111, user_id="42", voice_channel_id="555", text_channel_id="333",
         )
-        assert adapter.connected_voice_channel_id(111) == "555"
 
         # Release the older A: it completes late but is superseded.
         hold_a.set()
-        ok_a = await task_a
+        outcome_a = await task_a
 
-        assert ok_a is False  # A did not commit
-        # B's session and target are untouched — never disconnected.
-        adapter.leave_voice_channel.assert_not_awaited()
+        assert outcome_a == AUTO_JOIN_SUPERSEDED
+        # B's session, ownership stamp, and target are untouched.
         assert adapter.connected_voice_channel_id(111) == "555"
+        assert adapter._voice_session_owner[111] == b_owner
         assert adapter._voice_auto_join_targets[111].voice_channel_id == "555"
 
     @pytest.mark.asyncio
-    async def test_superseded_attempt_never_disconnects_manual_takeover(self):
-        """P1 (finding 1): an in-flight auto-join that completes after a manual
-        /voice-join takeover must not disconnect the hand-established session."""
+    async def test_superseded_stale_orphan_torn_down_when_newer_fails(self):
+        """P1 (finding 1/A): a stale attempt whose callback physically connects
+        AFTER a newer attempt superseded it — and the newer attempt then FAILS
+        (so nobody owns the session) — must not leave a dangling unowned VC, and
+        must schedule NO retry. Holds even with idle_timeout_seconds=0."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            # A large backoff would schedule a retry for a genuine FAILURE — the
+            # test proves SUPERSEDED schedules none regardless.
+            "failure_backoff_seconds": 30,
+            "idle_timeout_seconds": 0,
+        })
+        hold = asyncio.Event()
+        started = asyncio.Event()
+
+        async def _cb(**_kw):
+            started.set()
+            await hold.wait()
+            # Stale callback physically connects AFTER release (mutating the VC).
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True,
+                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
+            )
+            return True
+
+        adapter._voice_auto_join_callback = _cb
+        # Drive the stale attempt through the retry-capable entry point so we can
+        # prove no retry is scheduled for a superseded outcome.
+        join_task = asyncio.ensure_future(
+            adapter._attempt_voice_auto_join(111, "42", "222", "333")
+        )
+        await started.wait()
+
+        # A newer attempt B claims the pending slot (superseding A) and then FAILS
+        # (clears its own pending), committing nothing → no session owner.
+        token_b = adapter._register_pending_auto_join(111, "42", "222")
+        adapter._clear_pending_auto_join(111, token_b)
+
+        # Release the stale callback; its barrier now finalizes as superseded.
+        hold.set()
+        result = await join_task
+
+        assert result is False  # attempt did not commit (superseded, not retried)
+        # No dangling unowned VC, no ownership, no target, no pending, no retry.
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_session_owner
+        assert 111 not in adapter._voice_auto_join_targets
+        assert adapter._voice_auto_join_pending == {}
+        assert 111 not in adapter._voice_auto_join_retry_tasks
+
+    @pytest.mark.asyncio
+    async def test_stale_callback_after_manual_takeover_leaves_manual_intact(self):
+        """P1 (finding 1/A): a stale auto-join callback that MUTATES the VC after
+        a manual takeover established a manual-owned session must never disconnect
+        that manual session."""
+        from plugins.platforms.discord.adapter import (
+            AUTO_JOIN_SUPERSEDED, MANUAL_VOICE_SESSION_OWNER,
+        )
+
         adapter = self._make_adapter({
             "enabled": True,
             "allowed_user_ids": ["42"],
@@ -2247,37 +2324,41 @@ class TestDiscordVoiceAutoJoin:
             "reconnect_cooldown_seconds": 0,
             "failure_backoff_seconds": 0,
         })
-        adapter.leave_voice_channel = AsyncMock(
-            side_effect=lambda gid: adapter._voice_clients.pop(int(gid), None)
-        )
-
         hold = asyncio.Event()
+        started = asyncio.Event()
 
         async def _cb(**_kw):
+            started.set()
             await hold.wait()
+            # Stale callback actually mutates the VC (as a real join would).
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True,
+                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
+            )
             return True
 
         adapter._voice_auto_join_callback = _cb
         task = asyncio.ensure_future(
             adapter._run_auto_join_with_barrier(111, "42", "222", "333")
         )
-        await asyncio.sleep(0)
-        assert 111 in adapter._voice_auto_join_pending
+        await started.wait()
 
-        # A manual /voice-join takes over to channel 555 and supersedes the
-        # in-flight auto-follow ownership.
+        # Manual /voice-join takeover: establishes a MANUAL-owned session on 555
+        # and supersedes the in-flight auto-follow ownership.
         adapter._voice_clients[111] = SimpleNamespace(
             is_connected=lambda: True,
             channel=SimpleNamespace(id=555, members=[SimpleNamespace(id=42)]),
         )
+        adapter._voice_session_owner[111] = MANUAL_VOICE_SESSION_OWNER
         adapter.clear_voice_auto_join_ownership(111)
 
         hold.set()
-        ok = await task
+        outcome = await task
 
-        assert ok is False
-        adapter.leave_voice_channel.assert_not_awaited()
-        assert adapter.connected_voice_channel_id(111) == "555"  # manual session stands
+        assert outcome == AUTO_JOIN_SUPERSEDED
+        # The manual-owned session remains (never disconnected by the stale attempt).
+        assert 111 in adapter._voice_clients
+        assert adapter._voice_session_owner[111] == MANUAL_VOICE_SESSION_OWNER
 
     @pytest.mark.asyncio
     async def test_cancellation_after_side_effects_rolls_back_transactionally(self, tmp_path):
@@ -2466,6 +2547,167 @@ class TestDiscordVoiceAutoJoin:
         # The rejoin was followed without a second voice-state event.
         assert adapter.connected_voice_channel_id(111) == "222"
         assert 111 in adapter._voice_auto_join_targets
+
+    @pytest.mark.asyncio
+    async def test_leave_auto_join_state_query_is_guild_scoped(self, tmp_path):
+        """P2: an in-flight auto-join for guild A must not make an IDLE guild B's
+        /voice leave report success or mutate B's voice mode. The gateway asks a
+        guild-scoped snapshot, and direct tasks are keyed by guild."""
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+        })
+        runner.adapters[Platform.DISCORD] = adapter
+        runner._adapter_for_source = lambda source: adapter
+
+        # Guild A (111) is mid-auto-join: a direct barrier task + pending entry.
+        adapter._voice_auto_join_direct_tasks[111] = {MagicMock(name="A-direct-task")}
+        adapter._register_pending_auto_join(111, "42", "222")
+
+        # The snapshot is strictly guild-scoped.
+        state_a = adapter.voice_auto_join_state(111)
+        assert state_a.inflight and state_a.has_direct and state_a.has_pending
+        state_b = adapter.voice_auto_join_state(222)
+        assert not state_b.inflight
+        assert not state_b.has_direct and not state_b.has_pending
+
+        # /voice leave for the IDLE guild B (222): no physical VC, nothing in
+        # flight for B → "not in a voice channel", and B's mode is untouched.
+        runner._voice_mode = {}
+        source = SessionSource(chat_id="999", user_id="42", platform=MagicMock())
+        source.platform.value = "discord"
+        source.thread_id = None
+        leave_event = MessageEvent(
+            text="/voice leave", message_type=MessageType.TEXT, source=source
+        )
+        leave_event.raw_message = SimpleNamespace(guild_id=222, guild=None)
+
+        result = await runner._handle_voice_channel_leave(leave_event)
+        assert "not in" in result.lower()
+        assert runner._voice_mode == {}  # guild B's mode never mutated
+
+    @pytest.mark.asyncio
+    async def test_concurrent_manual_takeover_during_rollback_wait(self):
+        """P1 B: when a stale attempt's lock-scoped teardown must wait for the
+        guild voice lock, a manual takeover that grabs the lock first (stamping
+        manual ownership) is observed under the lock and left intact."""
+        from plugins.platforms.discord.adapter import (
+            AUTO_JOIN_CANCELLED, MANUAL_VOICE_SESSION_OWNER,
+        )
+
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+        })
+        guild_lock = asyncio.Lock()
+        adapter._voice_locks[111] = guild_lock
+
+        started = asyncio.Event()
+        release_cb = asyncio.Event()
+
+        async def _cb(**_kw):
+            started.set()
+            await release_cb.wait()
+            # Stale attempt's callback connected; it will be flagged cancelled.
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True,
+                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
+            )
+            return True
+
+        adapter._voice_auto_join_callback = _cb
+        task = asyncio.ensure_future(
+            adapter._run_auto_join_with_barrier(111, "42", "222", "333")
+        )
+        await started.wait()
+
+        # Flag the attempt cancelled, then HOLD the guild voice lock so the
+        # barrier's lock-scoped teardown must wait for it — the window in which a
+        # concurrent takeover completes.
+        adapter._cancel_pending_auto_join_if_matches(111, "42", "222")
+        await guild_lock.acquire()
+        release_cb.set()
+        await asyncio.sleep(0)  # let the barrier reach the lock and block
+
+        # A manual takeover completes while the rollback waits: it establishes a
+        # manual-owned session on 555 (this is what the real join does under the
+        # lock it currently holds).
+        adapter._voice_clients[111] = SimpleNamespace(
+            is_connected=lambda: True,
+            channel=SimpleNamespace(id=555, members=[SimpleNamespace(id=42)]),
+        )
+        adapter._voice_session_owner[111] = MANUAL_VOICE_SESSION_OWNER
+        guild_lock.release()
+
+        outcome = await task
+        assert outcome == AUTO_JOIN_CANCELLED
+        # The stale rollback re-checked ownership UNDER the lock and left the
+        # manual session strictly intact.
+        assert 111 in adapter._voice_clients
+        assert adapter._voice_session_owner[111] == MANUAL_VOICE_SESSION_OWNER
+        assert adapter.connected_voice_channel_id(111) == "555"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_finalize_lock_wait_completes_cleanup(self):
+        """P1 B: a cancellation that lands while the barrier is blocked acquiring
+        the guild voice lock for its finalize/rollback still completes the shielded
+        owned/orphan cleanup — no half-torn-down or dangling state survives."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0,
+        })
+        guild_lock = asyncio.Lock()
+        adapter._voice_locks[111] = guild_lock
+        started = asyncio.Event()
+        released = asyncio.Event()
+
+        async def _cb(**_kw):
+            started.set()
+            await released.wait()
+            # The attempt's own (orphan) session — nobody else owns it.
+            adapter._voice_clients[111] = SimpleNamespace(
+                is_connected=lambda: True,
+                channel=SimpleNamespace(id=222, members=[SimpleNamespace(id=42)]),
+            )
+            return True
+
+        adapter._voice_auto_join_callback = _cb
+        task = asyncio.ensure_future(
+            adapter._run_auto_join_with_barrier(111, "42", "222", "333")
+        )
+        await started.wait()
+
+        # Hold the guild lock so the barrier's finalize must WAIT for it.
+        await guild_lock.acquire()
+        released.set()
+        await asyncio.sleep(0)  # callback connects; barrier reaches the finalize lock
+
+        # Cancel while finalize is blocked on the lock, then release so the
+        # SHIELDED cleanup can run to completion.
+        task.cancel()
+        await asyncio.sleep(0)
+        guild_lock.release()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The shielded owned/orphan cleanup completed despite the cancellation.
+        assert 111 not in adapter._voice_clients
+        assert adapter._voice_auto_join_pending == {}
+        assert 111 not in adapter._voice_session_owner
 
 
 class TestVoiceProfileIsolation:
@@ -4656,8 +4898,9 @@ class TestTwoProfileVoiceStartupIsolation:
 
     @pytest.mark.asyncio
     async def test_opposite_voice_settings_isolated_across_profiles_and_reconnect(
-        self, tmp_path
+        self, tmp_path, monkeypatch
     ):
+        import hermes_cli.profiles as _profiles_mod
         from gateway.run import GatewayRunner
         from gateway.config import Platform
         from plugins.platforms.discord.adapter import DiscordAdapter
@@ -4737,16 +4980,28 @@ class TestTwoProfileVoiceStartupIsolation:
         assert b._voice_auto_join_callback is not None
         assert a._voice_auto_join_callback is not b._voice_auto_join_callback
 
-        # Reconnect profB: the reconnect path re-runs the same profile-scoped
-        # resync. Simulate drift, reconnect, and prove B re-derives from its OWN
-        # namespace only — no bleed from A, and A is left untouched.
-        b._auto_tts_enabled_chats.add("999")
-        b._auto_tts_disabled_chats.discard("200")
-        runner._sync_voice_mode_state_to_adapter(
-            b, profile_name="profB", profile_home=prof_b
+        # Reconnect profB through the ACTUAL runner reconnect path — it
+        # RECONSTRUCTS the adapter inside profB's runtime scope (via
+        # get_profile_dir + _create_adapter) and re-runs the profile-scoped voice
+        # syncs. Drop B's live adapter so the reconnect rebuilds a fresh one.
+        homes = {"profA": prof_a, "profB": prof_b}
+        monkeypatch.setattr(
+            _profiles_mod, "get_profile_dir", lambda name: homes[name]
         )
-        runner._sync_voice_auto_join_state_to_adapter(b, profile_name="profB")
-        assert b._auto_tts_enabled_chats == set()
-        assert b._auto_tts_disabled_chats == {"200"}
-        assert b._auto_tts_default is False
+        runner._running = True
+        runner._profile_failed_platforms = {}
+        runner._profile_adapters["profB"] = {}
+
+        await runner._run_secondary_profile_reconnect("profB", Platform.DISCORD)
+
+        b2 = runner._profile_adapters["profB"][Platform.DISCORD]
+        # A genuinely reconstructed adapter (not the pre-reconnect instance),
+        # re-derived from profB's OWN namespace only — no bleed from A.
+        assert b2 is not b
+        assert b2._auto_tts_default is False
+        assert b2._auto_tts_enabled_chats == set()
+        assert b2._auto_tts_disabled_chats == {"200"}
+        assert b2._voice_auto_join_callback is not None
+        # profA's adapter is untouched by profB's reconnect.
+        assert a._auto_tts_default is True
         assert a._auto_tts_enabled_chats == {"100"}

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1,5 +1,6 @@
 """Tests for the /voice command and auto voice reply in the gateway."""
 
+import asyncio
 import importlib.util
 import json
 import os
@@ -945,6 +946,42 @@ class TestVoiceChannelCommands:
             channel_id="222",
         )
 
+    @pytest.mark.asyncio
+    async def test_manual_leave_by_different_operator_suppresses_tracked_target(self, runner):
+        """A manual /voice leave issued by a DIFFERENT operator than the tracked
+        target still keys the cooldown to the followed target, not the issuer."""
+        from plugins.platforms.discord.adapter import DiscordAdapter, VoiceAutoJoinTarget
+        from gateway.config import Platform, PlatformConfig
+
+        config = PlatformConfig(enabled=True, extra={})
+        config.token = "fake-token"
+        adapter = object.__new__(DiscordAdapter)
+        adapter.platform = Platform.DISCORD
+        adapter.config = config
+        adapter._voice_auto_join_cfg = {"manual_leave_cooldown_seconds": 300}
+        adapter._voice_auto_join_suppressed_until = {}
+        adapter._voice_auto_join_retry_tasks = {}
+        adapter._voice_clients = {111: SimpleNamespace(is_connected=lambda: True)}
+        adapter._voice_auto_join_targets = {
+            111: VoiceAutoJoinTarget(
+                guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+            )
+        }
+        adapter.leave_voice_channel = AsyncMock()
+        adapter._voice_input_callback = None
+        adapter._auto_tts_enabled_chats = set()
+        adapter._auto_tts_disabled_chats = set()
+        # Issuer of /voice leave is "user1" — NOT the followed target ("42").
+        event = self._make_discord_event("/voice leave", user_id="user1")
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_voice_channel_leave(event)
+
+        # Cooldown is keyed to the tracked target, blocking the target's rejoin.
+        assert adapter._is_voice_auto_join_suppressed(111, "42", "222")
+        # The issuer is not what gates the follow.
+        assert not adapter._is_voice_auto_join_suppressed(111, "user1", "222")
+
     # -- _handle_voice_channel_input --
 
     @pytest.mark.asyncio
@@ -1134,6 +1171,7 @@ class TestDiscordVoiceAutoJoin:
         adapter._voice_auto_join_targets = {}
         adapter._voice_auto_join_suppressed_until = {}
         adapter._voice_auto_join_next_attempt_at = {}
+        adapter._voice_auto_join_retry_tasks = {}
         return adapter
 
     @staticmethod
@@ -1173,7 +1211,7 @@ class TestDiscordVoiceAutoJoin:
             voice_channel_id="222",
             text_channel_id="333",
         )
-        assert adapter._voice_auto_join_targets[111]["user_id"] == "42"
+        assert adapter._voice_auto_join_targets[111].user_id == "42"
 
     @pytest.mark.asyncio
     async def test_disallowed_user_or_channel_ignored(self):
@@ -1221,6 +1259,9 @@ class TestDiscordVoiceAutoJoin:
         await adapter._handle_voice_state_update(member, before, after)
 
         adapter._voice_auto_join_callback.assert_awaited_once()
+        # A retry task is scheduled after the failed join; cancel it so the
+        # 60s-backoff sleep does not dangle past the test.
+        adapter._cancel_voice_auto_join_retry(111)
 
     @pytest.mark.asyncio
     async def test_target_leave_cleanup_disconnects_and_notifies_runner(self):
@@ -1231,14 +1272,17 @@ class TestDiscordVoiceAutoJoin:
             "text_channel_id": "333",
             "target_leave_cleanup": True,
         })
+        from plugins.platforms.discord.adapter import VoiceAutoJoinTarget
+
         guild = SimpleNamespace(id=111, name="Guild")
         before_channel = SimpleNamespace(id=222, name="General", guild=guild)
         member = SimpleNamespace(id=42, display_name="Martin", guild=guild)
-        adapter._voice_auto_join_targets[111] = {
-            "user_id": "42",
-            "voice_channel_id": "222",
-            "text_channel_id": "333",
-        }
+        adapter._voice_auto_join_targets[111] = VoiceAutoJoinTarget(
+            guild_id=111,
+            user_id="42",
+            voice_channel_id="222",
+            text_channel_id="333",
+        )
         adapter._voice_text_channels[111] = 333
         adapter.leave_voice_channel = AsyncMock()
         disconnect_calls = []
@@ -1268,6 +1312,9 @@ class TestDiscordVoiceAutoJoin:
         adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
         adapter.join_voice_channel = AsyncMock(return_value=True)
         adapter.is_in_voice_channel = MagicMock(return_value=True)
+        # The adapter reports the ACTUAL connected channel, which is what the
+        # target must be recorded against.
+        adapter.connected_voice_channel_id = MagicMock(return_value="222")
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
         adapter._voice_input_callback = None
@@ -1284,6 +1331,8 @@ class TestDiscordVoiceAutoJoin:
             user_id="42",
             voice_channel_id="222",
             text_channel_id="333",
+            adapter=adapter,
+            profile=None,
         )
 
         assert success is True
@@ -1295,6 +1344,7 @@ class TestDiscordVoiceAutoJoin:
             user_id="42",
             voice_channel_id="222",
             text_channel_id="333",
+            profile=None,
         )
 
     @pytest.mark.asyncio
@@ -1359,6 +1409,311 @@ class TestDiscordVoiceAutoJoin:
         assert success is False
         adapter.join_voice_channel.assert_not_awaited()
         adapter.mark_voice_auto_join_target.assert_not_called()
+        # The live channel is resolved exactly once — the join path must not
+        # look it up a second time (that reopens the move TOCTOU).
+        assert adapter.get_user_voice_channel.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_runner_auto_join_resolves_channel_once_and_joins_it(self, tmp_path):
+        """The channel is resolved once and THAT channel is the one joined."""
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        guild = SimpleNamespace(id=111, name="Guild")
+        text_channel = SimpleNamespace(id=333, name="voice-chat", guild=guild, parent_id=None)
+        voice_channel = SimpleNamespace(id=222, name="General", guild=guild)
+        adapter = MagicMock()
+        adapter._client = MagicMock()
+        adapter._client.get_channel = MagicMock(return_value=text_channel)
+        adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
+        adapter.join_voice_channel = AsyncMock(return_value=True)
+        adapter.is_in_voice_channel = MagicMock(return_value=True)
+        adapter.connected_voice_channel_id = MagicMock(return_value="222")
+        adapter._voice_text_channels = {}
+        adapter._voice_sources = {}
+        adapter._voice_input_callback = None
+        adapter._on_voice_disconnect = None
+        adapter._voice_mode_getter = None
+        adapter._auto_tts_enabled_chats = set()
+        adapter._auto_tts_disabled_chats = set()
+        adapter._voice_auto_join_cfg = {"allowed_voice_channel_ids": {"222"}}
+        adapter.mark_voice_auto_join_target = MagicMock()
+        runner.adapters[Platform.DISCORD] = adapter
+
+        success = await runner._handle_discord_voice_auto_join(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+
+        assert success is True
+        # Exactly one resolution across the whole join path.
+        assert adapter.get_user_voice_channel.await_count == 1
+        adapter.join_voice_channel.assert_awaited_once_with(voice_channel)
+
+    @pytest.mark.asyncio
+    async def test_secondary_profile_auto_join_binds_owning_adapter(self, tmp_path):
+        """A bound callback drives the owning secondary-profile adapter, stamps
+        its profile, and never touches the active-profile adapter."""
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        runner._profile_adapters = {}
+        guild = SimpleNamespace(id=111, name="Guild")
+        text_channel = SimpleNamespace(id=333, name="voice-chat", guild=guild, parent_id=None)
+        voice_channel = SimpleNamespace(id=222, name="General", guild=guild)
+
+        adapter = MagicMock()
+        adapter.platform = Platform.DISCORD
+        adapter._voice_auto_join_callback = None
+        adapter._client = MagicMock()
+        adapter._client.get_channel = MagicMock(return_value=text_channel)
+        adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
+        adapter.join_voice_channel = AsyncMock(return_value=True)
+        adapter.is_in_voice_channel = MagicMock(return_value=True)
+        adapter.connected_voice_channel_id = MagicMock(return_value="222")
+        adapter._voice_text_channels = {}
+        adapter._voice_sources = {}
+        adapter._voice_input_callback = None
+        adapter._on_voice_disconnect = None
+        adapter._voice_mode_getter = None
+        adapter._auto_tts_enabled_chats = set()
+        adapter._auto_tts_disabled_chats = set()
+        adapter._voice_auto_join_cfg = {"allowed_voice_channel_ids": {"222"}}
+        adapter.mark_voice_auto_join_target = MagicMock()
+        runner._profile_adapters["coder"] = {Platform.DISCORD: adapter}
+
+        # An active-profile adapter that must NOT be driven by the secondary's
+        # event.
+        active = MagicMock()
+        active.platform = Platform.DISCORD
+        active.join_voice_channel = AsyncMock(return_value=True)
+        runner.adapters[Platform.DISCORD] = active
+
+        runner._sync_voice_auto_join_state_to_adapter(adapter, profile_name="coder")
+        assert adapter._voice_auto_join_callback is not None
+
+        success = await adapter._voice_auto_join_callback(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+
+        assert success is True
+        adapter.join_voice_channel.assert_awaited_once_with(voice_channel)
+        active.join_voice_channel.assert_not_awaited()
+        adapter.mark_voice_auto_join_target.assert_called_once_with(
+            111, user_id="42", voice_channel_id="222", text_channel_id="333", profile="coder",
+        )
+
+    @pytest.mark.asyncio
+    async def test_stale_secondary_adapter_rejected_on_identity_mismatch(self, tmp_path):
+        """A callback bound to an adapter that a reconnect has replaced is
+        rejected — it must not connect on the superseded bot session."""
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        runner._profile_adapters = {}
+        guild = SimpleNamespace(id=111, name="Guild")
+        text_channel = SimpleNamespace(id=333, name="voice-chat", guild=guild, parent_id=None)
+        voice_channel = SimpleNamespace(id=222, name="General", guild=guild)
+
+        stale = MagicMock()
+        stale.platform = Platform.DISCORD
+        stale._voice_auto_join_callback = None
+        stale._client = MagicMock()
+        stale._client.get_channel = MagicMock(return_value=text_channel)
+        stale.get_user_voice_channel = AsyncMock(return_value=voice_channel)
+        stale.join_voice_channel = AsyncMock(return_value=True)
+        stale._voice_auto_join_cfg = {"allowed_voice_channel_ids": {"222"}}
+
+        runner._sync_voice_auto_join_state_to_adapter(stale, profile_name="coder")
+
+        # A newer adapter has replaced the stale one in the registry.
+        fresh = MagicMock()
+        fresh.platform = Platform.DISCORD
+        runner._profile_adapters["coder"] = {Platform.DISCORD: fresh}
+
+        success = await stale._voice_auto_join_callback(
+            guild_id=111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+
+        assert success is False
+        stale.join_voice_channel.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_retry_task_rejoins_without_second_event(self):
+        """After a failed join, the retry task re-attempts on its own — no
+        second voice-state event is required."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 0.01,
+        })
+        calls = {"n": 0}
+
+        async def _cb(**_kw):
+            calls["n"] += 1
+            return calls["n"] > 1  # first attempt fails, retry succeeds
+
+        adapter._voice_auto_join_callback = _cb
+        guild = SimpleNamespace(id=111, name="Guild")
+        chan = SimpleNamespace(id=222, name="General", guild=guild)
+        adapter.get_user_voice_channel = AsyncMock(return_value=chan)
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        task = adapter._voice_auto_join_retry_tasks.get(111)
+        assert task is not None
+        await asyncio.wait_for(task, timeout=2)
+
+        assert calls["n"] >= 2
+        assert 111 in adapter._voice_auto_join_targets
+
+    @pytest.mark.asyncio
+    async def test_retry_task_cancelled_on_manual_leave(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 30,
+        })
+        adapter._voice_auto_join_callback = AsyncMock(return_value=False)
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+        task = adapter._voice_auto_join_retry_tasks.get(111)
+        assert task is not None and not task.done()
+
+        adapter.suppress_voice_auto_join(111, user_id="42", channel_id="222")
+        await asyncio.sleep(0)
+
+        assert task.done()
+        assert 111 not in adapter._voice_auto_join_retry_tasks
+
+    @pytest.mark.asyncio
+    async def test_retry_task_cancelled_on_target_leave(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 30,
+            "target_leave_cleanup": False,
+        })
+        adapter._voice_auto_join_callback = AsyncMock(return_value=False)
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+        task = adapter._voice_auto_join_retry_tasks.get(111)
+        assert task is not None and not task.done()
+        # Record a target so the leave path recognizes the departure.
+        adapter.mark_voice_auto_join_target(
+            111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+
+        left_member = SimpleNamespace(id=42, display_name="Martin", guild=SimpleNamespace(id=111, name="Guild"))
+        await adapter._handle_voice_state_update(
+            left_member,
+            SimpleNamespace(channel=SimpleNamespace(id=222, name="General")),
+            SimpleNamespace(channel=None),
+        )
+        await asyncio.sleep(0)
+
+        assert task.done()
+        assert 111 not in adapter._voice_auto_join_retry_tasks
+
+    @pytest.mark.asyncio
+    async def test_manual_connection_not_adopted_into_auto_follow(self):
+        """A pre-existing MANUAL voice connection is never adopted as an
+        auto-follow target, so target-leave cleanup can't tear it down."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+        })
+        # Bot is already MANUALLY connected to channel 222 (no auto-join target).
+        existing_vc = MagicMock()
+        existing_vc.is_connected.return_value = True
+        existing_vc.channel = SimpleNamespace(id=222, name="General")
+        adapter._voice_clients[111] = existing_vc
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        # No target recorded and no join attempted — the manual session stands.
+        assert 111 not in adapter._voice_auto_join_targets
+        adapter._voice_auto_join_callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_suppression_retained_across_target_leave_rejoin(self):
+        """Manual-leave suppression survives the target leaving and rejoining."""
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "manual_leave_cooldown_seconds": 300,
+        })
+        adapter.mark_voice_auto_join_target(
+            111, user_id="42", voice_channel_id="222", text_channel_id="333",
+        )
+        adapter.suppress_voice_auto_join(111, user_id="42", channel_id="222")
+
+        # Target leaves the channel...
+        await adapter._handle_voice_state_update(
+            SimpleNamespace(id=42, display_name="M", guild=SimpleNamespace(id=111, name="G")),
+            SimpleNamespace(channel=SimpleNamespace(id=222, name="General")),
+            SimpleNamespace(channel=None),
+        )
+        # ...suppression must NOT have been cleared by the leave.
+        assert adapter._is_voice_auto_join_suppressed(111, "42", "222")
+
+        # ...and rejoining is still blocked while the cooldown holds.
+        member, before, after, _channel = self._voice_state()
+        await adapter._handle_voice_state_update(member, before, after)
+        adapter._voice_auto_join_callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_voice_auto_join_config_loaded_from_temp_hermes_home(self, tmp_path):
+        """Integration: a real config.yaml under HERMES_HOME feeds the adapter's
+        voice-auto-join config loader end to end."""
+        import yaml
+        from hermes_constants import get_hermes_home
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        from gateway.config import Platform, PlatformConfig
+
+        home = get_hermes_home()
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text(yaml.safe_dump({
+            "discord": {
+                "voice_auto_join": {
+                    "enabled": True,
+                    "allowed_user_ids": ["42", "77"],
+                    "allowed_voice_channel_ids": ["<#222>"],
+                    "text_channel_id": "333",
+                    "reconnect_cooldown_seconds": 5,
+                },
+            },
+        }))
+
+        config = PlatformConfig(enabled=True, extra={})
+        config.token = "fake-token"
+        adapter = object.__new__(DiscordAdapter)
+        adapter.platform = Platform.DISCORD
+        adapter.config = config
+
+        cfg = adapter._load_voice_auto_join_config()
+
+        assert cfg["enabled"] is True
+        assert cfg["allowed_user_ids"] == {"42", "77"}
+        assert cfg["allowed_voice_channel_ids"] == {"222"}
+        assert cfg["text_channel_id"] == "333"
+        assert cfg["reconnect_cooldown_seconds"] == 5
 
 
 # =====================================================================
@@ -2320,14 +2675,18 @@ class TestVoiceTimeoutCleansRunnerState:
 
     @pytest.mark.asyncio
     async def test_timeout_stays_while_auto_join_target_present(self, adapter):
+        from plugins.platforms.discord.adapter import VoiceAutoJoinTarget
+
         adapter._voice_timeout_seconds = 17
         adapter._voice_auto_join_cfg = {"stay_while_target_present": True}
+        adapter._voice_auto_join_retry_tasks = {}
         adapter._voice_auto_join_targets = {
-            111: {
-                "user_id": "42",
-                "voice_channel_id": "222",
-                "text_channel_id": "999",
-            }
+            111: VoiceAutoJoinTarget(
+                guild_id=111,
+                user_id="42",
+                voice_channel_id="222",
+                text_channel_id="999",
+            )
         }
 
         target_member = SimpleNamespace(id=42)
@@ -2343,6 +2702,46 @@ class TestVoiceTimeoutCleansRunnerState:
 
         assert 111 in adapter._voice_clients
         mock_vc.disconnect.assert_not_called()
+        # The handler must REARM a fresh timeout task so a later target
+        # departure can still trigger the disconnect.
+        rearmed = adapter._voice_timeout_tasks.get(111)
+        assert rearmed is not None
+        rearmed.cancel()
+
+    @pytest.mark.asyncio
+    async def test_timeout_rearm_disconnects_after_target_leaves(self, adapter):
+        """Once the target is gone, the rearmed idle timeout disconnects even
+        when target_leave_cleanup is False (no leave event tears it down)."""
+        from plugins.platforms.discord.adapter import VoiceAutoJoinTarget
+
+        adapter._voice_timeout_seconds = 0
+        adapter._voice_auto_join_cfg = {
+            "stay_while_target_present": True,
+            "target_leave_cleanup": False,
+        }
+        adapter._voice_auto_join_retry_tasks = {}
+        # Target is no longer present in the channel (empty members).
+        adapter._voice_auto_join_targets = {
+            111: VoiceAutoJoinTarget(
+                guild_id=111,
+                user_id="42",
+                voice_channel_id="222",
+                text_channel_id="999",
+            )
+        }
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.disconnect = AsyncMock()
+        mock_vc.channel = SimpleNamespace(id=222, members=[])
+        adapter._voice_clients[111] = mock_vc
+        adapter._voice_text_channels[111] = 999
+        adapter.leave_voice_channel = AsyncMock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await adapter._voice_timeout_handler(111)
+
+        # Target absent → no stay/rearm; the idle timeout disconnects.
+        adapter.leave_voice_channel.assert_awaited_once_with(111)
 
 
 # =====================================================================

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -764,6 +764,39 @@ Notes:
 - All settings live in `config.yaml` (not `.env`) — they're behavioral, not secrets.
 - When `voice_fx.enabled` is `false`, voice playback uses the original one-shot path and nothing changes.
 
+### Voice Auto-Join (follow mode)
+
+Hermes can automatically follow a specific person into a specific voice channel: when an allowed user joins an allowed voice channel, the bot joins it too and links the session to a configured text channel — no `/voice join` needed. It's the hands-free companion to the manual [Voice Mode](/user-guide/features/voice-mode) join.
+
+This is **off by default and fails closed.** It never infers live Discord users or channels — every ID is explicit, and if any of the three required pieces (allowed users, allowed voice channels, linked text channel) is missing, auto-join does nothing. Enable it in `config.yaml`:
+
+```yaml
+discord:
+  voice_auto_join:
+    enabled: true                      # master switch (default: false)
+    allowed_user_ids:                  # only these users are followed
+      - "111111111111111111"
+    allowed_voice_channel_ids:         # only these voice channels are joined
+      - "222222222222222222"
+    text_channel_id: "333333333333333333"  # session is linked to this text channel
+    idle_timeout_seconds: 300          # leave after this many seconds of inactivity
+    target_leave_cleanup: true         # leave when the followed user leaves the channel
+    stay_while_target_present: false   # if true, skip the idle timeout while the user is still there
+    manual_leave_cooldown_seconds: 300 # after a manual /voice leave, suppress auto-rejoin this long
+    reconnect_cooldown_seconds: 15     # minimum gap between auto-join attempts for a channel
+    failure_backoff_seconds: 60        # extra wait after a failed auto-join before retrying
+```
+
+How the guardrails work:
+
+- **Allowlists are mandatory.** A user is followed only if their ID is in `allowed_user_ids` **and** the channel they joined is in `allowed_voice_channel_ids`. An empty list means "match nothing," so a half-configured block stays inert.
+- **The target channel is re-validated at join time.** The allowlist is checked when the voice-state event fires, and again against the user's *current* voice channel immediately before the bot connects. If the user hops to a non-allowlisted channel in the interim, auto-join is blocked — a channel-move race cannot land the bot in a channel outside policy.
+- **The linked text channel must be in the same guild as the voice event.** A `text_channel_id` that resolves into a different server is rejected, so the voice session can't be wired to another guild's channel.
+- **Manual leave is respected.** After you run `/voice leave`, auto-rejoin for that user/channel is suppressed for `manual_leave_cooldown_seconds` so the bot doesn't immediately follow you back in.
+- **Attempts are rate-limited.** `reconnect_cooldown_seconds` throttles repeated joins and `failure_backoff_seconds` adds extra spacing after a failed attempt, preventing reconnect thrash.
+
+All settings live in `config.yaml` (not `.env`) — they're behavioral, not secrets. `idle_timeout_seconds` also governs how long a manually-joined voice session waits before leaving on inactivity.
+
 
 ## Forum Channels
 


### PR DESCRIPTION
## What does this PR do?

Ships the fixed-point Discord voice auto-join candidate from internal OE-98. It preserves the follow-mode behavior introduced in #53747 while hardening the full lifecycle: profile and guild ownership, target validation, join token gating, overlapping joins, retry cancellation, leave/disconnect races, transactional teardown, rollback, and fail-closed outcomes.

This PR explicitly supersedes #53747. That predecessor is now closed; this successor is the single current review surface and carries the reviewed implementation plus the complete hardening and regression chain at exact head `f29524c82`.

## Related Issue

- Internal tracker: OE-98
- Supersedes #53747
- Duplicate-scope audit: #59885 and #62499 overlap voice auto-join behavior. They remain open and unchanged; this PR is specifically the hardened successor to our #53747 implementation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Adds configurable Discord voice auto-join follow mode and documents its configuration.
- Scopes callbacks, mode state, deduplication, and session ownership by adapter profile and guild.
- Validates allowed users, text/voice guild relationships, and target channels before joining.
- Makes joins token-gated and fail-closed, including legacy-looking spoof errors and incompatible call signatures.
- Serializes join, move, leave, teardown, rollback, and retry cleanup under the voice lock.
- Adds event-controlled regression coverage for overlap, disconnect, mid-move rollback, cleanup, and retry races.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_voice_command.py -q` — 256/256 passed at `f29524c82`.
2. `scripts/run_tests.sh tests/gateway/test_discord_missed_message_backfill.py -q` — 44/44 passed at the same head.
3. The complete Discord slice passed 594 tests.
4. The config/voice integration slice passed 384 tests.
5. Ruff, bytecode compilation, the Windows-footgun check, diff checks, and ancestry checks passed.
6. Independent Spec and Standards reviews approved the exact rebased head with zero findings.

No live Discord server was mutated during verification; lifecycle behavior is exercised through instrumented/event-controlled integration tests.

## Stale-Branch Integration Gate

- Rebased onto upstream `main` at `e361c5e20`.
- Branch is zero commits behind that upstream base and the merge-tree is clean.
- `git range-diff` confirms all 25 patches are equivalent after rebase.
- The newly upstreamed Discord missed-message recovery/backfill functions remain present and their 44-test suite passes.
- The final diff removes no recovery, backfill, cursor, claim, or one-turn-model-override lines introduced upstream.
- `python3 scripts/check-windows-footguns.py --diff origin/main` passes.
- Fork CI remains `action_required` with zero jobs until a NousResearch maintainer approves the workflow run.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing open and merged PRs for duplicate scope.
- [x] This PR contains only Discord voice auto-join implementation, hardening, tests, config, and docs.
- [ ] I ran the entire repository test suite. Focused and integration results are recorded above.
- [x] I added regression tests for the behavior and race conditions.
- [x] Tested on macOS with the hermetic `scripts/run_tests.sh` wrapper.

### Documentation & Housekeeping

- [x] Updated relevant Discord documentation.
- [ ] Updated `cli-config.yaml.example` if required; the option is documented in the Discord guide and defaults live in `hermes_cli/config.py`.
- [x] Architecture/workflow documentation changes are N/A.
- [x] Cross-platform impact was considered; no POSIX-only process or filesystem behavior was added.
- [x] Tool descriptions and schemas are N/A.

## Screenshots / Logs

Not applicable. This is gateway lifecycle behavior covered by automated tests.