### PR TITLE
fix(tools): warn when a cwd-shaped relative path resolves to a doubled tree

### DIFF
--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -16,6 +16,7 @@ Core invariant these tests pin:
 """
 
 import os
+import sys
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -459,3 +460,231 @@ def test_unregistered_session_never_inherits_another_sessions_record(
     assert not str(resolved).startswith(str(wt_a))
     assert not str(resolved).startswith(str(wt_b))
     assert resolved == (main / "target.py").resolve()
+
+
+# ── #67185: cwd-shaped relative input (absolute path missing leading /) ──────
+# A model echoing an absolute path without its leading separator
+# (``home/user/dev/notes/x.md``) joins onto the base and silently creates a
+# DOUBLED tree inside the workspace, so the out-of-workspace warning above
+# never fires. These tests pin the doubled-path warning.
+
+
+def _workspace_echo_input(workspace: Path, *tail: str) -> str:
+    """Build a relative input that replays *workspace*'s own directories."""
+    return str(Path(*workspace.parts[1:], *tail))
+
+
+def test_warning_fires_for_cwd_shaped_relative_input(_isolated_cwd, monkeypatch):
+    workspace, decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("default", str(workspace))
+
+    echo_input = _workspace_echo_input(workspace, "notes", "x.md")
+    resolved = ft._resolve_path_for_task(echo_input, task_id="default")
+
+    # Sanity: this is the doubled path, INSIDE the workspace.
+    assert resolved == workspace.joinpath(*workspace.parts[1:], "notes", "x.md")
+
+    warn = ft._path_resolution_warning(echo_input, resolved, task_id="default")
+
+    assert warn is not None
+    assert warn.startswith(ft._DOUBLED_PATH_MARKER)
+    # Paths are embedded repr-style ({...!r}), matching the existing
+    # out-of-workspace message format.
+    assert repr(str(resolved)) in warn
+    # The suggested fix names the intended absolute path.
+    assert repr(str(workspace / "notes" / "x.md")) in warn
+
+
+def test_warning_fires_for_bare_workspace_echo(_isolated_cwd, monkeypatch):
+    """The echo with no trailing segments is still a doubled target."""
+    workspace, decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("default", str(workspace))
+
+    echo_input = _workspace_echo_input(workspace)
+    resolved = ft._resolve_path_for_task(echo_input, task_id="default")
+
+    warn = ft._path_resolution_warning(echo_input, resolved, task_id="default")
+
+    assert warn is not None
+    assert warn.startswith(ft._DOUBLED_PATH_MARKER)
+
+
+def test_no_warning_for_ordinary_relative_path(_isolated_cwd, monkeypatch):
+    """A first segment merely equal to the workspace's first segment is fine."""
+    workspace, decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("default", str(workspace))
+
+    # Shares only a partial prefix with the workspace parts — not a full echo.
+    partial = str(Path(workspace.parts[1], "notes", "x.md"))
+    resolved = ft._resolve_path_for_task(partial, task_id="default")
+
+    warn = ft._path_resolution_warning(partial, resolved, task_id="default")
+
+    assert warn is None
+
+
+def test_no_warning_for_subdir_named_like_root_tail(_isolated_cwd, monkeypatch):
+    """workspace/<its-own-basename>/f.py is a legitimate subdirectory."""
+    workspace, decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("default", str(workspace))
+
+    inner = str(Path(workspace.name, "f.py"))
+    resolved = ft._resolve_path_for_task(inner, task_id="default")
+
+    warn = ft._path_resolution_warning(inner, resolved, task_id="default")
+
+    assert warn is None
+
+
+def test_write_file_surfaces_doubled_path_warning(_isolated_cwd, monkeypatch):
+    """End to end: write_file_tool returns _warning for the doubled path."""
+    import json
+
+    workspace, decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("t-echo", str(workspace))
+
+    echo_input = _workspace_echo_input(workspace, "notes", "x.md")
+    out = json.loads(ft.write_file_tool(echo_input, "digest\n", task_id="t-echo"))
+
+    assert not out.get("error")
+    assert out.get("_warning", "").startswith(ft._DOUBLED_PATH_MARKER)
+    assert repr(str(workspace / "notes" / "x.md")) in out["_warning"]
+
+
+def test_cwd_echo_warning_container_posix_semantics():
+    """Container roots are PurePosixPath — the echo check must stay POSIX."""
+    root = PurePosixPath("/home/user/dev")
+    resolved = PurePosixPath("/home/user/dev/home/user/dev/notes/x.md")
+
+    warn = ft._cwd_echo_warning("home/user/dev/notes/x.md", resolved, root)
+
+    assert warn is not None
+    assert warn.startswith(ft._DOUBLED_PATH_MARKER)
+    assert "'/home/user/dev/notes/x.md'" in warn
+
+
+def test_cwd_echo_warning_container_no_false_positive():
+    root = PurePosixPath("/home/user/dev")
+
+    warn = ft._cwd_echo_warning("notes/x.md", PurePosixPath("/home/user/dev/notes/x.md"), root)
+
+    assert warn is None
+
+
+def test_doubled_path_warning_wins_over_cross_agent_staleness(_isolated_cwd, monkeypatch):
+    """A misdirected write (#67185) must not be masked by staleness warnings.
+
+    In the issue's cron scenario the doubled target is written repeatedly by
+    fresh sessions, so the cross-agent staleness warning fires on every run
+    after the first — and previously would have shadowed the doubled-path
+    warning entirely.
+    """
+    import json
+
+    workspace, decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("t-prio", str(workspace))
+    monkeypatch.setattr(
+        ft.file_state, "check_stale", lambda task_id, resolved: "sibling subagent touched this file"
+    )
+
+    echo_input = _workspace_echo_input(workspace, "notes", "x.md")
+    out = json.loads(ft.write_file_tool(echo_input, "digest\n", task_id="t-prio"))
+
+    assert out.get("_warning", "").startswith(ft._DOUBLED_PATH_MARKER)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Symlinks require elevated privileges on Windows")
+def test_warning_fires_when_workspace_root_is_a_symlink(tmp_path, monkeypatch):
+    """The echo check must also match the symlinked (display) form of the root.
+
+    The model echoes the cwd the terminal reports — the symlink path — while
+    the containment root is resolve()d to the real path, so comparing against
+    the resolved form alone misses the echo.
+    """
+    real = tmp_path / "real-workspace"
+    real.mkdir()
+    link = tmp_path / "linked-workspace"
+    link.symlink_to(real, target_is_directory=True)
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    terminal_tool.record_session_cwd("default", str(link))
+
+    echo_input = _workspace_echo_input(link, "notes", "x.md")
+    resolved = ft._resolve_path_for_task(echo_input, task_id="default")
+
+    warn = ft._path_resolution_warning(echo_input, resolved, task_id="default")
+
+    assert warn is not None
+    assert warn.startswith(ft._DOUBLED_PATH_MARKER)
+
+
+def test_patch_tool_doubled_path_warning_wins_over_staleness(_isolated_cwd, monkeypatch):
+    """patch_tool must apply the same precedence as write_file_tool."""
+    import json
+
+    workspace, decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("t-patch-prio", str(workspace))
+    monkeypatch.setattr(
+        ft.file_state, "check_stale", lambda task_id, resolved: "sibling subagent touched this file"
+    )
+
+    echo_input = _workspace_echo_input(workspace, "target.py")
+    doubled = workspace.joinpath(*workspace.parts[1:], "target.py")
+    doubled.parent.mkdir(parents=True)
+    doubled.write_text("OLD\n")
+
+    out = json.loads(
+        ft.patch_tool(
+            mode="replace",
+            path=echo_input,
+            old_string="OLD",
+            new_string="NEW",
+            task_id="t-patch-prio",
+        )
+    )
+
+    warning = out.get("_warning") or " ".join(out.get("_warnings", []))
+    assert ft._DOUBLED_PATH_MARKER in warning
+
+
+def test_dotdot_that_undoes_the_echo_does_not_warn(_isolated_cwd, monkeypatch):
+    """'<echo>/../../..' collapses back out of the doubled tree — no warning."""
+    workspace, decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("default", str(workspace))
+
+    n = len(workspace.parts) - 1
+    collapsing = str(Path(*workspace.parts[1:], *[".."] * n, "plain.md"))
+    resolved = ft._resolve_path_for_task(collapsing, task_id="default")
+
+    warn = ft._path_resolution_warning(collapsing, resolved, task_id="default")
+
+    assert warn is None
+
+
+def test_dotdot_hidden_echo_is_still_detected(_isolated_cwd, monkeypatch):
+    """'junk/../<echo>/x' lexically collapses to the echo — must warn."""
+    workspace, decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("default", str(workspace))
+
+    hidden = str(Path("junk", "..", *workspace.parts[1:], "notes", "x.md"))
+    resolved = ft._resolve_path_for_task(hidden, task_id="default")
+
+    warn = ft._path_resolution_warning(hidden, resolved, task_id="default")
+
+    assert warn is not None
+    assert warn.startswith(ft._DOUBLED_PATH_MARKER)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="UNC path semantics are Windows-specific")
+def test_unc_root_echo_detection_and_no_false_positive():
+    """UNC anchors hold server+share — they must join the comparison parts."""
+    root = Path(r"\\server\share\work")
+    doubled = Path(r"\\server\share\work\server\share\work\notes\x.md")
+
+    warn = ft._cwd_echo_warning(r"server\share\work\notes\x.md", doubled, root)
+    assert warn is not None
+    assert warn.startswith(ft._DOUBLED_PATH_MARKER)
+    assert repr(r"\\server\share\work\notes\x.md") in warn
+
+    # A path that merely starts with the root's LAST component is legitimate.
+    ok = ft._cwd_echo_warning(r"work\x.md", Path(r"\\server\share\work\work\x.md"), root)
+    assert ok is None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -398,6 +398,68 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     return resolved.resolve()
 
 
+# Message prefix distinguishing the doubled-path warning (#67185) from the
+# plain out-of-workspace warning, so callers can prioritize it over staleness
+# (matched with str.startswith — path contents can't spoof it).
+_DOUBLED_PATH_MARKER = "Doubled path:"
+
+
+def _cwd_echo_warning(
+    filepath: str,
+    resolved: Path | PurePosixPath,
+    root: Path | PurePosixPath,
+) -> str | None:
+    """Warn when a relative input replays the workspace root's own directories.
+
+    Models sometimes echo an absolute path without its leading separator
+    (``home/user/dev/notes/x.md`` for ``/home/user/dev/notes/x.md``). Joined
+    onto the base, that resolves to a silently doubled tree
+    (``/home/user/dev/home/user/dev/notes/x.md``). The write succeeds (parents
+    are created) and the doubled path lands INSIDE the workspace, so the
+    out-of-workspace warning below never fires. Detect the replayed prefix and
+    name the absolute path the model most likely intended.
+    """
+    # Lexically collapse '.'/'..' first so 'junk/../home/user/dev/x' is still
+    # detected and 'home/user/dev/../../..' (which un-doubles itself) is not.
+    if isinstance(root, Path):
+        input_parts = Path(os.path.normpath(filepath)).parts
+    else:  # container mode — sandbox-local POSIX semantics
+        input_parts = PurePosixPath(posixpath.normpath(filepath)).parts
+    drive = getattr(root, "drive", "")
+    is_unc = drive.startswith("\\\\")
+    if is_unc:
+        # A UNC anchor holds server+share; an echoed UNC path replays them as
+        # ordinary segments, so include them in the comparison.
+        root_parts = tuple(s for s in drive.strip("\\").split("\\") if s) + root.parts[1:]
+    else:
+        root_parts = root.parts[1:]  # root is always absolute; drop the anchor
+    if not root_parts or len(input_parts) < len(root_parts):
+        return None
+    echo = input_parts[: len(root_parts)]
+    if isinstance(root, Path) and os.name == "nt":
+        # Match the filesystem's case-insensitivity rules, not casefold().
+        matches = tuple(os.path.normcase(p) for p in echo) == tuple(
+            os.path.normcase(p) for p in root_parts
+        )
+    else:
+        matches = echo == root_parts
+    if not matches:
+        return None
+    if not isinstance(root, Path):
+        suggested = str(PurePosixPath("/").joinpath(*input_parts))
+    elif is_unc:
+        suggested = "\\\\" + "\\".join(input_parts)
+    else:
+        suggested = str(Path(root.anchor).joinpath(*input_parts))
+    return (
+        f"{_DOUBLED_PATH_MARKER} relative input {filepath!r} repeats the "
+        f"active workspace's own directories ({str(root)!r}), so it resolved "
+        f"to {str(resolved)!r}. This usually means an absolute path missing "
+        f"its leading separator. If you meant {suggested!r}, pass that "
+        f"absolute path instead."
+    )
+
+
 def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
     """Warn when a relative path resolved OUTSIDE the task's workspace root.
 
@@ -407,6 +469,10 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
     than the one the agent is working in), return a message naming the absolute
     target. ``None`` when the path is absolute, the base is unknown, or the
     resolved path is correctly under the workspace root.
+
+    Also covers the inverse failure mode (#67185): a relative input that
+    replays the workspace root's own directories resolves to a doubled path
+    INSIDE the workspace — see :func:`_cwd_echo_warning`.
 
     The workspace root is the live terminal cwd when known, else a registered
     task/session cwd override, else a sentinel-free absolute ``$TERMINAL_CWD``
@@ -421,8 +487,21 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
             return None  # No authoritative workspace root to compare against.
         if _uses_container_paths(task_id):
             root = _normalize_without_host_deref(Path(_expand_tilde(workspace_root)))
+            display_root: Path | PurePosixPath = root
         else:
-            root = Path(_expand_tilde(workspace_root)).resolve()
+            display_root = Path(_expand_tilde(workspace_root))
+            root = display_root.resolve()
+        # Doubled-path guard first: a cwd-shaped relative input (absolute path
+        # missing its leading separator) resolves INSIDE the workspace, so the
+        # containment check below would wrongly stay silent (#67185). Check
+        # the pre-resolve() root too: when the workspace cwd is reached via a
+        # symlink, the model echoes the symlinked (display) form, whose parts
+        # don't match the resolved root's.
+        echo_warning = _cwd_echo_warning(filepath, resolved, root)
+        if echo_warning is None and display_root != root:
+            echo_warning = _cwd_echo_warning(filepath, resolved, display_root)
+        if echo_warning:
+            return echo_warning
         # Is `resolved` inside `root`?
         try:
             resolved.relative_to(root)
@@ -1628,7 +1707,13 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             file_ops = _get_file_ops(task_id)
             result = file_ops.write_file(_resolved, content)
             result_dict = result.to_dict()
-            effective_warning = cross_warning or stale_warning or cwd_warning
+            if cwd_warning and cwd_warning.startswith(_DOUBLED_PATH_MARKER):
+                # A doubled-path resolution (#67185) means the write itself is
+                # misdirected — staleness info about the wrong file would mask
+                # the real problem, so the misdirection warning wins.
+                effective_warning = cwd_warning
+            else:
+                effective_warning = cross_warning or stale_warning or cwd_warning
             if effective_warning:
                 result_dict["_warning"] = effective_warning
             # Always report the ABSOLUTE path actually written, so a wrong-cwd
@@ -1750,11 +1835,16 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     _r = None
                 _path_to_resolved[_p] = _r
                 _cross = file_state.check_stale(task_id, _r) if _r else None
-                _sw = _cross or _check_file_staleness(_p, task_id)
-                if not _sw and _r:
-                    # Workspace-divergence warning (worktree-cwd bug): relative
-                    # path resolving outside the terminal's cwd.
-                    _sw = _path_resolution_warning(_p, Path(_r), task_id)
+                # Workspace-divergence warning (worktree-cwd bug / doubled
+                # path, #67185): relative path resolving somewhere other than
+                # the terminal's cwd.
+                _pw = _path_resolution_warning(_p, Path(_r), task_id) if _r else None
+                if _pw and _pw.startswith(_DOUBLED_PATH_MARKER):
+                    # Misdirected edit (#67185) beats staleness of the wrong
+                    # file — same precedence as write_file_tool.
+                    _sw = _pw
+                else:
+                    _sw = _cross or _check_file_staleness(_p, task_id) or _pw
                 if _sw:
                     stale_warnings.append(_sw)
 


### PR DESCRIPTION
## What does this PR do?

A relative input that textually replays the workspace root's own directories — an absolute path missing its leading separator, e.g. `home/user/dev/notes/x.md` emitted by a small model — joins onto the base directory and silently resolves to a doubled tree like `/home/user/dev/home/user/dev/notes/x.md`. The write succeeds (`write_file` creates parents) and the doubled path lands *inside* the workspace, so the existing out-of-workspace divergence warning never fires.

This PR detects the replayed base prefix in `_path_resolution_warning()` and surfaces a warning naming the doubled target and the absolute path the model most likely intended. It follows the existing warning pattern (inform the model, don't rewrite the path) rather than stripping the duplicated prefix — a legitimate `workspace/<echo-shaped>` subtree keeps working, and the model can self-correct.

## Related Issue

Fixes #67185  
Ref: #67216

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py`
  - New `_DOUBLED_PATH_MARKER` constant and `_cwd_echo_warning()`: detects a relative input whose leading segments replay the workspace root (after lexical `normpath`, so `..` segments can neither hide an echo nor fake one that self-collapses). Case-insensitive via `os.path.normcase()` on native Windows; POSIX-exact in container mode (`PurePosixPath` roots). UNC roots decompose their server+share anchor into comparison parts.
  - `_path_resolution_warning()` runs the echo check before the containment check, against both the resolved root and its pre-`resolve()` (display) form — a symlinked cwd doesn't defeat detection.
  - `write_file_tool` / `patch_tool`: the doubled-path warning takes precedence over cross-agent/staleness warnings.
- `tests/tools/test_file_tools_cwd_resolution.py`: 14 regression tests — detection (basic, bare echo, `..`-hidden echo, symlinked root, UNC root, container mode), false-positive guards (ordinary relative path, subdir named like the root's tail, self-collapsing `..`, container), end-to-end `_warning` surfacing, and warning precedence for both `write_file_tool` and `patch_tool`.

## How to Test

```bash
pytest tests/tools/test_file_tools_cwd_resolution.py -q
```

Results: 43 passed, 1 skipped (Windows-only UNC test)