### PR TITLE
fix(kanban): pin task-scoped tool calls to their board (#67215)

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+from unittest.mock import Mock
 
 import pytest
 
@@ -1811,6 +1812,205 @@ def multi_board_env(monkeypatch, tmp_path):
     }
 
 
+@pytest.fixture
+def scoped_board_env(monkeypatch, multi_board_env):
+    """Task-scoped worker pinned to the default board for override tests."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", multi_board_env["default_seed"])
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    return multi_board_env
+
+
+def _board_snapshot(default_seed: str, alt_seed: str):
+    """Capture the visible state for the default/alt boards."""
+    from hermes_cli import kanban_db as kb
+
+    snapshot = {}
+    for board_name, task_id in (("default", default_seed), ("alt", alt_seed)):
+        with kb.connect(board=board_name) as conn:
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            snapshot[board_name] = {
+                "task_count": conn.execute(
+                    "SELECT COUNT(*) FROM tasks"
+                ).fetchone()[0],
+                "link_count": conn.execute(
+                    "SELECT COUNT(*) FROM task_links"
+                ).fetchone()[0],
+                "comment_count": conn.execute(
+                    "SELECT COUNT(*) FROM task_comments"
+                ).fetchone()[0],
+                "attachment_count": conn.execute(
+                    "SELECT COUNT(*) FROM task_attachments"
+                ).fetchone()[0],
+                "task": {
+                    "status": task.status,
+                    "claim_lock": task.claim_lock,
+                    "claim_expires": task.claim_expires,
+                    "last_heartbeat_at": task.last_heartbeat_at,
+                    "comment_count": len(kb.list_comments(conn, task_id)),
+                    "attachment_count": len(kb.list_attachments(conn, task_id)),
+                    "parents": tuple(kb.parent_ids(conn, task_id)),
+                    "children": tuple(kb.child_ids(conn, task_id)),
+                },
+            }
+    return snapshot
+
+
+@pytest.mark.parametrize(
+    ("case_name", "invoke"),
+    [
+        (
+            "show",
+            lambda kt, default_seed, _: kt._handle_show(
+                {"task_id": default_seed, "board": "alt"}
+            ),
+        ),
+        (
+            "complete",
+            lambda kt, default_seed, _: kt._handle_complete(
+                {"task_id": default_seed, "summary": "cross-board", "board": "alt"}
+            ),
+        ),
+        (
+            "block",
+            lambda kt, default_seed, _: kt._handle_block(
+                {"task_id": default_seed, "reason": "cross-board", "board": "alt"}
+            ),
+        ),
+        (
+            "heartbeat",
+            lambda kt, default_seed, _: kt._handle_heartbeat(
+                {"task_id": default_seed, "note": "cross-board", "board": "alt"}
+            ),
+        ),
+        (
+            "comment",
+            lambda kt, default_seed, _: kt._handle_comment(
+                {"task_id": default_seed, "body": "cross-board", "board": "alt"}
+            ),
+        ),
+        (
+            "attach",
+            lambda kt, default_seed, _: kt._handle_attach(
+                {
+                    "task_id": default_seed,
+                    "filename": "note.txt",
+                    "content_base64": "ZGF0YQ==",
+                    "board": "alt",
+                }
+            ),
+        ),
+        (
+            "attach_url",
+            lambda kt, default_seed, _: kt._handle_attach_url(
+                {
+                    "task_id": default_seed,
+                    "url": "https://example.com/file.txt",
+                    "board": "alt",
+                }
+            ),
+        ),
+        (
+            "attachments",
+            lambda kt, default_seed, _: kt._handle_attachments(
+                {"task_id": default_seed, "board": "alt"}
+            ),
+        ),
+        (
+            "create",
+            lambda kt, _, __: kt._handle_create(
+                {"title": "cross-board", "assignee": "worker", "board": "alt"}
+            ),
+        ),
+        (
+            "link",
+            lambda kt, default_seed, alt_seed: kt._handle_link(
+                {
+                    "parent_id": default_seed,
+                    "child_id": alt_seed,
+                    "board": "alt",
+                }
+            ),
+        ),
+    ],
+)
+def test_task_scoped_board_override_rejects_cross_board_without_side_effects(
+    scoped_board_env, monkeypatch, case_name, invoke
+):
+    from tools import kanban_tools as kt
+
+    before = _board_snapshot(
+        scoped_board_env["default_seed"], scoped_board_env["alt_seed"]
+    )
+    connect_mock = Mock(
+        side_effect=AssertionError(
+            f"{case_name} should not connect before the task-scoped board guard"
+        )
+    )
+    monkeypatch.setattr(kt, "_connect", connect_mock)
+    download_mock = Mock(
+        side_effect=AssertionError(
+            "kanban_attach_url should not fetch before the task-scoped board guard"
+        )
+    )
+    monkeypatch.setattr(kt, "_download_url_with_cap", download_mock)
+
+    out = invoke(
+        kt,
+        scoped_board_env["default_seed"],
+        scoped_board_env["alt_seed"],
+    )
+    err = json.loads(out).get("error", "")
+    assert "board" in err.lower(), f"got {err!r}"
+    assert connect_mock.call_count == 0
+    assert download_mock.call_count == 0
+    assert _board_snapshot(
+        scoped_board_env["default_seed"], scoped_board_env["alt_seed"]
+    ) == before
+
+
+def test_task_scoped_explicit_board_requires_env_board(scoped_board_env, monkeypatch):
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    connect_mock = Mock(
+        side_effect=AssertionError(
+            "board-scoped calls should fail before connecting when env board is missing"
+        )
+    )
+    monkeypatch.setattr(kt, "_connect", connect_mock)
+
+    out = kt._handle_show(
+        {"task_id": scoped_board_env["default_seed"], "board": "alt"}
+    )
+    err = json.loads(out).get("error", "")
+    assert "HERMES_KANBAN_BOARD" in err, f"got {err!r}"
+    assert connect_mock.call_count == 0
+
+
+def test_task_scoped_explicit_board_matches_env_board(scoped_board_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_show(
+        {"task_id": scoped_board_env["default_seed"], "board": "default"}
+    )
+    d = json.loads(out)
+    assert d["task"]["id"] == scoped_board_env["default_seed"]
+    assert d["task"]["status"] == "ready"
+
+
+@pytest.mark.parametrize("board", ["", "  "])
+def test_task_scoped_blank_board_falls_back_to_env_board(scoped_board_env, board):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_show(
+        {"task_id": scoped_board_env["default_seed"], "board": board}
+    )
+    d = json.loads(out)
+    assert d["task"]["id"] == scoped_board_env["default_seed"]
+    assert d["task"]["status"] == "ready"
+
+
 def test_board_param_routes_create_to_alt_board(multi_board_env):
     """kanban_create with ``board="alt"`` must write into the alt board's DB,
     not the default one."""
@@ -2001,6 +2201,7 @@ def test_board_param_routes_heartbeat_to_alt_board(monkeypatch, tmp_path):
         tid = kb.create_task(conn, title="alt hb", assignee="alt-worker")
         kb.claim_task(conn, tid)
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "alt")
 
     from tools import kanban_tools as kt
     out = kt._handle_heartbeat({"note": "alive on alt", "board": "alt"})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -179,6 +179,37 @@ def _connect(board: Optional[str] = None):
     return kb, kb.connect(board=board)
 
 
+def _resolve_task_scoped_board(board: Optional[str]) -> Optional[str]:
+    """Resolve a per-call board override with task-scope safety checks.
+
+    When ``HERMES_KANBAN_TASK`` is set and the caller passes ``board=``,
+    require ``HERMES_KANBAN_BOARD``, compare both values after the existing
+    slug normalization, and refuse mismatches before any board DB is opened.
+    Calls without an explicit ``board`` are left alone so the normal
+    environment-driven resolution chain still applies.
+    """
+    if board is None:
+        return None
+    from hermes_cli import kanban_db as kb
+
+    board_slug = kb._normalize_board_slug(board)
+    if board_slug is None:
+        return None
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return board_slug
+    env_board = os.environ.get("HERMES_KANBAN_BOARD")
+    if not env_board:
+        raise ValueError(
+            "HERMES_KANBAN_BOARD is required when board is explicit in a task-scoped worker"
+        )
+    env_board_slug = kb._normalize_board_slug(env_board)
+    if board_slug != env_board_slug:
+        raise ValueError(
+            f"board {board_slug!r} does not match task board {env_board_slug!r}"
+        )
+    return board_slug
+
+
 _GOAL_MODE_BLOCK_ALLOWED_KINDS = frozenset({"dependency", "needs_input"})
 
 
@@ -372,8 +403,8 @@ def _handle_show(args: dict, **kw) -> str:
         return tool_error(
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
-    board = args.get("board")
     try:
+        board = _resolve_task_scoped_board(args.get("board"))
         kb, conn = _connect(board=board)
         try:
             task = kb.get_task(conn, tid)
@@ -588,8 +619,8 @@ def _handle_complete(args: dict, **kw) -> str:
             f"metadata must be an object/dict, got {type(metadata).__name__}"
         )
     metadata = _stamp_worker_session_metadata(tid, metadata)
-    board = args.get("board")
     try:
+        board = _resolve_task_scoped_board(args.get("board"))
         kb, conn = _connect(board=board)
         try:
             # Goal-mode pre-completion judge gate (Issue #38367).
@@ -687,8 +718,8 @@ def _handle_block(args: dict, **kw) -> str:
         return tool_error("reason is required — explain what input you need")
     reason = redact_sensitive_text(str(reason), force=True)
     kind = args.get("kind")
-    board = args.get("board")
     try:
+        board = _resolve_task_scoped_board(args.get("board"))
         kb, conn = _connect(board=board)
         if kind is not None and kind not in kb.VALID_BLOCK_KINDS:
             conn.close()
@@ -769,8 +800,8 @@ def _handle_heartbeat(args: dict, **kw) -> str:
     if ownership_err:
         return ownership_err
     note = args.get("note")
-    board = args.get("board")
     try:
+        board = _resolve_task_scoped_board(args.get("board"))
         kb, conn = _connect(board=board)
         try:
             # Extend the claim TTL first. The dispatcher pins
@@ -823,8 +854,8 @@ def _handle_comment(args: dict, **kw) -> str:
     # Cross-task commenting itself remains unrestricted (see #19713) —
     # comments are the deliberate handoff channel between tasks.
     author = os.environ.get("HERMES_PROFILE") or "worker"
-    board = args.get("board")
     try:
+        board = _resolve_task_scoped_board(args.get("board"))
         kb, conn = _connect(board=board)
         try:
             cid = kb.add_comment(conn, tid, author=author, body=str(body))
@@ -869,8 +900,8 @@ def _handle_attach(args: dict, **kw) -> str:
     except (binascii.Error, ValueError) as e:
         return tool_error(f"content_base64 is not valid base64: {e}")
     content_type = args.get("content_type")
-    board = args.get("board")
     try:
+        board = _resolve_task_scoped_board(args.get("board"))
         _, conn = _connect(board=board)
         try:
             att_id = kb.store_attachment_bytes(
@@ -986,8 +1017,8 @@ def _handle_attach_url(args: dict, **kw) -> str:
         leaf = unquote(urlparse(url).path.rsplit("/", 1)[-1]).strip()
         filename = leaf or "download"
     content_type = args.get("content_type")
-    board = args.get("board")
     try:
+        board = _resolve_task_scoped_board(args.get("board"))
         data, fetched_ct = _download_url_with_cap(url, kb.KANBAN_ATTACHMENT_MAX_BYTES)
     except ValueError as e:
         return tool_error(f"kanban_attach_url: {e}")
@@ -1025,8 +1056,8 @@ def _handle_attachments(args: dict, **kw) -> str:
         return tool_error(
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
-    board = args.get("board")
     try:
+        board = _resolve_task_scoped_board(args.get("board"))
         kb, conn = _connect(board=board)
         try:
             if kb.get_task(conn, tid) is None:
@@ -1117,8 +1148,8 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(
             f"parents must be a list of task ids, got {type(parents).__name__}"
         )
-    board = args.get("board")
     try:
+        board = _resolve_task_scoped_board(args.get("board"))
         kb, conn = _connect(board=board)
         try:
             # Inherit the spawning worker's own task workspace when the
@@ -1310,8 +1341,8 @@ def _handle_link(args: dict, **kw) -> str:
     child_id = args.get("child_id")
     if not parent_id or not child_id:
         return tool_error("both parent_id and child_id are required")
-    board = args.get("board")
     try:
+        board = _resolve_task_scoped_board(args.get("board"))
         kb, conn = _connect(board=board)
         try:
             kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)


### PR DESCRIPTION
## Summary

Follow-up to #65372.

- Pin explicit `board=` calls made by task-scoped Kanban workers to the dispatcher-provided `HERMES_KANBAN_BOARD` before any target-board database access.
- Apply the protection to the existing non-administrative surface: task reads, lifecycle operations, comments, attachments, fan-out, and dependency links.
- Preserve explicit multiboard routing for callers without `HERMES_KANBAN_TASK` and preserve normal omitted/same-board behavior.
- Reject `kanban_attach_url` before its downloader runs when the requested board is forbidden.

## Context

#65372 addresses the administrative tool surface. This PR intentionally covers the pre-existing non-administrative handlers separately, keeping each security boundary reviewable and avoiding a scope expansion of the open administrative PR.

## Verification

- `pytest -q tests/tools/test_kanban_tools.py -k "test_task_scoped or test_board_param"` — **27 passed**
- `pytest -q tests/tools/test_kanban_tools.py -k "not (test_kanban_guidance or test_attach_url or test_create_subscribes or test_create_does_not or test_create_partial or test_maybe_auto)"` — **112 passed**
- `ruff check tools/kanban_tools.py tests/tools/test_kanban_tools.py` — passed
- `python -m py_compile tools/kanban_tools.py tests/tools/test_kanban_tools.py` — passed
- `git diff --check origin/main...HEAD` — passed

Closes #67215