### PR TITLE
fix(memory): deactivate providers that fail initialization

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1504,8 +1504,11 @@ def init_agent(
                         _init_kwargs["agent_workspace"] = "hermes"
                     except Exception:
                         pass
-                    agent._memory_manager.initialize_all(**_init_kwargs)
-                    _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
+                    initialized_providers = agent._memory_manager.initialize_all(**_init_kwargs)
+                    if _mem_provider_name in initialized_providers:
+                        _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
+                    if not agent._memory_manager.providers:
+                        agent._memory_manager = None
                 else:
                     _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
                     agent._memory_manager = None

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -459,6 +459,20 @@ class MemoryManager:
             len(provider.get_tool_schemas()),
         )
 
+    def _remove_provider(self, provider: MemoryProvider) -> None:
+        """Remove a provider and every tool route registered for it."""
+        self._providers = [
+            registered for registered in self._providers if registered is not provider
+        ]
+        self._tool_to_provider = {
+            name: registered
+            for name, registered in self._tool_to_provider.items()
+            if registered is not provider
+        }
+        self._has_external = any(
+            registered.name != "builtin" for registered in self._providers
+        )
+
     @property
     def providers(self) -> List[MemoryProvider]:
         """All registered providers in order."""
@@ -1211,17 +1225,22 @@ class MemoryManager:
             active_tasks,
         )
 
-    def initialize_all(self, session_id: str, **kwargs) -> None:
+    def initialize_all(self, session_id: str, **kwargs) -> List[str]:
         """Initialize all providers.
 
         Automatically injects ``hermes_home`` into *kwargs* so that every
         provider can resolve profile-scoped storage paths without importing
-        ``get_hermes_home()`` themselves.
+        ``get_hermes_home()`` themselves. Providers that fail initialization
+        are shut down and unregistered so they cannot advertise tools or
+        receive lifecycle calls in a partially initialized state.
+
+        Returns the names of providers that initialized successfully.
         """
         if "hermes_home" not in kwargs:
             from hermes_constants import get_hermes_home
             kwargs["hermes_home"] = str(get_hermes_home())
-        for provider in self._providers:
+        initialized = []
+        for provider in list(self._providers):
             try:
                 provider.initialize(session_id=session_id, **kwargs)
             except Exception as e:
@@ -1229,3 +1248,15 @@ class MemoryManager:
                     "Memory provider '%s' initialize failed: %s",
                     provider.name, e,
                 )
+                try:
+                    provider.shutdown()
+                except Exception:
+                    logger.warning(
+                        "Memory provider '%s' cleanup after failed initialization failed",
+                        provider.name,
+                        exc_info=True,
+                    )
+                self._remove_provider(provider)
+            else:
+                initialized.append(provider.name)
+        return initialized

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -396,11 +396,31 @@ class TestMemoryManager:
         mgr.add_provider(p1)
         mgr.add_provider(p2)
 
-        mgr.initialize_all(session_id="test-123", platform="cli")
+        initialized = mgr.initialize_all(session_id="test-123", platform="cli")
+        assert initialized == ["builtin", "external"]
         assert p1.initialized
         assert p2.initialized
         assert p1._init_kwargs["session_id"] == "test-123"
         assert p1._init_kwargs["platform"] == "cli"
+
+    def test_initialize_failure_unregisters_provider_and_tool_routes(self):
+        mgr = MemoryManager()
+        healthy = FakeMemoryProvider("builtin")
+        failed = FakeMemoryProvider("external")
+        failed.initialize = MagicMock(side_effect=RuntimeError("bad credentials"))
+        failed.shutdown = MagicMock()
+        failed.get_tool_schemas = MagicMock(
+            return_value=[{"name": "external_recall", "parameters": {}}]
+        )
+        mgr.add_provider(healthy)
+        mgr.add_provider(failed)
+
+        initialized = mgr.initialize_all(session_id="test-123", platform="cli")
+
+        assert initialized == ["builtin"]
+        assert mgr.providers == [healthy]
+        assert not mgr.has_tool("external_recall")
+        failed.shutdown.assert_called_once_with()
 
     # -- Error resilience ---------------------------------------------------
 

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -94,6 +94,40 @@ def test_aiagent_forwards_user_id_alt_to_memory_provider():
     assert "status_callback" not in provider.init_kwargs
 
 
+class FailingMemoryProvider(RecordingMemoryProvider):
+    name = "failing"
+
+    def initialize(self, session_id, **kwargs):
+        raise RuntimeError("provider initialization failed")
+
+
+def test_aiagent_does_not_keep_provider_that_fails_initialization():
+    provider = FailingMemoryProvider()
+    cfg = {"memory": {"provider": "failing"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+            session_id="sess-failed",
+            platform="api_server",
+        )
+
+    assert agent._memory_manager is None
+
+
 class CoreShadowProvider:
     """Provider that tries to register tools shadowing built-in core tools."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes a memory-provider lifecycle bug where a provider that loaded successfully but raised from `initialize()` remained registered. Hermes logged the initialization warning and then still logged the configured provider as activated. Its tools and later lifecycle calls remained routed to a partially initialized object, allowing completed turns to be silently dropped.

This is distinct from #47670, which covers providers that are missing or report unavailable before initialization. This PR covers post-load initialization exceptions such as invalid credentials, missing stable conversation scope, or an unreachable required backend.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/memory_manager.py`: unregister providers and tool routes after failed initialization, perform best-effort shutdown, and return successfully initialized provider names.
- `agent/agent_init.py`: only log activation for a provider that actually initialized and discard an empty failed manager.
- `tests/agent/test_memory_provider.py`: cover failed-provider cleanup, route removal, and successful-provider preservation.
- `tests/run_agent/test_memory_provider_init.py`: cover the real `AIAgent` initialization path.

## How to Test

```bash
cd /tmp/hermes-agent-66980 && uv run --with pytest pytest \
  tests/agent/test_memory_provider.py \
  tests/run_agent/test_memory_provider_init.py -q
```

Result: 107 passed, 0 failed.

Closes #66980