### PR TITLE
fix(gateway): scope webhook skill/config loading to the URL-resolved profile's  

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+_skill_commands_dir: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -134,6 +135,20 @@ def _resolve_skill_commands_platform() -> Optional[str]:
     except Exception:
         resolved_platform = os.getenv("HERMES_PLATFORM")
     return resolved_platform or None
+
+
+def _resolve_skill_commands_dir() -> str:
+    """Return the skills directory the next scan would read from.
+
+    Used to detect when the active profile has shifted (a multiplexed
+    gateway request scoped to a different profile via
+    ``set_hermes_home_override``) so :func:`get_skill_commands` can drop a
+    stale cache populated for another profile's skills directory — the
+    profile analogue of the platform check above (#14536).
+    """
+    from tools.skills_tool import _skills_dir
+
+    return str(_skills_dir())
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
     """Load a skill by name/path and return (loaded_payload, skill_dir, display_name)."""
@@ -323,20 +338,25 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands, _skill_commands_platform
+    global _skill_commands, _skill_commands_platform, _skill_commands_dir
     _skill_commands_platform = _resolve_skill_commands_platform()
+    _skill_commands_dir = _resolve_skill_commands_dir()
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
+        from tools.skills_tool import _skills_dir, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
-        # Scan local dir first, then external dirs
+        # Scan local dir first, then external dirs. Resolve via _skills_dir()
+        # (not the SKILLS_DIR constant) so a profile-scoped HERMES_HOME
+        # override — set for the duration of a multiplexed gateway request —
+        # is honored instead of always falling back to the process default.
+        skills_dir = _skills_dir()
         dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        if skills_dir.exists():
+            dirs_to_scan.append(skills_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
@@ -418,11 +438,16 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
 
     Rescans when the active platform scope changes (e.g. a gateway
     process serving Telegram and Discord concurrently) so each platform
-    sees its own ``skills.platform_disabled`` view (#14536).
+    sees its own ``skills.platform_disabled`` view (#14536), and likewise
+    when the active profile's skills directory changes (e.g. a multiplexed
+    gateway process serving webhook requests for several profiles) so a
+    request scoped to one profile doesn't inherit another profile's
+    skill set.
     """
     if (
         not _skill_commands
         or _skill_commands_platform != _resolve_skill_commands_platform()
+        or _skill_commands_dir != _resolve_skill_commands_dir()
     ):
         scan_skill_commands()
     return _skill_commands

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -540,15 +540,18 @@ def normalize_skill_lookup_name(identifier: str) -> str:
     if not identifier_path.is_absolute():
         return raw_identifier.lstrip("/")
 
-    # Look the primary skills root up on tools.skills_tool at CALL time
-    # (not via get_skills_dir()): callers and tests patch
-    # ``tools.skills_tool.SKILLS_DIR`` and skill_view() itself resolves
-    # against that module attribute, so normalization must agree with the
-    # exact root skill_view() will enforce.  Import deferred to avoid a
-    # module cycle (tools.skills_tool imports agent.skill_utils).
+    # Look the primary skills root up via tools.skills_tool._skills_dir() at
+    # CALL time: skill_view() resolves against that same live-profile root
+    # (falling back to a test-patched ``SKILLS_DIR`` module attribute when
+    # present), so normalization must agree with the exact root skill_view()
+    # will enforce — including inside a multiplexed profile's runtime scope,
+    # where ``SKILLS_DIR`` itself stays pinned to the process default and
+    # only ``_skills_dir()`` follows the active ``HERMES_HOME`` override.
+    # Import deferred to avoid a module cycle (tools.skills_tool imports
+    # agent.skill_utils).
     try:
         from tools import skills_tool as _skills_tool
-        primary_root = Path(_skills_tool.SKILLS_DIR)
+        primary_root = _skills_tool._skills_dir()
     except Exception:
         primary_root = get_skills_dir()
 

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -42,6 +42,7 @@ import subprocess
 import sys
 import time
 from collections import deque
+from contextlib import nullcontext
 from typing import Any, Deque, Dict, List, Optional
 
 try:
@@ -523,6 +524,31 @@ class WebhookAdapter(BasePlatformAdapter):
             return _PROFILE_REJECTED
         return profile
 
+    @staticmethod
+    def _profile_scope(profile: Optional[str]):
+        """Enter the multiplex profile runtime scope, or a no-op when unset.
+
+        Mirrors ``ApiServerAdapter._profile_scope`` — see that docstring for
+        why an unset profile still enters the default profile's scope when
+        multiplexing is active (fail-closed ``get_secret``, #61276).
+        """
+        if not profile:
+            try:
+                from agent.secret_scope import is_multiplex_active
+
+                if is_multiplex_active():
+                    from gateway.run import _profile_runtime_scope
+                    from hermes_constants import get_hermes_home
+
+                    return _profile_runtime_scope(get_hermes_home())
+            except Exception:
+                pass
+            return nullcontext()
+        from gateway.run import _profile_runtime_scope
+        from hermes_cli.profiles import get_profile_dir
+
+        return _profile_runtime_scope(get_profile_dir(profile))
+
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
         """POST /webhooks/{route_name} — receive and process a webhook event."""
         # Hot-reload dynamic subscriptions on each request (mtime-gated, cheap)
@@ -661,171 +687,177 @@ class WebhookAdapter(BasePlatformAdapter):
                 }
             )
 
-        if route_config.get("script"):
-            # run_route_script shells out (subprocess.run, up to its timeout);
-            # run it in a worker thread so it can't block the gateway event loop.
-            keep, transformed_payload = await asyncio.to_thread(
-                self._route_processor.run_route_script,
-                route_config.get("script"),
-                payload,
+        # Scope the remaining, profile-dependent work (route script,
+        # prompt templating, skill injection, deliver-only dispatch) to the
+        # resolved profile so skill/config lookups below resolve against
+        # that profile's HERMES_HOME instead of the process default (mirrors
+        # api_server.py's profile_prefix_middleware).
+        with self._profile_scope(profile):
+            if route_config.get("script"):
+                # run_route_script shells out (subprocess.run, up to its timeout);
+                # run it in a worker thread so it can't block the gateway event loop.
+                keep, transformed_payload = await asyncio.to_thread(
+                    self._route_processor.run_route_script,
+                    route_config.get("script"),
+                    payload,
+                )
+                if not keep:
+                    logger.info(
+                        "[webhook] script ignored event=%s route=%s",
+                        event_type,
+                        route_name,
+                    )
+                    return web.json_response(
+                        {
+                            "status": "ignored",
+                            "reason": "script",
+                            "route": route_name,
+                        }
+                    )
+                payload = transformed_payload or payload
+
+            # Format prompt from template
+            prompt_template = route_config.get("prompt", "")
+            prompt = self._render_prompt(
+                prompt_template, payload, event_type, route_name
             )
-            if not keep:
+
+            # Inject skill content if configured.
+            # We call build_skill_invocation_message() directly rather than
+            # using /skill-name slash commands — the gateway's command parser
+            # would intercept those and break the flow.
+            skills = route_config.get("skills", [])
+            if skills:
+                try:
+                    from agent.skill_commands import (
+                        build_skill_invocation_message,
+                        get_skill_commands,
+                    )
+
+                    skill_cmds = get_skill_commands()
+                    for skill_name in skills:
+                        cmd_key = f"/{skill_name}"
+                        if cmd_key in skill_cmds:
+                            skill_content = build_skill_invocation_message(
+                                cmd_key, user_instruction=prompt
+                            )
+                            if skill_content:
+                                prompt = skill_content
+                                break  # Load the first matching skill
+                        else:
+                            logger.warning(
+                                "[webhook] Skill '%s' not found", skill_name
+                            )
+                except Exception as e:
+                    logger.warning("[webhook] Skill loading failed: %s", e)
+
+            # Build a unique delivery ID
+            delivery_id = request.headers.get(
+                "X-GitHub-Delivery",
+                request.headers.get(
+                    "svix-id",
+                    request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                ),
+            )
+
+            # ── Idempotency ─────────────────────────────────────────
+            # Skip duplicate deliveries (webhook retries).
+            now = time.time()
+            if not self._record_delivery_id(delivery_id, now):
                 logger.info(
-                    "[webhook] script ignored event=%s route=%s",
-                    event_type,
-                    route_name,
+                    "[webhook] Skipping duplicate delivery %s", delivery_id
                 )
                 return web.json_response(
-                    {
-                        "status": "ignored",
-                        "reason": "script",
-                        "route": route_name,
-                    }
-                )
-            payload = transformed_payload or payload
-
-        # Format prompt from template
-        prompt_template = route_config.get("prompt", "")
-        prompt = self._render_prompt(
-            prompt_template, payload, event_type, route_name
-        )
-
-        # Inject skill content if configured.
-        # We call build_skill_invocation_message() directly rather than
-        # using /skill-name slash commands — the gateway's command parser
-        # would intercept those and break the flow.
-        skills = route_config.get("skills", [])
-        if skills:
-            try:
-                from agent.skill_commands import (
-                    build_skill_invocation_message,
-                    get_skill_commands,
+                    {"status": "duplicate", "delivery_id": delivery_id},
+                    status=200,
                 )
 
-                skill_cmds = get_skill_commands()
-                for skill_name in skills:
-                    cmd_key = f"/{skill_name}"
-                    if cmd_key in skill_cmds:
-                        skill_content = build_skill_invocation_message(
-                            cmd_key, user_instruction=prompt
-                        )
-                        if skill_content:
-                            prompt = skill_content
-                            break  # Load the first matching skill
-                    else:
-                        logger.warning(
-                            "[webhook] Skill '%s' not found", skill_name
-                        )
-            except Exception as e:
-                logger.warning("[webhook] Skill loading failed: %s", e)
-
-        # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
-        )
-
-        # ── Idempotency ─────────────────────────────────────────
-        # Skip duplicate deliveries (webhook retries).
-        now = time.time()
-        if not self._record_delivery_id(delivery_id, now):
-            logger.info(
-                "[webhook] Skipping duplicate delivery %s", delivery_id
-            )
-            return web.json_response(
-                {"status": "duplicate", "delivery_id": delivery_id},
-                status=200,
-            )
-
-        # ── Direct delivery mode (deliver_only) ─────────────────
-        # Skip the agent entirely — the rendered prompt IS the message we
-        # deliver.  Use case: external services (Supabase, monitoring,
-        # cron jobs, other agents) that need to push a plain notification
-        # to a user's chat with zero LLM cost.  Reuses the same HMAC auth,
-        # rate limiting, idempotency, and template rendering as agent mode.
-        if route_config.get("deliver_only"):
-            delivery = {
-                "deliver": route_config.get("deliver", "log"),
-                "deliver_extra": self._render_delivery_extra(
-                    route_config.get("deliver_extra", {}), payload
-                ),
-                "payload": payload,
-            }
-            logger.info(
-                "[webhook] direct-deliver event=%s route=%s target=%s msg_len=%d delivery=%s",
-                event_type,
-                route_name,
-                delivery["deliver"],
-                len(prompt),
-                delivery_id,
-            )
-            try:
-                result = await self._direct_deliver(prompt, delivery)
-            except Exception:
-                logger.exception(
-                    "[webhook] direct-deliver failed route=%s delivery=%s",
+            # ── Direct delivery mode (deliver_only) ─────────────────
+            # Skip the agent entirely — the rendered prompt IS the message we
+            # deliver.  Use case: external services (Supabase, monitoring,
+            # cron jobs, other agents) that need to push a plain notification
+            # to a user's chat with zero LLM cost.  Reuses the same HMAC auth,
+            # rate limiting, idempotency, and template rendering as agent mode.
+            if route_config.get("deliver_only"):
+                delivery = {
+                    "deliver": route_config.get("deliver", "log"),
+                    "deliver_extra": self._render_delivery_extra(
+                        route_config.get("deliver_extra", {}), payload
+                    ),
+                    "payload": payload,
+                }
+                logger.info(
+                    "[webhook] direct-deliver event=%s route=%s target=%s msg_len=%d delivery=%s",
+                    event_type,
                     route_name,
+                    delivery["deliver"],
+                    len(prompt),
                     delivery_id,
+                )
+                try:
+                    result = await self._direct_deliver(prompt, delivery)
+                except Exception:
+                    logger.exception(
+                        "[webhook] direct-deliver failed route=%s delivery=%s",
+                        route_name,
+                        delivery_id,
+                    )
+                    return web.json_response(
+                        {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
+                        status=502,
+                    )
+
+                if result.success:
+                    return web.json_response(
+                        {
+                            "status": "delivered",
+                            "route": route_name,
+                            "target": delivery["deliver"],
+                            "delivery_id": delivery_id,
+                        },
+                        status=200,
+                    )
+                # Delivery attempted but target rejected it — surface as 502
+                # with a generic error (don't leak adapter-level detail).
+                logger.warning(
+                    "[webhook] direct-deliver target rejected route=%s target=%s error=%s",
+                    route_name,
+                    delivery["deliver"],
+                    result.error,
                 )
                 return web.json_response(
                     {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
                     status=502,
                 )
 
-            if result.success:
-                return web.json_response(
-                    {
-                        "status": "delivered",
-                        "route": route_name,
-                        "target": delivery["deliver"],
-                        "delivery_id": delivery_id,
-                    },
-                    status=200,
-                )
-            # Delivery attempted but target rejected it — surface as 502
-            # with a generic error (don't leak adapter-level detail).
-            logger.warning(
-                "[webhook] direct-deliver target rejected route=%s target=%s error=%s",
-                route_name,
-                delivery["deliver"],
-                result.error,
+            # Use delivery_id in session key so concurrent webhooks on the
+            # same route get independent agent runs (not queued/interrupted).
+            session_chat_id = f"webhook:{route_name}:{delivery_id}"
+
+            # Store delivery info for send().  Read by every send() invocation
+            # for this chat_id (interim status messages and the final response),
+            # so we do NOT pop on send.  TTL-based cleanup keeps the dict bounded.
+            deliver_config = {
+                "deliver": route_config.get("deliver", "log"),
+                "deliver_extra": self._render_delivery_extra(
+                    route_config.get("deliver_extra", {}), payload
+                ),
+            }
+            self._delivery_info[session_chat_id] = deliver_config
+            self._delivery_info_created[session_chat_id] = now
+            self._delivery_info_order.append((now, session_chat_id))
+            self._prune_delivery_info(now)
+
+            # Build source and event
+            source = self.build_source(
+                chat_id=session_chat_id,
+                chat_name=f"webhook/{route_name}",
+                chat_type="webhook",
+                user_id=f"webhook:{route_name}",
+                user_name=route_name,
             )
-            return web.json_response(
-                {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
-                status=502,
-            )
-
-        # Use delivery_id in session key so concurrent webhooks on the
-        # same route get independent agent runs (not queued/interrupted).
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
-
-        # Store delivery info for send().  Read by every send() invocation
-        # for this chat_id (interim status messages and the final response),
-        # so we do NOT pop on send.  TTL-based cleanup keeps the dict bounded.
-        deliver_config = {
-            "deliver": route_config.get("deliver", "log"),
-            "deliver_extra": self._render_delivery_extra(
-                route_config.get("deliver_extra", {}), payload
-            ),
-        }
-        self._delivery_info[session_chat_id] = deliver_config
-        self._delivery_info_created[session_chat_id] = now
-        self._delivery_info_order.append((now, session_chat_id))
-        self._prune_delivery_info(now)
-
-        # Build source and event
-        source = self.build_source(
-            chat_id=session_chat_id,
-            chat_name=f"webhook/{route_name}",
-            chat_type="webhook",
-            user_id=f"webhook:{route_name}",
-            user_name=route_name,
-        )
-        if profile and isinstance(profile, str):
-            source.profile = profile
+            if profile and isinstance(profile, str):
+                source.profile = profile
         event = MessageEvent(
             text=prompt,
             message_type=MessageType.TEXT,

--- a/tests/gateway/test_webhook_multiplex_skill_scope.py
+++ b/tests/gateway/test_webhook_multiplex_skill_scope.py
@@ -1,0 +1,168 @@
+"""Regression test: multiplexed webhooks must load the URL profile's skills.
+
+Bug: a POST to ``/p/<profile>/webhooks/<route>`` resolved the profile from
+the URL (for session/credential scoping) but injected skill content BEFORE
+entering that profile's runtime scope, so ``get_skill_commands()`` always
+resolved skills against the process-default ``HERMES_HOME`` instead of the
+named profile's — regardless of which profile the webhook was addressed to.
+
+Covers:
+- ``/p/<profile>/webhooks/<route>`` loads that profile's skill content, not
+  the default profile's.
+- Back-to-back requests for different profiles each get their own profile's
+  skill content (the ``get_skill_commands()`` process-global cache must
+  invalidate on profile change, not just platform change — see #14536 for
+  the platform analogue).
+"""
+
+import asyncio
+import json
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import agent.skill_commands as skill_commands_module
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+
+
+def _make_skill(skills_dir, name, marker):
+    """A minimal skill whose body embeds ``marker`` so tests can tell which
+    profile's copy actually got loaded."""
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""\
+---
+name: {name}
+description: Test skill for {marker}.
+---
+
+# {name}
+
+{marker}
+"""
+    )
+    return skill_dir
+
+
+def _make_adapter(routes, multiplex: bool) -> WebhookAdapter:
+    config = PlatformConfig(
+        enabled=True, extra={"host": "127.0.0.1", "port": 0, "routes": routes}
+    )
+    adapter = WebhookAdapter(config)
+
+    class _Runner:
+        config = GatewayConfig(multiplex_profiles=multiplex)
+        adapters = {}
+
+        def get_home_channel(self, *a, **kw):
+            return None
+
+    adapter.gateway_runner = _Runner()
+    return adapter
+
+
+def _create_app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    app.router.add_route(
+        "*", "/p/{profile}/webhooks/{route_name}", adapter._handle_webhook
+    )
+    return app
+
+
+class TestWebhookMultiplexSkillScope:
+    @pytest.mark.asyncio
+    async def test_profile_prefixed_webhook_loads_that_profiles_skills(
+        self, tmp_path, monkeypatch
+    ):
+        default_home = tmp_path / "default"
+        coder_home = tmp_path / "coder"
+        (default_home / "skills").mkdir(parents=True)
+        (coder_home / "skills").mkdir(parents=True)
+        _make_skill(default_home / "skills", "greet", "DEFAULT-PROFILE-SKILL")
+        _make_skill(coder_home / "skills", "greet", "CODER-PROFILE-SKILL")
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex: [("default", default_home), ("coder", coder_home)],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir",
+            lambda name: coder_home if name == "coder" else default_home,
+        )
+        # Reset the process-global skill command cache so no earlier test
+        # in this process biases the first scan.
+        monkeypatch.setattr(skill_commands_module, "_skill_commands", {})
+        monkeypatch.setattr(skill_commands_module, "_skill_commands_platform", None)
+        monkeypatch.setattr(skill_commands_module, "_skill_commands_dir", None)
+
+        routes = {
+            "notify": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver_only": True,
+                "deliver": "telegram",
+                "deliver_extra": {"chat_id": "1"},
+                "prompt": "ping",
+                "skills": ["greet"],
+            }
+        }
+        adapter = _make_adapter(routes, multiplex=True)
+
+        from unittest.mock import AsyncMock
+
+        mock_target = AsyncMock()
+        mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        adapter.gateway_runner.adapters = {Platform("telegram"): mock_target}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/p/coder/webhooks/notify",
+                data=json.dumps({}).encode(),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": "d-coder",
+                },
+            )
+            assert resp.status == 200
+
+            resp = await cli.post(
+                "/p/default/webhooks/notify",
+                data=json.dumps({}).encode(),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": "d-default",
+                },
+            )
+            assert resp.status == 200
+
+            # Same profile again, to prove the cache invalidation isn't a
+            # one-shot toggle — it must follow every request.
+            resp = await cli.post(
+                "/p/coder/webhooks/notify",
+                data=json.dumps({}).encode(),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": "d-coder-2",
+                },
+            )
+            assert resp.status == 200
+
+        await asyncio.sleep(0.05)
+
+        assert mock_target.send.await_count == 3
+        delivered = [call.args[1] for call in mock_target.send.await_args_list]
+
+        assert "CODER-PROFILE-SKILL" in delivered[0]
+        assert "DEFAULT-PROFILE-SKILL" not in delivered[0]
+
+        assert "DEFAULT-PROFILE-SKILL" in delivered[1]
+        assert "CODER-PROFILE-SKILL" not in delivered[1]
+
+        assert "CODER-PROFILE-SKILL" in delivered[2]
+        assert "DEFAULT-PROFILE-SKILL" not in delivered[2]


### PR DESCRIPTION
## What does this PR do?

Fixes a profile-isolation bug in the gateway's webhook multiplexer. When `gateway.multiplex_profiles` is on, a POST to `/p/<profile>/webhooks/<route>` resolved the profile from the URL (for session/credential scoping) but injected skill content and rendered the prompt template *before* entering that profile's runtime scope. As a result, skill lookups always resolved against the process's default `HERMES_HOME` instead of the URL-named profile's, regardless of which profile the webhook was addressed to.

Two related bugs in the same code path made the fix incomplete without also touching them:

- `agent/skill_commands.py`: `scan_skill_commands()` read the frozen `SKILLS_DIR` module constant instead of the live-resolving `_skills_dir()` helper, and the process-global skill command cache only invalidated on platform change (#14536), never on profile change — so a request scoped to one profile could silently inherit another profile's skill set.
- `agent/skill_utils.py`: `normalize_skill_lookup_name()` also relied on the frozen `SKILLS_DIR` to decide whether an absolute skill path could be stripped to a relative name, causing intermittent failures when alternating between profiles.

The right fix is to scope the *entire* profile-dependent portion of the request handler to the URL-resolved profile — not just the one call site that happened to surface the symptom — using the same `_profile_runtime_scope` primitive the sibling `api_server.py` adapter already uses for its own `/p/<profile>/` routes. Patching only the symptom (e.g. passing a profile argument into `get_skill_commands()`) would have left the same class of bug latent for the next profile-dependent lookup added to this handler.

## Related Issue

Fixes #67277

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/webhook.py`: added `WebhookAdapter._profile_scope()` (mirrors `ApiServerAdapter._profile_scope`) and wrapped the profile-dependent portion of `_handle_webhook` (route script execution, prompt templating, skill injection, deliver-only dispatch) in `with self._profile_scope(profile):`.
- `agent/skill_commands.py`: `scan_skill_commands()` now resolves the scan root via the live `_skills_dir()` instead of the frozen `SKILLS_DIR` constant; added `_skill_commands_dir` tracking so `get_skill_commands()`'s process-global cache also invalidates on profile change, not just platform change.
- `agent/skill_utils.py`: `normalize_skill_lookup_name()` now resolves its "trusted root" via the live `_skills_tool._skills_dir()` instead of the frozen `SKILLS_DIR` constant, so it agrees with what `skill_view()` actually enforces inside a multiplexed profile's runtime scope.
- `tests/gateway/test_webhook_multiplex_skill_scope.py` (new): regression test — two profiles with same-named, differently-scoped skills; asserts `/p/<profile>/webhooks/<route>` delivers each profile's own skill content across back-to-back requests for different profiles.

## How to Test

1. Enable `gateway.multiplex_profiles` and configure two profiles (e.g. `default` and `coder`), each with a skill of the same name but different content under `<profile_home>/skills/`.
2. Configure a webhook route with `skills: [<name>]` on both profiles.
3. POST to `/p/coder/webhooks/<route>` and `/p/default/webhooks/<route>` — each response should carry that profile's own skill content, not the other's. Before this fix, both requests returned the default profile's skill content.

Or just run the new regression test:
`pytest tests/gateway/test_webhook_multiplex_skill_scope.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran `scripts/run_tests.sh` scoped to `tests/agent/`, `tests/gateway/`, and the skills-profile-related files under `tests/tools/` and `tests/hermes_cli/`, on both Linux (WSL2) and macOS — all green on both   (macOS had 21 pre-existing failures unrelated to this change: Keychain credential resolution, `/tmp`→`/private/tmp` symlink, abstract Unix sockets, an XML binding gap — none touch the files this PR modifies). Did **not** run the full monolithic `tests/` tree (e.g. plugin-specific suites outside agent/gateway were not exercised) — leaving this unchecked pending a full-suite run.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2) and macOS (Darwin), Python 3.11.15 on both

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `scripts/check-windows-footguns.py` clean on all changed files; no OS-specific file I/O, subprocess, or signal handling introduced. No Windows box available to run the suite; the change is pure Python control-flow/contextvar scoping.
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A