### PR TITLE
fix(tui_gateway): project last_active in session.list RPC (#67122)

### DIFF
--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -45,7 +45,6 @@ def server():
     }):
         import importlib
         mod = importlib.import_module("tui_gateway.server")
-
     # Tests below stub handlers ("session.list", "prompt.submit", ...) in
     # the module-level _methods dict shared with every other test file in
     # the process — snapshot and restore it around each test.
@@ -58,6 +57,7 @@ def server():
     mod._sessions.clear()
     mod._pending.clear()
     mod._answers.clear()
+    mod._db = None
 
 
 @pytest.fixture()

--- a/tests/tui_gateway/test_session_list_rpc.py
+++ b/tests/tui_gateway/test_session_list_rpc.py
@@ -1,0 +1,100 @@
+"""RPC contract tests for the ``session.list`` method in ``tui_gateway.server``.
+
+Issue #67122: ``session.list`` projected each session row to ``id``, ``title``,
+``preview``, ``started_at``, ``message_count``, ``source`` but dropped the
+``last_active`` timestamp that ``list_sessions_rich`` already computes. External
+clients (e.g. qelg/hermes-chat) could observe the ordering but could not
+display the latest activity timestamp.
+
+These tests exercise the real ``session.list`` handler against a real
+``SessionDB`` (no mock recomputation) and assert the ``last_active`` field is
+present in the RPC response, reflects the last appended message, and falls back
+to ``started_at`` for sessions that have no messages yet.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    """Import once; reload would duplicate the module's atexit hooks."""
+    mod = importlib.import_module("tui_gateway.server")
+    yield mod
+    mod._sessions.clear()
+    mod._pending.clear()
+    mod._answers.clear()
+    mod._db = None
+
+
+@pytest.fixture()
+def db(server, hermes_home, monkeypatch):
+    """A SessionDB whose ``list_sessions_rich`` the server reads.
+
+    Patches ``_get_db`` on the live module (the pattern used throughout
+    ``tests/test_tui_gateway_server.py``) so the handler resolves this instance
+    without auto-initialising one against the real HERMES_HOME. monkeypatch
+    restores the original on teardown.
+    """
+    instance = SessionDB(db_path=hermes_home / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: instance)
+    return instance
+
+
+def _call(server, method, **params):
+    return server._methods[method](1, params)
+
+
+def test_session_list_includes_last_active_reflecting_last_message(server, db):
+    """``last_active`` must be present and equal the last message timestamp."""
+    db.create_session("sess-with-msgs", source="tui")
+    db.append_message("sess-with-msgs", "user", "first", timestamp=1000.0)
+    db.append_message("sess-with-msgs", "assistant", "reply", timestamp=2000.0)
+    db.append_message("sess-with-msgs", "user", "second", timestamp=5000.0)
+
+    resp = _call(server, "session.list", limit=10)
+    sessions = resp["result"]["sessions"]
+    assert sessions, "expected at least one session in the list"
+    row = next(s for s in sessions if s["id"] == "sess-with-msgs")
+    assert "last_active" in row, "session.list must project last_active (#67122)"
+    assert row["last_active"] == 5000.0
+
+
+def test_session_list_last_active_falls_back_to_started_at(server, db):
+    """A session with no messages must still surface a usable ``last_active``."""
+    db.create_session("sess-empty", source="tui")
+    # No append_message calls -> last_active would otherwise be absent/None.
+
+    resp = _call(server, "session.list", limit=10)
+    sessions = resp["result"]["sessions"]
+    row = next(s for s in sessions if s["id"] == "sess-empty")
+    assert "last_active" in row, "last_active key must always be present"
+    started = row["started_at"]
+    # Falls back to started_at so external clients always get a timestamp.
+    assert row["last_active"] == started
+
+
+def test_session_list_last_active_is_numeric(server, db):
+    """``last_active`` must be a number external clients can sort on."""
+    db.create_session("sess-num", source="tui")
+    db.append_message("sess-num", "user", "hi", timestamp=12345.5)
+
+    resp = _call(server, "session.list", limit=10)
+    sessions = resp["result"]["sessions"]
+    row = next(s for s in sessions if s["id"] == "sess-num")
+    assert isinstance(row["last_active"], (int, float))

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -200,6 +200,7 @@ def _(rid, params: dict) -> dict:
                             "title": s.get("title") or "",
                             "preview": s.get("preview") or "",
                             "started_at": s.get("started_at") or 0,
+                            "last_active": s.get("last_active") or s.get("started_at") or 0,
                             "message_count": s.get("message_count") or 0,
                             "source": s.get("source") or "",
                         }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -222,6 +222,7 @@ export interface SessionActivateResponse {
 
 export interface SessionListItem {
   id: string
+  last_active: number
   message_count: number
   preview: string
   source?: string


### PR DESCRIPTION
## What

The `session.list` RPC handler calls `list_sessions_rich(..., order_by_last_active=True)` — which already computes a `last_active` timestamp per row — but the projection dict drops it, so external clients can observe the ordering but cannot display or sort by the latest activity timestamp themselves.

This adds `last_active` to each projected session row, falling back to `started_at` for sessions that have no messages yet (so the field is always present and usable).

Closes #67122.

## Why

`list_sessions_rich` already computes `last_active` (the timestamp of the last message, or `started_at` when there are none) as a SQL column — it is never absent from the returned rows. The `session.list` handler was simply not forwarding it. Consumer `qelg/hermes-chat#84` cannot show or independently sort sessions by latest activity without this field.

## Change

- `tui_gateway/server.py`: one line in the `session.list` projection dict:
  ```python
  "last_active": s.get("last_active") or s.get("started_at") or 0,
  ```
  placed right after `started_at` (the other timestamp field), matching the surrounding pattern (`s.get(...) or <default>`).
- `tests/tui_gateway/test_session_list_rpc.py` (new): RPC contract tests that exercise the **real** `session.list` handler against a real `SessionDB` (no mock recomputation):
  - `test_session_list_includes_last_active_reflecting_last_message` — `last_active` is present and equals the last appended message timestamp.
  - `test_session_list_last_active_falls_back_to_started_at` — a session with no messages still surfaces a usable `last_active` (falls back to `started_at`).
  - `test_session_list_last_active_is_numeric` — `last_active` is always a number external clients can sort on.

## How verified

**Red→green proof** (run against `upstream/main` with the production fix reverted):

```
3 failed in 0.23s
  test_session_list_includes_last_active_reflecting_last_message  FAILED (AssertionError: session.list must project last_active)
  test_session_list_last_active_falls_back_to_started_at          FAILED (AssertionError: last_active key must always be present)
  test_session_list_last_active_is_numeric                        FAILED (KeyError: 'last_active')
```

**With the fix applied** (commit `47a8fe53`):

```
3 passed in 0.35s
```

**Nearby suite** (`tests/tui_gateway/`): `383 passed, 1 failed` — the single failure (`test_projects_rpc.py::test_discover_repos_from_full_history`) is a pre-existing environment-specific test that reads the real local session DB and has no relation to `session.list` or `last_active` projection.

**Rebased onto current `upstream/main`** (`8e9c17611`); branch is exactly one commit ahead (`git rev-list --left-right --count upstream/main...HEAD` → `0 1`).

## Competitor analysis

No open PRs found referencing #67122 or the `session.list last_active` keywords.

---

Auto-published by Moonsong via Path B automated pipeline.