### PR TITLE
feat(auth): canonical shared xAI OAuth store for multi-profile single-use refresh tokens (#65394)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4045,8 +4045,18 @@ async def _retry_same_provider_async(
     )
 
 
-def _refresh_provider_credentials(provider: str) -> bool:
-    """Refresh short-lived credentials for OAuth-backed auxiliary providers."""
+def _refresh_provider_credentials(
+    provider: str,
+    *,
+    rejected_api_key: Optional[str] = None,
+    expected_generation: Optional[int] = None,
+) -> bool:
+    """Refresh short-lived credentials for OAuth-backed auxiliary providers.
+
+    ``rejected_api_key`` / ``expected_generation`` are optional G4/D1 hints so
+    a concurrent winner is adopted instead of double-rotating a single-use
+    refresh token (xAI shared store and pool).
+    """
     normalized = _normalize_aux_provider(provider)
     try:
         if normalized == "copilot":
@@ -4095,21 +4105,59 @@ def _refresh_provider_credentials(provider: str) -> bool:
             _evict_cached_clients(normalized)
             return True
         if normalized == "xai-oauth":
-            # Preference: pool-level refresh (uses refresh_token from pool entry),
-            # then fall back to singleton auth-store resolver.
+            # D1: pass rejected bearer + expected generation so a concurrent
+            # winner is adopted instead of double-rotating the single-use RT.
+            # Shared mode always goes through the canonical resolver first.
+            from hermes_cli.auth import (
+                _xai_shared_auth_enabled,
+                resolve_xai_oauth_runtime_credentials,
+            )
+
+            rejected = str(rejected_api_key or "").strip() or None
+            expected_gen = None
+            try:
+                expected_gen = (
+                    int(expected_generation)
+                    if expected_generation is not None
+                    else None
+                )
+            except (TypeError, ValueError):
+                expected_gen = None
+
+            if _xai_shared_auth_enabled():
+                creds = resolve_xai_oauth_runtime_credentials(
+                    force_refresh=True,
+                    rejected_access_token=rejected,
+                    expected_generation=expected_gen,
+                )
+                if not str(creds.get("api_key", "") or "").strip():
+                    return False
+                _evict_cached_clients(normalized)
+                return True
+
+            # Legacy gate-off: pool refresh first, then singleton with the
+            # rejected bearer so we don't re-POST after a winner.
             pool = load_pool(normalized)
             if pool and pool.has_credentials():
-                # Ensure a current entry is selected before trying to refresh.
-                pool.select()
-                refreshed = pool.try_refresh_current()
-                if refreshed is not None and str(getattr(refreshed, "runtime_api_key", "") or "").strip():
+                if rejected:
+                    refreshed = pool.try_refresh_matching(rejected)
+                else:
+                    pool.select()
+                    refreshed = pool.try_refresh_current()
+                if refreshed is not None and str(
+                    getattr(refreshed, "runtime_api_key", "") or ""
+                ).strip():
                     _evict_cached_clients(normalized)
                     return True
-            from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
-
-            creds = resolve_xai_oauth_runtime_credentials(force_refresh=True)
+            creds = resolve_xai_oauth_runtime_credentials(
+                force_refresh=True,
+                rejected_access_token=rejected,
+                expected_generation=expected_gen,
+            )
             if not str(creds.get("api_key", "") or "").strip():
                 return False
+            # G10: refresh success is insufficient if a cached aux client still
+            # holds the old bearer — always evict after canonical rotation.
             _evict_cached_clients(normalized)
             return True
         if normalized == "vertex":
@@ -4145,11 +4193,28 @@ def _auth_refresh_provider_for_route(
     Auto-routed auxiliary calls keep ``resolved_provider == "auto"`` even
     after _get_cached_client() selects a concrete backend. Infer the backend
     from the selected client's base URL so auth refresh works for auto →
-    Copilot/Codex/Anthropic/Nous routes too. (#20832)
+    Copilot/Codex/Anthropic/Nous/xAI routes too. (#20832, D2)
+
+    Configured fallback-chain labels look like
+    ``fallback_chain[0](xai-oauth)`` — extract the real provider id so refresh
+    hits the xai-oauth branch rather than treating the composite label as the
+    provider name (R6).
     """
-    normalized = _normalize_aux_provider(resolved_provider)
+    raw = (resolved_provider or "").strip()
+    # R6: unwrap fallback_chain[N](<provider>) before normalization.
+    chain_match = re.search(
+        r"fallback_chain\[\d+\]\(([^)]+)\)\s*$",
+        raw,
+        flags=re.IGNORECASE,
+    )
+    if chain_match:
+        raw = chain_match.group(1).strip()
+    normalized = _normalize_aux_provider(raw)
     if normalized and normalized != "auto":
-        return normalized
+        # Composite leftovers (e.g. still containing "fallback_chain") are not
+        # real providers — fall through to base-URL inference.
+        if "fallback_chain" not in normalized:
+            return normalized
     if base_url_host_matches(client_base_url, "api.githubcopilot.com"):
         return "copilot"
     if base_url_host_matches(client_base_url, "chatgpt.com"):
@@ -4158,7 +4223,11 @@ def _auth_refresh_provider_for_route(
         return "anthropic"
     if base_url_host_matches(client_base_url, "inference-api.nousresearch.com"):
         return "nous"
-    return normalized
+    # D2: auto-routed xAI aux clients must refresh xai-oauth, not keep a
+    # rejected bearer because the route label stayed "auto".
+    if base_url_host_matches(client_base_url, "api.x.ai"):
+        return "xai-oauth"
+    return normalized if "fallback_chain" not in (normalized or "") else "auto"
 
 
 def _fallback_entry_timeout(task: Optional[str], fb_label: str) -> Optional[float]:
@@ -4251,7 +4320,13 @@ def _call_fallback_candidate_sync(
         if not _is_auth_error(fb_err):
             raise
         fb_provider = _auth_refresh_provider_for_route(fb_label, fb_base)
-        if fb_provider not in {"auto", "", None} and _refresh_provider_credentials(fb_provider):
+        # F6: pass the rejected bearer so shared xAI adopts a concurrent winner
+        # instead of force-rotating the single-use RT a second time.
+        _rejected_bearer = str(getattr(fb_client, "api_key", None) or "").strip() or None
+        if fb_provider not in {"auto", "", None} and _refresh_provider_credentials(
+            fb_provider,
+            rejected_api_key=_rejected_bearer,
+        ):
             retry_client, retry_model = _get_cached_client(fb_provider, fb_model)
             if retry_client is not None:
                 retry_kwargs = _build_call_kwargs(
@@ -4329,7 +4404,13 @@ async def _call_fallback_candidate_async(
         if not _is_auth_error(fb_err):
             raise
         fb_provider = _auth_refresh_provider_for_route(fb_label, fb_base)
-        if fb_provider not in {"auto", "", None} and _refresh_provider_credentials(fb_provider):
+        # F6: pass the rejected bearer so shared xAI adopts a concurrent winner
+        # instead of force-rotating the single-use RT a second time.
+        _rejected_bearer = str(getattr(fb_client, "api_key", None) or "").strip() or None
+        if fb_provider not in {"auto", "", None} and _refresh_provider_credentials(
+            fb_provider,
+            rejected_api_key=_rejected_bearer,
+        ):
             retry_client, retry_model = _get_cached_client(
                 fb_provider, fb_model, async_mode=True)
             if retry_client is not None:
@@ -8351,7 +8432,15 @@ def call_llm(
         if (_is_auth_error(first_err)
                 and auth_refresh_provider not in {"auto", "", None}
                 and not client_is_nous):
-            if _refresh_provider_credentials(auth_refresh_provider):
+            # D1: pass the rejected bearer so shared xAI adopts a concurrent
+            # winner instead of double-rotating the single-use RT.
+            _rejected_bearer = str(
+                getattr(client, "api_key", None) or resolved_api_key or ""
+            ).strip() or None
+            if _refresh_provider_credentials(
+                auth_refresh_provider,
+                rejected_api_key=_rejected_bearer,
+            ):
                 if auth_refresh_provider != _normalize_aux_provider(resolved_provider):
                     # The stale client is cached under the route label
                     # (e.g. "auto"), not the concrete backend we refreshed.
@@ -8992,7 +9081,13 @@ async def async_call_llm(
         if (_is_auth_error(first_err)
                 and auth_refresh_provider not in {"auto", "", None}
                 and not client_is_nous):
-            if _refresh_provider_credentials(auth_refresh_provider):
+            _rejected_bearer = str(
+                getattr(client, "api_key", None) or resolved_api_key or ""
+            ).strip() or None
+            if _refresh_provider_credentials(
+                auth_refresh_provider,
+                rejected_api_key=_rejected_bearer,
+            ):
                 if auth_refresh_provider != _normalize_aux_provider(resolved_provider):
                     # The stale client is cached under the route label
                     # (e.g. "auto"), not the concrete backend we refreshed.

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1926,24 +1926,40 @@ def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[
 
 
 def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
-    """Resolve a fresh xAI OAuth (api_key, base_url) for auxiliary clients.
+    """Resolve fresh xAI OAuth credentials for auxiliary clients.
 
-    Prefer the credential pool, matching the main runtime/provider status
-    path.  Some xAI OAuth logins live only as pool entries; falling straight
-    to the singleton auth-store resolver would make auxiliary tasks such as
-    compression report "no provider configured" even though ``hermes auth
-    status`` shows xAI OAuth as logged in.
-
-    Falls back to ``hermes_cli.auth``'s singleton runtime resolver for older
-    auth-store-only logins. Returns ``None`` if the user is not authenticated
-    with xAI Grok OAuth.
+    Shared mode is fail-closed: the canonical resolver is the only allowed
+    source, so a disabled profile or missing/corrupt shared store can never
+    fall through to a stale legacy pool entry. Legacy mode retains the pool-
+    first behavior for older pool-only and auth-store-only logins.
     """
     try:
         from hermes_cli.auth import (
             DEFAULT_XAI_OAUTH_BASE_URL,
+            _xai_shared_auth_enabled,
             _xai_validate_inference_base_url,
+            resolve_xai_oauth_runtime_credentials,
         )
+    except Exception as exc:
+        logger.debug("Auxiliary xAI OAuth auth helper import failed: %s", exc)
+        return None
 
+    if _xai_shared_auth_enabled():
+        try:
+            creds = resolve_xai_oauth_runtime_credentials()
+        except Exception as exc:
+            logger.debug(
+                "Auxiliary shared xAI OAuth credential resolution failed closed: %s",
+                exc,
+            )
+            return None
+        api_key = str(creds.get("api_key") or "").strip()
+        base_url = str(creds.get("base_url") or "").strip().rstrip("/")
+        if not api_key or not base_url:
+            return None
+        return api_key, base_url
+
+    try:
         pool = load_pool("xai-oauth")
         if pool and pool.has_credentials():
             entry = pool.select()
@@ -1966,8 +1982,6 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
         logger.debug("Auxiliary xAI OAuth pool credential resolution failed: %s", exc)
 
     try:
-        from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
-
         creds = resolve_xai_oauth_runtime_credentials()
     except Exception as exc:
         logger.debug("Auxiliary xAI OAuth runtime credential resolution failed: %s", exc)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -840,22 +840,68 @@ class CredentialPool:
         return entry
 
     def _sync_xai_oauth_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
-        """Sync an xAI OAuth pool entry from auth.json if tokens differ.
+        """Sync an xAI OAuth pool entry from the canonical auth source.
 
-        xAI OAuth refresh tokens are single-use.  When another Hermes process
-        (or another profile sharing the same auth.json) refreshes the token,
-        it writes the new pair to ``providers["xai-oauth"]["tokens"]`` under
-        ``_auth_store_lock``.  Without this resync, our in-memory pool entry
-        keeps the consumed refresh_token and the next ``_refresh_entry`` call
-        would replay it and get a ``refresh_token_reused``-style 4xx.
-
-        Only applies to entries seeded from the singleton (``device_code``);
-        manually added entries are independent credentials with their own
-        refresh-token lifecycle.
+        Under shared xAI mode the canonical shared store is authoritative;
+        profile auth.json must never re-fork a durable refresh_token. A4:
+        same-family ``manual:*`` rows are rewritten onto the shared reference
+        rather than kept as independent durable RTs.
         """
-        if self.provider != "xai-oauth" or entry.source != "device_code":
+        if self.provider != "xai-oauth":
             return entry
+        source = str(entry.source or "")
+        if source.startswith("manual") and not auth_mod._xai_shared_auth_enabled():
+            return entry
+        if source not in {
+            "device_code",
+            auth_mod.XAI_SHARED_SOURCE,
+            "shared:xai-oauth",
+        } and not source.startswith("manual"):
+            # Unknown non-manual sources: only adopt shared when shared mode on.
+            if not auth_mod._xai_shared_auth_enabled():
+                return entry
+
         try:
+            if auth_mod._xai_shared_auth_enabled():
+                shared = auth_mod._read_shared_xai_state()
+                if not auth_mod._xai_shared_state_has_usable_tokens(shared):
+                    return entry
+                assert shared is not None
+                store_access = str(shared.get("access_token") or "")
+                # Intentionally do NOT copy refresh_token into durable pool state.
+                entry_access = entry.access_token or ""
+                needs_rewrite = (
+                    bool(entry.refresh_token)
+                    or source.startswith("manual")
+                    or source not in {auth_mod.XAI_SHARED_SOURCE, "shared:xai-oauth"}
+                    or (store_access and store_access != entry_access)
+                )
+                if needs_rewrite and store_access:
+                    logger.debug(
+                        "Pool entry %s: syncing xAI access token from shared store",
+                        entry.id,
+                    )
+                    field_updates: Dict[str, Any] = {
+                        "access_token": store_access,
+                        "refresh_token": None,
+                        "source": auth_mod.XAI_SHARED_SOURCE,
+                        "last_status": None,
+                        "last_status_at": None,
+                        "last_error_code": None,
+                        "last_error_reason": None,
+                        "last_error_message": None,
+                        "last_error_reset_at": None,
+                    }
+                    if shared.get("last_refresh"):
+                        field_updates["last_refresh"] = shared["last_refresh"]
+                    updated = replace(entry, **field_updates)
+                    self._replace_entry(entry, updated)
+                    self._persist()
+                    return updated
+                return entry
+
+            if entry.source != "device_code":
+                return entry
             with _auth_store_lock():
                 auth_store = _load_auth_store()
                 state = _load_provider_state(auth_store, "xai-oauth")
@@ -894,7 +940,7 @@ class CredentialPool:
                 self._persist()
                 return updated
         except Exception as exc:
-            logger.debug("Failed to sync xAI OAuth entry from auth.json: %s", exc)
+            logger.debug("Failed to sync xAI OAuth entry from auth store: %s", exc)
         return entry
 
     def _sync_xai_oauth_entry_from_pool_store(
@@ -1055,6 +1101,9 @@ class CredentialPool:
                     "openai-codex": "openai-codex",
                     "xai-oauth": "xai-oauth",
                 }.get(self.provider)
+                # G2: shared xAI mode disables the old root write-through path.
+                if self.provider == "xai-oauth" and auth_mod._xai_shared_auth_enabled():
+                    _wt_provider_id = None
                 write_through_to_root = bool(_wt_provider_id) and not (
                     isinstance(auth_store.get("providers"), dict)
                     and isinstance(
@@ -1099,6 +1148,10 @@ class CredentialPool:
                     _store_provider_state(auth_store, "openai-codex", state, set_active=False)
 
                 elif self.provider == "xai-oauth":
+                    # Shared mode: never materialize tokens into the profile.
+                    # The canonical resolver already wrote the shared store.
+                    if auth_mod._xai_shared_auth_enabled():
+                        return
                     state = _load_provider_state(auth_store, "xai-oauth")
                     if not isinstance(state, dict):
                         return
@@ -1124,10 +1177,22 @@ class CredentialPool:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
     def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
-        if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
+        # Shared xAI entries are reference-backed and intentionally omit a
+        # durable refresh_token; they still refresh via the canonical resolver.
+        # A4: under shared mode manuals also route through the shared path so
+        # they never pure-refresh a durable local RT outside the shared lock.
+        shared_xai = (
+            self.provider == "xai-oauth"
+            and auth_mod._xai_shared_auth_enabled()
+        )
+        if entry.auth_type != AUTH_TYPE_OAUTH or (not entry.refresh_token and not shared_xai):
             if force:
                 self._mark_exhausted(entry, None)
             return None
+
+        if shared_xai:
+            # G1/G3: do NOT hold profile auth.lock around the shared refresh.
+            return self._refresh_entry_impl(entry, force=force)
 
         # Codex and xAI OAuth refresh tokens are single-use.  The
         # sync→POST→write-back sequence below must run atomically across Hermes
@@ -1230,24 +1295,57 @@ class CredentialPool:
                     last_refresh=refreshed.get("last_refresh"),
                 )
             elif self.provider == "xai-oauth":
-                # Adopt fresher tokens from auth.json before spending the
-                # refresh_token — single-use tokens consumed by another
-                # process (or another profile sharing the singleton) would
-                # otherwise trigger ``refresh_token_reused`` on the next
-                # POST.  Only meaningful for singleton-seeded entries.
-                synced = self._sync_xai_oauth_entry_from_auth_store(entry)
-                if synced is not entry:
-                    entry = synced
-                refreshed = auth_mod.refresh_xai_oauth_pure(
-                    entry.access_token,
-                    entry.refresh_token,
-                )
-                updated = replace(
-                    entry,
-                    access_token=refreshed["access_token"],
-                    refresh_token=refreshed["refresh_token"],
-                    last_refresh=refreshed.get("last_refresh"),
-                )
+                source = str(entry.source or "")
+                if auth_mod._xai_shared_auth_enabled():
+                    # A4/G1: under shared mode EVERY xAI pool row — including
+                    # legacy manual:* — routes through the canonical shared
+                    # resolver + lock. Never pure-refresh a durable local RT.
+                    if source.startswith("manual") and entry.refresh_token:
+                        logger.warning(
+                            "xAI shared mode: refusing pure-refresh of manual "
+                            "pool entry %s; routing through canonical shared store",
+                            entry.id,
+                        )
+                    creds = auth_mod.resolve_xai_oauth_runtime_credentials(
+                        force_refresh=force,
+                        refresh_if_expiring=True,
+                        rejected_access_token=entry.access_token or None,
+                    )
+                    updated = replace(
+                        entry,
+                        access_token=str(creds.get("api_key") or ""),
+                        refresh_token=None,
+                        source=auth_mod.XAI_SHARED_SOURCE,
+                        last_refresh=creds.get("last_refresh"),
+                        base_url=creds.get("base_url") or entry.base_url,
+                    )
+                elif source.startswith("manual"):
+                    # Legacy gate-off: independent manual grant pure-refresh.
+                    refreshed = auth_mod.refresh_xai_oauth_pure(
+                        entry.access_token,
+                        entry.refresh_token,
+                    )
+                    updated = replace(
+                        entry,
+                        access_token=refreshed["access_token"],
+                        refresh_token=refreshed["refresh_token"],
+                        last_refresh=refreshed.get("last_refresh"),
+                    )
+                else:
+                    # Legacy singleton path.
+                    synced = self._sync_xai_oauth_entry_from_auth_store(entry)
+                    if synced is not entry:
+                        entry = synced
+                    refreshed = auth_mod.refresh_xai_oauth_pure(
+                        entry.access_token,
+                        entry.refresh_token,
+                    )
+                    updated = replace(
+                        entry,
+                        access_token=refreshed["access_token"],
+                        refresh_token=refreshed["refresh_token"],
+                        last_refresh=refreshed.get("last_refresh"),
+                    )
             elif self.provider == "nous":
                 synced = self._sync_nous_entry_from_auth_store(entry)
                 if synced is not entry:
@@ -1334,28 +1432,34 @@ class CredentialPool:
                         "xAI OAuth refresh token is terminally invalid; clearing local token state"
                     )
                     try:
-                        with _auth_store_lock():
-                            auth_store = _load_auth_store()
-                            state = _load_provider_state(auth_store, "xai-oauth") or {}
-                            if isinstance(state, dict):
-                                tokens = state.get("tokens") or {}
-                                if isinstance(tokens, dict):
-                                    store_refresh = str(tokens.get("refresh_token") or "").strip()
-                                    entry_refresh = str(entry.refresh_token or "").strip()
-                                    if not store_refresh or store_refresh == entry_refresh:
-                                        tokens.pop("access_token", None)
-                                        tokens.pop("refresh_token", None)
-                                        state["tokens"] = tokens
-                                        state["last_auth_error"] = {
-                                            "provider": "xai-oauth",
-                                            "code": getattr(exc, "code", "unknown"),
-                                            "message": str(exc),
-                                            "reason": "credential_pool_refresh_failure",
-                                            "relogin_required": True,
-                                            "at": datetime.now(timezone.utc).isoformat(),
-                                        }
-                                        _save_provider_state(auth_store, "xai-oauth", state)
-                                        _save_auth_store(auth_store)
+                        if auth_mod._xai_shared_auth_enabled():
+                            # Resolver already compare-and-cleared the shared
+                            # store under the shared lock when the failure was
+                            # raised there; do not hold profile auth.lock here.
+                            pass
+                        else:
+                            with _auth_store_lock():
+                                auth_store = _load_auth_store()
+                                state = _load_provider_state(auth_store, "xai-oauth") or {}
+                                if isinstance(state, dict):
+                                    tokens = state.get("tokens") or {}
+                                    if isinstance(tokens, dict):
+                                        store_refresh = str(tokens.get("refresh_token") or "").strip()
+                                        entry_refresh = str(entry.refresh_token or "").strip()
+                                        if not store_refresh or store_refresh == entry_refresh:
+                                            tokens.pop("access_token", None)
+                                            tokens.pop("refresh_token", None)
+                                            state["tokens"] = tokens
+                                            state["last_auth_error"] = {
+                                                "provider": "xai-oauth",
+                                                "code": getattr(exc, "code", "unknown"),
+                                                "message": str(exc),
+                                                "reason": "credential_pool_refresh_failure",
+                                                "relogin_required": True,
+                                                "at": datetime.now(timezone.utc).isoformat(),
+                                            }
+                                            _save_provider_state(auth_store, "xai-oauth", state)
+                                            _save_auth_store(auth_store)
                     except Exception as clear_exc:
                         logger.debug(
                             "Failed to clear terminal xAI OAuth state: %s", clear_exc
@@ -2467,7 +2571,123 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             )
 
     elif provider == "xai-oauth":
-        # When the user logs in via ``hermes model`` -> xAI Grok OAuth,
+        # Shared mode: seed a reference-backed ephemeral entry from the
+        # canonical shared store. Do NOT re-fork the refresh_token into the
+        # profile pool (G1). A3/A4: rewrite/discard pre-existing device_code
+        # and same-family manual rows so they cannot pure-refresh a local RT.
+        #
+        # F1 (CRITICAL): NEVER strip the last local RT while the canonical
+        # store is empty. Auto-promote first (durable shared write), THEN
+        # strip. If promotion cannot write, leave local intact and surface.
+        if auth_mod._xai_shared_auth_enabled():
+            if auth_mod._profile_xai_shared_disabled():
+                return changed, active_sources
+            source = auth_mod.XAI_SHARED_SOURCE
+            if _is_suppressed(provider, source) or _is_suppressed(provider, "device_code"):
+                return changed, active_sources
+
+            # Promote local → shared BEFORE any in-memory or on-disk strip.
+            # Raises AuthError on write/strip failure after a local grant was
+            # found (local RT preserved when the shared write itself failed).
+            shared = auth_mod.ensure_shared_xai_grant_from_local(strip_legacy=True)
+            if not auth_mod._xai_shared_state_has_usable_tokens(shared):
+                # Truly empty — leave any residual local rows alone; do not
+                # invent a "shared" seed and do not destroy local grants.
+                return changed, active_sources
+
+            # Shared has a durable grant: safe to rewrite/drop local forks.
+            rewritten: List[PooledCredential] = []
+            for entry in list(entries):
+                entry_source = str(entry.source or "")
+                if entry_source.startswith("manual") or entry_source in {
+                    "device_code",
+                    "loopback_pkce",
+                    "hermes_pkce",
+                }:
+                    changed = True
+                    continue  # drop durable local forks
+                if entry_source in {source, "shared:xai-oauth"}:
+                    if entry.refresh_token:
+                        changed = True
+                        rewritten.append(
+                            replace(
+                                entry,
+                                refresh_token=None,
+                                source=source,
+                                access_token=entry.access_token,
+                            )
+                        )
+                    else:
+                        rewritten.append(entry)
+                    continue
+                # Unknown sources: strip any RT and drop.
+                if entry.refresh_token:
+                    changed = True
+                    continue
+                rewritten.append(entry)
+            if len(rewritten) != len(entries) or changed:
+                entries[:] = rewritten
+                changed = True
+
+            assert shared is not None
+            active_sources.add(source)
+            from hermes_cli.auth import DEFAULT_XAI_OAUTH_BASE_URL
+
+            access = str(shared.get("access_token") or "")
+            changed |= _upsert_entry(
+                entries,
+                provider,
+                source,
+                {
+                    "source": source,
+                    "auth_type": AUTH_TYPE_OAUTH,
+                    "access_token": access,
+                    # Raw RT stripped at the persistence boundary via
+                    # borrowed-source sanitization; never seed it here.
+                    "refresh_token": None,
+                    "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+                    "last_refresh": shared.get("last_refresh"),
+                    "label": label_from_token(access, source),
+                },
+            )
+
+            # Active-profile residual strip (A1/A3). Fail loud (F3c) — never
+            # silently leave a durable local RT after seeding shared.
+            if auth_mod._auth_store_holds_durable_xai_refresh_token(
+                _load_auth_store()
+            ):
+                try:
+                    with _auth_store_lock():
+                        store = _load_auth_store()
+                        if auth_mod._strip_xai_secrets_in_store(
+                            store, remove_manuals=True
+                        ):
+                            _save_auth_store(store)
+                            changed = True
+                        verify = _load_auth_store()
+                        if auth_mod._auth_store_holds_durable_xai_refresh_token(
+                            verify
+                        ):
+                            raise auth_mod.AuthError(
+                                "Shared xAI OAuth load_pool could not strip residual "
+                                "durable refresh_token from the active profile after "
+                                "seeding the shared reference.",
+                                provider="xai-oauth",
+                                code="xai_shared_strip_incomplete",
+                                relogin_required=False,
+                            )
+                except auth_mod.AuthError:
+                    raise
+                except Exception as exc:
+                    raise auth_mod.AuthError(
+                        f"Shared xAI OAuth load_pool profile secret strip failed: {exc}",
+                        provider="xai-oauth",
+                        code="xai_shared_strip_incomplete",
+                        relogin_required=False,
+                    ) from exc
+            return changed, active_sources
+
+        # Legacy: When the user logs in via ``hermes model`` -> xAI Grok OAuth,
         # tokens are written to the auth.json singleton
         # (``providers["xai-oauth"]``).  Surface them in the pool too so
         # ``hermes auth list`` reflects the logged-in state and so the pool
@@ -2743,6 +2963,25 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
     raw_entries = read_credential_pool(provider)
+    # A7: under shared xAI mode, never materialize root-borrowed xAI rows
+    # (with real RTs) into the active profile. Prefer an empty local view and
+    # let the shared singleton seed supply a non-secret reference.
+    active_pool = _load_auth_store().get("credential_pool")
+    active_entries = active_pool.get(provider) if isinstance(active_pool, dict) else None
+    profile_owns_provider_rows = bool(
+        isinstance(active_entries, list) and active_entries
+    )
+    shared_xai = provider == "xai-oauth" and auth_mod._xai_shared_auth_enabled()
+    if shared_xai and not profile_owns_provider_rows:
+        # Borrowed-from-root only — drop secret-bearing rows before materialize.
+        raw_entries = [
+            payload
+            for payload in raw_entries
+            if isinstance(payload, dict)
+            and not str(payload.get("refresh_token") or "").strip()
+            and str(payload.get("source") or "")
+            in {auth_mod.XAI_SHARED_SOURCE, "shared:xai-oauth", ""}
+        ]
     disk_ids = {
         entry.get("id")
         for entry in raw_entries
@@ -2753,6 +2992,17 @@ def load_pool(provider: str) -> CredentialPool:
         and sanitize_borrowed_credential_payload(payload, provider) != payload
         for payload in raw_entries
     )
+    if shared_xai:
+        # A2/A3: also treat any durable RT under shared mode as needing rewrite.
+        raw_needs_sanitization = raw_needs_sanitization or any(
+            isinstance(payload, dict)
+            and (
+                str(payload.get("refresh_token") or "").strip()
+                or str(payload.get("source") or "")
+                not in {auth_mod.XAI_SHARED_SOURCE, "shared:xai-oauth", ""}
+            )
+            for payload in raw_entries
+        )
     entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
     raw_needs_auth_normalization = any(
         isinstance(payload, dict)
@@ -2767,9 +3017,8 @@ def load_pool(provider: str) -> CredentialPool:
         # A profile may be reading this provider from the global-root fallback.
         # Keep that fallback read-only: only the store that owns these rows may
         # rewrite them. Loading the default/root profile will heal global rows.
-        active_pool = _load_auth_store().get("credential_pool")
-        active_entries = active_pool.get(provider) if isinstance(active_pool, dict) else None
-        raw_needs_auth_normalization = bool(active_entries)
+        # (Re-use active_entries captured above.)
+        raw_needs_auth_normalization = bool(profile_owns_provider_rows)
 
     if provider.startswith(CUSTOM_POOL_PREFIX):
         # Custom endpoint pool — seed from custom_providers config and model config
@@ -2796,7 +3045,19 @@ def load_pool(provider: str) -> CredentialPool:
         )
         changed |= _normalize_pool_priorities(provider, entries)
 
+    # A7: under shared mode, never persist a write that only materializes
+    # root-borrowed secret rows. Seed may still have produced a local shared
+    # ref — that is fine to write (no RT).
     if changed:
+        if shared_xai and not profile_owns_provider_rows:
+            # Only allow writing non-secret shared references.
+            safe_entries = [
+                entry
+                for entry in entries
+                if not entry.refresh_token
+                and str(entry.source or "") in {auth_mod.XAI_SHARED_SOURCE, "shared:xai-oauth"}
+            ]
+            entries = safe_entries
         new_ids = {entry.id for entry in entries}
         write_credential_pool(
             provider,

--- a/agent/credential_sources.py
+++ b/agent/credential_sources.py
@@ -275,8 +275,45 @@ def _remove_xai_oauth_device_code(provider: str, removed) -> RemovalResult:
     entry from the still-present singleton — credentials reappear with no
     user feedback. Clearing the singleton in step with the suppression set
     by the central dispatcher makes the removal stick.
+
+    Under shared xAI mode the canonical grant is NOT deleted here — that
+    requires an explicit global logout. Removal only disables this profile's
+    use of the shared store and clears local non-secret references.
     """
     result = RemovalResult()
+    try:
+        from hermes_cli import auth as auth_mod
+        from hermes_cli.auth import AuthError
+    except Exception:
+        auth_mod = None
+        AuthError = Exception  # type: ignore[misc, assignment]
+
+    if auth_mod is not None and auth_mod._xai_shared_auth_enabled():
+        # B1/R8: clear local reference first, THEN re-write the durable
+        # disable marker so it survives the provider-block deletion.
+        # Disable failures must surface — never claim cleanup success when
+        # the durable disable marker did not land.
+        if _clear_auth_store_provider(provider):
+            result.cleaned.append(
+                f"Cleared {provider} profile reference from auth store"
+            )
+        try:
+            auth_mod.disable_profile_xai_shared_auth()
+        except AuthError:
+            raise
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to disable shared xAI OAuth for this profile: {exc}"
+            ) from exc
+        result.cleaned.append(
+            "Disabled shared xAI OAuth for this profile (canonical grant unchanged)"
+        )
+        result.hints.append(
+            "To delete the grant for all profiles: "
+            "`hermes logout --provider xai-oauth --global`"
+        )
+        return result
+
     if _clear_auth_store_provider(provider):
         result.cleaned.append(f"Cleared {provider} OAuth tokens from auth store")
     result.hints.append(

--- a/cli.py
+++ b/cli.py
@@ -719,7 +719,20 @@ def load_cli_config() -> Dict[str, Any]:
     for config_key, env_var in browser_env_mappings.items():
         if config_key in browser_config:
             os.environ[env_var] = str(browser_config[config_key])
-    
+
+    # Bridge shared_auth.* (config.yaml) → internal HERMES_XAI_SHARED_AUTH /
+    # HERMES_SHARED_AUTH_PROVIDERS env vars. User-facing activation is the
+    # config key (AGENTS.md env-var-for-config); the shared-store engine still
+    # reads the env vars. Gate-off (absent/empty shared_auth) leaves env alone.
+    try:
+        from hermes_cli.config import apply_shared_auth_config_to_env
+
+        # Prefer raw on-disk config so DEFAULT_CONFIG empty providers never
+        # looks like a deliberate user opt-in.
+        apply_shared_auth_config_to_env()
+    except Exception:
+        pass
+
     # Apply auxiliary model/direct-endpoint overrides to environment variables.
     # Vision and web_extract each have their own provider/model/base_url/api_key tuple.
     # Compression config is read directly from config.yaml by run_agent.py and

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3139,6 +3139,19 @@ def run_job(
         )
         reset_secret_source_cache()
         load_hermes_dotenv(hermes_home=_get_hermes_home())
+        # Bridge shared_auth.* from config.yaml → internal HERMES_* env so
+        # cron workers honor the same activation as CLI/gateway (config is
+        # user-facing; env is the internal mechanism). Gate-off leaves env
+        # untouched. Mirrors terminal.cwd → TERMINAL_CWD.
+        try:
+            from hermes_cli.config import apply_shared_auth_config_to_env
+
+            apply_shared_auth_config_to_env()
+        except Exception:
+            logger.debug(
+                "shared_auth config → env bridge failed for cron job",
+                exc_info=True,
+            )
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2053,6 +2053,16 @@ if _config_path.exists():
         _tz_cfg = _cfg.get("timezone", "")
         if _tz_cfg and isinstance(_tz_cfg, str):
             os.environ["HERMES_TIMEZONE"] = _tz_cfg.strip()
+        # Shared auth activation (config.yaml → internal HERMES_* env vars).
+        # User-facing switch is shared_auth.providers; engine still reads
+        # HERMES_XAI_SHARED_AUTH / HERMES_SHARED_AUTH_PROVIDERS (terminal.cwd
+        # → TERMINAL_CWD pattern). Absent/empty shared_auth leaves env alone.
+        try:
+            from hermes_cli.config import apply_shared_auth_config_to_env
+
+            apply_shared_auth_config_to_env(config=_cfg)
+        except Exception:
+            pass
         # Security settings
         _security_cfg = _cfg.get("security", {})
         if isinstance(_security_cfg, dict):

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -33,12 +33,12 @@ import threading
 import time
 import uuid
 import webbrowser
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Mapping, Optional, Sequence, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
@@ -1117,10 +1117,44 @@ def _auth_store_lock(
         yield
 
 
-def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
+def _empty_auth_store() -> Dict[str, Any]:
+    """Canonical empty auth-store shape (absent / empty-dict load result)."""
+    return {"version": AUTH_STORE_VERSION, "providers": {}}
+
+
+def _is_recognized_auth_store_shape(raw: Any) -> bool:
+    """True when decoded JSON is a recognized dict-shaped auth store.
+
+    Recognized:
+      - empty dict ``{}`` (legitimately empty)
+      - dict with ``providers`` mapping and/or ``credential_pool`` mapping
+      - legacy PR ``systems`` mapping (migrated on load)
+
+    Lists, strings, numbers, null, and other non-dict / unrecognized dict
+    shapes are NOT recognized — under ``fail_on_corrupt=True`` they must
+    raise rather than normalize to empty (R7-1).
+    """
+    if not isinstance(raw, dict):
+        return False
+    if not raw:
+        return True
+    if isinstance(raw.get("providers"), dict):
+        return True
+    if isinstance(raw.get("credential_pool"), dict):
+        return True
+    if isinstance(raw.get("systems"), dict):
+        return True
+    return False
+
+
+def _load_auth_store(
+    auth_file: Optional[Path] = None,
+    *,
+    fail_on_corrupt: bool = False,
+) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
-        return {"version": AUTH_STORE_VERSION, "providers": {}}
+        return _empty_auth_store()
 
     try:
         raw = json.loads(auth_file.read_text(encoding="utf-8"))
@@ -1131,12 +1165,45 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
             shutil.copy2(auth_file, corrupt_path)
         except Exception:
             pass
+        if fail_on_corrupt:
+            # R5: sole-owner audit must not treat unreadable/corrupt stores as empty.
+            raise AuthError(
+                f"auth store at {auth_file} is unreadable/corrupt: {exc}. "
+                f"Corrupt copy preserved at {corrupt_path}.",
+                provider="xai-oauth",
+                code="auth_store_unreadable",
+                relogin_required=False,
+            ) from exc
         logger.warning(
             "auth: failed to parse %s (%s) — starting with empty store. "
             "Corrupt file preserved at %s",
             auth_file, exc, corrupt_path,
         )
-        return {"version": AUTH_STORE_VERSION, "providers": {}}
+        return _empty_auth_store()
+
+    # R7-1: parseable but unsupported shapes must fail closed under strict load.
+    # Absent file → empty (above). Empty dict ``{}`` → empty. Ordinary empty
+    # provider dicts remain valid. Lists / strings / numbers / unrecognized
+    # dicts are NOT silently normalized when fail_on_corrupt=True — a hidden
+    # durable RT in an invalid-shaped store must not be treated as empty and
+    # promoted-over / certified clean.
+    if not _is_recognized_auth_store_shape(raw):
+        if fail_on_corrupt:
+            raise AuthError(
+                f"auth store at {auth_file} has unsupported shape "
+                f"({type(raw).__name__}); refusing to treat as empty under "
+                f"fail-closed load.",
+                provider="xai-oauth",
+                code="auth_store_unreadable",
+                relogin_required=False,
+            )
+        logger.warning(
+            "auth: unsupported auth store shape at %s (%s) — starting with "
+            "empty store.",
+            auth_file,
+            type(raw).__name__,
+        )
+        return _empty_auth_store()
 
     if isinstance(raw, dict) and (
         isinstance(raw.get("providers"), dict)
@@ -1147,6 +1214,10 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
             _migrate_stale_nous_portal_url(raw["providers"])
         return raw
 
+    # Empty dict ``{}`` — legitimately empty recognized store.
+    if isinstance(raw, dict) and not raw:
+        return _empty_auth_store()
+
     # Migrate from PR's "systems" format if present
     if isinstance(raw, dict) and isinstance(raw.get("systems"), dict):
         systems = raw["systems"]
@@ -1156,7 +1227,17 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         return {"version": AUTH_STORE_VERSION, "providers": providers,
                 "active_provider": "nous" if providers else None}
 
-    return {"version": AUTH_STORE_VERSION, "providers": {}}
+    # Defensive: recognized-shape predicate should have covered all cases.
+    if fail_on_corrupt:
+        raise AuthError(
+            f"auth store at {auth_file} has unsupported shape "
+            f"({type(raw).__name__}); refusing to treat as empty under "
+            f"fail-closed load.",
+            provider="xai-oauth",
+            code="auth_store_unreadable",
+            relogin_required=False,
+        )
+    return _empty_auth_store()
 
 
 def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = None) -> Path:
@@ -1561,6 +1642,14 @@ def write_credential_pool(
             if isinstance(entry, dict) else entry
             for entry in entries
         ]
+        # A2: final shared-mode guard — no durable xAI RT except the ephemeral
+        # shared reference, regardless of source label (device_code/manual/etc).
+        if str(provider_id or "").strip().lower() == "xai-oauth" and _xai_shared_auth_enabled():
+            sanitized_entries = [
+                sanitize_xai_shared_pool_payload(entry, provider_id)
+                if isinstance(entry, dict) else entry
+                for entry in sanitized_entries
+            ]
         existing = pool.get(provider_id)
         existing_list = existing if isinstance(existing, list) else []
         existing_by_id = {
@@ -1587,7 +1676,28 @@ def write_credential_pool(
             disk_id = disk_entry.get("id")
             if not disk_id or disk_id in new_ids or disk_id in removed:
                 continue
-            merged.append(sanitize_borrowed_credential_payload(disk_entry, provider_id))
+            merged_entry = sanitize_borrowed_credential_payload(disk_entry, provider_id)
+            if str(provider_id or "").strip().lower() == "xai-oauth" and _xai_shared_auth_enabled():
+                merged_entry = sanitize_xai_shared_pool_payload(merged_entry, provider_id)
+            merged.append(merged_entry)
+        # Collapse duplicate shared refs after merge (sole ownership).
+        if str(provider_id or "").strip().lower() == "xai-oauth" and _xai_shared_auth_enabled():
+            collapsed: List[Dict[str, Any]] = []
+            saw_shared = False
+            for entry in merged:
+                if not isinstance(entry, dict):
+                    continue
+                source = str(entry.get("source") or "")
+                if source == XAI_SHARED_SOURCE or not source.startswith("manual"):
+                    if saw_shared:
+                        continue
+                    collapsed.append(sanitize_xai_shared_pool_payload(entry, provider_id))
+                    saw_shared = True
+                else:
+                    # manual:* under shared mode is rewritten to shared ref above;
+                    # anything still labeled manual is dropped.
+                    continue
+            merged = collapsed
         pool[provider_id] = merged
         return _save_auth_store(auth_store)
 
@@ -4291,11 +4401,2378 @@ def _pool_codex_access_token() -> str:
 
 
 # =============================================================================
+# Shared xAI OAuth store — ONE grant family across all profiles
+# =============================================================================
+#
+# Canonical state lives at ${HERMES_SHARED_AUTH_DIR}/xai_oauth.json (default
+# ``<hermes-root>/shared/xai_oauth.json``). Every profile READS that store.
+# Any process may refresh, but only while holding ``xai_oauth.lock``. After a
+# waiter acquires the lock it re-reads and ADOPTS the winner's rotated tokens
+# instead of POSTing a stale single-use refresh token again.
+#
+# Explicit opt-in only (G7): HERMES_SHARED_AUTH_DIR may already be set for
+# Nous. Shared xAI ownership is gated by the INTERNAL env vars:
+#   - HERMES_XAI_SHARED_AUTH=1 (truthy), or
+#   - HERMES_SHARED_AUTH_PROVIDERS containing ``xai-oauth`` (comma list)
+# User-facing activation is config.yaml ``shared_auth.providers: [xai-oauth]``
+# (or `hermes auth xai enable-shared`), bridged to those env vars at process
+# startup — AGENTS.md env-var-for-config / terminal.cwd→TERMINAL_CWD pattern.
+# This function deliberately still reads only the env vars so the engine stays
+# env-driven and tests/power-user overrides keep working.
+#
+# When active, this OVERRIDES the legacy profile→root fallback + write-through
+# machinery. Profile auth.json / credential_pool rows keep non-secret metadata
+# and a reference (``source: shared:xai-oauth``) — NEVER the canonical refresh
+# token. Require a local filesystem with reliable advisory locking (no NFS/SMB).
+# =============================================================================
+
+XAI_SHARED_STORE_FILENAME = "xai_oauth.json"
+XAI_SHARED_SOURCE = "shared:xai-oauth"
+XAI_SHARED_SCHEMA_VERSION = 1
+# One-time post-upgrade marker: fleet sole-owner strip has run against a
+# pre-existing canonical grant (R4). Lives beside the shared store.
+XAI_SOLE_OWNER_MARKER_FILENAME = "xai_oauth.sole_owner_verified"
+# Pool/provider statuses that are never eligible for auto-promote (R2).
+_XAI_NON_PROMOTABLE_STATUSES = frozenset(
+    {
+        "dead",
+        "exhausted",
+        "invalid_grant",
+        "error",
+        "revoked",
+    }
+)
+_XAI_NON_PROMOTABLE_REASONS = frozenset(
+    {
+        "invalid_grant",
+        "invalid_token",
+        "token_invalidated",
+        "token_revoked",
+        "refresh_token_reused",
+        "unauthorized_client",
+    }
+)
+_xai_shared_lock_holder = threading.local()
+
+
+def _xai_shared_auth_enabled() -> bool:
+    """True when the canonical shared xAI OAuth store is deliberately enabled.
+
+    HERMES_SHARED_AUTH_DIR alone does NOT flip this — that env is shared with
+    the Nous convenience store and must not silently change xAI ownership.
+    """
+    if is_truthy_value(os.getenv("HERMES_XAI_SHARED_AUTH", ""), default=False):
+        return True
+    raw = os.getenv("HERMES_SHARED_AUTH_PROVIDERS", "").strip()
+    if not raw:
+        return False
+    tokens = {part.strip().lower() for part in raw.split(",") if part.strip()}
+    return bool(tokens & {"xai-oauth", "xai", "grok-oauth", "x-ai-oauth"})
+
+
+def _xai_shared_auth_dir() -> Path:
+    """Resolve the directory that holds the shared xAI OAuth store.
+
+    Same path resolution as the Nous shared store (``HERMES_SHARED_AUTH_DIR``
+    override, else ``<hermes-root>/shared/``).
+    """
+    override = os.getenv("HERMES_SHARED_AUTH_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root() / "shared"
+
+
+def _xai_shared_store_path() -> Path:
+    path = _xai_shared_auth_dir() / XAI_SHARED_STORE_FILENAME
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        # Compare against the *platform native* user home (not
+        # get_default_hermes_root(), which follows HERMES_HOME profile roots
+        # and would false-positive when a test uses tmp/profiles/<name> plus
+        # tmp/shared). Mirrors ``_auth_file_path`` seat belt intent.
+        from hermes_constants import _get_platform_default_hermes_home
+        real_home_shared = (
+            _get_platform_default_hermes_home() / "shared" / XAI_SHARED_STORE_FILENAME
+        ).resolve(strict=False)
+        try:
+            resolved = path.resolve(strict=False)
+        except Exception:
+            resolved = path
+        if resolved == real_home_shared:
+            raise RuntimeError(
+                f"Refusing to touch real user shared xAI auth store during test run: "
+                f"{path}. Set HERMES_SHARED_AUTH_DIR to a tmp_path in your test fixture."
+            )
+    return path
+
+
+@contextmanager
+def _xai_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    """Cross-profile lock for the canonical shared xAI OAuth store.
+
+    Lock ordering (G3/H1): shared (outer) → auth-store locks in deterministic
+    sorted-path order (inner). NEVER hold a profile ``auth.lock`` while waiting
+    on this lock (deadlock risk against a waiter that already holds shared).
+
+    Network under locks (G3 — intentional sole-refresher design):
+      - NEVER perform network I/O under a profile/auth-store lock.
+      - The shared lock INTENTIONALLY serializes the runtime refresh HTTP
+        (``refresh_xai_oauth_pure`` / discovery) so only one process refreshes
+        the rotating RT. That is the sole-refresher design, not a bug.
+      - Election, promote, migrate, strip, and fleet-marker paths do no HTTP
+        under either lock class.
+
+    Promote/migrate holds shared outer, then BOTH profile and root store locks
+    (sorted path order) through elect + recheck + canonical write (H1/H2) so a
+    concurrent logout/writer cannot clear or inject a second live RT between
+    election and commit.
+    """
+    try:
+        lock_path = _xai_shared_store_path().with_suffix(".lock")
+    except RuntimeError:
+        yield
+        return
+
+    with _file_lock(
+        lock_path,
+        _xai_shared_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for shared xAI OAuth auth lock",
+    ):
+        yield
+
+
+def _xai_shared_state_has_usable_tokens(state: Optional[Dict[str, Any]]) -> bool:
+    if not isinstance(state, dict):
+        return False
+    access = str(state.get("access_token", "") or "").strip()
+    refresh = str(state.get("refresh_token", "") or "").strip()
+    return bool(access and refresh)
+
+
+def _shared_xai_state_is_quarantined(state: Optional[Dict[str, Any]]) -> bool:
+    """R1: True when the canonical store is intentionally non-promotable.
+
+    Terminal quarantine (invalid_grant etc.) and global logout leave a
+    tombstone with ``last_auth_error`` and empty tokens. Auto-promote must
+    NOT resurrect these into a live grant.
+    """
+    if not isinstance(state, dict):
+        return False
+    if _xai_shared_state_has_usable_tokens(state):
+        return False
+    if state.get("last_auth_error"):
+        return True
+    if is_truthy_value(state.get("logged_out"), default=False):
+        return True
+    if is_truthy_value(state.get("quarantined"), default=False):
+        return True
+    return False
+
+
+def _shared_xai_store_is_never_initialized() -> bool:
+    """True when the canonical shared file has never been written (or is gone)."""
+    try:
+        path = _xai_shared_store_path()
+    except RuntimeError:
+        return True
+    return not path.is_file()
+
+
+def _xai_sole_owner_marker_path() -> Path:
+    return _xai_shared_auth_dir() / XAI_SOLE_OWNER_MARKER_FILENAME
+
+
+def _clear_xai_sole_owner_marker() -> None:
+    """Drop the post-upgrade sole-owner marker (e.g. after global logout)."""
+    try:
+        path = _xai_sole_owner_marker_path()
+    except RuntimeError:
+        return
+    try:
+        if path.is_file():
+            path.unlink()
+    except OSError:
+        pass
+
+
+def _fsync_parent_dir(
+    path: Path,
+    *,
+    context: str,
+    code: str = "xai_shared_parent_fsync_failed",
+) -> None:
+    """Crash-durability: fsync the parent directory of ``path`` (H5).
+
+    Parent-dir open AND fsync failures are raised — never swallowed — so a
+    rename/unlink that is not durable cannot be reported as success.
+    """
+    parent = path if path.is_dir() else path.parent
+    try:
+        dir_fd = os.open(str(parent), os.O_RDONLY)
+    except OSError as exc:
+        raise AuthError(
+            f"Failed to open parent directory for fsync ({context}) at "
+            f"{parent}: {exc}",
+            provider="xai-oauth",
+            code=code,
+            relogin_required=False,
+        ) from exc
+    try:
+        try:
+            os.fsync(dir_fd)
+        except OSError as exc:
+            raise AuthError(
+                f"Failed to fsync parent directory ({context}) at "
+                f"{parent}: {exc}",
+                provider="xai-oauth",
+                code=code,
+                relogin_required=False,
+            ) from exc
+    finally:
+        try:
+            os.close(dir_fd)
+        except OSError:
+            pass
+
+
+def _xai_auth_path_sort_key(path: Path) -> str:
+    """Deterministic lock/order key for an auth-store path."""
+    try:
+        return str(path.resolve(strict=False))
+    except Exception:
+        return str(path)
+
+
+@contextmanager
+def _xai_ordered_auth_store_locks(
+    paths: Sequence[Path],
+    *,
+    timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS,
+):
+    """Acquire auth-store locks in deterministic sorted-path order (H2/H3).
+
+    Fail-closed: any lock timeout or unresolvable path raises AuthError —
+    never silently omit a store from a multi-store critical section.
+    Yields the ordered list of distinct Paths actually locked.
+    """
+    resolved: List[Tuple[str, Path]] = []
+    seen: set = set()
+    for path in paths:
+        if path is None:
+            raise AuthError(
+                "Shared xAI multi-store operation received an unresolvable "
+                "auth path (None). Refusing to proceed fail-open.",
+                provider="xai-oauth",
+                code="xai_auth_store_unreadable",
+                relogin_required=False,
+            )
+        try:
+            key = _xai_auth_path_sort_key(path)
+        except Exception as exc:
+            raise AuthError(
+                f"Shared xAI multi-store operation cannot resolve auth path "
+                f"{path}: {exc}",
+                provider="xai-oauth",
+                code="xai_auth_store_unreadable",
+                relogin_required=False,
+            ) from exc
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved.append((key, path))
+    resolved.sort(key=lambda item: item[0])
+    ordered_paths = [path for _key, path in resolved]
+
+    with ExitStack() as stack:
+        for path in ordered_paths:
+            try:
+                stack.enter_context(
+                    _auth_store_lock(
+                        timeout_seconds=timeout_seconds,
+                        target_path=path,
+                    )
+                )
+            except TimeoutError as exc:
+                raise AuthError(
+                    f"Timed out acquiring auth store lock for {path} during "
+                    f"shared xAI multi-store operation. Refusing fail-open.",
+                    provider="xai-oauth",
+                    code="xai_auth_store_lock_failed",
+                    relogin_required=False,
+                ) from exc
+            except AuthError:
+                raise
+            except Exception as exc:
+                raise AuthError(
+                    f"Failed to acquire auth store lock for {path} during "
+                    f"shared xAI multi-store operation: {exc}",
+                    provider="xai-oauth",
+                    code="xai_auth_store_lock_failed",
+                    relogin_required=False,
+                ) from exc
+        yield ordered_paths
+
+
+def _xai_profile_and_root_election_paths() -> List[Path]:
+    """Resolve active-profile + global-root auth paths for sole-live election.
+
+    Fail-closed: inability to resolve the active profile path raises. Root is
+    included only when distinct; root resolution failure raises (a live RT in
+    an unresolvable root must not escape the sole-live check).
+    """
+    try:
+        active_path = _auth_file_path()
+    except Exception as exc:
+        raise AuthError(
+            f"Cannot resolve active profile auth path for shared xAI election: "
+            f"{exc}",
+            provider="xai-oauth",
+            code="xai_auth_store_unreadable",
+            relogin_required=False,
+        ) from exc
+
+    paths: List[Path] = [active_path]
+    try:
+        root_path = _global_auth_file_path()
+    except Exception as exc:
+        raise AuthError(
+            f"Cannot resolve global-root auth path for shared xAI election: "
+            f"{exc}",
+            provider="xai-oauth",
+            code="xai_auth_store_unreadable",
+            relogin_required=False,
+        ) from exc
+    if root_path is not None and not _same_path(root_path, active_path):
+        paths.append(root_path)
+    return paths
+
+
+def _xai_fleet_auth_inventory(
+    *,
+    fail_loud: bool = True,
+    paths: Optional[Sequence[Path]] = None,
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Inventory audited auth-store paths for sole-owner marker binding.
+
+    Digest is SECURITY-RELEVANT only (R7-3): per-path presence plus whether a
+    durable xAI OAuth refresh_token remains. Volatile non-secret metadata
+    (``shared_generation``, timestamps, mtime/size of metadata-only rewrites)
+    is intentionally excluded so a normal refresh does not churn the marker
+    and force a full fleet re-audit.
+
+    A restored/new auth.json with (or without) a durable RT still changes the
+    digest and forces re-audit. Real RT reintroduction MUST invalidate.
+
+    Fail-closed (H3/R7-1): read/parse/unsupported-shape errors raise when
+    ``fail_loud`` (default) — they are NEVER hashed into a "valid" fleet
+    digest. Callers that hold fleet locks should pass ``paths`` so inventory
+    cannot race enumeration.
+    """
+    if paths is None:
+        paths = _iter_xai_auth_json_paths(
+            include_global_root=True,
+            fail_loud=fail_loud,
+        )
+    entries: List[Dict[str, Any]] = []
+    for path in paths:
+        try:
+            resolved = str(path.resolve(strict=False))
+        except Exception:
+            resolved = str(path)
+        if not path.is_file():
+            entries.append(
+                {
+                    "path": resolved,
+                    "present": False,
+                    "has_durable_xai_rt": False,
+                }
+            )
+            continue
+        try:
+            # R7-1/R7-3: strict load — unsupported shapes / corrupt JSON fail
+            # closed rather than hashing as "empty / RT-free".
+            store = _load_auth_store(path, fail_on_corrupt=True)
+            has_rt = _auth_store_holds_durable_xai_refresh_token(store)
+            entries.append(
+                {
+                    "path": resolved,
+                    "present": True,
+                    "has_durable_xai_rt": bool(has_rt),
+                }
+            )
+        except AuthError as exc:
+            if fail_loud:
+                raise AuthError(
+                    f"Fleet inventory cannot read auth store at {path}: "
+                    f"{exc}. Refusing to hash an unreadable store into a "
+                    f"sole-owner marker.",
+                    provider="xai-oauth",
+                    code="xai_shared_fleet_inventory_failed",
+                    relogin_required=False,
+                ) from exc
+            entries.append(
+                {
+                    "path": resolved,
+                    "present": True,
+                    "error": str(exc),
+                }
+            )
+        except OSError as exc:
+            if fail_loud:
+                raise AuthError(
+                    f"Fleet inventory cannot read/stat auth store at {path}: "
+                    f"{exc}. Refusing to hash an unreadable store into a "
+                    f"sole-owner marker.",
+                    provider="xai-oauth",
+                    code="xai_shared_fleet_inventory_failed",
+                    relogin_required=False,
+                ) from exc
+            entries.append(
+                {
+                    "path": resolved,
+                    "present": True,
+                    "error": str(exc),
+                }
+            )
+    entries.sort(key=lambda e: str(e.get("path") or ""))
+    blob = json.dumps(entries, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()
+    return digest, entries
+
+
+def _persist_xai_sole_owner_marker_payload(payload: Dict[str, Any]) -> None:
+    """Durable write of an already-computed sole-owner marker payload."""
+    path = _xai_sole_owner_marker_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    secure_parent_dir(path)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    try:
+        fd = os.open(
+            str(tmp),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(text)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, path)
+            _fsync_parent_dir(
+                path,
+                context="sole-owner marker rename",
+                code="xai_shared_sole_owner_marker_failed",
+            )
+        finally:
+            try:
+                if tmp.exists():
+                    tmp.unlink()
+            except OSError:
+                pass
+    except AuthError:
+        raise
+    except Exception as exc:
+        raise AuthError(
+            f"Failed to persist shared xAI sole-owner verification marker at "
+            f"{path}: {exc}",
+            provider="xai-oauth",
+            code="xai_shared_sole_owner_marker_failed",
+            relogin_required=False,
+        ) from exc
+
+
+def _audit_fleet_refresh_token_free(
+    paths: Sequence[Path],
+    *,
+    fail_loud: bool = True,
+) -> List[str]:
+    """Fail-closed content audit: every store must be durable-RT-free.
+
+    Caller must already hold each path's auth-store lock. Returns residual
+    path strings; raises when ``fail_loud`` and any residual/unreadable.
+    """
+    residual: List[str] = []
+    failures: List[str] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        try:
+            store = _load_auth_store(path, fail_on_corrupt=True)
+            if _auth_store_holds_durable_xai_refresh_token(store):
+                residual.append(str(path))
+        except AuthError as exc:
+            failures.append(f"{path}: {exc}")
+        except Exception as exc:
+            failures.append(f"{path}: {exc}")
+    if (failures or residual) and fail_loud:
+        parts = []
+        if failures:
+            parts.append("audit failures: " + "; ".join(failures))
+        if residual:
+            parts.append(
+                "durable xAI refresh_token still present at: "
+                + ", ".join(residual)
+            )
+        raise AuthError(
+            "Shared xAI fleet is not refresh-token-free. "
+            + " | ".join(parts)
+            + ". Refusing to write a sole-owner marker over a dirty fleet.",
+            provider="xai-oauth",
+            code="xai_shared_strip_incomplete",
+            relogin_required=False,
+        )
+    return residual
+
+
+def _write_xai_sole_owner_marker(
+    *,
+    generation: Optional[int] = None,
+    _holding_shared_lock: bool = False,
+    _holding_store_locks: bool = False,
+    _locked_paths: Optional[Sequence[Path]] = None,
+) -> None:
+    """Persist a VERIFIABLE fleet sole-owner marker (R4/H3/R7-3).
+
+    Binds to a fail-closed digest of audited auth-store paths covering
+    security-relevant state only (path presence + durable xAI RT presence).
+    Existence alone never certifies a clean fleet — consumers must validate
+    via ``_xai_sole_owner_marker_is_valid``.
+
+    Atomicity (H3): when store locks are not already held, this acquires the
+    shared lock (outer) then ALL audited-store locks (sorted) and re-audits
+    that every store is refresh-token-free BEFORE hashing + persisting the
+    marker. Inventory read/stat errors raise — never hashed as clean.
+    """
+
+    def _do_write(paths: Sequence[Path]) -> None:
+        # Pre-commit fail-closed content audit under held locks.
+        _audit_fleet_refresh_token_free(paths, fail_loud=True)
+        fleet_digest, fleet_paths = _xai_fleet_auth_inventory(
+            fail_loud=True,
+            paths=paths,
+        )
+        payload = {
+            "verified_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "generation": generation,
+            "schema": XAI_SHARED_SCHEMA_VERSION,
+            "fleet_digest": fleet_digest,
+            "fleet_path_count": len(fleet_paths),
+        }
+        _persist_xai_sole_owner_marker_payload(payload)
+
+    def _with_store_locks() -> None:
+        if _holding_store_locks:
+            if _locked_paths is None:
+                raise AuthError(
+                    "Internal error: sole-owner marker write claimed held "
+                    "store locks without providing locked paths.",
+                    provider="xai-oauth",
+                    code="xai_shared_sole_owner_marker_failed",
+                    relogin_required=False,
+                )
+            _do_write(_locked_paths)
+            return
+        paths = _iter_xai_auth_json_paths(
+            include_global_root=True,
+            fail_loud=True,
+        )
+        with _xai_ordered_auth_store_locks(paths):
+            _do_write(paths)
+
+    if _holding_shared_lock:
+        _with_store_locks()
+        return
+    with _xai_shared_store_lock():
+        _with_store_locks()
+
+
+def _xai_sole_owner_marker_is_valid(
+    *,
+    generation: Optional[int] = None,
+    _holding_shared_lock: bool = False,
+    _holding_store_locks: bool = False,
+    _locked_paths: Optional[Sequence[Path]] = None,
+) -> bool:
+    """H3/R7-2: True only when the marker matches current fleet digest.
+
+    A marker that cannot be parsed, whose fleet inventory cannot be read
+    (fail-closed), or whose digest does not match current inventory must NOT
+    skip the fleet audit.
+
+    Lock discipline (R7-2): inventory is read under the SAME protocol as
+    marker creation — shared outer lock then sorted store locks — unless the
+    caller already holds those locks and passes ``_locked_paths``. No skip may
+    be granted from an unlocked/stale inventory read (TOCTOU).
+
+    Ops: generation is recorded for diagnostics but a normal canonical gen
+    bump / profile metadata rewrite (refresh) does NOT by itself invalidate a
+    still-clean fleet digest (R7-3) — that avoids a full fleet re-strip on
+    every token refresh.
+    """
+    del generation  # retained for call-site compatibility; digest is authority
+    try:
+        marker = _xai_sole_owner_marker_path()
+    except RuntimeError:
+        return False
+    if not marker.is_file():
+        return False
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    marker_digest = str(payload.get("fleet_digest") or "").strip()
+    if not marker_digest:
+        # Pre-H3 existence-only markers are never trusted.
+        return False
+
+    def _compare_under_paths(paths: Sequence[Path]) -> bool:
+        try:
+            current_digest, _entries = _xai_fleet_auth_inventory(
+                fail_loud=True,
+                paths=paths,
+            )
+        except AuthError:
+            # Cannot verify fleet → re-audit (treat as invalid).
+            return False
+        except Exception:
+            return False
+        return marker_digest == current_digest
+
+    def _with_store_locks() -> bool:
+        if _holding_store_locks:
+            if _locked_paths is None:
+                return False
+            return _compare_under_paths(_locked_paths)
+        try:
+            paths = _iter_xai_auth_json_paths(
+                include_global_root=True,
+                fail_loud=True,
+            )
+        except Exception:
+            return False
+        try:
+            with _xai_ordered_auth_store_locks(paths) as locked:
+                return _compare_under_paths(locked)
+        except AuthError:
+            return False
+        except Exception:
+            return False
+
+    if _holding_shared_lock:
+        return _with_store_locks()
+    try:
+        with _xai_shared_store_lock():
+            return _with_store_locks()
+    except Exception:
+        return False
+
+
+def _ensure_xai_fleet_sole_owner_verified(
+    *,
+    force: bool = False,
+    generation: Optional[int] = None,
+) -> None:
+    """R4/H3/R7-2: on shared consumption, sweep fleet unless marker validates.
+
+    A pre-existing canonical grant (deploy upgrade state) previously short-
+    circuited ``ensure_shared`` and never ran the fleet strip — leaving dormant
+    per-profile RTs. The marker gates the sweep but is VERIFIABLE: stale or
+    existence-only markers never certify a dirty fleet.
+
+    Atomicity (H3): strip → inventory → marker-persist is ONE critical section
+    holding the shared lock + ALL audited-store locks. No concurrent writer can
+    restore an RT between strip and the digest that certifies the fleet clean.
+
+    Marker validation (R7-2) itself takes the same lock protocol, so an early
+    skip is never granted on an unlocked inventory snapshot.
+    """
+    if not _xai_shared_auth_enabled():
+        return
+    if not force and _xai_sole_owner_marker_is_valid(generation=generation):
+        return
+
+    with _xai_shared_store_lock():
+        # Re-check under the shared lock so two consumers don't double-strip.
+        # Pass _holding_shared_lock so validation does not re-enter the shared
+        # lock unnecessarily; it still acquires store locks for inventory.
+        if not force and _xai_sole_owner_marker_is_valid(
+            generation=generation,
+            _holding_shared_lock=True,
+        ):
+            return
+        paths = _iter_xai_auth_json_paths(
+            include_global_root=True,
+            fail_loud=True,
+        )
+        with _xai_ordered_auth_store_locks(paths) as locked_fleet:
+            # Final locked re-check: skip strip only if fleet still matches
+            # under the same locks that protect strip → marker.
+            if not force and _xai_sole_owner_marker_is_valid(
+                generation=generation,
+                _holding_shared_lock=True,
+                _holding_store_locks=True,
+                _locked_paths=locked_fleet,
+            ):
+                return
+            _strip_legacy_xai_oauth_secrets_under_held_locks(
+                locked_fleet,
+                fail_loud=True,
+            )
+            _write_xai_sole_owner_marker(
+                generation=generation,
+                _holding_shared_lock=True,
+                _holding_store_locks=True,
+                _locked_paths=locked_fleet,
+            )
+
+
+def _normalize_shared_xai_state(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return a well-formed shared-state dict or None if unusable."""
+    if not isinstance(payload, dict):
+        return None
+    access = str(payload.get("access_token", "") or "").strip()
+    refresh = str(payload.get("refresh_token", "") or "").strip()
+    if not access or not refresh:
+        # Terminal-error-only payloads are still readable for status/clear.
+        if payload.get("last_auth_error"):
+            return dict(payload)
+        return None
+    state = dict(payload)
+    state["access_token"] = access
+    state["refresh_token"] = refresh
+    state["token_type"] = str(state.get("token_type") or "Bearer").strip() or "Bearer"
+    try:
+        state["generation"] = int(state.get("generation") or 0)
+    except (TypeError, ValueError):
+        state["generation"] = 0
+    try:
+        state["_schema"] = int(state.get("_schema") or XAI_SHARED_SCHEMA_VERSION)
+    except (TypeError, ValueError):
+        state["_schema"] = XAI_SHARED_SCHEMA_VERSION
+    discovery = state.get("discovery")
+    if not isinstance(discovery, dict):
+        state["discovery"] = {}
+    return state
+
+
+def _read_shared_xai_state(
+    *,
+    raise_on_unreadable: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Return the canonical shared xAI OAuth state, or None if missing/unusable.
+
+    When ``raise_on_unreadable`` is True and the store file exists but cannot
+    be parsed, raise AuthError instead of returning None (availability and
+    promote paths must fail closed — R7).
+    """
+    try:
+        path = _xai_shared_store_path()
+    except RuntimeError:
+        return None
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.debug("Shared xAI auth store at %s is unreadable: %s", path, exc)
+        if raise_on_unreadable:
+            raise AuthError(
+                f"Shared xAI OAuth store at {path} is unreadable: {exc}",
+                provider="xai-oauth",
+                code="xai_shared_store_unreadable",
+                relogin_required=False,
+            ) from exc
+        return None
+    return _normalize_shared_xai_state(payload)
+
+
+def _write_shared_xai_state(
+    state: Dict[str, Any],
+    *,
+    bump_generation: bool = True,
+    _holding_lock: bool = False,
+) -> Dict[str, Any]:
+    """Persist canonical shared xAI state. Fail LOUD on write failure (G5).
+
+    Callers that already hold ``_xai_shared_store_lock`` must pass
+    ``_holding_lock=True`` to avoid re-entrancy issues with nested network work
+    (the lock itself is reentrant, but the contract is clearer this way).
+    """
+    access = str(state.get("access_token", "") or "").strip()
+    refresh = str(state.get("refresh_token", "") or "").strip()
+    if not access or not refresh:
+        raise AuthError(
+            "Refusing to write shared xAI OAuth state without access_token and "
+            "refresh_token.",
+            provider="xai-oauth",
+            code="xai_shared_write_incomplete",
+            relogin_required=True,
+        )
+
+    def _do_write() -> Dict[str, Any]:
+        path = _xai_shared_store_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        secure_parent_dir(path)
+
+        existing: Dict[str, Any] = {}
+        if path.is_file():
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    existing = raw
+            except (OSError, ValueError):
+                existing = {}
+
+        try:
+            prev_gen = int(existing.get("generation") or 0)
+        except (TypeError, ValueError):
+            prev_gen = 0
+        try:
+            incoming_gen = int(state.get("generation") or 0)
+        except (TypeError, ValueError):
+            incoming_gen = 0
+
+        if bump_generation:
+            generation = max(prev_gen, incoming_gen) + 1
+        else:
+            generation = max(prev_gen, incoming_gen, 1)
+
+        shared = {
+            "_schema": XAI_SHARED_SCHEMA_VERSION,
+            "generation": generation,
+            "access_token": access,
+            "refresh_token": refresh,
+            "token_type": str(state.get("token_type") or "Bearer").strip() or "Bearer",
+            "expires_in": state.get("expires_in"),
+            "last_refresh": state.get("last_refresh")
+            or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "auth_mode": str(state.get("auth_mode") or "oauth_device_code"),
+            "discovery": dict(state.get("discovery") or {})
+            if isinstance(state.get("discovery"), dict)
+            else {},
+            "redirect_uri": str(state.get("redirect_uri") or ""),
+        }
+        # D3: refresh responses supply id_token; keep it in the canonical grant.
+        id_token = str(state.get("id_token") or "").strip()
+        if id_token:
+            shared["id_token"] = id_token
+        elif existing.get("id_token"):
+            # Preserve prior id_token when a write omits it (metadata-only updates).
+            shared["id_token"] = existing.get("id_token")
+        if state.get("last_auth_error") is not None:
+            shared["last_auth_error"] = state.get("last_auth_error")
+
+        tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+        payload = json.dumps(shared, indent=2, sort_keys=True) + "\n"
+        try:
+            fd = os.open(
+                str(tmp),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    fh.write(payload)
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                os.replace(tmp, path)
+                # H5: parent-dir open/fsync failures are crash-durability
+                # invariant violations — surface them, never swallow.
+                _fsync_parent_dir(
+                    path,
+                    context="shared xAI canonical write",
+                    code="xai_shared_persist_failed",
+                )
+            finally:
+                try:
+                    if tmp.exists():
+                        tmp.unlink()
+                except OSError:
+                    pass
+        except AuthError:
+            raise
+        except Exception as exc:
+            raise AuthError(
+                f"Failed to persist shared xAI OAuth state to {path}: {exc}. "
+                f"The refresh must NOT be treated as committed; re-authenticate "
+                f"or retry after fixing filesystem permissions on the shared "
+                f"auth directory (local FS with advisory locking required).",
+                provider="xai-oauth",
+                code="xai_shared_persist_failed",
+                relogin_required=False,
+            ) from exc
+
+        _oauth_trace(
+            "xai_shared_store_written",
+            path=str(path),
+            generation=generation,
+            refresh_token_fp=_token_fingerprint(refresh),
+            access_token_fp=_token_fingerprint(access),
+        )
+        return shared
+
+    if _holding_lock:
+        return _do_write()
+    with _xai_shared_store_lock():
+        return _do_write()
+
+
+def _persist_shared_xai_tombstone(
+    path: Path,
+    tombstone: Dict[str, Any],
+    *,
+    context: str,
+    fail_code: str,
+) -> None:
+    """Durably write a non-promotable shared-store tombstone (H4/H5).
+
+    Fail-closed: any write or parent-dir fsync failure raises AuthError and
+    leaves the prior store bytes in place (never unlinks to a promotable-absent
+    state that auto-promote could resurrect into).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    secure_parent_dir(path)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    payload = json.dumps(tombstone, indent=2, sort_keys=True) + "\n"
+    try:
+        fd = os.open(
+            str(tmp),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, path)
+            _fsync_parent_dir(
+                path,
+                context=context,
+                code=fail_code,
+            )
+        finally:
+            try:
+                if tmp.exists():
+                    tmp.unlink()
+            except OSError:
+                pass
+    except AuthError:
+        raise
+    except Exception as exc:
+        raise AuthError(
+            f"Failed to persist shared xAI OAuth tombstone at {path} "
+            f"({context}): {exc}. Store left non-promotable/in-place; "
+            f"refusing unlink fallback that would enable auto-promote "
+            f"resurrection.",
+            provider="xai-oauth",
+            code=fail_code,
+            relogin_required=True,
+        ) from exc
+
+
+def _clear_shared_xai_state(
+    reason: str,
+    *,
+    terminal_error: Optional[Dict[str, Any]] = None,
+    only_if_refresh_token: Optional[str] = None,
+    only_if_generation: Optional[int] = None,
+    _holding_lock: bool = False,
+) -> bool:
+    """Quarantine/clear the canonical shared grant (G6 compare-and-clear).
+
+    When ``only_if_refresh_token`` / ``only_if_generation`` are provided, clear
+    ONLY if the failed token is still canonical — a loser must not erase a
+    newer grant. Returns True if the store was cleared or rewritten.
+    """
+
+    def _do_clear() -> bool:
+        path = _xai_shared_store_path()
+        current = _read_shared_xai_state()
+        if current is None:
+            # Unusable/missing normalized state. If a raw file still exists,
+            # replace it with a durable logout tombstone (H4) rather than
+            # unlinking to a promotable-absent store.
+            if path.is_file():
+                try:
+                    raw = json.loads(path.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    raw = {}
+                if not isinstance(raw, dict):
+                    raw = {}
+                try:
+                    prev_gen = int(raw.get("generation") or 0)
+                except (TypeError, ValueError):
+                    prev_gen = 0
+                logout_error = {
+                    "code": "global_logout" if reason == "global_logout" else reason,
+                    "message": (
+                        "Shared xAI OAuth grant was cleared by global logout. "
+                        "Re-authenticate with `hermes model`."
+                        if reason == "global_logout"
+                        else f"Shared xAI OAuth grant cleared ({reason})."
+                    ),
+                    "relogin_required": True,
+                    "reason": reason,
+                }
+                tombstone = {
+                    "_schema": XAI_SHARED_SCHEMA_VERSION,
+                    "generation": prev_gen + 1,
+                    "access_token": "",
+                    "refresh_token": "",
+                    "token_type": "Bearer",
+                    "auth_mode": "oauth_device_code",
+                    "discovery": {},
+                    "redirect_uri": "",
+                    "updated_at": datetime.now(timezone.utc)
+                    .isoformat()
+                    .replace("+00:00", "Z"),
+                    "logged_out": True,
+                    "last_auth_error": logout_error,
+                }
+                _persist_shared_xai_tombstone(
+                    path,
+                    tombstone,
+                    context=f"shared xAI clear ({reason})",
+                    fail_code="xai_shared_logout_tombstone_failed",
+                )
+                _clear_xai_sole_owner_marker()
+                _oauth_trace("xai_shared_store_cleared", reason=reason)
+                return True
+            return False
+
+        if only_if_refresh_token is not None:
+            cur_rt = str(current.get("refresh_token") or "").strip()
+            if cur_rt and cur_rt != str(only_if_refresh_token or "").strip():
+                _oauth_trace(
+                    "xai_shared_quarantine_skipped_rt_changed",
+                    reason=reason,
+                    generation=current.get("generation"),
+                )
+                return False
+        if only_if_generation is not None:
+            try:
+                cur_gen = int(current.get("generation") or 0)
+            except (TypeError, ValueError):
+                cur_gen = 0
+            if cur_gen != int(only_if_generation):
+                _oauth_trace(
+                    "xai_shared_quarantine_skipped_gen_changed",
+                    reason=reason,
+                    generation=cur_gen,
+                    expected=only_if_generation,
+                )
+                return False
+
+        if terminal_error is not None:
+            # Atomically replace with terminal-error metadata, no usable tokens.
+            tombstone = {
+                "_schema": XAI_SHARED_SCHEMA_VERSION,
+                "generation": int(current.get("generation") or 0) + 1,
+                "access_token": "",
+                "refresh_token": "",
+                "token_type": current.get("token_type") or "Bearer",
+                "auth_mode": current.get("auth_mode") or "oauth_device_code",
+                "discovery": current.get("discovery") or {},
+                "redirect_uri": current.get("redirect_uri") or "",
+                "last_refresh": current.get("last_refresh"),
+                "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "last_auth_error": terminal_error,
+            }
+            _persist_shared_xai_tombstone(
+                path,
+                tombstone,
+                context=f"shared xAI quarantine ({reason})",
+                fail_code="xai_shared_quarantine_failed",
+            )
+            _oauth_trace("xai_shared_store_quarantined", reason=reason)
+            return True
+
+        # R1/G6/H4: global logout writes a durable logout tombstone rather than
+        # a plain delete, so auto-promote cannot resurrect a dead grant.
+        # Tombstone-write failure is FAIL-CLOSED: never fall back to unlink
+        # (absent store is greenfield-promotable).
+        logout_error = {
+            "code": "global_logout" if reason == "global_logout" else reason,
+            "message": (
+                "Shared xAI OAuth grant was cleared by global logout. "
+                "Re-authenticate with `hermes model`."
+                if reason == "global_logout"
+                else f"Shared xAI OAuth grant cleared ({reason})."
+            ),
+            "relogin_required": True,
+            "reason": reason,
+        }
+        tombstone = {
+            "_schema": XAI_SHARED_SCHEMA_VERSION,
+            "generation": int(current.get("generation") or 0) + 1,
+            "access_token": "",
+            "refresh_token": "",
+            "token_type": current.get("token_type") or "Bearer",
+            "auth_mode": current.get("auth_mode") or "oauth_device_code",
+            "discovery": current.get("discovery") or {},
+            "redirect_uri": current.get("redirect_uri") or "",
+            "last_refresh": current.get("last_refresh"),
+            "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "logged_out": True,
+            "last_auth_error": logout_error,
+        }
+        _persist_shared_xai_tombstone(
+            path,
+            tombstone,
+            context=f"shared xAI logout tombstone ({reason})",
+            fail_code="xai_shared_logout_tombstone_failed",
+        )
+        _clear_xai_sole_owner_marker()
+        _oauth_trace("xai_shared_store_cleared", reason=reason)
+        return True
+
+    if _holding_lock:
+        return _do_clear()
+    with _xai_shared_store_lock():
+        return _do_clear()
+
+
+def _merge_shared_xai_state(into: Dict[str, Any]) -> bool:
+    """Copy fresher canonical shared tokens into a local dict (bootstrap only).
+
+    Used only for migration/diagnostics. Runtime paths must treat the shared
+    store as authoritative — not a best-effort mirror of profile state.
+    """
+    shared = _read_shared_xai_state()
+    if not _xai_shared_state_has_usable_tokens(shared):
+        return False
+    assert shared is not None
+    shared_refresh = str(shared.get("refresh_token") or "").strip()
+    local_refresh = str(into.get("refresh_token") or "").strip()
+    try:
+        shared_gen = int(shared.get("generation") or 0)
+    except (TypeError, ValueError):
+        shared_gen = 0
+    try:
+        local_gen = int(into.get("generation") or 0)
+    except (TypeError, ValueError):
+        local_gen = 0
+    refresh_changed = shared_refresh != local_refresh
+    gen_newer = shared_gen > local_gen
+    if not refresh_changed and not gen_newer:
+        return False
+    for key in (
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "token_type",
+        "expires_in",
+        "last_refresh",
+        "auth_mode",
+        "discovery",
+        "redirect_uri",
+        "generation",
+        "_schema",
+        "updated_at",
+        "last_auth_error",
+    ):
+        if key in shared:
+            into[key] = shared[key]
+    return True
+
+
+def _shared_xai_tokens_view(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Project shared-state fields into the legacy tokens dict shape."""
+    tokens = {
+        "access_token": str(state.get("access_token", "") or "").strip(),
+        "refresh_token": str(state.get("refresh_token", "") or "").strip(),
+        "token_type": str(state.get("token_type") or "Bearer").strip() or "Bearer",
+    }
+    if state.get("expires_in") is not None:
+        tokens["expires_in"] = state.get("expires_in")
+    if state.get("id_token"):
+        tokens["id_token"] = state.get("id_token")
+    return tokens
+
+
+def _profile_xai_shared_disabled(auth_store: Optional[Dict[str, Any]] = None) -> bool:
+    """True when this profile has explicitly opted out of the shared xAI grant."""
+    try:
+        store = auth_store if auth_store is not None else _load_auth_store()
+    except Exception:
+        return False
+    providers = store.get("providers") if isinstance(store, dict) else None
+    state = providers.get("xai-oauth") if isinstance(providers, dict) else None
+    if not isinstance(state, dict):
+        return False
+    if state.get("enabled") is False:
+        return True
+    if is_truthy_value(state.get("shared_disabled"), default=False):
+        return True
+    return False
+
+
+def _xai_shared_pool_secret_keys() -> frozenset:
+    return frozenset(
+        {
+            "access_token",
+            "refresh_token",
+            "id_token",
+            "agent_key",
+            "api_key",
+            "token",
+            "tokens",
+        }
+    )
+
+
+def _strip_xai_pool_entry_to_shared_ref(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Rewrite one pool entry to a non-secret shared reference."""
+    secret_keys = _xai_shared_pool_secret_keys()
+    ref = {k: v for k, v in entry.items() if k not in secret_keys}
+    ref["source"] = XAI_SHARED_SOURCE
+    ref["auth_type"] = str(ref.get("auth_type") or "oauth")
+    # Explicitly clear any residual secret fields that slipped past filtering.
+    for key in secret_keys:
+        ref.pop(key, None)
+    return ref
+
+
+def _auth_store_holds_durable_xai_refresh_token(store: Dict[str, Any]) -> bool:
+    """True when any durable xAI OAuth refresh_token remains in ``store``."""
+    providers = store.get("providers") if isinstance(store, dict) else None
+    if isinstance(providers, dict):
+        state = providers.get("xai-oauth")
+        if isinstance(state, dict):
+            tokens = state.get("tokens")
+            if isinstance(tokens, dict) and str(tokens.get("refresh_token") or "").strip():
+                return True
+            if str(state.get("refresh_token") or "").strip():
+                return True
+    pool = store.get("credential_pool") if isinstance(store, dict) else None
+    if isinstance(pool, dict):
+        entries = pool.get("xai-oauth")
+        if isinstance(entries, list):
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                if str(entry.get("refresh_token") or "").strip():
+                    return True
+    return False
+
+
+def _strip_xai_secrets_in_store(
+    store: Dict[str, Any],
+    *,
+    remove_manuals: bool = True,
+    audit: Optional[List[str]] = None,
+) -> bool:
+    """Strip durable xAI OAuth secrets from one auth store in place.
+
+    When ``remove_manuals`` is True (shared sole-ownership mode), same-family
+    ``manual:*`` pool rows are removed rather than left as independent RT
+    holders. Returns True when the store was mutated.
+    """
+    changed = False
+    providers = store.get("providers")
+    if isinstance(providers, dict) and isinstance(providers.get("xai-oauth"), dict):
+        state = dict(providers["xai-oauth"])
+        had_tokens = "tokens" in state or "access_token" in state or "refresh_token" in state
+        state.pop("tokens", None)
+        state.pop("access_token", None)
+        state.pop("refresh_token", None)
+        state.pop("id_token", None)
+        # Preserve an explicit per-profile disable marker if present.
+        if state.get("enabled") is False or is_truthy_value(
+            state.get("shared_disabled"), default=False
+        ):
+            state["source"] = XAI_SHARED_SOURCE
+            state["enabled"] = False
+            state["shared_disabled"] = True
+        else:
+            state["source"] = XAI_SHARED_SOURCE
+        providers["xai-oauth"] = state
+        if had_tokens:
+            changed = True
+
+    pool = store.get("credential_pool")
+    if isinstance(pool, dict) and isinstance(pool.get("xai-oauth"), list):
+        cleaned: List[Dict[str, Any]] = []
+        saw_shared_ref = False
+        for entry in pool["xai-oauth"]:
+            if not isinstance(entry, dict):
+                continue
+            source = str(entry.get("source") or "")
+            if source.startswith("manual"):
+                if remove_manuals:
+                    changed = True
+                    if audit is not None:
+                        audit.append(
+                            f"removed same-family manual pool entry "
+                            f"(source={source!r}, id={entry.get('id')!r})"
+                        )
+                    continue
+                cleaned.append(entry)
+                continue
+            if str(entry.get("refresh_token") or "").strip() or source != XAI_SHARED_SOURCE:
+                changed = True
+            ref = _strip_xai_pool_entry_to_shared_ref(entry)
+            if not saw_shared_ref:
+                cleaned.append(ref)
+                saw_shared_ref = True
+            else:
+                # Collapse duplicate non-manual rows into a single shared ref.
+                changed = True
+        pool["xai-oauth"] = cleaned
+    return changed
+
+
+def _iter_xai_auth_json_paths(
+    *,
+    include_global_root: bool = True,
+    fail_loud: bool = True,
+) -> List[Path]:
+    """Return every durable auth.json path that may hold xAI OAuth secrets.
+
+    Covers the active HERMES_HOME, the global/default root, and every named
+    profile under the profiles root. Dedupes by resolved path.
+
+    Profile-root enumeration failures FAIL LOUD by default (F3a): a silent
+    omit would let migration claim "stripped from all profiles" without
+    actually enumerating them.
+    """
+    paths: List[Path] = []
+    seen: set = set()
+
+    def _add(path: Optional[Path]) -> None:
+        if path is None:
+            return
+        try:
+            key = str(path.resolve(strict=False))
+        except Exception:
+            key = str(path)
+        if key in seen:
+            return
+        seen.add(key)
+        paths.append(path)
+
+    path_failures: List[str] = []
+
+    try:
+        _add(_auth_file_path())
+    except Exception as exc:
+        # R5: do not silently omit the active auth path from the sole-owner audit.
+        path_failures.append(f"active auth path: {exc}")
+
+    if include_global_root:
+        try:
+            _add(_global_auth_file_path())
+        except Exception as exc:
+            path_failures.append(f"global auth path: {exc}")
+        try:
+            from hermes_constants import get_default_hermes_root
+
+            _add(get_default_hermes_root() / "auth.json")
+        except Exception as exc:
+            path_failures.append(f"default hermes root auth path: {exc}")
+
+    try:
+        from hermes_cli.profiles import _get_profiles_root
+
+        profiles_root = _get_profiles_root()
+        if profiles_root.is_dir():
+            for entry in sorted(profiles_root.iterdir()):
+                if entry.is_dir() and not entry.name.startswith("."):
+                    _add(entry / "auth.json")
+    except Exception as exc:
+        message = (
+            "Shared xAI OAuth sole-ownership strip cannot enumerate profiles: "
+            f"{exc}"
+        )
+        if fail_loud:
+            raise AuthError(
+                message,
+                provider="xai-oauth",
+                code="xai_shared_profile_enum_failed",
+                relogin_required=False,
+            ) from exc
+        logger.debug("xAI shared: profile enumeration for strip failed: %s", exc)
+        path_failures.append(f"profiles root: {exc}")
+
+    if path_failures and fail_loud:
+        raise AuthError(
+            "Shared xAI OAuth sole-ownership strip cannot resolve auth paths: "
+            + "; ".join(path_failures),
+            provider="xai-oauth",
+            code="xai_shared_profile_enum_failed",
+            relogin_required=False,
+        )
+
+    return paths
+
+
+def sanitize_xai_shared_pool_payload(
+    payload: Mapping[str, Any],
+    provider_id: Any = None,
+) -> Dict[str, Any]:
+    """Final persistence guard for xAI pool rows under shared mode (A2).
+
+    Strips every refresh_token / secret field from xai-oauth pool entries when
+    shared mode is on, regardless of source label (device_code, manual,
+    singleton). The only durable pool shape is a non-secret
+    ``shared:xai-oauth`` reference. Callers outside shared mode get a no-op.
+    """
+    result = dict(payload)
+    if str(provider_id or "").strip().lower() not in {"xai-oauth", "xai", "grok-oauth"}:
+        return result
+    if not _xai_shared_auth_enabled():
+        return result
+    source = str(result.get("source") or "")
+    # Manual same-family rows must not survive as durable local RTs.
+    if source.startswith("manual"):
+        return _strip_xai_pool_entry_to_shared_ref(result)
+    return _strip_xai_pool_entry_to_shared_ref(result)
+
+
+def _write_profile_xai_shared_reference(
+    *,
+    enabled: bool = True,
+    last_refresh: Optional[str] = None,
+    generation: Optional[int] = None,
+    set_active: bool = False,
+    target_path: Optional[Path] = None,
+) -> None:
+    """Persist NON-SECRET profile metadata referencing the shared store.
+
+    Never writes access_token / refresh_token into the profile.
+    Must be called AFTER releasing the shared lock (G3).
+
+    Fail-loud (F3b): lock/write failures raise AuthError — callers that treat
+    the marker as best-effort (post-resolve metadata) must catch explicitly.
+    When shared mode is OFF (F4b), only non-secret metadata is updated; durable
+    local tokens are NOT stripped.
+    """
+    shared_on = _xai_shared_auth_enabled()
+    try:
+        with _auth_store_lock(target_path=target_path):
+            auth_store = (
+                _load_auth_store(target_path)
+                if target_path is not None
+                else _load_auth_store()
+            )
+            state = {}
+            providers = auth_store.get("providers")
+            if isinstance(providers, dict) and isinstance(providers.get("xai-oauth"), dict):
+                prior = dict(providers["xai-oauth"])
+                if shared_on:
+                    # Drop any legacy secret material so a forgotten local RT
+                    # cannot refresh independently of the canonical store.
+                    prior.pop("tokens", None)
+                    prior.pop("access_token", None)
+                    prior.pop("refresh_token", None)
+                    prior.pop("id_token", None)
+                state = prior
+            if shared_on:
+                state["source"] = XAI_SHARED_SOURCE
+            state["enabled"] = bool(enabled)
+            state.pop("shared_disabled", None)
+            if not enabled:
+                state["shared_disabled"] = True
+            if last_refresh:
+                state["last_refresh"] = last_refresh
+            if generation is not None:
+                state["shared_generation"] = int(generation)
+            if shared_on:
+                # Ensure no nested secret blobs survive under shared mode.
+                state.pop("tokens", None)
+            _store_provider_state(auth_store, "xai-oauth", state, set_active=set_active)
+            # Strip profile-local pool RTs only when shared sole-ownership is on.
+            if shared_on:
+                pool = auth_store.get("credential_pool")
+                if isinstance(pool, dict):
+                    entries = pool.get("xai-oauth")
+                    if isinstance(entries, list):
+                        cleaned = []
+                        saw_shared = False
+                        for entry in entries:
+                            if not isinstance(entry, dict):
+                                continue
+                            source = str(entry.get("source") or "")
+                            if source.startswith("manual"):
+                                # Same-family manuals pure-refresh outside the
+                                # shared lock — drop them so sole ownership holds.
+                                continue
+                            if saw_shared:
+                                continue
+                            cleaned.append(_strip_xai_pool_entry_to_shared_ref(entry))
+                            saw_shared = True
+                        pool["xai-oauth"] = cleaned
+            _save_auth_store(auth_store, target_path=target_path)
+    except AuthError:
+        raise
+    except Exception as exc:
+        raise AuthError(
+            f"Failed to persist shared xAI OAuth profile reference/marker: {exc}",
+            provider="xai-oauth",
+            code="xai_shared_reference_write_failed",
+            relogin_required=False,
+        ) from exc
+
+
+def _legacy_xai_oauth_state_from_profile_or_root() -> Optional[Dict[str, Any]]:
+    """Read legacy profile/root xAI tokens for migration/bootstrap only."""
+    try:
+        auth_store = _load_auth_store()
+    except Exception:
+        auth_store = {}
+    state = _xai_oauth_state_from_store(auth_store)
+    if _xai_oauth_state_has_usable_tokens(state):
+        return state
+    try:
+        global_state = _xai_oauth_state_from_store(_load_global_auth_store())
+    except Exception:
+        global_state = None
+    if _xai_oauth_state_has_usable_tokens(global_state):
+        return global_state
+    return None
+
+
+def _xai_oauth_refresh_identity(state: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Stable identity of a local grant: its refresh_token string."""
+    if not isinstance(state, dict):
+        return None
+    tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else None
+    if isinstance(tokens, dict):
+        rt = str(tokens.get("refresh_token") or "").strip()
+        if rt:
+            return rt
+    rt = str(state.get("refresh_token") or "").strip()
+    return rt or None
+
+
+def _elect_sole_promotable_xai_under_lock(
+    auth_path: Optional[Path],
+) -> Optional[Dict[str, Any]]:
+    """R2/R3: elect a sole live local grant while holding the profile auth lock.
+
+    Caller must already hold ``_auth_store_lock(target_path=auth_path)``.
+    Returns None when no live grant, or raises AuthError on ambiguous multi-grant.
+    """
+    store = (
+        _load_auth_store(auth_path, fail_on_corrupt=True)
+        if auth_path is not None
+        else _load_auth_store(fail_on_corrupt=True)
+    )
+    return _xai_oauth_state_from_store(store, sole_live=True)
+
+
+def _collect_live_promotable_xai_under_held_locks(
+    paths: Sequence[Path],
+) -> List[Tuple[Path, str, Dict[str, Any]]]:
+    """H2: elect sole-live grants from each path. Caller holds every lock.
+
+    Fail-closed: lock is assumed held; path/read/corrupt errors raise —
+    stores are NEVER silently omitted. Raises ``xai_promote_ambiguous_local``
+    when a single store itself has multiple live identities.
+    """
+    found: List[Tuple[Path, str, Dict[str, Any]]] = []
+    for path in paths:
+        try:
+            elected = _elect_sole_promotable_xai_under_lock(path)
+        except AuthError:
+            raise
+        except Exception as exc:
+            raise AuthError(
+                f"Cannot read auth store at {path} during shared xAI sole-live "
+                f"election: {exc}. Refusing fail-open omission.",
+                provider="xai-oauth",
+                code="xai_auth_store_unreadable",
+                relogin_required=False,
+            ) from exc
+        if not _xai_oauth_state_has_usable_tokens(elected):
+            continue
+        identity = _xai_oauth_refresh_identity(elected)
+        if not identity:
+            continue
+        assert elected is not None
+        found.append((path, identity, elected))
+    return found
+
+
+def _collect_live_promotable_xai_across_profile_and_root(
+    *,
+    _locks_held: bool = False,
+    _locked_paths: Optional[Sequence[Path]] = None,
+) -> List[Tuple[Path, str, Dict[str, Any]]]:
+    """H2: collect sole-live promotable grants from active profile AND root.
+
+    When ``_locks_held`` is False, acquires shared (outer) then BOTH profile
+    and root store locks in deterministic sorted-path order, collects, and
+    releases. Promote/migrate pass ``_locks_held=True`` so collection and
+    canonical commit share one critical section.
+
+    Fail-closed: unreadable/unlockable stores raise — never omit.
+    """
+    if _locks_held:
+        if _locked_paths is None:
+            raise AuthError(
+                "Internal error: election claimed held locks without paths.",
+                provider="xai-oauth",
+                code="xai_auth_store_unreadable",
+                relogin_required=False,
+            )
+        return _collect_live_promotable_xai_under_held_locks(_locked_paths)
+
+    paths = _xai_profile_and_root_election_paths()
+    with _xai_shared_store_lock():
+        with _xai_ordered_auth_store_locks(paths) as locked:
+            return _collect_live_promotable_xai_under_held_locks(locked)
+
+
+def _xai_sole_live_promotable_across_profile_and_root_for_probe() -> bool:
+    """Availability probe: True only when exactly one distinct live identity.
+
+    Consistent with the promoter (no profile-first short-circuit). Fail-closed
+    on unreadable/unlockable/ambiguous stores → False (never advertise
+    available when promote would reject).
+    """
+    try:
+        cross = _collect_live_promotable_xai_across_profile_and_root()
+    except Exception:
+        return False
+    identities = {identity for _path, identity, _state in cross}
+    return len(identities) == 1
+
+
+def migrate_xai_oauth_to_shared_store(
+    *,
+    source: str = "explicit",
+    strip_legacy: bool = True,
+    force: bool = False,
+) -> Dict[str, Any]:
+    """One-time migration: install a chosen legacy grant as the canonical store.
+
+    ``source``:
+      - ``login`` / ``explicit``: refuse unless shared already empty or force
+      - ``profile``: use this profile's providers.xai-oauth tokens
+      - ``root``: use the global-root auth.json tokens
+      - ``auto``: sole live identity across profile+root (explicit CLI choice)
+
+    Does NOT elect a winner by last_refresh clocks. Any validating refresh of
+    the chosen source must happen under the shared lock and persist there.
+    When ``strip_legacy`` is True, removes secret material from profile (and
+    root, when distinct) so forgotten local copies cannot refresh independently.
+
+    R1/R2/R3/H1/H2: promotion is quarantine-aware, sole-live across profile
+    AND root (no profile-first short-circuit), and atomic with local logout
+    (shared outer → BOTH profile and root locks held through elect + recheck
+    + canonical write; no network under auth-store locks; shared lock may
+    serialize refresh HTTP on the separate runtime path).
+    """
+    if not _xai_shared_auth_enabled():
+        raise AuthError(
+            "Shared xAI OAuth is not enabled. Run `hermes auth xai enable-shared` "
+            "(writes shared_auth.providers: [xai-oauth] to config.yaml) before migrating.",
+            provider="xai-oauth",
+            code="xai_shared_not_enabled",
+        )
+
+    source_key = (source or "explicit").strip().lower()
+    written: Optional[Dict[str, Any]] = None
+    with _xai_shared_store_lock():
+        existing = _read_shared_xai_state(raise_on_unreadable=True)
+        if _xai_shared_state_has_usable_tokens(existing) and not force:
+            raise AuthError(
+                "Canonical shared xAI OAuth store already has a grant. "
+                "Pass force=True / --force to overwrite, or log out globally first.",
+                provider="xai-oauth",
+                code="xai_shared_already_present",
+            )
+        # R1: never promote into a tombstoned / globally-logged-out store.
+        if (
+            not force
+            and existing is not None
+            and _shared_xai_state_is_quarantined(existing)
+        ):
+            err = existing.get("last_auth_error") if isinstance(existing, dict) else None
+            detail = ""
+            if isinstance(err, dict) and err.get("message"):
+                detail = f" Last error: {err.get('message')}"
+            raise AuthError(
+                "Canonical shared xAI OAuth store is quarantined or globally "
+                "logged out; refusing to auto-promote a local grant."
+                + detail
+                + " Re-authenticate with `hermes model` (writes a fresh grant).",
+                provider="xai-oauth",
+                code="xai_shared_quarantined",
+                relogin_required=True,
+            )
+
+        # H2: hold BOTH profile and root locks for election → commit so a
+        # concurrent writer cannot slip a second live RT into the unselected
+        # store after collection but before the canonical write.
+        election_paths = _xai_profile_and_root_election_paths()
+        with _xai_ordered_auth_store_locks(election_paths) as locked_paths:
+            cross = _collect_live_promotable_xai_under_held_locks(locked_paths)
+            distinct_identities = {
+                identity for _path, identity, _state in cross
+            }
+            if len(distinct_identities) > 1:
+                raise AuthError(
+                    "Ambiguous local xAI OAuth state: multiple distinct live "
+                    "refresh tokens present across the active profile and "
+                    "global root. Refusing to auto-promote; resolve to a "
+                    "single live grant or run an explicit migrate with a "
+                    "chosen source.",
+                    provider="xai-oauth",
+                    code="xai_promote_ambiguous_local",
+                    relogin_required=True,
+                )
+
+            chosen: Optional[Dict[str, Any]] = None
+            chosen_identity: Optional[str] = None
+            chosen_path: Optional[Path] = None
+
+            def _pick_from_cross(prefer: str) -> None:
+                nonlocal chosen, chosen_identity, chosen_path
+                if prefer == "profile":
+                    try:
+                        active = _auth_file_path()
+                    except Exception:
+                        active = None
+                    for path, identity, state in cross:
+                        if active is not None and _same_path(path, active):
+                            chosen, chosen_identity, chosen_path = (
+                                state,
+                                identity,
+                                path,
+                            )
+                            return
+                elif prefer == "root":
+                    try:
+                        root = _global_auth_file_path()
+                    except Exception:
+                        root = None
+                    if root is None:
+                        return
+                    for path, identity, state in cross:
+                        if _same_path(path, root):
+                            chosen, chosen_identity, chosen_path = (
+                                state,
+                                identity,
+                                path,
+                            )
+                            return
+                else:
+                    # auto/explicit/login: sole candidate (already disambiguated).
+                    if cross:
+                        path, identity, state = cross[0]
+                        chosen, chosen_identity, chosen_path = (
+                            state,
+                            identity,
+                            path,
+                        )
+
+            if source_key == "profile":
+                _pick_from_cross("profile")
+                if not _xai_oauth_state_has_usable_tokens(chosen):
+                    raise AuthError(
+                        "No usable xAI OAuth tokens in this profile's "
+                        "auth.json to migrate.",
+                        provider="xai-oauth",
+                        code="xai_migrate_source_empty",
+                        relogin_required=True,
+                    )
+            elif source_key == "root":
+                _pick_from_cross("root")
+                if not _xai_oauth_state_has_usable_tokens(chosen):
+                    raise AuthError(
+                        "No usable xAI OAuth tokens in the global-root "
+                        "auth.json to migrate.",
+                        provider="xai-oauth",
+                        code="xai_migrate_source_empty",
+                        relogin_required=True,
+                    )
+            else:
+                # auto / explicit / login
+                _pick_from_cross("auto")
+                if not _xai_oauth_state_has_usable_tokens(chosen):
+                    raise AuthError(
+                        "No usable legacy xAI OAuth tokens found to migrate. "
+                        "Prefer a fresh `hermes model` / device-code login with "
+                        "shared mode enabled (writes directly to the canonical "
+                        "store).",
+                        provider="xai-oauth",
+                        code="xai_migrate_source_empty",
+                        relogin_required=True,
+                    )
+            assert chosen is not None
+            assert chosen_path is not None
+            if not chosen_identity:
+                raise AuthError(
+                    "Elected local xAI grant has no refresh_token identity; "
+                    "refusing promote.",
+                    provider="xai-oauth",
+                    code="xai_migrate_source_empty",
+                    relogin_required=True,
+                )
+
+            # H1/H2: re-elect across ALL held stores (not just chosen) so a
+            # concurrent identity injected into the other store is observed.
+            recheck_cross = _collect_live_promotable_xai_under_held_locks(
+                locked_paths
+            )
+            recheck_identities = {
+                identity for _path, identity, _state in recheck_cross
+            }
+            if len(recheck_identities) > 1:
+                raise AuthError(
+                    "Ambiguous local xAI OAuth state detected during promotion "
+                    "(cross-store race). Refusing to write into the canonical "
+                    "shared store.",
+                    provider="xai-oauth",
+                    code="xai_promote_ambiguous_local",
+                    relogin_required=True,
+                )
+            recheck = _elect_sole_promotable_xai_under_lock(chosen_path)
+            recheck_identity = _xai_oauth_refresh_identity(recheck)
+            if recheck_identity != chosen_identity:
+                raise AuthError(
+                    "Local xAI OAuth grant was removed or changed during "
+                    "promotion (logout race). Refusing to write a stale grant "
+                    "into the canonical shared store.",
+                    provider="xai-oauth",
+                    code="xai_promote_local_race",
+                    relogin_required=True,
+                )
+            if not _xai_oauth_state_has_usable_tokens(recheck):
+                raise AuthError(
+                    "Local xAI OAuth grant was removed during promotion "
+                    "(logout race). Refusing to write a stale grant into the "
+                    "canonical shared store.",
+                    provider="xai-oauth",
+                    code="xai_promote_local_race",
+                    relogin_required=True,
+                )
+            chosen = recheck
+            tokens = (
+                chosen.get("tokens")
+                if isinstance(chosen.get("tokens"), dict)
+                else {}
+            )
+            shared_payload = {
+                "access_token": tokens.get("access_token"),
+                "refresh_token": tokens.get("refresh_token"),
+                "token_type": tokens.get("token_type") or "Bearer",
+                "expires_in": tokens.get("expires_in"),
+                "last_refresh": chosen.get("last_refresh"),
+                "auth_mode": chosen.get("auth_mode") or "oauth_device_code",
+                "discovery": chosen.get("discovery") or {},
+                "redirect_uri": chosen.get("redirect_uri") or "",
+                "generation": 0,
+            }
+            # F7: preserve id_token across migration.
+            id_token = str(
+                tokens.get("id_token") or chosen.get("id_token") or ""
+            ).strip()
+            if id_token:
+                shared_payload["id_token"] = id_token
+            # Final identity re-check immediately before the durable write,
+            # still under BOTH profile and root locks.
+            final_cross = _collect_live_promotable_xai_under_held_locks(
+                locked_paths
+            )
+            final_identities = {
+                identity for _path, identity, _state in final_cross
+            }
+            if len(final_identities) > 1:
+                raise AuthError(
+                    "Ambiguous local xAI OAuth state detected during promotion "
+                    "(cross-store race). Refusing to write into the canonical "
+                    "shared store.",
+                    provider="xai-oauth",
+                    code="xai_promote_ambiguous_local",
+                    relogin_required=True,
+                )
+            final = _elect_sole_promotable_xai_under_lock(chosen_path)
+            final_identity = _xai_oauth_refresh_identity(final)
+            if final_identity != chosen_identity:
+                raise AuthError(
+                    "Local xAI OAuth grant was removed or changed during "
+                    "promotion (logout race). Refusing to write a stale grant "
+                    "into the canonical shared store.",
+                    provider="xai-oauth",
+                    code="xai_promote_local_race",
+                    relogin_required=True,
+                )
+            written = _write_shared_xai_state(
+                shared_payload, bump_generation=True, _holding_lock=True
+            )
+
+        # H3: strip → inventory → marker under shared + ALL fleet locks while
+        # the shared lock is still held (no RT restore between strip and mark).
+        if strip_legacy and written is not None:
+            fleet_paths = _iter_xai_auth_json_paths(
+                include_global_root=True,
+                fail_loud=True,
+            )
+            with _xai_ordered_auth_store_locks(fleet_paths) as locked_fleet:
+                _strip_legacy_xai_oauth_secrets_under_held_locks(
+                    locked_fleet,
+                    fail_loud=True,
+                )
+                _write_xai_sole_owner_marker(
+                    generation=written.get("generation"),
+                    _holding_shared_lock=True,
+                    _holding_store_locks=True,
+                    _locked_paths=locked_fleet,
+                )
+
+    assert written is not None
+    if strip_legacy:
+        # Outside shared lock: non-secret profile reference only.
+        _write_profile_xai_shared_reference(
+            enabled=True,
+            last_refresh=written.get("last_refresh"),
+            generation=written.get("generation"),
+            set_active=True,
+        )
+    return written
+
+
+def _strip_legacy_xai_oauth_secrets_under_held_locks(
+    paths: Sequence[Path],
+    *,
+    fail_loud: bool = True,
+) -> List[str]:
+    """Strip durable xAI secrets from ``paths``. Caller holds every lock.
+
+    Fail-closed: unreadable/corrupt stores and residual RTs fail the strip
+    when ``fail_loud`` (default).
+    """
+    audit: List[str] = []
+    failures: List[str] = []
+    residual: List[str] = []
+
+    for path in paths:
+        if not path.is_file():
+            continue
+        try:
+            # R5: unreadable/corrupt stores FAIL the audit (never certify clean).
+            store = _load_auth_store(path, fail_on_corrupt=True)
+            if not isinstance(store, dict):
+                failures.append(f"{path}: auth store load returned non-dict")
+                continue
+            mutated = _strip_xai_secrets_in_store(
+                store, remove_manuals=True, audit=audit
+            )
+            if mutated:
+                _save_auth_store(store, target_path=path)
+                audit.append(f"stripped xAI secrets from {path}")
+            # Re-read after save to verify no durable RT remains.
+            verify = _load_auth_store(path, fail_on_corrupt=True)
+            if _auth_store_holds_durable_xai_refresh_token(verify):
+                residual.append(str(path))
+        except AuthError as exc:
+            failures.append(f"{path}: {exc}")
+            logger.warning(
+                "xAI shared: legacy secret strip failed for %s: %s", path, exc
+            )
+        except Exception as exc:
+            failures.append(f"{path}: {exc}")
+            logger.warning(
+                "xAI shared: legacy secret strip failed for %s: %s", path, exc
+            )
+
+    if failures or residual:
+        parts = []
+        if failures:
+            parts.append("cleanup failures: " + "; ".join(failures))
+        if residual:
+            parts.append(
+                "durable xAI refresh_token still present after strip at: "
+                + ", ".join(residual)
+            )
+        message = (
+            "Shared xAI OAuth sole-ownership strip incomplete. "
+            + " | ".join(parts)
+            + ". Migration/login cannot proceed while a local fork remains."
+        )
+        if fail_loud:
+            raise AuthError(
+                message,
+                provider="xai-oauth",
+                code="xai_shared_strip_incomplete",
+                relogin_required=False,
+            )
+        logger.error(message)
+    return audit
+
+
+def _strip_legacy_xai_oauth_secrets(
+    *,
+    include_global_root: bool = True,
+    fail_loud: bool = True,
+) -> List[str]:
+    """Hard-strip durable xAI OAuth secrets from ALL profiles + root.
+
+    Shared sole ownership (A1/A4/A5): every auth.json under the default hermes
+    root, every named profile, and the active HERMES_HOME must lose local
+    refresh tokens. Same-family ``manual:*`` pool rows are removed (they
+    pure-refresh outside the shared lock). Cleanup failures and residual
+    durable refresh tokens FAIL LOUDLY so migration/login cannot report
+    success while a fork still exists.
+
+    Atomicity: acquires ALL store locks in deterministic sorted-path order
+    before mutating any file, so a concurrent writer cannot restore an RT
+    between per-file strip steps of the same sweep.
+
+    Returns a list of audit lines describing removals.
+    """
+    # F3a: enumeration failure fails the strip when fail_loud (default).
+    try:
+        paths = _iter_xai_auth_json_paths(
+            include_global_root=include_global_root,
+            fail_loud=fail_loud,
+        )
+    except AuthError:
+        raise
+    except Exception as exc:
+        if fail_loud:
+            raise AuthError(
+                f"Shared xAI OAuth sole-ownership strip cannot enumerate auth "
+                f"paths: {exc}",
+                provider="xai-oauth",
+                code="xai_shared_profile_enum_failed",
+                relogin_required=False,
+            ) from exc
+        logger.error(
+            "Shared xAI OAuth sole-ownership strip cannot enumerate auth paths: %s",
+            exc,
+        )
+        return []
+
+    with _xai_ordered_auth_store_locks(paths):
+        return _strip_legacy_xai_oauth_secrets_under_held_locks(
+            paths,
+            fail_loud=fail_loud,
+        )
+
+
+def _strip_root_xai_oauth_secrets(*, fail_loud: bool = True) -> None:
+    """A5: strip durable xAI OAuth secrets from the global-root auth.json only."""
+    paths: List[Path] = []
+    try:
+        global_path = _global_auth_file_path()
+        if global_path is not None:
+            paths.append(global_path)
+    except Exception:
+        pass
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        root = get_default_hermes_root() / "auth.json"
+        # Avoid double-work when profile == root (classic mode).
+        if not any(_same_path(root, p) for p in paths):
+            # Only add when distinct from the active profile auth path.
+            try:
+                active = _auth_file_path()
+            except Exception:
+                active = None
+            if active is None or not _same_path(root, active):
+                paths.append(root)
+    except Exception:
+        pass
+
+    residual: List[str] = []
+    failures: List[str] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        try:
+            with _auth_store_lock(target_path=path):
+                store = _load_auth_store(path)
+                if not store:
+                    continue
+                if _strip_xai_secrets_in_store(store, remove_manuals=True):
+                    _save_auth_store(store, target_path=path)
+                verify = _load_auth_store(path)
+                if _auth_store_holds_durable_xai_refresh_token(verify):
+                    residual.append(str(path))
+        except Exception as exc:
+            failures.append(f"{path}: {exc}")
+    if failures or residual:
+        message = (
+            "Shared xAI OAuth root strip incomplete. "
+            + (f"failures={failures}; " if failures else "")
+            + (f"residual_rt_at={residual}" if residual else "")
+        )
+        if fail_loud:
+            raise AuthError(
+                message,
+                provider="xai-oauth",
+                code="xai_shared_root_strip_incomplete",
+                relogin_required=False,
+            )
+        logger.error(message)
+
+
+def disable_profile_xai_shared_auth() -> bool:
+    """Per-profile opt-out of the shared xAI grant (does NOT clear the grant).
+
+    Writes the durable disable marker. Callers that also clear provider state
+    (logout / auth remove) MUST re-invoke this AFTER the clear so the marker
+    survives (B1).
+
+    Fail-loud (F3b/F4b): requires shared mode ON; marker write failures raise
+    (never report success when the disable did not persist).
+    """
+    if not _xai_shared_auth_enabled():
+        raise AuthError(
+            "Shared xAI OAuth is not enabled. Run `hermes auth xai enable-shared` "
+            "(or set shared_auth.providers: [xai-oauth] in config.yaml) before disabling.",
+            provider="xai-oauth",
+            code="xai_shared_not_enabled",
+        )
+    _write_profile_xai_shared_reference(enabled=False)
+    # Verify the marker actually landed — never claim "Disabled" on a no-op write.
+    if not _profile_xai_shared_disabled():
+        raise AuthError(
+            "Failed to persist per-profile shared xAI OAuth disable marker.",
+            provider="xai-oauth",
+            code="xai_shared_disable_failed",
+            relogin_required=False,
+        )
+    return True
+
+
+def enable_profile_xai_shared_auth() -> bool:
+    """Re-enable this profile's use of the shared xAI grant.
+
+    Also sweeps residual durable RTs from all profiles + root (A1) so enabling
+    cannot leave a silent fork.
+
+    F4a: requires shared mode ON and a usable canonical shared grant before any
+    multi-profile strip. Never strips the last local RT when the gate is off
+    or the shared store is empty.
+    """
+    if not _xai_shared_auth_enabled():
+        raise AuthError(
+            "Shared xAI OAuth is not enabled. Run `hermes auth xai enable-shared` "
+            "(or set shared_auth.providers: [xai-oauth] in config.yaml) before enabling.",
+            provider="xai-oauth",
+            code="xai_shared_not_enabled",
+        )
+    shared = _read_shared_xai_state()
+    if not _xai_shared_state_has_usable_tokens(shared):
+        raise AuthError(
+            "Cannot enable shared xAI OAuth: the canonical shared store is empty. "
+            "Log in via `hermes model` / device-code, or run "
+            "`hermes auth xai migrate-shared` first. Local refresh tokens were "
+            "NOT stripped.",
+            provider="xai-oauth",
+            code="xai_shared_empty",
+            relogin_required=True,
+        )
+    _write_profile_xai_shared_reference(enabled=True)
+    _strip_legacy_xai_oauth_secrets(include_global_root=True, fail_loud=True)
+    return True
+
+
+def ensure_shared_xai_grant_from_local(
+    *,
+    strip_legacy: bool = True,
+) -> Optional[Dict[str, Any]]:
+    """F1: when shared is empty but a local grant exists, promote it first.
+
+    Under shared mode, NEVER strip the last durable refresh token before a
+    durable write into the canonical shared store. Returns:
+
+    - the existing shared state if the canonical store already has a grant
+      (and R4: ensures a one-time fleet sole-owner sweep has run)
+    - the newly written shared state after a successful local→shared promote
+    - ``None`` when there is nothing to promote (truly empty) OR when the
+      canonical store is tombstoned/quarantined (R1 — no resurrection)
+
+    Raises AuthError when a local grant was found but the durable shared write
+    (or post-write sole-ownership strip) failed — in the write-failure case the
+    local grant is left intact.
+    """
+    if not _xai_shared_auth_enabled():
+        return None
+    if _profile_xai_shared_disabled():
+        return None
+
+    existing = _read_shared_xai_state(raise_on_unreadable=True)
+    if _xai_shared_state_has_usable_tokens(existing):
+        # R4: pre-existing canonical (upgrade deploy state) must still sweep
+        # dormant per-profile RTs once on first shared consumption.
+        try:
+            gen = int((existing or {}).get("generation") or 0)
+        except (TypeError, ValueError):
+            gen = 0
+        _ensure_xai_fleet_sole_owner_verified(generation=gen)
+        return existing
+
+    # R1: tombstoned / globally-logged-out / quarantined → do NOT promote.
+    if existing is not None and _shared_xai_state_is_quarantined(existing):
+        return None
+    if not _shared_xai_store_is_never_initialized() and existing is not None:
+        # File present, unusable, but not a recognized tombstone — still refuse
+        # silent resurrection (treat as intentionally non-live).
+        if not _xai_shared_state_has_usable_tokens(existing):
+            return None
+
+    # H2: atomic sole-live promote across profile AND root lives entirely
+    # inside migrate (shared outer → both store locks held election→commit).
+    # No separate unlocked pre-collect that could race.
+    try:
+        return migrate_xai_oauth_to_shared_store(
+            source="auto",
+            strip_legacy=strip_legacy,
+            force=False,
+        )
+    except AuthError as exc:
+        # Concurrent winner already installed the grant — adopt it.
+        if getattr(exc, "code", None) == "xai_shared_already_present":
+            shared = _read_shared_xai_state()
+            if _xai_shared_state_has_usable_tokens(shared):
+                return shared
+        code = getattr(exc, "code", None)
+        # Ambiguous / unreadable / unlockable / strip failures must surface
+        # (fail-closed). Empty/quarantined/race → no usable grant for callers
+        # that treat None as empty.
+        if code == "xai_promote_ambiguous_local":
+            raise
+        if code in {
+            "xai_auth_store_unreadable",
+            "xai_auth_store_lock_failed",
+            "xai_shared_strip_incomplete",
+            "xai_shared_fleet_inventory_failed",
+            "xai_shared_sole_owner_marker_failed",
+            "xai_shared_persist_failed",
+            "xai_shared_profile_enum_failed",
+        }:
+            raise
+        if code in {
+            "xai_shared_quarantined",
+            "xai_promote_local_race",
+            "xai_migrate_source_empty",
+        }:
+            return None
+        raise
+
+
+
+# =============================================================================
 # xAI Grok OAuth — tokens stored in ~/.hermes/auth.json
 # =============================================================================
 
-def _xai_oauth_state_from_store(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Return usable xAI OAuth state from provider state or credential pool."""
+def _xai_entry_source_suppressed(auth_store: Dict[str, Any], source: str) -> bool:
+    suppressed = auth_store.get("suppressed_sources") if isinstance(auth_store, dict) else None
+    if not isinstance(suppressed, dict):
+        return False
+    entries = suppressed.get("xai-oauth")
+    if not isinstance(entries, list):
+        return False
+    source = str(source or "")
+    if source in entries:
+        return True
+    # Broad suppress of device_code also blocks pool device_code rows.
+    if "device_code" in entries and source in {
+        "device_code",
+        "loopback_pkce",
+        "hermes_pkce",
+        "",
+    }:
+        return True
+    return False
+
+
+def _xai_pool_entry_is_live_promotable(
+    entry: Dict[str, Any],
+    auth_store: Dict[str, Any],
+) -> bool:
+    """R2: True when a pool row is a live, unsuppressed, non-dead grant."""
+    if not isinstance(entry, dict):
+        return False
+    access_token = str(entry.get("access_token", "") or "").strip()
+    refresh_token = str(entry.get("refresh_token", "") or "").strip()
+    if not access_token or not refresh_token:
+        return False
+    source = str(entry.get("source") or "")
+    if source.startswith("shared:"):
+        return False
+    if _xai_entry_source_suppressed(auth_store, source):
+        return False
+    status = str(entry.get("last_status") or "").strip().lower()
+    if status in _XAI_NON_PROMOTABLE_STATUSES:
+        return False
+    reason = str(
+        entry.get("last_error_reason") or entry.get("last_error") or ""
+    ).strip().lower()
+    if reason in _XAI_NON_PROMOTABLE_REASONS:
+        return False
+    return True
+
+
+def _xai_provider_state_is_live_promotable(
+    state: Optional[Dict[str, Any]],
+    auth_store: Dict[str, Any],
+) -> bool:
+    """R2: True when providers.xai-oauth holds a live unsuppressed grant."""
+    if not isinstance(state, dict):
+        return False
+    if state.get("enabled") is False:
+        return False
+    if is_truthy_value(state.get("shared_disabled"), default=False):
+        return False
+    tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else None
+    if not isinstance(tokens, dict):
+        access = str(state.get("access_token", "") or "").strip()
+        refresh = str(state.get("refresh_token", "") or "").strip()
+        if not (access and refresh):
+            return False
+    else:
+        access = str(tokens.get("access_token", "") or "").strip()
+        refresh = str(tokens.get("refresh_token", "") or "").strip()
+        if not (access and refresh):
+            return False
+    source = str(state.get("source") or "device_code")
+    if source.startswith("shared:"):
+        return False
+    if _xai_entry_source_suppressed(auth_store, source):
+        return False
+    if _xai_entry_source_suppressed(auth_store, "device_code"):
+        return False
+    status = str(state.get("last_status") or "").strip().lower()
+    if status in _XAI_NON_PROMOTABLE_STATUSES:
+        return False
+    last_err = state.get("last_auth_error")
+    if isinstance(last_err, dict):
+        code = str(last_err.get("code") or "").strip().lower()
+        if code in _XAI_NON_PROMOTABLE_REASONS or code in _XAI_NON_PROMOTABLE_STATUSES:
+            # Terminal error still attached with residual tokens → not promotable.
+            return False
+        if is_truthy_value(last_err.get("relogin_required"), default=False):
+            return False
+    return True
+
+
+def _xai_oauth_state_from_store_legacy(
+    auth_store: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Gate-off resolution — byte-identical to 60891a4ef (H6/G7).
+
+    Legacy first-wins: providers singleton (via ``_load_provider_state``,
+    which may fall back to global root) if it has access+refresh, else the
+    first token-bearing pool row. Does NOT reject dead/suppressed/exhausted
+    rows and does NOT sole-live-dedup — those strict rules are shared-mode
+    only (``sole_live=True``).
+    """
     state = _load_provider_state(auth_store, "xai-oauth")
     tokens = state.get("tokens") if isinstance(state, dict) else None
     if isinstance(tokens, dict):
@@ -4324,12 +6801,106 @@ def _xai_oauth_state_from_store(auth_store: Dict[str, Any]) -> Optional[Dict[str
                 "refresh_token": refresh_token,
                 "token_type": str(entry.get("token_type") or "Bearer"),
             }
+            id_token = str(entry.get("id_token") or "").strip()
+            if id_token:
+                merged["tokens"]["id_token"] = id_token
             if entry.get("last_refresh"):
                 merged["last_refresh"] = entry.get("last_refresh")
             merged.setdefault("auth_mode", "oauth_pkce")
             return merged
 
     return state if isinstance(state, dict) else None
+
+
+def _xai_oauth_state_from_store(
+    auth_store: Dict[str, Any],
+    *,
+    sole_live: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Return usable xAI OAuth state from provider state or credential pool.
+
+    H6/G7: when ``sole_live`` is False (gate-off / legacy readers), behavior
+    is byte-identical to 60891a4ef — first token-bearing row wins, including
+    dead/suppressed rows.
+
+    When ``sole_live`` is True (shared-mode auto-promote / migrate), R2
+    rejects dead/exhausted/suppressed rows and AMBIGUOUS multi-live-grant
+    stores raise ``xai_promote_ambiguous_local``.
+    """
+    if not sole_live:
+        return _xai_oauth_state_from_store_legacy(auth_store)
+
+    # Shared-mode sole-live path: collect live candidates keyed by
+    # refresh_token identity so a singleton + matching pool row for the same
+    # grant counts as ONE candidate.
+    by_rt: Dict[str, Dict[str, Any]] = {}
+
+    # Provider singleton (do not use _load_provider_state — it may fall back to
+    # global root; callers that want root must load that store themselves).
+    providers = auth_store.get("providers") if isinstance(auth_store, dict) else None
+    state = providers.get("xai-oauth") if isinstance(providers, dict) else None
+    if isinstance(state, dict) and _xai_provider_state_is_live_promotable(state, auth_store):
+        tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else None
+        if isinstance(tokens, dict):
+            rt = str(tokens.get("refresh_token") or "").strip()
+            access = str(tokens.get("access_token") or "").strip()
+            if rt and access:
+                by_rt[rt] = dict(state)
+        else:
+            rt = str(state.get("refresh_token") or "").strip()
+            access = str(state.get("access_token") or "").strip()
+            if rt and access:
+                merged = dict(state)
+                merged["tokens"] = {
+                    "access_token": access,
+                    "refresh_token": rt,
+                    "token_type": str(state.get("token_type") or "Bearer"),
+                }
+                by_rt[rt] = merged
+
+    credential_pool = auth_store.get("credential_pool")
+    entries = (
+        credential_pool.get("xai-oauth")
+        if isinstance(credential_pool, dict)
+        else None
+    )
+    if isinstance(entries, list):
+        for entry in entries:
+            if not _xai_pool_entry_is_live_promotable(entry, auth_store):
+                continue
+            access_token = str(entry.get("access_token", "") or "").strip()
+            refresh_token = str(entry.get("refresh_token", "") or "").strip()
+            if refresh_token in by_rt:
+                # Same grant already seen via providers singleton.
+                continue
+            merged = dict(state or {}) if isinstance(state, dict) else {}
+            merged["tokens"] = {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "token_type": str(entry.get("token_type") or "Bearer"),
+            }
+            id_token = str(entry.get("id_token") or "").strip()
+            if id_token:
+                merged["tokens"]["id_token"] = id_token
+            if entry.get("last_refresh"):
+                merged["last_refresh"] = entry.get("last_refresh")
+            merged.setdefault("auth_mode", "oauth_pkce")
+            by_rt[refresh_token] = merged
+
+    if not by_rt:
+        return None
+
+    if len(by_rt) > 1:
+        raise AuthError(
+            "Ambiguous local xAI OAuth state: multiple distinct live refresh "
+            "tokens present. Refusing to auto-promote; resolve to a single "
+            "live grant or run an explicit migrate with a chosen source.",
+            provider="xai-oauth",
+            code="xai_promote_ambiguous_local",
+            relogin_required=True,
+        )
+
+    return next(iter(by_rt.values()))
 
 
 def _xai_oauth_state_has_usable_tokens(state: Optional[Dict[str, Any]]) -> bool:
@@ -4342,6 +6913,50 @@ def _xai_oauth_state_has_usable_tokens(state: Optional[Dict[str, Any]]) -> bool:
 
 
 def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+    """Load xAI OAuth tokens.
+
+    When shared mode is active the canonical shared store is the ONLY durable
+    source of secret material. Profile/root stores are not consulted for tokens
+    (they may still carry non-secret references). When shared mode is off, the
+    legacy profile → credential-pool → global-root fallback remains unchanged.
+    """
+    if _xai_shared_auth_enabled():
+        if _profile_xai_shared_disabled():
+            raise AuthError(
+                "xAI shared OAuth is disabled for this profile. "
+                "Re-enable with `hermes auth xai enable-shared` or log in again.",
+                provider="xai-oauth",
+                code="xai_shared_profile_disabled",
+                relogin_required=False,
+            )
+        shared = _read_shared_xai_state()
+        if not _xai_shared_state_has_usable_tokens(shared):
+            err = (shared or {}).get("last_auth_error") if isinstance(shared, dict) else None
+            detail = ""
+            if isinstance(err, dict) and err.get("message"):
+                detail = f" Last error: {err.get('message')}"
+            raise AuthError(
+                "No xAI OAuth credentials in the shared store. "
+                "Select xAI Grok OAuth in `hermes model`, or run "
+                "`hermes auth xai migrate-shared`."
+                + detail,
+                provider="xai-oauth",
+                code="xai_auth_missing",
+                relogin_required=True,
+            )
+        assert shared is not None
+        tokens = _shared_xai_tokens_view(shared)
+        return {
+            "tokens": tokens,
+            "last_refresh": shared.get("last_refresh"),
+            "discovery": shared.get("discovery") or {},
+            "redirect_uri": shared.get("redirect_uri"),
+            "generation": shared.get("generation"),
+            "auth_mode": shared.get("auth_mode") or "oauth_device_code",
+            "auth_store": "shared",
+            "shared_path": str(_xai_shared_store_path()),
+        }
+
     if _lock:
         with _auth_store_lock():
             auth_store = _load_auth_store()
@@ -4416,7 +7031,13 @@ def _write_through_xai_oauth_to_global_root(state: Dict[str, Any]) -> None:
     profile store (the caller already saved that). Swallows all errors — a
     failed write-through degrades to the pre-existing behavior (root stale),
     it must never break the profile's own successful save.
+
+    When shared xAI mode is active (G2) this is a hard no-op: the canonical
+    shared store is the only durable secret home and running both systems
+    would re-fork rotating refresh tokens.
     """
+    if _xai_shared_auth_enabled():
+        return
     global_path = _global_auth_file_path()
     if global_path is None:
         # Classic mode (profile == root); the profile save already hit root.
@@ -4453,6 +7074,7 @@ def _save_xai_oauth_tokens(
     last_refresh: Optional[str] = None,
     auth_mode: str = "oauth_device_code",
     set_active: bool = True,
+    generation: Optional[int] = None,
 ) -> None:
     """Persist xAI OAuth tokens into the auth store.
 
@@ -4464,6 +7086,37 @@ def _save_xai_oauth_tokens(
     """
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    # Shared mode: canonical store is authoritative. Do NOT materialize tokens
+    # into the profile providers.xai-oauth block (G1 / invariant 5).
+    if _xai_shared_auth_enabled():
+        shared_payload = {
+            "access_token": tokens.get("access_token"),
+            "refresh_token": tokens.get("refresh_token"),
+            "token_type": tokens.get("token_type") or "Bearer",
+            "expires_in": tokens.get("expires_in"),
+            "id_token": tokens.get("id_token"),
+            "last_refresh": last_refresh,
+            "auth_mode": auth_mode,
+            "discovery": discovery or {},
+            "redirect_uri": redirect_uri,
+        }
+        if generation is not None:
+            shared_payload["generation"] = generation
+        written = _write_shared_xai_state(shared_payload, bump_generation=True)
+        # AFTER shared lock release inside _write_shared_xai_state: profile metadata only.
+        _write_profile_xai_shared_reference(
+            enabled=True,
+            last_refresh=written.get("last_refresh"),
+            generation=written.get("generation"),
+            set_active=True,
+        )
+        # A5: root providers.xai-oauth.tokens.refresh_token must not survive a
+        # shared save. Active profile is already reference-only above. Full
+        # multi-profile sweeps happen on migrate/login/enable (A1).
+        _strip_root_xai_oauth_secrets(fail_loud=True)
+        return
+
     with _auth_store_lock():
         auth_store = _load_auth_store()
         # A profile that lacks its own xai-oauth block is reading the root
@@ -4789,15 +7442,24 @@ def _refresh_xai_oauth_tokens(
     token_endpoint: str,
     redirect_uri: str = "",
     timeout_seconds: float,
+    auth_mode: str = "oauth_device_code",
+    discovery: Optional[Dict[str, Any]] = None,
+    expected_generation: Optional[int] = None,
+    persist: bool = True,
 ) -> Dict[str, Any]:
     # Re-persist whatever auth_mode is already stored (legacy pre-device-code
     # logins may still carry ``oauth_pkce``): the refresh hot path must not
     # relabel how the grant was originally obtained.
-    try:
-        state = _load_provider_state(_load_auth_store(), "xai-oauth") or {}
-        auth_mode = str(state.get("auth_mode") or "oauth_device_code")
-    except Exception:
-        auth_mode = "oauth_device_code"
+    if not auth_mode:
+        try:
+            if _xai_shared_auth_enabled():
+                shared = _read_shared_xai_state() or {}
+                auth_mode = str(shared.get("auth_mode") or "oauth_device_code")
+            else:
+                state = _load_provider_state(_load_auth_store(), "xai-oauth") or {}
+                auth_mode = str(state.get("auth_mode") or "oauth_device_code")
+        except Exception:
+            auth_mode = "oauth_device_code"
     refreshed = refresh_xai_oauth_pure(
         str(tokens.get("access_token", "") or ""),
         str(tokens.get("refresh_token", "") or ""),
@@ -4813,17 +7475,193 @@ def _refresh_xai_oauth_tokens(
         updated_tokens["expires_in"] = refreshed["expires_in"]
     if refreshed.get("token_type"):
         updated_tokens["token_type"] = refreshed["token_type"]
-    _save_xai_oauth_tokens(
-        updated_tokens,
-        discovery={"token_endpoint": token_endpoint},
-        redirect_uri=redirect_uri,
-        last_refresh=refreshed["last_refresh"],
-        auth_mode=auth_mode,
-        # Refresh must not flip active_provider — TTS/side tools can refresh
-        # xAI tokens while chat still routes through another provider.
-        set_active=False,
-    )
+    if persist:
+        _save_xai_oauth_tokens(
+            updated_tokens,
+            discovery=discovery or {"token_endpoint": token_endpoint},
+            redirect_uri=redirect_uri,
+            last_refresh=refreshed["last_refresh"],
+            auth_mode=auth_mode,
+            # Refresh must not flip active_provider — TTS/side tools can refresh
+            # xAI tokens while chat still routes through another provider.
+            set_active=False,
+            generation=expected_generation,
+        )
+    updated_tokens["last_refresh"] = refreshed["last_refresh"]
     return updated_tokens
+
+
+def _resolve_xai_oauth_runtime_credentials_shared(
+    *,
+    force_refresh: bool = False,
+    refresh_if_expiring: bool = True,
+    refresh_skew_seconds: Optional[int] = None,
+    rejected_access_token: Optional[str] = None,
+    expected_generation: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Canonical shared-store resolver: one lock, one refresher, adopt-on-wait."""
+    if _profile_xai_shared_disabled():
+        raise AuthError(
+            "xAI shared OAuth is disabled for this profile.",
+            provider="xai-oauth",
+            code="xai_shared_profile_disabled",
+        )
+
+    # F1: empty canonical + sole local grant → promote (durable write) BEFORE
+    # any strip/refresh. Fail loud if promotion cannot write; leave local intact.
+    ensure_shared_xai_grant_from_local(strip_legacy=True)
+
+    refresh_timeout_seconds = env_float("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", 20)
+    lock_timeout = max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)
+
+    # Snapshot pre-lock identity for generation compare (G4). Prefer explicit
+    # rejected-token args; otherwise snapshot current canonical state when a
+    # refresh is being requested so a waiter never re-POSTs after a winner.
+    pre_access = str(rejected_access_token or "").strip() or None
+    pre_generation = expected_generation
+    try:
+        pre = _read_shared_xai_state()
+    except Exception:
+        pre = None
+    if pre_access is None and isinstance(pre, dict):
+        pre_access = str(pre.get("access_token") or "").strip() or None
+    if pre_generation is None and isinstance(pre, dict):
+        try:
+            pre_generation = int(pre.get("generation") or 0)
+        except (TypeError, ValueError):
+            pre_generation = None
+
+    with _xai_shared_store_lock(timeout_seconds=lock_timeout):
+        shared = _read_shared_xai_state()
+        if not _xai_shared_state_has_usable_tokens(shared):
+            raise AuthError(
+                "No xAI OAuth credentials in the shared store. "
+                "Select xAI Grok OAuth in `hermes model`.",
+                provider="xai-oauth",
+                code="xai_auth_missing",
+                relogin_required=True,
+            )
+        assert shared is not None
+        tokens = _shared_xai_tokens_view(shared)
+        access_token = tokens["access_token"]
+        discovery = dict(shared.get("discovery") or {})
+        token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
+        redirect_uri = str(shared.get("redirect_uri", "") or "").strip()
+        auth_mode = str(shared.get("auth_mode") or "oauth_device_code")
+        try:
+            current_generation = int(shared.get("generation") or 0)
+        except (TypeError, ValueError):
+            current_generation = 0
+        last_refresh = shared.get("last_refresh")
+
+        effective_skew = (
+            int(refresh_skew_seconds)
+            if refresh_skew_seconds is not None
+            else _xai_proactive_refresh_skew_seconds(access_token)
+        )
+
+        # G4: force_refresh is NOT unconditional after re-read. Only refresh if
+        # the canonical generation/token still matches what the caller rejected
+        # (or what we observed pre-lock). Otherwise adopt the winner.
+        should_refresh = False
+        if force_refresh:
+            still_same_access = (
+                pre_access is None
+                or str(access_token).strip() == str(pre_access).strip()
+            )
+            still_same_gen = (
+                pre_generation is None
+                or int(current_generation) == int(pre_generation)
+            )
+            should_refresh = still_same_access and still_same_gen
+            if not should_refresh:
+                _oauth_trace(
+                    "xai_shared_adopt_winner",
+                    generation=current_generation,
+                    pre_generation=pre_generation,
+                    access_token_fp=_token_fingerprint(access_token),
+                )
+        elif refresh_if_expiring:
+            should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
+
+        if should_refresh:
+            if not token_endpoint:
+                # Discovery is network I/O while holding the shared lock — same
+                # trade-off as the legacy path (must serialize before refresh).
+                token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]
+                discovery["token_endpoint"] = token_endpoint
+            try:
+                refreshed = refresh_xai_oauth_pure(
+                    access_token,
+                    tokens["refresh_token"],
+                    token_endpoint=token_endpoint,
+                    timeout_seconds=refresh_timeout_seconds,
+                )
+                new_state = {
+                    "access_token": refreshed["access_token"],
+                    "refresh_token": refreshed["refresh_token"],
+                    "token_type": refreshed.get("token_type") or "Bearer",
+                    "expires_in": refreshed.get("expires_in"),
+                    "id_token": refreshed.get("id_token"),
+                    "last_refresh": refreshed["last_refresh"],
+                    "auth_mode": auth_mode,
+                    "discovery": discovery,
+                    "redirect_uri": redirect_uri,
+                    "generation": current_generation,
+                }
+                # G5: durable write is NOT best-effort — fail loud if it fails.
+                written = _write_shared_xai_state(
+                    new_state, bump_generation=True, _holding_lock=True
+                )
+                access_token = str(written.get("access_token") or "").strip()
+                last_refresh = written.get("last_refresh")
+                current_generation = int(written.get("generation") or 0)
+                tokens = _shared_xai_tokens_view(written)
+            except AuthError as exc:
+                if _is_terminal_xai_oauth_refresh_error(exc):
+                    # G6: compare-and-clear under the lock.
+                    terminal = {
+                        "provider": "xai-oauth",
+                        "code": exc.code or "xai_refresh_failed",
+                        "message": str(exc),
+                        "reason": "runtime_refresh_failure",
+                        "relogin_required": True,
+                        "at": datetime.now(timezone.utc).isoformat(),
+                    }
+                    _clear_shared_xai_state(
+                        "runtime_refresh_failure",
+                        terminal_error=terminal,
+                        only_if_refresh_token=tokens.get("refresh_token"),
+                        only_if_generation=current_generation,
+                        _holding_lock=True,
+                    )
+                raise
+
+    # AFTER releasing the shared lock: best-effort non-secret profile metadata.
+    try:
+        _write_profile_xai_shared_reference(
+            enabled=True,
+            last_refresh=last_refresh if isinstance(last_refresh, str) else None,
+            generation=current_generation,
+        )
+    except Exception:
+        pass
+
+    base_url = _xai_validate_inference_base_url(
+        os.getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
+        or os.getenv("XAI_BASE_URL", "").strip().rstrip("/"),
+        fallback=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    return {
+        "provider": "xai-oauth",
+        "base_url": base_url,
+        "api_key": access_token,
+        "source": XAI_SHARED_SOURCE,
+        "last_refresh": last_refresh,
+        "auth_mode": "oauth_device_code",
+        "generation": current_generation,
+        "auth_store": str(_xai_shared_store_path()),
+    }
 
 
 def resolve_xai_oauth_runtime_credentials(
@@ -4831,7 +7669,18 @@ def resolve_xai_oauth_runtime_credentials(
     force_refresh: bool = False,
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: Optional[int] = None,
+    rejected_access_token: Optional[str] = None,
+    expected_generation: Optional[int] = None,
 ) -> Dict[str, Any]:
+    if _xai_shared_auth_enabled():
+        return _resolve_xai_oauth_runtime_credentials_shared(
+            force_refresh=force_refresh,
+            refresh_if_expiring=refresh_if_expiring,
+            refresh_skew_seconds=refresh_skew_seconds,
+            rejected_access_token=rejected_access_token,
+            expected_generation=expected_generation,
+        )
+
     data = _read_xai_oauth_tokens()
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
@@ -4839,6 +7688,10 @@ def resolve_xai_oauth_runtime_credentials(
     discovery = dict(data.get("discovery") or {})
     token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
     redirect_uri = str(data.get("redirect_uri", "") or "").strip()
+
+    # Snapshot for generation-style compare even on the legacy path so concurrent
+    # waiters adopt a winner's tokens when force_refresh is set.
+    pre_access = str(rejected_access_token or access_token or "").strip()
 
     effective_skew = (
         int(refresh_skew_seconds)
@@ -4861,9 +7714,16 @@ def resolve_xai_oauth_runtime_credentials(
                 if refresh_skew_seconds is not None
                 else _xai_proactive_refresh_skew_seconds(access_token)
             )
-            should_refresh = bool(force_refresh)
-            if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
+            if force_refresh:
+                # Only refresh if the on-disk access token is still the one that
+                # failed/was observed; else adopt the winner.
+                should_refresh = (
+                    not pre_access or access_token == pre_access
+                )
+            else:
+                should_refresh = False
+                if refresh_if_expiring:
+                    should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
             if should_refresh:
                 if not token_endpoint:
                     token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]
@@ -6654,6 +9514,42 @@ def get_codex_auth_status() -> Dict[str, Any]:
 
 
 def get_xai_oauth_auth_status() -> Dict[str, Any]:
+    shared_mode = _xai_shared_auth_enabled()
+    auth_store_path = (
+        str(_xai_shared_store_path()) if shared_mode else str(_auth_file_path())
+    )
+
+    if shared_mode:
+        if _profile_xai_shared_disabled():
+            return {
+                "logged_in": False,
+                "auth_store": auth_store_path,
+                "shared_mode": True,
+                "profile_enabled": False,
+                "error": "xAI shared OAuth disabled for this profile",
+            }
+        try:
+            creds = resolve_xai_oauth_runtime_credentials(refresh_if_expiring=False)
+            return {
+                "logged_in": True,
+                "auth_store": auth_store_path,
+                "shared_mode": True,
+                "profile_enabled": True,
+                "last_refresh": creds.get("last_refresh"),
+                "auth_mode": creds.get("auth_mode"),
+                "source": creds.get("source") or XAI_SHARED_SOURCE,
+                "api_key": creds.get("api_key"),
+                "generation": creds.get("generation"),
+            }
+        except AuthError as exc:
+            return {
+                "logged_in": False,
+                "auth_store": auth_store_path,
+                "shared_mode": True,
+                "profile_enabled": True,
+                "error": str(exc),
+            }
+
     try:
         from agent.credential_pool import load_pool
 
@@ -7541,6 +10437,37 @@ def _login_openai_codex(
     print(f"  Config updated: {config_path} (model.provider=openai-codex)")
 
 
+def _confirm_replace_shared_xai_grant(args, *, profile_disabled: bool) -> bool:
+    """B2: require explicit confirmation before clobbering the fleet grant."""
+    if bool(
+        getattr(args, "force_replace_shared", False)
+        or getattr(args, "force", False)
+        or getattr(args, "yes", False)
+    ):
+        return True
+    print()
+    if profile_disabled:
+        print(
+            "This profile has shared xAI OAuth disabled. A new device login would "
+            "REPLACE the canonical shared grant used by ALL profiles."
+        )
+        print(
+            "To re-use the existing fleet grant without replacing it, run: "
+            "`hermes auth xai enable-shared`"
+        )
+    else:
+        print(
+            "A canonical shared xAI OAuth grant already exists. A new device login "
+            "would REPLACE it for EVERY Hermes profile that uses shared mode."
+        )
+    print("Pass --force-replace-shared to confirm non-interactively.")
+    try:
+        answer = input("Replace the GLOBAL shared xAI grant? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        answer = "n"
+    return answer in {"y", "yes"}
+
+
 def _login_xai_oauth(
     args,
     pconfig: ProviderConfig,
@@ -7549,7 +10476,16 @@ def _login_xai_oauth(
 ) -> None:
     del pconfig
 
-    if not force_new_login:
+    shared_mode = _xai_shared_auth_enabled()
+    profile_disabled = shared_mode and _profile_xai_shared_disabled()
+    shared_present = False
+    if shared_mode:
+        try:
+            shared_present = _xai_shared_state_has_usable_tokens(_read_shared_xai_state())
+        except Exception:
+            shared_present = False
+
+    if not force_new_login and not profile_disabled:
         try:
             existing = resolve_xai_oauth_runtime_credentials()
             api_key = existing.get("api_key", "")
@@ -7568,8 +10504,25 @@ def _login_xai_oauth(
                     print("Login successful!")
                     print(f"  Config updated: {config_path} (model.provider=xai-oauth)")
                     return
-        except AuthError:
-            pass
+        except AuthError as exc:
+            # B2: profile-disabled must NOT fall through as "missing auth" and
+            # silently overwrite the global grant.
+            if getattr(exc, "code", None) == "xai_shared_profile_disabled":
+                profile_disabled = True
+            # Other AuthErrors (missing shared grant, etc.) fall through to login.
+
+    # B2: any fresh device-code login writes the canonical store. When a
+    # usable fleet grant already exists, require explicit confirmation so a
+    # disabled profile (or declined reuse) cannot silently clobber everyone.
+    # Empty shared store is the normal first-seed path — no confirm.
+    if shared_mode and shared_present:
+        if not _confirm_replace_shared_xai_grant(
+            args, profile_disabled=profile_disabled
+        ):
+            print("Aborted. Shared grant was not modified.")
+            if profile_disabled:
+                print("Re-enable with: hermes auth xai enable-shared")
+            return
 
     print()
     print("Signing in to xAI Grok OAuth (SuperGrok / Premium+)...")
@@ -7601,11 +10554,22 @@ def _login_xai_oauth(
     # of ``_save_xai_oauth_tokens`` on purpose — that helper is shared with the
     # refresh hot path, which must never mutate suppression state.
     unsuppress_credential_source("xai-oauth", "device_code")
+    unsuppress_credential_source("xai-oauth", XAI_SHARED_SOURCE)
+    if shared_mode:
+        # Login is the preferred way to seed the canonical store; also strip
+        # any leftover legacy secret material so local copies cannot refresh.
+        # Fail loud (A1): login must not report success if a fork remains.
+        _strip_legacy_xai_oauth_secrets(include_global_root=True, fail_loud=True)
+        enable_profile_xai_shared_auth()
     config_path = _update_config_for_provider("xai-oauth", creds.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL))
     print()
     print("Login successful!")
-    from hermes_constants import display_hermes_home as _dhh
-    print(f"  Auth state: {_dhh()}/auth.json")
+    if shared_mode:
+        print(f"  Auth state (shared, canonical): {_xai_shared_store_path()}")
+        print("  Profile holds a non-secret reference only (source: shared:xai-oauth).")
+    else:
+        from hermes_constants import display_hermes_home as _dhh
+        print(f"  Auth state: {_dhh()}/auth.json")
     print(f"  Config updated: {config_path} (model.provider=xai-oauth)")
 
 
@@ -8855,7 +11819,12 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
 
 
 def logout_command(args) -> None:
-    """Clear auth state for a provider."""
+    """Clear auth state for a provider.
+
+    For xAI OAuth under shared mode (G8):
+      - default / ``--profile``: per-profile disable (does NOT delete the grant)
+      - ``--global`` / ``--shared``: explicit GLOBAL logout (deletes canonical grant)
+    """
     provider_id = getattr(args, "provider", None)
 
     if provider_id and not is_known_auth_provider(provider_id):
@@ -8871,6 +11840,65 @@ def logout_command(args) -> None:
 
     should_reset_config = _should_reset_config_provider_on_logout(target)
     provider_name = get_auth_provider_display_name(target)
+
+    global_logout = bool(
+        getattr(args, "global_logout", False)
+        or getattr(args, "shared", False)
+        or getattr(args, "global", False)
+    )
+
+    if target == "xai-oauth" and _xai_shared_auth_enabled():
+        if global_logout:
+            print(
+                "GLOBAL xAI OAuth logout: deleting the canonical shared grant "
+                f"at {_xai_shared_store_path()}."
+            )
+            print(
+                "This affects EVERY Hermes profile that uses shared xAI OAuth."
+            )
+            cleared_shared = _clear_shared_xai_state("global_logout")
+            # Also clear local reference metadata / legacy material.
+            clear_provider_auth("xai-oauth")
+            # F3c: fleet strip must fail loud — never report global logout
+            # success while a durable xAI refresh token remains.
+            try:
+                _strip_legacy_xai_oauth_secrets(
+                    include_global_root=True, fail_loud=True
+                )
+            except AuthError as exc:
+                print(f"ERROR: global xAI OAuth logout incomplete: {exc}")
+                raise SystemExit(1) from exc
+            if should_reset_config:
+                _reset_config_provider()
+            if cleared_shared or should_reset_config:
+                print(f"Logged out of {provider_name} (GLOBAL shared grant cleared).")
+            else:
+                print(f"No shared auth state found for {provider_name}.")
+            return
+
+        # Per-profile disable (default). B1: clear first, THEN write the
+        # durable disable marker so clear_provider_auth cannot delete it.
+        clear_provider_auth("xai-oauth")
+        try:
+            disable_profile_xai_shared_auth()
+        except AuthError as exc:
+            print(f"ERROR: failed to disable shared xAI OAuth for this profile: {exc}")
+            raise SystemExit(1) from exc
+        if should_reset_config:
+            _reset_config_provider()
+        print(
+            f"Disabled shared xAI OAuth for this profile only "
+            f"(canonical grant at {_xai_shared_store_path()} is unchanged)."
+        )
+        print(
+            "To delete the grant for ALL profiles: "
+            "`hermes logout --provider xai-oauth --global`"
+        )
+        if should_reset_config and os.getenv("OPENROUTER_API_KEY"):
+            print("Hermes will use OpenRouter for inference.")
+        elif should_reset_config:
+            print("Run `hermes model` or configure an API key to use Hermes.")
+        return
 
     if clear_provider_auth(target) or should_reset_config:
         if should_reset_config:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import os
 import sys
 import time
 from types import SimpleNamespace
@@ -346,6 +347,16 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "xai-oauth":
+        if auth_mod._xai_shared_auth_enabled():
+            raise SystemExit(
+                "Shared xAI OAuth mode is active: refusing to add a separate "
+                "manual:device_code pool entry that would fork the single-use "
+                "refresh-token family.\n"
+                "Use `hermes model` / device-code login (writes the canonical "
+                "shared store) or `hermes auth xai migrate-shared`.\n"
+                "Disable shared mode (`hermes auth xai disable-shared`) only if you "
+                "intentionally want independent per-entry grants."
+            )
         creds = auth_mod._xai_oauth_device_code_login(
             timeout_seconds=getattr(args, "timeout", None) or 20.0,
             open_browser=not getattr(args, "no_browser", False),
@@ -527,7 +538,15 @@ def auth_status_command(args) -> None:
 
 
 def auth_logout_command(args) -> None:
-    auth_mod.logout_command(SimpleNamespace(provider=getattr(args, "provider", None)))
+    auth_mod.logout_command(
+        SimpleNamespace(
+            provider=getattr(args, "provider", None),
+            global_logout=bool(
+                getattr(args, "global_logout", False) or getattr(args, "shared", False)
+            ),
+            shared=bool(getattr(args, "shared", False)),
+        )
+    )
 
 
 def auth_spotify_command(args) -> None:
@@ -775,6 +794,119 @@ def _interactive_strategy() -> None:
     print(f"Set {provider} strategy to: {strategy}")
 
 
+def auth_xai_command(args) -> None:
+    """Manage the canonical shared xAI OAuth store."""
+    action = getattr(args, "xai_action", None)
+    if action == "migrate-shared":
+        if not auth_mod._xai_shared_auth_enabled():
+            raise SystemExit(
+                "Shared xAI OAuth is not enabled.\n"
+                "Enable it with `hermes auth xai enable-shared` (writes "
+                "shared_auth.providers: [xai-oauth] to config.yaml), then retry.\n"
+                "Every gateway/cron/desktop process must load that config so the "
+                "internal env bridge activates fleet-wide."
+            )
+        try:
+            written = auth_mod.migrate_xai_oauth_to_shared_store(
+                source=getattr(args, "source", "auto") or "auto",
+                strip_legacy=True,  # A8: --keep-legacy removed; sole ownership required
+                force=bool(getattr(args, "force", False)),
+            )
+        except auth_mod.AuthError as exc:
+            raise SystemExit(str(exc)) from exc
+        print("Migrated xAI OAuth grant into the canonical shared store.")
+        print(f"  Shared path: {auth_mod._xai_shared_store_path()}")
+        print(f"  Generation:  {written.get('generation')}")
+        print(f"  Last refresh:{written.get('last_refresh')}")
+        print(
+            "  Legacy secret material was stripped from all profiles + root "
+            "(sole ownership)."
+        )
+        return
+    if action == "enable-shared":
+        # User-facing activation: write config.yaml (not HERMES_* env vars).
+        # Bridges into the internal env vars for this process so the engine
+        # gate flips on immediately (AGENTS.md env-var-for-config policy).
+        from hermes_cli.config import enable_shared_auth_provider
+
+        providers = enable_shared_auth_provider("xai-oauth")
+        print(
+            "Enabled shared xAI OAuth in config.yaml "
+            f"(shared_auth.providers: {providers})."
+        )
+        print(
+            "  Internal bridge set HERMES_XAI_SHARED_AUTH for this process; "
+            "restart gateway/cron/desktop workers so they reload config."
+        )
+        # If a usable canonical grant already exists, also re-enable this
+        # profile's marker and strip residual local RTs (prior behavior).
+        try:
+            if auth_mod._xai_shared_state_has_usable_tokens(
+                auth_mod._read_shared_xai_state()
+            ):
+                auth_mod.enable_profile_xai_shared_auth()
+                print("  Profile re-enabled against the existing shared grant.")
+            else:
+                print(
+                    "  Shared store is empty — run `hermes auth xai migrate-shared` "
+                    "or log in via `hermes model` / device-code to seed it."
+                )
+        except auth_mod.AuthError as exc:
+            raise SystemExit(str(exc)) from exc
+        return
+    if action == "disable-shared":
+        # Turn off the user-facing config switch (removes xai-oauth from
+        # shared_auth.providers). Also write the per-profile disable marker
+        # when the gate was on so mid-session consumers stop using the grant.
+        from hermes_cli.config import disable_shared_auth_provider
+
+        was_enabled = auth_mod._xai_shared_auth_enabled()
+        if was_enabled:
+            try:
+                auth_mod.disable_profile_xai_shared_auth()
+            except auth_mod.AuthError as exc:
+                # Gate might race; still proceed to clear config.
+                print(f"Note: per-profile disable marker: {exc}")
+        remaining = disable_shared_auth_provider("xai-oauth")
+        # Explicit user intent: ensure this process's internal gate is off even
+        # if the gate was env-only (no config key yet) or a stale .env export.
+        os.environ.pop("HERMES_XAI_SHARED_AUTH", None)
+        raw_providers = os.environ.get("HERMES_SHARED_AUTH_PROVIDERS", "")
+        if raw_providers.strip():
+            _xai_aliases = {"xai-oauth", "xai", "grok-oauth", "x-ai-oauth"}
+            left = [
+                p.strip()
+                for p in raw_providers.split(",")
+                if p.strip() and p.strip().lower() not in _xai_aliases
+            ]
+            if left:
+                os.environ["HERMES_SHARED_AUTH_PROVIDERS"] = ",".join(left)
+            else:
+                os.environ.pop("HERMES_SHARED_AUTH_PROVIDERS", None)
+        if remaining:
+            print(
+                "Removed xai-oauth from shared_auth.providers in config.yaml "
+                f"(remaining providers: {remaining})."
+            )
+        else:
+            print(
+                "Disabled shared xAI OAuth in config.yaml "
+                "(shared_auth.providers no longer lists xai-oauth)."
+            )
+        print(
+            "  Canonical grant is unchanged. Use "
+            "`hermes logout --provider xai-oauth --global` to delete it for "
+            "all profiles."
+        )
+        print(
+            "  Restart gateway/cron/desktop workers so they reload config."
+        )
+        return
+    raise SystemExit(
+        "usage: hermes auth xai {migrate-shared,enable-shared,disable-shared}"
+    )
+
+
 def auth_command(args) -> None:
     action = getattr(args, "auth_action", "")
     if action == "add":
@@ -797,6 +929,9 @@ def auth_command(args) -> None:
         return
     if action == "spotify":
         auth_spotify_command(args)
+        return
+    if action == "xai":
+        auth_xai_command(args)
         return
     # No subcommand — launch interactive mode
     _interactive_auth()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3828,6 +3828,23 @@ DEFAULT_CONFIG = {
         "region": "global",
     },
 
+    # Cross-profile shared OAuth stores (non-secret activation switch).
+    # User-facing opt-in for the canonical shared xAI OAuth store lives here —
+    # NOT as HERMES_XAI_SHARED_AUTH in .env (AGENTS.md env-var-for-config policy).
+    # Bridged to internal HERMES_XAI_SHARED_AUTH / HERMES_SHARED_AUTH_PROVIDERS
+    # at process startup (same pattern as terminal.cwd → TERMINAL_CWD). Empty /
+    # absent = legacy per-profile auth (byte-identical; engine gate still reads
+    # the internal env vars so tests and power-user overrides keep working).
+    "shared_auth": {
+        # Provider names that own grants in the shared auth directory.
+        # Include "xai-oauth" (or xai / grok-oauth / x-ai-oauth) to enable the
+        # multi-profile single-use refresh-token store for xAI Grok OAuth.
+        "providers": [],
+        # Optional override for the shared auth directory (mirrors
+        # HERMES_SHARED_AUTH_DIR). Leave unset to use <hermes-root>/shared/.
+        # "dir": "~/.hermes/shared",
+    },
+
     # Config schema version - bump this when adding new required fields
     "_config_version": 33,
 }
@@ -7692,6 +7709,220 @@ def apply_terminal_config_to_env(
         if should_override or env_var not in target:
             target[env_var] = _terminal_env_value(value)
     return target
+
+
+# Aliases that activate the shared xAI OAuth store (must match
+# hermes_cli.auth._xai_shared_auth_enabled). Kept here so the config→env bridge
+# can force-export without importing the auth engine.
+_XAI_SHARED_AUTH_PROVIDER_ALIASES = frozenset(
+    {"xai-oauth", "xai", "grok-oauth", "x-ai-oauth"}
+)
+
+
+def _normalize_shared_auth_providers(raw: Any) -> List[str]:
+    """Coerce shared_auth.providers from list/str/None into a clean string list."""
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [part.strip() for part in raw.split(",") if part.strip()]
+    if isinstance(raw, (list, tuple)):
+        return [str(part).strip() for part in raw if str(part).strip()]
+    return []
+
+
+def _shared_auth_section_from_config(
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return the user-facing shared_auth dict, or None if absent.
+
+    Prefer the raw on-disk config so DEFAULT_CONFIG's empty ``providers: []``
+    never looks like a deliberate user setting. Callers that already hold a
+    merged or partial dict can pass it via *config*.
+    """
+    if config is not None:
+        shared = config.get("shared_auth") if isinstance(config, dict) else None
+    else:
+        raw = read_raw_config()
+        shared = raw.get("shared_auth") if isinstance(raw, dict) else None
+    if not isinstance(shared, dict):
+        return None
+    return shared
+
+
+def apply_shared_auth_config_to_env(
+    *,
+    env: Optional[Dict[str, str]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, str]:
+    """Bridge ``shared_auth.*`` config into internal HERMES_* env vars.
+
+    User-facing activation is ``shared_auth.providers`` in config.yaml
+    (AGENTS.md env-var-for-config policy: non-secret feature flags belong in
+    config.yaml, not ``HERMES_*`` env vars). The shared-store engine still
+    gates on ``HERMES_XAI_SHARED_AUTH`` / ``HERMES_SHARED_AUTH_PROVIDERS`` —
+    those remain the **internal** mechanism, bridged here the same way
+    ``terminal.cwd`` is force-exported to ``TERMINAL_CWD``.
+
+    Gate-off invariant: if ``shared_auth`` is absent or ``providers`` is empty,
+    this function does **not** set or modify any related env vars. Legacy
+    behavior is byte-identical, and a power-user/test that sets
+    ``HERMES_XAI_SHARED_AUTH`` directly still works.
+    """
+    target = os.environ if env is None else env
+    shared = _shared_auth_section_from_config(config)
+    if shared is None:
+        return target
+
+    providers = _normalize_shared_auth_providers(shared.get("providers"))
+    if not providers:
+        # Empty providers list = no user opt-in. Do not clobber env overrides.
+        return target
+
+    # Config is authoritative when providers is non-empty (force-export so a
+    # stale/missing .env cannot leave fleet workers on the legacy path).
+    target["HERMES_SHARED_AUTH_PROVIDERS"] = ",".join(providers)
+
+    tokens = {p.lower() for p in providers}
+    if tokens & _XAI_SHARED_AUTH_PROVIDER_ALIASES:
+        target["HERMES_XAI_SHARED_AUTH"] = "1"
+
+    shared_dir = shared.get("dir")
+    if isinstance(shared_dir, str) and shared_dir.strip():
+        # Optional only — do not invent a default dir env var.
+        target["HERMES_SHARED_AUTH_DIR"] = os.path.expanduser(shared_dir.strip())
+
+    return target
+
+
+def enable_shared_auth_provider(provider: str = "xai-oauth") -> List[str]:
+    """Add *provider* to config.yaml ``shared_auth.providers`` and bridge env.
+
+    Returns the resulting providers list. Writes only the user config (no
+    default dump). Force-bridges into ``os.environ`` so the current process
+    sees the gate immediately (CLI commands that follow do not need a restart).
+    """
+    provider = (provider or "").strip()
+    if not provider:
+        raise ValueError("provider must be a non-empty string")
+
+    if is_managed():
+        managed_error("enable shared auth")
+        return []
+
+    config_path = get_config_path()
+    require_readable_config_before_write(config_path)
+    user_config: Dict[str, Any] = {}
+    if config_path.exists():
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                user_config = fast_safe_load(f) or {}
+        except Exception:
+            user_config = {}
+    if not isinstance(user_config, dict):
+        user_config = {}
+
+    shared = user_config.get("shared_auth")
+    if not isinstance(shared, dict):
+        shared = {}
+        user_config["shared_auth"] = shared
+
+    providers = _normalize_shared_auth_providers(shared.get("providers"))
+    # De-dupe case-insensitively while preserving the first spelling.
+    lower_seen = {p.lower() for p in providers}
+    if provider.lower() not in lower_seen:
+        providers.append(provider)
+    shared["providers"] = providers
+
+    ensure_hermes_home()
+    from utils import atomic_yaml_write
+
+    # atomic_yaml_write updates mtime/size so the next load_config() cache miss
+    # re-reads the file; no explicit cache invalidation needed.
+    atomic_yaml_write(config_path, user_config, sort_keys=False)
+
+    apply_shared_auth_config_to_env(config={"shared_auth": shared})
+    return list(providers)
+
+
+def disable_shared_auth_provider(provider: str = "xai-oauth") -> List[str]:
+    """Remove *provider* from config.yaml ``shared_auth.providers``.
+
+    When the providers list becomes empty the ``providers`` key is dropped
+    (and ``shared_auth`` itself if empty). Does **not** invent env vars for
+    remaining state; when no xAI alias remains, clears ``HERMES_XAI_SHARED_AUTH``
+    on the current process so the CLI gate flips off without a restart.
+    Power-user env-only setups without a config key are left alone
+    (no shared_auth section → no-op write, no env pop of unrelated vars).
+    """
+    provider = (provider or "").strip()
+    if not provider:
+        raise ValueError("provider must be a non-empty string")
+
+    if is_managed():
+        managed_error("disable shared auth")
+        return []
+
+    config_path = get_config_path()
+    require_readable_config_before_write(config_path)
+    user_config: Dict[str, Any] = {}
+    if config_path.exists():
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                user_config = fast_safe_load(f) or {}
+        except Exception:
+            user_config = {}
+    if not isinstance(user_config, dict):
+        user_config = {}
+
+    shared = user_config.get("shared_auth")
+    had_section = isinstance(shared, dict)
+    if not had_section:
+        shared = {}
+
+    providers = _normalize_shared_auth_providers(shared.get("providers"))
+    remaining = [p for p in providers if p.lower() != provider.lower()]
+    had_xai = any(p.lower() in _XAI_SHARED_AUTH_PROVIDER_ALIASES for p in providers)
+    still_has_xai = any(
+        p.lower() in _XAI_SHARED_AUTH_PROVIDER_ALIASES for p in remaining
+    )
+    xai_gate_cleared = had_xai and not still_has_xai
+
+    if remaining:
+        shared = dict(shared) if had_section else {}
+        shared["providers"] = remaining
+        user_config["shared_auth"] = shared
+    elif had_section:
+        shared = dict(shared)
+        shared.pop("providers", None)
+        if shared:
+            user_config["shared_auth"] = shared
+        else:
+            user_config.pop("shared_auth", None)
+
+    if had_section or providers:
+        ensure_hermes_home()
+        from utils import atomic_yaml_write
+
+        atomic_yaml_write(config_path, user_config, sort_keys=False)
+
+    # Sync current process: re-bridge remaining providers; clear xAI gate if gone.
+    if remaining:
+        bridge_cfg = dict(shared) if isinstance(shared, dict) else {}
+        bridge_cfg["providers"] = remaining
+        apply_shared_auth_config_to_env(config={"shared_auth": bridge_cfg})
+        if xai_gate_cleared:
+            # Bridge only *sets* HERMES_XAI_SHARED_AUTH when an xAI alias is
+            # present; it never pops. Clear explicitly when the last xAI alias
+            # was removed but other providers remain.
+            os.environ.pop("HERMES_XAI_SHARED_AUTH", None)
+    elif xai_gate_cleared or providers:
+        # Config no longer enables shared providers. Drop the bridge targets so
+        # this process matches a fresh start with gate-off config. Do not touch
+        # HERMES_SHARED_AUTH_DIR (pre-existing Nous path; optional).
+        os.environ.pop("HERMES_XAI_SHARED_AUTH", None)
+        os.environ.pop("HERMES_SHARED_AUTH_PROVIDERS", None)
+
+    return list(remaining)
 
 
 def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -684,6 +684,19 @@ from hermes_cli.env_loader import load_hermes_dotenv
 
 load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
 
+# Bridge shared_auth.* (config.yaml) → internal HERMES_XAI_SHARED_AUTH /
+# HERMES_SHARED_AUTH_PROVIDERS so every subcommand (auth, chat, gateway
+# helpers, etc.) sees the same activation. User-facing switch is config.yaml
+# (AGENTS.md env-var-for-config); engine still reads the env vars. Gate-off
+# (absent/empty shared_auth) leaves env alone — power-user/test env overrides
+# keep working. Same pattern as terminal.cwd → TERMINAL_CWD.
+try:
+    from hermes_cli.config import apply_shared_auth_config_to_env as _apply_shared_auth
+
+    _apply_shared_auth()
+except Exception:
+    pass
+
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at
 # module-import time). Without this, config.yaml's toggle is ignored because
@@ -2256,8 +2269,12 @@ def _launch_tui(
 
     env = os.environ.copy()
     try:
-        from hermes_cli.config import apply_terminal_config_to_env
+        from hermes_cli.config import (
+            apply_shared_auth_config_to_env,
+            apply_terminal_config_to_env,
+        )
         apply_terminal_config_to_env(env=env)
+        apply_shared_auth_config_to_env(env=env)
     except Exception:
         logger.debug("Failed to apply terminal config bridge for TUI launch", exc_info=True)
     active_session_fd, active_session_file = tempfile.mkstemp(
@@ -15200,9 +15217,13 @@ def cmd_dashboard(args):
     # (#63141, #54449, #61115, #65696). PTY chat spawns already bridge their
     # child env copy; this covers the in-process consumers.
     try:
-        from hermes_cli.config import apply_terminal_config_to_env
+        from hermes_cli.config import (
+            apply_shared_auth_config_to_env,
+            apply_terminal_config_to_env,
+        )
 
         apply_terminal_config_to_env()
+        apply_shared_auth_config_to_env()
     except Exception:
         logger.debug("terminal config → env bridge failed for dashboard/serve",
                      exc_info=True)

--- a/hermes_cli/proxy/adapters/xai.py
+++ b/hermes_cli/proxy/adapters/xai.py
@@ -50,11 +50,54 @@ class XAIGrokAdapter(UpstreamAdapter):
         return _ALLOWED_PATHS
 
     def is_authenticated(self) -> bool:
+        # C1/F2/R7: shared mode probes the canonical store (and promotable
+        # local grants on profile OR root), never a surviving legacy pool row
+        # after profile disable. Canonical READ errors fail closed (False)
+        # with no pool fallthrough.
+        try:
+            from hermes_cli import auth as auth_mod
+
+            if auth_mod._xai_shared_auth_enabled():
+                try:
+                    if auth_mod._profile_xai_shared_disabled():
+                        return False
+                    shared = auth_mod._read_shared_xai_state(raise_on_unreadable=True)
+                    if auth_mod._xai_shared_state_has_usable_tokens(shared):
+                        return True
+                    if auth_mod._shared_xai_state_is_quarantined(shared):
+                        return False
+                    # F1/R7/H2: sole live across profile AND root together
+                    # (no profile-first short-circuit vs promoter ambiguity).
+                    return bool(
+                        auth_mod._xai_sole_live_promotable_across_profile_and_root_for_probe()
+                    )
+                except Exception:
+                    return False
+        except Exception:
+            pass
         pool = self._load_pool()
         return bool(pool and pool.has_available())
 
     def get_credential(self) -> UpstreamCredential:
         with self._lock:
+            from hermes_cli import auth as auth_mod
+
+            # C1/A6/F2: shared mode is fail-closed — never select a legacy pool row.
+            if auth_mod._xai_shared_auth_enabled():
+                if auth_mod._profile_xai_shared_disabled():
+                    raise RuntimeError(
+                        "xAI shared OAuth is disabled for this profile. "
+                        "Re-enable with `hermes auth xai enable-shared` or log in again."
+                    )
+                shared_cred = self._credential_from_shared(raise_on_error=True)
+                if shared_cred is not None:
+                    return shared_cred
+                raise RuntimeError(
+                    "No xAI OAuth credentials in the shared store. "
+                    "Select xAI Grok OAuth in `hermes model` or run "
+                    "`hermes auth xai migrate-shared`."
+                )
+
             pool = self._load_pool()
             if pool is None or not pool.has_credentials():
                 raise RuntimeError(
@@ -79,23 +122,65 @@ class XAIGrokAdapter(UpstreamAdapter):
         failed_credential: UpstreamCredential,
         status_code: int,
     ) -> Optional[UpstreamCredential]:
-        if status_code not in {401, 429}:
+        # C3: treat auth-shaped 401 AND 403 as refresh triggers (not only 401).
+        if status_code not in {401, 403, 429}:
             return None
 
         with self._lock:
+            from hermes_cli import auth as auth_mod
+
+            shared_on = auth_mod._xai_shared_auth_enabled()
+            if status_code in {401, 403}:
+                # Prefer canonical shared force-refresh with the rejected bearer.
+                shared_retry = self._credential_from_shared(
+                    force_refresh=True,
+                    rejected_access_token=failed_credential.bearer,
+                    raise_on_error=False,
+                )
+                if (
+                    shared_retry is not None
+                    and shared_retry.bearer != failed_credential.bearer
+                ):
+                    logger.info(
+                        "proxy: xAI upstream returned %s; retrying with "
+                        "canonical shared credential",
+                        status_code,
+                    )
+                    return shared_retry
+                # F2: shared mode never falls through to a legacy pool row.
+                if shared_on:
+                    return None
+
+            # R9: under shared mode a 429 is sole-grant / rate-limit policy —
+            # do NOT run generic OAuth-pool rotation (would mark the wrong
+            # reference after another process rotated). Let 429 flow back.
+            if status_code == 429 and shared_on:
+                logger.info(
+                    "proxy: xAI upstream returned 429 under shared mode; "
+                    "canonical sole-grant policy (no pool rotation)"
+                )
+                return None
+
+            # Gate-off (or non-shared 429): pool rotation path.
             pool = self._pool or self._load_pool()
             if pool is None:
                 return None
 
             if status_code == 429:
                 # Mark the rate-limited key with its 1-hour cooldown and rotate
-                # to the next available credential. Returns None when the pool
-                # has no other key to offer — the 429 will flow back to the client.
-                refreshed = pool.mark_exhausted_and_rotate(status_code=status_code)
+                # to the next available credential. Pass the failed bearer so a
+                # freshly loaded pool cannot mark the wrong/newer entry.
+                refreshed = pool.mark_exhausted_and_rotate(
+                    status_code=status_code,
+                    api_key_hint=failed_credential.bearer,
+                )
             else:
                 refreshed = pool.try_refresh_current()
                 if refreshed is None:
-                    refreshed = pool.mark_exhausted_and_rotate(status_code=status_code)
+                    refreshed = pool.mark_exhausted_and_rotate(
+                        status_code=status_code,
+                        api_key_hint=failed_credential.bearer,
+                    )
             if refreshed is None:
                 return None
 
@@ -113,6 +198,52 @@ class XAIGrokAdapter(UpstreamAdapter):
             return load_pool(_POOL_PROVIDER)
         except Exception as exc:
             logger.warning("proxy: failed to load xAI OAuth credential pool: %s", exc)
+            return None
+
+    def _credential_from_shared(
+        self,
+        *,
+        force_refresh: bool = False,
+        rejected_access_token: Optional[str] = None,
+        raise_on_error: bool = False,
+    ) -> Optional[UpstreamCredential]:
+        try:
+            from hermes_cli import auth as auth_mod
+
+            if not auth_mod._xai_shared_auth_enabled():
+                return None
+            if auth_mod._profile_xai_shared_disabled():
+                if raise_on_error:
+                    raise RuntimeError(
+                        "xAI shared OAuth is disabled for this profile."
+                    )
+                return None
+            creds = auth_mod.resolve_xai_oauth_runtime_credentials(
+                force_refresh=force_refresh,
+                refresh_if_expiring=not force_refresh,
+                rejected_access_token=rejected_access_token,
+            )
+            bearer = str(creds.get("api_key") or "").strip()
+            if not bearer:
+                return None
+            base_url = str(
+                creds.get("base_url") or DEFAULT_XAI_OAUTH_BASE_URL
+            ).strip().rstrip("/")
+            return UpstreamCredential(
+                bearer=bearer,
+                base_url=base_url or DEFAULT_XAI_OAUTH_BASE_URL,
+                expires_at=None,
+            )
+        except RuntimeError:
+            if raise_on_error:
+                raise
+            return None
+        except Exception as exc:
+            if raise_on_error:
+                raise RuntimeError(
+                    f"Shared xAI OAuth credential resolve failed: {exc}"
+                ) from exc
+            logger.debug("proxy: shared xAI credential resolve failed: %s", exc)
             return None
 
     def _credential_from_entry(self, entry: PooledCredential) -> UpstreamCredential:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1825,6 +1825,39 @@ def resolve_runtime_provider(
             and not has_runtime_override
         )
 
+    # A6: shared xAI mode is CANONICAL-FIRST, not pool-first. A legacy
+    # local/manual pool row must never win over the shared fleet grant.
+    if provider == "xai-oauth":
+        try:
+            from hermes_cli import auth as _auth_mod
+
+            if _auth_mod._xai_shared_auth_enabled():
+                try:
+                    creds = resolve_xai_oauth_runtime_credentials()
+                    return {
+                        "provider": "xai-oauth",
+                        "api_mode": "codex_responses",
+                        "base_url": (creds.get("base_url") or "").rstrip("/")
+                        or DEFAULT_XAI_OAUTH_BASE_URL,
+                        "api_key": creds.get("api_key", ""),
+                        "source": creds.get("source", _auth_mod.XAI_SHARED_SOURCE),
+                        "last_refresh": creds.get("last_refresh"),
+                        "requested_provider": requested_provider,
+                    }
+                except AuthError:
+                    if requested_provider != "auto":
+                        raise
+                    logger.info(
+                        "Shared xAI OAuth credentials failed; "
+                        "falling through to next provider."
+                    )
+                    # Fall through to env-var providers below — skip pool.
+                    should_use_pool = False
+        except AuthError:
+            raise
+        except Exception:
+            pass
+
     try:
         pool = load_pool(provider) if should_use_pool else None
     except Exception:

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -95,4 +95,44 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_spotify.add_argument(
         "--timeout", type=float, help="Callback/token exchange timeout in seconds"
     )
+    auth_xai = auth_subparsers.add_parser(
+        "xai",
+        help="Manage the canonical shared xAI OAuth store",
+    )
+    auth_xai_sub = auth_xai.add_subparsers(dest="xai_action")
+    auth_xai_migrate = auth_xai_sub.add_parser(
+        "migrate-shared",
+        help=(
+            "Install a chosen legacy xAI grant into the shared store and strip "
+            "profile-local secret copies (requires shared_auth.providers to "
+            "include xai-oauth; run `hermes auth xai enable-shared` first)"
+        ),
+    )
+    auth_xai_migrate.add_argument(
+        "--source",
+        choices=["auto", "profile", "root"],
+        default="auto",
+        help="Which legacy store to migrate (never elected by last_refresh clock)",
+    )
+    auth_xai_migrate.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing canonical shared grant",
+    )
+    # A8: --keep-legacy removed — sole ownership requires stripping every
+    # durable local RT. Keeping legacy copies directly forks the grant.
+    auth_xai_sub.add_parser(
+        "enable-shared",
+        help=(
+            "Enable shared xAI OAuth via config.yaml "
+            "(shared_auth.providers: [xai-oauth]) and re-enable this profile"
+        ),
+    )
+    auth_xai_sub.add_parser(
+        "disable-shared",
+        help=(
+            "Disable shared xAI OAuth in config.yaml (remove xai-oauth from "
+            "shared_auth.providers); does not delete the canonical grant"
+        ),
+    )
     auth_parser.set_defaults(func=cmd_auth)

--- a/hermes_cli/subcommands/logout.py
+++ b/hermes_cli/subcommands/logout.py
@@ -25,4 +25,19 @@ def build_logout_parser(subparsers, *, cmd_logout: Callable) -> None:
         default=None,
         help="Provider to log out from (default: active provider)",
     )
+    logout_parser.add_argument(
+        "--global",
+        dest="global_logout",
+        action="store_true",
+        help=(
+            "For xai-oauth shared mode: delete the canonical shared grant "
+            "(affects every profile). Default is per-profile disable only."
+        ),
+    )
+    logout_parser.add_argument(
+        "--shared",
+        dest="shared",
+        action="store_true",
+        help="Alias of --global for xai-oauth shared-store logout.",
+    )
     logout_parser.set_defaults(func=cmd_logout)

--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -333,13 +333,49 @@ class XAIImageGenProvider(ImageGenProvider):
             payload["storage_options"] = storage_options
 
         try:
-            response = requests.post(
-                endpoint_url,
-                headers=headers,
-                json=payload,
-                timeout=120,
-            )
-            response.raise_for_status()
+            response = None
+            last_http_exc: Optional[Exception] = None
+            for attempt in range(2):
+                try:
+                    response = requests.post(
+                        endpoint_url,
+                        headers=headers,
+                        json=payload,
+                        timeout=120,
+                    )
+                    response.raise_for_status()
+                    last_http_exc = None
+                    break
+                except requests.HTTPError as exc:
+                    last_http_exc = exc
+                    status = (
+                        exc.response.status_code if exc.response is not None else 0
+                    )
+                    # C3: one canonical refresh + retry on 401/403 for OAuth.
+                    if (
+                        attempt == 0
+                        and status in {401, 403}
+                        and provider_name == "xai-oauth"
+                    ):
+                        try:
+                            from tools.xai_http import force_refresh_xai_http_credentials
+
+                            refreshed = force_refresh_xai_http_credentials(api_key)
+                            new_key = str(refreshed.get("api_key") or "").strip()
+                            if new_key and new_key != api_key:
+                                api_key = new_key
+                                headers["Authorization"] = f"Bearer {api_key}"
+                                continue
+                        except Exception as refresh_exc:
+                            logger.warning(
+                                "xAI image gen OAuth refresh after %s failed: %s",
+                                status,
+                                refresh_exc,
+                            )
+                    break
+            if last_http_exc is not None:
+                raise last_http_exc
+            assert response is not None
         except requests.HTTPError as exc:
             response = exc.response
             status = response.status_code if response is not None else 0

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -310,20 +310,56 @@ async def _submit(
     api_key: str,
     base_url: str,
     endpoint: str = "generations",
-) -> str:
-    """POST to one of xAI's async video endpoints and return request_id."""
-    response = await client.post(
-        f"{base_url}/videos/{endpoint}",
-        headers={**_xai_headers(api_key), "x-idempotency-key": str(uuid.uuid4())},
-        json=payload,
-        timeout=60,
-    )
-    response.raise_for_status()
-    body = response.json()
-    request_id = body.get("request_id")
-    if not request_id:
-        raise RuntimeError("xAI video response did not include request_id")
-    return request_id
+) -> Tuple[str, str]:
+    """POST to one of xAI's async video endpoints.
+
+    Returns ``(request_id, active_api_key)`` so a mid-submit OAuth refresh is
+    propagated into the subsequent poll (F5) — never poll with a stale bearer
+    after submit recovered.
+
+    C3: on 401/403 auth failure, force a canonical OAuth refresh once and retry.
+    """
+    active_key = api_key
+    last_exc: Optional[Exception] = None
+    for attempt in range(2):
+        try:
+            response = await client.post(
+                f"{base_url}/videos/{endpoint}",
+                headers={
+                    **_xai_headers(active_key),
+                    "x-idempotency-key": str(uuid.uuid4()),
+                },
+                json=payload,
+                timeout=60,
+            )
+            response.raise_for_status()
+            body = response.json()
+            request_id = body.get("request_id")
+            if not request_id:
+                raise RuntimeError("xAI video response did not include request_id")
+            return request_id, active_key
+        except httpx.HTTPStatusError as exc:
+            last_exc = exc
+            status = exc.response.status_code if exc.response is not None else 0
+            if attempt == 0 and status in {401, 403}:
+                try:
+                    from tools.xai_http import force_refresh_xai_http_credentials
+
+                    refreshed = force_refresh_xai_http_credentials(active_key)
+                    new_key = str(refreshed.get("api_key") or "").strip()
+                    if new_key and new_key != active_key:
+                        active_key = new_key
+                        continue
+                except Exception as refresh_exc:
+                    logger.debug(
+                        "xAI video OAuth refresh after %s failed: %s",
+                        status,
+                        refresh_exc,
+                    )
+            raise
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("xAI video submit failed without a response")
 
 
 async def _poll(
@@ -335,15 +371,38 @@ async def _poll(
     timeout_seconds: int,
     poll_interval: int,
 ) -> Dict[str, Any]:
+    """Poll a video job; one bounded 401/403 canonical recovery (F5)."""
+    active_key = api_key
+    refreshed_once = False
     elapsed = 0.0
     last_status = "queued"
     while elapsed < timeout_seconds:
-        response = await client.get(
-            f"{base_url}/videos/{request_id}",
-            headers=_xai_headers(api_key),
-            timeout=30,
-        )
-        response.raise_for_status()
+        try:
+            response = await client.get(
+                f"{base_url}/videos/{request_id}",
+                headers=_xai_headers(active_key),
+                timeout=30,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code if exc.response is not None else 0
+            if not refreshed_once and status in {401, 403}:
+                refreshed_once = True
+                try:
+                    from tools.xai_http import force_refresh_xai_http_credentials
+
+                    refreshed = force_refresh_xai_http_credentials(active_key)
+                    new_key = str(refreshed.get("api_key") or "").strip()
+                    if new_key and new_key != active_key:
+                        active_key = new_key
+                        continue
+                except Exception as refresh_exc:
+                    logger.debug(
+                        "xAI video poll OAuth refresh after %s failed: %s",
+                        status,
+                        refresh_exc,
+                    )
+            raise
         body = response.json()
         last_status = (body.get("status") or "").lower()
 
@@ -813,7 +872,8 @@ async def _submit_xai_video_payload(
 
     async with httpx.AsyncClient() as client:
         try:
-            request_id = await _submit(
+            # F5: propagate any post-401 refreshed bearer into poll.
+            request_id, poll_api_key = await _submit(
                 client, payload, api_key=api_key, base_url=base_url,
                 endpoint=endpoint,
             )
@@ -833,7 +893,7 @@ async def _submit_xai_video_payload(
 
         poll_result = await _poll(
             client, request_id,
-            api_key=api_key, base_url=base_url,
+            api_key=poll_api_key, base_url=base_url,
             timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
             poll_interval=DEFAULT_POLL_INTERVAL_SECONDS,
         )

--- a/plugins/web/xai/provider.py
+++ b/plugins/web/xai/provider.py
@@ -264,10 +264,12 @@ class XAIWebSearchProvider(WebSearchProvider):
                 break
             except httpx.HTTPStatusError as exc:
                 status = exc.response.status_code if exc.response is not None else 0
-                if status == 401 and attempt == 0 and is_oauth_path:
+                # C3: refresh on auth-shaped 401 AND 403 (xAI often uses 403).
+                if status in {401, 403} and attempt == 0 and is_oauth_path:
                     logger.info(
-                        "xAI web search got 401 on first attempt; forcing OAuth "
+                        "xAI web search got %s on first attempt; forcing OAuth "
                         "refresh and retrying once.",
+                        status,
                     )
                     try:
                         refreshed = resolve_xai_http_credentials(
@@ -283,7 +285,8 @@ class XAIWebSearchProvider(WebSearchProvider):
                         # in retrying. Fall through to the error return below.
                     except Exception as refresh_exc:  # noqa: BLE001
                         logger.warning(
-                            "xAI web search OAuth refresh after 401 failed: %s",
+                            "xAI web search OAuth refresh after %s failed: %s",
+                            status,
                             refresh_exc,
                         )
                 body = ""

--- a/run_agent.py
+++ b/run_agent.py
@@ -5045,7 +5045,13 @@ class AIAgent:
             else:
                 from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
 
-                creds = resolve_xai_oauth_runtime_credentials(force_refresh=force)
+                # Carry the rejected bearer so the shared store can generation-
+                # compare: if another process already rotated, adopt that grant
+                # instead of POSTing a stale single-use refresh token (G4/G10).
+                creds = resolve_xai_oauth_runtime_credentials(
+                    force_refresh=force,
+                    rejected_access_token=str(self.api_key or "") or None,
+                )
         except Exception as exc:
             logger.debug("%s credential refresh failed: %s", self.provider, exc)
             return False

--- a/tests/agent/test_auxiliary_xai_shared_recovery.py
+++ b/tests/agent/test_auxiliary_xai_shared_recovery.py
@@ -1,0 +1,306 @@
+"""D1/D2 + E2E: auxiliary xAI recovery under shared mode."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import auth
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').decode().rstrip("=")
+    payload = (
+        base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).decode().rstrip("=")
+    )
+    return f"{header}.{payload}.sig"
+
+
+@pytest.fixture
+def shared_env(tmp_path, monkeypatch):
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    monkeypatch.setenv("HERMES_XAI_SHARED_AUTH", "1")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    return {
+        "store": shared_dir / "xai_oauth.json",
+        "profile_auth": hermes_home / "auth.json",
+    }
+
+
+def _write_shared(env, *, access="at-1", refresh="rt-1", generation=1):
+    payload = {
+        "_schema": 1,
+        "generation": generation,
+        "access_token": access,
+        "refresh_token": refresh,
+        "token_type": "Bearer",
+        "auth_mode": "oauth_device_code",
+        "last_refresh": "2026-07-01T00:00:00Z",
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth/token"},
+    }
+    env["store"].write_text(json.dumps(payload), encoding="utf-8")
+    return payload
+
+
+def test_auth_refresh_provider_detects_api_x_ai():
+    """D2: auto-routed aux clients on api.x.ai map to xai-oauth."""
+    from agent.auxiliary_client import _auth_refresh_provider_for_route
+
+    assert (
+        _auth_refresh_provider_for_route("auto", "https://api.x.ai/v1/")
+        == "xai-oauth"
+    )
+    assert (
+        _auth_refresh_provider_for_route("auto", "https://api.x.ai/v1/chat/completions")
+        == "xai-oauth"
+    )
+
+
+def test_refresh_provider_credentials_passes_rejected_bearer(shared_env, monkeypatch):
+    """D1: shared recovery force-refreshes with the rejected bearer (no double POST)."""
+    from agent.auxiliary_client import _refresh_provider_credentials
+
+    old = _jwt(int(time.time()) + 30)
+    _write_shared(shared_env, access=old, refresh="rt-1", generation=1)
+    posts = []
+
+    def fake_pure(access, refresh, **kwargs):
+        posts.append(refresh)
+        return {
+            "access_token": "should-not",
+            "refresh_token": "should-not",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-18T00:00:00Z",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", fake_pure)
+    # Winner already rotated under the lock.
+    _write_shared(shared_env, access="winner-at", refresh="winner-rt", generation=2)
+
+    with patch("agent.auxiliary_client._evict_cached_clients") as evict:
+        ok = _refresh_provider_credentials(
+            "xai-oauth",
+            rejected_api_key=old,
+            expected_generation=1,
+        )
+    assert ok is True
+    assert posts == []  # adopted winner — no second POST
+    evict.assert_called()
+
+
+def test_e2e_stale_request_401_canonical_refresh_replaces_client(
+    shared_env, monkeypatch
+):
+    """E2E: stale bearer → auth error → canonical refresh → client rebuilt."""
+    from agent import auxiliary_client as aux
+
+    stale = "stale-bearer"
+    fresh = "fresh-bearer"
+    _write_shared(shared_env, access=stale, refresh="rt-1", generation=1)
+
+    posts = []
+
+    def fake_pure(access, refresh, **kwargs):
+        posts.append(refresh)
+        return {
+            "access_token": fresh,
+            "refresh_token": "rt-2",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-18T03:00:00Z",
+            "id_token": "id-after-refresh",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", fake_pure)
+    monkeypatch.setattr(
+        auth,
+        "_xai_oauth_discovery",
+        lambda *_a, **_k: {"token_endpoint": "https://auth.x.ai/oauth/token"},
+    )
+
+    # Simulate refresh path used by call_llm recovery.
+    with patch.object(aux, "_evict_cached_clients") as evict:
+        ok = aux._refresh_provider_credentials(
+            "xai-oauth",
+            rejected_api_key=stale,
+        )
+    assert ok is True
+    assert posts == ["rt-1"]
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared["access_token"] == fresh
+    assert shared["refresh_token"] == "rt-2"
+    assert shared.get("id_token") == "id-after-refresh"
+    assert shared["generation"] == 2
+    evict.assert_called_with("xai-oauth")
+
+    # Auto-routed path also resolves to xai-oauth (D2).
+    assert (
+        aux._auth_refresh_provider_for_route("auto", "https://api.x.ai/v1/")
+        == "xai-oauth"
+    )
+
+
+def test_proxy_adapter_uses_canonical_and_retries_403(shared_env, monkeypatch):
+    """C1/C3: proxy adapter resolves shared grant and refreshes on 403."""
+    from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
+    from hermes_cli.proxy.adapters.base import UpstreamCredential
+
+    stale = "stale-at"
+    _write_shared(shared_env, access=stale, refresh="rt-1", generation=1)
+
+    posts = []
+
+    def fake_pure(access, refresh, **kwargs):
+        posts.append(refresh)
+        return {
+            "access_token": "fresh-at",
+            "refresh_token": "rt-2",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-18T04:00:00Z",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", fake_pure)
+    monkeypatch.setattr(
+        auth,
+        "_xai_oauth_discovery",
+        lambda *_a, **_k: {"token_endpoint": "https://auth.x.ai/oauth/token"},
+    )
+
+    adapter = XAIGrokAdapter()
+    assert adapter.is_authenticated() is True
+    cred = adapter.get_credential()
+    assert cred.bearer == stale
+
+    retry = adapter.get_retry_credential(
+        failed_credential=UpstreamCredential(
+            bearer=stale,
+            base_url="https://api.x.ai/v1",
+            expires_at=None,
+        ),
+        status_code=403,
+    )
+    assert retry is not None
+    assert retry.bearer == "fresh-at"
+    assert posts == ["rt-1"]
+
+
+def test_auth_refresh_provider_unwraps_fallback_chain_label():
+    """R6: composite fallback_chain[N](xai-oauth) must resolve to xai-oauth."""
+    from agent.auxiliary_client import _auth_refresh_provider_for_route
+
+    assert (
+        _auth_refresh_provider_for_route(
+            "fallback_chain[0](xai-oauth)",
+            "https://api.x.ai/v1/",
+        )
+        == "xai-oauth"
+    )
+    # Even without a usable base URL, the label unwrap must win.
+    assert (
+        _auth_refresh_provider_for_route(
+            "fallback_chain[2](xai-oauth)",
+            "",
+        )
+        == "xai-oauth"
+    )
+
+
+def test_f6_fallback_chain_passes_rejected_bearer(shared_env, monkeypatch):
+    """F6/R6: real fallback-chain path refreshes xAI without route-helper patch.
+
+    Critical: do NOT patch ``_auth_refresh_provider_for_route`` — the bug was
+    that composite labels like ``fallback_chain[0](xai-oauth)`` never resolved
+    to the xai-oauth refresh branch. This test exercises the real path.
+    """
+    from agent import auxiliary_client as aux
+
+    old = _jwt(int(time.time()) + 30)
+    _write_shared(shared_env, access=old, refresh="rt-1", generation=1)
+    posts = []
+    refresh_providers = []
+
+    def fake_pure(access, refresh, **kwargs):
+        posts.append(refresh)
+        return {
+            "access_token": "should-not",
+            "refresh_token": "should-not",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-18T00:00:00Z",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", fake_pure)
+    # Concurrent winner already rotated the grant.
+    _write_shared(shared_env, access="winner-at", refresh="winner-rt", generation=2)
+
+    class BoomCompletions:
+        def create(self, **kwargs):
+            err = Exception("401 unauthorized")
+            err.status_code = 401
+            raise err
+
+    class BoomChat:
+        completions = BoomCompletions()
+
+    class BoomClient:
+        api_key = old
+        base_url = "https://api.x.ai/v1/"
+        chat = BoomChat()
+
+    retry_client = SimpleNamespace(
+        api_key="winner-at",
+        base_url="https://api.x.ai/v1/",
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **kw: SimpleNamespace(
+                    choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+                )
+            )
+        ),
+    )
+
+    real_refresh = aux._refresh_provider_credentials
+
+    def tracking_refresh(provider, **kwargs):
+        refresh_providers.append(provider)
+        return real_refresh(provider, **kwargs)
+
+    with patch.object(aux, "_is_auth_error", return_value=True), patch.object(
+        aux, "_refresh_provider_credentials", side_effect=tracking_refresh
+    ), patch.object(
+        aux, "_get_cached_client", return_value=(retry_client, "grok")
+    ), patch.object(
+        aux, "_validate_llm_response", side_effect=lambda r, t: r
+    ), patch.object(
+        aux, "_build_call_kwargs", return_value={"model": "grok", "messages": []}
+    ), patch.object(
+        aux, "_evict_cached_clients"
+    ), patch.object(
+        aux, "_mark_provider_unhealthy"
+    ):
+        result = aux._call_fallback_candidate_sync(
+            BoomClient(),
+            "grok",
+            "fallback_chain[0](xai-oauth)",
+            task="compression",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=None,
+            max_tokens=16,
+            tools=None,
+            effective_timeout=30.0,
+            effective_extra_body={},
+            reasoning_config=None,
+        )
+    assert result is not None
+    assert posts == []  # adopted winner — no second POST
+    # R6 de-mask: real route resolution must hand "xai-oauth" to refresh.
+    assert refresh_providers == ["xai-oauth"]

--- a/tests/agent/test_auxiliary_xai_shared_recovery.py
+++ b/tests/agent/test_auxiliary_xai_shared_recovery.py
@@ -67,6 +67,57 @@ def test_auth_refresh_provider_detects_api_x_ai():
     )
 
 
+def test_aux_shared_mode_prefers_canonical_over_legacy_pool(monkeypatch):
+    """Shared mode must never let a stale pool entry outrank the canonical grant."""
+    from agent import auxiliary_client as aux
+
+    legacy_pool = MagicMock()
+    legacy_pool.has_credentials.return_value = True
+    legacy_pool.select.return_value = SimpleNamespace(
+        runtime_api_key="legacy-at",
+        runtime_base_url="https://api.x.ai/v1",
+    )
+    monkeypatch.setattr(aux, "load_pool", lambda _provider: legacy_pool)
+    monkeypatch.setattr(auth, "_xai_shared_auth_enabled", lambda: True)
+    monkeypatch.setattr(
+        auth,
+        "resolve_xai_oauth_runtime_credentials",
+        lambda: {"api_key": "canonical-at", "base_url": "https://api.x.ai/v1"},
+    )
+
+    assert aux._resolve_xai_oauth_for_aux() == (
+        "canonical-at",
+        "https://api.x.ai/v1",
+    )
+    legacy_pool.select.assert_not_called()
+
+
+def test_aux_shared_mode_canonical_failure_does_not_fallback_pool(monkeypatch):
+    """Profile disable/corrupt shared state must fail closed, not use legacy pool."""
+    from agent import auxiliary_client as aux
+
+    legacy_pool = MagicMock()
+    legacy_pool.has_credentials.return_value = True
+    legacy_pool.select.return_value = SimpleNamespace(
+        runtime_api_key="legacy-at",
+        runtime_base_url="https://api.x.ai/v1",
+    )
+    monkeypatch.setattr(aux, "load_pool", lambda _provider: legacy_pool)
+    monkeypatch.setattr(auth, "_xai_shared_auth_enabled", lambda: True)
+
+    def fail_closed():
+        raise auth.AuthError(
+            "Shared xAI OAuth is disabled for this profile.",
+            provider="xai-oauth",
+            code="profile_disabled",
+        )
+
+    monkeypatch.setattr(auth, "resolve_xai_oauth_runtime_credentials", fail_closed)
+
+    assert aux._resolve_xai_oauth_for_aux() is None
+    legacy_pool.select.assert_not_called()
+
+
 def test_refresh_provider_credentials_passes_rejected_bearer(shared_env, monkeypatch):
     """D1: shared recovery force-refreshes with the rejected bearer (no double POST)."""
     from agent.auxiliary_client import _refresh_provider_credentials

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -348,3 +348,81 @@ def test_codex_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_p
     # The invariant: the single-use token POST ran inside the auth-store lock.
     assert lock_held["during_post"] is True
 
+
+
+# ---------------------------------------------------------------------------
+# Shared-mode (issue #65394): pool must not materialize providers.xai-oauth tokens
+# ---------------------------------------------------------------------------
+
+
+def test_pool_sync_back_skips_profile_when_shared_mode(tmp_path, monkeypatch):
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "root" / "auth.json"
+    profile_path.parent.mkdir(parents=True)
+    root_path.parent.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_path.parent))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    monkeypatch.setenv("HERMES_XAI_SHARED_AUTH", "1")
+    monkeypatch.setenv("HOME", str(tmp_path / "not-root"))
+    monkeypatch.setattr(A, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: root_path)
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(root_path, {"version": 1, "providers": {}})
+
+    pool = CredentialPool("xai-oauth", [])
+    pool._sync_device_code_entry_to_auth_store(
+        _entry("xai-oauth", id="e1", access_token="a", refresh_token="r")
+    )
+
+    profile = _read_store(profile_path)
+    # Must not materialize providers.xai-oauth tokens into the profile.
+    assert "xai-oauth" not in profile.get("providers", {})
+    root = _read_store(root_path)
+    assert "xai-oauth" not in root.get("providers", {})
+
+
+def test_pool_seed_from_shared_strips_refresh_token(tmp_path, monkeypatch):
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    monkeypatch.setenv("HERMES_XAI_SHARED_AUTH", "1")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+
+    (shared_dir / "xai_oauth.json").write_text(
+        json.dumps(
+            {
+                "_schema": 1,
+                "generation": 1,
+                "access_token": "shared-at",
+                "refresh_token": "shared-rt-must-not-fork",
+                "token_type": "Bearer",
+                "auth_mode": "oauth_device_code",
+                "last_refresh": "2026-07-01T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}}), encoding="utf-8"
+    )
+
+    pool = CP.load_pool("xai-oauth")
+    entries = pool.entries()
+    assert len(entries) >= 1
+    shared_entries = [e for e in entries if e.source == A.XAI_SHARED_SOURCE]
+    assert shared_entries, entries
+    entry = shared_entries[0]
+    assert entry.access_token == "shared-at"
+    # In-memory may briefly hold None; durable disk must never hold the RT.
+    assert not entry.refresh_token
+    raw = A.read_credential_pool("xai-oauth")
+    for row in raw if isinstance(raw, list) else []:
+        if isinstance(row, dict) and row.get("source") == A.XAI_SHARED_SOURCE:
+            assert not row.get("refresh_token")
+            assert "shared-rt-must-not-fork" not in json.dumps(row)

--- a/tests/agent/test_credential_sources_xai_remove.py
+++ b/tests/agent/test_credential_sources_xai_remove.py
@@ -1,0 +1,57 @@
+"""R8: hermes auth remove must surface shared-mode disable failures."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import auth
+from hermes_cli.auth import AuthError
+
+
+@pytest.fixture
+def shared_env(tmp_path, monkeypatch):
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    monkeypatch.setenv("HERMES_XAI_SHARED_AUTH", "1")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    store = shared_dir / "xai_oauth.json"
+    store.write_text(
+        json.dumps(
+            {
+                "_schema": 1,
+                "generation": 1,
+                "access_token": "at",
+                "refresh_token": "rt",
+                "token_type": "Bearer",
+                "auth_mode": "oauth_device_code",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return {"store": store, "profile_auth": hermes_home / "auth.json"}
+
+
+def test_r8_auth_remove_propagates_disable_failure(shared_env, monkeypatch):
+    """R8: disable failure must raise — not silently fall through to legacy clear."""
+    from agent.credential_sources import _remove_xai_oauth_device_code
+
+    def boom():
+        raise AuthError(
+            "marker write failed",
+            provider="xai-oauth",
+            code="xai_shared_disable_failed",
+        )
+
+    monkeypatch.setattr(auth, "disable_profile_xai_shared_auth", boom)
+    removed = SimpleNamespace(source="device_code", label="xai")
+    with pytest.raises(AuthError) as exc:
+        _remove_xai_oauth_device_code("xai-oauth", removed)
+    assert exc.value.code == "xai_shared_disable_failed"

--- a/tests/hermes_cli/test_shared_auth_config_bridge.py
+++ b/tests/hermes_cli/test_shared_auth_config_bridge.py
@@ -1,0 +1,207 @@
+"""config.yaml → internal env bridge for shared xAI OAuth activation.
+
+User-facing switch is shared_auth.providers (AGENTS.md env-var-for-config).
+The shared-store engine still reads HERMES_XAI_SHARED_AUTH /
+HERMES_SHARED_AUTH_PROVIDERS; this module only tests the bridge + config
+writers. Engine gate body stays env-driven.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli import auth
+from hermes_cli.config import (
+    apply_shared_auth_config_to_env,
+    disable_shared_auth_provider,
+    enable_shared_auth_provider,
+)
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so config writes never touch the live install.
+
+    Also hard-resets the internal bridge env vars on teardown. The bridge
+    writes ``os.environ`` directly (like TERMINAL_CWD), so monkeypatch alone
+    does not always undo force-exports and later suite tests would see a
+    leaked gate-on.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    hermes = tmp_path / ".hermes"
+    hermes.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes))
+    monkeypatch.setenv("HOME", str(home))
+    # Start gate-off for every test unless the test sets env itself.
+    for key in (
+        "HERMES_XAI_SHARED_AUTH",
+        "HERMES_SHARED_AUTH_PROVIDERS",
+        "HERMES_SHARED_AUTH_DIR",
+    ):
+        monkeypatch.delenv(key, raising=False)
+        os.environ.pop(key, None)
+
+    yield hermes
+
+    # Teardown: bridge force-exports bypass monkeypatch tracking.
+    for key in (
+        "HERMES_XAI_SHARED_AUTH",
+        "HERMES_SHARED_AUTH_PROVIDERS",
+        "HERMES_SHARED_AUTH_DIR",
+    ):
+        os.environ.pop(key, None)
+
+
+def _write_config(hermes_home: Path, payload: dict) -> Path:
+    path = hermes_home / "config.yaml"
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def test_bridge_from_config_enables_gate(isolated_home, monkeypatch):
+    """config.yaml shared_auth.providers:[xai-oauth] → bridge → gate True."""
+    _write_config(
+        isolated_home,
+        {"shared_auth": {"providers": ["xai-oauth"]}},
+    )
+    # Prove gate is off before bridge.
+    assert auth._xai_shared_auth_enabled() is False
+    assert "HERMES_XAI_SHARED_AUTH" not in os.environ
+
+    apply_shared_auth_config_to_env()
+
+    assert os.environ.get("HERMES_XAI_SHARED_AUTH") == "1"
+    assert "xai-oauth" in os.environ.get("HERMES_SHARED_AUTH_PROVIDERS", "")
+    assert auth._xai_shared_auth_enabled() is True
+
+
+def test_bridge_gate_off_when_shared_auth_absent(isolated_home):
+    """Absent shared_auth + no env → bridge sets nothing → gate False.
+
+    Byte-identical legacy: do not invent HERMES_* vars when config is silent.
+    """
+    _write_config(isolated_home, {"model": "some-model"})
+    before = {
+        "HERMES_XAI_SHARED_AUTH": os.environ.get("HERMES_XAI_SHARED_AUTH"),
+        "HERMES_SHARED_AUTH_PROVIDERS": os.environ.get("HERMES_SHARED_AUTH_PROVIDERS"),
+        "HERMES_SHARED_AUTH_DIR": os.environ.get("HERMES_SHARED_AUTH_DIR"),
+    }
+
+    apply_shared_auth_config_to_env()
+
+    assert os.environ.get("HERMES_XAI_SHARED_AUTH") == before["HERMES_XAI_SHARED_AUTH"]
+    assert (
+        os.environ.get("HERMES_SHARED_AUTH_PROVIDERS")
+        == before["HERMES_SHARED_AUTH_PROVIDERS"]
+    )
+    assert os.environ.get("HERMES_SHARED_AUTH_DIR") == before["HERMES_SHARED_AUTH_DIR"]
+    assert auth._xai_shared_auth_enabled() is False
+
+
+def test_bridge_gate_off_when_providers_empty(isolated_home):
+    """Empty providers list must not set or clear env (gate-off invariant)."""
+    _write_config(isolated_home, {"shared_auth": {"providers": []}})
+    apply_shared_auth_config_to_env()
+    assert "HERMES_XAI_SHARED_AUTH" not in os.environ
+    assert "HERMES_SHARED_AUTH_PROVIDERS" not in os.environ
+    assert auth._xai_shared_auth_enabled() is False
+
+
+def test_bridge_does_not_clobber_power_user_env_when_config_absent(
+    isolated_home, monkeypatch
+):
+    """Power-user / tests that set HERMES_XAI_SHARED_AUTH directly still work."""
+    _write_config(isolated_home, {"model": "x"})
+    monkeypatch.setenv("HERMES_XAI_SHARED_AUTH", "1")
+    assert auth._xai_shared_auth_enabled() is True
+
+    apply_shared_auth_config_to_env()
+
+    # Bridge must not pop a deliberate env override when config is silent.
+    assert os.environ.get("HERMES_XAI_SHARED_AUTH") == "1"
+    assert auth._xai_shared_auth_enabled() is True
+
+
+def test_bridge_optional_dir(isolated_home, tmp_path):
+    shared_dir = tmp_path / "custom-shared"
+    _write_config(
+        isolated_home,
+        {
+            "shared_auth": {
+                "providers": ["xai-oauth"],
+                "dir": str(shared_dir),
+            }
+        },
+    )
+    apply_shared_auth_config_to_env()
+    assert os.environ.get("HERMES_SHARED_AUTH_DIR") == str(shared_dir)
+
+
+def test_enable_shared_writes_config_not_env_file(isolated_home):
+    """enable-shared adds xai-oauth to config.yaml providers (not .env)."""
+    _write_config(isolated_home, {"model": "m"})
+    providers = enable_shared_auth_provider("xai-oauth")
+    assert "xai-oauth" in providers
+
+    raw = yaml.safe_load((isolated_home / "config.yaml").read_text(encoding="utf-8"))
+    assert "xai-oauth" in raw["shared_auth"]["providers"]
+    # Must not write a .env for this non-secret flag.
+    env_path = isolated_home / ".env"
+    if env_path.exists():
+        assert "HERMES_XAI_SHARED_AUTH" not in env_path.read_text(encoding="utf-8")
+    # Current process bridge must flip the engine gate on.
+    assert auth._xai_shared_auth_enabled() is True
+    assert os.environ.get("HERMES_XAI_SHARED_AUTH") == "1"
+
+
+def test_disable_shared_removes_config_key(isolated_home):
+    """disable-shared removes xai-oauth from config.yaml providers."""
+    _write_config(
+        isolated_home,
+        {"shared_auth": {"providers": ["xai-oauth", "other"]}},
+    )
+    enable_shared_auth_provider("xai-oauth")  # ensure env bridged
+    remaining = disable_shared_auth_provider("xai-oauth")
+    assert remaining == ["other"]
+
+    raw = yaml.safe_load((isolated_home / "config.yaml").read_text(encoding="utf-8"))
+    assert raw["shared_auth"]["providers"] == ["other"]
+
+
+def test_disable_shared_clears_empty_section(isolated_home):
+    _write_config(
+        isolated_home,
+        {"shared_auth": {"providers": ["xai-oauth"]}},
+    )
+    enable_shared_auth_provider("xai-oauth")
+    remaining = disable_shared_auth_provider("xai-oauth")
+    assert remaining == []
+
+    raw = yaml.safe_load((isolated_home / "config.yaml").read_text(encoding="utf-8")) or {}
+    shared = raw.get("shared_auth")
+    if shared is not None:
+        assert not shared.get("providers")
+    # Process gate off after disable.
+    assert auth._xai_shared_auth_enabled() is False
+    assert "HERMES_XAI_SHARED_AUTH" not in os.environ
+
+
+def test_engine_gate_body_still_env_driven(monkeypatch, isolated_home):
+    """Regression: _xai_shared_auth_enabled must keep reading env vars only."""
+    # Config on disk is irrelevant if env is not bridged and not set.
+    _write_config(
+        isolated_home,
+        {"shared_auth": {"providers": ["xai-oauth"]}},
+    )
+    monkeypatch.delenv("HERMES_XAI_SHARED_AUTH", raising=False)
+    monkeypatch.delenv("HERMES_SHARED_AUTH_PROVIDERS", raising=False)
+    # Without calling the bridge, engine gate stays off even if config exists.
+    assert auth._xai_shared_auth_enabled() is False
+    monkeypatch.setenv("HERMES_SHARED_AUTH_PROVIDERS", "xai-oauth")
+    assert auth._xai_shared_auth_enabled() is True

--- a/tests/hermes_cli/test_xai_oauth_writethrough.py
+++ b/tests/hermes_cli/test_xai_oauth_writethrough.py
@@ -167,3 +167,80 @@ def test_write_through_failure_does_not_break_profile_save(profile_and_root, mon
 
     profile = _read_store(profile_path)
     assert profile["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "r"
+
+
+# ---------------------------------------------------------------------------
+# Shared-mode override (issue #65394): no profile fork, no root write-through
+# ---------------------------------------------------------------------------
+
+
+def test_shared_mode_save_does_not_fork_into_profile(tmp_path, monkeypatch):
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    profile_path.parent.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_path.parent))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    monkeypatch.setenv("HERMES_XAI_SHARED_AUTH", "1")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(auth, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: None)
+    _write_store(profile_path, {"version": 1, "providers": {}})
+
+    auth._save_xai_oauth_tokens(
+        {"access_token": "shared-at", "refresh_token": "shared-rt"}
+    )
+
+    shared = json.loads((shared_dir / "xai_oauth.json").read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "shared-rt"
+
+    profile = _read_store(profile_path)
+    state = profile["providers"]["xai-oauth"]
+    assert state.get("source") == "shared:xai-oauth"
+    assert "tokens" not in state
+    # Absolute precedence: no local RT may re-grow.
+    assert state.get("refresh_token") in (None, "")
+
+
+def test_shared_mode_disables_root_write_through(tmp_path, monkeypatch):
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "root" / "auth.json"
+    profile_path.parent.mkdir(parents=True)
+    root_path.parent.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_path.parent))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    monkeypatch.setenv("HERMES_XAI_SHARED_AUTH", "1")
+    monkeypatch.setenv("HOME", str(tmp_path / "not-root"))
+    monkeypatch.setattr(auth, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_path)
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "root-old",
+                        "refresh_token": "root-old-rt",
+                    }
+                }
+            },
+        },
+    )
+
+    auth._save_xai_oauth_tokens(
+        {"access_token": "new-at", "refresh_token": "new-rt"}
+    )
+
+    root = _read_store(root_path)
+    # A5: root must NOT keep a durable RT after a shared save (sole ownership).
+    # Shared store is the only home for the rotating grant.
+    xai_state = root.get("providers", {}).get("xai-oauth") or {}
+    tokens = xai_state.get("tokens") if isinstance(xai_state.get("tokens"), dict) else {}
+    assert not tokens.get("refresh_token")
+    assert not xai_state.get("refresh_token")
+    shared = json.loads((shared_dir / "xai_oauth.json").read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "new-rt"

--- a/tests/hermes_cli/test_xai_shared_auth_store.py
+++ b/tests/hermes_cli/test_xai_shared_auth_store.py
@@ -1,0 +1,2601 @@
+"""Canonical shared xAI OAuth store — issue #65394.
+
+Unlike the Nous shared store (profile is source of truth + best-effort mirror),
+the xAI shared store itself is authoritative: one grant family, one lock, one
+serialized refresher, no per-profile forking of the rotating refresh token.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import stat
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_cli import auth
+from hermes_cli.auth import AuthError
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').decode().rstrip("=")
+    payload = (
+        base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).decode().rstrip("=")
+    )
+    return f"{header}.{payload}.sig"
+
+
+@pytest.fixture
+def shared_env(tmp_path, monkeypatch):
+    """Enable shared xAI mode with an isolated shared dir + profile auth."""
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    monkeypatch.setenv("HERMES_XAI_SHARED_AUTH", "1")
+    # Keep seat belts off real home.
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    # Ensure gate reads as enabled.
+    assert auth._xai_shared_auth_enabled() is True
+    return {
+        "shared_dir": shared_dir,
+        "hermes_home": hermes_home,
+        "store": shared_dir / "xai_oauth.json",
+        "profile_auth": hermes_home / "auth.json",
+    }
+
+
+def _write_shared(env, *, access="at-1", refresh="rt-1", generation=1, **extra):
+    payload = {
+        "_schema": 1,
+        "generation": generation,
+        "access_token": access,
+        "refresh_token": refresh,
+        "token_type": "Bearer",
+        "auth_mode": "oauth_device_code",
+        "last_refresh": "2026-07-01T00:00:00Z",
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth/token"},
+        **extra,
+    }
+    env["store"].write_text(json.dumps(payload), encoding="utf-8")
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Seat belt / gate / path
+# ---------------------------------------------------------------------------
+
+
+def test_shared_mode_disabled_by_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_XAI_SHARED_AUTH", raising=False)
+    monkeypatch.delenv("HERMES_SHARED_AUTH_PROVIDERS", raising=False)
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared"))
+    assert auth._xai_shared_auth_enabled() is False
+
+
+def test_shared_mode_via_providers_list(monkeypatch):
+    monkeypatch.delenv("HERMES_XAI_SHARED_AUTH", raising=False)
+    monkeypatch.setenv("HERMES_SHARED_AUTH_PROVIDERS", "nous,xai-oauth")
+    assert auth._xai_shared_auth_enabled() is True
+
+
+def test_pytest_seat_belt_refuses_real_shared_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_XAI_SHARED_AUTH", "1")
+    # Point the shared dir at the platform-native real path so the seat belt
+    # has something dangerous to refuse (conftest normally isolates HERMES_HOME).
+    from hermes_constants import _get_platform_default_hermes_home
+
+    real_shared = _get_platform_default_hermes_home() / "shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(real_shared))
+    with pytest.raises(RuntimeError, match="Refusing to touch real user shared xAI"):
+        auth._xai_shared_store_path()
+
+
+def test_write_shared_creates_0600_file(shared_env):
+    written = auth._write_shared_xai_state(
+        {
+            "access_token": "at",
+            "refresh_token": "rt",
+            "auth_mode": "oauth_device_code",
+        }
+    )
+    path = shared_env["store"]
+    assert path.is_file()
+    mode = stat.S_IMODE(path.stat().st_mode)
+    assert mode == 0o600
+    assert written["generation"] == 1
+    assert written["refresh_token"] == "rt"
+
+
+def test_write_shared_bumps_generation(shared_env):
+    auth._write_shared_xai_state(
+        {"access_token": "a1", "refresh_token": "r1"}
+    )
+    second = auth._write_shared_xai_state(
+        {"access_token": "a2", "refresh_token": "r2"}
+    )
+    assert second["generation"] == 2
+
+
+def test_persist_failure_is_loud(shared_env, monkeypatch):
+    def boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "open", boom)
+    with pytest.raises(AuthError) as exc:
+        auth._write_shared_xai_state(
+            {"access_token": "a", "refresh_token": "r"}
+        )
+    assert exc.value.code == "xai_shared_persist_failed"
+
+
+# ---------------------------------------------------------------------------
+# Read / save / no profile fork
+# ---------------------------------------------------------------------------
+
+
+def test_read_prefers_shared_not_profile(shared_env):
+    _write_shared(shared_env, access="shared-at", refresh="shared-rt")
+    # Poison the profile with a different RT — must be ignored.
+    shared_env["profile_auth"].write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "xai-oauth": {
+                        "tokens": {
+                            "access_token": "profile-at",
+                            "refresh_token": "profile-rt",
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    data = auth._read_xai_oauth_tokens(_lock=False)
+    assert data["tokens"]["access_token"] == "shared-at"
+    assert data["tokens"]["refresh_token"] == "shared-rt"
+    assert data["auth_store"] == "shared"
+
+
+def test_save_writes_shared_and_strips_profile_tokens(shared_env):
+    auth._save_xai_oauth_tokens(
+        {"access_token": "new-at", "refresh_token": "new-rt", "token_type": "Bearer"},
+        discovery={"token_endpoint": "https://auth.x.ai/oauth/token"},
+    )
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "new-rt"
+    assert shared["access_token"] == "new-at"
+    assert shared["generation"] >= 1
+
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    state = profile["providers"]["xai-oauth"]
+    assert state.get("source") == auth.XAI_SHARED_SOURCE
+    assert "tokens" not in state
+    assert state.get("refresh_token") is None
+
+
+def test_write_through_disabled_when_shared_active(shared_env, monkeypatch):
+    root = shared_env["hermes_home"].parent / "root" / "auth.json"
+    root.parent.mkdir(parents=True, exist_ok=True)
+    root.write_text(json.dumps({"version": 1, "providers": {}}), encoding="utf-8")
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root)
+    # Should no-op entirely.
+    auth._write_through_xai_oauth_to_global_root(
+        {"tokens": {"access_token": "a", "refresh_token": "r"}}
+    )
+    root_store = json.loads(root.read_text(encoding="utf-8"))
+    assert "xai-oauth" not in root_store.get("providers", {})
+
+
+# ---------------------------------------------------------------------------
+# Generation compare / concurrent adopt
+# ---------------------------------------------------------------------------
+
+
+def test_force_refresh_adopts_winner_without_second_post(shared_env, monkeypatch):
+    _write_shared(
+        shared_env,
+        access=_jwt(int(time.time()) + 30),
+        refresh="rt-stale",
+        generation=3,
+    )
+    posts = {"n": 0}
+
+    def fake_pure(access, refresh, **kwargs):
+        posts["n"] += 1
+        return {
+            "access_token": "should-not-run",
+            "refresh_token": "should-not-run",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-18T00:00:00Z",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", fake_pure)
+
+    # Simulate: caller still holds the rejected old access token, but another
+    # process already rotated the shared store to a new generation.
+    _write_shared(
+        shared_env,
+        access="winner-at",
+        refresh="winner-rt",
+        generation=4,
+    )
+    creds = auth.resolve_xai_oauth_runtime_credentials(
+        force_refresh=True,
+        rejected_access_token=_jwt(int(time.time()) + 30),
+        expected_generation=3,
+    )
+    assert posts["n"] == 0
+    assert creds["api_key"] == "winner-at"
+    assert creds["generation"] == 4
+
+
+def test_refresh_posts_once_and_persists(shared_env, monkeypatch):
+    old_at = _jwt(int(time.time()) - 10)  # expired
+    _write_shared(shared_env, access=old_at, refresh="rt-1", generation=1)
+    posts = []
+
+    def fake_pure(access, refresh, **kwargs):
+        posts.append(refresh)
+        return {
+            "access_token": "new-at",
+            "refresh_token": "new-rt",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-18T01:00:00Z",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", fake_pure)
+    monkeypatch.setattr(
+        auth,
+        "_xai_oauth_discovery",
+        lambda *_a, **_k: {"token_endpoint": "https://auth.x.ai/oauth/token"},
+    )
+
+    creds = auth.resolve_xai_oauth_runtime_credentials(refresh_if_expiring=True)
+    assert posts == ["rt-1"]
+    assert creds["api_key"] == "new-at"
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "new-rt"
+    assert shared["generation"] == 2
+
+
+def test_concurrent_waiters_second_adopts(shared_env, monkeypatch):
+    old_at = _jwt(int(time.time()) - 5)
+    _write_shared(shared_env, access=old_at, refresh="rt-only-once", generation=1)
+    posts = []
+    barrier = threading.Barrier(2)
+    hold = threading.Event()
+
+    def fake_pure(access, refresh, **kwargs):
+        posts.append(refresh)
+        # Hold the lock (we're inside pure only after lock acquired by resolve)
+        # Simulate slow network so the second waiter queues on the flock.
+        hold.wait(timeout=2.0)
+        return {
+            "access_token": "rotated-at",
+            "refresh_token": "rotated-rt",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-18T02:00:00Z",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", fake_pure)
+    monkeypatch.setattr(
+        auth,
+        "_xai_oauth_discovery",
+        lambda *_a, **_k: {"token_endpoint": "https://auth.x.ai/oauth/token"},
+    )
+
+    results = [None, None]
+    errors = [None, None]
+
+    def worker(idx):
+        try:
+            barrier.wait(timeout=5)
+            if idx == 0:
+                # First through does the refresh.
+                results[idx] = auth.resolve_xai_oauth_runtime_credentials(
+                    force_refresh=True,
+                    rejected_access_token=old_at,
+                    expected_generation=1,
+                )
+                hold.set()
+            else:
+                # Give winner a head start to acquire the lock.
+                time.sleep(0.05)
+                results[idx] = auth.resolve_xai_oauth_runtime_credentials(
+                    force_refresh=True,
+                    rejected_access_token=old_at,
+                    expected_generation=1,
+                )
+        except Exception as exc:  # pragma: no cover
+            errors[idx] = exc
+            hold.set()
+
+    t0 = threading.Thread(target=worker, args=(0,))
+    t1 = threading.Thread(target=worker, args=(1,))
+    t0.start()
+    t1.start()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+    assert errors == [None, None]
+    # Exactly one POST of the single-use RT.
+    assert posts == ["rt-only-once"]
+    assert results[0]["api_key"] == "rotated-at"
+    assert results[1]["api_key"] == "rotated-at"
+
+
+# ---------------------------------------------------------------------------
+# Quarantine compare-and-clear
+# ---------------------------------------------------------------------------
+
+
+def test_quarantine_skips_when_generation_changed(shared_env):
+    _write_shared(shared_env, access="a", refresh="rt-old", generation=5)
+    # Simulate loser trying to clear with stale RT while winner already rotated.
+    _write_shared(shared_env, access="a2", refresh="rt-new", generation=6)
+    cleared = auth._clear_shared_xai_state(
+        "test",
+        terminal_error={"code": "xai_refresh_failed", "message": "nope"},
+        only_if_refresh_token="rt-old",
+        only_if_generation=5,
+    )
+    assert cleared is False
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "rt-new"
+    assert shared["generation"] == 6
+
+
+def test_quarantine_clears_when_still_canonical(shared_env):
+    _write_shared(shared_env, access="a", refresh="rt-dead", generation=2)
+    cleared = auth._clear_shared_xai_state(
+        "test",
+        terminal_error={
+            "provider": "xai-oauth",
+            "code": "xai_refresh_failed",
+            "message": "invalid_grant",
+            "relogin_required": True,
+        },
+        only_if_refresh_token="rt-dead",
+        only_if_generation=2,
+    )
+    assert cleared is True
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert not shared.get("refresh_token")
+    assert shared.get("last_auth_error", {}).get("code") == "xai_refresh_failed"
+
+
+# ---------------------------------------------------------------------------
+# Status / profile disable / migration
+# ---------------------------------------------------------------------------
+
+
+def test_status_points_at_shared_path(shared_env):
+    _write_shared(
+        shared_env,
+        access=_jwt(int(time.time()) + 3600),
+        refresh="rt",
+        generation=1,
+    )
+    status = auth.get_xai_oauth_auth_status()
+    assert status["logged_in"] is True
+    assert status["shared_mode"] is True
+    assert str(shared_env["store"]) in status["auth_store"]
+    assert status["source"] == auth.XAI_SHARED_SOURCE
+    # Never leak full RT in status.
+    assert "refresh_token" not in status
+
+
+def test_profile_disable_blocks_resolve(shared_env):
+    _write_shared(shared_env, access="a", refresh="r")
+    auth.disable_profile_xai_shared_auth()
+    with pytest.raises(AuthError) as exc:
+        auth.resolve_xai_oauth_runtime_credentials(refresh_if_expiring=False)
+    assert exc.value.code == "xai_shared_profile_disabled"
+    # Canonical grant remains.
+    assert shared_env["store"].is_file()
+
+
+def test_migrate_shared_strips_legacy(shared_env, monkeypatch):
+    # Seed legacy profile tokens.
+    shared_env["profile_auth"].write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "xai-oauth": {
+                        "tokens": {
+                            "access_token": "legacy-at",
+                            "refresh_token": "legacy-rt",
+                        },
+                        "last_refresh": "2026-06-01T00:00:00Z",
+                        "auth_mode": "oauth_device_code",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    written = auth.migrate_xai_oauth_to_shared_store(source="profile", strip_legacy=True)
+    assert written["refresh_token"] == "legacy-rt"
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "legacy-rt"
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    state = profile["providers"]["xai-oauth"]
+    assert "tokens" not in state
+    assert state.get("source") == auth.XAI_SHARED_SOURCE
+
+
+def test_merge_shared_updates_local_dict(shared_env):
+    _write_shared(shared_env, access="sa", refresh="sr", generation=9)
+    local = {"access_token": "la", "refresh_token": "lr", "generation": 1}
+    assert auth._merge_shared_xai_state(local) is True
+    assert local["refresh_token"] == "sr"
+    assert local["generation"] == 9
+
+
+# ---------------------------------------------------------------------------
+# A1/A3/A4/A5 — multi-profile legacy pool strip + sole ownership
+# ---------------------------------------------------------------------------
+
+
+def _seed_legacy_pool_auth(path: Path, *, access: str, refresh: str, manual: bool = False):
+    source = "manual:device_code" if manual else "device_code"
+    payload = {
+        "version": 1,
+        "providers": {
+            "xai-oauth": {
+                "tokens": {
+                    "access_token": access,
+                    "refresh_token": refresh,
+                },
+                "auth_mode": "oauth_device_code",
+            }
+        },
+        "credential_pool": {
+            "xai-oauth": [
+                {
+                    "id": f"{source}-{refresh[:8]}",
+                    "source": source,
+                    "auth_type": "oauth",
+                    "access_token": access,
+                    "refresh_token": refresh,
+                    "priority": 0,
+                }
+            ]
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_strip_covers_all_profiles_and_manuals(shared_env, tmp_path, monkeypatch):
+    """A1/A4: strip removes RTs from EVERY profile + root + manual pool rows."""
+    # Make default hermes root == tmp home so profile enumeration is in-sandbox.
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    profiles_root = hermes_root / "profiles"
+    profiles_root.mkdir()
+
+    # Active profile (HERMES_HOME)
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="p-at", refresh="p-rt", manual=False
+    )
+    # Second named profile with a manual RT
+    other = profiles_root / "coder" / "auth.json"
+    _seed_legacy_pool_auth(other, access="c-at", refresh="c-rt", manual=True)
+    # Root auth.json with device_code RT
+    root_auth = hermes_root / "auth.json"
+    _seed_legacy_pool_auth(root_auth, access="r-at", refresh="r-rt", manual=False)
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    audit = auth._strip_legacy_xai_oauth_secrets(include_global_root=True, fail_loud=True)
+    assert audit  # something was cleaned
+
+    for path in (shared_env["profile_auth"], other, root_auth):
+        store = json.loads(path.read_text(encoding="utf-8"))
+        assert not auth._auth_store_holds_durable_xai_refresh_token(store), path
+        pool = store.get("credential_pool", {}).get("xai-oauth", [])
+        for entry in pool:
+            assert not entry.get("refresh_token")
+            assert not str(entry.get("source") or "").startswith("manual")
+
+
+def test_migrate_with_legacy_pools_leaves_no_fork(shared_env, tmp_path, monkeypatch):
+    """Pre-populated device_code + same-RT pool fork is gone after migrate.
+
+    R2: a *different* live RT (true multi-grant) is refused as ambiguous —
+    this test uses a same-identity pool fork so promote is well-defined.
+    """
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    (hermes_root / "profiles").mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="legacy-at", refresh="legacy-rt"
+    )
+    # Same-identity pool fork (duplicate RT) — still a sole live grant.
+    store = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    store["credential_pool"]["xai-oauth"].append(
+        {
+            "id": "manual-fork",
+            "source": "manual:device_code",
+            "auth_type": "oauth",
+            "access_token": "legacy-at",
+            "refresh_token": "legacy-rt",
+            "priority": 1,
+        }
+    )
+    shared_env["profile_auth"].write_text(json.dumps(store), encoding="utf-8")
+
+    written = auth.migrate_xai_oauth_to_shared_store(source="profile", strip_legacy=True)
+    assert written["refresh_token"] == "legacy-rt"
+
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    assert not auth._auth_store_holds_durable_xai_refresh_token(profile)
+    pool = profile.get("credential_pool", {}).get("xai-oauth", [])
+    assert all(not e.get("refresh_token") for e in pool)
+    assert all(not str(e.get("source") or "").startswith("manual") for e in pool)
+
+
+def test_strip_fails_loud_when_residual_rt_remains(shared_env, monkeypatch):
+    """A1: migration/login must fail if a durable RT cannot be removed."""
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="a", refresh="rt-stuck"
+    )
+
+    real_save = auth._save_auth_store
+
+    def save_but_restore_rt(store, target_path=None):
+        # Pretend write succeeded but leave a residual RT (poisoned write).
+        path = real_save(store, target_path=target_path)
+        poisoned = json.loads(path.read_text(encoding="utf-8"))
+        poisoned.setdefault("providers", {})["xai-oauth"] = {
+            "tokens": {"access_token": "a", "refresh_token": "rt-stuck"}
+        }
+        path.write_text(json.dumps(poisoned), encoding="utf-8")
+        return path
+
+    monkeypatch.setattr(auth, "_save_auth_store", save_but_restore_rt)
+    with pytest.raises(AuthError) as exc:
+        auth._strip_legacy_xai_oauth_secrets(include_global_root=False, fail_loud=True)
+    assert exc.value.code == "xai_shared_strip_incomplete"
+
+
+def test_logout_preserves_disable_marker(shared_env):
+    """B1: hermes logout --provider xai-oauth keeps shared_disabled marker."""
+    _write_shared(shared_env, access="a", refresh="r", generation=1)
+    auth._write_profile_xai_shared_reference(enabled=True, generation=1)
+
+    # Simulate logout_command shared-mode profile path (clear then disable).
+    auth.clear_provider_auth("xai-oauth")
+    auth.disable_profile_xai_shared_auth()
+
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    state = profile["providers"]["xai-oauth"]
+    assert state.get("enabled") is False
+    assert state.get("shared_disabled") is True
+    # Canonical grant still present.
+    assert shared_env["store"].is_file()
+    with pytest.raises(AuthError) as exc:
+        auth.resolve_xai_oauth_runtime_credentials(refresh_if_expiring=False)
+    assert exc.value.code == "xai_shared_profile_disabled"
+
+
+def test_logout_command_shared_profile_path(shared_env):
+    """B1 end-to-end via logout_command."""
+    from types import SimpleNamespace
+
+    _write_shared(shared_env, access="a", refresh="r")
+    auth._write_profile_xai_shared_reference(enabled=True)
+
+    args = SimpleNamespace(
+        provider="xai-oauth",
+        reset_config=False,
+        global_logout=False,
+        shared=False,
+        **{"global": False},
+    )
+    auth.logout_command(args)
+
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    state = profile["providers"]["xai-oauth"]
+    assert state.get("shared_disabled") is True
+    assert state.get("enabled") is False
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared.get("refresh_token") == "r"
+
+
+def test_load_pool_rewrites_device_code_and_manual(shared_env):
+    """A3/A4: load_pool under shared mode discards local RTs."""
+    from agent.credential_pool import load_pool
+
+    _write_shared(shared_env, access="shared-at", refresh="shared-rt", generation=2)
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="old-at", refresh="old-rt", manual=False
+    )
+    store = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    store["credential_pool"]["xai-oauth"].append(
+        {
+            "id": "manual-1",
+            "source": "manual:device_code",
+            "auth_type": "oauth",
+            "access_token": "manual-at",
+            "refresh_token": "manual-rt",
+            "priority": 1,
+        }
+    )
+    shared_env["profile_auth"].write_text(json.dumps(store), encoding="utf-8")
+
+    pool = load_pool("xai-oauth")
+    assert pool.has_credentials()
+    for entry in pool.entries():
+        assert not entry.refresh_token
+        assert str(entry.source) == auth.XAI_SHARED_SOURCE
+
+    # Persisted profile must not hold RTs either.
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    assert not auth._auth_store_holds_durable_xai_refresh_token(profile)
+
+
+def test_manual_row_does_not_pure_refresh_under_shared(shared_env, monkeypatch):
+    """A4: legacy manual entry cannot pure-refresh a local RT outside the lock."""
+    from agent.credential_pool import CredentialPool, PooledCredential, AUTH_TYPE_OAUTH
+
+    _write_shared(shared_env, access="shared-at", refresh="shared-rt", generation=1)
+    pure_calls = []
+
+    def fake_pure(access, refresh, **kwargs):
+        pure_calls.append(refresh)
+        return {
+            "access_token": "should-not",
+            "refresh_token": "should-not",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-18T00:00:00Z",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", fake_pure)
+    monkeypatch.setattr(
+        auth,
+        "_xai_oauth_discovery",
+        lambda *_a, **_k: {"token_endpoint": "https://auth.x.ai/oauth/token"},
+    )
+
+    entry = PooledCredential(
+        id="manual-1",
+        provider="xai-oauth",
+        label="manual-1",
+        source="manual:device_code",
+        auth_type=AUTH_TYPE_OAUTH,
+        access_token="manual-at",
+        refresh_token="manual-rt",
+        priority=0,
+    )
+    pool = CredentialPool("xai-oauth", [entry])
+    # Force refresh path
+    refreshed = pool._refresh_entry(entry, force=True)
+    assert pure_calls == []  # must not pure-refresh local RT
+    assert refreshed is not None
+    assert refreshed.refresh_token is None
+    assert refreshed.source == auth.XAI_SHARED_SOURCE
+
+
+def test_write_shared_persists_id_token(shared_env):
+    """D3: id_token from refresh is persisted in the canonical store."""
+    written = auth._write_shared_xai_state(
+        {
+            "access_token": "at",
+            "refresh_token": "rt",
+            "id_token": "id-tok-1",
+        }
+    )
+    assert written.get("id_token") == "id-tok-1"
+    on_disk = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert on_disk.get("id_token") == "id-tok-1"
+
+
+def test_save_strips_root_rt(shared_env, tmp_path, monkeypatch):
+    """A5: shared save clears root providers.xai-oauth refresh_token."""
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    root_auth = hermes_root / "auth.json"
+    _seed_legacy_pool_auth(root_auth, access="root-at", refresh="root-rt")
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_auth)
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    auth._save_xai_oauth_tokens(
+        {
+            "access_token": "new-at",
+            "refresh_token": "new-rt",
+            "token_type": "Bearer",
+            "id_token": "id-1",
+        }
+    )
+    root = json.loads(root_auth.read_text(encoding="utf-8"))
+    assert not auth._auth_store_holds_durable_xai_refresh_token(root)
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "new-rt"
+    assert shared.get("id_token") == "id-1"
+
+
+def test_login_refuses_silent_replace_when_disabled(shared_env, monkeypatch):
+    """B2: disabled profile login does not silently clobber the fleet grant."""
+    from types import SimpleNamespace
+
+    _write_shared(shared_env, access="fleet-at", refresh="fleet-rt", generation=3)
+    auth.disable_profile_xai_shared_auth()
+
+    # Non-interactive decline
+    monkeypatch.setattr("builtins.input", lambda *_a, **_k: "n")
+    login_called = {"n": 0}
+
+    def boom_login(**kwargs):
+        login_called["n"] += 1
+        raise AssertionError("device login must not run without confirmation")
+
+    monkeypatch.setattr(auth, "_xai_oauth_device_code_login", boom_login)
+    auth._login_xai_oauth(
+        SimpleNamespace(timeout=5, no_browser=True),
+        auth.PROVIDER_REGISTRY["xai-oauth"],
+        force_new_login=True,
+    )
+    assert login_called["n"] == 0
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "fleet-rt"
+
+
+def test_persistence_guard_strips_device_code_rt(shared_env):
+    """A2: write_credential_pool under shared mode cannot persist a device_code RT."""
+    from hermes_cli.auth import write_credential_pool
+
+    write_credential_pool(
+        "xai-oauth",
+        [
+            {
+                "id": "dc-1",
+                "source": "device_code",
+                "auth_type": "oauth",
+                "access_token": "at",
+                "refresh_token": "rt-should-die",
+                "priority": 0,
+            }
+        ],
+    )
+    store = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    entries = store["credential_pool"]["xai-oauth"]
+    assert len(entries) == 1
+    assert not entries[0].get("refresh_token")
+    assert entries[0]["source"] == auth.XAI_SHARED_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# Round-3 F1–F7: fail-closed / fail-loud / auto-promote
+# ---------------------------------------------------------------------------
+
+
+def test_f1_load_pool_empty_shared_promotes_device_code_rt(shared_env):
+    """F1: empty shared + sole device_code RT → promote, never lose the RT."""
+    from agent.credential_pool import load_pool
+
+    assert not shared_env["store"].exists()
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="solo-at", refresh="solo-rt", manual=False
+    )
+
+    pool = load_pool("xai-oauth")
+    assert pool.has_credentials()
+
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "solo-rt"
+    assert shared["access_token"] == "solo-at"
+
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    assert not auth._auth_store_holds_durable_xai_refresh_token(profile)
+    for entry in pool.entries():
+        assert not entry.refresh_token
+        assert entry.source == auth.XAI_SHARED_SOURCE
+
+
+def test_f1_load_pool_empty_shared_promotes_manual_rt(shared_env):
+    """F1: empty shared + sole manual RT → promote, never lose the RT."""
+    from agent.credential_pool import load_pool
+
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="man-at", refresh="man-rt", manual=True
+    )
+    # Pool-only manual (providers tokens also present via seed helper).
+    pool = load_pool("xai-oauth")
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "man-rt"
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    assert not auth._auth_store_holds_durable_xai_refresh_token(profile)
+    assert pool.has_credentials()
+
+
+def test_f1_resolve_empty_shared_promotes_local_rt(shared_env):
+    """F1: resolve with empty shared + local RT promotes rather than failing."""
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="r-at", refresh="r-rt", manual=False
+    )
+    assert not shared_env["store"].exists()
+    creds = auth.resolve_xai_oauth_runtime_credentials(refresh_if_expiring=False)
+    assert creds["api_key"] == "r-at"
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared["refresh_token"] == "r-rt"
+
+
+def test_f1_poisoned_shared_write_preserves_local_rt(shared_env, monkeypatch):
+    """F1: if shared write fails, local RT must remain and error surfaces."""
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="keep-at", refresh="keep-rt"
+    )
+
+    def boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "open", boom)
+    with pytest.raises(AuthError):
+        auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+
+    assert not shared_env["store"].exists()
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    assert auth._auth_store_holds_durable_xai_refresh_token(profile)
+    tokens = profile["providers"]["xai-oauth"]["tokens"]
+    assert tokens["refresh_token"] == "keep-rt"
+
+
+def test_f2_resolve_http_fail_closed_profile_disabled(shared_env, monkeypatch):
+    """F2: shared mode + profile disabled + surviving manual row → not returned."""
+    from tools.xai_http import has_xai_credentials, resolve_xai_http_credentials
+
+    _write_shared(shared_env, access="shared-at", refresh="shared-rt")
+    auth.disable_profile_xai_shared_auth()
+    # Plant a surviving manual-style row that legacy would have picked.
+    store = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    store.setdefault("credential_pool", {})["xai-oauth"] = [
+        {
+            "id": "manual-surviving",
+            "source": "manual:device_code",
+            "auth_type": "oauth",
+            "access_token": "manual-at",
+            "refresh_token": "manual-rt",
+            "priority": 0,
+        }
+    ]
+    shared_env["profile_auth"].write_text(json.dumps(store), encoding="utf-8")
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+
+    assert has_xai_credentials() is False
+    creds = resolve_xai_http_credentials()
+    assert creds.get("api_key") in ("", None)
+    assert creds.get("source") != auth.XAI_SHARED_SOURCE
+    assert creds.get("api_key") != "manual-at"
+
+
+def test_f2_resolve_http_fail_closed_empty_canonical(shared_env, monkeypatch):
+    """F2: empty shared + no promotable grant + leftover access-only pool row."""
+    from tools.xai_http import has_xai_credentials, resolve_xai_http_credentials
+
+    # Access-only pool row (no RT) — cannot promote; must not win under shared.
+    shared_env["profile_auth"].write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "orphan",
+                            "source": "manual:device_code",
+                            "auth_type": "oauth",
+                            "access_token": "orphan-at",
+                            "priority": 0,
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    assert has_xai_credentials() is False
+    creds = resolve_xai_http_credentials()
+    assert creds.get("api_key") != "orphan-at"
+
+
+def test_f2_proxy_fail_closed_profile_disabled(shared_env):
+    """F2: proxy does not return a legacy pool row when profile is disabled."""
+    from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
+
+    _write_shared(shared_env, access="shared-at", refresh="shared-rt")
+    auth.disable_profile_xai_shared_auth()
+    store = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    store.setdefault("credential_pool", {})["xai-oauth"] = [
+        {
+            "id": "manual-1",
+            "source": "manual:device_code",
+            "auth_type": "oauth",
+            "access_token": "manual-at",
+            "refresh_token": "manual-rt",
+            "priority": 0,
+        }
+    ]
+    shared_env["profile_auth"].write_text(json.dumps(store), encoding="utf-8")
+
+    adapter = XAIGrokAdapter()
+    assert adapter.is_authenticated() is False
+    with pytest.raises(RuntimeError, match="disabled"):
+        adapter.get_credential()
+
+
+def test_f3a_enumeration_failure_fails_strip(shared_env, monkeypatch):
+    """F3a: profile enumeration failure fails migration/strip (no silent omit)."""
+
+    def boom():
+        raise OSError("profiles root unreadable")
+
+    monkeypatch.setattr("hermes_cli.profiles._get_profiles_root", boom)
+    with pytest.raises(AuthError) as exc:
+        auth._strip_legacy_xai_oauth_secrets(include_global_root=True, fail_loud=True)
+    assert exc.value.code == "xai_shared_profile_enum_failed"
+
+
+def test_f3b_disable_marker_write_failure_raises(shared_env, monkeypatch):
+    """F3b: disable marker write failure raises — no false success."""
+    _write_shared(shared_env, access="a", refresh="r")
+
+    def boom(*_a, **_k):
+        raise OSError("cannot write auth.json")
+
+    monkeypatch.setattr(auth, "_save_auth_store", boom)
+    with pytest.raises(AuthError) as exc:
+        auth.disable_profile_xai_shared_auth()
+    assert exc.value.code in {
+        "xai_shared_reference_write_failed",
+        "xai_shared_disable_failed",
+    }
+    # Marker must not falsely claim disabled.
+    assert auth._profile_xai_shared_disabled() is False
+
+
+def test_f3c_global_logout_surfaces_strip_failure(shared_env, monkeypatch, capsys):
+    """F3c: global logout does not report success when fleet strip fails."""
+    from types import SimpleNamespace
+
+    _write_shared(shared_env, access="a", refresh="r")
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="left", refresh="left-rt"
+    )
+
+    def fail_strip(**_k):
+        raise AuthError(
+            "residual rt",
+            provider="xai-oauth",
+            code="xai_shared_strip_incomplete",
+        )
+
+    monkeypatch.setattr(auth, "_strip_legacy_xai_oauth_secrets", fail_strip)
+    args = SimpleNamespace(
+        provider="xai-oauth",
+        reset_config=False,
+        global_logout=True,
+        shared=False,
+        **{"global": False},
+    )
+    with pytest.raises(SystemExit) as exc:
+        auth.logout_command(args)
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "ERROR" in out
+    assert "Logged out" not in out
+
+
+def test_f4a_enable_gate_off_no_strip(monkeypatch, tmp_path):
+    """F4a: enable with gate OFF does not strip multi-profile RTs."""
+    monkeypatch.delenv("HERMES_XAI_SHARED_AUTH", raising=False)
+    monkeypatch.delenv("HERMES_SHARED_AUTH_PROVIDERS", raising=False)
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    auth_path = hermes_home / "auth.json"
+    _seed_legacy_pool_auth(auth_path, access="local-at", refresh="local-rt")
+
+    with pytest.raises(AuthError) as exc:
+        auth.enable_profile_xai_shared_auth()
+    assert exc.value.code == "xai_shared_not_enabled"
+
+    store = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert auth._auth_store_holds_durable_xai_refresh_token(store)
+
+
+def test_f4a_enable_empty_shared_no_strip(shared_env):
+    """F4a: enable with empty shared store refuses and leaves local RT."""
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="local-at", refresh="local-rt"
+    )
+    with pytest.raises(AuthError) as exc:
+        auth.enable_profile_xai_shared_auth()
+    assert exc.value.code == "xai_shared_empty"
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    assert auth._auth_store_holds_durable_xai_refresh_token(profile)
+
+
+def test_f4b_disable_gate_off_raises(monkeypatch, tmp_path):
+    """F4b: disable-shared requires gate ON; does not strip tokens when off."""
+    monkeypatch.delenv("HERMES_XAI_SHARED_AUTH", raising=False)
+    monkeypatch.delenv("HERMES_SHARED_AUTH_PROVIDERS", raising=False)
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    auth_path = hermes_home / "auth.json"
+    _seed_legacy_pool_auth(auth_path, access="local-at", refresh="local-rt")
+
+    with pytest.raises(AuthError) as exc:
+        auth.disable_profile_xai_shared_auth()
+    assert exc.value.code == "xai_shared_not_enabled"
+    store = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert auth._auth_store_holds_durable_xai_refresh_token(store)
+
+
+def test_f4b_write_reference_gate_off_does_not_strip(monkeypatch, tmp_path):
+    """F4b: reference writer must not strip tokens when shared mode is off."""
+    monkeypatch.delenv("HERMES_XAI_SHARED_AUTH", raising=False)
+    monkeypatch.delenv("HERMES_SHARED_AUTH_PROVIDERS", raising=False)
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    auth_path = hermes_home / "auth.json"
+    _seed_legacy_pool_auth(auth_path, access="local-at", refresh="local-rt")
+
+    # Direct writer call with gate off should preserve RTs.
+    auth._write_profile_xai_shared_reference(enabled=False)
+    store = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert auth._auth_store_holds_durable_xai_refresh_token(store)
+
+
+def test_f7_migrate_preserves_id_token(shared_env):
+    """F7: migration copies tokens.id_token into the shared store."""
+    shared_env["profile_auth"].write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "xai-oauth": {
+                        "tokens": {
+                            "access_token": "legacy-at",
+                            "refresh_token": "legacy-rt",
+                            "id_token": "legacy-id-token",
+                        },
+                        "last_refresh": "2026-06-01T00:00:00Z",
+                        "auth_mode": "oauth_device_code",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    written = auth.migrate_xai_oauth_to_shared_store(source="profile", strip_legacy=True)
+    assert written.get("id_token") == "legacy-id-token"
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert shared.get("id_token") == "legacy-id-token"
+
+
+# ---------------------------------------------------------------------------
+# Round-4: quarantine / race / upgrade / corrupt / availability / 429 / remove
+# ---------------------------------------------------------------------------
+
+
+def test_r1_quarantine_then_promote_no_resurrection(shared_env):
+    """R1/G6: tombstoned canonical + dead local must NOT resurrect."""
+    # Terminal quarantine of the shared grant.
+    _write_shared(shared_env, access="old-at", refresh="old-rt", generation=3)
+    cleared = auth._clear_shared_xai_state(
+        "invalid_grant",
+        terminal_error={
+            "provider": "xai-oauth",
+            "code": "invalid_grant",
+            "message": "refresh token revoked",
+            "relogin_required": True,
+        },
+        only_if_refresh_token="old-rt",
+        only_if_generation=3,
+    )
+    assert cleared is True
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert not shared.get("refresh_token")
+    assert shared.get("last_auth_error", {}).get("code") == "invalid_grant"
+
+    # Plant a local row that looks like a grant (even a dead one).
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="zombie-at", refresh="zombie-rt"
+    )
+    store = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    store["credential_pool"]["xai-oauth"][0]["last_status"] = "dead"
+    store["credential_pool"]["xai-oauth"][0]["last_error_reason"] = "invalid_grant"
+    # Also mark the providers singleton as terminal.
+    store["providers"]["xai-oauth"]["last_auth_error"] = {
+        "code": "invalid_grant",
+        "relogin_required": True,
+    }
+    shared_env["profile_auth"].write_text(json.dumps(store), encoding="utf-8")
+
+    result = auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    assert result is None
+    # Canonical stays tombstoned — no resurrection.
+    after = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert not after.get("refresh_token")
+    assert after.get("last_auth_error", {}).get("code") == "invalid_grant"
+    assert after.get("access_token", "") in ("", None)
+
+
+def test_r1_live_local_also_refused_when_quarantined(shared_env):
+    """R1: even a *live* local grant must not resurrect a tombstoned store."""
+    _write_shared(shared_env, access="a", refresh="r", generation=1)
+    auth._clear_shared_xai_state(
+        "invalid_grant",
+        terminal_error={
+            "code": "invalid_grant",
+            "message": "dead",
+            "relogin_required": True,
+        },
+        only_if_refresh_token="r",
+        only_if_generation=1,
+    )
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="live-at", refresh="live-rt"
+    )
+    assert auth.ensure_shared_xai_grant_from_local(strip_legacy=True) is None
+    after = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert not after.get("refresh_token")
+    assert after.get("last_auth_error")
+
+
+def test_r2_rejects_dead_and_ambiguous_local(shared_env):
+    """R2: dead rows rejected; multiple distinct live RTs are ambiguous."""
+    # Dead-only pool: not promotable.
+    shared_env["profile_auth"].write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "dead-1",
+                            "source": "device_code",
+                            "auth_type": "oauth",
+                            "access_token": "d-at",
+                            "refresh_token": "d-rt",
+                            "last_status": "dead",
+                            "last_error_reason": "invalid_grant",
+                            "priority": 0,
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = auth._load_auth_store()
+    assert auth._xai_oauth_state_from_store(store, sole_live=True) is None
+
+    # Two distinct live RTs → ambiguous.
+    shared_env["profile_auth"].write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "xai-oauth": {
+                        "tokens": {
+                            "access_token": "a1",
+                            "refresh_token": "rt-1",
+                        }
+                    }
+                },
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "other",
+                            "source": "manual:device_code",
+                            "auth_type": "oauth",
+                            "access_token": "a2",
+                            "refresh_token": "rt-2",
+                            "priority": 1,
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = auth._load_auth_store()
+    with pytest.raises(AuthError) as exc:
+        auth._xai_oauth_state_from_store(store, sole_live=True)
+    assert exc.value.code == "xai_promote_ambiguous_local"
+
+
+def test_r3_logout_during_promote_does_not_resurrect(shared_env, monkeypatch):
+    """R3: concurrent local logout wins — promotion must not write removed grant.
+
+    Sequence: ensure probe elects live grant → migrate elects live grant →
+    concurrent logout clears local → recheck under profile lock sees identity
+    gone → refuse write.
+    """
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="race-at", refresh="race-rt"
+    )
+    assert not shared_env["store"].exists()
+
+    real_elect = auth._elect_sole_promotable_xai_under_lock
+    calls = {"n": 0}
+
+    def elect_then_logout(path):
+        calls["n"] += 1
+        state = real_elect(path)
+        # After migrate's first elect (call 2: ensure probe is call 1), clear
+        # the local source so the recheck (call 3) observes logout.
+        if calls["n"] == 2 and state is not None:
+            shared_env["profile_auth"].write_text(
+                json.dumps({"version": 1, "providers": {}}),
+                encoding="utf-8",
+            )
+        return state
+
+    monkeypatch.setattr(auth, "_elect_sole_promotable_xai_under_lock", elect_then_logout)
+    result = auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    assert result is None
+    # Canonical must not hold the removed grant.
+    if shared_env["store"].exists():
+        shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+        assert shared.get("refresh_token") not in {"race-rt"}
+        assert not auth._xai_shared_state_has_usable_tokens(shared)
+    # Local remains cleared.
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    assert not auth._auth_store_holds_durable_xai_refresh_token(profile)
+    assert calls["n"] >= 3  # probe + elect + recheck
+
+
+def test_r4_upgrade_state_sweeps_all_profiles(shared_env, tmp_path, monkeypatch):
+    """R4: populated canonical + dormant per-profile RTs → first consume sweeps."""
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    profiles_root = hermes_root / "profiles"
+    profiles_root.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    # Pre-existing canonical grant (deploy upgrade state).
+    _write_shared(shared_env, access="canon-at", refresh="canon-rt", generation=7)
+    # Dormant per-profile RTs left from earlier rounds.
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="p-at", refresh="p-rt"
+    )
+    other = profiles_root / "worker" / "auth.json"
+    _seed_legacy_pool_auth(other, access="w-at", refresh="w-rt", manual=True)
+    root_auth = hermes_root / "auth.json"
+    _seed_legacy_pool_auth(root_auth, access="r-at", refresh="r-rt")
+
+    # Marker must not exist yet.
+    marker = auth._xai_sole_owner_marker_path()
+    assert not marker.exists()
+
+    result = auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    assert auth._xai_shared_state_has_usable_tokens(result)
+    assert result["refresh_token"] == "canon-rt"
+    assert marker.is_file()
+
+    for path in (shared_env["profile_auth"], other, root_auth):
+        store = json.loads(path.read_text(encoding="utf-8"))
+        assert not auth._auth_store_holds_durable_xai_refresh_token(store), path
+
+
+def test_r5_corrupt_auth_store_fails_sole_owner_audit(shared_env, tmp_path, monkeypatch):
+    """R5: unreadable auth.json holding a live RT must FAIL the audit."""
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    (hermes_root / "profiles").mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    # Write a valid seed then corrupt the file bytes while keeping it present.
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="c-at", refresh="c-rt"
+    )
+    # Overwrite with non-JSON so parse fails (live RT bytes still on disk).
+    shared_env["profile_auth"].write_bytes(
+        b'{"version":1,"providers":{"xai-oauth":{"tokens":'
+        b'{"access_token":"c-at","refresh_token":"c-rt"}}}'  # truncated / corrupt
+        b"NOT-JSON-TRAILER"
+    )
+
+    with pytest.raises(AuthError) as exc:
+        auth._strip_legacy_xai_oauth_secrets(include_global_root=True, fail_loud=True)
+    assert exc.value.code in {
+        "xai_shared_strip_incomplete",
+        "auth_store_unreadable",
+    }
+    # Must not certify clean.
+    assert "unreadable" in str(exc.value).lower() or "corrupt" in str(exc.value).lower() or "incomplete" in str(exc.value).lower()
+
+
+def test_r9_shared_mode_429_no_pool_rotation(shared_env, monkeypatch):
+    """R9: shared-mode proxy 429 stays on canonical policy (no wrong-ref mark)."""
+    from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
+    from hermes_cli.proxy.adapters.base import UpstreamCredential
+
+    _write_shared(shared_env, access="shared-at", refresh="shared-rt", generation=1)
+    adapter = XAIGrokAdapter()
+    rotate_calls = []
+
+    class FakePool:
+        def mark_exhausted_and_rotate(self, **kwargs):
+            rotate_calls.append(kwargs)
+            return None
+
+        def try_refresh_current(self):
+            return None
+
+    adapter._pool = FakePool()  # type: ignore[assignment]
+    retry = adapter.get_retry_credential(
+        failed_credential=UpstreamCredential(
+            bearer="shared-at",
+            base_url="https://api.x.ai/v1",
+            expires_at=None,
+        ),
+        status_code=429,
+    )
+    assert retry is None
+    assert rotate_calls == []
+
+
+def test_r10_global_logout_leaves_non_promotable_tombstone(shared_env):
+    """R1/R10: global logout tombstones the store (no auto-promote resurrection)."""
+    _write_shared(shared_env, access="a", refresh="r", generation=2)
+    cleared = auth._clear_shared_xai_state("global_logout")
+    assert cleared is True
+    assert shared_env["store"].is_file()
+    shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert not shared.get("refresh_token")
+    assert shared.get("logged_out") is True or shared.get("last_auth_error")
+    assert auth._shared_xai_state_is_quarantined(shared)
+
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="z-at", refresh="z-rt"
+    )
+    assert auth.ensure_shared_xai_grant_from_local(strip_legacy=True) is None
+    after = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+    assert after.get("refresh_token") in ("", None)
+
+
+# ---------------------------------------------------------------------------
+# Round-5: H1 race window / H2 cross-store sole-live / H3 verifiable marker /
+# H4 fail-closed logout / H5 parent fsync / H6 gate-off byte-identical
+# ---------------------------------------------------------------------------
+
+
+def test_h1_concurrent_real_logout_cannot_install_removed_grant(shared_env, monkeypatch):
+    """H1: REAL concurrent clear_provider_auth vs unpatched promote.
+
+    A second thread runs the real logout path (``clear_provider_auth``), which
+    acquires the profile auth lock the normal way — no lock-bypass monkeypatch
+    of the code under test. Explicit ordering relative to the canonical commit:
+
+    - If promotion committed ``race-rt``, logout must NOT have completed before
+      that commit (proves ``logout clears source → stale promotion commits`` is
+      impossible under the dual-lock critical section).
+    - If promote did not install a grant, the canonical store must NOT hold
+      the removed ``race-rt``.
+    """
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="race-at", refresh="race-rt"
+    )
+    assert not shared_env["store"].exists()
+
+    barrier = threading.Barrier(2)
+    outcomes = {"promote": "unset", "logout": "unset", "promote_exc": None}
+    order: list = []
+    order_lock = threading.Lock()
+
+    real_write = auth._write_shared_xai_state
+
+    def write_recording(*args, **kwargs):
+        with order_lock:
+            order.append("commit_start")
+        result = real_write(*args, **kwargs)
+        with order_lock:
+            order.append("commit_done")
+        return result
+
+    monkeypatch.setattr(auth, "_write_shared_xai_state", write_recording)
+
+    def do_promote():
+        barrier.wait(timeout=5.0)
+        try:
+            result = auth.migrate_xai_oauth_to_shared_store(
+                source="profile", strip_legacy=True
+            )
+            outcomes["promote"] = result
+        except Exception as exc:
+            outcomes["promote"] = None
+            outcomes["promote_exc"] = exc
+
+    def do_logout():
+        barrier.wait(timeout=5.0)
+        try:
+            outcomes["logout"] = auth.clear_provider_auth("xai-oauth")
+        except Exception as exc:
+            outcomes["logout"] = exc
+        with order_lock:
+            order.append("logout_done")
+
+    t_promote = threading.Thread(target=do_promote, name="h1-promote")
+    t_logout = threading.Thread(target=do_logout, name="h1-logout")
+    t_promote.start()
+    t_logout.start()
+    t_promote.join(timeout=30.0)
+    t_logout.join(timeout=30.0)
+    assert not t_promote.is_alive() and not t_logout.is_alive()
+
+    store = shared_env["store"]
+    shared = None
+    if store.is_file():
+        shared = json.loads(store.read_text(encoding="utf-8"))
+
+    promote_ok = (
+        isinstance(outcomes["promote"], dict)
+        and outcomes["promote"].get("refresh_token") == "race-rt"
+    )
+    if promote_ok:
+        assert shared is not None
+        assert shared.get("refresh_token") == "race-rt"
+        assert auth._xai_shared_state_has_usable_tokens(shared)
+        # R7-4: promotion committed ⇒ logout did not complete before commit.
+        assert "commit_done" in order, order
+        assert "logout_done" in order, order
+        assert order.index("commit_done") < order.index("logout_done"), order
+    else:
+        # Promote lost the race or aborted — must not install removed grant.
+        if shared is not None:
+            assert shared.get("refresh_token") != "race-rt"
+            assert not (
+                auth._xai_shared_state_has_usable_tokens(shared)
+                and shared.get("refresh_token") == "race-rt"
+            )
+        # Race abort / empty source are acceptable; lock failures are not.
+        if outcomes["promote_exc"] is not None:
+            assert isinstance(outcomes["promote_exc"], AuthError)
+            assert outcomes["promote_exc"].code in {
+                "xai_promote_local_race",
+                "xai_migrate_source_empty",
+            }
+
+
+def test_h1_profile_lock_held_through_canonical_write(shared_env, monkeypatch):
+    """H1: foreign LOCK_NB probe — profile-source lock held across write."""
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="hold-at", refresh="hold-rt"
+    )
+    held_during_write = {"value": None}
+    real_write = auth._write_shared_xai_state
+
+    def write_probe(state, **kwargs):
+        # Non-blocking foreign-thread probe against the REAL lock file.
+        result_box = {"acquired": None}
+
+        def try_acquire():
+            lock_path = shared_env["profile_auth"].with_suffix(".lock")
+            try:
+                fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+            except OSError:
+                result_box["acquired"] = True
+                return
+            try:
+                if hasattr(auth, "fcntl") and auth.fcntl is not None:
+                    try:
+                        auth.fcntl.flock(fd, auth.fcntl.LOCK_EX | auth.fcntl.LOCK_NB)
+                        result_box["acquired"] = True
+                        auth.fcntl.flock(fd, auth.fcntl.LOCK_UN)
+                    except (OSError, BlockingIOError):
+                        result_box["acquired"] = False
+                else:
+                    result_box["acquired"] = None
+            finally:
+                os.close(fd)
+
+        t = threading.Thread(target=try_acquire)
+        t.start()
+        t.join(timeout=2.0)
+        held_during_write["value"] = result_box["acquired"] is False
+        return real_write(state, **kwargs)
+
+    monkeypatch.setattr(auth, "_write_shared_xai_state", write_probe)
+    written = auth.migrate_xai_oauth_to_shared_store(
+        source="profile", strip_legacy=True
+    )
+    assert written.get("refresh_token") == "hold-rt"
+    assert held_during_write["value"] is True
+
+
+def test_h2_distinct_profile_and_root_rts_are_ambiguous(shared_env, tmp_path, monkeypatch):
+    """H2: live RT-A in profile + live RT-B in root → ambiguous (not profile-first)."""
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+    # Ensure global-root path resolves to hermes_root/auth.json (distinct from
+    # the active profile under HERMES_HOME).
+    root_auth = hermes_root / "auth.json"
+    _seed_legacy_pool_auth(root_auth, access="root-at", refresh="root-rt-B")
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="prof-at", refresh="prof-rt-A"
+    )
+    # Force _global_auth_file_path to the distinct root.
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_auth)
+
+    with pytest.raises(AuthError) as exc:
+        auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    assert exc.value.code == "xai_promote_ambiguous_local"
+    # Must not have silently installed the profile grant.
+    if shared_env["store"].exists():
+        shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+        assert shared.get("refresh_token") not in {"prof-rt-A", "root-rt-B"}
+
+
+def test_h2_unreadable_store_fails_election(shared_env, tmp_path, monkeypatch):
+    """H2 fail-closed: unreadable/corrupt store fails election (never omit)."""
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+    root_auth = hermes_root / "auth.json"
+    root_auth.write_text("{not-json", encoding="utf-8")
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="prof-at", refresh="prof-rt"
+    )
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_auth)
+
+    with pytest.raises(AuthError) as exc:
+        auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    assert exc.value.code in {
+        "xai_auth_store_unreadable",
+        "auth_store_unreadable",
+    }
+    # Must not have silently promoted the readable profile grant.
+    if shared_env["store"].exists():
+        shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+        assert shared.get("refresh_token") != "prof-rt"
+
+
+def test_h2_availability_probe_no_profile_first_short_circuit(
+    shared_env, tmp_path, monkeypatch
+):
+    """H2: has_xai_credentials / is_authenticated match promoter on ambiguity."""
+    from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
+    from tools.xai_http import has_xai_credentials
+
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+    root_auth = hermes_root / "auth.json"
+    _seed_legacy_pool_auth(root_auth, access="root-at", refresh="root-rt-B")
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="prof-at", refresh="prof-rt-A"
+    )
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_auth)
+    # Empty/never-initialized shared so probes fall into local promote check.
+    assert not shared_env["store"].exists()
+
+    assert has_xai_credentials() is False
+    adapter = XAIGrokAdapter()
+    assert adapter.is_authenticated() is False
+
+
+def test_h3_stale_marker_reaudits_restored_profile_rt(
+    shared_env, tmp_path, monkeypatch
+):
+    """H3 exact window: marker present, then restore dormant profile RT → re-audit.
+
+    Existence-only markers used to certify a dirty fleet forever. After a
+    valid marker is written, introducing/restoring a profile RT must invalidate
+    the marker digest and force a fail-loud fleet strip on next consume.
+    """
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    profiles_root = hermes_root / "profiles"
+    profiles_root.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    _write_shared(shared_env, access="canon-at", refresh="canon-rt", generation=7)
+    # First consume: sweep + write verifiable marker.
+    result = auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    assert auth._xai_shared_state_has_usable_tokens(result)
+    marker = auth._xai_sole_owner_marker_path()
+    assert marker.is_file()
+    marker_payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert marker_payload.get("fleet_digest")
+    digest_before = marker_payload["fleet_digest"]
+
+    # Exact dirtying window: restore a dormant profile RT after marker commit.
+    other = profiles_root / "restored" / "auth.json"
+    _seed_legacy_pool_auth(other, access="restored-at", refresh="restored-rt")
+    assert auth._auth_store_holds_durable_xai_refresh_token(
+        json.loads(other.read_text(encoding="utf-8"))
+    )
+
+    # Marker must no longer validate against the dirty fleet.
+    assert auth._xai_sole_owner_marker_is_valid(generation=7) is False
+
+    # Next consume re-audits and strips the restored RT.
+    result2 = auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    assert auth._xai_shared_state_has_usable_tokens(result2)
+    store = json.loads(other.read_text(encoding="utf-8"))
+    assert not auth._auth_store_holds_durable_xai_refresh_token(store)
+    # Marker refreshed — digest must change vs the pre-restore clean fleet
+    # (restored path is now present and RT-free, so inventory differs).
+    marker_after = json.loads(marker.read_text(encoding="utf-8"))
+    assert marker_after.get("fleet_digest")
+    assert marker_after["fleet_digest"] != digest_before
+    assert auth._xai_sole_owner_marker_is_valid(generation=7) is True
+
+
+def test_h3_concurrent_restore_cannot_certify_dirty_fleet(
+    shared_env, tmp_path, monkeypatch
+):
+    """H3/R7-4: force the EXACT strip→inventory window with explicit sync.
+
+    Thread A runs the production fleet sole-owner path. A window-forcing hook
+    on the real strip (under held fleet locks) signals after strip returns and
+    blocks before inventory/marker. Thread B uses the REAL auth-store lock path
+    to restore a durable RT in that window — it must BLOCK until marker commit
+    releases the locks. No scheduler-luck start-only barrier; no lock-bypass.
+
+    Invariant: a valid marker must NEVER certify a fleet that still holds a
+    durable RT; restore_acquired must not precede marker_done.
+    """
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    profiles_root = hermes_root / "profiles"
+    profiles_root.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    _write_shared(shared_env, access="canon-at", refresh="canon-rt", generation=5)
+    dirty = profiles_root / "dirty" / "auth.json"
+    _seed_legacy_pool_auth(dirty, access="dirty-at", refresh="dirty-rt")
+    target = profiles_root / "race" / "auth.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    in_strip_inventory_window = threading.Event()
+    release_window = threading.Event()
+    order: list = []
+    order_lock = threading.Lock()
+    errors = []
+
+    real_strip = auth._strip_legacy_xai_oauth_secrets_under_held_locks
+    real_persist = auth._persist_xai_sole_owner_marker_payload
+
+    def strip_window(*args, **kwargs):
+        out = real_strip(*args, **kwargs)
+        with order_lock:
+            order.append("strip_done")
+        # Exact strip→inventory gap: still under fleet locks held by caller.
+        in_strip_inventory_window.set()
+        assert release_window.wait(timeout=10.0), "timed out in strip→inventory window"
+        return out
+
+    def persist_recording(payload):
+        result = real_persist(payload)
+        with order_lock:
+            order.append("marker_done")
+        return result
+
+    monkeypatch.setattr(
+        auth, "_strip_legacy_xai_oauth_secrets_under_held_locks", strip_window
+    )
+    monkeypatch.setattr(
+        auth, "_persist_xai_sole_owner_marker_payload", persist_recording
+    )
+
+    def do_ensure():
+        try:
+            auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+        except Exception as exc:
+            errors.append(("ensure", exc))
+
+    def do_restore():
+        assert in_strip_inventory_window.wait(timeout=10.0)
+        try:
+            with auth._auth_store_lock(target_path=target):
+                with order_lock:
+                    order.append("restore_acquired")
+                _seed_legacy_pool_auth(
+                    target, access="race-at", refresh="race-restore-rt"
+                )
+            with order_lock:
+                order.append("restore_done")
+        except Exception as exc:
+            errors.append(("restore", exc))
+
+    t_a = threading.Thread(target=do_ensure, name="h3-ensure")
+    t_b = threading.Thread(target=do_restore, name="h3-restore")
+    t_a.start()
+    t_b.start()
+    # Wait until production path is parked in the strip→inventory window.
+    assert in_strip_inventory_window.wait(timeout=10.0)
+    # Restore thread must be blocked on the held store lock (not yet acquired).
+    time.sleep(0.15)
+    with order_lock:
+        assert "restore_acquired" not in order, (
+            "restore acquired lock during strip→inventory window: " + str(order)
+        )
+    release_window.set()
+    t_a.join(timeout=30.0)
+    t_b.join(timeout=30.0)
+    assert not t_a.is_alive() and not t_b.is_alive()
+
+    for label, exc in errors:
+        if label == "ensure":
+            raise AssertionError(f"ensure failed unexpectedly: {exc}") from exc
+
+    with order_lock:
+        snapshot = list(order)
+    assert "strip_done" in snapshot, snapshot
+    assert "marker_done" in snapshot, snapshot
+    assert "restore_acquired" in snapshot, snapshot
+    # Deterministic ordering: marker commit under fleet locks before restore.
+    assert snapshot.index("marker_done") < snapshot.index("restore_acquired"), snapshot
+
+    paths = auth._iter_xai_auth_json_paths(include_global_root=True, fail_loud=True)
+    residual = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        try:
+            store = auth._load_auth_store(path, fail_on_corrupt=True)
+        except AuthError:
+            residual.append(str(path))
+            continue
+        if auth._auth_store_holds_durable_xai_refresh_token(store):
+            residual.append(str(path))
+
+    if auth._xai_sole_owner_marker_is_valid(generation=5):
+        assert residual == [], (
+            f"valid sole-owner marker certified dirty fleet: {residual}"
+        )
+    else:
+        assert residual, "expected residual RT when marker is invalid"
+        auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+        for path in paths:
+            if not path.is_file():
+                continue
+            store = auth._load_auth_store(path, fail_on_corrupt=True)
+            assert not auth._auth_store_holds_durable_xai_refresh_token(store)
+        assert auth._xai_sole_owner_marker_is_valid(generation=5) is True
+
+
+def test_h3_inventory_read_error_rejects_marker(shared_env, tmp_path, monkeypatch):
+    """H3 fail-closed: inventory read/stat error must reject marker creation.
+
+    Uses a real unreadable file (chmod 0) — not a tautology monkeypatch — so
+    the pre-fix path (hash error entries into the digest) fails this test and
+    the fail-closed path raises.
+    """
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    (hermes_root / "profiles").mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    _write_shared(shared_env, access="c-at", refresh="c-rt", generation=2)
+    profile = shared_env["profile_auth"]
+    profile.write_text(
+        json.dumps({"version": 1, "providers": {}}),
+        encoding="utf-8",
+    )
+    marker = auth._xai_sole_owner_marker_path()
+    if marker.is_file():
+        marker.unlink()
+
+    profile.chmod(0o000)
+    try:
+        with pytest.raises(AuthError) as exc:
+            auth._write_xai_sole_owner_marker(generation=2)
+        assert exc.value.code in {
+            "xai_shared_fleet_inventory_failed",
+            "xai_shared_strip_incomplete",
+            "auth_store_unreadable",
+            "xai_auth_store_unreadable",
+        }
+        # Marker must not certify an unreadable fleet.
+        assert not marker.is_file() or not auth._xai_sole_owner_marker_is_valid(
+            generation=2
+        )
+    finally:
+        profile.chmod(0o600)
+
+
+def test_h3_rt_after_strip_before_marker_not_certified(
+    shared_env, tmp_path, monkeypatch
+):
+    """H3 window: durable RT reappears after strip returns, before marker commit.
+
+    Wraps the production strip so that immediately after it returns a durable
+    RT is restored (the exact pre-fix strip→inventory gap). A valid marker
+    must never certify that dirty fleet — either marker creation aborts
+    (fail-closed re-audit under held locks) or the marker is invalid while
+    residual RT remains.
+    """
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    profiles_root = hermes_root / "profiles"
+    profiles_root.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    _write_shared(shared_env, access="canon-at", refresh="canon-rt", generation=9)
+    target = profiles_root / "window" / "auth.json"
+    _seed_legacy_pool_auth(target, access="pre-at", refresh="pre-rt")
+    marker = auth._xai_sole_owner_marker_path()
+    if marker.is_file():
+        marker.unlink()
+
+    def _restore_after(fn):
+        def wrapped(*args, **kwargs):
+            out = fn(*args, **kwargs)
+            _seed_legacy_pool_auth(
+                target, access="window-at", refresh="window-rt"
+            )
+            return out
+
+        return wrapped
+
+    monkeypatch.setattr(
+        auth,
+        "_strip_legacy_xai_oauth_secrets",
+        _restore_after(auth._strip_legacy_xai_oauth_secrets),
+    )
+    if hasattr(auth, "_strip_legacy_xai_oauth_secrets_under_held_locks"):
+        monkeypatch.setattr(
+            auth,
+            "_strip_legacy_xai_oauth_secrets_under_held_locks",
+            _restore_after(auth._strip_legacy_xai_oauth_secrets_under_held_locks),
+        )
+
+    raised = None
+    try:
+        auth._ensure_xai_fleet_sole_owner_verified(force=True, generation=9)
+    except AuthError as exc:
+        raised = exc
+
+    residual = auth._auth_store_holds_durable_xai_refresh_token(
+        json.loads(target.read_text(encoding="utf-8"))
+    )
+    valid = auth._xai_sole_owner_marker_is_valid(generation=9)
+    # HARD invariant (must fail on pre-fix: marker written over restored RT).
+    assert not (valid and residual), (
+        "sole-owner marker certified a dirty fleet after strip→marker window restore"
+    )
+    if residual:
+        # Dirty residual is only acceptable when marker creation aborted or
+        # the marker does not validate.
+        assert raised is not None or not valid
+
+
+def test_h3_existence_only_marker_never_skips_audit(shared_env, tmp_path, monkeypatch):
+    """H3: pre-H3 existence-only markers (no fleet_digest) must not skip audit."""
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    (hermes_root / "profiles").mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    _write_shared(shared_env, access="c-at", refresh="c-rt", generation=3)
+    marker = auth._xai_sole_owner_marker_path()
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    # Existence-only legacy marker (schema/generation only — no fleet_digest).
+    marker.write_text(
+        json.dumps(
+            {
+                "verified_at": "2026-07-01T00:00:00Z",
+                "generation": 3,
+                "schema": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert marker.is_file()
+    assert auth._xai_sole_owner_marker_is_valid(generation=3) is False
+
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="dirty-at", refresh="dirty-rt"
+    )
+    auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    assert not auth._auth_store_holds_durable_xai_refresh_token(profile)
+    # Marker rewritten with verifiable digest.
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload.get("fleet_digest")
+
+
+def test_h4_tombstone_write_failure_leaves_non_promotable(shared_env, monkeypatch):
+    """H4 exact window: tombstone-persist failure must NOT unlink → resurrect.
+
+    Simulates durable tombstone write failure during global logout. Store must
+    remain non-promotable (not bare-absent), failure surfaced, and a surviving
+    local RT must not auto-promote afterward.
+    """
+    _write_shared(shared_env, access="live-at", refresh="live-rt", generation=4)
+    prior = shared_env["store"].read_text(encoding="utf-8")
+
+    real_fsync = auth._fsync_parent_dir
+
+    def fsync_boom(path, *, context, code="xai_shared_parent_fsync_failed"):
+        if "logout tombstone" in context or "clear" in context:
+            raise OSError("simulated tombstone parent fsync failure")
+        return real_fsync(path, context=context, code=code)
+
+    monkeypatch.setattr(auth, "_fsync_parent_dir", fsync_boom)
+
+    with pytest.raises(AuthError) as exc:
+        auth._clear_shared_xai_state("global_logout")
+    assert exc.value.code == "xai_shared_logout_tombstone_failed"
+    assert "tombstone" in str(exc.value).lower() or "fsync" in str(exc.value).lower()
+
+    # Store must still exist (no unlink-to-absent fallback).
+    assert shared_env["store"].is_file()
+    after_bytes = shared_env["store"].read_text(encoding="utf-8")
+    assert after_bytes.strip()
+    # Surviving local RT must NOT auto-promote into the failed-logout store.
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="surv-at", refresh="surv-rt"
+    )
+    result = auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    if result is not None:
+        # Prior grant still usable (tombstone never committed) — must not be
+        # replaced by the surviving local RT.
+        assert result.get("refresh_token") != "surv-rt"
+        assert result.get("refresh_token") == "live-rt"
+    else:
+        shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+        assert shared.get("refresh_token") not in {"surv-rt"}
+    assert shared_env["store"].is_file()
+    # No bare-absent: either prior grant or a tombstone — never unlinked.
+    # (fsync fails after os.replace in our helper, so file may already be
+    # tombstoned on disk; either prior or tombstone is non-promotable for
+    # surv-rt resurrection. What must not happen is store absence.)
+    assert shared_env["store"].is_file()
+
+
+def test_h5_parent_dir_fsync_failure_on_canonical_write_is_loud(
+    shared_env, monkeypatch
+):
+    """H5: parent-dir open/fsync failure on canonical write is surfaced."""
+    calls = {"n": 0}
+    real_fsync = auth._fsync_parent_dir
+
+    def fsync_fail(path, *, context, code="xai_shared_parent_fsync_failed"):
+        calls["n"] += 1
+        if "canonical write" in context:
+            raise auth.AuthError(
+                f"Failed to open parent directory for fsync ({context})",
+                provider="xai-oauth",
+                code=code,
+                relogin_required=False,
+            )
+        return real_fsync(path, context=context, code=code)
+
+    monkeypatch.setattr(auth, "_fsync_parent_dir", fsync_fail)
+    with pytest.raises(AuthError) as exc:
+        auth._write_shared_xai_state(
+            {
+                "access_token": "a",
+                "refresh_token": "r",
+                "token_type": "Bearer",
+            },
+            bump_generation=True,
+        )
+    assert exc.value.code == "xai_shared_persist_failed"
+    assert calls["n"] >= 1
+    # Must not swallow — error message is observable.
+    assert "fsync" in str(exc.value).lower() or "parent" in str(exc.value).lower()
+
+
+def test_h6_gate_off_dead_first_row_is_legacy_first_wins(monkeypatch, tmp_path):
+    """H6/G7: gate-off store with dead/suppressed FIRST token-bearing row matches 60891a4ef.
+
+    Round-4 strict reject was applied globally and changed gate-off resolution.
+    Gate-off must be legacy first-wins again (byte-identical to 60891a4ef).
+    """
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    # Gate OFF — no shared mode.
+    monkeypatch.delenv("HERMES_XAI_SHARED_AUTH", raising=False)
+    monkeypatch.delenv("HERMES_SHARED_AUTH_PROVIDERS", raising=False)
+    monkeypatch.delenv("HERMES_SHARED_AUTH_DIR", raising=False)
+    assert auth._xai_shared_auth_enabled() is False
+
+    auth_path = hermes_home / "auth.json"
+    # Dead/suppressed FIRST token-bearing provider row — legacy first-wins
+    # returns it; strict shared-mode would reject it.
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "xai-oauth": {
+                        "tokens": {
+                            "access_token": "dead-at",
+                            "refresh_token": "dead-rt",
+                        },
+                        "last_status": "dead",
+                        "last_auth_error": {
+                            "code": "invalid_grant",
+                            "relogin_required": True,
+                        },
+                        "source": "device_code",
+                    }
+                },
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "live-later",
+                            "source": "device_code",
+                            "auth_type": "oauth",
+                            "access_token": "live-at",
+                            "refresh_token": "live-rt",
+                            "priority": 1,
+                        }
+                    ]
+                },
+                "suppressed_sources": {"xai-oauth": ["device_code"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    store = auth._load_auth_store()
+    # sole_live=False (gate-off default): legacy first-wins → dead-rt.
+    state = auth._xai_oauth_state_from_store(store)
+    assert state is not None
+    tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else {}
+    assert tokens.get("refresh_token") == "dead-rt"
+    assert tokens.get("access_token") == "dead-at"
+
+    # End-to-end gate-off read path.
+    read = auth._read_xai_oauth_tokens()
+    assert read["tokens"]["refresh_token"] == "dead-rt"
+
+    # Shared-mode sole_live path still rejects dead/suppressed.
+    assert auth._xai_oauth_state_from_store(store, sole_live=True) is None
+
+
+# ---------------------------------------------------------------------------
+# Round-7: invalid-shape fail-closed / locked marker validation /
+# refresh-stable digest / deterministic election→commit race
+# ---------------------------------------------------------------------------
+
+
+def _hidden_rt_list_payload():
+    """Hermes R7-1 repro shape: JSON list wrapping a providers grant."""
+    return [
+        {
+            "providers": {
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "hidden-at",
+                        "refresh_token": "hidden-rt",
+                    }
+                }
+            }
+        }
+    ]
+
+
+def _assert_raises_auth_store_unreadable(fn):
+    with pytest.raises(AuthError) as exc:
+        fn()
+    assert exc.value.code in {
+        "auth_store_unreadable",
+        "xai_auth_store_unreadable",
+        "xai_shared_strip_incomplete",
+        "xai_shared_fleet_inventory_failed",
+    }
+    return exc.value
+
+
+def test_r7_1_list_shaped_root_store_fails_closed_election_strip_audit(
+    shared_env, tmp_path, monkeypatch
+):
+    """R7-1 Hermes repro: list-shaped root holding hidden RT must fail closed.
+
+    Pre-fix (bf58c54e6): parseable list normalizes to empty → profile promote
+    succeeds, hidden RT survives, marker certifies clean after consume.
+    Post-fix: election / strip / pre-commit RT audit raise auth_store_unreadable
+    (or wrap it); hidden RT is NOT promoted-over and NOT certified clean.
+    """
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    (hermes_root / "profiles").mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+    root_auth = hermes_root / "auth.json"
+    root_auth.write_text(json.dumps(_hidden_rt_list_payload()), encoding="utf-8")
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_auth)
+
+    # Profile has a promotable grant — pre-fix would elect it and ignore root.
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="prof-at", refresh="prof-rt"
+    )
+
+    # Strict load itself rejects the shape.
+    _assert_raises_auth_store_unreadable(
+        lambda: auth._load_auth_store(root_auth, fail_on_corrupt=True)
+    )
+
+    # Election / migrate must not promote-over the hidden RT.
+    with pytest.raises(AuthError) as exc:
+        auth.migrate_xai_oauth_to_shared_store(source="profile", strip_legacy=True)
+    assert exc.value.code in {
+        "auth_store_unreadable",
+        "xai_auth_store_unreadable",
+        "xai_shared_strip_incomplete",
+        "xai_shared_fleet_inventory_failed",
+        "xai_promote_ambiguous_local",
+    }
+    # Hidden RT must still be on disk (not stripped as "empty"); profile grant
+    # must not have been installed into the canonical store over it.
+    assert "hidden-rt" in root_auth.read_text(encoding="utf-8")
+    if shared_env["store"].is_file():
+        shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+        # If anything was written, it must not be a successful promote-over.
+        if auth._xai_shared_state_has_usable_tokens(shared):
+            pytest.fail("promoted over invalid-shaped root store holding hidden RT")
+
+    # Fleet strip fail-closed on the invalid-shaped store.
+    _assert_raises_auth_store_unreadable(
+        lambda: auth._strip_legacy_xai_oauth_secrets(
+            include_global_root=True, fail_loud=True
+        )
+    )
+
+    # Pre-commit RT-free audit fail-closed.
+    _assert_raises_auth_store_unreadable(
+        lambda: auth._audit_fleet_refresh_token_free([root_auth], fail_loud=True)
+    )
+
+    # Marker must not certify clean over the hidden RT.
+    assert auth._xai_sole_owner_marker_is_valid(generation=1) is False
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not-a-store",
+        42,
+        3.14,
+        True,
+    ],
+)
+def test_r7_1_string_number_shaped_store_fails_closed(shared_env, raw, tmp_path, monkeypatch):
+    """R7-1: string/number/bool-shaped stores fail closed under strict load."""
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    (hermes_root / "profiles").mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+    bad = hermes_root / "auth.json"
+    bad.write_text(json.dumps(raw), encoding="utf-8")
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: bad)
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="prof-at", refresh="prof-rt"
+    )
+
+    _assert_raises_auth_store_unreadable(
+        lambda: auth._load_auth_store(bad, fail_on_corrupt=True)
+    )
+    with pytest.raises(AuthError):
+        auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    if shared_env["store"].is_file():
+        shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+        assert not (
+            auth._xai_shared_state_has_usable_tokens(shared)
+            and shared.get("refresh_token") == "prof-rt"
+        )
+
+
+def test_r7_1_empty_dict_and_absent_remain_empty(shared_env):
+    """R7-1 preserve: absent file and ``{}`` still load as empty (not errors)."""
+    missing = shared_env["hermes_home"] / "no-such-auth.json"
+    assert not missing.exists()
+    empty_absent = auth._load_auth_store(missing, fail_on_corrupt=True)
+    assert empty_absent == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
+
+    empty_path = shared_env["hermes_home"] / "empty-auth.json"
+    empty_path.write_text("{}", encoding="utf-8")
+    empty_dict = auth._load_auth_store(empty_path, fail_on_corrupt=True)
+    assert empty_dict == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
+
+    providers_empty = shared_env["hermes_home"] / "providers-empty.json"
+    providers_empty.write_text(
+        json.dumps({"version": 1, "providers": {}}), encoding="utf-8"
+    )
+    ok = auth._load_auth_store(providers_empty, fail_on_corrupt=True)
+    assert isinstance(ok.get("providers"), dict)
+
+
+def test_r7_2_marker_validation_holds_locks_during_inventory(
+    shared_env, tmp_path, monkeypatch
+):
+    """R7-2: validation inventory is lock-disciplined (no unlocked skip).
+
+    Force a store change attempt DURING validation's inventory read via an
+    explicit barrier. Concurrent writer must block on the store lock (or
+    validation must re-check under lock) — a skip must not be granted from an
+    unlocked/stale inventory snapshot while a dirty change is in flight.
+    """
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    profiles_root = hermes_root / "profiles"
+    profiles_root.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    _write_shared(shared_env, access="canon-at", refresh="canon-rt", generation=3)
+    # Establish a valid clean marker.
+    auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    assert auth._xai_sole_owner_marker_is_valid(generation=3) is True
+
+    target = profiles_root / "during-validation" / "auth.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # Path is enumerated (parent profile dir exists) but file absent → clean.
+
+    in_inventory = threading.Event()
+    release_inventory = threading.Event()
+    order: list = []
+    order_lock = threading.Lock()
+    inventory_calls = {"n": 0}
+
+    real_inventory = auth._xai_fleet_auth_inventory
+
+    def inventory_window(*, fail_loud=True, paths=None):
+        inventory_calls["n"] += 1
+        # Only the first validation inventory is the forced TOCTOU window.
+        if inventory_calls["n"] == 1:
+            with order_lock:
+                order.append("inventory_start")
+            in_inventory.set()
+            assert release_inventory.wait(timeout=10.0), "inventory window timeout"
+            result = real_inventory(fail_loud=fail_loud, paths=paths)
+            with order_lock:
+                order.append("inventory_done")
+            return result
+        return real_inventory(fail_loud=fail_loud, paths=paths)
+
+    monkeypatch.setattr(auth, "_xai_fleet_auth_inventory", inventory_window)
+
+    validation_result = {"value": None, "exc": None}
+
+    def do_validate():
+        try:
+            validation_result["value"] = auth._xai_sole_owner_marker_is_valid(
+                generation=3
+            )
+        except Exception as exc:
+            validation_result["exc"] = exc
+
+    def do_dirty():
+        assert in_inventory.wait(timeout=10.0)
+        # Real lock path — must block while validation holds fleet store locks.
+        with auth._auth_store_lock(target_path=target):
+            with order_lock:
+                order.append("dirty_acquired")
+            _seed_legacy_pool_auth(
+                target, access="during-at", refresh="during-rt"
+            )
+        with order_lock:
+            order.append("dirty_done")
+
+    t_v = threading.Thread(target=do_validate, name="r7-2-validate")
+    t_d = threading.Thread(target=do_dirty, name="r7-2-dirty")
+    t_v.start()
+    t_d.start()
+    assert in_inventory.wait(timeout=10.0)
+    time.sleep(0.15)
+    with order_lock:
+        assert "dirty_acquired" not in order, (
+            "dirty writer acquired store lock during locked validation inventory: "
+            + str(order)
+        )
+    release_inventory.set()
+    t_v.join(timeout=30.0)
+    t_d.join(timeout=30.0)
+    assert not t_v.is_alive() and not t_d.is_alive()
+    assert validation_result["exc"] is None
+
+    with order_lock:
+        snapshot = list(order)
+    assert "inventory_done" in snapshot, snapshot
+    assert "dirty_acquired" in snapshot, snapshot
+    # Dirty write cannot interleave under the inventory locks.
+    assert snapshot.index("inventory_done") < snapshot.index("dirty_acquired"), snapshot
+
+    # After concurrent dirt, marker must not validate (digest change) and audit
+    # must run on next ensure (strip the restored RT).
+    assert auth._xai_sole_owner_marker_is_valid(generation=3) is False
+    auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    store = auth._load_auth_store(target, fail_on_corrupt=True)
+    assert not auth._auth_store_holds_durable_xai_refresh_token(store)
+    assert auth._xai_sole_owner_marker_is_valid(generation=3) is True
+
+
+def test_r7_3_refresh_metadata_does_not_churn_fleet_digest(
+    shared_env, tmp_path, monkeypatch
+):
+    """R7-3: normal refresh metadata must NOT invalidate the fleet-clean marker.
+
+    Hermes repro: marker_valid_before_refresh True → after profile
+    shared_generation/metadata write → still True. Reintroducing an RT must
+    invalidate and force re-audit strip.
+    """
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    profiles_root = hermes_root / "profiles"
+    profiles_root.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+
+    _write_shared(shared_env, access="canon-at", refresh="canon-rt", generation=4)
+    # Profile already holds non-secret shared reference (post-login settle state)
+    # so the refresh path only mutates volatile metadata — not path presence.
+    auth._write_profile_xai_shared_reference(
+        enabled=True,
+        last_refresh="2026-07-01T00:00:00Z",
+        generation=4,
+        set_active=True,
+    )
+    auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    marker = auth._xai_sole_owner_marker_path()
+    assert marker.is_file()
+    digest_before = json.loads(marker.read_text(encoding="utf-8"))["fleet_digest"]
+    assert auth._xai_sole_owner_marker_is_valid(generation=4) is True
+    marker_valid_before_refresh = True
+
+    # Simulate post-refresh profile metadata settle (shared_generation bump).
+    auth._write_profile_xai_shared_reference(
+        enabled=True,
+        last_refresh="2026-07-18T12:00:00Z",
+        generation=5,
+        set_active=True,
+    )
+    profile = json.loads(shared_env["profile_auth"].read_text(encoding="utf-8"))
+    assert profile["providers"]["xai-oauth"].get("shared_generation") == 5
+    assert profile["providers"]["xai-oauth"].get("last_refresh") == (
+        "2026-07-18T12:00:00Z"
+    )
+    # Tokens must remain absent after metadata-only rewrite.
+    assert "tokens" not in profile["providers"]["xai-oauth"]
+    assert not profile["providers"]["xai-oauth"].get("refresh_token")
+
+    marker_valid_after_refresh = auth._xai_sole_owner_marker_is_valid(generation=5)
+    assert marker_valid_before_refresh is True
+    assert marker_valid_after_refresh is True, (
+        "metadata-only refresh churned fleet_digest / invalidated sole-owner marker"
+    )
+    digest_after = json.loads(marker.read_text(encoding="utf-8"))["fleet_digest"]
+    assert digest_after == digest_before
+
+    # Real RT reintroduction MUST still invalidate.
+    other = profiles_root / "reintro" / "auth.json"
+    _seed_legacy_pool_auth(other, access="re-at", refresh="re-rt")
+    assert auth._xai_sole_owner_marker_is_valid(generation=5) is False
+    auth.ensure_shared_xai_grant_from_local(strip_legacy=True)
+    assert not auth._auth_store_holds_durable_xai_refresh_token(
+        auth._load_auth_store(other, fail_on_corrupt=True)
+    )
+    assert auth._xai_sole_owner_marker_is_valid(generation=5) is True
+
+
+def test_r7_4_h2_election_commit_blocks_unselected_store_inject(
+    shared_env, tmp_path, monkeypatch
+):
+    """R7-4/H2: inject distinct RT into UNSELECTED store during election→commit.
+
+    Promote holds BOTH store locks through elect + recheck + canonical write.
+    A concurrent writer injecting a distinct live RT into the unselected root
+    must BLOCK until commit (or promote raises ambiguous). Explicit events —
+    no scheduler-luck, no lock-bypass of the production path.
+    Fail-pre on 74eff54fa (root unlocked mid-promote) / pass-post.
+    """
+    hermes_root = tmp_path / "home" / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    (hermes_root / "profiles").mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: hermes_root
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: hermes_root
+    )
+    root_auth = hermes_root / "auth.json"
+    # Root starts empty (unselected). Profile holds the sole live grant.
+    root_auth.write_text(
+        json.dumps({"version": 1, "providers": {}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_auth)
+    _seed_legacy_pool_auth(
+        shared_env["profile_auth"], access="prof-at", refresh="prof-rt-A"
+    )
+    assert not shared_env["store"].exists()
+
+    in_commit_window = threading.Event()
+    release_commit = threading.Event()
+    order: list = []
+    order_lock = threading.Lock()
+    outcomes = {"promote": None, "promote_exc": None, "inject_exc": None}
+
+    real_write = auth._write_shared_xai_state
+
+    def write_window(*args, **kwargs):
+        with order_lock:
+            order.append("commit_start")
+        # Still under dual store locks held by migrate.
+        in_commit_window.set()
+        assert release_commit.wait(timeout=10.0), "commit window timeout"
+        result = real_write(*args, **kwargs)
+        with order_lock:
+            order.append("commit_done")
+        return result
+
+    monkeypatch.setattr(auth, "_write_shared_xai_state", write_window)
+
+    def do_promote():
+        try:
+            outcomes["promote"] = auth.migrate_xai_oauth_to_shared_store(
+                source="profile", strip_legacy=True
+            )
+        except Exception as exc:
+            outcomes["promote_exc"] = exc
+
+    def do_inject():
+        assert in_commit_window.wait(timeout=10.0)
+        try:
+            with auth._auth_store_lock(target_path=root_auth):
+                with order_lock:
+                    order.append("inject_acquired")
+                _seed_legacy_pool_auth(
+                    root_auth, access="root-at", refresh="root-rt-B"
+                )
+            with order_lock:
+                order.append("inject_done")
+        except Exception as exc:
+            outcomes["inject_exc"] = exc
+
+    t_p = threading.Thread(target=do_promote, name="r7-h2-promote")
+    t_i = threading.Thread(target=do_inject, name="r7-h2-inject")
+    t_p.start()
+    t_i.start()
+    assert in_commit_window.wait(timeout=10.0)
+    time.sleep(0.15)
+    with order_lock:
+        assert "inject_acquired" not in order, (
+            "inject acquired unselected-store lock during election→commit: "
+            + str(order)
+        )
+    release_commit.set()
+    t_p.join(timeout=30.0)
+    t_i.join(timeout=30.0)
+    assert not t_p.is_alive() and not t_i.is_alive()
+
+    with order_lock:
+        snapshot = list(order)
+    assert "commit_start" in snapshot, snapshot
+    # Concurrent inject must not complete before commit under held locks.
+    if "inject_acquired" in snapshot and "commit_done" in snapshot:
+        assert snapshot.index("commit_done") < snapshot.index("inject_acquired"), (
+            snapshot
+        )
+
+    if outcomes["promote_exc"] is not None:
+        # Acceptable: ambiguous if inject somehow became visible, or lock fail.
+        assert isinstance(outcomes["promote_exc"], AuthError)
+        assert outcomes["promote_exc"].code in {
+            "xai_promote_ambiguous_local",
+            "xai_promote_local_race",
+            "xai_auth_store_lock_failed",
+            "auth_store_unreadable",
+        }
+    else:
+        assert outcomes["promote"] is not None
+        assert outcomes["promote"].get("refresh_token") == "prof-rt-A"
+        shared = json.loads(shared_env["store"].read_text(encoding="utf-8"))
+        assert shared.get("refresh_token") == "prof-rt-A"
+        # Inject ran after commit — must not have been silently merged mid-window.
+        assert "inject_acquired" in snapshot, snapshot

--- a/tests/hermes_cli/test_xai_shared_auth_two_process.py
+++ b/tests/hermes_cli/test_xai_shared_auth_two_process.py
@@ -1,0 +1,589 @@
+"""Two-OS-process regression for the shared xAI OAuth store (#65394 / PR #67261).
+
+Acceptance boundary this file alone covers:
+
+* Two **separate OS processes** (distinct interpreter PIDs), each with its own
+  ``HERMES_HOME``, both pointing at one shared ``HERMES_SHARED_AUTH_DIR``.
+* Real kernel advisory locking (``fcntl.flock`` on ``xai_oauth.json.lock``),
+  not an in-process ``threading`` stand-in.
+* Exactly **one** refresh POST to a single-use local HTTP stub; the loser
+  must adopt the winner's rotated tokens instead of re-POSTing the burned RT.
+
+This deliberately does **not** monkeypatch the shared lock, the resolve/adopt
+path, or ``refresh_xai_oauth_pure``'s HTTP body. The only worker-side patch is
+``_xai_validate_oauth_endpoint`` so a loopback stub URL is accepted (production
+pins ``*.x.ai`` HTTPS — that pin is unit-tested elsewhere).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import threading
+import time
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import pytest
+
+# Repo root so worker subprocesses can import hermes_cli with PYTHONPATH=.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKER_FLAG = "--xai-shared-auth-two-process-worker"
+
+
+# ---------------------------------------------------------------------------
+# Helpers (parent + worker)
+# ---------------------------------------------------------------------------
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').decode().rstrip("=")
+    payload = (
+        base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).decode().rstrip("=")
+    )
+    return f"{header}.{payload}.sig"
+
+
+def _wait_for_path(path: Path, timeout: float, *, label: str) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.01)
+    raise TimeoutError(f"timed out after {timeout}s waiting for {label}: {path}")
+
+
+def _wait_for_paths(paths: Tuple[Path, ...], timeout: float, *, label: str) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if all(p.exists() for p in paths):
+            return
+        time.sleep(0.01)
+    missing = [str(p) for p in paths if not p.exists()]
+    raise TimeoutError(f"timed out after {timeout}s waiting for {label}; missing={missing}")
+
+
+def _scrub_credential_env(env: Dict[str, str]) -> Dict[str, str]:
+    """Drop credential-shaped vars so workers cannot inherit live keys."""
+    suffixes = (
+        "_API_KEY",
+        "_TOKEN",
+        "_SECRET",
+        "_PASSWORD",
+        "_CREDENTIALS",
+        "_ACCESS_KEY",
+        "_SECRET_ACCESS_KEY",
+        "_PRIVATE_KEY",
+        "_OAUTH_TOKEN",
+    )
+    # Keep our coordination env vars even if a suffix would match by accident.
+    keep_prefixes = ("HERMES_XAI_TP_",)
+    out: Dict[str, str] = {}
+    for key, value in env.items():
+        if any(key.startswith(p) for p in keep_prefixes):
+            out[key] = value
+            continue
+        if key in {
+            "XAI_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+        }:
+            continue
+        if any(key.endswith(suf) for suf in suffixes):
+            continue
+        out[key] = value
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Single-use refresh stub (parent process)
+# ---------------------------------------------------------------------------
+
+
+class _SingleUseRefreshStub:
+    """Local token endpoint that burns the seeded RT on first successful POST.
+
+    * First POST presenting ``seed_rt`` → 200 with rotated tokens (gen2).
+      The response is **held** until ``release_path`` exists so the second
+      OS process can queue on the shared flock while the winner still holds it.
+    * Any later POST with the same consumed RT → 400 ``invalid_grant``.
+    * Thread-safe counters for successful / invalid_grant POSTs.
+    """
+
+    def __init__(
+        self,
+        *,
+        seed_rt: str,
+        rotated_access: str,
+        rotated_refresh: str,
+        first_post_path: Path,
+        release_path: Path,
+        hold_timeout: float = 20.0,
+    ) -> None:
+        self.seed_rt = seed_rt
+        self.rotated_access = rotated_access
+        self.rotated_refresh = rotated_refresh
+        self.first_post_path = first_post_path
+        self.release_path = release_path
+        self.hold_timeout = hold_timeout
+        self._lock = threading.Lock()
+        self.success_posts = 0
+        self.invalid_grant_posts = 0
+        self.other_posts = 0
+        self._server: Optional[ThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+        self.token_endpoint = ""
+
+    def start(self) -> str:
+        stub = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802 — http.server API
+                length = int(self.headers.get("Content-Length", "0") or 0)
+                raw = self.rfile.read(length).decode("utf-8") if length else ""
+                params = urllib.parse.parse_qs(raw, keep_blank_values=True)
+                rt = (params.get("refresh_token") or [""])[0]
+                grant = (params.get("grant_type") or [""])[0]
+
+                hold_after_claim = False
+                status = 400
+                body: Dict[str, Any] = {
+                    "error": "invalid_request",
+                    "error_description": "unexpected",
+                }
+
+                with stub._lock:
+                    if grant != "refresh_token" or not rt:
+                        stub.other_posts += 1
+                        body = {
+                            "error": "invalid_request",
+                            "error_description": "missing grant_type or refresh_token",
+                        }
+                    elif rt == stub.seed_rt:
+                        if stub.success_posts >= 1:
+                            # Seeded RT already consumed — single-use enforcement.
+                            stub.invalid_grant_posts += 1
+                            body = {
+                                "error": "invalid_grant",
+                                "error_description": "refresh_token already used",
+                            }
+                        else:
+                            stub.success_posts += 1
+                            hold_after_claim = True
+                            status = 200
+                            body = {
+                                "access_token": stub.rotated_access,
+                                "refresh_token": stub.rotated_refresh,
+                                "token_type": "Bearer",
+                                "expires_in": 3600,
+                            }
+                    else:
+                        stub.other_posts += 1
+                        body = {
+                            "error": "invalid_grant",
+                            "error_description": "unknown refresh_token",
+                        }
+
+                if hold_after_claim:
+                    # Signal parent that the winner is inside pure-refresh HTTP
+                    # while still holding the shared flock.
+                    stub.first_post_path.write_text("1", encoding="utf-8")
+                    deadline = time.monotonic() + stub.hold_timeout
+                    while not stub.release_path.exists():
+                        if time.monotonic() >= deadline:
+                            # Fail loud rather than release early and race.
+                            status = 500
+                            body = {
+                                "error": "server_error",
+                                "error_description": "hold timeout waiting for release",
+                            }
+                            break
+                        time.sleep(0.01)
+
+                payload = json.dumps(body).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+                return  # silence access log noise in pytest output
+
+        # Bind ephemeral port on loopback only.
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._server = server
+        host, port = server.server_address[:2]
+        self.token_endpoint = f"http://{host}:{port}/oauth/token"
+        self._thread = threading.Thread(target=server.serve_forever, daemon=True)
+        self._thread.start()
+        return self.token_endpoint
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+
+
+# ---------------------------------------------------------------------------
+# Worker entrypoint (runs in a child OS process)
+# ---------------------------------------------------------------------------
+
+
+def _worker_main() -> int:
+    """Child process: barrier → real resolve/refresh → write result JSON."""
+    label = os.environ["HERMES_XAI_TP_LABEL"]
+    coord = Path(os.environ["HERMES_XAI_TP_COORD"])
+    result_path = Path(os.environ["HERMES_XAI_TP_RESULT"])
+    stub_url = os.environ["HERMES_XAI_TP_TOKEN_ENDPOINT"]
+    expired_at = os.environ["HERMES_XAI_TP_EXPIRED_AT"]
+    barrier_timeout = float(os.environ.get("HERMES_XAI_TP_BARRIER_TIMEOUT", "25"))
+
+    def _write_result(payload: Dict[str, Any], *, exit_code: int) -> int:
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+        return exit_code
+
+    # Phase 1: filesystem barrier — both children must arrive before either
+    # enters resolve, so they genuinely contend on the flock.
+    try:
+        (coord / f"ready_{label}").write_text(str(os.getpid()), encoding="utf-8")
+        _wait_for_path(coord / "go", barrier_timeout, label="parent go signal")
+    except Exception as exc:
+        return _write_result(
+            {
+                "ok": False,
+                "pid": os.getpid(),
+                "error": f"barrier: {type(exc).__name__}: {exc}",
+            },
+            exit_code=2,
+        )
+
+    # Allow the loopback stub as token_endpoint. Production validation pins
+    # https://*.x.ai; we do NOT patch the lock, pure-refresh HTTP, or adopt path.
+    from hermes_cli import auth
+
+    real_validate = auth._xai_validate_oauth_endpoint
+
+    def _allow_stub_endpoint(url: str, *, field: str) -> str:
+        if url == stub_url:
+            return url
+        return real_validate(url, field=field)
+
+    auth._xai_validate_oauth_endpoint = _allow_stub_endpoint  # type: ignore[assignment]
+
+    (coord / f"starting_{label}").write_text(str(os.getpid()), encoding="utf-8")
+
+    try:
+        creds = auth.resolve_xai_oauth_runtime_credentials(
+            force_refresh=True,
+            rejected_access_token=expired_at,
+            expected_generation=1,
+        )
+    except Exception as exc:
+        return _write_result(
+            {
+                "ok": False,
+                "pid": os.getpid(),
+                "error": f"{type(exc).__name__}: {exc}",
+                "code": getattr(exc, "code", None),
+            },
+            exit_code=1,
+        )
+
+    return _write_result(
+        {
+            "ok": True,
+            "pid": os.getpid(),
+            "api_key": creds.get("api_key"),
+            "generation": creds.get("generation"),
+            "source": creds.get("source"),
+            "auth_store": creds.get("auth_store"),
+            "error": None,
+            "code": None,
+        },
+        exit_code=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parent test
+# ---------------------------------------------------------------------------
+
+
+def test_two_os_processes_shared_store_one_refresh_loser_adopts(tmp_path: Path) -> None:
+    """#65394 multi-profile/multi-gateway death scenario — real two-process path.
+
+    Spawns two genuine child interpreters with distinct HERMES_HOME roots and
+    one shared auth dir. A single-use HTTP stub + filesystem barrier force
+    flock contention so exactly one process POSTs and the other adopts.
+    """
+    import subprocess
+
+    from hermes_cli import auth
+
+    shared_dir = tmp_path / "shared"
+    root_a = tmp_path / "rootA"
+    root_b = tmp_path / "rootB"
+    home_sandbox = tmp_path / "home"
+    coord = tmp_path / "coord"
+    for path in (shared_dir, root_a, root_b, home_sandbox, coord):
+        path.mkdir()
+
+    # Empty profile-root under sandbox HOME so fleet enumeration never
+    # walks the real user's ~/.hermes/profiles (HOME-anchored).
+    (home_sandbox / ".hermes" / "profiles").mkdir(parents=True)
+
+    seed_rt = "seed-rt-single-use-gen1"
+    rotated_access = "rotated-access-token-gen2"
+    rotated_refresh = "rotated-refresh-token-gen2"
+    expired_access = _jwt(int(time.time()) - 120)
+
+    first_post_path = coord / "first_post_received"
+    release_path = coord / "release_first_response"
+
+    stub = _SingleUseRefreshStub(
+        seed_rt=seed_rt,
+        rotated_access=rotated_access,
+        rotated_refresh=rotated_refresh,
+        first_post_path=first_post_path,
+        release_path=release_path,
+        hold_timeout=20.0,
+    )
+    token_endpoint = stub.start()
+    try:
+        # Seed canonical shared store: generation 1, expired AT, single-use RT.
+        store_path = shared_dir / "xai_oauth.json"
+        store_path.write_text(
+            json.dumps(
+                {
+                    "_schema": 1,
+                    "generation": 1,
+                    "access_token": expired_access,
+                    "refresh_token": seed_rt,
+                    "token_type": "Bearer",
+                    "auth_mode": "oauth_device_code",
+                    "last_refresh": "2026-07-01T00:00:00Z",
+                    "discovery": {"token_endpoint": token_endpoint},
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(store_path, 0o600)
+
+        # Clean per-root auth.json — no local RT forks to start with.
+        empty_auth = json.dumps({"version": 1, "providers": {}}, indent=2) + "\n"
+        for root in (root_a, root_b):
+            (root / "auth.json").write_text(empty_auth, encoding="utf-8")
+            os.chmod(root / "auth.json", 0o600)
+
+        parent_pid = os.getpid()
+        result_a = coord / "result_a.json"
+        result_b = coord / "result_b.json"
+
+        base_env = _scrub_credential_env(dict(os.environ))
+        base_env.update(
+            {
+                "PYTHONPATH": str(_REPO_ROOT),
+                "TZ": "UTC",
+                "LANG": "C.UTF-8",
+                "HOME": str(home_sandbox),
+                "HERMES_XAI_SHARED_AUTH": "1",
+                "HERMES_SHARED_AUTH_DIR": str(shared_dir),
+                "HERMES_XAI_TP_COORD": str(coord),
+                "HERMES_XAI_TP_TOKEN_ENDPOINT": token_endpoint,
+                "HERMES_XAI_TP_EXPIRED_AT": expired_access,
+                "HERMES_XAI_TP_BARRIER_TIMEOUT": "25",
+                # Keep refresh + lock windows bounded for the test.
+                "HERMES_XAI_REFRESH_TIMEOUT_SECONDS": "15",
+                # Seat belt: refuse real-user shared path if misconfigured.
+                "PYTEST_CURRENT_TEST": (
+                    "tests/hermes_cli/test_xai_shared_auth_two_process.py::"
+                    "test_two_os_processes_shared_store_one_refresh_loser_adopts"
+                ),
+            }
+        )
+        # Do not inherit a parent HERMES_HOME into children; each sets its own.
+        base_env.pop("HERMES_HOME", None)
+
+        worker_cmd = [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            _WORKER_FLAG,
+        ]
+        env_a = {
+            **base_env,
+            "HERMES_HOME": str(root_a),
+            "HERMES_XAI_TP_LABEL": "a",
+            "HERMES_XAI_TP_RESULT": str(result_a),
+        }
+        env_b = {
+            **base_env,
+            "HERMES_HOME": str(root_b),
+            "HERMES_XAI_TP_LABEL": "b",
+            "HERMES_XAI_TP_RESULT": str(result_b),
+        }
+
+        proc_a = subprocess.Popen(
+            worker_cmd,
+            env=env_a,
+            cwd=str(_REPO_ROOT),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        proc_b = subprocess.Popen(
+            worker_cmd,
+            env=env_b,
+            cwd=str(_REPO_ROOT),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        try:
+            # Barrier: both children ready, then release them together.
+            _wait_for_paths(
+                (coord / "ready_a", coord / "ready_b"),
+                20.0,
+                label="both workers ready",
+            )
+            (coord / "go").write_text("1", encoding="utf-8")
+
+            # Winner must enter pure-refresh (first POST) AND both must have
+            # entered resolve so the loser is blocked on the advisory lock
+            # while the stub still holds the winner's HTTP response.
+            _wait_for_paths(
+                (
+                    first_post_path,
+                    coord / "starting_a",
+                    coord / "starting_b",
+                ),
+                20.0,
+                label="first POST held + both workers in resolve",
+            )
+            # Tiny beat so the non-holder has entered the flock wait loop
+            # (non-blocking flock retries every 50ms in _file_lock).
+            time.sleep(0.08)
+            release_path.write_text("1", encoding="utf-8")
+
+            try:
+                out_a, err_a = proc_a.communicate(timeout=35)
+            except subprocess.TimeoutExpired:
+                proc_a.kill()
+                out_a, err_a = proc_a.communicate(timeout=5)
+            try:
+                out_b, err_b = proc_b.communicate(timeout=35)
+            except subprocess.TimeoutExpired:
+                proc_b.kill()
+                out_b, err_b = proc_b.communicate(timeout=5)
+        finally:
+            if proc_a.poll() is None:
+                proc_a.kill()
+            if proc_b.poll() is None:
+                proc_b.kill()
+
+        def _load_result(path: Path, *, name: str, rc: int, err: str) -> Dict[str, Any]:
+            if not path.is_file():
+                pytest.fail(
+                    f"{name}: no result file (rc={rc}). stderr={err!r}"
+                )
+            return json.loads(path.read_text(encoding="utf-8"))
+
+        payload_a = _load_result(result_a, name="worker-a", rc=proc_a.returncode, err=err_a)
+        payload_b = _load_result(result_b, name="worker-b", rc=proc_b.returncode, err=err_b)
+
+        # --- PID sanity: genuine separate OS processes ---
+        pid_a = int(payload_a["pid"])
+        pid_b = int(payload_b["pid"])
+        assert pid_a != pid_b, "workers must have distinct PIDs"
+        assert pid_a != parent_pid and pid_b != parent_pid, (
+            "workers must not share the parent PID"
+        )
+        assert pid_a == proc_a.pid and pid_b == proc_b.pid
+
+        # --- Both resolve successfully (loser must not hit invalid_grant) ---
+        if not payload_a.get("ok") or not payload_b.get("ok"):
+            pytest.fail(
+                "one or both workers failed resolve/refresh:\n"
+                f"  A: {payload_a}\n"
+                f"  B: {payload_b}\n"
+                f"  stub success={stub.success_posts} invalid_grant={stub.invalid_grant_posts}\n"
+                f"  stderr_a={err_a!r}\n"
+                f"  stderr_b={err_b!r}\n"
+                f"  stdout_a={out_a!r}\n"
+                f"  stdout_b={out_b!r}"
+            )
+
+        # --- Exactly one successful refresh POST; no invalid_grant ---
+        assert stub.success_posts == 1, (
+            f"expected exactly one successful refresh POST, got {stub.success_posts}; "
+            f"invalid_grant={stub.invalid_grant_posts} other={stub.other_posts}"
+        )
+        assert stub.invalid_grant_posts == 0, (
+            "loser re-POSTed the consumed RT (invalid_grant) — adopt/lock regressed"
+        )
+        assert stub.other_posts == 0
+
+        # --- Both processes use the winner's rotated access token ---
+        assert payload_a["api_key"] == rotated_access
+        assert payload_b["api_key"] == rotated_access
+        assert payload_a["generation"] == 2
+        assert payload_b["generation"] == 2
+        assert payload_a["source"] == auth.XAI_SHARED_SOURCE
+        assert payload_b["source"] == auth.XAI_SHARED_SOURCE
+
+        # --- Shared store advanced exactly once; one rotated RT ---
+        shared_state = json.loads(store_path.read_text(encoding="utf-8"))
+        assert shared_state["generation"] == 2
+        assert shared_state["access_token"] == rotated_access
+        assert shared_state["refresh_token"] == rotated_refresh
+        assert shared_state["refresh_token"] != seed_rt
+
+        # --- Neither HERMES_HOME retains a durable local xAI RT fork ---
+        for root, name in ((root_a, "rootA"), (root_b, "rootB")):
+            auth_path = root / "auth.json"
+            assert auth_path.is_file(), f"{name} missing auth.json after resolve"
+            store = json.loads(auth_path.read_text(encoding="utf-8"))
+            assert not auth._auth_store_holds_durable_xai_refresh_token(store), (
+                f"{name} retained a durable xAI refresh_token fork: {store}"
+            )
+            state = (store.get("providers") or {}).get("xai-oauth") or {}
+            assert state.get("source") == auth.XAI_SHARED_SOURCE, (
+                f"{name} profile source should be shared reference, got {state!r}"
+            )
+            assert "tokens" not in state or not (
+                isinstance(state.get("tokens"), dict)
+                and str(state["tokens"].get("refresh_token") or "").strip()
+            )
+            assert not str(state.get("refresh_token") or "").strip()
+            pool = (store.get("credential_pool") or {}).get("xai-oauth") or []
+            for entry in pool:
+                if not isinstance(entry, dict):
+                    continue
+                assert not str(entry.get("refresh_token") or "").strip(), (
+                    f"{name} credential_pool retained refresh_token: {entry}"
+                )
+    finally:
+        stub.stop()
+
+
+if __name__ == "__main__":
+    if _WORKER_FLAG in sys.argv:
+        raise SystemExit(_worker_main())
+    raise SystemExit(
+        f"This module is a pytest file. Worker mode: python {sys.argv[0]} {_WORKER_FLAG}"
+    )

--- a/tests/plugins/video_gen/test_xai_plugin.py
+++ b/tests/plugins/video_gen/test_xai_plugin.py
@@ -224,3 +224,148 @@ def test_xai_video_file_input_blocks_credential_store_symlink(tmp_path, monkeypa
 
     with pytest.raises(ValueError, match="credential store"):
         _video_ref_to_xai_url(str(video_link))
+
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+
+def test_f5_submit_propagates_refreshed_bearer_to_poll():
+    """F5: submit 401 → refresh → poll uses the NEW bearer."""
+    from plugins.video_gen.xai import _submit, _poll
+
+    stale = "stale-bearer"
+    fresh = "fresh-bearer"
+    poll_keys = []
+
+    class FakeResponse:
+        def __init__(self, status, payload):
+            self.status_code = status
+            self._payload = payload
+            self.text = str(payload)
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError(
+                    "err",
+                    request=MagicMock(),
+                    response=self,
+                )
+
+        def json(self):
+            return self._payload
+
+    submit_calls = {"n": 0}
+
+    async def fake_post(url, **kwargs):
+        submit_calls["n"] += 1
+        headers = kwargs.get("headers") or {}
+        authz = headers.get("Authorization") or headers.get("authorization") or ""
+        if submit_calls["n"] == 1:
+            assert stale in authz
+            return FakeResponse(401, {"error": "unauthorized"})
+        assert fresh in authz
+        return FakeResponse(200, {"request_id": "req-1"})
+
+    async def fake_get(url, **kwargs):
+        headers = kwargs.get("headers") or {}
+        authz = headers.get("Authorization") or headers.get("authorization") or ""
+        poll_keys.append(authz)
+        return FakeResponse(200, {"status": "done", "video": {"url": "https://x/v.mp4"}})
+
+    client = MagicMock()
+    client.post = fake_post
+    client.get = fake_get
+
+    def fake_refresh(rejected=None):
+        assert rejected == stale
+        return {"api_key": fresh, "base_url": "https://api.x.ai/v1"}
+
+    async def run():
+        with patch(
+            "tools.xai_http.force_refresh_xai_http_credentials",
+            side_effect=fake_refresh,
+        ):
+            request_id, active_key = await _submit(
+                client,
+                {"model": "grok-imagine-video", "prompt": "hi"},
+                api_key=stale,
+                base_url="https://api.x.ai/v1",
+            )
+            assert request_id == "req-1"
+            assert active_key == fresh
+            result = await _poll(
+                client,
+                request_id,
+                api_key=active_key,
+                base_url="https://api.x.ai/v1",
+                timeout_seconds=5,
+                poll_interval=1,
+            )
+            assert result["status"] == "done"
+
+    asyncio.run(run())
+    assert any(fresh in k for k in poll_keys)
+    assert not any(stale in k for k in poll_keys)
+
+
+def test_f5_poll_one_canonical_401_recovery():
+    """F5: poll 401 → one canonical recovery then succeeds."""
+    from plugins.video_gen.xai import _poll
+
+    stale = "stale-poll"
+    fresh = "fresh-poll"
+    get_calls = {"n": 0}
+
+    class FakeResponse:
+        def __init__(self, status, payload):
+            self.status_code = status
+            self._payload = payload
+            self.text = str(payload)
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError(
+                    "err",
+                    request=MagicMock(),
+                    response=self,
+                )
+
+        def json(self):
+            return self._payload
+
+    async def fake_get(url, **kwargs):
+        get_calls["n"] += 1
+        headers = kwargs.get("headers") or {}
+        authz = headers.get("Authorization") or ""
+        if get_calls["n"] == 1:
+            assert stale in authz
+            return FakeResponse(401, {"error": "unauthorized"})
+        assert fresh in authz
+        return FakeResponse(200, {"status": "done", "video": {}})
+
+    client = MagicMock()
+    client.get = fake_get
+
+    def fake_refresh(rejected=None):
+        return {"api_key": fresh}
+
+    async def run():
+        with patch(
+            "tools.xai_http.force_refresh_xai_http_credentials",
+            side_effect=fake_refresh,
+        ):
+            result = await _poll(
+                client,
+                "req-2",
+                api_key=stale,
+                base_url="https://api.x.ai/v1",
+                timeout_seconds=5,
+                poll_interval=1,
+            )
+            assert result["status"] == "done"
+
+    asyncio.run(run())
+    assert get_calls["n"] == 2

--- a/tests/tools/test_xai_http_shared_mode.py
+++ b/tests/tools/test_xai_http_shared_mode.py
@@ -1,0 +1,273 @@
+"""C1/C2/C3: xai_http consumers under canonical shared xAI OAuth mode."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import auth
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').decode().rstrip("=")
+    payload = (
+        base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).decode().rstrip("=")
+    )
+    return f"{header}.{payload}.sig"
+
+
+@pytest.fixture
+def shared_env(tmp_path, monkeypatch):
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    monkeypatch.setenv("HERMES_XAI_SHARED_AUTH", "1")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    return {
+        "shared_dir": shared_dir,
+        "hermes_home": hermes_home,
+        "store": shared_dir / "xai_oauth.json",
+        "profile_auth": hermes_home / "auth.json",
+    }
+
+
+def _write_shared(env, *, access="at-1", refresh="rt-1", generation=1):
+    payload = {
+        "_schema": 1,
+        "generation": generation,
+        "access_token": access,
+        "refresh_token": refresh,
+        "token_type": "Bearer",
+        "auth_mode": "oauth_device_code",
+        "last_refresh": "2026-07-01T00:00:00Z",
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth/token"},
+    }
+    env["store"].write_text(json.dumps(payload), encoding="utf-8")
+    return payload
+
+
+def test_has_xai_credentials_true_under_clean_shared(shared_env):
+    """C2: clean shared mode (no profile tokens) still reports available."""
+    from tools.xai_http import has_xai_credentials
+
+    _write_shared(shared_env, access="shared-at", refresh="shared-rt")
+    # No profile auth.json at all.
+    assert not shared_env["profile_auth"].exists()
+    assert has_xai_credentials() is True
+
+
+def test_has_xai_credentials_false_when_profile_disabled(shared_env):
+    from tools.xai_http import has_xai_credentials
+
+    _write_shared(shared_env)
+    auth.disable_profile_xai_shared_auth()
+    assert has_xai_credentials() is False
+
+
+def test_has_xai_credentials_fail_closed_on_shared_read_error(shared_env, monkeypatch):
+    """R7: shared-mode canonical READ error → False (no legacy fallthrough)."""
+    from tools.xai_http import has_xai_credentials
+
+    _write_shared(shared_env, access="shared-at", refresh="shared-rt")
+    # Plant a legacy pool row that would have been "available" under gate-off.
+    shared_env["profile_auth"].write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "xai-oauth": {
+                        "tokens": {
+                            "access_token": "legacy-at",
+                            "refresh_token": "legacy-rt",
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def boom(**_k):
+        raise auth.AuthError(
+            "unreadable",
+            provider="xai-oauth",
+            code="xai_shared_store_unreadable",
+        )
+
+    monkeypatch.setattr(auth, "_read_shared_xai_state", boom)
+    assert has_xai_credentials() is False
+
+
+def test_has_xai_credentials_recognizes_root_only_promotable(shared_env, monkeypatch):
+    """R7: empty shared + root-only sole live grant → True (matches promoter)."""
+    from tools.xai_http import has_xai_credentials
+
+    # No shared store, no active-profile grant.
+    assert not shared_env["store"].exists()
+    root_auth = shared_env["hermes_home"].parent / "root_auth.json"
+    root_auth.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "xai-oauth": {
+                        "tokens": {
+                            "access_token": "root-at",
+                            "refresh_token": "root-rt",
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_auth)
+    monkeypatch.setattr(
+        auth,
+        "_load_global_auth_store",
+        lambda: json.loads(root_auth.read_text(encoding="utf-8")),
+    )
+    assert has_xai_credentials() is True
+
+
+def test_resolve_canonical_first_over_legacy_pool(shared_env):
+    """C1/A6: legacy pool RT must not win over the shared grant."""
+    from tools.xai_http import resolve_xai_http_credentials
+
+    _write_shared(shared_env, access="shared-at", refresh="shared-rt", generation=5)
+    # Poison profile pool with a different access token that would win pool-first.
+    shared_env["profile_auth"].write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "legacy",
+                            "source": "device_code",
+                            "auth_type": "oauth",
+                            "access_token": "legacy-pool-at",
+                            "refresh_token": "legacy-pool-rt",
+                            "priority": 0,
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    creds = resolve_xai_http_credentials()
+    assert creds["api_key"] == "shared-at"
+    assert creds.get("source") == auth.XAI_SHARED_SOURCE
+
+
+def test_force_refresh_passes_rejected_bearer(shared_env, monkeypatch):
+    """C3 helper adopts winner when generation already moved."""
+    from tools.xai_http import force_refresh_xai_http_credentials
+
+    old = _jwt(int(time.time()) + 30)
+    _write_shared(shared_env, access=old, refresh="rt-old", generation=1)
+    posts = []
+
+    def fake_pure(access, refresh, **kwargs):
+        posts.append(refresh)
+        return {
+            "access_token": "new-at",
+            "refresh_token": "new-rt",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-18T00:00:00Z",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", fake_pure)
+    # Concurrent winner already rotated.
+    _write_shared(shared_env, access="winner-at", refresh="winner-rt", generation=2)
+
+    creds = force_refresh_xai_http_credentials(old)
+    assert posts == []
+    assert creds["api_key"] == "winner-at"
+
+
+def test_x_search_retries_after_401(shared_env, monkeypatch):
+    """C3: x_search refreshes once on 401 and retries."""
+    import requests
+    from tools import x_search_tool
+
+    _write_shared(
+        shared_env,
+        access=_jwt(int(time.time()) + 3600),
+        refresh="rt-1",
+        generation=1,
+    )
+
+    calls = {"n": 0}
+    refresh_calls = {"n": 0}
+
+    class FakeResp:
+        def __init__(self, status, payload=None):
+            self.status_code = status
+            self._payload = payload or {}
+            self.text = json.dumps(self._payload)
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                err = requests.HTTPError(f"{self.status_code}")
+                err.response = self
+                raise err
+
+        def json(self):
+            return self._payload
+
+    def fake_post(url, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return FakeResp(401, {"error": "bad token"})
+        return FakeResp(
+            200,
+            {
+                "output_text": "ok",
+                "citations": [],
+                "output": [],
+            },
+        )
+
+    def fake_refresh(rejected=None):
+        refresh_calls["n"] += 1
+        return {
+            "provider": "xai-oauth",
+            "api_key": "fresh-at",
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(x_search_tool.requests, "post", fake_post)
+    monkeypatch.setattr(
+        x_search_tool,
+        "resolve_xai_http_credentials",
+        lambda **kw: {
+            "provider": "xai-oauth",
+            "api_key": "stale-at",
+            "base_url": "https://api.x.ai/v1",
+        },
+    )
+    monkeypatch.setattr(
+        "tools.xai_http.force_refresh_xai_http_credentials",
+        fake_refresh,
+    )
+    monkeypatch.setattr(x_search_tool, "_get_x_search_retries", lambda: 0)
+    monkeypatch.setattr(x_search_tool, "_get_x_search_timeout_seconds", lambda: 5)
+    monkeypatch.setattr(x_search_tool, "_get_x_search_model", lambda: "grok-4")
+
+    result = x_search_tool.x_search_tool("hello")
+    data = json.loads(result)
+    assert data.get("answer") == "ok" or "ok" in result
+    assert calls["n"] == 2
+    assert refresh_calls["n"] == 1

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1740,18 +1740,54 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
     if text_normalization:
         payload["text_normalization"] = True
 
-    response = requests.post(
-        f"{base_url}/tts",
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-            "User-Agent": hermes_xai_user_agent(),
-        },
-        json=payload,
-        timeout=60,
-        stream=True,
-    )
-    response.raise_for_status()
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": hermes_xai_user_agent(),
+    }
+    provider_name = str(creds.get("provider") or "xai")
+    response = None
+    last_http_exc = None
+    for attempt in range(2):
+        try:
+            response = requests.post(
+                f"{base_url}/tts",
+                headers=headers,
+                json=payload,
+                timeout=60,
+                stream=True,
+            )
+            response.raise_for_status()
+            last_http_exc = None
+            break
+        except requests.HTTPError as exc:
+            last_http_exc = exc
+            status = exc.response.status_code if exc.response is not None else 0
+            # C3: one canonical refresh + retry on 401/403 for OAuth.
+            if (
+                attempt == 0
+                and status in {401, 403}
+                and provider_name == "xai-oauth"
+            ):
+                try:
+                    from tools.xai_http import force_refresh_xai_http_credentials
+
+                    refreshed = force_refresh_xai_http_credentials(api_key)
+                    new_key = str(refreshed.get("api_key") or "").strip()
+                    if new_key and new_key != api_key:
+                        api_key = new_key
+                        headers["Authorization"] = f"Bearer {api_key}"
+                        continue
+                except Exception as refresh_exc:
+                    logger.debug(
+                        "xAI TTS OAuth refresh after %s failed: %s",
+                        status,
+                        refresh_exc,
+                    )
+            break
+    if last_http_exc is not None:
+        raise last_http_exc
+    assert response is not None
 
     _write_tts_response_to_file(response, output_path, label="xAI TTS")
 

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -352,7 +352,10 @@ def x_search_tool(
         timeout_seconds = _get_x_search_timeout_seconds()
         max_retries = _get_x_search_retries()
         response: Optional[requests.Response] = None
-        for attempt in range(max_retries + 1):
+        auth_refreshed = False
+        # +1 extra slot so a one-shot 401/403 auth refresh can retry even when
+        # max_retries is 0 (C3 must not depend on the 5xx retry budget).
+        for attempt in range(max_retries + 1 + (1 if source == "xai-oauth" else 0)):
             try:
                 response = requests.post(
                     f"{base_url}/responses",
@@ -368,6 +371,37 @@ def x_search_tool(
                 break
             except requests.HTTPError as e:
                 status_code = getattr(getattr(e, "response", None), "status_code", None)
+                # C3: on 401/403 auth failure, canonical-refresh once and retry.
+                if (
+                    status_code in {401, 403}
+                    and not auth_refreshed
+                    and source == "xai-oauth"
+                ):
+                    auth_refreshed = True
+                    try:
+                        from tools.xai_http import force_refresh_xai_http_credentials
+
+                        refreshed = force_refresh_xai_http_credentials(api_key)
+                        new_key = str(refreshed.get("api_key") or "").strip()
+                        if new_key and new_key != api_key:
+                            logger.info(
+                                "x_search got %s; refreshed xAI OAuth and retrying once",
+                                status_code,
+                            )
+                            api_key = new_key
+                            base_url = str(
+                                refreshed.get("base_url") or base_url
+                            ).strip().rstrip("/")
+                            continue
+                    except Exception as refresh_exc:
+                        logger.warning(
+                            "x_search OAuth refresh after %s failed: %s",
+                            status_code,
+                            refresh_exc,
+                        )
+                # Auth failures (after optional refresh) are terminal.
+                if status_code in {401, 403}:
+                    raise
                 if status_code is None or status_code < 500 or attempt >= max_retries:
                     raise
                 logger.warning(

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -26,11 +26,15 @@ def has_xai_credentials() -> bool:
     Resolution order, fast-to-slow:
 
     1. ``XAI_API_KEY`` env var (cheapest; covers explicit-key users).
-    2. ``~/.hermes/auth.json`` has a non-empty ``providers.xai-oauth.tokens.access_token``
-       (single file read, no expiry check, no refresh).
-    3. ``credential_pool.xai-oauth`` has any entry with a non-empty
-       ``access_token`` (covers multi-account ``hermes auth add xai-oauth``
-       grants that are pool-only / ``manual:device_code``).
+    2. **Shared mode (C2/F2/R7/H2):** the canonical shared store has usable
+       tokens (single file read, no refresh). Profile-disabled → False.
+       Empty shared + sole live local grant that can be auto-promoted (F1) →
+       True only when profile AND root together yield exactly one distinct
+       live identity (matches the promoter; no profile-first short-circuit).
+       Canonical READ / unreadable-store errors fail closed (False) with NO
+       legacy fallthrough.
+    3. (gate OFF only) ``~/.hermes/auth.json`` providers.xai-oauth access_token
+       or pool-only grants.
 
     Returns False on any exception so a corrupted auth store can't block
     other availability scans. Truthful refresh + expiry handling happens
@@ -38,6 +42,33 @@ def has_xai_credentials() -> bool:
     """
     if os.environ.get("XAI_API_KEY", "").strip():
         return True
+    try:
+        from hermes_cli import auth as auth_mod
+    except Exception:
+        auth_mod = None
+
+    # R7: under shared mode, never fall through to the legacy profile scan.
+    if auth_mod is not None and auth_mod._xai_shared_auth_enabled():
+        try:
+            if auth_mod._profile_xai_shared_disabled():
+                return False
+            shared = auth_mod._read_shared_xai_state(raise_on_unreadable=True)
+            if auth_mod._xai_shared_state_has_usable_tokens(shared):
+                return True
+            # Tombstoned / quarantined: not available, not promotable.
+            if auth_mod._shared_xai_state_is_quarantined(shared):
+                return False
+            # F1/R7/H2: never-initialized shared still counts when a sole live
+            # local grant can be auto-promoted. Consider profile AND root
+            # together (no profile-first short-circuit that would advertise
+            # available while the promoter rejects cross-store ambiguity).
+            return bool(
+                auth_mod._xai_sole_live_promotable_across_profile_and_root_for_probe()
+            )
+        except Exception:
+            # Shared-mode read/audit failure → fail closed (no legacy scan).
+            return False
+
     try:
         from hermes_constants import get_hermes_home
 
@@ -250,6 +281,11 @@ def maybe_mark_xai_storage_notice_seen(section_name: str) -> Optional[str]:
         return notice
 
 
+def is_xai_http_auth_status(status_code: Optional[int]) -> bool:
+    """True for HTTP statuses that mean the bearer is rejected (C3)."""
+    return status_code in {401, 403}
+
+
 def resolve_xai_http_credentials(
     *,
     force_refresh: bool = False,
@@ -268,10 +304,60 @@ def resolve_xai_http_credentials(
     Reactive callers should also pass the rejected bearer as ``api_key_hint``
     so a freshly loaded multi-account pool refreshes the exact issuing entry,
     not whichever entry its strategy would otherwise select first.
+
+    **Shared mode (C1/A6/F2):** resolves the canonical shared store first —
+    never pool-first — so a legacy local/manual pool row cannot win over the
+    fleet grant. On canonical failure / empty / profile-disabled, FAIL CLOSED:
+    do not select a surviving legacy pool row. Only ``XAI_API_KEY`` remains as
+    a non-OAuth fallback. Empty shared + sole local grant auto-promotes (F1)
+    via the shared resolver before any strip.
     """
+    import hermes_cli.auth as auth_mod
+
+    # C1/A6/F2: shared mode → canonical only (no legacy pool fallback).
+    if auth_mod._xai_shared_auth_enabled():
+        try:
+            creds = auth_mod.resolve_xai_oauth_runtime_credentials(
+                force_refresh=force_refresh,
+                refresh_if_expiring=not force_refresh,
+                rejected_access_token=api_key_hint,
+            )
+            access_token = str(creds.get("api_key") or "").strip()
+            if access_token:
+                override_base_url = str(
+                    get_env_value("HERMES_XAI_BASE_URL")
+                    or get_env_value("XAI_BASE_URL")
+                    or ""
+                ).strip().rstrip("/")
+                base_url = auth_mod._xai_validate_inference_base_url(
+                    override_base_url,
+                    fallback=str(
+                        creds.get("base_url") or auth_mod.DEFAULT_XAI_OAUTH_BASE_URL
+                    ).strip().rstrip("/"),
+                )
+                return {
+                    "provider": "xai-oauth",
+                    "api_key": access_token,
+                    "base_url": base_url,
+                    "source": auth_mod.XAI_SHARED_SOURCE,
+                    "generation": creds.get("generation"),
+                }
+        except Exception:
+            # Fail closed: do not select a legacy manual/pool OAuth row.
+            pass
+        # Non-OAuth API key is still allowed; OAuth pool is not.
+        api_key = str(get_env_value("XAI_API_KEY") or "").strip()
+        base_url = str(
+            get_env_value("XAI_BASE_URL") or "https://api.x.ai/v1"
+        ).strip().rstrip("/")
+        return {
+            "provider": "xai",
+            "api_key": api_key,
+            "base_url": base_url,
+        }
+
     try:
         from agent.credential_pool import load_pool
-        import hermes_cli.auth as auth_mod
 
         pool = load_pool("xai-oauth")
         entry = (
@@ -323,3 +409,13 @@ def resolve_xai_http_credentials(
         "api_key": api_key,
         "base_url": base_url,
     }
+
+
+def force_refresh_xai_http_credentials(
+    rejected_api_key: Optional[str] = None,
+) -> Dict[str, str]:
+    """C3 helper: canonical force-refresh after a 401/403 with the rejected bearer."""
+    return resolve_xai_http_credentials(
+        force_refresh=True,
+        api_key_hint=rejected_api_key,
+    )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -55,6 +55,15 @@ _hermes_home = get_hermes_home()
 load_hermes_dotenv(
     hermes_home=_hermes_home, project_env=Path(__file__).parent.parent / ".env"
 )
+# Bridge shared_auth.* (config.yaml) → internal HERMES_XAI_SHARED_AUTH etc.
+# so headless tui_gateway sees the same activation as CLI/gateway. Gate-off
+# (absent/empty shared_auth) leaves env alone.
+try:
+    from hermes_cli.config import apply_shared_auth_config_to_env
+
+    apply_shared_auth_config_to_env()
+except Exception:
+    logger.debug("shared_auth config → env bridge failed for tui_gateway", exc_info=True)
 
 
 # ── Panic logger ─────────────────────────────────────────────────────

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -224,13 +224,81 @@ The auth store has no `xai-oauth` entry and no `XAI_API_KEY` is set. You haven't
 
 ## Logging Out
 
-To remove all stored xAI Grok OAuth credentials:
+To remove all stored xAI Grok OAuth credentials (legacy per-profile mode):
 
 ```bash
 hermes auth logout xai-oauth
+# or
+hermes logout --provider xai-oauth
 ```
 
 This clears both the singleton OAuth entry in `auth.json` and any credential-pool rows for `xai-oauth`. Use `hermes auth remove xai-oauth <index|id|label>` if you only want to drop a single pool entry (run `hermes auth list xai-oauth` to see them).
+
+### Shared-store mode (multi-profile)
+
+xAI rotates the refresh token on every refresh. If each Hermes profile keeps its
+own copy, concurrent refreshes kill the whole grant family. **Shared xAI mode**
+keeps exactly one durable refresh token in a canonical store that every profile
+reads under a shared lock.
+
+**Opt-in only** (setting `HERMES_SHARED_AUTH_DIR` for Nous is not enough). The
+user-facing switch is **config.yaml**, not an environment variable
+(AGENTS.md: non-secret feature flags belong in config.yaml; Hermes bridges
+them to internal env vars at process startup, same pattern as
+`terminal.cwd` → `TERMINAL_CWD`):
+
+```yaml
+# ~/.hermes/config.yaml  (or a profile's config.yaml)
+shared_auth:
+  providers: [xai-oauth]
+  # optional: override shared directory (default <hermes-root>/shared/)
+  # dir: ~/.hermes/shared
+```
+
+Or enable via CLI (writes the same config key and bridges for the current process):
+
+```bash
+hermes auth xai enable-shared
+```
+
+Restart every gateway, cron worker, and desktop launch so they reload
+config.yaml — the internal bridge sets `HERMES_XAI_SHARED_AUTH` /
+`HERMES_SHARED_AUTH_PROVIDERS` from that file. Do **not** put those env vars
+in `.env` by hand; they are internal bridge targets.
+
+Canonical files (default root = `~/.hermes/shared/`):
+
+- `xai_oauth.json` — access + refresh tokens, generation, discovery metadata
+- `xai_oauth.lock` — cross-process advisory lock (requires a **local filesystem**
+  with reliable locking — not NFS/SMB)
+
+Prefer a local path under the machine Hermes root (not NFS/SMB).
+
+**Login** with shared mode on writes the grant into the shared store and leaves
+only a non-secret `source: shared:xai-oauth` reference in the profile.
+
+**Migrate** an existing legacy grant once (does not elect a winner by clock;
+prefers an explicit source, then strips local secret copies):
+
+```bash
+hermes auth xai enable-shared   # if not already enabled in config.yaml
+hermes auth xai migrate-shared --source auto
+# or: --source profile | --source root
+# --force overwrites an existing shared grant
+```
+
+**Logout / disable semantics:**
+
+```bash
+# Turn off shared mode in config.yaml (canonical grant stays on disk)
+hermes auth xai disable-shared
+
+# Per-profile logout while shared mode is still on (marker only; grant stays)
+hermes logout --provider xai-oauth
+
+# Global logout — deletes the grant for EVERY profile (noisy on purpose)
+hermes logout --provider xai-oauth --global
+```
 
 ## See Also
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -89,6 +89,9 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `OLLAMA_BASE_URL` | Override Ollama Cloud base URL (default: `https://ollama.com/v1`) |
 | `XAI_API_KEY` | xAI (Grok) API key for chat + TTS + web search ([console.x.ai](https://console.x.ai/)) |
 | `XAI_BASE_URL` | Override xAI base URL (default: `https://api.x.ai/v1`) |
+| `HERMES_XAI_SHARED_AUTH` | **Internal bridge target** — do not set by hand. Force-exported from config.yaml `shared_auth.providers` when the list includes an xAI alias (`xai-oauth` / `xai` / `grok-oauth` / `x-ai-oauth`). User-facing activation: `shared_auth.providers: [xai-oauth]` or `hermes auth xai enable-shared`. See [xAI Grok OAuth](../guides/xai-grok-oauth.md#shared-store-mode-multi-profile). |
+| `HERMES_SHARED_AUTH_PROVIDERS` | **Internal bridge target** — do not set by hand. Force-exported from config.yaml `shared_auth.providers` (comma-joined). Prefer the config key / `hermes auth xai enable-shared`. |
+| `HERMES_SHARED_AUTH_DIR` | Optional directory for cross-profile shared auth files (default: `<hermes-root>/shared/`). Holds `nous_auth.json` and, when shared xAI is enabled, `xai_oauth.json` + lock. Also settable via `shared_auth.dir` in config.yaml. Must be a **local** filesystem with reliable advisory locking (not NFS/SMB). Every gateway/cron/desktop process must resolve the same path. |
 | `MISTRAL_API_KEY` | Mistral API key for Voxtral TTS and Voxtral STT ([console.mistral.ai](https://console.mistral.ai)) |
 | `AWS_REGION` | AWS region for Bedrock inference (e.g. `us-east-1`, `eu-central-1`). Read by boto3. |
 | `AWS_PROFILE` | AWS named profile for Bedrock authentication (reads `~/.aws/credentials`). Leave unset to use default boto3 credential chain. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -933,6 +933,33 @@ credential_pool_strategies:
 
 Options: `fill_first` (default), `round_robin`, `least_used`, `random`. See [Credential Pools](/user-guide/features/credential-pools) for full documentation.
 
+## Shared auth stores (`shared_auth`)
+
+Cross-profile **shared OAuth** activation is a non-secret config switch — not a
+`HERMES_*` env var. Hermes force-exports internal bridge env vars at process
+startup (same pattern as `terminal.cwd` → `TERMINAL_CWD`).
+
+```yaml
+shared_auth:
+  # Provider names that own grants in the shared auth directory.
+  # Include xai-oauth (or xai / grok-oauth / x-ai-oauth) to enable the
+  # multi-profile single-use refresh-token store for xAI Grok OAuth.
+  providers: [xai-oauth]
+  # Optional directory override (default: <hermes-root>/shared/)
+  # dir: ~/.hermes/shared
+```
+
+CLI equivalents:
+
+```bash
+hermes auth xai enable-shared    # adds xai-oauth to shared_auth.providers
+hermes auth xai disable-shared   # removes it
+hermes auth xai migrate-shared   # one-time legacy grant → shared store
+```
+
+Absent or empty `shared_auth` leaves legacy per-profile auth unchanged. See
+[xAI Grok OAuth — Shared-store mode](/guides/xai-grok-oauth#shared-store-mode-multi-profile).
+
 ## Prompt caching
 
 Hermes turns on cross-session prompt caching automatically when the active provider supports it — no user config needed.


### PR DESCRIPTION
## Summary

Fixes multi-profile death for xAI Grok OAuth (issue #65394): xAI issues **single-use rotating refresh tokens**, so when each Hermes profile forks its own copy into `auth.json`, the first profile to refresh **revokes** every other copy (`invalid_grant`). This PR introduces an **opt-in canonical shared store** that all profiles read and refresh under one shared lock — one grant, one refresher, no per-profile forking.

**Activation is config.yaml (not a user-facing env var).** This addresses the `env-var-for-config` closure of #67243 (AGENTS.md: non-secret feature flags belong in `config.yaml`; bridge to an internal env var if the mechanism needs one — same pattern as `terminal.cwd` → `TERMINAL_CWD`). The activation move leaves the core election/sweep/marker/lock engine unchanged; this refresh additionally hardens auxiliary shared-mode resolution so stale legacy pool entries can never bypass canonical or profile-disable state.

## Problem

Today each profile (and the root `~/.hermes/auth.json`) can hold its own xAI OAuth grant. xAI rotates the refresh token on every successful refresh:

1. Profile A refreshes → new RT written to A's store; old RT revoked at xAI.
2. Profile B still holds the old RT → next refresh gets `invalid_grant`.
3. Concurrent gateways / cron / desktop / CLI workers multiply the race.

This is the multi-profile fork/death path described in #65394. Write-through helpers and pool entries that also persist raw refresh tokens make the blast radius worse.

## Solution

A **canonical sole-owner store** (not a Nous-style convenience layer) at:

```text
${HERMES_SHARED_AUTH_DIR}/xai_oauth.json   # default: ~/.hermes/shared/xai_oauth.json
${HERMES_SHARED_AUTH_DIR}/xai_oauth.lock   # cross-process advisory lock
```

All profiles **read / refresh / persist** through one resolver under that lock. Profile and root stores keep only a non-secret `source: shared:xai-oauth` reference (no raw RT forking).

### Opt-in gate (config.yaml user-facing; internal env bridge)

Shared xAI mode does **not** activate just because `HERMES_SHARED_AUTH_DIR` is set (that directory is already used for Nous shared auth).

**User-facing activation** (non-secret feature flag in config.yaml):

```yaml
# ~/.hermes/config.yaml  (or a profile's config.yaml)
shared_auth:
  providers: [xai-oauth]
  # optional: dir: ~/.hermes/shared
```

```bash
hermes auth xai enable-shared    # writes the config key + bridges for this process
hermes auth xai disable-shared   # removes xai-oauth from shared_auth.providers
```

At process startup (CLI, gateway, cron, dashboard/serve, TUI), Hermes **force-exports** the internal bridge targets from that config (AGENTS.md env-var-for-config / `terminal.cwd` → `TERMINAL_CWD` precedent):

- `HERMES_XAI_SHARED_AUTH=1` when providers includes an xAI alias
- `HERMES_SHARED_AUTH_PROVIDERS=<comma-joined list>`
- `HERMES_SHARED_AUTH_DIR` only when `shared_auth.dir` is set

The engine gate (`_xai_shared_auth_enabled()`) still **reads only those env vars** — they remain the internal mechanism so tests and power-user overrides keep working. **Gate-off** (absent/empty `shared_auth` in config) does not set or modify those env vars → byte-identical legacy behavior.

### Key properties

| Property | Behavior |
|----------|----------|
| **Canonical sole-owner** | One durable RT in the shared store; profiles never hold a forked secret copy |
| **Atomic multi-store election + sweep** | Under all-store locks: elect a winner, write shared, strip residual RTs across profile/root/pool/manual rows |
| **Fail-closed shapes** | Unreadable or wrong-shape stores (list, string, number) fail election / strip / sole-owner audit — never silent first-wins |
| **Fleet sole-owner marker** | Verifiable digest over inventory; stale/existence-only markers never skip re-audit |
| **Fail-loud persistence** | Durable write + parent-dir fsync; poison/partial write leaves non-promotable state |
| **Quarantine compare-and-clear** | Dead grants quarantined by generation; concurrent winner is adopted, not double-rotated |
| **Full consumer routing** | Runtime, credential pool, auxiliary client, proxy adapter, x_search / image / video / tts / stt, availability probes all go through the canonical resolver |
| **Auxiliary canonical-first / fail-closed** | In shared mode, auxiliary calls never consult a stale legacy pool before the canonical resolver; profile-disable, missing, or corrupt canonical state cannot fall back to legacy tokens |
| **Codex / Nous isolation** | Shared xAI path does not couple into Codex or Nous shared-auth ownership |
| **Config-not-env activation** | User-facing switch is `shared_auth.providers`; env vars are internal bridge targets only |

### Enablement + migration

```bash
# 1) Opt in (writes config.yaml; restart gateway/cron/desktop so they reload)
hermes auth xai enable-shared

# 2) One-time fleet migrate (or a single device-code login seeds the shared store)
hermes auth xai migrate-shared --source auto
# --source profile | --source root
# --force overwrites an existing shared grant

# 3) Login (if no legacy grant to migrate)
hermes auth add xai-oauth
```

**Logout semantics under shared mode:**

- `hermes auth xai disable-shared` — removes `xai-oauth` from `shared_auth.providers` in config.yaml (canonical grant stays on disk)
- `hermes logout --provider xai-oauth` — per-profile disable marker while shared mode remains on; canonical grant stays for other profiles
- `hermes logout --provider xai-oauth --global` — deletes the grant for **every** profile (intentionally noisy)

Requires a **local** filesystem with reliable advisory locking (not NFS/SMB). Every gateway/cron/desktop process must load the same config.yaml (shell-only exports are not the activation path).

## Testing

The provider overlay was integrated and promoted as candidate
`fce3427db0baabe316686d2bd3923cd20ddc4dbf`, which contains upstream
`07e97d2f5dc3d2092cfe693ef07b2527a36cd2d8`. That merge completed without
textual conflicts. The same four commits in this PR have also been replayed
onto the upstream tip observed during this refresh,
`32fd9d65cf091269709c5a6301b25aadac681aa8`, without manual conflict
resolution. All 9 changed Python test files then passed: **131 passed**.

The integration lane passed all of its normal gates:

- **229 passed, 2 deselected** — exact historical provider/auth/runtime suite
- **330 passed** — broader provider/auth/runtime superset
- **13 passed** — focused semantic controls
- **33/33 passed** — profile/model pin validation
- **Scanner controls passed in both directions** — the clean fixture was
  accepted and the positive fixture was detected

The pytest instruments were also tested against genuine zero collection. The
229-suite, 330-suite, and 13-control commands each returned pytest exit `5`
when their selectors collected no tests. A green receipt from these gates
therefore cannot be a vacuous zero-test pass.

Deliberately poisoned candidates proved that the semantic gate detects and
names lost capabilities:

- dropping the auxiliary fail-closed commit reports
  `auxiliary xAI shared credentials fail-closed`
- dropping the config bridge reports `shared-auth config bridge`
- dropping the two-process canonical-store proof reports the canonical shared
  xAI store capability as missing

The historical 229-test suite alone still passed on a poisoned candidate.
That result is why the lane requires the semantic capability gate instead of
treating the historical suite as sufficient.

- `tests/hermes_cli/test_shared_auth_config_bridge.py` — config → env bridge, gate-off byte-identical, power-user env override preserved, enable/disable write config.yaml
- `tests/hermes_cli/test_xai_shared_auth_store.py` — gate off/on, generation bump, fail-loud persist, concurrent waiters adopt winner, quarantine compare-and-clear, migrate/strip sole-owner, election fail-closed on unreadable/wrong-shape stores, concurrent logout vs promote, fleet marker digest races, no-resurrection after quarantine, gate-off byte-identical legacy
- `tests/hermes_cli/test_xai_shared_auth_two_process.py` — genuine two-OS-process, cross-`HERMES_HOME` lock contention; one refresh winner and loser-adopts assertions. This directly exercises the OS-process boundary and real advisory locking raised in teknium1's review, rather than using threads as a proxy.
- `tests/agent/test_auxiliary_xai_shared_recovery.py` — aux auth-error recovery with rejected bearer / generation plus canonical-first, no-legacy-fallback regressions
- `tests/agent/test_credential_pool_oauth_writethrough.py` / `test_credential_sources_xai_remove.py` — pool write-through + source removal under shared mode
- `tests/hermes_cli/test_xai_oauth_writethrough.py` — OAuth write-through boundaries
- `tests/tools/test_xai_http_shared_mode.py` — tool HTTP path uses canonical resolver
- `tests/plugins/video_gen/test_xai_plugin.py` — plugin routing under shared mode

The gate-off path remains byte-identical to legacy behavior. Coverage also
includes deterministic concurrency (election→commit race, strip→inventory
race), fail-closed invalid shapes, and no-resurrection guarantees.

## Production soak

The promoted change set has been running since 2026-07-25 in a real
multi-profile deployment spanning 8 gateways and 33 profiles. Live xAI and
Anthropic probes pass, and the xAI auth monitor reports
`XAI_AUTH_HEALTHY` with no affected profiles. This is operational soak
evidence from the promoted fork deployment; it is not a claim that upstream
CI has run or passed on this PR.

## Docs

- `website/docs/guides/xai-grok-oauth.md` — Shared-store mode uses config.yaml / `enable-shared`
- `website/docs/user-guide/configuration.md` — `shared_auth` section
- `website/docs/reference/environment-variables.md` — `HERMES_XAI_SHARED_AUTH` / `HERMES_SHARED_AUTH_PROVIDERS` labeled **internal bridge targets** (do not set by hand)

## Scope notes

- **Opt-in only** — default behavior unchanged until `shared_auth.providers` includes an xAI alias (or a power-user sets the internal env var).
- **Activation does not alter the core engine gate** — `_xai_shared_auth_enabled()` still reads env only; auxiliary shared-mode entry is additionally hardened to resolve canonical-first and fail closed.
- Does not change Codex or Nous shared-auth semantics beyond co-using the directory path convention.
- Closes / addresses #65394; re-scopes activation to satisfy the policy that closed #67243 (`env-var-for-config`).

## Checklist

- [x] Gate-off preserves legacy path (proven by bridge + store tests)
- [x] User-facing activation is config.yaml (not a new `HERMES_*` .env flag)
- [x] Internal env bridge at CLI / gateway / cron / dashboard / TUI startup
- [x] All xAI OAuth consumers routed through canonical resolver
- [x] Fail-closed election / strip / audit on bad store shapes
- [x] Docs for enablement + migration + logout
- [x] Adversarial concurrency + no-fork tests
- [x] Two-process cross-profile acceptance test
- [x] Auxiliary shared mode cannot bypass canonical/profile-disable state via stale legacy pool entries
