### PR TITLE
fix(update): terminate stray venv holder processes on unattended Windows update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9266,12 +9266,14 @@ def _detect_venv_python_processes(
     dependency sync mid-update dies with access-denied and strands the venv
     half-updated (ryanc's brotlicffi/_sodium.pyd incidents, July 2026).
 
-    Killing them from here is pointless — the Desktop app supervises its
-    backend and respawns it within seconds — so the caller should refuse and
-    tell the user to close the app instead. Returns ``(pid, name, cmdline)``
-    tuples; empty off-Windows / without psutil / when nothing matches. The
-    calling process and its ancestors are always excluded (a CLI ``hermes
-    update`` itself runs from the venv python). Never raises.
+    Interactive callers should refuse and tell the user to close the app —
+    while the Desktop app runs it supervises its backend and respawns it
+    within seconds. Unattended callers (``--yes``) instead clear strays via
+    ``_terminate_venv_python_holders`` once gateways are paused, then re-scan
+    with this function. Returns ``(pid, name, cmdline)`` tuples; empty
+    off-Windows / without psutil / when nothing matches. The calling process
+    and its ancestors are always excluded (a CLI ``hermes update`` itself
+    runs from the venv python). Never raises.
     """
     if not _is_windows():
         return []
@@ -9367,7 +9369,54 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
     )
     lines.append("    hermes update")
     lines.append("  (or use `hermes update --force-venv` to proceed anyway at your own risk)")
+    lines.append(
+        "  Unattended runs (`hermes update --yes`) terminate stray holders automatically."
+    )
     return "\n".join(lines)
+
+
+def _terminate_venv_python_holders(
+    matches: list[tuple[int, str, str]],
+    *,
+    grace_timeout: float = 20.0,
+) -> None:
+    """Best-effort graceful stop of processes holding the venv interpreter.
+
+    Only called on unattended updates (``--yes``): by that point the Windows
+    gateways are paused, and with them the in-gateway cron ticker — so
+    nothing spawns replacements for the stray/transient holders that remain
+    (cron job runs, abandoned CLI sessions). Terminate, wait up to
+    ``grace_timeout`` for exit, then force-kill survivors. The caller
+    re-scans afterwards and still refuses if anything is left (e.g. a
+    supervised Desktop backend that respawned). Never raises.
+    """
+    try:
+        import psutil
+    except Exception:
+        return
+
+    procs = []
+    for pid, name, cmdline in matches:
+        try:
+            proc = psutil.Process(pid)
+            proc.terminate()
+            procs.append(proc)
+            print(f"  → Terminating venv holder PID {pid} ({name}): {cmdline[:110]}")
+        except psutil.NoSuchProcess:
+            continue
+        except Exception as exc:
+            logger.debug("Could not terminate venv holder %s: %s", pid, exc)
+    if not procs:
+        return
+    _, alive = psutil.wait_procs(procs, timeout=grace_timeout)
+    for proc in alive:
+        try:
+            proc.kill()
+            print(f"  → Force-killed venv holder PID {proc.pid}")
+        except Exception as exc:
+            logger.debug("Could not kill venv holder %s: %s", proc.pid, exc)
+    if alive:
+        psutil.wait_procs(alive, timeout=5)
 
 
 def _pause_windows_gateways_for_update() -> dict | None:
@@ -9854,6 +9903,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # --force-venv is the explicit escape hatch.
     if _is_windows() and not getattr(args, "force_venv", False):
         _venv_holders = _detect_venv_python_processes()
+        if _venv_holders and getattr(args, "yes", False):
+            # Unattended run (the desktop bootstrap updater passes --yes):
+            # gateways — and with them the in-gateway cron ticker — are
+            # already paused, so the remaining holders are stray/transient
+            # processes (cron job runs, abandoned CLI sessions) that nothing
+            # respawns. Dead-ending the whole update on them means an
+            # unattended update can never converge; terminate them instead,
+            # then re-scan. Anything that reappears (a supervised desktop
+            # backend) still trips the refusal below.
+            print("→ Clearing stray Hermes venv process(es) before the dependency sync…")
+            _terminate_venv_python_holders(_venv_holders)
+            _venv_holders = _detect_venv_python_processes()
         if _venv_holders:
             print(_format_venv_python_holders_message(_venv_holders))
             _resume_windows_gateways_after_update(_windows_gateway_resume)

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -69,7 +69,7 @@ def _fake_venv_python(tmp_path, *, windows: bool = False):
 
 def test_venv_health_reports_missing_imports(tmp_path):
     """Probe output lines are surfaced as the unhealthy detail."""
-    _fake_venv_python(tmp_path)
+    _fake_venv_python(tmp_path, windows=cli_main._is_windows())
 
     fake = SimpleNamespace(
         returncode=0,
@@ -97,7 +97,7 @@ def test_venv_health_healthy_when_probe_clean(tmp_path):
 
 def test_venv_health_broken_interpreter_is_unhealthy(tmp_path):
     """Nonzero exit with no module list = interpreter itself is broken."""
-    _fake_venv_python(tmp_path)
+    _fake_venv_python(tmp_path, windows=cli_main._is_windows())
     fake = SimpleNamespace(returncode=1, stdout="", stderr="Fatal Python error: init failed\n")
     with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
         cli_main.subprocess, "run", return_value=fake
@@ -295,13 +295,16 @@ def _update_args(**overrides):
     return SimpleNamespace(**defaults)
 
 
-def _run_update_until_guard(args):
+def _run_update_until_guard(args, *, detect_side_effect=None):
     """Drive _cmd_update_impl just far enough to hit the venv-holder guard.
 
     Everything before the guard is stubbed; the guard firing is observed via
     SystemExit(2). The first statement AFTER the guard is
     ``git_dir = PROJECT_ROOT / ".git"`` — a PROJECT_ROOT sentinel whose
-    ``__truediv__`` raises marks 'guard passed'."""
+    ``__truediv__`` raises marks 'guard passed'.
+
+    Returns ``(outcome, mocks)`` so tests can assert on the terminate helper.
+    """
 
     class _PastGuard(Exception):
         pass
@@ -310,6 +313,14 @@ def _run_update_until_guard(args):
         def __truediv__(self, _other):
             raise _PastGuard
 
+    detect = MagicMock()
+    if detect_side_effect is not None:
+        detect.side_effect = detect_side_effect
+    else:
+        detect.return_value = [(101, "python.exe", "python.exe -m hermes_cli.main serve")]
+    terminate = MagicMock()
+    mocks = SimpleNamespace(detect=detect, terminate=terminate)
+
     with patch.object(cli_main, "_is_windows", return_value=True), patch.object(
         cli_main, "_venv_scripts_dir", return_value=None
     ), patch.object(cli_main, "_run_pre_update_backup"), patch.object(
@@ -317,19 +328,19 @@ def _run_update_until_guard(args):
     ), patch.object(
         cli_main, "_resume_windows_gateways_after_update"
     ), patch.object(
-        cli_main,
-        "_detect_venv_python_processes",
-        return_value=[(101, "python.exe", "python.exe -m hermes_cli.main serve")],
+        cli_main, "_detect_venv_python_processes", detect
+    ), patch.object(
+        cli_main, "_terminate_venv_python_holders", terminate
     ), patch.object(
         cli_main, "PROJECT_ROOT", _RootSentinel()
     ):
         try:
             cli_main._cmd_update_impl(args, gateway_mode=False)
         except _PastGuard:
-            return "past_guard"
+            return "past_guard", mocks
         except SystemExit as exc:
-            return f"exit_{exc.code}"
-    return "returned"
+            return f"exit_{exc.code}", mocks
+    return "returned", mocks
 
 
 @pytest.mark.parametrize(
@@ -342,5 +353,69 @@ def _run_update_until_guard(args):
     ],
 )
 def test_venv_holder_guard_force_semantics(force, force_venv, expected, capsys):
-    result = _run_update_until_guard(_update_args(force=force, force_venv=force_venv))
+    result, _mocks = _run_update_until_guard(_update_args(force=force, force_venv=force_venv))
     assert result == expected, capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# --yes unattended quiesce of stray venv holders
+# ---------------------------------------------------------------------------
+
+
+def test_venv_holder_guard_yes_terminates_strays_and_proceeds(capsys):
+    """Unattended (--yes) update clears stray holders instead of dead-ending."""
+    holders = [(101, "pythonw.exe", "pythonw.exe -m hermes_cli.main cron run abc123")]
+    result, mocks = _run_update_until_guard(
+        _update_args(yes=True),
+        detect_side_effect=[holders, []],  # cleared after terminate
+    )
+    assert result == "past_guard", capsys.readouterr().out
+    mocks.terminate.assert_called_once_with(holders)
+
+
+def test_venv_holder_guard_yes_still_refuses_when_holders_persist(capsys):
+    """Holders that survive termination (e.g. a respawned desktop backend)
+    must still trip the refusal — the re-scan is authoritative."""
+    result, mocks = _run_update_until_guard(_update_args(yes=True))
+    assert result == "exit_2", capsys.readouterr().out
+    mocks.terminate.assert_called_once()
+
+
+def test_venv_holder_guard_interactive_never_terminates(capsys):
+    """Interactive runs keep the plain refusal — no killing behind the user's back."""
+    result, mocks = _run_update_until_guard(_update_args(yes=False))
+    assert result == "exit_2", capsys.readouterr().out
+    mocks.terminate.assert_not_called()
+
+
+def test_terminate_venv_holders_terminates_then_kills_survivors():
+    """Graceful terminate first; force-kill only the processes still alive."""
+    calls = []
+
+    class _FakeProc:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def terminate(self):
+            calls.append(("terminate", self.pid))
+
+        def kill(self):
+            calls.append(("kill", self.pid))
+
+    procs = {pid: _FakeProc(pid) for pid in (101, 102)}
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda pid: procs[pid],
+        NoSuchProcess=Exception,
+        # first wait: 101 gone, 102 alive; second wait: everything gone
+        wait_procs=lambda ps, timeout=None: (ps[:1], ps[1:]),
+    )
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        cli_main._terminate_venv_python_holders(
+            [(101, "pythonw.exe", "cmd one"), (102, "pythonw.exe", "cmd two")],
+            grace_timeout=0,
+        )
+
+    assert ("terminate", 101) in calls
+    assert ("terminate", 102) in calls
+    assert ("kill", 102) in calls
+    assert ("kill", 101) not in calls


### PR DESCRIPTION
## What does this PR do?

Fixes a permanent dead-end of unattended Windows updates at the venv-process guard.

Today the update flow pauses gateways and then **refuses** (exit 2) when any other process runs from the install venv. On a busy install that refusal is effectively unconditional: cron job runs spawn `pythonw` from `venv\Scripts` at all hours, and abandoned CLI sessions linger. The desktop one-click handoff exits cleanly and launches the updater, the updater dies at the guard, and the next retry simply collides with the next job — the update can never converge without manual process hunting.

Key observation: once `_pause_windows_gateways_for_update()` has run, the in-gateway **cron ticker is stopped too**, so nothing spawns replacements. The remaining holders are strays that nothing supervises — killing them is safe, and that is exactly what an unattended update should do instead of dead-ending.

This PR teaches `hermes update` to converge on unattended runs:

- When holders are detected and `--yes` is set (the desktop bootstrap updater always passes `--yes`), terminate them gracefully (psutil `terminate()`, wait up to 20 s, then `kill()`), logging each PID + cmdline, then **re-scan**.
- The refusal still fires when holders persist or reappear (e.g. a supervised desktop backend that respawned) — the re-scan is authoritative, so the safety property of the guard is unchanged.
- Interactive runs (no `--yes`) keep the plain refusal; the message now hints that `--yes` clears strays automatically.
- `--force-venv` semantics are untouched, and the new code path is Windows-gated (`_is_windows()`), no-op without psutil.

Scope note / related PRs: #61515 reaps gateway-spawned venv children inside the gateway pause (complementary — this PR covers everything the pause legitimately can't: cron job runs, stray CLIs). #62445 kills external holders from the desktop handoff (desktop path only; this PR fixes it in the update flow itself, so plain `hermes update` CLI runs converge too). #63318 surfaces blockers in the UI (orthogonal).

## Related Issue

No tracking issue; reproduction and a live run are included below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`
  - new `_terminate_venv_python_holders()` (graceful → force, bounded waits, never raises)
  - guard wiring: `--yes` runs terminate strays and re-scan before refusing
  - refusal message gains the `--yes` hint; `_detect_venv_python_processes` docstring updated to match the new contract
- `tests/hermes_cli/test_update_venv_health.py`
  - harness now returns mocks for the detect/terminate helpers
  - new cases: `--yes` + strays cleared → past guard; holders persist → still exit 2; interactive → never terminates; terminate → force-kill only survivors
  - two older venv-health tests made host-aware (they built a POSIX-layout fake venv without patching `_is_windows`, so they could only pass off-Windows)

## How to Test

1. Start a stray holder: `venv\Scripts\pythonw.exe -c "import time; time.sleep(600)"`
2. Run `hermes update --yes --force --branch main`
3. The log shows `→ Terminating venv holder PID …`, the holder is gone, and the update proceeds instead of exiting 2.

Unit: `pytest tests/hermes_cli/test_update_venv_health.py -q` → 22 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see scope note above: #61515, #62445, #63318)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests (`pytest tests/hermes_cli/test_update_venv_health.py -q` — 22 passed; full suite not run locally)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (26100), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — docstrings updated; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — new behavior is Windows-gated; other platforms unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Live unattended update on an install that had been dead-ended for two days (stray holder planted deliberately):

```
→ Stopping Windows gateway process(es) before updating Hermes...
  ✓ Paused gateway profile(s): default
→ Clearing stray Hermes venv process(es) before the dependency sync…
  → Terminating venv holder PID 59476 (pythonw.exe): C:\...\hermes-agent\venv\Scripts\pythonw.exe -c import time; time.sleep(1800)
→ Fetching updates...
→ Found 43 new commit(s)
...
✓ Update complete!
  ✓ Restarting Windows gateway profile(s): default
```
