### PR TITLE
fix(feishu): repair Windows system SOCKS proxy for WS event channel (#67244)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1295,6 +1295,72 @@ def _strip_edge_self_mentions(
             return remaining
 
 
+def _socks_runtime_available() -> bool:
+    """Return True when the ``python-socks`` runtime websockets needs is importable."""
+    try:
+        import python_socks  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _resolve_ws_socks_proxy_override(conn_url: str) -> tuple[bool, Optional[str]]:
+    """Repair the SOCKS proxy websockets would auto-derive for the WS event channel.
+
+    ``websockets>=14`` picks its proxy from ``urllib.request.getproxies()`` when
+    ``connect()`` is called without an explicit ``proxy`` (which the Lark SDK does).
+    On Windows, ``getproxies_registry()`` reports a system SOCKS proxy as the bare
+    ``socks://host:port`` alias; websockets only rewrites the ``http://`` spelling of
+    that entry, so the bare scheme reaches ``parse_proxy()`` and raises
+    "scheme socks isn't supported". The main Feishu channel (a ``requests``-based HTTP
+    client) uses the ``https`` proxy entry and connects fine, but the WS event channel
+    dies on the SOCKS alias and retries forever, silently dropping inbound messages
+    (issue #67244).
+
+    Mirror websockets' own proxy selection and, only when it would land on that broken
+    ``socks://`` alias, hand it a scheme it accepts: ``socks5h://`` (remote DNS, matching
+    the ``rdns=True`` SOCKS behaviour used elsewhere in the gateway) when ``python-socks``
+    is installed, otherwise fall back to the system HTTP(S) proxy the main channel already
+    uses, or a direct connection.
+
+    Returns ``(False, None)`` to leave websockets' default behaviour untouched, or
+    ``(True, proxy_url)`` to force ``proxy=proxy_url`` (``None`` disables the proxy).
+    """
+    import urllib.request
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(conn_url)
+    except ValueError:
+        return False, None
+    secure = parsed.scheme == "wss"
+    host = parsed.hostname or ""
+    port = parsed.port or (443 if secure else 80)
+    try:
+        if host and urllib.request.proxy_bypass(f"{host}:{port}"):
+            return False, None
+    except (ValueError, OSError):
+        pass
+
+    proxies = urllib.request.getproxies()
+    # websockets.uri.get_proxy() scheme priority — SOCKS outranks HTTPS for WS.
+    ws_schemes = ["wss", "socks", "https"] if secure else ["ws", "socks", "https", "http"]
+    selected = next((proxies[s] for s in ws_schemes if proxies.get(s)), "")
+    if not selected.lower().startswith("socks://"):
+        # No proxy, or a scheme websockets already handles correctly — leave default.
+        return False, None
+
+    if _socks_runtime_available():
+        return True, "socks5h://" + selected[len("socks://"):]
+    # No SOCKS runtime: reuse the HTTP(S) proxy the main channel connects through,
+    # else connect directly rather than retrying the unsupported SOCKS alias forever.
+    for scheme in ("https", "http"):
+        http_proxy = proxies.get(scheme, "")
+        if http_proxy and not http_proxy.lower().startswith("socks"):
+            return True, http_proxy
+    return True, None
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
@@ -1321,6 +1387,16 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
+        if "proxy" not in kwargs:
+            conn_url = args[0] if args else kwargs.get("uri", "")
+            override, proxy_url = _resolve_ws_socks_proxy_override(str(conn_url or ""))
+            if override:
+                kwargs["proxy"] = proxy_url
+                logger.info(
+                    "[Feishu] Rewrote unsupported system SOCKS proxy for WS event "
+                    "channel -> %s",
+                    proxy_url if proxy_url is not None else "direct connection",
+                )
         return original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1361,6 +1361,19 @@ def _resolve_ws_socks_proxy_override(conn_url: str) -> tuple[bool, Optional[str]
     return True, None
 
 
+def _proxy_log_mode(proxy_url: Optional[str]) -> str:
+    """Describe a proxy for logging using only its scheme — never its host or userinfo.
+
+    A proxy URL can embed ``user:password@`` credentials that the global log
+    redactor leaves unmasked, so only the scheme (or ``direct connection``) is safe
+    to emit.
+    """
+    if not proxy_url:
+        return "direct connection"
+    scheme = proxy_url.split("://", 1)[0].strip().lower()
+    return f"{scheme} proxy" if scheme else "proxy"
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
@@ -1392,10 +1405,14 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             override, proxy_url = _resolve_ws_socks_proxy_override(str(conn_url or ""))
             if override:
                 kwargs["proxy"] = proxy_url
+                # Log only the scheme, never the full URL: a proxy URL may carry
+                # ``user:password@`` userinfo that the global log formatter leaves
+                # unmasked (see agent/redact.py), which would persist proxy
+                # credentials in gateway.log.
                 logger.info(
                     "[Feishu] Rewrote unsupported system SOCKS proxy for WS event "
                     "channel -> %s",
-                    proxy_url if proxy_url is not None else "direct connection",
+                    _proxy_log_mode(proxy_url),
                 )
         return original_connect(*args, **kwargs)
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1038,10 +1038,14 @@ def _install_lark_ws_isolation(ws_client_module: Any) -> None:
                 override, proxy_url = _resolve_ws_socks_proxy_override(str(conn_url or ""))
                 if override:
                     kwargs["proxy"] = proxy_url
+                    # Log only the scheme, never the full URL: a proxy URL may carry
+                    # ``user:password@`` userinfo that the global log formatter leaves
+                    # unmasked (see agent/redact.py), which would persist proxy
+                    # credentials in gateway.log.
                     logger.info(
                         "[Feishu] Rewrote unsupported system SOCKS proxy for WS event "
                         "channel -> %s",
-                        proxy_url if proxy_url is not None else "direct connection",
+                        _proxy_log_mode(proxy_url),
                     )
             return real_connect(*args, **kwargs)
 
@@ -1116,6 +1120,19 @@ def _resolve_ws_socks_proxy_override(conn_url: str) -> tuple[bool, Optional[str]
         if http_proxy and not http_proxy.lower().startswith("socks"):
             return True, http_proxy
     return True, None
+
+
+def _proxy_log_mode(proxy_url: Optional[str]) -> str:
+    """Describe a proxy for logging using only its scheme — never its host or userinfo.
+
+    A proxy URL can embed ``user:password@`` credentials that the global log
+    redactor leaves unmasked, so only the scheme (or ``direct connection``) is safe
+    to emit.
+    """
+    if not proxy_url:
+        return "direct connection"
+    scheme = proxy_url.split("://", 1)[0].strip().lower()
+    return f"{scheme} proxy" if scheme else "proxy"
 
 
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1030,6 +1030,19 @@ def _install_lark_ws_isolation(ws_client_module: Any) -> None:
             overrides = getattr(_ws_isolation_state, "connect_kwargs", None) or {}
             for key, value in overrides.items():
                 kwargs.setdefault(key, value)
+            # Repair the SOCKS proxy websockets would otherwise auto-derive for the WS
+            # event channel (#67244). Stateless in the conn URL + system proxies, so it
+            # is safe to apply here in the process-wide dispatcher for every WS thread.
+            if "proxy" not in kwargs:
+                conn_url = args[0] if args else kwargs.get("uri", "")
+                override, proxy_url = _resolve_ws_socks_proxy_override(str(conn_url or ""))
+                if override:
+                    kwargs["proxy"] = proxy_url
+                    logger.info(
+                        "[Feishu] Rewrote unsupported system SOCKS proxy for WS event "
+                        "channel -> %s",
+                        proxy_url if proxy_url is not None else "direct connection",
+                    )
             return real_connect(*args, **kwargs)
 
         # Keep inspect.signature(websockets.connect) honest — the SDK probes it for ``proxy`` support.
@@ -1037,6 +1050,72 @@ def _install_lark_ws_isolation(ws_client_module: Any) -> None:
         _dispatch_connect.__name__ = getattr(real_connect, "__name__", "connect")
         ws_client_module.websockets.connect = _dispatch_connect
         _WS_ISOLATION_INSTALLED = True
+
+
+def _socks_runtime_available() -> bool:
+    """Return True when the ``python-socks`` runtime websockets needs is importable."""
+    try:
+        import python_socks  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _resolve_ws_socks_proxy_override(conn_url: str) -> tuple[bool, Optional[str]]:
+    """Repair the SOCKS proxy websockets would auto-derive for the WS event channel.
+
+    ``websockets>=14`` picks its proxy from ``urllib.request.getproxies()`` when
+    ``connect()`` is called without an explicit ``proxy`` (which the Lark SDK does).
+    On Windows, ``getproxies_registry()`` reports a system SOCKS proxy as the bare
+    ``socks://host:port`` alias; websockets only rewrites the ``http://`` spelling of
+    that entry, so the bare scheme reaches ``parse_proxy()`` and raises
+    "scheme socks isn't supported". The main Feishu channel (a ``requests``-based HTTP
+    client) uses the ``https`` proxy entry and connects fine, but the WS event channel
+    dies on the SOCKS alias and retries forever, silently dropping inbound messages
+    (issue #67244).
+
+    Mirror websockets' own proxy selection and, only when it would land on that broken
+    ``socks://`` alias, hand it a scheme it accepts: ``socks5h://`` (remote DNS, matching
+    the ``rdns=True`` SOCKS behaviour used elsewhere in the gateway) when ``python-socks``
+    is installed, otherwise fall back to the system HTTP(S) proxy the main channel already
+    uses, or a direct connection.
+
+    Returns ``(False, None)`` to leave websockets' default behaviour untouched, or
+    ``(True, proxy_url)`` to force ``proxy=proxy_url`` (``None`` disables the proxy).
+    """
+    import urllib.request
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(conn_url)
+    except ValueError:
+        return False, None
+    secure = parsed.scheme == "wss"
+    host = parsed.hostname or ""
+    port = parsed.port or (443 if secure else 80)
+    try:
+        if host and urllib.request.proxy_bypass(f"{host}:{port}"):
+            return False, None
+    except (ValueError, OSError):
+        pass
+
+    proxies = urllib.request.getproxies()
+    # websockets.uri.get_proxy() scheme priority — SOCKS outranks HTTPS for WS.
+    ws_schemes = ["wss", "socks", "https"] if secure else ["ws", "socks", "https", "http"]
+    selected = next((proxies[s] for s in ws_schemes if proxies.get(s)), "")
+    if not selected.lower().startswith("socks://"):
+        # No proxy, or a scheme websockets already handles correctly — leave default.
+        return False, None
+
+    if _socks_runtime_available():
+        return True, "socks5h://" + selected[len("socks://"):]
+    # No SOCKS runtime: reuse the HTTP(S) proxy the main channel connects through,
+    # else connect directly rather than retrying the unsupported SOCKS alias forever.
+    for scheme in ("https", "http"):
+        http_proxy = proxies.get(scheme, "")
+        if http_proxy and not http_proxy.lower().startswith("socks"):
+            return True, http_proxy
+    return True, None
 
 
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -846,6 +846,22 @@ class TestAdapterModule(unittest.TestCase):
 
         self.assertEqual(captured["kwargs"].get("proxy"), "socks5h://127.0.0.1:8687")
 
+    def test_proxy_log_mode_never_leaks_credentials(self):
+        # A proxy URL can carry user:password@ userinfo the global log formatter
+        # leaves unmasked; the connect-override log must emit only the scheme.
+        from plugins.platforms.feishu.adapter import _proxy_log_mode
+
+        for url, expected in (
+            ("socks5h://user:s3cret@127.0.0.1:8687", "socks5h proxy"),
+            ("http://alice:hunter2@127.0.0.1:8686", "http proxy"),
+            (None, "direct connection"),
+        ):
+            mode = _proxy_log_mode(url)
+            self.assertEqual(mode, expected)
+            self.assertNotIn("s3cret", mode)
+            self.assertNotIn("hunter2", mode)
+            self.assertNotIn("127.0.0.1", mode)
+
 
 def _admits_group(adapter, message, sender_id, chat_id=""):
     """Group-path shim: run a message through ``_admit`` and return a bool."""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -711,6 +711,141 @@ class TestAdapterModule(unittest.TestCase):
         self.assertEqual(fake_client._reconnect_interval, 3)
         self.assertEqual(fake_client._ping_interval, 4)
 
+    def test_ws_socks_proxy_alias_rewritten_to_socks5h_when_runtime_present(self):
+        # Windows getproxies_registry() reports a system SOCKS proxy as the bare
+        # 'socks://' alias that websockets rejects (issue #67244); with
+        # python-socks available it must become 'socks5h://' (remote DNS).
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        proxies = {
+            "http": "http://127.0.0.1:8686",
+            "https": "http://127.0.0.1:8686",
+            "socks": "socks://127.0.0.1:8687",
+        }
+        with patch("urllib.request.getproxies", return_value=proxies), \
+                patch("urllib.request.proxy_bypass", return_value=False), \
+                patch("plugins.platforms.feishu.adapter._socks_runtime_available", return_value=True):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertTrue(override)
+        self.assertEqual(proxy_url, "socks5h://127.0.0.1:8687")
+
+    def test_ws_socks_proxy_alias_falls_back_to_http_proxy_without_runtime(self):
+        # No python-socks runtime: reuse the HTTP(S) proxy the main channel
+        # already connects through instead of retrying the SOCKS alias forever.
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        proxies = {
+            "https": "http://127.0.0.1:8686",
+            "socks": "socks://127.0.0.1:8687",
+        }
+        with patch("urllib.request.getproxies", return_value=proxies), \
+                patch("urllib.request.proxy_bypass", return_value=False), \
+                patch("plugins.platforms.feishu.adapter._socks_runtime_available", return_value=False):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertTrue(override)
+        self.assertEqual(proxy_url, "http://127.0.0.1:8686")
+
+    def test_ws_socks_proxy_alias_direct_when_no_http_proxy_and_no_runtime(self):
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        proxies = {"socks": "socks://127.0.0.1:8687"}
+        with patch("urllib.request.getproxies", return_value=proxies), \
+                patch("urllib.request.proxy_bypass", return_value=False), \
+                patch("plugins.platforms.feishu.adapter._socks_runtime_available", return_value=False):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertTrue(override)
+        self.assertIsNone(proxy_url)
+
+    def test_ws_proxy_override_left_untouched_for_plain_http_proxy(self):
+        # A normal HTTP(S) system proxy is handled natively by websockets — do
+        # not override and do not disturb the default behaviour.
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        proxies = {"https": "http://127.0.0.1:8686"}
+        with patch("urllib.request.getproxies", return_value=proxies), \
+                patch("urllib.request.proxy_bypass", return_value=False):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertFalse(override)
+        self.assertIsNone(proxy_url)
+
+    def test_ws_proxy_override_noop_when_no_proxy_configured(self):
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        with patch("urllib.request.getproxies", return_value={}), \
+                patch("urllib.request.proxy_bypass", return_value=False):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertFalse(override)
+        self.assertIsNone(proxy_url)
+
+    def test_ws_proxy_override_respects_proxy_bypass(self):
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        proxies = {"socks": "socks://127.0.0.1:8687"}
+        with patch("urllib.request.getproxies", return_value=proxies), \
+                patch("urllib.request.proxy_bypass", return_value=True):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertFalse(override)
+        self.assertIsNone(proxy_url)
+
+    def test_connect_override_injects_rewritten_socks_proxy(self):
+        # End-to-end: the websockets.connect override the WS thread installs must
+        # inject the repaired proxy kwarg so the Lark SDK's bare connect() call
+        # no longer trips over the SOCKS alias.
+        import sys
+        from types import ModuleType
+
+        captured = {}
+
+        def _fake_connect(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            raise RuntimeError("stop test client")
+
+        class _FakeWSClient:
+            def __init__(self):
+                self._reconnect_nonce = 30
+                self._reconnect_interval = 120
+                self._ping_interval = 120
+
+            def start(self):
+                # Emulate the Lark SDK calling connect(conn_url) with no proxy.
+                ws_module = sys.modules["lark_oapi.ws.client"]
+                ws_module.websockets.connect("wss://open.feishu.cn/callback/ws")
+
+        fake_client = _FakeWSClient()
+        fake_adapter = SimpleNamespace(
+            _ws_thread_loop=None,
+            _ws_reconnect_nonce=2,
+            _ws_reconnect_interval=3,
+            _ws_ping_interval=None,
+            _ws_ping_timeout=None,
+        )
+        fake_client_module = ModuleType("lark_oapi.ws.client")
+        fake_client_module.loop = None
+        fake_client_module.websockets = SimpleNamespace(connect=_fake_connect)
+        fake_ws_module = ModuleType("lark_oapi.ws")
+        fake_ws_module.client = fake_client_module
+        fake_root_module = ModuleType("lark_oapi")
+        fake_root_module.ws = fake_ws_module
+
+        proxies = {"socks": "socks://127.0.0.1:8687"}
+        original_modules = sys.modules.copy()
+        sys.modules["lark_oapi"] = fake_root_module
+        sys.modules["lark_oapi.ws"] = fake_ws_module
+        sys.modules["lark_oapi.ws.client"] = fake_client_module
+        try:
+            from plugins.platforms.feishu.adapter import _run_official_feishu_ws_client
+
+            with patch("urllib.request.getproxies", return_value=proxies), \
+                    patch("urllib.request.proxy_bypass", return_value=False), \
+                    patch("plugins.platforms.feishu.adapter._socks_runtime_available", return_value=True):
+                _run_official_feishu_ws_client(fake_client, fake_adapter)
+        finally:
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+        self.assertEqual(captured["kwargs"].get("proxy"), "socks5h://127.0.0.1:8687")
+
 
 def _admits_group(adapter, message, sender_id, chat_id=""):
     """Group-path shim: run a message through ``_admit`` and return a bool."""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -359,6 +359,141 @@ class TestAdapterModule(unittest.TestCase):
         self.assertEqual(fake_client._reconnect_interval, 3)
         self.assertEqual(fake_client._ping_interval, 4)
 
+    def test_ws_socks_proxy_alias_rewritten_to_socks5h_when_runtime_present(self):
+        # Windows getproxies_registry() reports a system SOCKS proxy as the bare
+        # 'socks://' alias that websockets rejects (issue #67244); with
+        # python-socks available it must become 'socks5h://' (remote DNS).
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        proxies = {
+            "http": "http://127.0.0.1:8686",
+            "https": "http://127.0.0.1:8686",
+            "socks": "socks://127.0.0.1:8687",
+        }
+        with patch("urllib.request.getproxies", return_value=proxies), \
+                patch("urllib.request.proxy_bypass", return_value=False), \
+                patch("plugins.platforms.feishu.adapter._socks_runtime_available", return_value=True):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertTrue(override)
+        self.assertEqual(proxy_url, "socks5h://127.0.0.1:8687")
+
+    def test_ws_socks_proxy_alias_falls_back_to_http_proxy_without_runtime(self):
+        # No python-socks runtime: reuse the HTTP(S) proxy the main channel
+        # already connects through instead of retrying the SOCKS alias forever.
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        proxies = {
+            "https": "http://127.0.0.1:8686",
+            "socks": "socks://127.0.0.1:8687",
+        }
+        with patch("urllib.request.getproxies", return_value=proxies), \
+                patch("urllib.request.proxy_bypass", return_value=False), \
+                patch("plugins.platforms.feishu.adapter._socks_runtime_available", return_value=False):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertTrue(override)
+        self.assertEqual(proxy_url, "http://127.0.0.1:8686")
+
+    def test_ws_socks_proxy_alias_direct_when_no_http_proxy_and_no_runtime(self):
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        proxies = {"socks": "socks://127.0.0.1:8687"}
+        with patch("urllib.request.getproxies", return_value=proxies), \
+                patch("urllib.request.proxy_bypass", return_value=False), \
+                patch("plugins.platforms.feishu.adapter._socks_runtime_available", return_value=False):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertTrue(override)
+        self.assertIsNone(proxy_url)
+
+    def test_ws_proxy_override_left_untouched_for_plain_http_proxy(self):
+        # A normal HTTP(S) system proxy is handled natively by websockets — do
+        # not override and do not disturb the default behaviour.
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        proxies = {"https": "http://127.0.0.1:8686"}
+        with patch("urllib.request.getproxies", return_value=proxies), \
+                patch("urllib.request.proxy_bypass", return_value=False):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertFalse(override)
+        self.assertIsNone(proxy_url)
+
+    def test_ws_proxy_override_noop_when_no_proxy_configured(self):
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        with patch("urllib.request.getproxies", return_value={}), \
+                patch("urllib.request.proxy_bypass", return_value=False):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertFalse(override)
+        self.assertIsNone(proxy_url)
+
+    def test_ws_proxy_override_respects_proxy_bypass(self):
+        from plugins.platforms.feishu.adapter import _resolve_ws_socks_proxy_override
+
+        proxies = {"socks": "socks://127.0.0.1:8687"}
+        with patch("urllib.request.getproxies", return_value=proxies), \
+                patch("urllib.request.proxy_bypass", return_value=True):
+            override, proxy_url = _resolve_ws_socks_proxy_override("wss://open.feishu.cn/callback/ws")
+        self.assertFalse(override)
+        self.assertIsNone(proxy_url)
+
+    def test_connect_override_injects_rewritten_socks_proxy(self):
+        # End-to-end: the websockets.connect override the WS thread installs must
+        # inject the repaired proxy kwarg so the Lark SDK's bare connect() call
+        # no longer trips over the SOCKS alias.
+        import sys
+        from types import ModuleType
+
+        captured = {}
+
+        def _fake_connect(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            raise RuntimeError("stop test client")
+
+        class _FakeWSClient:
+            def __init__(self):
+                self._reconnect_nonce = 30
+                self._reconnect_interval = 120
+                self._ping_interval = 120
+
+            def start(self):
+                # Emulate the Lark SDK calling connect(conn_url) with no proxy.
+                ws_module = sys.modules["lark_oapi.ws.client"]
+                ws_module.websockets.connect("wss://open.feishu.cn/callback/ws")
+
+        fake_client = _FakeWSClient()
+        fake_adapter = SimpleNamespace(
+            _ws_thread_loop=None,
+            _ws_reconnect_nonce=2,
+            _ws_reconnect_interval=3,
+            _ws_ping_interval=None,
+            _ws_ping_timeout=None,
+        )
+        fake_client_module = ModuleType("lark_oapi.ws.client")
+        fake_client_module.loop = None
+        fake_client_module.websockets = SimpleNamespace(connect=_fake_connect)
+        fake_ws_module = ModuleType("lark_oapi.ws")
+        fake_ws_module.client = fake_client_module
+        fake_root_module = ModuleType("lark_oapi")
+        fake_root_module.ws = fake_ws_module
+
+        proxies = {"socks": "socks://127.0.0.1:8687"}
+        original_modules = sys.modules.copy()
+        sys.modules["lark_oapi"] = fake_root_module
+        sys.modules["lark_oapi.ws"] = fake_ws_module
+        sys.modules["lark_oapi.ws.client"] = fake_client_module
+        try:
+            from plugins.platforms.feishu.adapter import _run_official_feishu_ws_client
+
+            with patch("urllib.request.getproxies", return_value=proxies), \
+                    patch("urllib.request.proxy_bypass", return_value=False), \
+                    patch("plugins.platforms.feishu.adapter._socks_runtime_available", return_value=True):
+                _run_official_feishu_ws_client(fake_client, fake_adapter)
+        finally:
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+        self.assertEqual(captured["kwargs"].get("proxy"), "socks5h://127.0.0.1:8687")
+
 
 def _admits_group(adapter, message, sender_id, chat_id=""):
     """Group-path shim: run a message through ``_admit`` and return a bool."""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -494,6 +494,22 @@ class TestAdapterModule(unittest.TestCase):
 
         self.assertEqual(captured["kwargs"].get("proxy"), "socks5h://127.0.0.1:8687")
 
+    def test_proxy_log_mode_never_leaks_credentials(self):
+        # A proxy URL can carry user:password@ userinfo the global log formatter
+        # leaves unmasked; the connect-override log must emit only the scheme.
+        from plugins.platforms.feishu.adapter import _proxy_log_mode
+
+        for url, expected in (
+            ("socks5h://user:s3cret@127.0.0.1:8687", "socks5h proxy"),
+            ("http://alice:hunter2@127.0.0.1:8686", "http proxy"),
+            (None, "direct connection"),
+        ):
+            mode = _proxy_log_mode(url)
+            self.assertEqual(mode, expected)
+            self.assertNotIn("s3cret", mode)
+            self.assertNotIn("hunter2", mode)
+            self.assertNotIn("127.0.0.1", mode)
+
 
 def _admits_group(adapter, message, sender_id, chat_id=""):
     """Group-path shim: run a message through ``_admit`` and return a bool."""


### PR DESCRIPTION
## What does this PR do?

Fixes the Feishu WebSocket event channel silently dropping every inbound message when the Windows **system** proxy includes a SOCKS entry (common with Clash / V2Ray, e.g. `http=127.0.0.1:8686;https=127.0.0.1:8686;socks=127.0.0.1:8687`).

Root cause: `websockets>=14` auto-derives its proxy from `urllib.request.getproxies()` when `connect()` is called without an explicit `proxy` — which the Lark SDK's WS client does (`await websockets.connect(conn_url)`). On Windows, `getproxies_registry()` reports the system SOCKS proxy as the bare `socks://host:port` alias. `websockets` only rewrites the `http://` spelling of that entry (`websockets/uri.py:get_proxy`), so the bare `socks://` scheme reaches `parse_proxy()` and raises `InvalidProxy: scheme socks isn't supported`.

The main Feishu channel (a `requests`-based HTTP client) uses the `https` proxy entry and connects fine — hence `✓ feishu connected` in `gateway.log` — but the WS event channel dies on the SOCKS alias and retries forever, so inbound messages are never delivered. The error surfaces only in `gateway-stdio.log`.

The fix hooks the `websockets.connect` override the WS thread **already installs** (for ping/reconnect tuning) and, *only* when `websockets` would land on that broken `socks://` alias, hands it a scheme it accepts:
- `socks5h://` (remote DNS — matches the `rdns=True` SOCKS behaviour already used for aiohttp elsewhere in the gateway) when `python-socks` is installed, else
- the system HTTP(S) proxy the main channel already connects through, else
- a direct connection.

No new dependency, and no behaviour change for HTTP proxies, non-SOCKS setups, or non-Windows platforms (the override is a no-op unless the derived proxy is the bare `socks://` alias).

## Related Issue

Fixes #67244

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py`:
  - Add `_socks_runtime_available()` — whether the `python-socks` runtime websockets needs is importable.
  - Add `_resolve_ws_socks_proxy_override(conn_url)` — mirrors websockets' own proxy-scheme priority and repairs the bare `socks://` alias (→ `socks5h://`, HTTP proxy fallback, or direct); returns a no-op signal otherwise.
  - Wire it into the existing `_connect_with_overrides` in `_run_official_feishu_ws_client` so the injected `proxy=` kwarg reaches `websockets.connect`.
- `tests/gateway/test_feishu.py`: 7 regression tests (alias→socks5h, HTTP-proxy fallback, direct fallback, plain-HTTP no-op, no-proxy no-op, `proxy_bypass` respected, and end-to-end connect-override injection).

## How to Test

```
scripts/run_tests.sh tests/gateway/test_feishu.py -k "ws_socks or ws_proxy or connect_override_injects"
```

Result: `7 passed`. The change adds zero regressions — the 8 unrelated failures present in the file are pre-existing on plain `upstream/main` in this local venv (aiohttp/websockets test-client version artifacts), not introduced here.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(feishu):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and my new tests pass (7 passed; pre-existing unrelated failures documented above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (root cause is Windows-specific system-proxy behaviour, reproduced via unit tests that patch `urllib.request.getproxies`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — override is a no-op except for the Windows bare-`socks://` case
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
