### PR TITLE
fix(auxiliary): forward main_runtime through the async auth-recovery retry

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3639,6 +3639,7 @@ async def _retry_same_provider_async(
     resolved_base_url: Optional[str],
     resolved_api_key: Optional[str],
     resolved_api_mode: Optional[str],
+    main_runtime: Optional[Dict[str, Any]] = None,
     final_model: Optional[str],
     messages: list,
     temperature: Optional[float],
@@ -3664,6 +3665,14 @@ async def _retry_same_provider_async(
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            # Mirrors the sync twin. Without it the rebuilt client resolves
+            # against an EMPTY runtime (``_normalize_main_runtime(None)`` ->
+            # ``{}``), dropping the main agent's provider / model / base_url /
+            # api_key. ``main_runtime`` is also part of the client cache key,
+            # so the retry cannot reuse the correct cached client either: the
+            # recovery attempt targets the wrong endpoint and fails, defeating
+            # the credential refresh that just succeeded.
+            main_runtime=main_runtime,
         )
     if retry_client is None:
         raise RuntimeError(
@@ -7864,6 +7873,7 @@ async def async_call_llm(
                     resolved_base_url=resolved_base_url,
                     resolved_api_key=resolved_api_key,
                     resolved_api_mode=resolved_api_mode,
+                    main_runtime=main_runtime,
                     final_model=final_model,
                     messages=messages,
                     temperature=temperature,
@@ -7902,6 +7912,7 @@ async def async_call_llm(
                         resolved_base_url=resolved_base_url,
                         resolved_api_key=resolved_api_key,
                         resolved_api_mode=resolved_api_mode,
+                        main_runtime=main_runtime,
                         final_model=final_model,
                         messages=messages,
                         temperature=temperature,

--- a/tests/agent/test_aux_async_retry_main_runtime.py
+++ b/tests/agent/test_aux_async_retry_main_runtime.py
@@ -1,0 +1,118 @@
+"""``_retry_same_provider_async`` must forward ``main_runtime`` like its sync twin.
+
+The auth-recovery retry rebuilds the provider client after refreshing
+credentials. ``_retry_same_provider_sync`` passes ``main_runtime`` to
+``_get_cached_client``; the async twin did not, even though ``main_runtime`` is
+in scope at both async call sites (the very next statement there uses it for
+``_recoverable_pool_provider``).
+
+Without it the rebuilt client resolves against an EMPTY runtime
+(``_normalize_main_runtime(None) -> {}``), dropping the main agent's
+provider/model/base_url/api_key. ``main_runtime`` is also part of the client
+cache key, so the retry cannot reuse the correct cached client either — the
+recovery attempt targets the wrong endpoint and fails, defeating the refresh
+that just succeeded.
+"""
+import asyncio
+import inspect
+
+import pytest
+
+import agent.auxiliary_client as ac
+
+_MAIN_RUNTIME = {
+    "provider": "openai-compatible",
+    "model": "main-model",
+    "base_url": "https://main.endpoint/v1",
+    "api_key": "sk-MAIN",
+    "api_mode": "chat_completions",
+}
+
+_COMMON = dict(
+    task="compression",
+    resolved_provider="auto",
+    resolved_model="m",
+    resolved_base_url=None,
+    resolved_api_key=None,
+    resolved_api_mode=None,
+    final_model="m",
+    messages=[{"role": "user", "content": "x"}],
+    temperature=None,
+    max_tokens=None,
+    tools=None,
+    effective_timeout=30.0,
+    effective_extra_body={},
+    reasoning_config=None,
+)
+
+
+class _Resp:
+    pass
+
+
+def _install_stubs(monkeypatch, seen, *, is_async):
+    class _Client:
+        base_url = "https://main.endpoint/v1"
+
+        class chat:
+            class completions:
+                if is_async:
+                    @staticmethod
+                    async def create(**kwargs):
+                        return _Resp()
+                else:
+                    @staticmethod
+                    def create(**kwargs):
+                        return _Resp()
+
+    def _fake_get_cached_client(provider, model=None, **kwargs):
+        seen["main_runtime"] = kwargs.get("main_runtime")
+        return _Client(), model
+
+    monkeypatch.setattr(ac, "_get_cached_client", _fake_get_cached_client)
+    monkeypatch.setattr(ac, "_validate_llm_response", lambda resp, task: resp)
+    monkeypatch.setattr(ac, "_build_call_kwargs", lambda *a, **k: {})
+    monkeypatch.setattr(ac, "_is_anthropic_compat_endpoint", lambda *a, **k: False)
+
+
+def test_async_retry_accepts_main_runtime():
+    """The async twin must expose the same knob as the sync one."""
+    assert "main_runtime" in inspect.signature(ac._retry_same_provider_async).parameters
+
+
+def test_sync_retry_forwards_main_runtime(monkeypatch):
+    seen = {}
+    _install_stubs(monkeypatch, seen, is_async=False)
+
+    ac._retry_same_provider_sync(main_runtime=_MAIN_RUNTIME, **_COMMON)
+
+    assert seen["main_runtime"] == _MAIN_RUNTIME
+
+
+def test_async_retry_forwards_main_runtime(monkeypatch):
+    """Regression: the async retry dropped it and rebuilt against an empty runtime."""
+    seen = {}
+    _install_stubs(monkeypatch, seen, is_async=True)
+
+    asyncio.run(ac._retry_same_provider_async(main_runtime=_MAIN_RUNTIME, **_COMMON))
+
+    assert seen["main_runtime"] == _MAIN_RUNTIME, (
+        "async retry rebuilt the client without the main runtime; the recovery "
+        "call targets the wrong endpoint"
+    )
+
+
+def test_dropping_main_runtime_changes_client_resolution():
+    """Why it matters: the omitted value drives both construction and the cache key."""
+    assert ac._normalize_main_runtime(_MAIN_RUNTIME) != ac._normalize_main_runtime(None)
+    assert ac._normalize_main_runtime(None) == {}
+
+    key_with = ac._client_cache_key(
+        "auto", async_mode=True, base_url=None, api_key=None, api_mode=None,
+        main_runtime=_MAIN_RUNTIME, is_vision=False, task="compression", model=None,
+    )
+    key_without = ac._client_cache_key(
+        "auto", async_mode=True, base_url=None, api_key=None, api_mode=None,
+        main_runtime=None, is_vision=False, task="compression", model=None,
+    )
+    assert key_with != key_without


### PR DESCRIPTION
## What does this PR do?

`_retry_same_provider_sync` and `_retry_same_provider_async` are hand-maintained twins: after refreshing credentials on an auth error they rebuild the provider client and re-issue the call. The sync twin passes `main_runtime` to `_get_cached_client`; the async twin neither accepts nor forwards it.

This is a plumbing gap rather than a deliberate difference — `main_runtime` is in scope at both async call sites, and the statement immediately after each one already uses it:

```python
pool_provider = _recoverable_pool_provider(..., main_runtime=main_runtime)
```

It matters because that value drives both client construction **and** the client cache key:

```
_normalize_main_runtime(rt)   -> {'provider': 'openai-compatible', 'model': 'main-model',
                                  'base_url': 'https://main.endpoint/v1', 'api_key': 'sk-MAIN', ...}
_normalize_main_runtime(None) -> {}

cache key WITH    -> ('auto', True, '', '', '', ('openai-compatible', 'main-model',
                      'https://main.endpoint/v1', ...), ...)
cache key WITHOUT -> ('auto', True, '', '', '', ('', '', '', '', '', ''), ...)
```

So an auxiliary task configured to reuse the main agent's runtime rebuilds against an **empty** runtime on the async path: the main provider / model / base_url / api_key are dropped, and the differing cache key means the correct cached client can't be reused either. The recovery attempt targets the wrong endpoint and fails — defeating the credential refresh that just succeeded — while the sync path recovers normally.

Same plumbing class as #19470 (`main_runtime` dropped in vision aux resolution), at the retry site.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — `_retry_same_provider_async` now accepts `main_runtime` and forwards it to `_get_cached_client`, mirroring the sync twin; both async call sites pass it. Vision resolution is untouched (both twins already omit it there).
- `tests/agent/test_aux_async_retry_main_runtime.py` — new: the async twin exposes and forwards `main_runtime`, the sync twin still does, and the mechanism itself (normalize + cache-key divergence) is pinned so the omission can't silently return.

## How to Test

1. Run:

       pytest tests/agent/test_aux_async_retry_main_runtime.py -q

   `test_async_retry_accepts_main_runtime` and `test_async_retry_forwards_main_runtime` fail without the fix (`TypeError` — the parameter didn't exist) and pass with it.

2. No regressions: `pytest tests/agent/ -k "auxiliary or aux_"` gives `554 passed, 0 failed` on clean `main` and `558 passed, 0 failed` with this change (554 + the 4 added tests).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(auxiliary):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suites and verified no regressions against a clean `main` baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline comments) — the forwarded argument documents why it must match the sync twin
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (argument plumbing only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A****