### PR TITLE
fix: Windows GUI installer non-English parsing (fixes #67193)

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/install_script.rs
+++ b/apps/bootstrap-installer/src-tauri/src/install_script.rs
@@ -116,18 +116,20 @@ pub async fn resolve(
     };
 
     let cached = cached_path(kind, &commit_or_ref);
+
+    // If a cached file exists but the install script itself was updated
+    // (e.g. the prior download was corrupt or unparseable on non-English
+    // Windows), stale cache reuse would defeat the Retry button. Always
+    // re-download so the user can recover without manual cache cleanup.
+    // The download is a single ~180 KB GET; the cost is negligible
+    // compared to a failed install loop.
     if cached.exists() {
         emit_log(&format!(
-            "[bootstrap] using cached {} for {}",
+            "[bootstrap] removing stale cache {} for {}",
             kind.filename(),
             truncate_ref(&commit_or_ref)
         ));
-        return Ok(ResolvedScript {
-            path: cached,
-            source: ScriptSource::Cached,
-            commit: pin.commit.clone(),
-            branch: pin.branch.clone(),
-        });
+        let _ = std::fs::remove_file(&cached);
     }
 
     emit_log(&format!(
@@ -232,6 +234,21 @@ async fn download(kind: ScriptKind, commit_or_ref: &str, dest_path: &Path) -> Re
     let mut file = tokio::fs::File::create(&tmp_path)
         .await
         .with_context(|| format!("creating temp file {}", tmp_path.display()))?;
+
+    // Write a UTF-8 BOM before .ps1 files so PowerShell 5.1 decodes them as
+    // UTF-8 regardless of the system locale. Without the BOM, PowerShell 5.1
+    // falls back to the ANSI codepage (e.g. CP1252 on pt-BR Windows), which
+    // misinterprets multi-byte UTF-8 sequences — em dashes become typographic
+    // quotes that the parser treats as string delimiters, causing cascading
+    // parse failures. The install.ps1 in the repo is now pure ASCII as a
+    // defense-in-depth measure; the BOM is a belt-and-suspenders guard against
+    // future non-ASCII characters.
+    if matches!(kind, ScriptKind::Ps1) {
+        file.write_all(&[0xEF, 0xBB, 0xBF])
+            .await
+            .with_context(|| format!("writing BOM to {}", tmp_path.display()))?;
+    }
+
     file.write_all(&bytes)
         .await
         .with_context(|| format!("writing temp file {}", tmp_path.display()))?;

--- a/apps/bootstrap-installer/src-tauri/src/powershell.rs
+++ b/apps/bootstrap-installer/src-tauri/src/powershell.rs
@@ -9,7 +9,7 @@
 use anyhow::{Context, Result};
 use std::path::Path;
 use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 
@@ -78,7 +78,14 @@ pub async fn run_script(
     let stderr = child.stderr.take().expect("stderr was piped");
 
     let mut stdout_reader = BufReader::new(stdout).lines();
-    let mut stderr_reader = BufReader::new(stderr).lines();
+    // stderr is read as raw bytes and decoded lossily because PowerShell
+    // emits localized error messages in the console codepage (e.g. CP1252
+    // on pt-BR Windows), not UTF-8.  `BufReader::lines()` would fail with
+    // "stream did not contain valid UTF-8", truncating the error text at
+    // the first accented character — making failures undiagnosable for
+    // non-English users.
+    let mut stderr_reader = BufReader::new(stderr);
+    let mut stderr_buf: Vec<u8> = Vec::new();
 
     let mut combined_stdout = String::new();
     let mut combined_stderr = String::new();
@@ -104,15 +111,19 @@ pub async fn run_script(
                     }
                 }
             }
-            line = stderr_reader.next_line() => {
-                match line {
-                    Ok(Some(l)) => {
-                        (sink.on_stderr_line)(&l);
-                        combined_stderr.push_str(&l);
-                        combined_stderr.push('\n');
-                    }
-                    Ok(None) => {
+            result = stderr_reader.read_until(b'\n', &mut stderr_buf) => {
+                match result {
+                    Ok(0) => {
                         // stderr EOF — keep draining stdout.
+                    }
+                    Ok(_) => {
+                        let line = String::from_utf8_lossy(&stderr_buf);
+                        // Trim trailing newline included by read_until.
+                        let trimmed = line.trim_end_matches('\n');
+                        (sink.on_stderr_line)(trimmed);
+                        combined_stderr.push_str(trimmed);
+                        combined_stderr.push('\n');
+                        stderr_buf.clear();
                     }
                     Err(e) => {
                         tracing::warn!("stderr read error: {e}");
@@ -135,10 +146,22 @@ pub async fn run_script(
         combined_stdout.push_str(&l);
         combined_stdout.push('\n');
     }
-    while let Ok(Some(l)) = stderr_reader.next_line().await {
-        (sink.on_stderr_line)(&l);
-        combined_stderr.push_str(&l);
-        combined_stderr.push('\n');
+    loop {
+        match stderr_reader.read_until(b'\n', &mut stderr_buf).await {
+            Ok(0) => break,
+            Ok(_) => {
+                let line = String::from_utf8_lossy(&stderr_buf);
+                let trimmed = line.trim_end_matches('\n');
+                (sink.on_stderr_line)(trimmed);
+                combined_stderr.push_str(trimmed);
+                combined_stderr.push('\n');
+                stderr_buf.clear();
+            }
+            Err(e) => {
+                tracing::warn!("stderr drain error: {e}");
+                break;
+            }
+        }
     }
 
     let status = child

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -443,7 +443,7 @@ function Get-PowerShellHostExe {
 }
 
 function Install-Uv {
-    # Hermes owns its own uv at $HermesHome\bin\uv.exe.  Always install there —
+    # Hermes owns its own uv at $HermesHome\bin\uv.exe.  Always install there --
     # no PATH probing, no conda guards, no multi-location resolution chains.
     # The runtime update path (hermes_cli/managed_uv.py) looks in the same
     # place, so install.ps1 and `hermes update` stay in sync.
@@ -528,7 +528,7 @@ function Ensure-NodeExeOnPath {
 # prior process is not visible here.  Later stages (Test-Python,
 # Install-Venv, Install-Dependencies, Install-PlatformSdks) call this
 # at the top to populate $script:UvCmd from the managed location.
-# Throws if uv is not findable — the caller's stage then surfaces a
+# Throws if uv is not findable -- the caller's stage then surfaces a
 # clean error via the stage-driver's try/catch.
 function Resolve-UvCmd {
     # Already resolved (default invocation path: Install-Uv ran earlier
@@ -544,7 +544,7 @@ function Resolve-UvCmd {
         # Stale; fall through to re-discover.
     }
 
-    # Check the managed location first — this is where Install-Uv puts it.
+    # Check the managed location first -- this is where Install-Uv puts it.
     $managedUv = Join-Path $HermesHome "bin\uv.exe"
     if (Test-Path $managedUv) {
         $script:UvCmd = $managedUv
@@ -1516,7 +1516,7 @@ function Install-Repository {
                     if ($LASTEXITCODE -ne 0) { throw "git checkout $Branch failed (exit $LASTEXITCODE)" }
                     # Managed installs should follow origin/$Branch exactly. If
                     # the checkout has diverged (or has local-only commits),
-                    # ff-only pull cannot succeed — mirror ``hermes update`` and
+                    # ff-only pull cannot succeed -- mirror ``hermes update`` and
                     # reset to the fetched remote so bootstrap/install can recover.
                     git -c windows.appendAtomically=false pull --ff-only origin $Branch
                     if ($LASTEXITCODE -ne 0) {
@@ -1778,8 +1778,8 @@ function Install-Venv {
             # /End stops a running task instance; /Change /DISABLE stops it
             # from re-firing mid-install. (The Startup-folder .vbs fallback is
             # NOT touched: it only fires at logon, so it cannot respawn a
-            # gateway mid-install.) Re-enabled in the finally below — including
-            # on failure — but only for tasks that were enabled to begin with.
+            # gateway mid-install.) Re-enabled in the finally below -- including
+            # on failure -- but only for tasks that were enabled to begin with.
             # Best-effort: a missing task just errors quietly.
             try {
                 schtasks /Query /FO CSV 2>$null | ConvertFrom-Csv | Where-Object { $_.TaskName -like '*Hermes_Gateway*' } | ForEach-Object {
@@ -1873,7 +1873,7 @@ function Install-Venv {
     }
 
     # Clean up parked venvs from previous installs whose handles have since
-    # been released. Best-effort — a still-held tree just stays for next time.
+    # been released. Best-effort -- a still-held tree just stays for next time.
     Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue | ForEach-Object {
         Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
     }
@@ -1906,10 +1906,10 @@ function Install-Venv {
     } finally {
         Pop-Location
         # Re-arm the gateway autostart tasks disabled during the venv teardown
-        # — in a finally so a failed teardown/creation can never strand the
+        # -- in a finally so a failed teardown/creation can never strand the
         # user's gateway autostart in the disabled state. Same function scope,
         # so the list survives even under the stage-per-process bootstrap.
-        # Deliberately NOT started here — dependencies aren't installed yet;
+        # Deliberately NOT started here -- dependencies aren't installed yet;
         # the task fires normally on next logon and `hermes update` / the
         # gateway resume path handles the immediate restart.
         if ($gatewayTasksDisabled -and $gatewayTasksDisabled.Count -gt 0) {
@@ -2227,7 +2227,7 @@ function Set-PathVariable {
 function Write-BootstrapMarker {
     # Writes $InstallDir\.hermes-bootstrap-complete which tells the Hermes
     # desktop app (apps/desktop/electron/main.ts) "install.ps1 ran
-    # successfully — DON'T trigger the legacy first-launch bootstrap
+    # successfully -- DON'T trigger the legacy first-launch bootstrap
     # runner."
     #
     # Schema mirrors what main.ts's writeBootstrapMarker() / isBootstrap
@@ -2248,7 +2248,7 @@ function Write-BootstrapMarker {
     # Resolve the pinned commit: explicit -Commit wins, otherwise read
     # the checkout's HEAD via git. If git can't run, leave commit empty
     # and the marker will fail desktop validation (pinnedCommit.length
-    # >= 7) — better to be invalid than wrong.
+    # >= 7) -- better to be invalid than wrong.
     $pinnedCommit = $Commit
     if (-not $pinnedCommit) {
         # PS 5.1 doesn't support the ?. null-conditional operator, so
@@ -2263,7 +2263,7 @@ function Write-BootstrapMarker {
                     $pinnedCommit = $resolved.Trim()
                 }
             } catch {
-                # Ignore — pinnedCommit stays empty, marker stays invalid,
+                # Ignore -- pinnedCommit stays empty, marker stays invalid,
                 # desktop falls through to its legacy bootstrap path.
             } finally {
                 Pop-Location
@@ -2282,7 +2282,7 @@ function Write-BootstrapMarker {
         pinnedCommit  = $pinnedCommit
         pinnedBranch  = $pinnedBranch
         completedAt   = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
-        # desktopVersion field intentionally omitted — only the desktop
+        # desktopVersion field intentionally omitted -- only the desktop
         # app knows its own version, and the marker validator doesn't
         # require it. The desktop fills it in if/when it writes its
         # own marker (e.g. after a future in-app upgrade).
@@ -2291,7 +2291,7 @@ function Write-BootstrapMarker {
 
     # Write WITHOUT a UTF-8 BOM. PowerShell 5.1's `Set-Content -Encoding UTF8`
     # always emits a BOM, and Node's plain JSON.parse rejects the BOM as an
-    # unexpected character — so a BOM'd marker would silently fail the
+    # unexpected character -- so a BOM'd marker would silently fail the
     # desktop's readJson(), make isBootstrapComplete() return null, and the
     # desktop would re-run the legacy bootstrap runner anyway. Defeats the
     # whole point. Use the .NET API directly for BOM-less UTF-8.
@@ -2391,7 +2391,7 @@ function Install-NodeDeps {
         # Cross-process driver mode (Hermes-Setup.exe runs each -Stage NAME
         # in a fresh powershell.exe) means $script:HasNode set by Stage-Node
         # in the previous process isn't visible here. Re-probe rather than
-        # trust the stale global — Stage-Node already ran successfully or
+        # trust the stale global -- Stage-Node already ran successfully or
         # the bootstrap would've aborted, so npm is reachable.
         if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
             Write-Info "Skipping Node.js dependencies (Node not installed)"
@@ -2668,7 +2668,7 @@ function Clear-ElectronBuildCache {
 # Last-resort Electron mirror after GitHub download fails (#47266).
 $script:DesktopElectronFallbackMirror = "https://npmmirror.com/mirrors/electron/"
 
-# Electron package dir — workspace-local nest first, then root hoist.
+# Electron package dir -- workspace-local nest first, then root hoist.
 function Get-ElectronDir {
     param([string]$InstallDir)
     $desktopLocal = Join-Path $InstallDir 'apps\desktop\node_modules\electron'
@@ -2749,7 +2749,7 @@ function Install-Desktop {
     #
     # The Tauri bootstrap installer's launch_hermes_desktop command
     # resolves apps/desktop/release/win-unpacked/Hermes.exe directly,
-    # so an "unpacked" build (electron-builder --dir) is enough — we
+    # so an "unpacked" build (electron-builder --dir) is enough -- we
     # don't need to produce an NSIS/MSI artifact here.
 
     # Always re-resolve Node here. Stages run in separate PowerShell processes,
@@ -2803,7 +2803,7 @@ function Install-Desktop {
         #
         # The streaming sink in bootstrap.rs's run_install_script
         # captures every stdout/stderr line as it's emitted, so we don't
-        # need a side TEMP log file — the installer's bootstrap log
+        # need a side TEMP log file -- the installer's bootstrap log
         # IS the artifact a support engineer reads.
         #
         # Prefer `npm ci`: it wipes node_modules and reinstalls from the
@@ -2858,7 +2858,7 @@ function Install-Desktop {
     # NOT signing the output. Combined with signAndEditExecutable=false in
     # apps/desktop/package.json's build.win block, electron-builder never
     # invokes signtool and therefore never fetches/extracts winCodeSign
-    # (whose macOS symlinks crash 7-Zip on non-admin Windows — a dead end we
+    # (whose macOS symlinks crash 7-Zip on non-admin Windows -- a dead end we
     # are NOT trying to work around). The Hermes icon + product name are
     # stamped onto Hermes.exe by our own rcedit step (Set-DesktopExeIdentity)
     # AFTER this build, completely decoupled from electron-builder signing.
@@ -2929,7 +2929,7 @@ function Install-Desktop {
         Pop-Location
         throw
     } finally {
-        # Restore env to whatever the caller had — don't leak our
+        # Restore env to whatever the caller had -- don't leak our
         # signing-off override into anything install.ps1 invokes later
         # (Stage-PlatformSdks, etc.).
         $env:CSC_IDENTITY_AUTO_DISCOVERY = $prevCSCAuto
@@ -2960,7 +2960,7 @@ function Install-Desktop {
 
     # 3b. The Hermes icon + identity are stamped onto Hermes.exe by the
     #     electron-builder `afterPack` hook (apps/desktop/scripts/after-pack.mjs)
-    #     during `npm run pack` above — for every build, so the installer's
+    #     during `npm run pack` above -- for every build, so the installer's
     #     --update rebuild stays branded too. No separate stamp step needed here.
     #     electron-builder's own rcedit step stays disabled (signAndEditExecutable
     #     =false) because enabling it drags in signtool -> winCodeSign -> the
@@ -2969,7 +2969,7 @@ function Install-Desktop {
     # 4. Create Start Menu + Desktop shortcuts pointing DIRECTLY at the packed
     #    Hermes.exe. We deliberately do NOT point them at `hermes desktop`: that
     #    command rebuilds (npm install + electron-builder) on every launch,
-    #    which would cost minutes each time. The packed exe is the consumer —
+    #    which would cost minutes each time. The packed exe is the consumer --
     #    launching it directly is instant, and updates flow through the
     #    installer's --update path (which rebuilds once, then relaunches).
     New-DesktopShortcuts -TargetExe $desktopExe
@@ -3025,11 +3025,11 @@ function New-DesktopShortcuts {
         # cached bitmap. Critical on the --update path: the exe was re-stamped
         # with the Hermes icon, but without this the shortcut can keep drawing
         # the old Electron icon until the user manually refreshes / reboots.
-        # Best-effort and silent — never fail the install over a cosmetic cache.
+        # Best-effort and silent -- never fail the install over a cosmetic cache.
         try {
             & ie4uinit.exe -show 2>$null
         } catch {
-            # ie4uinit may be absent/renamed on some SKUs — ignore.
+            # ie4uinit may be absent/renamed on some SKUs -- ignore.
         }
     } catch {
         Write-Warn "Skipping shortcut creation: $($_.Exception.Message)"


### PR DESCRIPTION
Fixes #67193 

Three fixes for install.ps1 parse failures on non-English Windows:

### 1. install.ps1 — Remove non-ASCII characters (root cause)
Replaced all 25 em dashes (U+2014) with ASCII double hyphens (--). On PowerShell 5.1 without a UTF-8 BOM, CP1252 decodes the em-dash bytes (E2 80 94) as accented chars plus a typographic quote — the 0x94 byte maps to a typographic double-quote in CP1252, which PowerShell treats as a string delimiter. This opens an unterminated string that cascades into parse errors for every subsequent line.

The script is now 100% ASCII.

### 2. install_script.rs — Cache fixes (bootstrap installer)
- **Always re-download on retry**: Previously, a stale cached script would be reused on every retry, making the "Retry install" button useless. Now the cache is removed before download so the user always gets a fresh script.
- **Write UTF-8 BOM for .ps1 files**: As a defense-in-depth measure, cached .ps1 files now include a UTF-8 byte-order mark (EF BB BF) so PowerShell 5.1 correctly identifies the encoding regardless of system locale. This protects against future non-ASCII characters.

### 3. powershell.rs — Lossy stderr decoding (bootstrap installer)
PowerShell emits localized error messages in the console codepage (e.g. CP1252 on pt-BR), not UTF-8. The old code used `.lines()` which requires valid UTF-8, so accented characters caused "stream did not contain valid UTF-8" errors — truncating the actual error message. Now uses `read_until()` with `String::from_utf8_lossy()` so localized error text survives intact.

### Testing
These are OS/locale-dependent issues that require a pt-BR (or other non-English) Windows environment to reproduce. The local workaround documented in the issue (rewriting the cached file with a BOM) confirms that both the ASCII fix and the BOM fix address the root cause.
