### PR TITLE
fix(desktop): scope provider readiness to active profile

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -21,6 +21,7 @@ import subprocess
 from pathlib import Path
 from urllib.parse import urlparse
 
+from agent.secret_scope import get_secret as _get_secret
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
 from utils import base_url_host_matches, normalize_proxy_env_vars
@@ -1300,7 +1301,7 @@ def resolve_anthropic_token() -> Optional[str]:
     creds = read_claude_code_credentials()
 
     # 1. Hermes-managed OAuth/setup token env var
-    token = os.getenv("ANTHROPIC_TOKEN", "").strip()
+    token = (_get_secret("ANTHROPIC_TOKEN", "") or "").strip()
     if token:
         preferred = _prefer_refreshable_claude_code_token(token, creds)
         if preferred:
@@ -1308,7 +1309,7 @@ def resolve_anthropic_token() -> Optional[str]:
         return token
 
     # 2. CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
-    cc_token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+    cc_token = (_get_secret("CLAUDE_CODE_OAUTH_TOKEN", "") or "").strip()
     if cc_token:
         preferred = _prefer_refreshable_claude_code_token(cc_token, creds)
         if preferred:
@@ -1327,7 +1328,7 @@ def resolve_anthropic_token() -> Optional[str]:
 
     # 5. Regular API key, or a legacy OAuth token saved in ANTHROPIC_API_KEY.
     # This remains as a compatibility fallback for pre-migration Hermes configs.
-    api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
+    api_key = (_get_secret("ANTHROPIC_API_KEY", "") or "").strip()
     if api_key:
         return api_key
 
@@ -1370,7 +1371,7 @@ def run_oauth_setup_token() -> Optional[str]:
 
     # Check env vars that may have been set
     for env_var in ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_TOKEN"):
-        val = os.getenv(env_var, "").strip()
+        val = (_get_secret(env_var, "") or "").strip()
         if val:
             return val
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
-from agent.secret_scope import get_secret as _get_secret
+from agent.secret_scope import current_secret_scope, get_secret as _get_secret
 from agent.credential_persistence import (
     is_borrowed_credential_source,
     sanitize_borrowed_credential_payload,
@@ -2319,9 +2319,15 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         # references straight into .env rather than the secrets.onepassword
         # config block.  For every non-op:// value the original
         # .env-takes-precedence behaviour is preserved unchanged.
-        if raw.startswith("op://") and env_val:
+        scope = current_secret_scope()
+        if raw.startswith("op://") and env_val and scope is None:
             return env_val
-        return raw or _get_secret(key, "") or env_val
+        scoped = (_get_secret(key, "") or "").strip()
+        if scope is not None:
+            if raw.startswith("op://"):
+                return "" if scoped.startswith("op://") else scoped
+            return raw or scoped
+        return raw or scoped or env_val
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it

--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -14,7 +14,8 @@ const onboarding = atom({ manual: false })
 vi.mock('@/hermes', () => ({
   disconnectOAuthProvider: (providerId: string) => disconnectOAuthProvider(providerId),
   getEnvVars: () => getEnvVars(),
-  listOAuthProviders: () => listOAuthProviders()
+  listOAuthProviders: () => listOAuthProviders(),
+  setApiRequestProfile: vi.fn()
 }))
 
 vi.mock('@/store/onboarding', () => ({

--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection } from '@/store/session'
+
+import { useStatusSnapshot } from './use-status-snapshot'
+
+afterEach(() => {
+  cleanup()
+  $activeGatewayProfile.set('default')
+  $connection.set(null)
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('useStatusSnapshot', () => {
+  it('polls readiness for the active named profile', async () => {
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        api: vi.fn(async () => ({ gateway_running: true }))
+      }
+    })
+
+    $activeGatewayProfile.set('coder')
+    $connection.set({ mode: 'remote', source: 'settings' } as never)
+
+    const calls: Array<[string, Record<string, unknown> | undefined]> = []
+
+    const requestGateway = async <T = unknown,>(method: string, params?: Record<string, unknown>): Promise<T> => {
+      calls.push([method, params])
+
+      return (
+        method === 'setup.status'
+          ? { profile_name: 'coder', provider_configured: true }
+          : { ok: true, profile_name: 'coder' }
+      ) as T
+    }
+
+    renderHook(() => useStatusSnapshot('open', requestGateway))
+
+    await waitFor(() => expect(calls).toHaveLength(2))
+    expect(calls).toEqual([
+      ['setup.status', { profile: 'coder' }],
+      ['setup.runtime_check', { profile: 'coder' }]
+    ])
+  })
+
+  it('does not accept unscoped readiness from an old app-global remote backend', async () => {
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api: vi.fn(async () => ({ gateway_running: true })) }
+    })
+    $connection.set({ mode: 'remote', source: 'settings' } as never)
+
+    const requestGateway = async <T = unknown,>(method: string): Promise<T> =>
+      (method === 'setup.status' ? { provider_configured: true } : { ok: true }) as T
+
+    const { result } = renderHook(() => useStatusSnapshot('open', requestGateway))
+
+    await waitFor(() => expect(result.current.inferenceStatus).not.toBeNull())
+    expect(result.current.inferenceStatus?.ready).toBe(false)
+    expect(result.current.inferenceStatus?.reason).toMatch(/update/i)
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
@@ -1,7 +1,10 @@
+import { useStore } from '@nanostores/react'
 import { useEffect, useState } from 'react'
 
 import { getStatus } from '@/hermes'
-import { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
+import { evaluateRuntimeReadiness, requiresProfileIdentity, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection } from '@/store/session'
 import type { StatusResponse } from '@/types/hermes'
 
 const REFRESH_MS = 15_000
@@ -9,6 +12,8 @@ const REFRESH_MS = 15_000
 type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 
 export function useStatusSnapshot(gatewayState: string | undefined, requestGateway: GatewayRequester) {
+  const profile = useStore($activeGatewayProfile)
+  const connection = useStore($connection)
   const [statusSnapshot, setStatusSnapshot] = useState<StatusResponse | null>(null)
   const [inferenceStatus, setInferenceStatus] = useState<RuntimeReadinessResult | null>(null)
 
@@ -20,7 +25,10 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
         const [next, inference] = await Promise.all([
           getStatus(),
           gatewayState === 'open'
-            ? evaluateRuntimeReadiness(requestGateway).catch(error => ({
+            ? evaluateRuntimeReadiness(requestGateway, {
+                profile,
+                requireProfileIdentity: requiresProfileIdentity(connection)
+              }).catch(error => ({
                 checksDisagree: false,
                 ready: false,
                 reason: error instanceof Error ? error.message : String(error),
@@ -47,7 +55,7 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
       cancelled = true
       window.clearInterval(timer)
     }
-  }, [gatewayState, requestGateway])
+  }, [connection, gatewayState, profile, requestGateway])
 
   return { inferenceStatus, statusSnapshot }
 }

--- a/apps/desktop/src/components/onboarding/flow.tsx
+++ b/apps/desktop/src/components/onboarding/flow.tsx
@@ -236,8 +236,8 @@ function ConfirmingModelPanel({
   // Pull pricing + tier for the just-picked default so the confirm card
   // shows the same $/Mtok + Free/Pro info the picker and CLI do.
   const options = useQuery({
-    queryKey: ['onboarding-model-options', flow.providerSlug],
-    queryFn: () => getGlobalModelOptions({ includeUnconfigured: true, explicitOnly: false })
+    queryKey: ['onboarding-model-options', flow.profile, flow.providerSlug],
+    queryFn: () => getGlobalModelOptions({ includeUnconfigured: true, explicitOnly: false }, flow.profile)
   })
 
   const providerRow = options.data?.providers?.find(

--- a/apps/desktop/src/components/onboarding/index.test.tsx
+++ b/apps/desktop/src/components/onboarding/index.test.tsx
@@ -1,8 +1,16 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { $desktopOnboarding, type DesktopOnboardingState, type OnboardingContext } from '@/store/onboarding'
+import {
+  $desktopOnboarding,
+  type DesktopOnboardingState,
+  type OnboardingContext,
+  type OnboardingFlow
+} from '@/store/onboarding'
 import type { OAuthProvider } from '@/types/hermes'
+
+import { FlowPanel } from './flow'
 
 import { Picker } from '.'
 
@@ -52,6 +60,47 @@ afterEach(() => {
     firstRunSkipped: false,
     manual: false,
     localEndpoint: false
+  })
+  Reflect.deleteProperty(window, 'hermesDesktop')
+})
+
+describe('onboarding profile scope', () => {
+  it('fetches confirmation metadata for the flow profile instead of the mutable active profile', async () => {
+    const api = vi.fn().mockResolvedValue({
+      providers: [{ models: ['gpt-test'], name: 'OpenAI Codex', slug: 'openai-codex' }]
+    })
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api }
+    })
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    const flow = {
+      currentModel: 'gpt-test',
+      label: 'OpenAI Codex',
+      profile: 'coder',
+      providerSlug: 'openai-codex',
+      requireProfileIdentity: true,
+      saving: false,
+      status: 'confirming_model'
+    } satisfies Extract<OnboardingFlow, { status: 'confirming_model' }>
+
+    render(
+      <QueryClientProvider client={client}>
+        <FlowPanel ctx={ctx} flow={flow} leaving={false} onBegin={() => undefined} />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() =>
+      expect(api).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/api/model/options?include_unconfigured=1',
+          profile: 'coder'
+        })
+      )
+    )
   })
 })
 

--- a/apps/desktop/src/components/onboarding/index.tsx
+++ b/apps/desktop/src/components/onboarding/index.tsx
@@ -25,6 +25,8 @@ import {
   setOnboardingMode,
   startProviderOAuth
 } from '@/store/onboarding'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import { $connection } from '@/store/session'
 import type { ModelOptionProvider, OAuthProvider } from '@/types/hermes'
 
 import { DocsLink, FlowPanel, Status } from './flow'
@@ -112,16 +114,18 @@ const API_KEY_OPTIONS: ApiKeyOption[] = [
 // OAuth / external providers are intentionally excluded here — they go through
 // the OAuth picker / sign-in flow, not a pasted key.
 function useApiKeyCatalog(): ApiKeyOption[] {
+  const activeProfile = normalizeProfileKey(useStore($activeGatewayProfile))
   const [rows, setRows] = useState<ModelOptionProvider[]>([])
 
   useEffect(() => {
     let cancelled = false
+    setRows([])
 
     // Best-effort — on failure the curated defaults still render. Wrapped in
     // Promise.resolve().then so a synchronous throw (e.g. no desktop bridge in
     // tests) is funneled into the same .catch instead of escaping.
     void Promise.resolve()
-      .then(() => getGlobalModelOptions({ includeUnconfigured: true, explicitOnly: false }))
+      .then(() => getGlobalModelOptions({ includeUnconfigured: true, explicitOnly: false }, activeProfile))
       .then(res => {
         if (!cancelled) {
           setRows(res.providers ?? [])
@@ -134,7 +138,7 @@ function useApiKeyCatalog(): ApiKeyOption[] {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [activeProfile])
 
   return useMemo(() => {
     const curatedByEnv = new Map(API_KEY_OPTIONS.map(o => [o.envKey, o]))
@@ -181,6 +185,8 @@ export function DesktopOnboardingOverlay({ enabled, onCompleted, requestGateway 
   const { t } = useI18n()
   const onboarding = useStore($desktopOnboarding)
   const boot = useStore($desktopBoot)
+  const activeProfile = normalizeProfileKey(useStore($activeGatewayProfile))
+  const connection = useStore($connection)
   const ctxRef = useRef<OnboardingContext>({ requestGateway, onCompleted })
   ctxRef.current = { requestGateway, onCompleted }
 
@@ -218,7 +224,7 @@ export function DesktopOnboardingOverlay({ enabled, onCompleted, requestGateway 
     if (enabled || onboarding.requested) {
       void refreshOnboarding(ctx)
     }
-  }, [ctx, enabled, onboarding.requested])
+  }, [activeProfile, connection, ctx, enabled, onboarding.requested])
 
   // When the Providers settings page asked to connect a specific provider, the
   // store stashed its id. Once the provider list has loaded and we're back at

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -387,7 +387,7 @@ export interface HermesConnection {
   mode?: 'local' | 'remote'
   authMode?: 'oauth' | 'token'
   nativeOverlayWidth: number
-  source?: 'env' | 'local' | 'settings'
+  source?: 'env' | 'local' | 'profile' | 'settings'
   token: string
   wsUrl: string
   logs: string[]

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -10,6 +10,7 @@ import {
   getSessionMessages,
   getStatus,
   listAllProfileSessions,
+  listOAuthProviders,
   listSessions,
   listSidebarSessions
 } from './hermes'
@@ -191,6 +192,17 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith(
       expect.objectContaining({
         path: '/api/model/options?refresh=1&include_unconfigured=1'
+      })
+    )
+  })
+
+  it('allows an onboarding provider refresh to stay pinned to its starting profile', async () => {
+    await listOAuthProviders('coder')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/providers/oauth',
+        profile: 'coder'
       })
     )
   })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -192,8 +192,10 @@ export function setApiRequestProfile(profile: null | string): void {
   _apiProfile = profile || null
 }
 
-function profileScoped(): { profile?: string } {
-  return _apiProfile ? { profile: _apiProfile } : {}
+function profileScoped(profile?: string): { profile?: string } {
+  const scopedProfile = profile === undefined ? _apiProfile : profile.trim() || null
+
+  return scopedProfile ? { profile: scopedProfile } : {}
 }
 
 /** Options for a plugin REST call — mirrors the app's own `hermesDesktop.api`
@@ -597,9 +599,9 @@ export function getEnvVars(): Promise<Record<string, EnvVarInfo>> {
   })
 }
 
-export function setEnvVar(key: string, value: string): Promise<{ ok: boolean }> {
+export function setEnvVar(key: string, value: string, profile?: string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/env',
     method: 'PUT',
     body: { key, value }
@@ -609,10 +611,11 @@ export function setEnvVar(key: string, value: string): Promise<{ ok: boolean }> 
 export function validateProviderCredential(
   key: string,
   value: string,
-  apiKey?: string
+  apiKey?: string,
+  profile?: string
 ): Promise<{ ok: boolean; reachable: boolean; message: string; models?: string[] }> {
   return window.hermesDesktop.api<{ ok: boolean; reachable: boolean; message: string; models?: string[] }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/providers/validate',
     method: 'POST',
     body: { key, value, api_key: apiKey ?? '' }
@@ -637,9 +640,9 @@ export function revealEnvVar(key: string): Promise<{ key: string; value: string 
   })
 }
 
-export function listOAuthProviders(): Promise<OAuthProvidersResponse> {
+export function listOAuthProviders(profile?: string): Promise<OAuthProvidersResponse> {
   return window.hermesDesktop.api<OAuthProvidersResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/providers/oauth'
   })
 }
@@ -652,34 +655,39 @@ export function disconnectOAuthProvider(providerId: string): Promise<{ ok: boole
   })
 }
 
-export function startOAuthLogin(providerId: string): Promise<OAuthStartResponse> {
+export function startOAuthLogin(providerId: string, profile?: string): Promise<OAuthStartResponse> {
   return window.hermesDesktop.api<OAuthStartResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/providers/oauth/${encodeURIComponent(providerId)}/start`,
     method: 'POST',
     body: {}
   })
 }
 
-export function submitOAuthCode(providerId: string, sessionId: string, code: string): Promise<OAuthSubmitResponse> {
+export function submitOAuthCode(
+  providerId: string,
+  sessionId: string,
+  code: string,
+  profile?: string
+): Promise<OAuthSubmitResponse> {
   return window.hermesDesktop.api<OAuthSubmitResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/providers/oauth/${encodeURIComponent(providerId)}/submit`,
     method: 'POST',
     body: { session_id: sessionId, code }
   })
 }
 
-export function pollOAuthSession(providerId: string, sessionId: string): Promise<OAuthPollResponse> {
+export function pollOAuthSession(providerId: string, sessionId: string, profile?: string): Promise<OAuthPollResponse> {
   return window.hermesDesktop.api<OAuthPollResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/providers/oauth/${encodeURIComponent(providerId)}/poll/${encodeURIComponent(sessionId)}`
   })
 }
 
-export function cancelOAuthSession(sessionId: string): Promise<{ ok: boolean }> {
+export function cancelOAuthSession(sessionId: string, profile?: string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/providers/oauth/sessions/${encodeURIComponent(sessionId)}`,
     method: 'DELETE'
   })
@@ -1094,11 +1102,14 @@ export function getUsageAnalytics(days = 30): Promise<AnalyticsResponse> {
   })
 }
 
-export function getGlobalModelOptions(opts?: {
-  refresh?: boolean
-  includeUnconfigured?: boolean
-  explicitOnly?: boolean
-}): Promise<ModelOptionsResponse> {
+export function getGlobalModelOptions(
+  opts?: {
+    refresh?: boolean
+    includeUnconfigured?: boolean
+    explicitOnly?: boolean
+  },
+  profile?: string
+): Promise<ModelOptionsResponse> {
   const params = new URLSearchParams()
 
   if (opts?.refresh) {
@@ -1114,7 +1125,7 @@ export function getGlobalModelOptions(opts?: {
   }
 
   return window.hermesDesktop.api<ModelOptionsResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: params.size > 0 ? `/api/model/options?${params.toString()}` : '/api/model/options',
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
@@ -1130,9 +1141,9 @@ export interface RecommendedDefaultModel {
 // Recommended default model for a freshly-authenticated provider. Mirrors the
 // curation `hermes model` does — for Nous it honors the free/paid tier so a
 // free user gets a free model instead of a paid default.
-export function getRecommendedDefaultModel(provider: string): Promise<RecommendedDefaultModel> {
+export function getRecommendedDefaultModel(provider: string, profile?: string): Promise<RecommendedDefaultModel> {
   return window.hermesDesktop.api<RecommendedDefaultModel>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/model/recommended-default?provider=${encodeURIComponent(provider)}`
   })
 }
@@ -1176,9 +1187,9 @@ export function saveMoaModels(body: MoaConfigResponse): Promise<MoaConfigRespons
   })
 }
 
-export function setModelAssignment(body: ModelAssignmentRequest): Promise<ModelAssignmentResponse> {
+export function setModelAssignment(body: ModelAssignmentRequest, profile?: string): Promise<ModelAssignmentResponse> {
   return window.hermesDesktop.api<ModelAssignmentResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/model/set',
     method: 'POST',
     body

--- a/apps/desktop/src/lib/runtime-readiness.test.ts
+++ b/apps/desktop/src/lib/runtime-readiness.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from 'vitest'
 
-import { evaluateRuntimeReadiness, fetchRuntimeReadinessSignals, interpretRuntimeReadiness } from './runtime-readiness'
+import {
+  evaluateRuntimeReadiness,
+  fetchRuntimeReadinessSignals,
+  interpretRuntimeReadiness,
+  requiresProfileIdentity
+} from './runtime-readiness'
+
+describe('requiresProfileIdentity', () => {
+  it('requires identity only for app-global remote connections', () => {
+    expect(requiresProfileIdentity({ mode: 'remote', source: 'settings' })).toBe(true)
+    expect(requiresProfileIdentity({ mode: 'remote', source: 'env' })).toBe(true)
+    expect(requiresProfileIdentity({ mode: 'remote', source: 'profile' })).toBe(false)
+    expect(requiresProfileIdentity({ mode: 'local', source: 'local' })).toBe(false)
+    expect(requiresProfileIdentity(null)).toBe(false)
+  })
+})
 
 describe('interpretRuntimeReadiness', () => {
   it('prefers runtime_check when both signals exist', () => {
@@ -86,6 +101,27 @@ describe('fetchRuntimeReadinessSignals', () => {
 
     expect(calls).toEqual([{ method: 'setup.status' }, { method: 'setup.runtime_check', params: { provider: 'nous' } }])
   })
+
+  it('preserves the literal default profile for a shared remote gateway', async () => {
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+
+    const requestGateway = async <T = unknown>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      return (
+        method === 'setup.status'
+          ? { profile_name: 'default', provider_configured: true }
+          : { ok: true, profile_name: 'default' }
+      ) as T
+    }
+
+    await fetchRuntimeReadinessSignals(requestGateway, undefined, 'default')
+
+    expect(calls).toEqual([
+      { method: 'setup.status', params: { profile: 'default' } },
+      { method: 'setup.runtime_check', params: { profile: 'default' } }
+    ])
+  })
 })
 
 describe('evaluateRuntimeReadiness', () => {
@@ -105,6 +141,91 @@ describe('evaluateRuntimeReadiness', () => {
     }
 
     const result = await evaluateRuntimeReadiness(requestGateway, { requestedProvider: 'nous' })
+
+    expect(result.ready).toBe(true)
+  })
+
+  it('scopes both readiness checks to the active profile', async () => {
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+
+    const requestGateway = async <T = unknown>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      return (method === 'setup.status' ? { provider_configured: true } : { ok: true }) as T
+    }
+
+    await evaluateRuntimeReadiness(requestGateway, {
+      profile: 'coder',
+      requireProfileIdentity: true,
+      requestedProvider: 'openai-codex'
+    })
+
+    expect(calls).toEqual([
+      { method: 'setup.status', params: { profile: 'coder' } },
+      { method: 'setup.runtime_check', params: { profile: 'coder', provider: 'openai-codex' } }
+    ])
+  })
+
+  it('does not send a Desktop-local profile label to a dedicated backend', async () => {
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+
+    const requestGateway = async <T = unknown>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      return (method === 'setup.status' ? { provider_configured: true } : { ok: true }) as T
+    }
+
+    const result = await evaluateRuntimeReadiness(requestGateway, {
+      profile: 'desktop-only-label',
+      requireProfileIdentity: false,
+      requestedProvider: 'openai-codex'
+    })
+
+    expect(result.ready).toBe(true)
+    expect(calls).toEqual([
+      { method: 'setup.status', params: undefined },
+      { method: 'setup.runtime_check', params: { provider: 'openai-codex' } }
+    ])
+  })
+
+  it('rejects an old shared remote backend that cannot confirm the requested profile', async () => {
+    const requestGateway = async <T = unknown>(method: string) =>
+      (method === 'setup.status' ? { provider_configured: true } : { ok: true }) as T
+
+    const result = await evaluateRuntimeReadiness(requestGateway, {
+      profile: 'coder',
+      requireProfileIdentity: true
+    })
+
+    expect(result.ready).toBe(false)
+    expect(result.source).toBe('fallback')
+    expect(result.reason).toMatch(/update/i)
+  })
+
+  it('rejects readiness resolved for a different remote profile', async () => {
+    const requestGateway = async <T = unknown>(method: string) =>
+      (method === 'setup.status'
+        ? { profile_name: 'default', provider_configured: true }
+        : { ok: true, profile_name: 'default' }) as T
+
+    const result = await evaluateRuntimeReadiness(requestGateway, {
+      profile: 'coder',
+      requireProfileIdentity: true
+    })
+
+    expect(result.ready).toBe(false)
+    expect(result.reason).toContain('default')
+    expect(result.reason).toContain('coder')
+  })
+
+  it('accepts legacy readiness without a profile marker when no shared remote scope is required', async () => {
+    const requestGateway = async <T = unknown>(method: string) =>
+      (method === 'setup.status' ? { provider_configured: true } : { ok: true }) as T
+
+    const result = await evaluateRuntimeReadiness(requestGateway, {
+      profile: 'coder',
+      requireProfileIdentity: false
+    })
 
     expect(result.ready).toBe(true)
   })

--- a/apps/desktop/src/lib/runtime-readiness.ts
+++ b/apps/desktop/src/lib/runtime-readiness.ts
@@ -1,10 +1,14 @@
+import type { HermesConnection } from '@/global'
+
 export interface SetupStatusSnapshot {
+  profile_name?: string
   provider_configured?: boolean
 }
 
 export interface RuntimeCheckSnapshot {
   error?: string
   ok?: boolean
+  profile_name?: string
 }
 
 export interface RuntimeReadinessSignals {
@@ -16,6 +20,8 @@ export interface RuntimeReadinessSignals {
 
 export interface RuntimeReadinessOptions {
   defaultReason?: string
+  profile?: string
+  requireProfileIdentity?: boolean
   requestedProvider?: string
   unknownReady?: boolean
 }
@@ -30,6 +36,12 @@ export interface RuntimeReadinessResult {
 export type RuntimeReadinessRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 
 const DEFAULT_NOT_READY_REASON = 'Add a provider credential before sending your first message.'
+
+export function requiresProfileIdentity(
+  connection: null | Pick<HermesConnection, 'mode' | 'source'> | undefined
+): boolean {
+  return connection?.mode === 'remote' && (connection.source === 'env' || connection.source === 'settings')
+}
 
 function toErrorMessage(error: unknown): null | string {
   if (error instanceof Error) {
@@ -67,12 +79,20 @@ async function requestWithFallback<T>(
 
 export async function fetchRuntimeReadinessSignals(
   requestGateway: RuntimeReadinessRequester,
-  requestedProvider?: string
+  requestedProvider?: string,
+  profile?: string
 ): Promise<RuntimeReadinessSignals> {
-  const runtimeParams = requestedProvider?.trim() ? { provider: requestedProvider.trim() } : undefined
+  const requestedProfile = profile?.trim()
+  const profileParams = requestedProfile ? { profile: requestedProfile } : undefined
+  const requestedRuntimeProvider = requestedProvider?.trim()
+
+  const runtimeParams =
+    profileParams || requestedRuntimeProvider
+      ? { ...profileParams, ...(requestedRuntimeProvider ? { provider: requestedRuntimeProvider } : {}) }
+      : undefined
 
   const [setup, runtime] = await Promise.all([
-    requestWithFallback<SetupStatusSnapshot>(requestGateway, 'setup.status'),
+    requestWithFallback<SetupStatusSnapshot>(requestGateway, 'setup.status', profileParams),
     requestWithFallback<RuntimeCheckSnapshot>(requestGateway, 'setup.runtime_check', runtimeParams)
   ])
 
@@ -100,6 +120,35 @@ export function interpretRuntimeReadiness(
 
   const checksDisagree =
     typeof setupConfigured === 'boolean' && typeof runtimeOk === 'boolean' && setupConfigured !== runtimeOk
+
+  if (options.requireProfileIdentity) {
+    const requestedProfile = options.profile?.trim() || 'default'
+
+    const resolvedProfile =
+      typeof runtimeOk === 'boolean'
+        ? signals.runtime?.profile_name?.trim()
+        : typeof setupConfigured === 'boolean'
+          ? signals.setup?.profile_name?.trim()
+          : undefined
+
+    if (!resolvedProfile) {
+      return {
+        checksDisagree: false,
+        ready: false,
+        reason: `Update the Hermes backend before Desktop can verify readiness for profile "${requestedProfile}".`,
+        source: 'fallback'
+      }
+    }
+
+    if (resolvedProfile !== requestedProfile) {
+      return {
+        checksDisagree: false,
+        ready: false,
+        reason: `Hermes resolved readiness for profile "${resolvedProfile}" instead of requested profile "${requestedProfile}".`,
+        source: 'fallback'
+      }
+    }
+  }
 
   if (typeof runtimeOk === 'boolean') {
     if (runtimeOk) {
@@ -146,7 +195,11 @@ export async function evaluateRuntimeReadiness(
   requestGateway: RuntimeReadinessRequester,
   options: RuntimeReadinessOptions = {}
 ): Promise<RuntimeReadinessResult> {
-  const signals = await fetchRuntimeReadinessSignals(requestGateway, options.requestedProvider)
+  // Only an app-global remote backend needs the Desktop's local profile label.
+  // Local and per-profile remote connections already serve their own launch
+  // profile, and that label may not exist on a dedicated remote host.
+  const gatewayProfile = options.requireProfileIdentity ? options.profile : undefined
+  const signals = await fetchRuntimeReadinessSignals(requestGateway, options.requestedProvider, gatewayProfile)
 
   return interpretRuntimeReadiness(signals, options)
 }

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as notifications from '@/store/notifications'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection } from '@/store/session'
 import type { OAuthProvider } from '@/types/hermes'
 
 import {
@@ -39,7 +41,7 @@ function baseState(overrides: Partial<DesktopOnboardingState> = {}): DesktopOnbo
   }
 }
 
-function installApiMock(api: (request: { path: string }) => Promise<unknown>) {
+function installApiMock(api: (request: { body?: unknown; path: string; profile?: string }) => Promise<unknown>) {
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
     value: { api }
@@ -77,13 +79,101 @@ function fallbackTimeoutGateway(): OnboardingContext['requestGateway'] {
 describe('refreshOnboarding', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    $activeGatewayProfile.set('default')
+    $connection.set(null)
     $desktopOnboarding.set(baseState())
   })
 
   afterEach(() => {
     window.localStorage.clear()
+    $activeGatewayProfile.set('default')
+    $connection.set(null)
     $desktopOnboarding.set(baseState())
     vi.restoreAllMocks()
+  })
+
+  it('does not apply a late readiness result after the active profile changes', async () => {
+    let resolveSetup!: (value: unknown) => void
+    let resolveRuntime!: (value: unknown) => void
+
+    const setup = new Promise(resolve => {
+      resolveSetup = resolve
+    })
+
+    const runtime = new Promise(resolve => {
+      resolveRuntime = resolve
+    })
+
+    $activeGatewayProfile.set('coder')
+    $connection.set({ mode: 'remote', source: 'settings' } as never)
+    $desktopOnboarding.set(baseState({ configured: false }))
+
+    const pending = refreshOnboarding(
+      onboardingContext(async method => (method === 'setup.status' ? setup : runtime) as never)
+    )
+
+    $activeGatewayProfile.set('default')
+    $connection.set({ mode: 'local', source: 'local' } as never)
+    resolveSetup({ profile_name: 'coder', provider_configured: true })
+    resolveRuntime({ ok: true, profile_name: 'coder' })
+
+    await pending
+
+    expect($desktopOnboarding.get().configured).toBe(false)
+  })
+
+  it('does not apply readiness captured under an obsolete connection policy', async () => {
+    let resolveSetup!: (value: unknown) => void
+    let resolveRuntime!: (value: unknown) => void
+
+    const setup = new Promise(resolve => {
+      resolveSetup = resolve
+    })
+
+    const runtime = new Promise(resolve => {
+      resolveRuntime = resolve
+    })
+
+    $activeGatewayProfile.set('coder')
+    $connection.set({ mode: 'local', source: 'local' } as never)
+    $desktopOnboarding.set(baseState({ configured: false }))
+
+    const pending = refreshOnboarding(
+      onboardingContext(async method => (method === 'setup.status' ? setup : runtime) as never)
+    )
+
+    $connection.set({ mode: 'remote', source: 'settings' } as never)
+    resolveSetup({ provider_configured: true })
+    resolveRuntime({ ok: true })
+
+    await pending
+
+    expect($desktopOnboarding.get().configured).toBe(false)
+  })
+
+  it('drops an in-progress flow that belongs to the previous profile', async () => {
+    installApiMock(async ({ path }) => {
+      if (path === '/api/providers/oauth') {
+        return { providers: [] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+    $activeGatewayProfile.set('default')
+    $desktopOnboarding.set(
+      baseState({
+        flow: {
+          profile: 'coder',
+          provider: provider('openai-codex'),
+          requireProfileIdentity: true,
+          status: 'starting'
+        }
+      })
+    )
+
+    await refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
+
+    expect($desktopOnboarding.get().flow.status).toBe('idle')
   })
 
   it('refreshes OAuth providers again when onboarding was explicitly requested', async () => {
@@ -264,21 +354,29 @@ describe('refreshOnboarding', () => {
 describe('OAuth onboarding', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    $activeGatewayProfile.set('default')
+    $connection.set(null)
     $desktopOnboarding.set(baseState())
   })
 
   afterEach(() => {
     window.localStorage.clear()
+    $activeGatewayProfile.set('default')
+    $connection.set(null)
     $desktopOnboarding.set(baseState())
     vi.restoreAllMocks()
   })
 
   it('clears stale readiness errors after OAuth succeeds and model confirmation is shown', async () => {
     const model = 'anthropic/claude-opus-4.8'
-    const calls: { body?: unknown; path: string }[] = []
+    const calls: { body?: unknown; path: string; profile?: string }[] = []
+    const gatewayCalls: Array<{ method: string; params?: Record<string, unknown> }> = []
 
-    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
-      calls.push({ body, path })
+    $activeGatewayProfile.set('coder')
+    $connection.set({ mode: 'remote', source: 'settings' } as never)
+
+    installApiMock(async ({ body, path, profile }) => {
+      calls.push({ body, path, profile })
 
       if (path === '/api/providers/oauth/nous/submit') {
         return { ok: true, status: 'approved' }
@@ -308,18 +406,18 @@ describe('OAuth onboarding', () => {
     })
 
     const requestGateway: OnboardingContext['requestGateway'] = async (method, params) => {
-      if (method === 'reload.env') {
-        return {} as never
-      }
+      gatewayCalls.push({ method, params })
 
       if (method === 'setup.status') {
-        return { provider_configured: true } as never
+        expect(params).toEqual({ profile: 'coder' })
+
+        return { profile_name: 'coder', provider_configured: true } as never
       }
 
       if (method === 'setup.runtime_check') {
-        expect(params).toEqual({ provider: 'nous' })
+        expect(params).toEqual({ profile: 'coder', provider: 'nous' })
 
-        return { ok: true } as never
+        return { ok: true, profile_name: 'coder' } as never
       }
 
       throw new Error(`unexpected gateway method: ${method}`)
@@ -329,6 +427,8 @@ describe('OAuth onboarding', () => {
       baseState({
         flow: {
           status: 'awaiting_user',
+          profile: 'coder',
+          requireProfileIdentity: true,
           provider: provider('nous', 'Nous Portal'),
           start: {
             auth_url: 'https://portal.example/auth',
@@ -364,6 +464,102 @@ describe('OAuth onboarding', () => {
     expect(optionsIndex).toBeGreaterThanOrEqual(0)
     expect(recommendedIndex).toBeGreaterThan(optionsIndex)
     expect(setIndex).toBeGreaterThan(recommendedIndex)
+    expect(calls.every(call => call.profile === 'coder')).toBe(true)
+    expect(gatewayCalls).toEqual([
+      { method: 'setup.status', params: { profile: 'coder' } },
+      { method: 'setup.runtime_check', params: { profile: 'coder', provider: 'nous' } }
+    ])
+  })
+
+  it('keeps an in-flight OAuth completion scoped to its starting profile without overwriting a new active profile', async () => {
+    const model = 'openai/gpt-5.4'
+    const apiCalls: Array<{ path: string; profile?: string }> = []
+    const gatewayCalls: Array<{ method: string; params?: Record<string, unknown> }> = []
+    const notify = vi.spyOn(notifications, 'notify')
+    let resolveOptions!: (value: unknown) => void
+
+    const options = new Promise(resolve => {
+      resolveOptions = resolve
+    })
+
+    $activeGatewayProfile.set('coder')
+    $connection.set({ mode: 'remote', source: 'settings' } as never)
+
+    installApiMock(async ({ path, profile }) => {
+      apiCalls.push({ path, profile })
+
+      if (path === '/api/providers/oauth/openai-codex/submit') {
+        return { ok: true, status: 'approved' }
+      }
+
+      if (path.startsWith('/api/model/options')) {
+        return options
+      }
+
+      if (path.startsWith('/api/model/recommended-default?')) {
+        return { provider: 'openai-codex', model, free_tier: null }
+      }
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'openai-codex', model, gateway_tools: ['web'] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const requestGateway: OnboardingContext['requestGateway'] = async (method, params) => {
+      gatewayCalls.push({ method, params })
+
+      if (method === 'reload.env') {
+        return {} as never
+      }
+
+      if (method === 'setup.status') {
+        return { profile_name: 'coder', provider_configured: true } as never
+      }
+
+      if (method === 'setup.runtime_check') {
+        return { ok: true, profile_name: 'coder' } as never
+      }
+
+      throw new Error(`unexpected gateway method: ${method}`)
+    }
+
+    $desktopOnboarding.set(
+      baseState({
+        flow: {
+          code: 'one-time-code',
+          profile: 'coder',
+          requireProfileIdentity: true,
+          provider: provider('openai-codex', 'OpenAI Codex'),
+          start: {
+            auth_url: 'https://example.invalid/auth',
+            expires_in: 600,
+            flow: 'pkce',
+            session_id: 'codex-session'
+          },
+          status: 'awaiting_user'
+        },
+        requested: true
+      })
+    )
+
+    const completion = submitOnboardingCode(onboardingContext(requestGateway))
+    await vi.waitFor(() => expect(apiCalls.some(call => call.path.startsWith('/api/model/options'))).toBe(true))
+
+    $activeGatewayProfile.set('default')
+    $connection.set({ mode: 'local', source: 'local' } as never)
+    resolveOptions({ providers: [{ name: 'OpenAI Codex', slug: 'openai-codex', models: [model] }] })
+    await completion
+
+    expect(apiCalls.every(call => call.profile === 'coder')).toBe(true)
+    expect(gatewayCalls).toEqual([
+      { method: 'setup.status', params: { profile: 'coder' } },
+      { method: 'setup.runtime_check', params: { profile: 'coder', provider: 'openai-codex' } }
+    ])
+    expect($desktopOnboarding.get().configured).not.toBe(true)
+    expect($desktopOnboarding.get().flow.status).not.toBe('confirming_model')
+    expect(notify).not.toHaveBeenCalled()
   })
 })
 
@@ -379,8 +575,12 @@ describe('saveOnboardingLocalEndpoint', () => {
     vi.restoreAllMocks()
   })
 
-  function readyGateway(): OnboardingContext['requestGateway'] {
-    return async method => {
+  function readyGateway(
+    calls?: Array<{ method: string; params?: Record<string, unknown> }>
+  ): OnboardingContext['requestGateway'] {
+    return async (method, params) => {
+      calls?.push({ method, params })
+
       if (method === 'reload.env') {
         return {} as never
       }
@@ -438,10 +638,11 @@ describe('saveOnboardingLocalEndpoint', () => {
 
     installApiMock(api)
     const onCompleted = vi.fn()
+    const gatewayCalls: Array<{ method: string; params?: Record<string, unknown> }> = []
 
     const result = await saveOnboardingLocalEndpoint('http://127.0.0.1:8000/v1', '', {
       onCompleted,
-      requestGateway: readyGateway()
+      requestGateway: readyGateway(gatewayCalls)
     })
 
     expect(result.ok).toBe(true)
@@ -456,6 +657,7 @@ describe('saveOnboardingLocalEndpoint', () => {
 
     expect(onCompleted).toHaveBeenCalledTimes(1)
     expect($desktopOnboarding.get().configured).toBe(true)
+    expect(gatewayCalls[0]).toEqual({ method: 'reload.env', params: undefined })
   })
 
   it('forwards the API key to the probe and persists it for auth-gated endpoints', async () => {

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -12,8 +12,10 @@ import {
   submitOAuthCode,
   validateProviderCredential
 } from '@/hermes'
-import { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
+import { evaluateRuntimeReadiness, requiresProfileIdentity, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { notify, notifyError } from '@/store/notifications'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import { $connection } from '@/store/session'
 import type { ModelOptionProvider, OAuthProvider, OAuthStartResponse } from '@/types/hermes'
 
 type PkceStart = Extract<OAuthStartResponse, { flow: 'pkce' }>
@@ -21,15 +23,20 @@ type DeviceStart = Extract<OAuthStartResponse, { flow: 'device_code' }>
 
 export type OnboardingMode = 'apikey' | 'oauth'
 
+interface OnboardingProfileScope {
+  profile: string
+  requireProfileIdentity: boolean
+}
+
 export type OnboardingFlow =
   | { status: 'idle' }
-  | { provider: OAuthProvider; status: 'starting' }
-  | { code: string; provider: OAuthProvider; start: PkceStart; status: 'awaiting_user' }
-  | { copied: boolean; provider: OAuthProvider; start: DeviceStart; status: 'polling' }
-  | { provider: OAuthProvider; start: OAuthStartResponse; status: 'submitting' }
-  | { copied: boolean; provider: OAuthProvider; status: 'external_pending' }
-  | { provider: OAuthProvider; status: 'success' }
-  | {
+  | ({ provider: OAuthProvider; status: 'starting' } & OnboardingProfileScope)
+  | ({ code: string; provider: OAuthProvider; start: PkceStart; status: 'awaiting_user' } & OnboardingProfileScope)
+  | ({ copied: boolean; provider: OAuthProvider; start: DeviceStart; status: 'polling' } & OnboardingProfileScope)
+  | ({ provider: OAuthProvider; start: OAuthStartResponse; status: 'submitting' } & OnboardingProfileScope)
+  | ({ copied: boolean; provider: OAuthProvider; status: 'external_pending' } & OnboardingProfileScope)
+  | ({ provider: OAuthProvider; status: 'success' } & OnboardingProfileScope)
+  | ({
       // After successful credential acquisition, before completing
       // onboarding: show the user which model they're getting and let
       // them change it. providerSlug is the model.options slug for the
@@ -42,8 +49,13 @@ export type OnboardingFlow =
       providerSlug: string
       saving: boolean
       status: 'confirming_model'
-    }
-  | { message: string; provider?: OAuthProvider; start?: OAuthStartResponse; status: 'error' }
+    } & OnboardingProfileScope)
+  | ({
+      message: string
+      provider?: OAuthProvider
+      start?: OAuthStartResponse
+      status: 'error'
+    } & Partial<OnboardingProfileScope>)
 
 export interface DesktopOnboardingState {
   /** null until the first runtime check resolves. Seeded from localStorage so
@@ -157,7 +169,7 @@ const INITIAL: DesktopOnboardingState = {
 export const $desktopOnboarding = atom<DesktopOnboardingState>(INITIAL)
 
 let pollTimer: number | null = null
-let providersRefreshPromise: null | Promise<void> = null
+const providerRefreshPromises = new Map<string, Promise<OAuthProvider[]>>()
 
 const errMessage = (e: unknown) => (e instanceof Error ? e.message : String(e))
 
@@ -175,9 +187,28 @@ function clearPoll() {
   }
 }
 
-async function checkRuntime(ctx: OnboardingContext, requestedProvider?: string): Promise<RuntimeReadinessResult> {
+function activeOnboardingScope(): OnboardingProfileScope {
+  return {
+    profile: normalizeProfileKey($activeGatewayProfile.get()),
+    requireProfileIdentity: requiresProfileIdentity($connection.get())
+  }
+}
+
+function profileIsActive(scope: OnboardingProfileScope): boolean {
+  const active = activeOnboardingScope()
+
+  return active.profile === scope.profile && active.requireProfileIdentity === scope.requireProfileIdentity
+}
+
+async function checkRuntime(
+  ctx: OnboardingContext,
+  requestedProvider?: string,
+  scope: OnboardingProfileScope = activeOnboardingScope()
+): Promise<RuntimeReadinessResult> {
   return evaluateRuntimeReadiness(ctx.requestGateway, {
     defaultReason: DEFAULT_ONBOARDING_REASON,
+    profile: scope.profile,
+    requireProfileIdentity: scope.requireProfileIdentity,
     requestedProvider,
     unknownReady: false
   })
@@ -234,12 +265,13 @@ function notifyGatewayTools(tools: string[] | undefined) {
 // we had before, which works but is surprising. The confirm step is
 // opportunistic polish, not a hard requirement for onboarding.
 async function fetchProviderDefaultModel(
-  preferredSlugs: string[]
+  preferredSlugs: string[],
+  scope: OnboardingProfileScope
 ): Promise<null | { providerSlug: string; defaultModel: string }> {
   let options
 
   try {
-    options = await getGlobalModelOptions({ includeUnconfigured: true, explicitOnly: false })
+    options = await getGlobalModelOptions({ includeUnconfigured: true, explicitOnly: false }, scope.profile)
   } catch {
     return null
   }
@@ -271,7 +303,7 @@ async function fetchProviderDefaultModel(
   let defaultModel = String(models[0])
 
   try {
-    const recommended = await getRecommendedDefaultModel(String(matched.slug))
+    const recommended = await getRecommendedDefaultModel(String(matched.slug), scope.profile)
 
     if (recommended.model && models.map(String).includes(recommended.model)) {
       defaultModel = recommended.model
@@ -303,38 +335,56 @@ async function completeWithModelConfirm(
   providerLabel: string,
   preferredSlugs: string[],
   onFail: (reason: null | string) => void,
+  scope: OnboardingProfileScope,
   // When true, a failing runtime check no longer blocks progression — the
   // user is allowed through onboarding regardless. Used by the API-key path,
   // where we intentionally don't validate the key (it blocked too many users).
   ignoreRuntimeGate = false
 ) {
-  await ctx.requestGateway('reload.env').catch(() => undefined)
+  // A shared remote backend from before contract v4 silently ignores the
+  // profile parameter and would reload its launch profile's process-global
+  // environment. Profile-scoped readiness rebuilds an isolated secret scope,
+  // so global-remote flows neither need nor safely support reload.env.
+  if (!scope.requireProfileIdentity) {
+    await ctx.requestGateway('reload.env').catch(() => undefined)
+  }
 
-  const defaults = await fetchProviderDefaultModel(preferredSlugs)
+  const defaults = await fetchProviderDefaultModel(preferredSlugs, scope)
 
   if (defaults) {
     // Persist the chosen provider/model before the runtime gate so a stale
     // config provider (e.g. anthropic from a prior failed setup) cannot make
     // setup.runtime_check validate the wrong backend after a fresh OAuth login.
     try {
-      const res = await setModelAssignment({
-        scope: 'main',
-        provider: defaults.providerSlug,
-        model: defaults.defaultModel
-      })
+      const res = await setModelAssignment(
+        {
+          scope: 'main',
+          provider: defaults.providerSlug,
+          model: defaults.defaultModel
+        },
+        scope.profile
+      )
 
-      notifyGatewayTools(res.gateway_tools)
+      if (profileIsActive(scope)) {
+        notifyGatewayTools(res.gateway_tools)
+      }
     } catch {
       // Persistence failed — still run the scoped runtime check below and
       // show the confirm card so the user can pick something explicitly.
     }
   }
 
-  const runtime = await checkRuntime(ctx, preferredSlugs[0])
+  const runtime = await checkRuntime(ctx, preferredSlugs[0], scope)
 
   if (!runtime.ready && !ignoreRuntimeGate) {
-    onFail(runtime.reason)
+    if (profileIsActive(scope)) {
+      onFail(runtime.reason)
+    }
 
+    return
+  }
+
+  if (!profileIsActive(scope)) {
     return
   }
 
@@ -349,6 +399,7 @@ async function completeWithModelConfirm(
 
   setFlow({
     status: 'confirming_model',
+    ...scope,
     providerSlug: defaults.providerSlug,
     currentModel: defaults.defaultModel,
     label: providerLabel,
@@ -364,25 +415,29 @@ function providerResolutionFailure(reason: null | string) {
     : 'Connected, but Hermes still cannot resolve a usable provider.'
 }
 
-async function refreshProviders() {
-  if (providersRefreshPromise) {
-    await providersRefreshPromise
+async function refreshProviders(scope: OnboardingProfileScope = activeOnboardingScope()) {
+  let pending = providerRefreshPromises.get(scope.profile)
 
-    return
+  if (!pending) {
+    pending = listOAuthProviders(scope.profile).then(({ providers }) => providers)
+    providerRefreshPromises.set(scope.profile, pending)
   }
 
-  providersRefreshPromise = (async () => {
-    try {
-      const { providers } = await listOAuthProviders()
-      patch({ mode: providers.length > 0 ? 'oauth' : 'apikey', providers })
-    } catch {
-      patch({ mode: 'apikey', providers: [] })
-    } finally {
-      providersRefreshPromise = null
-    }
-  })()
+  try {
+    const providers = await pending
 
-  await providersRefreshPromise
+    if (profileIsActive(scope)) {
+      patch({ mode: providers.length > 0 ? 'oauth' : 'apikey', providers })
+    }
+  } catch {
+    if (profileIsActive(scope)) {
+      patch({ mode: 'apikey', providers: [] })
+    }
+  } finally {
+    if (providerRefreshPromises.get(scope.profile) === pending) {
+      providerRefreshPromises.delete(scope.profile)
+    }
+  }
 }
 
 export function requestDesktopOnboarding(reason = DEFAULT_ONBOARDING_REASON) {
@@ -495,17 +550,32 @@ export function setOnboardingMode(mode: OnboardingMode) {
 }
 
 export async function refreshOnboarding(ctx: OnboardingContext) {
+  const scope = activeOnboardingScope()
+  const startingFlow = $desktopOnboarding.get().flow
+
+  // Profile switches do not remount this store. Drop any old profile's UI
+  // state (and pending OAuth session) before checking the newly active one.
+  if ('profile' in startingFlow && startingFlow.profile && startingFlow.profile !== scope.profile) {
+    cancelOnboardingFlow()
+  }
+
   // Manual mode (user opened the selector from a working app): never
   // auto-dismiss on runtime-ready — the whole point is to let them add /
   // switch a provider while already configured. Just ensure the provider
   // list is loaded and show the picker.
   if ($desktopOnboarding.get().manual) {
-    await refreshProviders()
+    await refreshProviders(scope)
 
     return false
   }
 
-  const runtime = await checkRuntime(ctx)
+  const runtime = await checkRuntime(ctx, undefined, scope)
+
+  // A profile switch may complete while either readiness request is in
+  // flight. Never apply profile A's answer to profile B's onboarding state.
+  if (!profileIsActive(scope)) {
+    return false
+  }
 
   if (runtime.ready) {
     completeDesktopOnboarding()
@@ -541,7 +611,7 @@ export async function refreshOnboarding(ctx: OnboardingContext) {
     return false
   }
 
-  await refreshProviders()
+  await refreshProviders(scope)
 
   return false
 }
@@ -568,55 +638,85 @@ async function openSignInUrl(url: string) {
 
 export async function startProviderOAuth(provider: OAuthProvider, ctx: OnboardingContext) {
   clearPoll()
+  const scope = activeOnboardingScope()
 
   if (provider.flow === 'external') {
-    setFlow({ status: 'external_pending', provider, copied: false })
+    setFlow({ status: 'external_pending', provider, copied: false, ...scope })
 
     return
   }
 
-  setFlow({ status: 'starting', provider })
+  setFlow({ status: 'starting', provider, ...scope })
 
   try {
-    const start = await startOAuthLogin(provider.id)
+    const start = await startOAuthLogin(provider.id, scope.profile)
     const browserUrl = start.flow === 'device_code' ? start.verification_url : start.auth_url
     await openSignInUrl(browserUrl)
 
-    if (start.flow === 'pkce') {
-      setFlow({ status: 'awaiting_user', provider, start, code: '' })
+    if (!profileIsActive(scope)) {
+      cancelOAuthSession(start.session_id, scope.profile).catch(() => undefined)
 
       return
     }
 
-    setFlow({ status: 'polling', provider, start, copied: false })
-    pollTimer = window.setInterval(() => void pollSession(provider, start, ctx), POLL_MS)
+    if (start.flow === 'pkce') {
+      setFlow({ status: 'awaiting_user', provider, start, code: '', ...scope })
+
+      return
+    }
+
+    setFlow({ status: 'polling', provider, start, copied: false, ...scope })
+    pollTimer = window.setInterval(() => void pollSession(provider, start, ctx, scope), POLL_MS)
   } catch (error) {
-    setFlow({ status: 'error', provider, message: `Could not start sign-in: ${errMessage(error)}` })
+    if (profileIsActive(scope)) {
+      setFlow({ status: 'error', provider, message: `Could not start sign-in: ${errMessage(error)}`, ...scope })
+    }
   }
 }
 
 // Poll a session-backed device-code flow until it resolves.
-async function pollSession(provider: OAuthProvider, start: DeviceStart, ctx: OnboardingContext) {
+async function pollSession(
+  provider: OAuthProvider,
+  start: DeviceStart,
+  ctx: OnboardingContext,
+  scope: OnboardingProfileScope
+) {
   try {
-    const { error_message, status } = await pollOAuthSession(provider.id, start.session_id)
+    const { error_message, status } = await pollOAuthSession(provider.id, start.session_id, scope.profile)
 
     if (status === 'approved') {
       clearPoll()
-      setFlow({ status: 'success', provider })
-      await completeWithModelConfirm(ctx, provider.name, [provider.id], reason =>
-        setFlow({
-          status: 'error',
-          provider,
-          message: providerResolutionFailure(reason)
-        })
+
+      if (profileIsActive(scope)) {
+        setFlow({ status: 'success', provider, ...scope })
+      }
+
+      await completeWithModelConfirm(
+        ctx,
+        provider.name,
+        [provider.id],
+        reason =>
+          setFlow({
+            status: 'error',
+            provider,
+            message: providerResolutionFailure(reason),
+            ...scope
+          }),
+        scope
       )
     } else if (status !== 'pending') {
       clearPoll()
-      setFlow({ status: 'error', provider, start, message: error_message || `Sign-in ${status}.` })
+
+      if (profileIsActive(scope)) {
+        setFlow({ status: 'error', provider, start, message: error_message || `Sign-in ${status}.`, ...scope })
+      }
     }
   } catch (error) {
     clearPoll()
-    setFlow({ status: 'error', provider, start, message: `Polling failed: ${errMessage(error)}` })
+
+    if (profileIsActive(scope)) {
+      setFlow({ status: 'error', provider, start, message: `Polling failed: ${errMessage(error)}`, ...scope })
+    }
   }
 }
 
@@ -635,35 +735,50 @@ export async function submitOnboardingCode(ctx: OnboardingContext) {
     return
   }
 
-  const { provider, start, code } = flow
-  setFlow({ status: 'submitting', provider, start })
+  const { provider, start, code, profile, requireProfileIdentity } = flow
+  const scope = { profile, requireProfileIdentity }
+  setFlow({ status: 'submitting', provider, start, ...scope })
 
   try {
-    const resp = await submitOAuthCode(provider.id, start.session_id, code.trim())
+    const resp = await submitOAuthCode(provider.id, start.session_id, code.trim(), scope.profile)
 
     if (resp.ok && resp.status === 'approved') {
-      setFlow({ status: 'success', provider })
-      await completeWithModelConfirm(ctx, provider.name, [provider.id], reason =>
-        setFlow({
-          status: 'error',
-          provider,
-          message: providerResolutionFailure(reason)
-        })
+      if (profileIsActive(scope)) {
+        setFlow({ status: 'success', provider, ...scope })
+      }
+
+      await completeWithModelConfirm(
+        ctx,
+        provider.name,
+        [provider.id],
+        reason =>
+          setFlow({
+            status: 'error',
+            provider,
+            message: providerResolutionFailure(reason),
+            ...scope
+          }),
+        scope
       )
     } else {
-      setFlow({ status: 'error', provider, start, message: resp.message || 'Token exchange failed.' })
+      if (profileIsActive(scope)) {
+        setFlow({ status: 'error', provider, start, message: resp.message || 'Token exchange failed.', ...scope })
+      }
     }
   } catch (error) {
-    setFlow({ status: 'error', provider, start, message: errMessage(error) })
+    if (profileIsActive(scope)) {
+      setFlow({ status: 'error', provider, start, message: errMessage(error), ...scope })
+    }
   }
 }
 
 export function cancelOnboardingFlow() {
   clearPoll()
-  const sessionId = sessionIdFor($desktopOnboarding.get().flow)
+  const flow = $desktopOnboarding.get().flow
+  const sessionId = sessionIdFor(flow)
 
   if (sessionId) {
-    cancelOAuthSession(sessionId).catch(() => undefined)
+    cancelOAuthSession(sessionId, 'profile' in flow ? flow.profile : undefined).catch(() => undefined)
   }
 
   setFlow({ status: 'idle' })
@@ -721,15 +836,22 @@ export async function recheckExternalSignin(ctx: OnboardingContext) {
     return
   }
 
-  const { provider } = flow
-  await completeWithModelConfirm(ctx, provider.name, [provider.id], reason =>
-    setFlow({
-      status: 'error',
-      provider,
-      message:
-        reason?.trim() ||
-        `Hermes still cannot reach ${provider.name}. Run \`${provider.cli_command}\` in a terminal first.`
-    })
+  const { provider, profile, requireProfileIdentity } = flow
+  const scope = { profile, requireProfileIdentity }
+  await completeWithModelConfirm(
+    ctx,
+    provider.name,
+    [provider.id],
+    reason =>
+      setFlow({
+        status: 'error',
+        provider,
+        message:
+          reason?.trim() ||
+          `Hermes still cannot reach ${provider.name}. Run \`${provider.cli_command}\` in a terminal first.`,
+        ...scope
+      }),
+    scope
   )
 }
 
@@ -744,6 +866,7 @@ export async function saveOnboardingApiKey(
   endpointApiKey?: string
 ) {
   const trimmed = value.trim()
+  const scope = activeOnboardingScope()
 
   if (!trimmed) {
     return { ok: false, message: 'Enter a value first.' }
@@ -763,7 +886,7 @@ export async function saveOnboardingApiKey(
   // provider probes, self-hosted endpoints). We now save the value as-is and
   // let the user proceed; an actually-bad key surfaces later at chat time.
   try {
-    await setEnvVar(envKey, trimmed)
+    await setEnvVar(envKey, trimmed, scope.profile)
     // For API-key flows we don't have a definitive provider id (the
     // user picked which API key they're entering, but the corresponding
     // backend slug — e.g. OPENROUTER_API_KEY → "openrouter" — is the
@@ -772,7 +895,7 @@ export async function saveOnboardingApiKey(
     // provider returned by /api/model/options if none match.
     const slugCandidates = [envKey.replace(/_API_KEY$/, '').toLowerCase(), label.toLowerCase()]
     // ignoreRuntimeGate=true: never block onboarding on the runtime check.
-    await completeWithModelConfirm(ctx, label, slugCandidates, () => undefined, true)
+    await completeWithModelConfirm(ctx, label, slugCandidates, () => undefined, scope, true)
 
     return { ok: true }
   } catch (error) {
@@ -801,6 +924,7 @@ export async function saveOnboardingApiKey(
 export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: string, ctx: OnboardingContext) {
   const url = baseUrl.trim()
   const key = apiKey.trim()
+  const scope = activeOnboardingScope()
 
   if (!url) {
     return { ok: false, message: 'Enter the endpoint URL first.' }
@@ -812,7 +936,7 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
   let model = ''
 
   try {
-    const probe = await validateProviderCredential('OPENAI_BASE_URL', url, key)
+    const probe = await validateProviderCredential('OPENAI_BASE_URL', url, key, scope.profile)
 
     if (!probe.ok && probe.reachable) {
       return { ok: false, message: probe.message || 'Could not reach that endpoint.' }
@@ -835,10 +959,13 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
   }
 
   try {
-    await setModelAssignment({ scope: 'main', provider: 'custom', model, base_url: url, api_key: key })
-    await ctx.requestGateway('reload.env').catch(() => undefined)
+    await setModelAssignment({ scope: 'main', provider: 'custom', model, base_url: url, api_key: key }, scope.profile)
 
-    const runtime = await checkRuntime(ctx)
+    if (!scope.requireProfileIdentity) {
+      await ctx.requestGateway('reload.env').catch(() => undefined)
+    }
+
+    const runtime = await checkRuntime(ctx, undefined, scope)
 
     if (!runtime.ready) {
       const detail = (runtime.reason ?? '').trim()
@@ -846,9 +973,11 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
       return { ok: false, message: detail || `Saved, but Hermes still cannot reach ${url}.` }
     }
 
-    notifyReady('Local / custom endpoint')
-    completeDesktopOnboarding()
-    ctx.onCompleted?.()
+    if (profileIsActive(scope)) {
+      notifyReady('Local / custom endpoint')
+      completeDesktopOnboarding()
+      ctx.onCompleted?.()
+    }
 
     return { ok: true }
   } catch (error) {
@@ -872,21 +1001,24 @@ export async function setOnboardingModel(model: string) {
   setFlow({ ...flow, currentModel: model, saving: true })
 
   try {
-    await setModelAssignment({
-      scope: 'main',
-      provider: flow.providerSlug,
-      model
-    })
+    await setModelAssignment(
+      {
+        scope: 'main',
+        provider: flow.providerSlug,
+        model
+      },
+      flow.profile
+    )
     const current = $desktopOnboarding.get().flow
 
-    if (current.status === 'confirming_model') {
+    if (current.status === 'confirming_model' && current.profile === flow.profile && profileIsActive(flow)) {
       setFlow({ ...current, currentModel: model, saving: false })
     }
   } catch (error) {
     notifyError(error, 'Could not change model')
     const current = $desktopOnboarding.get().flow
 
-    if (current.status === 'confirming_model') {
+    if (current.status === 'confirming_model' && current.profile === flow.profile && profileIsActive(flow)) {
       setFlow({ ...current, currentModel: previous, saving: false })
     }
   }
@@ -900,6 +1032,10 @@ export function confirmOnboardingModel(ctx: OnboardingContext) {
   const { flow } = $desktopOnboarding.get()
 
   if (flow.status !== 'confirming_model') {
+    return
+  }
+
+  if (!profileIsActive(flow)) {
     return
   }
 

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -120,7 +120,7 @@ describe('reportBackendContract', () => {
   })
 
   it('dismisses the toast when the backend meets the contract', () => {
-    reportBackendContract(3)
+    reportBackendContract(4)
     expect(dismissSpy).toHaveBeenCalledWith('backend-contract-skew')
     expect(notifySpy).not.toHaveBeenCalled()
   })
@@ -128,7 +128,7 @@ describe('reportBackendContract', () => {
   it('warns when the backend is behind (or reports no contract)', () => {
     reportBackendContract(undefined)
     expect(notifySpy).toHaveBeenCalledTimes(1)
-    reportBackendContract(1)
+    reportBackendContract(3)
     expect(notifySpy).toHaveBeenCalledTimes(2)
   })
 
@@ -160,8 +160,8 @@ describe('reportBackendContract', () => {
     lastToast().onDismiss()
     notifySpy.mockClear()
 
-    reportBackendContract(3) // backend updated → satisfied, snooze cleared
-    reportBackendContract(2) // a later regression must warn immediately
+    reportBackendContract(4) // backend updated → satisfied, snooze cleared
+    reportBackendContract(3) // a later regression must warn immediately
     expect(notifySpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -92,7 +92,8 @@ function isUpdateToastSnoozed(): boolean {
 // value (or none — a pre-GUI checkout) means GUI<->backend skew.
 // v2: requires the file.attach RPC (remote-gateway non-image file upload).
 // v3: requires approvals.mode config RPCs and session.info reconciliation.
-const REQUIRED_BACKEND_CONTRACT = 3
+// v4: requires profile-scoped provider readiness with response identity.
+const REQUIRED_BACKEND_CONTRACT = 4
 const SKEW_TOAST_ID = 'backend-contract-skew'
 // The contract check runs on every session.resume (applyRuntimeInfo), so
 // without a snooze the warning re-popped on every thread the user opened, even

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -51,9 +51,16 @@ from hermes_cli.config import (
 )
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
+from agent.secret_scope import get_secret as _get_secret
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
 
 logger = logging.getLogger(__name__)
+
+
+def _getenv(name: str, default: str = "") -> str:
+    """Read provider configuration through the active profile secret scope."""
+    value = _get_secret(name, default)
+    return value if value is not None else default
 
 try:
     import fcntl
@@ -1615,7 +1622,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
         for env_var in pconfig.api_key_env_vars:
             if env_var in _IMPLICIT_ENV_VARS:
                 continue
-            if has_usable_secret(os.getenv(env_var, "")):
+            if has_usable_secret(_getenv(env_var, "")):
                 return True
 
     # 4. Check persisted credential-pool entries that came from EXPLICIT flows
@@ -1634,7 +1641,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
                 # the user deletes the env var (#55790) — only count it when
                 # the referenced var still resolves to a usable secret NOW.
                 env_var = entry.get("source", "").split(":", 1)[1].strip()
-                if env_var and has_usable_secret(os.getenv(env_var, "")):
+                if env_var and has_usable_secret(_getenv(env_var, "")):
                     return True
                 continue
             if (
@@ -1841,7 +1848,9 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
 
-    if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
+    if has_usable_secret(_getenv("OPENAI_API_KEY")) or has_usable_secret(
+        _getenv("OPENROUTER_API_KEY")
+    ):
         return "openrouter"
 
     # Auto-detect an OpenRouter credential added via `hermes auth add openrouter`
@@ -1884,7 +1893,7 @@ def resolve_provider(
         if pid in {"copilot", "lmstudio"}:
             continue
         for env_var in pconfig.api_key_env_vars:
-            if has_usable_secret(os.getenv(env_var, "")):
+            if has_usable_secret(_getenv(env_var, "")):
                 # An exported API key now wins over a logged-in OAuth provider
                 # (the #29285 fix). Surface that so a user who deliberately uses
                 # OAuth but has a stale key in ~/.hermes/.env isn't silently
@@ -2075,7 +2084,7 @@ def _nous_inference_env_override() -> Optional[str]:
     Returns a trailing-slash-stripped non-empty string, or ``None`` when
     the env var is unset/blank.
     """
-    return _optional_base_url(os.getenv("NOUS_INFERENCE_BASE_URL"))
+    return _optional_base_url(_getenv("NOUS_INFERENCE_BASE_URL"))
 
 
 def _nous_portal_env_override() -> Optional[str]:
@@ -2096,7 +2105,7 @@ def _nous_portal_env_override() -> Optional[str]:
     neither env var is set/blank.
     """
     return _optional_base_url(
-        os.getenv("HERMES_PORTAL_BASE_URL") or os.getenv("NOUS_PORTAL_BASE_URL")
+        _getenv("HERMES_PORTAL_BASE_URL") or _getenv("NOUS_PORTAL_BASE_URL")
     )
 
 
@@ -2480,7 +2489,7 @@ def resolve_qwen_runtime_credentials(
             code="qwen_access_token_missing",
         )
 
-    base_url = os.getenv("HERMES_QWEN_BASE_URL", "").strip().rstrip("/") or DEFAULT_QWEN_BASE_URL
+    base_url = _getenv("HERMES_QWEN_BASE_URL", "").strip().rstrip("/") or DEFAULT_QWEN_BASE_URL
     return {
         "provider": "qwen-oauth",
         "base_url": base_url,
@@ -3761,7 +3770,7 @@ def resolve_codex_runtime_credentials(
         pool_token = _pool_codex_access_token()
         if pool_token:
             base_url = (
-                os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+                _getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
                 or DEFAULT_CODEX_BASE_URL
             )
             return {
@@ -3824,7 +3833,7 @@ def resolve_codex_runtime_credentials(
                 access_token = str(tokens.get("access_token", "") or "").strip()
 
     base_url = (
-        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        _getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
         or DEFAULT_CODEX_BASE_URL
     )
 
@@ -4551,8 +4560,8 @@ def resolve_xai_oauth_runtime_credentials(
                     raise
 
     base_url = _xai_validate_inference_base_url(
-        os.getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
-        or os.getenv("XAI_BASE_URL", "").strip().rstrip("/"),
+        _getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
+        or _getenv("XAI_BASE_URL", "").strip().rstrip("/"),
         fallback=DEFAULT_XAI_OAUTH_BASE_URL,
     )
     return {
@@ -5675,8 +5684,8 @@ def resolve_nous_runtime_credentials(
             """Resolve every routing value that shared OAuth state can replace."""
             portal_url = (
                 _optional_base_url(state.get("portal_base_url"))
-                or os.getenv("HERMES_PORTAL_BASE_URL")
-                or os.getenv("NOUS_PORTAL_BASE_URL")
+                or _getenv("HERMES_PORTAL_BASE_URL")
+                or _getenv("NOUS_PORTAL_BASE_URL")
                 or DEFAULT_NOUS_PORTAL_URL
             ).rstrip("/")
 
@@ -6357,7 +6366,7 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        env_url = _getenv(pconfig.base_url_env_var, "").strip()
 
     if provider_id in {"kimi-coding", "kimi-coding-cn"}:
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -6383,13 +6392,13 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
         return {"configured": False}
 
     command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
+        _getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+        or _getenv("COPILOT_CLI_PATH", "").strip()
         or "copilot"
     )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+    raw_args = _getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = _getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -6513,7 +6522,7 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
     try:
         api_key = get_env_value_prefer_dotenv("AZURE_FOUNDRY_API_KEY") or ""
     except Exception:
-        api_key = os.getenv("AZURE_FOUNDRY_API_KEY", "")
+        api_key = _getenv("AZURE_FOUNDRY_API_KEY", "")
     info["logged_in"] = has_usable_secret(api_key)
     return info
 
@@ -6544,7 +6553,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        env_url = _getenv(pconfig.base_url_env_var, "").strip()
 
     if provider_id in {"kimi-coding", "kimi-coding-cn"}:
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -6602,16 +6611,16 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = _getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
     command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
+        _getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+        or _getenv("COPILOT_CLI_PATH", "").strip()
         or "copilot"
     )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+    raw_args = _getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
@@ -7075,7 +7084,7 @@ def _login_openai_codex(
                 do_import = "n"
             if do_import in {"y", "yes"}:
                 _save_codex_tokens(cli_tokens)
-                base_url = os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/") or DEFAULT_CODEX_BASE_URL
+                base_url = _getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/") or DEFAULT_CODEX_BASE_URL
                 config_path = _update_config_for_provider("openai-codex", base_url)
                 print()
                 print("Credentials imported. Note: if Codex CLI refreshes its token,")
@@ -7334,8 +7343,8 @@ def _xai_oauth_device_code_login(
             code="xai_device_token_invalid",
         )
     base_url = _xai_validate_inference_base_url(
-        os.getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
-        or os.getenv("XAI_BASE_URL", "").strip().rstrip("/"),
+        _getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
+        or _getenv("XAI_BASE_URL", "").strip().rstrip("/"),
         fallback=DEFAULT_XAI_OAUTH_BASE_URL,
     )
     return {
@@ -7537,7 +7546,7 @@ def _codex_device_code_login() -> Dict[str, Any]:
 
     # Return tokens for the caller to persist (no longer writes to ~/.codex/)
     base_url = (
-        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        _getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
         or DEFAULT_CODEX_BASE_URL
     )
 
@@ -8001,13 +8010,13 @@ def _nous_device_code_login(
     pconfig = PROVIDER_REGISTRY["nous"]
     portal_base_url = (
         portal_base_url
-        or os.getenv("HERMES_PORTAL_BASE_URL")
-        or os.getenv("NOUS_PORTAL_BASE_URL")
+        or _getenv("HERMES_PORTAL_BASE_URL")
+        or _getenv("NOUS_PORTAL_BASE_URL")
         or pconfig.portal_base_url
     ).rstrip("/")
     requested_inference_url = (
         inference_base_url
-        or os.getenv("NOUS_INFERENCE_BASE_URL")
+        or _getenv("NOUS_INFERENCE_BASE_URL")
         or pconfig.inference_base_url
     ).rstrip("/")
     client_id = client_id or pconfig.client_id
@@ -8436,7 +8445,7 @@ def logout_command(args) -> None:
         if should_reset_config:
             _reset_config_provider()
         print(f"Logged out of {provider_name}.")
-        if should_reset_config and os.getenv("OPENROUTER_API_KEY"):
+        if should_reset_config and _getenv("OPENROUTER_API_KEY"):
             print("Hermes will use OpenRouter for inference.")
         elif should_reset_config:
             print("Run `hermes model` or configure an API key to use Hermes.")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7901,6 +7901,33 @@ def _env_line_defines_key(line: str, key: str) -> bool:
     return stripped.startswith(f"{key}=")
 
 
+def _using_foreign_hermes_home() -> bool:
+    """Return whether this context targets a non-launch Hermes home."""
+    try:
+        return get_hermes_home().resolve() != get_process_hermes_home().resolve()
+    except OSError:
+        return os.path.abspath(str(get_hermes_home())) != os.path.abspath(
+            str(get_process_hermes_home())
+        )
+
+
+def _update_scoped_secret(key: str, value: Optional[str]) -> None:
+    """Keep a mutable request-local secret snapshot coherent after a write."""
+    try:
+        from collections.abc import MutableMapping
+        from agent.secret_scope import current_secret_scope
+
+        scope = current_secret_scope()
+        if not isinstance(scope, MutableMapping):
+            return
+        if value is None:
+            scope.pop(key, None)
+        else:
+            scope[key] = value
+    except ImportError:
+        pass
+
+
 def save_env_value(key: str, value: str):
     """Save or update a value in ~/.hermes/.env."""
     if is_managed():
@@ -7991,7 +8018,10 @@ def save_env_value(key: str, value: str):
             pass
         raise
 
-    os.environ[key] = value
+    if _using_foreign_hermes_home():
+        _update_scoped_secret(key, value)
+    else:
+        os.environ[key] = value
     invalidate_env_cache()
 
 
@@ -8019,7 +8049,10 @@ def remove_env_value(key: str) -> bool:
         raise ValueError(f"Invalid environment variable name: {key!r}")
     env_path = get_env_path()
     if not env_path.exists():
-        os.environ.pop(key, None)
+        if _using_foreign_hermes_home():
+            _update_scoped_secret(key, None)
+        else:
+            os.environ.pop(key, None)
         return False
 
     read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
@@ -8063,7 +8096,10 @@ def remove_env_value(key: str) -> bool:
                 pass
             raise
 
-    os.environ.pop(key, None)
+    if _using_foreign_hermes_home():
+        _update_scoped_secret(key, None)
+    else:
+        os.environ.pop(key, None)
     invalidate_env_cache()
     return found
 
@@ -8112,6 +8148,11 @@ def reload_env() -> int:
     _EXTRA_ENV_KEYS — to avoid clobbering unrelated environment).
     """
     env_vars = load_env()
+    if _using_foreign_hermes_home():
+        # A multiplexed process cannot copy one profile's .env into the
+        # process environment. Profile-aware callers rebuild or update their
+        # request-local secret scope instead.
+        return 0
     known_keys = set(OPTIONAL_ENV_VARS.keys()) | _EXTRA_ENV_KEYS
     count = 0
     for key, value in env_vars.items():
@@ -8128,6 +8169,17 @@ def reload_env() -> int:
 
 def get_env_value(key: str) -> Optional[str]:
     """Get a value from ~/.hermes/.env or environment."""
+    if _using_foreign_hermes_home():
+        try:
+            from agent.secret_scope import current_secret_scope
+
+            scope = current_secret_scope()
+            if scope is not None:
+                return scope.get(key)
+        except ImportError:
+            pass
+        return load_env().get(key)
+
     # Check environment first
     if key in os.environ:
         return os.environ[key]
@@ -8151,16 +8203,28 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
     is scope-checked rather than leaking another profile's raw ``os.environ``
     value — matching the credential-pool seeding path's behaviour.
     """
+    if _using_foreign_hermes_home():
+        env_vars = load_env()
+        try:
+            from agent.secret_scope import current_secret_scope
+
+            scope = current_secret_scope()
+        except ImportError:
+            scope = None
+        value = scope.get(key) if scope is not None else env_vars.get(key)
+        if isinstance(value, str) and value.strip().startswith("op://"):
+            return None
+        return value
+
     env_vars = load_env()
     val = env_vars.get(key)
     if val:
         return val
     try:
         from agent.secret_scope import get_secret as _get_secret
-
-        return _get_secret(key)
-    except Exception:
+    except ImportError:
         return os.environ.get(key)
+    return _get_secret(key)
 
 
 # =============================================================================

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -27,6 +27,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from agent.secret_scope import get_secret as _get_secret
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
 
 logger = logging.getLogger(__name__)
@@ -80,7 +81,7 @@ def resolve_copilot_token() -> tuple[str, str]:
     """
     # 1. Check env vars in priority order
     for env_var in COPILOT_ENV_VARS:
-        val = os.getenv(env_var, "").strip()
+        val = (_get_secret(env_var, "") or "").strip()
         if val:
             valid, msg = validate_copilot_token(val)
             if not valid:

--- a/hermes_cli/credential_lifecycle.py
+++ b/hermes_cli/credential_lifecycle.py
@@ -245,9 +245,10 @@ def save_provider_env_credential(env_var: str, value: str) -> Dict[str, Any]:
 def remove_provider_env_credential(env_var: str) -> Dict[str, Any]:
     """Remove a credential from EVERY store it lives in.
 
-    Clears the ``.env`` entry (and process env), prunes env-seeded
-    ``credential_pool`` entries, drops the affected providers' model-cache
-    rows, and removes any config.yaml mirror holding the same value.
+    Clears the ``.env`` entry, prunes env-seeded ``credential_pool`` entries,
+    drops the affected providers' model-cache rows, and removes any config.yaml
+    mirror holding the same value. Launch-profile calls also clear process env;
+    foreign-profile calls update only their request-local secret scope.
     OAuth/device-code/manual credentials are preserved (see module docstring).
 
     ``found`` is True when ANY store held the credential — callers that

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -823,6 +823,7 @@ def _has_any_provider_configured() -> bool:
     # OPENAI_BASE_URL alone counts — local models (vLLM, llama.cpp, etc.)
     # often don't require an API key.
     from hermes_cli.auth import PROVIDER_REGISTRY
+    from agent.secret_scope import get_secret
 
     # Collect all provider env vars
     provider_env_vars = {
@@ -835,7 +836,7 @@ def _has_any_provider_configured() -> bool:
     for pconfig in PROVIDER_REGISTRY.values():
         if pconfig.auth_type == "api_key":
             provider_env_vars.update(pconfig.api_key_env_vars)
-    if any(os.getenv(v) for v in provider_env_vars):
+    if any(get_secret(v) for v in provider_env_vars):
         return True
 
     # Check .env file for keys

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -885,7 +885,7 @@ def canonical_custom_identity(
         except Exception:
             candidate = ""
     if not candidate:
-        candidate = os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip()
+        candidate = _getenv("HERMES_INFERENCE_PROVIDER", "").strip()
 
     candidate_norm = _normalize_custom_provider_name(candidate)
     # A bare/non-routable candidate cannot heal a bare custom override.
@@ -1330,8 +1330,9 @@ def _resolve_azure_foundry_runtime(
     api_key = explicit_api_key
     if not api_key:
         try:
-            from hermes_cli.config import get_env_value
-            api_key = get_env_value("AZURE_FOUNDRY_API_KEY") or ""
+            from hermes_cli.config import get_env_value_prefer_dotenv
+
+            api_key = get_env_value_prefer_dotenv("AZURE_FOUNDRY_API_KEY") or ""
         except Exception:
             api_key = ""
     if not api_key:
@@ -1982,6 +1983,9 @@ def resolve_runtime_provider(
         # credentials from session"). Route these users through the Converse
         # API regardless of model. Ref: #28156.
         _current_model = str(target_model or model_cfg.get("default") or "").strip()
+        # Bedrock currently executes through boto3's process credential chain;
+        # keep this routing decision at the same machine-global scope until the
+        # adapter can accept an explicit profile-scoped boto3 Session.
         _has_bearer_token = bool(os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip())
         if is_anthropic_bedrock_model(_current_model) and not _has_bearer_token:
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6111,7 +6111,9 @@ def get_model_options(
 
 
 @app.get("/api/model/recommended-default")
-def get_recommended_default_model(provider: str = ""):
+def get_recommended_default_model(
+    provider: str = "", profile: Optional[str] = None
+):
     """Return the recommended default model for a freshly-authenticated provider.
 
     Mirrors the model-curation `hermes model` does so GUI onboarding lands on a
@@ -6123,7 +6125,16 @@ def get_recommended_default_model(provider: str = ""):
     Response: {"provider": str, "model": str, "free_tier": bool | None}
     where free_tier is True/False for Nous and None otherwise. `model` may be
     empty if nothing could be resolved (caller degrades gracefully).
+
+    ``profile`` binds auth, tier, config, and model discovery to the same
+    profile that onboarding just authenticated and will update.
     """
+    with _profile_scope(profile):
+        return _recommended_default_model_payload(provider)
+
+
+def _recommended_default_model_payload(provider: str = ""):
+    """Build the recommended-model response inside the caller's profile scope."""
     slug = (provider or "").strip().lower()
 
     if slug == "nous":

--- a/tests/hermes_cli/test_profile_credential_scope.py
+++ b/tests/hermes_cli/test_profile_credential_scope.py
@@ -1,0 +1,182 @@
+"""Profile-scoped provider credentials must not inherit process-global values."""
+
+from contextlib import contextmanager
+import os
+
+from agent.secret_scope import reset_secret_scope, set_secret_scope
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@contextmanager
+def _foreign_profile_scope(home, secrets):
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    (home / ".env").write_text(
+        "".join(f"{key}={value}\n" for key, value in secrets.items()),
+        encoding="utf-8",
+    )
+    home_token = set_hermes_home_override(home)
+    secret_token = set_secret_scope(dict(secrets))
+    try:
+        yield
+    finally:
+        reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+
+
+def test_setup_status_ignores_launch_profile_provider_key(tmp_path, monkeypatch):
+    from hermes_cli.main import _has_any_provider_configured
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "launch-profile-placeholder")
+    with _foreign_profile_scope(tmp_path / "foreign", {}):
+        assert _has_any_provider_configured() is False
+
+
+def test_auto_provider_uses_profile_key_over_launch_profile_key(tmp_path, monkeypatch):
+    from hermes_cli.auth import resolve_provider
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "launch-profile-placeholder")
+    with _foreign_profile_scope(
+        tmp_path / "foreign",
+        {"ANTHROPIC_API_KEY": "profile-placeholder"},
+    ):
+        assert resolve_provider("auto") == "anthropic"
+
+
+def test_api_key_provider_base_url_uses_profile_scope(tmp_path, monkeypatch):
+    from hermes_cli.auth import resolve_api_key_provider_credentials
+
+    monkeypatch.setenv("GLM_BASE_URL", "https://launch.invalid/v1")
+    with _foreign_profile_scope(
+        tmp_path / "foreign",
+        {
+            "GLM_API_KEY": "profile-placeholder",
+            "GLM_BASE_URL": "https://profile.invalid/v1",
+        },
+    ):
+        resolved = resolve_api_key_provider_credentials("zai")
+
+    assert resolved["api_key"] == "profile-placeholder"
+    assert resolved["base_url"] == "https://profile.invalid/v1"
+
+
+def test_azure_runtime_uses_profile_key_over_launch_profile_key(tmp_path, monkeypatch):
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "launch-profile-placeholder")
+    monkeypatch.setattr(rp, "resolve_provider", lambda *args, **kwargs: "azure-foundry")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "azure-foundry",
+            "base_url": "https://profile.openai.azure.com/openai/v1",
+            "api_mode": "chat_completions",
+            "default": "gpt-4.1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
+    with _foreign_profile_scope(
+        tmp_path / "foreign",
+        {"AZURE_FOUNDRY_API_KEY": "profile-placeholder"},
+    ):
+        resolved = rp.resolve_runtime_provider(requested="azure-foundry")
+
+    assert resolved["api_key"] == "profile-placeholder"
+
+
+def test_launch_profile_save_still_updates_process_environment(monkeypatch):
+    from hermes_cli.config import save_env_value
+
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    save_env_value("FAL_KEY", "launch-profile-placeholder")
+    assert os.environ["FAL_KEY"] == "launch-profile-placeholder"
+
+
+def test_auth_getenv_keeps_launch_profile_process_environment(monkeypatch):
+    from hermes_cli.auth import _getenv
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "launch-profile-placeholder")
+    assert _getenv("OPENROUTER_API_KEY") == "launch-profile-placeholder"
+
+
+def test_profile_op_reference_does_not_seed_raw_or_launch_secret(tmp_path, monkeypatch):
+    from agent.credential_pool import _seed_from_env
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "launch-profile-placeholder")
+    with _foreign_profile_scope(
+        tmp_path / "foreign",
+        {"OPENROUTER_API_KEY": "op://Example/Item/credential"},
+    ):
+        entries = []
+        changed, active_sources = _seed_from_env("openrouter", entries)
+
+    assert changed is False
+    assert active_sources == set()
+    assert entries == []
+
+
+def test_profile_op_reference_is_not_accepted_as_runtime_api_key(tmp_path, monkeypatch):
+    from hermes_cli.auth import resolve_api_key_provider_credentials
+
+    monkeypatch.setenv("GLM_API_KEY", "launch-profile-placeholder")
+    with _foreign_profile_scope(
+        tmp_path / "foreign",
+        {"GLM_API_KEY": "op://Example/Item/credential"},
+    ):
+        resolved = resolve_api_key_provider_credentials("zai")
+
+    assert resolved["api_key"] == ""
+    assert resolved["source"] == "default"
+
+
+def test_anthropic_runtime_ignores_launch_token_for_empty_profile(tmp_path, monkeypatch):
+    from agent import anthropic_adapter as adapter
+
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "launch-profile-placeholder")
+    monkeypatch.setattr(adapter, "read_claude_code_credentials", lambda: None)
+    monkeypatch.setattr(adapter, "_resolve_anthropic_pool_token", lambda: None)
+
+    with _foreign_profile_scope(tmp_path / "foreign", {}):
+        assert adapter.resolve_anthropic_token() is None
+
+
+def test_anthropic_runtime_uses_foreign_profile_token(tmp_path, monkeypatch):
+    from agent import anthropic_adapter as adapter
+
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "launch-profile-placeholder")
+    monkeypatch.setattr(adapter, "read_claude_code_credentials", lambda: None)
+    monkeypatch.setattr(adapter, "_resolve_anthropic_pool_token", lambda: None)
+
+    with _foreign_profile_scope(
+        tmp_path / "foreign",
+        {"ANTHROPIC_TOKEN": "profile-placeholder"},
+    ):
+        assert adapter.resolve_anthropic_token() == "profile-placeholder"
+
+
+def test_copilot_runtime_ignores_launch_token_for_empty_profile(tmp_path, monkeypatch):
+    from hermes_cli import copilot_auth
+
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_launch_profile_placeholder")
+    monkeypatch.setattr(copilot_auth, "_try_gh_cli_token", lambda: None)
+
+    with _foreign_profile_scope(tmp_path / "foreign", {}):
+        assert copilot_auth.resolve_copilot_token() == ("", "")
+
+
+def test_copilot_runtime_uses_foreign_profile_token(tmp_path, monkeypatch):
+    from hermes_cli import copilot_auth
+
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_launch_profile_placeholder")
+    monkeypatch.setattr(copilot_auth, "_try_gh_cli_token", lambda: None)
+
+    with _foreign_profile_scope(
+        tmp_path / "foreign",
+        {"COPILOT_GITHUB_TOKEN": "gho_profile_placeholder"},
+    ):
+        assert copilot_auth.resolve_copilot_token() == (
+            "gho_profile_placeholder",
+            "COPILOT_GITHUB_TOKEN",
+        )

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -22,6 +22,7 @@ These tests pin the corrected behavior.
 import asyncio
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 import httpx
@@ -336,6 +337,98 @@ def test_codex_dashboard_worker_persists_inside_session_profile(tmp_path, monkey
 
         assert ws._oauth_sessions[sid]["status"] == "approved"
         assert saved_homes == [profile_home]
+    finally:
+        ws._oauth_sessions.pop(sid, None)
+
+
+def test_codex_profile_oauth_is_ready_through_profile_scoped_gateway(tmp_path, monkeypatch):
+    """A named-profile OAuth success must be usable by the readiness RPCs."""
+    default_home = tmp_path / ".hermes"
+    profile_home = default_home / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    from hermes_cli import web_server as ws
+    from tui_gateway import server
+
+    class _Resp:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, url, **kwargs):
+            if url.endswith("/deviceauth/usercode"):
+                return _Resp(
+                    200,
+                    {
+                        "device_auth_id": "synthetic-device-auth-id",
+                        "interval": 3,
+                        "user_code": "TEST-ONLY",
+                    },
+                )
+            if url.endswith("/deviceauth/token"):
+                return _Resp(
+                    200,
+                    {
+                        "authorization_code": "synthetic-authorization-code",
+                        "code_verifier": "synthetic-code-verifier",
+                    },
+                )
+            return _Resp(
+                200,
+                {
+                    "access_token": "h.eyJleHAiOjk5OTk5OTk5OTl9.synthetic",
+                    "refresh_token": "synthetic-refresh-value",
+                },
+            )
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+    monkeypatch.setattr(ws.time, "sleep", lambda _: None)
+
+    sid, _ = ws._new_oauth_session(
+        "openai-codex",
+        "device_code",
+        profile="coder",
+    )
+    try:
+        ws._codex_full_login_worker(sid)
+        assert ws._oauth_sessions[sid]["status"] == "approved"
+
+        setup = server.handle_request(
+            {
+                "id": "setup",
+                "method": "setup.status",
+                "params": {"profile": "coder"},
+            }
+        )
+        runtime = server.handle_request(
+            {
+                "id": "runtime",
+                "method": "setup.runtime_check",
+                "params": {
+                    "profile": "coder",
+                    "provider": "openai-codex",
+                },
+            }
+        )
+
+        assert setup["result"]["provider_configured"] is True
+        assert runtime["result"]["ok"] is True
+        assert runtime["result"]["provider"] == "openai-codex"
     finally:
         ws._oauth_sessions.pop(sid, None)
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4253,6 +4253,49 @@ class TestWebServerEndpoints:
         assert data["model"] == "top/model"
         assert data["free_tier"] is False
 
+    def test_recommended_default_uses_requested_profile_scope(self, monkeypatch):
+        """Tier/auth lookup must use the profile onboarding authenticated."""
+        from hermes_constants import get_hermes_home
+        import hermes_cli.models as models_mod
+
+        profile_home = get_hermes_home() / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+        seen_homes = []
+
+        monkeypatch.setattr(
+            models_mod,
+            "get_curated_nous_model_ids",
+            lambda: ["free/profile-model"],
+        )
+        monkeypatch.setattr(
+            models_mod, "get_pricing_for_provider", lambda provider: {}
+        )
+        monkeypatch.setattr(
+            models_mod,
+            "check_nous_free_tier",
+            lambda *, force_fresh=False: seen_homes.append(get_hermes_home())
+            or True,
+        )
+        monkeypatch.setattr(
+            models_mod,
+            "union_with_portal_free_recommendations",
+            lambda ids, pricing, url: (ids, pricing),
+        )
+        monkeypatch.setattr(
+            models_mod,
+            "partition_nous_models_by_tier",
+            lambda ids, pricing, free_tier: (ids, []),
+        )
+
+        resp = self.client.get(
+            "/api/model/recommended-default?provider=nous&profile=coder"
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "free/profile-model"
+        assert seen_homes == [profile_home]
+
     def test_recommended_default_handles_failure_gracefully(self, monkeypatch):
         """Endpoint never 500s — returns empty model on internal error."""
         import hermes_cli.models as models_mod

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -6,6 +6,8 @@ profile switcher can target any profile's HERMES_HOME. These tests pin:
 reads/writes land in the REQUESTED profile, the dashboard's own profile
 stays untouched, and the chat PTY env is scoped via HERMES_HOME.
 """
+import os
+
 import pytest
 import yaml
 
@@ -108,7 +110,10 @@ class TestProfileScopedConfig:
 
 
 class TestProfileScopedEnv:
-    def test_env_set_lands_in_target_profile_only(self, client, isolated_profiles):
+    def test_env_set_lands_in_target_profile_only(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        monkeypatch.setenv("FAL_KEY", "launch-profile-value")
         resp = client.put(
             "/api/env",
             json={"key": "FAL_KEY", "value": "test-fal-123", "profile": "worker_beta"},
@@ -119,6 +124,7 @@ class TestProfileScopedEnv:
         default_env_path = isolated_profiles["default"] / ".env"
         if default_env_path.exists():
             assert "test-fal-123" not in default_env_path.read_text()
+        assert os.environ["FAL_KEY"] == "launch-profile-value"
 
     def test_env_list_reads_target_profile(self, client, isolated_profiles):
         (isolated_profiles["worker_beta"] / ".env").write_text(
@@ -130,7 +136,8 @@ class TestProfileScopedEnv:
         resp = client.get("/api/env")
         assert resp.json()["FAL_KEY"]["is_set"] is False
 
-    def test_env_delete_scoped(self, client, isolated_profiles):
+    def test_env_delete_scoped(self, client, isolated_profiles, monkeypatch):
+        monkeypatch.setenv("FAL_KEY", "launch-profile-value")
         (isolated_profiles["worker_beta"] / ".env").write_text(
             "FAL_KEY=doomed\n", encoding="utf-8"
         )
@@ -141,6 +148,7 @@ class TestProfileScopedEnv:
         )
         assert resp.status_code == 200
         assert "doomed" not in (isolated_profiles["worker_beta"] / ".env").read_text()
+        assert os.environ["FAL_KEY"] == "launch-profile-value"
 
 
 class TestProfileScopedMcp:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3973,8 +3973,8 @@ def test_config_set_approval_mode_persists_three_way_value_and_emits_live_status
     assert emitted[0][2]["approval_mode"] == "manual"
 
 
-def test_desktop_contract_includes_approval_mode_rpc():
-    assert server.DESKTOP_BACKEND_CONTRACT >= 3
+def test_desktop_contract_includes_profile_scoped_provider_readiness():
+    assert server.DESKTOP_BACKEND_CONTRACT >= 4
 
 
 def test_config_set_approval_mode_rejects_unknown_value():
@@ -4448,6 +4448,110 @@ def test_setup_status_reports_provider_config(monkeypatch):
     assert resp["result"]["provider_configured"] is False
 
 
+def _provider_profile_homes(monkeypatch, tmp_path, *, launch: str = "default"):
+    """Build an isolated default + named-profile layout for readiness RPCs."""
+    from hermes_cli import profiles as profiles_mod
+
+    default_home = tmp_path / ".hermes"
+    coder_home = default_home / "profiles" / "coder"
+    coder_home.mkdir(parents=True)
+    (default_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    (coder_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(profiles_mod, "_get_default_hermes_home", lambda: default_home)
+    monkeypatch.setattr(profiles_mod, "_get_profiles_root", lambda: default_home / "profiles")
+    monkeypatch.setattr(
+        server,
+        "_hermes_home",
+        coder_home if launch == "coder" else default_home,
+    )
+    return default_home, coder_home
+
+
+def test_setup_status_explicit_default_scopes_away_from_named_launch(
+    monkeypatch, tmp_path
+):
+    """Literal default must mean the root profile, not the gateway launch profile."""
+    from hermes_constants import get_hermes_home, get_hermes_home_override
+
+    default_home, _ = _provider_profile_homes(monkeypatch, tmp_path, launch="coder")
+    seen = []
+    monkeypatch.setattr(
+        "hermes_cli.main._has_any_provider_configured",
+        lambda: seen.append(get_hermes_home()) or True,
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "setup.status", "params": {"profile": "default"}}
+    )
+
+    assert resp["result"]["provider_configured"] is True
+    assert resp["result"]["profile_name"] == "default"
+    assert seen == [default_home]
+    assert get_hermes_home_override() is None
+
+
+def test_setup_status_echoes_explicit_named_profile(monkeypatch, tmp_path):
+    """Readiness results identify the profile whose credentials were inspected."""
+    _provider_profile_homes(monkeypatch, tmp_path)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "setup.status", "params": {"profile": "coder"}}
+    )
+
+    assert resp["result"] == {
+        "provider_configured": True,
+        "profile_name": "coder",
+    }
+
+
+@pytest.mark.parametrize("profile", ["../../escaped", "Bad Name!"])
+def test_setup_status_rejects_invalid_profile_without_using_launch_credentials(
+    monkeypatch, tmp_path, profile
+):
+    """Invalid profile input is an RPC error, never a launch-profile fallback."""
+    default_home, _ = _provider_profile_homes(monkeypatch, tmp_path)
+    # Prove traversal fails closed even when the old joined path would exist.
+    (default_home.parent / "escaped").mkdir(exist_ok=True)
+    calls = {"n": 0}
+
+    def _configured():
+        calls["n"] += 1
+        return True
+
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", _configured)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "setup.status", "params": {"profile": profile}}
+    )
+
+    assert resp["error"]["code"] == 4002
+    assert calls["n"] == 0
+
+
+def test_setup_status_rejects_missing_profile_without_using_launch_credentials(
+    monkeypatch, tmp_path
+):
+    """A valid-but-unknown profile must not silently inspect the launch profile."""
+    _provider_profile_homes(monkeypatch, tmp_path)
+    calls = {"n": 0}
+
+    def _configured():
+        calls["n"] += 1
+        return True
+
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", _configured)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "setup.status", "params": {"profile": "ghost"}}
+    )
+
+    assert resp["error"]["code"] == 4044
+    assert "ghost" in resp["error"]["message"]
+    assert calls["n"] == 0
+
+
 def test_setup_runtime_check_rejects_empty_runtime_key(monkeypatch):
     monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
     monkeypatch.setattr(
@@ -4480,6 +4584,37 @@ def test_setup_runtime_check_allows_no_key_custom_runtime(monkeypatch):
 
     assert resp["result"]["ok"] is True
     assert resp["result"]["provider"] == "custom"
+
+
+@pytest.mark.parametrize(
+    ("api_key", "expected_ok"),
+    [("", False), ("no-key-required", True)],
+)
+def test_setup_runtime_check_echoes_profile_for_ready_and_not_ready_results(
+    monkeypatch, tmp_path, api_key, expected_ok
+):
+    """Both successful JSON-RPC result shapes carry the resolved profile identity."""
+    _provider_profile_homes(monkeypatch, tmp_path)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None: {
+            "provider": "custom",
+            "api_key": api_key,
+            "source": "env/config",
+        },
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "setup.runtime_check",
+            "params": {"profile": "coder"},
+        }
+    )
+
+    assert resp["result"]["ok"] is expected_ok
+    assert resp["result"]["profile_name"] == "coder"
 
 
 def test_setup_runtime_check_rejects_implicit_bedrock_when_unconfigured(monkeypatch):
@@ -9196,6 +9331,29 @@ def test_reload_env_rpc_calls_hermes_cli_reload_env(monkeypatch):
 
     assert resp["result"] == {"updated": 7}
     assert calls["n"] == 1
+
+
+def test_reload_env_named_profile_does_not_mutate_process_env(monkeypatch, tmp_path):
+    """Named-profile reloads use the isolated request scope, not os.environ."""
+    _, profile_home = _provider_profile_homes(monkeypatch, tmp_path)
+    calls = {"n": 0}
+
+    def _fake_reload():
+        calls["n"] += 1
+        return 7
+
+    fake = types.SimpleNamespace(reload_env=_fake_reload)
+    with patch.dict(sys.modules, {"hermes_cli.config": fake}):
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "reload.env",
+                "params": {"profile": "coder"},
+            }
+        )
+
+    assert resp["result"] == {"updated": 0, "profile_name": "coder"}
+    assert calls["n"] == 0
 
 
 def test_reload_env_rpc_surfaces_errors(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1087,6 +1087,95 @@ def _profile_scoped(handler):
     return wrapper
 
 
+def _provider_profile_home(profile: object) -> Path | None:
+    """Strictly resolve provider RPC scope, or raise for invalid/missing input.
+
+    ``None`` means only one thing here: use the gateway's launch profile.  The
+    permissive ``_profile_home`` helper also returns ``None`` for malformed and
+    unknown names, which is appropriate for its legacy consumers but would let
+    readiness checks silently inspect the launch profile's credentials.
+    """
+    if profile is None:
+        return None
+    if not isinstance(profile, str):
+        raise ValueError("profile must be a string")
+
+    requested = profile.strip()
+    if not requested:
+        return None
+
+    from hermes_cli import profiles as profiles_mod
+
+    canon = profiles_mod.normalize_profile_name(requested)
+    profiles_mod.validate_profile_name(canon)
+    if not profiles_mod.profile_exists(canon):
+        raise FileNotFoundError(f"Profile {canon!r} does not exist.")
+
+    home = Path(profiles_mod.get_profile_dir(canon))
+    if home.resolve() == Path(_hermes_home).resolve():
+        return None
+    return home
+
+
+def _profile_provider_scoped(handler):
+    """Bind a named profile's home and isolated provider secrets for one RPC.
+
+    Global-remote Desktop connections share one dashboard gateway process, so
+    provider readiness for another profile must not read the launch profile's
+    config, auth store, or process-global environment.  Keep this separate from
+    ``_profile_scoped``: pet RPCs need filesystem/config routing but should not
+    rebuild a credential scope on their high-frequency paths.
+    """
+
+    def wrapper(rid, params):
+        requested_profile = (
+            params.get("profile") if isinstance(params, dict) else None
+        )
+        explicit_profile = (
+            isinstance(requested_profile, str) and bool(requested_profile.strip())
+        )
+        try:
+            home = _provider_profile_home(requested_profile)
+        except FileNotFoundError as exc:
+            return _err(rid, 4044, str(exc))
+        except (TypeError, ValueError) as exc:
+            return _err(rid, 4002, str(exc))
+
+        def invoke_scoped():
+            response = handler(rid, params)
+            result = response.get("result") if isinstance(response, dict) else None
+            if explicit_profile and isinstance(result, dict):
+                response = {
+                    **response,
+                    "result": {
+                        **result,
+                        "profile_name": _current_profile_name(),
+                    },
+                }
+            return response
+
+        if home is None:
+            return invoke_scoped()
+
+        from agent.secret_scope import (
+            build_profile_secret_scope,
+            reset_secret_scope,
+            set_secret_scope,
+        )
+
+        home_token = set_hermes_home_override(home)
+        try:
+            secret_token = set_secret_scope(build_profile_secret_scope(home))
+            try:
+                return invoke_scoped()
+            finally:
+                reset_secret_scope(secret_token)
+        finally:
+            reset_hermes_home_override(home_token)
+
+    return wrapper
+
+
 # Placeholder ``terminal.cwd`` values that don't name a real directory — the
 # gateway resolves these to the home dir at runtime, so they must NOT be treated
 # as an explicit workspace (mirrors gateway/run.py's config bridge).
@@ -3686,7 +3775,10 @@ def _current_profile_name() -> str:
 # cryptically downstream. Bump whenever the desktop's backend contract changes.
 # v2: adds the file.attach RPC (remote-gateway non-image file upload).
 # v3: adds approvals.mode config RPCs and session.info reconciliation.
-DESKTOP_BACKEND_CONTRACT = 3
+# v4: setup/reload provider RPCs resolve profiles strictly, use isolated
+# credential scopes, and echo the resolved profile identity for app-global
+# remote Desktop connections.
+DESKTOP_BACKEND_CONTRACT = 4
 
 
 def _session_usage_snapshot(session: dict | None) -> dict:
@@ -12425,6 +12517,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("setup.status")
+@_profile_provider_scoped
 def _(rid, params: dict) -> dict:
     try:
         from hermes_cli.main import _has_any_provider_configured
@@ -12435,6 +12528,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("setup.runtime_check")
+@_profile_provider_scoped
 def _(rid, params: dict) -> dict:
     """Strict provider check: does the configured/default model actually resolve to a usable runtime?
 
@@ -12669,6 +12763,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("reload.env")
+@_profile_provider_scoped
 def _(rid, params: dict) -> dict:
     """Re-read ``~/.hermes/.env`` into the gateway process via
     ``hermes_cli.config.reload_env``, matching classic CLI's ``/reload``
@@ -12681,6 +12776,14 @@ def _(rid, params: dict) -> dict:
     should follow with ``/new``.
     """
     try:
+        # A named profile's credential scope was freshly rebuilt by the
+        # decorator above.  Do not copy that profile's .env into process-global
+        # os.environ: one global-remote process may serve several profiles, and
+        # mutating it here would leak the last-reloaded profile into the rest.
+        requested_profile = str(params.get("profile") or "").strip()
+        if requested_profile and get_hermes_home_override() is not None:
+            return _ok(rid, {"updated": 0})
+
         from hermes_cli.config import reload_env
 
         count = reload_env()


### PR DESCRIPTION
## Summary

Fix provider readiness in Desktop global-remote multi-profile mode so it is evaluated against the active profile rather than the gateway process's launch-time `HERMES_HOME`.

This is an upstream bug, reproduced from clean `main` at `614dc194ea7d853d39f9e84582ec62156f41a475`: profile-aware REST OAuth stores Codex credentials under the selected named profile, while the WebSocket `setup.status` / `setup.runtime_check` requests previously omitted that profile and checked the default home instead. The resulting UI could report “No Codex credentials stored” immediately after a successful OAuth cycle.

## What changed

- Scope `setup.status`, `setup.runtime_check`, and safe environment reload behavior to an explicitly validated profile.
- Return `profile_name` from profile-scoped readiness calls and bump the gateway contract to v4.
- Make Desktop send the active profile only for app-global remote connections and reject missing/mismatched readiness identities.
- Keep local and dedicated per-profile remote connections on their existing launch-home behavior.
- Scope provider credential/model discovery to the request profile and fail closed rather than falling back to unrelated process credentials.
- Prevent late onboarding results from one profile/connection from overwriting another.
- Add an end-to-end regression that completes synthetic Codex OAuth into a named profile, then exercises the real gateway readiness handlers.

No live-user configuration, network topology, firewall, Tailscale, or OpenAI-account condition is required to reproduce the failure.

## Validation

- Rebased cleanly onto `e361c5e20402375c74a65ca52810c6a380461226` with no conflicts.
- Post-rebase focused Python suites: 664 passed. Three unchanged Darwin-only `TestRunOauthSetupToken` failures are caused by the test's global `subprocess.run` mock intercepting the existing macOS keychain lookup before PR code executes.
- Post-rebase Ruff and `git diff --check` passed; independent review found no P0–P2 issues.
- Pre-rebase full Desktop Vitest: 1,991 passed, 2 skipped; Desktop typecheck, focused ESLint, production build, and the broader Python suites passed.
- A post-rebase Desktop rerun was locally infrastructure-blocked before test collection by macOS filesystem-provenance worker startup timeouts; GitHub CI is the authoritative remaining run and may require maintainer approval for this fork PR.

Related to #50737, which tracks broader profile/readiness leakage; this PR addresses the concrete Desktop global-remote OAuth/readiness mismatch.