### PR TITLE
fix: ignore deprecation and skipped optional packages in TUI install check

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1396,7 +1396,7 @@ def _print_tui_exit_summary(
     )
 
 
-_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer"})
+_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer", "deprecated"})
 """Lockfile fields npm writes non-deterministically at install time.
 
 ``ideallyInert`` is npm's runtime annotation for packages it skipped installing
@@ -1535,10 +1535,11 @@ def _tui_need_npm_install(root: Path) -> bool:
                 continue
             return True
 
-        if isinstance(installed[name], dict) and comparable(pkg) != comparable(
-            installed[name]
-        ):
-            return True
+        if isinstance(installed[name], dict):
+            if pkg.get("optional") and "version" not in installed[name]:
+                continue
+            if comparable(pkg) != comparable(installed[name]):
+                return True
 
     return False
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -604,3 +604,60 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     assert install_cmd[:2] == ["/bin/npm", "install"]
     # cwd must be tui_dir (standalone), not parent
     assert calls[0][1]["cwd"] == str(tui_dir)
+
+
+def test_tui_need_npm_install_ignores_deprecated_and_skipped_optional(
+    tmp_path: Path, main_mod
+) -> None:
+    """_tui_need_npm_install should ignore deprecation warnings and skipped optional platform packages."""
+    import json
+
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+
+    # Simulate a lockfile at workspace root (tmp_path)
+    # package 'boolean' has a deprecation warning in wanted, but not in installed
+    # package '@tailwindcss/oxide-darwin-arm64' is optional in wanted, but is missing/skipped in installed (version not present)
+    wanted_lock = {
+        "packages": {
+            "node_modules/boolean": {
+                "version": "3.2.0",
+                "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+                "deprecated": "Package no longer supported.",
+                "optional": True,
+            },
+            "node_modules/@tailwindcss/oxide-darwin-arm64": {
+                "version": "4.3.1",
+                "optional": True,
+                "os": ["darwin"],
+            },
+        }
+    }
+
+    installed_marker = {
+        "packages": {
+            "node_modules/boolean": {
+                "version": "3.2.0",
+                "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+                "optional": True,
+            },
+            "node_modules/@tailwindcss/oxide-darwin-arm64": {
+                "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+                "optional": True,
+            },
+        }
+    }
+
+    (tmp_path / "package-lock.json").write_text(json.dumps(wanted_lock))
+
+    node_modules = tmp_path / "node_modules"
+    node_modules.mkdir()
+    (node_modules / ".package-lock.json").write_text(json.dumps(installed_marker))
+
+    # Also fake the @hermes/ink package.json
+    ink_dir = node_modules / "@hermes" / "ink"
+    ink_dir.mkdir(parents=True)
+    (ink_dir / "package.json").write_text("{}")
+
+    assert main_mod._tui_need_npm_install(tui_dir) is False


### PR DESCRIPTION
Fixes #66978.

### Problem
Every TUI launch triggers a full  because:
1. npm strips  warnings from the hidden local  file in node_modules, causing a mismatch with the root lockfile.
2. Optional package targets for other operating systems/CPUs are skipped by npm, leaving version-less stubs that trigger a mismatch.

### Fix
- Excluded  from the lockfile comparison keys.
- Skipped validation for optional dependencies that npm elected not to install locally (lacking a  key).
- Appended regression unit tests to  (which pass successfully).