### PR TITLE
feat(whatsapp): implement focused WhatsApp-bridge mentions support (#67179)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -813,7 +813,7 @@ app.post('/send', async (req, res) => {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
 
-  const { chatId, message, replyTo } = req.body;
+  const { chatId, message, replyTo, mentions } = req.body;
   if (!chatId || !message) {
     return res.status(400).json({ error: 'chatId and message are required' });
   }
@@ -826,6 +826,7 @@ app.post('/send', async (req, res) => {
         chatId,
         replyTo: i === 0 ? replyTo : undefined,
         messageStore,
+        mentions: i === 0 ? mentions : undefined,
       });
       const sent = await sendWithTimeout(chatId, payload, options);
       trackSentMessageId(sent);

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -383,4 +383,64 @@ import {
   console.log('  ✓ captioned failed download keeps caption and appends note');
 }
 
+// -- inbound mention detection -------------------------------------------
+{
+  const event = await extractBridgeEvent({
+    msg: {
+      key: { id: 'mention-1', remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
+      messageTimestamp: 456,
+      message: {
+        extendedTextMessage: {
+          text: 'Hey @bot test',
+          contextInfo: { mentionedJid: ['15559999999@s.whatsapp.net'] },
+        },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15551234567@s.whatsapp.net',
+    senderNumber: '15551234567',
+    botIds: ['15559999999@s.whatsapp.net'],
+  });
+  assert.equal(event.mentioned, true);
+  assert.deepEqual(event.mentionedIds, ['15559999999@s.whatsapp.net']);
+  console.log('  ✓ extractBridgeEvent sets mentioned=true when bot is mentioned');
+}
+
+{
+  const event = await extractBridgeEvent({
+    msg: {
+      key: { id: 'no-mention-1', remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
+      messageTimestamp: 456,
+      message: { conversation: 'Just a regular message' },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15551234567@s.whatsapp.net',
+    senderNumber: '15551234567',
+    botIds: ['15559999999@s.whatsapp.net'],
+  });
+  assert.equal(event.mentioned, false);
+  assert.deepEqual(event.mentionedIds, []);
+  console.log('  ✓ extractBridgeEvent sets mentioned=false when bot is not mentioned');
+}
+
+// -- outbound mentions payload -------------------------------------------
+{
+  const { content, options } = buildTextSendPayload('Hello @user', {
+    chatId: '15551234567@s.whatsapp.net',
+    mentions: ['15551111111@s.whatsapp.net', '15552222222'],
+  });
+  assert.deepEqual(content, { text: 'Hello @user' });
+  assert.deepEqual(options.mentions, ['15551111111@s.whatsapp.net', '15552222222@s.whatsapp.net']);
+  console.log('  ✓ buildTextSendPayload normalizes and includes mentions');
+}
+
+{
+  const { content, options } = buildTextSendPayload('plain text', {
+    chatId: '15551234567@s.whatsapp.net',
+  });
+  assert.deepEqual(content, { text: 'plain text' });
+  assert.equal(options.mentions, undefined);
+  console.log('  ✓ buildTextSendPayload omits mentions when none provided');
+}
+
 console.log('\n✅ All WhatsApp native bridge helper tests passed.');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -157,7 +157,7 @@ export function pollUpdateForAggregation({
   return null;
 }
 
-export function buildTextSendPayload(text, { replyTo, messageStore } = {}) {
+export function buildTextSendPayload(text, { replyTo, messageStore, mentions } = {}) {
   const content = { text };
   const options = {};
   const quoted = messageStore?.get(replyTo);
@@ -166,6 +166,9 @@ export function buildTextSendPayload(text, { replyTo, messageStore } = {}) {
     // message content payload. Keeping this split avoids silently sending a
     // literal/ignored `quoted` field instead of a native WhatsApp reply.
     options.quoted = quoted;
+  }
+  if (Array.isArray(mentions) && mentions.length > 0) {
+    options.mentions = mentions.map(jid => normalizeWhatsAppId(String(jid))).filter(Boolean);
   }
   return { content, options };
 }
@@ -310,6 +313,7 @@ export async function extractBridgeEvent({
   const messageContent = getMessageContent(msg);
   const contextInfo = getContextInfo(messageContent);
   const mentionedIds = Array.from(new Set((contextInfo?.mentionedJid || []).map(normalizeWhatsAppId).filter(Boolean)));
+  const mentioned = botIds && botIds.length > 0 && mentionedIds.some(id => botIds.includes(id));
   const quotedMessageId = contextInfo?.stanzaId || null;
   const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
   const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
@@ -477,6 +481,7 @@ export async function extractBridgeEvent({
     nativeMetadata,
     mediaUrls,
     mentionedIds,
+    mentioned,
     quotedMessageId,
     quotedParticipant,
     quotedRemoteJid,


### PR DESCRIPTION
Closes #67179

Adds inbound mention detection and outbound mention payload support to the WhatsApp bridge, scoped exclusively to mentions — no unrelated changes.

**Inbound** (`bridge_helpers.js`):
- `extractBridgeEvent` now surfaces a `mentioned` boolean when the bridge bot's identity appears in `mentionedIds` from `contextInfo`
- Preserves existing `mentionedIds` array for downstream consumers

**Outbound** (`bridge_helpers.js` + `bridge.js`):
- `buildTextSendPayload` accepts optional `mentions` JID array, normalizes via `normalizeWhatsAppId`, includes as Baileys `sendMessage` options
- `/send` route extracts `mentions` from request body, passes to first chunk only

**Tests** (4 new scenarios in `bridge.native.test.mjs`):
- Inbound: bot mentioned → `mentioned: true`
- Inbound: bot not mentioned → `mentioned: false`
- Outbound: mentions normalized with `@s.whatsapp.net` suffix
- Outbound: no mentions → `mentions` omitted from options