### PR TITLE
fix(desktop): multi-profile message routing sends messages to wrong profile (#67097)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6593,6 +6593,9 @@ async function spawnPoolBackend(profile, entry) {
         // scheduler tick loop (the gateway isn't running under the app).
         HERMES_DESKTOP: '1',
         HERMES_WEB_DIST: webDist,
+        // Pin the session profile so that subprocess tools and env queries
+        // correctly resolve the profile the backend is running under (#67097).
+        HERMES_SESSION_PROFILE: profile,
         ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
       },
       shell: backend.shell,
@@ -6831,7 +6834,7 @@ async function startHermes() {
           // resolves to the SAME location our resolveHermesHome() picked. Without
           // this pin, Python falls back to ~/.hermes on every platform — fine on
           // mac/linux (where our default matches), but on Windows our default is
-          // %LOCALAPPDATA%\hermes, which differs from C:\Users\<u>\.hermes.
+          // %LOCALAPPDATA%\\hermes, which differs from C:\\Users\\<u>\\.hermes.
           // Mismatch would split config / sessions / .env / logs across two
           // directories. install.ps1 sets HERMES_HOME via setx; the desktop
           // can't reliably do that, so we set it inline for every spawn.
@@ -6843,6 +6846,9 @@ async function startHermes() {
           // scheduler tick loop (the gateway isn't running under the app).
           HERMES_DESKTOP: '1',
           HERMES_WEB_DIST: webDist,
+          // Pin the session profile so that subprocess tools and env queries
+          // correctly resolve the profile the backend is running under (#67097).
+          HERMES_SESSION_PROFILE: activeProfile || 'default',
           ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
         },
         shell: backend.shell,
@@ -9156,6 +9162,14 @@ app.on('open-url', (event, url) => {
 })
 
 app.whenReady().then(() => {
+  // Initialize active-profile.json on first boot so there's a persisted
+  // record of the active profile state. Without this, the file is only created
+  // when the user explicitly switches profiles via the UI, leaving no record
+  // of the profile state on a fresh install (#67097).
+  if (readActiveDesktopProfile() === null) {
+    writeActiveDesktopProfile(null)
+  }
+
   const systemCa = installWindowsSystemCaTrust(tls)
 
   if (systemCa.applied) {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -71,7 +71,10 @@ export function activeGateway(): HermesGateway | null {
     return primaryGateway
   }
 
-  return secondaries.get(activeKey)?.gateway ?? primaryGateway
+  // When the active profile is not the primary, only return its own gateway.
+  // Silently falling back to primaryGateway would route messages meant for a
+  // remote/secondary profile to the local primary backend instead (#67097).
+  return secondaries.get(activeKey)?.gateway ?? null
 }
 
 // Mirror a backend's connection state into the global composer state, but only
@@ -208,6 +211,12 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
   const key = normKey(profile)
 
   if (key === primaryProfile) {
+    // Close all secondary WebSocket connections before activating the primary.
+    // Leaving secondaries open with wantOpen=true while the active key flips to
+    // primary creates stale connections that can receive messages if the active
+    // key state gets confused, routing them to the wrong profile (#67097).
+    closeSecondaryGateways()
+
     setActive(key)
 
     return


### PR DESCRIPTION
## Summary

Fixes #67097 — Desktop multi-profile message routing intermittently sends messages to the wrong profile's gateway.

## Root Causes & Fixes

### 1. `activeGateway()` silent fallback to primary gateway (`store/gateway.ts`)
**Problem:** When `activeKey` pointed to a non-primary profile and the secondary didn't exist (transient state), `activeGateway()` silently fell back to `primaryGateway`, routing messages meant for a remote profile to the local backend.
**Fix:** Return `null` instead of `primaryGateway` — the callers already handle null.

### 2. Secondary WebSockets not closed on primary switch (`store/gateway.ts`)
**Problem:** `ensureGatewayForProfile("default")` called `setActive(key)` and returned immediately for the primary profile, but left all secondary WebSocket connections open with `wantOpen = true`. Stale connections could receive messages if active key state was confused.
**Fix:** Call `closeSecondaryGateways()` before `setActive()` when switching to the primary profile.

### 3. `HERMES_SESSION_PROFILE` env var empty (`electron/main.ts`)
**Problem:** Both `startHermes()` and `spawnPoolBackend()` inherited `HERMES_SESSION_PROFILE=""` from `process.env`. Subprocess tools that query `get_session_env("HERMES_SESSION_PROFILE")` got an empty string instead of the correct profile name.
**Fix:** Set `HERMES_SESSION_PROFILE` explicitly:
- `startHermes()`: `activeProfile || 'default'`
- `spawnPoolBackend()`: the profile name

### 4. `active-profile.json` never created on boot (`electron/main.ts`)
**Problem:** `active-profile.json` was only written when the user explicitly switched profiles via the UI. On first boot (missing file), there was no persisted record of the profile state.
**Fix:** Initialize `active-profile.json` in `app.whenReady()` by calling `writeActiveDesktopProfile(null)` when the file is missing.

## Files Changed
- `apps/desktop/src/store/gateway.ts` — Fixes 1 & 2
- `apps/desktop/electron/main.ts` — Fixes 3 & 4