### PR TITLE
fix: inline combinator-path $refs before strip_nullable_unions (#67131)

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -759,3 +759,167 @@ def test_strip_slash_enum_ignores_non_string_enum_values():
     props = tools[0]["function"]["parameters"]["properties"]
     assert props["level"]["enum"] == [1, 2, 3]
     assert props["flag"]["enum"] == [True, False]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# inline_local_refs — resolves combinator-path $refs before
+# strip_nullable_unions collapses the combinator (#67131).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_combinator_path_ref_inlined_before_nullable_collapse():
+    """$ref traversing anyOf/N → inlined so strip_nullable_unions doesn't break it."""
+    from tools.schema_sanitizer import sanitize_tool_schemas
+
+    # Minimal reproduction from #67131: after collapse, a $ref walks through
+    # metadata/anyOf/0/... but metadata no longer has anyOf.
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "metadata": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "sections": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "rows": {
+                                            "type": "array",
+                                            "items": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {"const": "text"},
+                                                            "label": {"type": "string", "nullable": True},
+                                                            "text": {"type": "string"},
+                                                        },
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {"const": "code"},
+                                                            "label": {
+                                                                "$ref": "#/properties/metadata/anyOf/0/properties/sections/items/properties/rows/items/anyOf/0/properties/label"
+                                                            },
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    {"type": "null"},
+                ],
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    params = out[0]["function"]["parameters"]
+
+    # metadata should be collapsed from anyOf:[object,null] to object+nullable.
+    meta = params["properties"]["metadata"]
+    assert meta["type"] == "object"
+    assert meta.get("nullable") is True
+    assert "anyOf" not in meta
+
+    # The $ref inside rows.items.anyOf[1]/properties/label should be inlined
+    # to a concrete schema — no $ref should remain pointing into metadata/anyOf/...
+    rows_items = (
+        meta["properties"]["sections"]["items"]["properties"]["rows"]["items"]
+    )
+    variants = rows_items["anyOf"]
+    # Check variant[0] (text row) — its label is a plain type:string
+    assert variants[0]["properties"]["label"] == {"type": "string", "nullable": True}
+    # Check variant[1] (code row) — its label was previously a $ref but should
+    # now be inlined to the same concrete schema from variant[0].
+    code_label = variants[1]["properties"]["label"]
+    assert "$ref" not in code_label, f"$ref should be inlined, got {code_label}"
+    assert code_label["type"] == "string"
+    assert code_label.get("nullable") is True
+
+
+def test_defs_ref_not_inlined():
+    """$defs-based $refs (no combinator in path) are left alone."""
+    from tools.schema_sanitizer import sanitize_tool_schemas
+
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "payload": {"$ref": "#/$defs/Payload", "default": None},
+        },
+        "$defs": {
+            "Payload": {
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    payload = out[0]["function"]["parameters"]["properties"]["payload"]
+    # $ref should still be present (not inlined), default stripped.
+    assert payload["$ref"] == "#/$defs/Payload"
+    assert "default" not in payload
+
+
+def test_non_combinator_ref_not_inlined():
+    """Property-path $ref without combinator segments is left alone."""
+    from tools.schema_sanitizer import sanitize_tool_schemas
+
+    # A ref like #/properties/foo/properties/bar (no combinator segments)
+    # shouldn't be inlined — it stays as a $ref.
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "shared": {"type": "string", "description": "reusable"},
+            "alias": {
+                "$ref": "#/properties/shared",
+                "description": "alias to shared",
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    props = out[0]["function"]["parameters"]["properties"]
+    assert props["shared"]["type"] == "string"
+    assert props["alias"]["$ref"] == "#/properties/shared"
+    assert props["alias"]["description"] == "alias to shared"
+
+
+def test_combinator_ref_inline_preserves_siblings():
+    """When a $ref with combinator path is inlined, sibling keywords survive."""
+    from tools.schema_sanitizer import sanitize_tool_schemas
+
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "wrapper": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                        },
+                    },
+                    {"type": "null"},
+                ],
+            },
+            "alias": {
+                "$ref": "#/properties/wrapper/anyOf/0",
+                "description": "reuses wrapper shape",
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    props = out[0]["function"]["parameters"]["properties"]
+    # alias should be inlined (combinator-path), with description preserved.
+    alias = props["alias"]
+    assert "$ref" not in alias
+    assert alias["description"] == "reuses wrapper shape"
+    assert alias["type"] == "object"
+    assert alias["properties"]["name"]["type"] == "string"

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -61,6 +61,24 @@ def sanitize_tool_schemas(tools: list[dict]) -> list[dict]:
     return sanitized
 
 
+def _count_refs(node: Any) -> int:
+    """Count local ``$ref`` pointers that traverse combinator segments."""
+    if isinstance(node, list):
+        return sum(_count_refs(item) for item in node)
+    if not isinstance(node, dict):
+        return 0
+    count = 0
+    for key, value in node.items():
+        if key == "$ref" and isinstance(value, str) and value.startswith("#/"):
+            # Count only combinator-path refs (same filter as inline_local_refs).
+            segments = value[2:].split("/")
+            if any(seg in ("anyOf", "oneOf", "allOf") for seg in segments):
+                count += 1
+        elif isinstance(value, (dict, list)):
+            count += _count_refs(value)
+    return count
+
+
 def _sanitize_single_tool(tool: dict) -> dict:
     """Deep-copy and sanitize a single OpenAI-format tool entry."""
     out = copy.deepcopy(tool)
@@ -84,6 +102,17 @@ def _sanitize_single_tool(tool: dict) -> dict:
             top["type"] = "object"
         if "properties" not in top or not isinstance(top.get("properties"), dict):
             top["properties"] = {}
+    # Resolve local ``$ref`` pointers before nullable-union collapse so
+    # that refs walking through ``anyOf/N`` segments (common in Zod/MCP
+    # tool schemas) don't become dangling when ``strip_nullable_unions``
+    # drops the ``anyOf`` wrapper (#67131).
+    inline_refs_count = _count_refs(fn["parameters"])
+    if inline_refs_count:
+        fn["parameters"] = inline_local_refs(fn["parameters"])
+        logger.debug(
+            "schema_sanitizer: inlined %d local $ref(s) in %s tool schema",
+            inline_refs_count, fn.get("name", "<tool>"),
+        )
     # Final pass: collapse nullable anyOf/oneOf unions that the recursive
     # sanitizer above leaves intact (it only handles the array-form
     # ``type: [X, "null"]``). Keep the ``nullable: true`` hint so runtime
@@ -161,6 +190,116 @@ def _strip_top_level_combinators(params: dict, *, path: str = "<tool>") -> dict:
             )
             out.pop(key, None)
     return out
+
+
+def inline_local_refs(schema: dict, max_depth: int = 20) -> dict:
+    """Resolve local ``$ref`` pointers (``#/...``) in-place on the schema tree.
+
+    MCP/Zod tools commonly emit internal property-path ``$ref`` strings that
+    walk through ``anyOf`` / ``oneOf`` combinator segments, e.g.::
+
+        #/properties/metadata/anyOf/0/properties/sections/.../properties/label
+
+    When ``strip_nullable_unions`` later collapses a parent ``anyOf: [T, null]``
+    into the non-null branch, those pointer paths become unresolvable. xAI's
+    strict ``/v1/responses`` validator rejects them with HTTP 400.
+
+    This function resolves local refs eagerly so the tree is self-contained
+    before any combinator-stripping step.  Sibling metadata (``description``,
+    ``title``) on the ``$ref`` node survives — the resolved schema is
+    deep-merged under the ref node (the ref itself is deleted).
+
+    ``$ref`` pointers that traverse now-missing ``anyOf``/``oneOf``/``allOf``
+    segments are silently skipped (e.g. when a nullable union was already
+    collapsed before this call in a prior pipeline stage).
+    """
+    import json  # nosec — stdlib, no external data
+
+    def _resolve_pointer(root: dict, pointer: str):
+        """Follow a JSON Pointer (RFC 6901) path against *root* and return the
+        resolved sub-tree, or None if any segment is missing."""
+        if not pointer.startswith("#/"):
+            return None  # not a local ref
+        segments = pointer[2:].split("/") if pointer.startswith("#/") else []
+        current: Any = root
+        for seg in segments:
+            # Unescape RFC 6901 ~0 → ~ and ~1 → /
+            seg = seg.replace("~1", "/").replace("~0", "~")
+            if isinstance(current, list):
+                try:
+                    idx = int(seg)
+                    current = current[idx]
+                except (ValueError, IndexError):
+                    return None
+            elif isinstance(current, dict):
+                if seg in current:
+                    current = current[seg]
+                # Soft skip: combinator segment (anyOf/oneOf/allOf/<index>)
+                # that doesn't exist — e.g. after collapse.
+                elif seg in ("anyOf", "oneOf", "allOf"):
+                    return None
+                else:
+                    return None
+            else:
+                return None
+        return current
+
+    def _walk(node: Any, root: dict, depth: int):
+        if depth <= 0:
+            return node
+        if isinstance(node, list):
+            for i, item in enumerate(node):
+                node[i] = _walk(item, root, depth)
+            return node
+        if not isinstance(node, dict):
+            return node
+
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/"):
+            # Only inline refs whose path traverses a combinator segment
+            # (anyOf/oneOf/allOf) — those are the ones that become
+            # unresolvable after strip_nullable_unions collapses the
+            # combinator.  $defs-based refs are left alone.
+            segments = ref[2:].split("/")
+            if any(seg in ("anyOf", "oneOf", "allOf") for seg in segments):
+                resolved = _resolve_pointer(root, ref)
+                if resolved is not None and isinstance(resolved, dict):
+                    # Deep-copy the resolved schema so the ref target isn't
+                    # shared with its original location (avoid cross-talk).
+                    resolved_copy = copy.deepcopy(resolved)
+                    # Merge sibling metadata from the $ref node into the
+                    # resolved copy, then recurse into the result (resolved
+                    # schema may itself contain further $refs).
+                    merged = {k: v for k, v in node.items() if k != "$ref"}
+                    merged.update(resolved_copy)
+                    return _walk(merged, root, depth - 1)
+                # Soft skip: unresolvable ref (e.g. path broken by prior
+                # collapse).
+                logger.debug(
+                    "schema_sanitizer: skipping unresolvable local $ref %r", ref,
+                )
+
+        # Recurse into child nodes.
+        out: dict = {}
+        for key, value in node.items():
+            if key in ("properties", "$defs", "definitions") and isinstance(value, dict):
+                out[key] = {
+                    sub_k: _walk(sub_v, root, depth - 1)
+                    for sub_k, sub_v in value.items()
+                }
+            elif key == "items" and isinstance(value, dict):
+                out[key] = _walk(value, root, depth - 1)
+            elif key in ("anyOf", "oneOf", "allOf") and isinstance(value, list):
+                out[key] = [_walk(item, root, depth - 1) for item in value]
+            elif key == "additionalProperties" and isinstance(value, dict):
+                out[key] = _walk(value, root, depth - 1)
+            elif isinstance(value, (dict, list)):
+                out[key] = _walk(value, root, depth - 1)
+            else:
+                out[key] = value
+        return out
+
+    return _walk(copy.deepcopy(schema), schema, max_depth)
 
 
 def strip_nullable_unions(


### PR DESCRIPTION
Fixes #67131

## Summary

MCP/Zod tools emit internal property-path `$ref` strings that walk through `anyOf/N` segments. When `strip_nullable_unions` later collapses the parent `anyOf: [T, null]` into `T`, those pointer paths become unresolvable. xAI's strict `/v1/responses` validator rejects them with HTTP 400: `key 'anyOf' not found`.

## Fix

- Add `inline_local_refs()` that resolves local `#/...` `$ref`s whose path contains a combinator segment (`anyOf`/`oneOf`/`allOf`)
- Hook it into `_sanitize_single_tool` **before** `strip_nullable_unions` runs
- `$defs`-based refs and non-combinator property-path refs are left alone (they don't become dangling)
- Soft skip: `$ref`s whose target combinator segment is already missing (e.g. from a prior pipeline stage) are silently skipped

## How it works

Before `strip_nullable_unions` collapses:
```
metadata: { anyOf: [object, null] }
```

The function walks the tree and finds `$ref: "#/properties/metadata/anyOf/0/properties/.../label"`. Since this traverses `anyOf`, it resolves the pointer against the schema root and inlines the concrete schema. Then `strip_nullable_unions` can safely remove the `anyOf` wrapper.

## Tests

4 new tests cover:
- The exact reproduction case from the issue (#67131)
- `$defs`-based refs are NOT inlined
- Non-combinator property-path refs are NOT inlined
- Sibling metadata (description, etc.) is preserved on inlined refs