### PR TITLE
fix(agent): persist delivered response when turn tail is a tool-call row

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -25,6 +25,21 @@ from __future__ import annotations
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.message_content import flatten_message_text
+
+
+def _is_pure_tool_call_tail(msg: dict) -> bool:
+    """An assistant row with ``tool_calls`` but no visible text content of its own.
+
+    Such a row satisfies the role check (``tail role == "assistant"``) while
+    carrying none of the delivered answer — see the #43849/#44100 invariant
+    block in :func:`finalize_turn`. Uses :func:`flatten_message_text` so that
+    multimodal (list-type) content is evaluated by its text parts, not just
+    its type.
+    """
+    if not msg.get("tool_calls"):
+        return False
+    return not flatten_message_text(msg.get("content")).strip()
 
 
 def finalize_turn(
@@ -222,11 +237,31 @@ def finalize_turn(
         # holds regardless of which path produced it. (#43849 / #44100)
         if final_response and not interrupted:
             try:
-                _tail_role = messages[-1].get("role") if messages else None
+                _tail = messages[-1] if messages else None
             except Exception:
-                _tail_role = None
+                _tail = None
+            _tail_role = _tail.get("role") if isinstance(_tail, dict) else None
             if _tail_role != "assistant":
                 messages.append({"role": "assistant", "content": final_response})
+            elif isinstance(_tail, dict) and _is_pure_tool_call_tail(_tail):
+                # The tail IS an assistant row, but a *pure tool-call turn*:
+                # tool_calls with no text of its own. The role check alone
+                # leaves the #43849/#44100 invariant unmet — the user saw a
+                # response that never reached the transcript, and the next turn
+                # replays the user backlog and re-answers it (the very symptom
+                # this block was added for). Fill that row's empty content
+                # instead of appending, so the durable turn ends with the answer
+                # without disturbing the tool-call structure or creating an
+                # assistant→assistant pair.
+                _tail["content"] = final_response
+                # The row may have already been flushed to SQLite by the
+                # incremental tool-call persist (conversation_loop.py:4990),
+                # which stamps ``_DB_PERSISTED_MARKER`` so subsequent flushes
+                # skip it. Pop the marker so the next ``_persist_session``
+                # re-writes the filled content to the durable store —
+                # otherwise ``/resume`` reloads ``content=""`` and the bug
+                # resurfaces cross-session.
+                _tail.pop("_db_persisted", None)
 
         # The model has completed its request, so replace API-local
         # voice/model/skill guidance with the clean user input before writing the

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -196,3 +196,135 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
     assert result["messages"][-1] == {"role": "assistant", "content": "Done."}
     assert agent.persisted_messages is not None
     assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}
+
+
+def test_final_response_fills_pure_tool_call_tail(monkeypatch):
+    """A tail assistant row that is a *pure tool-call turn* carries no answer.
+
+    The role check alone ("tail is assistant ⇒ nothing to do") leaves the
+    #43849/#44100 invariant unmet when the tail is ``assistant(tool_calls)``
+    with no text of its own: the caller and the gateway already delivered
+    ``final_response``, but it never reaches the transcript. The next turn then
+    replays the user backlog and the model re-answers it — the exact symptom
+    that block exists to prevent.
+    """
+    agent = FakeAgent()
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "f", "arguments": "{}"}}
+            ],
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="Here is your answer.",
+        api_call_count=3,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="t",
+        turn_id="tid",
+        user_message="q",
+        original_user_message="q",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+    persisted = agent.persisted_messages
+    assert any(
+        m.get("role") == "assistant" and m.get("content") == result["final_response"]
+        for m in persisted
+    ), "delivered final_response never reached the durable transcript"
+    # Filled in place — no assistant→assistant pair, tool_calls preserved.
+    assert persisted[-1]["content"] == "Here is your answer."
+    assert persisted[-1]["tool_calls"]
+    assert sum(1 for m in persisted if m.get("role") == "assistant") == 1
+
+
+def test_final_response_does_not_clobber_tool_call_tail_with_text(monkeypatch):
+    """A tail tool-call turn that already carries model text must be left alone."""
+    agent = FakeAgent()
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "partial text",
+            "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "f", "arguments": "{}"}}
+            ],
+        },
+    ]
+
+    finalize_turn(
+        agent,
+        final_response="Here is your answer.",
+        api_call_count=3,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="t",
+        turn_id="tid",
+        user_message="q",
+        original_user_message="q",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+    assert agent.persisted_messages[-1]["content"] == "partial text"
+
+
+def test_fill_pops_db_persisted_marker_for_durable_rewrite(monkeypatch):
+    """The incremental tool-call persist stamps ``_db_persisted`` on the row.
+
+    If finalize_turn fills the tail's content but leaves the marker, the next
+    ``_flush_messages_to_session_db`` skips the row and the durable SQLite
+    store keeps ``content=""`` — so ``/resume`` reloads the empty content and
+    the bug resurfaces cross-session. The fix pops the marker so the filled
+    content is re-written.
+    """
+    agent = FakeAgent()
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "f", "arguments": "{}"}}
+            ],
+            "_db_persisted": True,  # stamped by conversation_loop.py:4990
+        },
+    ]
+
+    finalize_turn(
+        agent,
+        final_response="Here is your answer.",
+        api_call_count=3,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="t",
+        turn_id="tid",
+        user_message="q",
+        original_user_message="q",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+    persisted = agent.persisted_messages
+    assert persisted is not None
+    assert persisted[-1]["content"] == "Here is your answer."
+    assert persisted[-1]["tool_calls"]
+    assert "_db_persisted" not in persisted[-1], (
+        "marker must be popped so the next flush re-writes the filled content"
+    )


### PR DESCRIPTION
## Summary

Persists the delivered `final_response` into the transcript when the turn tail is a pure tool-call assistant row (empty content + `tool_calls`), closing a gap in the #43849/#44100 invariant — and fixes a SQLite durability regression where the filled content didn't reach the durable store.

## Changes

- `agent/turn_finalizer.py`: add `_is_pure_tool_call_tail()` helper using `flatten_message_text` for multimodal awareness; when the tail is an assistant row with tool_calls and no content, persist the delivered response in place (`_tail["content"] = final_response`) and pop the `_DB_PERSISTED_MARKER` for durable rewrite
- `tests/agent/test_turn_finalizer_final_response_persistence.py`: 3 new tests covering pure tool-call fill, non-clobber of existing text, and `_db_persisted` marker removal

Salvage of #66984 by @Frowtek (commit `7a0959140` preserved authorship). Follow-up refactor + durability fix `9f0c16959` is ours.

## Validation

|  | Before (main) | After (this PR) |
|---|---|---|
| Pure tool-call tail persisted (in-memory) | `content=""`, answer absent | `content=final_response`, tool_calls preserved |
| Pure tool-call tail persisted (SQLite durable) | `content=""` | `content=final_response` (marker popped) |
| Alternation invariant | OK (no AA pair) | OK (no AA pair) |
| Multimodal tail with empty text | not detected | detected as pure tool-call (via `flatten_message_text`) |
| Multimodal tail with real text | not detected | not detected (left alone) |
| `tests/agent/` targeted suite | 3 passed | 6 passed (+3 new tests) |

Closes #66984