### PR TITLE
fix: increase keepalive_expiry from 20s to 300s for Cloudflare/OpenRouter streaming (#67012)

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -142,6 +142,27 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
     return proxy
 
 
+_DEFAULT_AGENT_KEEPALIVE_EXPIRY_S = 300.0
+
+
+def _get_agent_keepalive_expiry() -> float:
+    """Return ``keepalive_expiry`` for the agent's HTTP pool.
+
+    Reads ``HERMES_HTTPX_KEEPALIVE_EXPIRY`` env var; falls back to
+    ``_DEFAULT_AGENT_KEEPALIVE_EXPIRY_S`` (300 s — generous enough for
+    Cloudflare/OpenRouter streaming, #67012).
+    """
+    raw = os.environ.get("HERMES_HTTPX_KEEPALIVE_EXPIRY", "").strip()
+    if raw:
+        try:
+            val = float(raw)
+            if val > 0:
+                return val
+        except (TypeError, ValueError):
+            pass
+    return _DEFAULT_AGENT_KEEPALIVE_EXPIRY_S
+
+
 def build_keepalive_http_client(
     base_url: str = "",
     *,
@@ -157,11 +178,14 @@ def build_keepalive_http_client(
     applied. Mirrors ``AIAgent._build_keepalive_http_client``.
 
     Connection lifecycle is managed at the HTTP pool layer
-    (``keepalive_expiry=20.0`` reaps idle connections before reverse proxies'
-    typical 30-60 s timeouts) instead of the former custom
-    ``socket_options`` transport, which broke streaming behind reverse
-    proxies (#54049, #12952) and stalled TLS handshakes by stripping
-    ``TCP_NODELAY``.
+    (``keepalive_expiry``, default 300.0 s, reaps idle connections before
+    reverse-proxy timeouts) instead of the former custom ``socket_options``
+    transport, which broke streaming behind reverse proxies (#54049,
+    #12952) and stalled TLS handshakes by stripping ``TCP_NODELAY``.
+
+    The default 300 s accommodates Cloudflare/OpenRouter (100–600 s proxy
+    timeout, #67012) while still preventing unbounded CLOSE-WAIT
+    accumulation.  Override via ``HERMES_HTTPX_KEEPALIVE_EXPIRY`` env var.
 
     ``verify`` is forwarded to httpx so auxiliary-client calls (compression,
     vision, web_extract, title generation, etc.) honor the same per-provider
@@ -177,7 +201,7 @@ def build_keepalive_http_client(
         limits = httpx.Limits(
             max_keepalive_connections=20,
             max_connections=100,
-            keepalive_expiry=20.0,
+            keepalive_expiry=_get_agent_keepalive_expiry(),
         )
         # Generous read=None for SSE streaming endpoints.
         timeout = httpx.Timeout(connect=15.0, read=None, write=15.0, pool=10.0)
@@ -223,5 +247,6 @@ __all__ = [
     "_install_safe_stdio",
     "_get_proxy_from_env",
     "_get_proxy_for_base_url",
+    "_get_agent_keepalive_expiry",
     "build_keepalive_http_client",
 ]

--- a/run_agent.py
+++ b/run_agent.py
@@ -164,7 +164,7 @@ from agent.prompt_builder import (  # noqa: F401  # re-exported via _ra() / mock
     build_nous_subscription_prompt,
     load_soul_md,
 )
-from agent.process_bootstrap import _get_proxy_from_env  # noqa: F401
+from agent.process_bootstrap import _get_proxy_from_env, _get_agent_keepalive_expiry  # noqa: F401
 from agent.message_sanitization import (  # noqa: F401
     _SURROGATE_RE,
     _sanitize_surrogates,
@@ -4022,11 +4022,16 @@ class AIAgent:
         and SSE encoding.
 
         The fix moves connection lifecycle management from the socket layer
-        to the HTTP pool layer: ``keepalive_expiry=20.0`` tells httpx to
-        close idle pooled connections *before* a reverse proxy's typical
-        30–60 s timeout drops them, preventing CLOSE-WAIT accumulation
+        to the HTTP pool layer: ``keepalive_expiry`` (default 300.0 s)
+        tells httpx to close idle pooled connections *before* a reverse
+        proxy's timeout drops them, preventing CLOSE-WAIT accumulation
         without modifying socket options.  The default httpx transport
         preserves OS TCP defaults (including ``TCP_NODELAY``).
+
+        The default 300 s accommodates Cloudflare/OpenRouter (100–600 s
+        proxy timeout, #67012) while still preventing unbounded CLOSE-WAIT
+        accumulation.  Override via ``HERMES_HTTPX_KEEPALIVE_EXPIRY``
+        env var.
 
         ``verify`` carries per-provider ``ssl_ca_cert`` / ``ssl_verify`` and
         ``HERMES_CA_BUNDLE`` settings.  It is passed on the client AND on
@@ -4040,13 +4045,14 @@ class AIAgent:
             # HTTP_PROXY / HTTPS_PROXY / NO_PROXY correctly.
             _proxy = _get_proxy_for_base_url(base_url)
 
-            # Proactive pool reaping: close idle connections at 20 s,
-            # before reverse proxies (30–60 s typical) send FIN and
-            # cause CLOSE-WAIT accumulation.
+            # Proactive pool reaping: close idle connections at the
+            # configured keepalive_expiry (default 300 s, configurable
+            # via HERMES_HTTPX_KEEPALIVE_EXPIRY) — accommodates
+            # Cloudflare/OpenRouter streaming (#67012).
             _limits = _httpx.Limits(
                 max_keepalive_connections=20,
                 max_connections=100,
-                keepalive_expiry=20.0,
+                keepalive_expiry=_get_agent_keepalive_expiry(),
             )
 
             # Timeouts: generous read=None for SSE streaming endpoints.

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -1,10 +1,12 @@
 """Regression guard: _create_openai_client must honor HTTP(S)_PROXY env vars.
 
-The keepalive client now uses ``httpx.Limits(keepalive_expiry=20.0)``
+The keepalive client now uses ``httpx.Limits(keepalive_expiry)``
+(default 300 s, configurable via ``HERMES_HTTPX_KEEPALIVE_EXPIRY``)
 instead of a custom ``httpx.HTTPTransport(socket_options=...)`` to
 prevent CLOSE-WAIT accumulation.  This avoids breaking streaming for
 providers behind reverse proxies (#54049, #12952) while still reaping
-idle connections before a proxy's timeout drops them.
+idle connections before a proxy's timeout drops them.  The default
+300 s accommodates Cloudflare/OpenRouter (#67012).
 
 This test pins that the constructed ``httpx.Client`` mounts an
 ``HTTPProxy`` pool when a proxy env var is set, and that no


### PR DESCRIPTION
## Summary

Fixes #67012 — `keepalive_expiry=20.0` in `httpx.Limits` was too aggressive for providers behind Cloudflare (proxy timeout 100–600 s). During streaming, idle periods from model reasoning or slow generation could hit the 20 s pool expiry, causing connections to be closed mid-stream.

## Root Cause

Commit `8324dd19c` replaced custom `socket_options` transport with `httpx.Limits(keepalive_expiry=20.0)`. While this prevents CLOSE-WAIT accumulation for reverse proxies with 30–60 s timeouts, Cloudflare's minimum proxy timeout is 100 s (free/pro plans), rising to 600 s for enterprise. The 20 s expiry closes idle pooled connections well before Cloudflare would drop them — but during active streaming, idle gaps exceed 20 s regularly (model reasoning, slow token generation).

## Changes

- **Increase default `keepalive_expiry` from 20.0 → 300.0 (5 minutes)**
  - Accommodates Cloudflare's 100–600 s proxy timeout range
  - Still prevents unbounded CLOSE-WAIT accumulation
- **Add `HERMES_HTTPX_KEEPALIVE_EXPIRY` env var** for per-deployment tuning
- **Add `_get_agent_keepalive_expiry()` helper** in `agent.process_bootstrap`, shared by both client builders:
  - `agent/process_bootstrap.py` → `build_keepalive_http_client()` (auxiliary clients)
  - `run_agent.py` → `AIAgent._build_keepalive_http_client()` (main agent client)

## Files Changed

- `agent/process_bootstrap.py` — added `_get_agent_keepalive_expiry()` helper, updated `build_keepalive_http_client()`
- `run_agent.py` — updated `_build_keepalive_http_client()`, imports shared helper
- `tests/run_agent/test_create_openai_client_proxy_env.py` — updated docstring

## Verification

- All 10 tests in `test_create_openai_client_proxy_env.py` pass
- All 3 tests in `test_create_openai_client_ssl_verify.py` pass
- `_get_agent_keepalive_expiry()` correctly reads `HERMES_HTTPX_KEEPALIVE_EXPIRY` and falls back to 300.0 for invalid/negative values