### PR TITLE
feat(auth): add credential pool switch command

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1860,6 +1860,29 @@ class CredentialPool:
             self._current_id = None
         return removed
 
+    def activate_index(self, index: int) -> Optional[PooledCredential]:
+        """Make the 1-based entry at *index* the first credential in the pool.
+
+        Credential-pool selection is intentionally priority/order based for the
+        default ``fill_first`` strategy and as the stable tie-breaker for lease
+        selection. Persisting the selected credential at priority 0 gives the
+        CLI a durable, profile-local way to choose the next credential without
+        introducing a second "active credential" state that could drift from
+        the on-disk pool order.
+        """
+        with self._lock:
+            if index < 1 or index > len(self._entries):
+                return None
+            selected = self._entries[index - 1]
+            ordered = [selected, *self._entries[: index - 1], *self._entries[index:]]
+            self._entries = [
+                replace(entry, priority=new_priority)
+                for new_priority, entry in enumerate(ordered)
+            ]
+            self._current_id = selected.id
+            self._persist()
+            return self._entries[0]
+
     def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
         raw = str(target or "").strip()
         if not raw:

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -51,6 +51,7 @@ Examples:
     hermes auth add <provider>    Add a pooled credential
     hermes auth list              List pooled credentials
     hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
+    hermes auth switch <p> <t>    Move pooled credential to first by index, id, or label
     hermes auth reset <provider>  Clear exhaustion status for a provider
     hermes model                  Select default model
     hermes fallback [list]        Show fallback provider chain

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import sys
 import time
+from dataclasses import replace
 from types import SimpleNamespace
 import uuid
 
@@ -14,6 +15,7 @@ from agent.credential_pool import (
     CUSTOM_POOL_PREFIX,
     SOURCE_MANUAL,
     SOURCE_MANUAL_DEVICE_CODE,
+    STATUS_DEAD,
     STATUS_EXHAUSTED,
     STRATEGY_FILL_FIRST,
     STRATEGY_ROUND_ROBIN,
@@ -499,6 +501,126 @@ def auth_remove_command(args) -> None:
         print(line)
 
 
+def _switch_codex_pool_and_singleton(
+    selected_id: str,
+) -> PooledCredential | None:
+    """Atomically promote a Codex OAuth pool entry and mirror singleton state.
+
+    Codex still has singleton-auth paths for token refresh and usage/status
+    checks.  If the user switches to an independent manual Codex account, the
+    selected entry must become the singleton-backed ``device_code`` entry rather
+    than merely copying its tokens into ``providers.openai-codex``. Otherwise
+    the next ``load_pool('openai-codex')`` would seed a duplicate device_code
+    entry and leave the old account mislabeled.
+    """
+    with auth_mod._auth_store_lock():
+        auth_store = auth_mod._load_auth_store()
+        pool_store = auth_store.get("credential_pool")
+        if not isinstance(pool_store, dict):
+            return None
+        payloads = pool_store.get("openai-codex")
+        if not isinstance(payloads, list):
+            return None
+        entries = [
+            PooledCredential.from_dict("openai-codex", payload)
+            for payload in payloads
+            if isinstance(payload, dict)
+        ]
+        selected = next((entry for entry in entries if entry.id == selected_id), None)
+        if selected is None or selected.auth_type != AUTH_TYPE_OAUTH:
+            return None
+        access_token = (selected.access_token or "").strip()
+        refresh_token = (selected.refresh_token or "").strip()
+        if not access_token:
+            return None
+        if not refresh_token:
+            raise SystemExit(
+                "Selected openai-codex OAuth credential is missing refresh_token. "
+                "Re-authenticate it with `hermes auth add openai-codex` before switching."
+            )
+
+        promoted_entries: list[PooledCredential] = []
+        for entry in entries:
+            updated = entry
+            if entry.id == selected_id:
+                updated = replace(entry, source="device_code")
+            elif entry.source == "device_code":
+                updated = replace(entry, source=SOURCE_MANUAL_DEVICE_CODE)
+            promoted_entries.append(updated)
+
+        selected_promoted = next(entry for entry in promoted_entries if entry.id == selected_id)
+        ordered = [
+            selected_promoted,
+            *[entry for entry in promoted_entries if entry.id != selected_id],
+        ]
+        ordered = [
+            replace(entry, priority=new_priority)
+            for new_priority, entry in enumerate(ordered)
+        ]
+        selected_promoted = ordered[0]
+        pool_store["openai-codex"] = [entry.to_dict() for entry in ordered]
+
+        state = auth_mod._load_provider_state(auth_store, "openai-codex") or {}
+        if not isinstance(state, dict):
+            state = {}
+        tokens = state.get("tokens")
+        if not isinstance(tokens, dict):
+            tokens = {}
+        tokens["access_token"] = access_token
+        tokens["refresh_token"] = refresh_token
+        state["tokens"] = tokens
+        state["auth_mode"] = state.get("auth_mode") or "chatgpt"
+        if selected_promoted.last_refresh:
+            state["last_refresh"] = selected_promoted.last_refresh
+        else:
+            state.pop("last_refresh", None)
+        if selected_promoted.label:
+            state["label"] = selected_promoted.label
+        auth_mod._store_provider_state(
+            auth_store,
+            "openai-codex",
+            state,
+            set_active=False,
+        )
+        auth_mod._save_auth_store(auth_store)
+    return selected_promoted
+
+
+def auth_switch_command(args) -> None:
+    provider = _normalize_provider(getattr(args, "provider", ""))
+    target = getattr(args, "target", None)
+    pool = load_pool(provider)
+    index, matched, error = pool.resolve_target(target)
+    if matched is None or index is None:
+        raise SystemExit(f"{error} Provider: {provider}.")
+
+    selected = None
+    synced_singleton = False
+    if provider == "openai-codex" and matched.auth_type == AUTH_TYPE_OAUTH:
+        selected = _switch_codex_pool_and_singleton(matched.id)
+        synced_singleton = selected is not None
+    else:
+        selected = pool.activate_index(index)
+    if selected is None:
+        raise SystemExit(f'No credential matching "{target}" for provider {provider}.')
+
+    print(f"Switched {provider} to credential \"{selected.label}\" (now #1)")
+    strategy = get_pool_strategy(provider)
+    if strategy in {STRATEGY_ROUND_ROBIN, STRATEGY_RANDOM, STRATEGY_LEAST_USED}:
+        print(
+            f"Note: {provider} uses {strategy}; later requests may select "
+            "another credential according to that strategy."
+        )
+    if selected.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}:
+        print(
+            "Note: selected credential is currently marked "
+            f"{selected.last_status}; run `hermes auth reset {provider}` "
+            "if you intentionally want to clear cooldown state."
+        )
+    if synced_singleton:
+        print("Synchronized openai-codex singleton auth state with the selected credential.")
+
+
 def auth_reset_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
     pool = load_pool(provider)
@@ -785,6 +907,9 @@ def auth_command(args) -> None:
         return
     if action == "remove":
         auth_remove_command(args)
+        return
+    if action == "switch":
+        auth_switch_command(args)
         return
     if action == "reset":
         auth_reset_command(args)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -748,6 +748,7 @@ def _interactive_auth() -> None:
     choices = [
         "Add a credential",
         "Remove a credential",
+        "Switch active credential for a provider",
         "Reset cooldowns for a provider",
         "Set rotation strategy for a provider",
         "Exit",
@@ -769,8 +770,10 @@ def _interactive_auth() -> None:
     elif raw == "2":
         _interactive_remove()
     elif raw == "3":
-        _interactive_reset()
+        _interactive_switch()
     elif raw == "4":
+        _interactive_reset()
+    elif raw == "5":
         _interactive_strategy()
 
 
@@ -847,6 +850,29 @@ def _interactive_remove() -> None:
         return
 
     auth_remove_command(SimpleNamespace(provider=provider, target=raw))
+
+
+def _interactive_switch() -> None:
+    provider = _pick_provider("Provider to switch credential for")
+    pool = load_pool(provider)
+    if not pool.has_credentials():
+        print(f"No credentials for {provider}.")
+        return
+
+    current = pool.peek()
+    for i, e in enumerate(pool.entries(), 1):
+        marker = " ←" if current is not None and e.id == current.id else ""
+        exhausted = _format_exhausted_status(e)
+        print(f"  #{i}  {e.label:25s} {e.auth_type:10s} {e.source}{exhausted} [id:{e.id}]{marker}")
+
+    try:
+        raw = input("Switch to #, id, or label (blank to cancel): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return
+    if not raw:
+        return
+
+    auth_switch_command(SimpleNamespace(provider=provider, target=raw))
 
 
 def _interactive_reset() -> None:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -503,6 +503,8 @@ def auth_remove_command(args) -> None:
 
 def _switch_codex_pool_and_singleton(
     selected_id: str,
+    *,
+    fallback_entries: list[PooledCredential] | None = None,
 ) -> PooledCredential | None:
     """Atomically promote a Codex OAuth pool entry and mirror singleton state.
 
@@ -517,15 +519,22 @@ def _switch_codex_pool_and_singleton(
         auth_store = auth_mod._load_auth_store()
         pool_store = auth_store.get("credential_pool")
         if not isinstance(pool_store, dict):
-            return None
+            pool_store = {}
+            auth_store["credential_pool"] = pool_store
         payloads = pool_store.get("openai-codex")
-        if not isinstance(payloads, list):
+        if isinstance(payloads, list) and payloads:
+            entries = [
+                PooledCredential.from_dict("openai-codex", payload)
+                for payload in payloads
+                if isinstance(payload, dict)
+            ]
+        elif fallback_entries:
+            # Profile reads may inherit this provider from the global auth
+            # store. Match generic pool-switch behavior by materializing that
+            # inherited pool into the active profile before reordering it.
+            entries = [replace(entry) for entry in fallback_entries]
+        else:
             return None
-        entries = [
-            PooledCredential.from_dict("openai-codex", payload)
-            for payload in payloads
-            if isinstance(payload, dict)
-        ]
         selected = next((entry for entry in entries if entry.id == selected_id), None)
         if selected is None or selected.auth_type != AUTH_TYPE_OAUTH:
             return None
@@ -566,11 +575,10 @@ def _switch_codex_pool_and_singleton(
         state = auth_mod._load_provider_state(auth_store, "openai-codex") or {}
         if not isinstance(state, dict):
             state = {}
-        tokens = state.get("tokens")
-        if not isinstance(tokens, dict):
-            tokens = {}
-        tokens["access_token"] = access_token
-        tokens["refresh_token"] = refresh_token
+        tokens = {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        }
         state["tokens"] = tokens
         state["auth_mode"] = state.get("auth_mode") or "chatgpt"
         if selected_promoted.last_refresh:
@@ -600,7 +608,10 @@ def auth_switch_command(args) -> None:
     selected = None
     synced_singleton = False
     if provider == "openai-codex" and matched.auth_type == AUTH_TYPE_OAUTH:
-        selected = _switch_codex_pool_and_singleton(matched.id)
+        selected = _switch_codex_pool_and_singleton(
+            matched.id,
+            fallback_entries=pool.entries(),
+        )
         synced_singleton = selected is not None
     else:
         selected = pool.activate_index(index)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -532,7 +532,10 @@ def _switch_codex_pool_and_singleton(
         access_token = (selected.access_token or "").strip()
         refresh_token = (selected.refresh_token or "").strip()
         if not access_token:
-            return None
+            raise SystemExit(
+                "Selected openai-codex OAuth credential is missing access_token. "
+                "Re-authenticate it with `hermes auth add openai-codex` before switching."
+            )
         if not refresh_token:
             raise SystemExit(
                 "Selected openai-codex OAuth credential is missing refresh_token. "

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -58,6 +58,13 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_remove.add_argument(
         "target", help="Credential index, entry id, or exact label"
     )
+    auth_switch = auth_subparsers.add_parser(
+        "switch", help="Move a pooled credential to #1 for a provider"
+    )
+    auth_switch.add_argument("provider", help="Provider id")
+    auth_switch.add_argument(
+        "target", help="Credential index, entry id, or exact label"
+    )
     auth_reset = auth_subparsers.add_parser(
         "reset", help="Clear exhaustion status for all credentials for a provider"
     )

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -805,6 +805,315 @@ def test_auth_remove_prefers_exact_numeric_label_over_index(tmp_path, monkeypatc
     assert labels == ["first", "third"]
 
 
+def test_auth_switch_reorders_provider_pool(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-a",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-primary",
+                    },
+                    {
+                        "id": "cred-b",
+                        "label": "backup",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-backup",
+                    },
+                    {
+                        "id": "cred-c",
+                        "label": "third",
+                        "auth_type": "api_key",
+                        "priority": 2,
+                        "source": "manual",
+                        "access_token": "sk-or-third",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openrouter"
+        target = "backup"
+
+    auth_switch_command(_Args())
+
+    out = capsys.readouterr().out
+    assert 'Switched openrouter to credential "backup" (now #1)' in out
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openrouter"]
+    assert [entry["label"] for entry in entries] == ["backup", "primary", "third"]
+    assert [entry["priority"] for entry in entries] == [0, 1, 2]
+
+
+def test_auth_switch_accepts_id_target(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "first-id",
+                        "label": "first",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-first",
+                    },
+                    {
+                        "id": "second-id",
+                        "label": "second",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-second",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openrouter"
+        target = "second-id"
+
+    auth_switch_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openrouter"]
+    assert [entry["id"] for entry in entries] == ["second-id", "first-id"]
+    assert [entry["priority"] for entry in entries] == [0, 1]
+
+
+def test_auth_switch_syncs_codex_singleton_without_changing_active_provider(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "active_provider": "openrouter",
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    "auth_mode": "chatgpt",
+                    "label": "account-A",
+                },
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "acctA",
+                        "label": "account-A",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    {
+                        "id": "acctB",
+                        "label": "account-B",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "acctB-at",
+                        "refresh_token": "acctB-rt",
+                        "last_refresh": "2026-06-13T00:00:00Z",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openai-codex"
+        target = "account-B"
+
+    auth_switch_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert payload["active_provider"] == "openrouter"
+    entries = payload["credential_pool"]["openai-codex"]
+    assert [entry["id"] for entry in entries] == ["acctB", "acctA"]
+    assert [entry["source"] for entry in entries] == [
+        "device_code",
+        "manual:device_code",
+    ]
+    singleton = payload["providers"]["openai-codex"]
+    assert singleton["tokens"] == {
+        "access_token": "acctB-at",
+        "refresh_token": "acctB-rt",
+    }
+    assert singleton["label"] == "account-B"
+    assert singleton["last_refresh"] == "2026-06-13T00:00:00Z"
+
+    from agent.credential_pool import load_pool
+
+    reloaded = load_pool("openai-codex").entries()
+    assert [(entry.id, entry.label, entry.source) for entry in reloaded] == [
+        ("acctB", "account-B", "device_code"),
+        ("acctA", "account-A", "manual:device_code"),
+    ]
+
+
+def test_auth_switch_codex_uses_fresh_on_disk_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    "auth_mode": "chatgpt",
+                },
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "acctA",
+                        "label": "account-A",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    {
+                        "id": "acctB",
+                        "label": "account-B",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "acctB-stale-at",
+                        "refresh_token": "acctB-stale-rt",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    import hermes_cli.auth_commands as auth_commands
+
+    # Simulate a command that resolved acctB from an older in-memory pool before
+    # another process refreshed acctB's single-use OAuth tokens on disk.
+    _idx, matched, _error = load_pool("openai-codex").resolve_target("account-B")
+    assert matched is not None
+    assert matched.id == "acctB"
+    auth_path = tmp_path / "hermes" / "auth.json"
+    payload = json.loads(auth_path.read_text())
+    acct_b = next(entry for entry in payload["credential_pool"]["openai-codex"] if entry["id"] == "acctB")
+    acct_b["access_token"] = "acctB-fresh-at"
+    acct_b["refresh_token"] = "acctB-fresh-rt"
+    auth_path.write_text(json.dumps(payload, indent=2))
+
+    selected = getattr(auth_commands, "_switch_codex_pool_and_singleton")("acctB")
+
+    assert selected is not None
+    payload = json.loads(auth_path.read_text())
+    singleton = payload["providers"]["openai-codex"]
+    assert singleton["tokens"] == {
+        "access_token": "acctB-fresh-at",
+        "refresh_token": "acctB-fresh-rt",
+    }
+    acct_b = payload["credential_pool"]["openai-codex"][0]
+    assert acct_b["id"] == "acctB"
+    assert acct_b["access_token"] == "acctB-fresh-at"
+    assert acct_b["refresh_token"] == "acctB-fresh-rt"
+
+
+def test_auth_switch_codex_requires_refresh_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    "auth_mode": "chatgpt",
+                },
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "acctA",
+                        "label": "account-A",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    {
+                        "id": "acctB",
+                        "label": "account-B",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "acctB-at",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openai-codex"
+        target = "account-B"
+
+    with pytest.raises(SystemExit, match="missing refresh_token"):
+        auth_switch_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert payload["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "acctA-at",
+        "refresh_token": "acctA-rt",
+    }
+    assert [entry["id"] for entry in payload["credential_pool"]["openai-codex"]] == [
+        "acctA",
+        "acctB",
+    ]
+
+
 def test_auth_reset_clears_provider_statuses(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1163,6 +1163,238 @@ def test_auth_switch_codex_requires_refresh_token(tmp_path, monkeypatch):
     ]
 
 
+def test_auth_switch_preserves_exhausted_status(tmp_path, monkeypatch, capsys):
+    """Plain switch must reorder only; it must not clear unhealthy state."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-a",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-primary-secret",
+                    },
+                    {
+                        "id": "cred-b",
+                        "label": "backup",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-backup-secret",
+                        "last_status": "exhausted",
+                        "last_status_at": 1711230000.0,
+                        "last_error_code": 429,
+                        "last_error_reason": "rate_limited",
+                        "last_error_message": "quota hit",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openrouter"
+        target = "backup"
+
+    auth_switch_command(_Args())
+
+    out = capsys.readouterr().out
+    assert 'Switched openrouter to credential "backup" (now #1)' in out
+    assert "currently marked exhausted" in out
+    assert "sk-or-primary-secret" not in out
+    assert "sk-or-backup-secret" not in out
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openrouter"]
+    assert [entry["id"] for entry in entries] == ["cred-b", "cred-a"]
+    selected = entries[0]
+    assert selected["last_status"] == "exhausted"
+    assert selected["last_status_at"] == 1711230000.0
+    assert selected["last_error_code"] == 429
+    assert selected["last_error_reason"] == "rate_limited"
+    assert selected["last_error_message"] == "quota hit"
+    assert selected["access_token"] == "sk-or-backup-secret"
+
+
+def test_auth_switch_preserves_concurrently_added_credential(tmp_path, monkeypatch):
+    """A stale switch snapshot must not overwrite a credential added on disk."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-a",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-primary",
+                    },
+                    {
+                        "id": "cred-b",
+                        "label": "backup",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-backup",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    stale_pool = load_pool("openrouter")
+    auth_path = tmp_path / "hermes" / "auth.json"
+    payload = json.loads(auth_path.read_text())
+    payload["credential_pool"]["openrouter"].append(
+        {
+            "id": "cred-c",
+            "label": "concurrent",
+            "auth_type": "api_key",
+            "priority": 2,
+            "source": "manual",
+            "access_token": "sk-or-concurrent",
+        }
+    )
+    auth_path.write_text(json.dumps(payload, indent=2))
+
+    selected = stale_pool.activate_index(2)
+
+    assert selected is not None
+    payload = json.loads(auth_path.read_text())
+    assert [entry["id"] for entry in payload["credential_pool"]["openrouter"]] == [
+        "cred-b",
+        "cred-a",
+        "cred-c",
+    ]
+
+
+def test_auth_switch_ambiguous_label_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-a",
+                        "label": "shared",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-a",
+                    },
+                    {
+                        "id": "cred-b",
+                        "label": "shared",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-b",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openrouter"
+        target = "shared"
+
+    with pytest.raises(SystemExit, match="Ambiguous credential label"):
+        auth_switch_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert [entry["id"] for entry in payload["credential_pool"]["openrouter"]] == [
+        "cred-a",
+        "cred-b",
+    ]
+
+
+def test_auth_switch_codex_missing_access_token_has_clear_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    "auth_mode": "chatgpt",
+                },
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "acctA",
+                        "label": "account-A",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    {
+                        "id": "acctB",
+                        "label": "account-B",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "",
+                        "refresh_token": "acctB-rt",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openai-codex"
+        target = "account-B"
+
+    with pytest.raises(SystemExit, match="missing access_token"):
+        auth_switch_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert [entry["id"] for entry in payload["credential_pool"]["openai-codex"]] == [
+        "acctA",
+        "acctB",
+    ]
+
+
 def test_auth_reset_clears_provider_statuses(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -970,6 +970,7 @@ def test_auth_switch_syncs_codex_singleton_without_changing_active_provider(tmp_
                     "tokens": {
                         "access_token": "acctA-at",
                         "refresh_token": "acctA-rt",
+                        "account_id": "acctA-id",
                     },
                     "auth_mode": "chatgpt",
                     "label": "account-A",
@@ -1102,6 +1103,86 @@ def test_auth_switch_codex_uses_fresh_on_disk_tokens(tmp_path, monkeypatch):
     assert acct_b["id"] == "acctB"
     assert acct_b["access_token"] == "acctB-fresh-at"
     assert acct_b["refresh_token"] == "acctB-fresh-rt"
+
+
+def test_auth_switch_codex_materializes_global_fallback_in_profile(tmp_path, monkeypatch):
+    global_root = tmp_path / "global-hermes"
+    profile_root = tmp_path / "profile-hermes"
+    global_root.mkdir()
+    profile_root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(profile_root))
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root",
+        lambda: global_root,
+    )
+
+    global_payload = {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {
+                    "access_token": "acctA-at",
+                    "refresh_token": "acctA-rt",
+                },
+                "auth_mode": "chatgpt",
+                "label": "account-A",
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "acctA",
+                    "label": "account-A",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "device_code",
+                    "access_token": "acctA-at",
+                    "refresh_token": "acctA-rt",
+                },
+                {
+                    "id": "acctB",
+                    "label": "account-B",
+                    "auth_type": "oauth",
+                    "priority": 1,
+                    "source": "manual:device_code",
+                    "access_token": "acctB-at",
+                    "refresh_token": "acctB-rt",
+                },
+            ]
+        },
+    }
+    global_auth_path = global_root / "auth.json"
+    global_auth_path.write_text(json.dumps(global_payload, indent=2))
+    profile_auth_path = profile_root / "auth.json"
+    profile_auth_path.write_text(
+        json.dumps(
+            {"version": 1, "providers": {}, "active_provider": "openrouter"},
+            indent=2,
+        )
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openai-codex"
+        target = "account-B"
+
+    auth_switch_command(_Args())
+
+    profile_payload = json.loads(profile_auth_path.read_text())
+    assert profile_payload["active_provider"] == "openrouter"
+    assert [
+        (entry["id"], entry["source"])
+        for entry in profile_payload["credential_pool"]["openai-codex"]
+    ] == [
+        ("acctB", "device_code"),
+        ("acctA", "manual:device_code"),
+    ]
+    assert profile_payload["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "acctB-at",
+        "refresh_token": "acctB-rt",
+    }
+    assert json.loads(global_auth_path.read_text()) == global_payload
 
 
 def test_auth_switch_codex_requires_refresh_token(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -862,6 +862,55 @@ def test_auth_switch_reorders_provider_pool(tmp_path, monkeypatch, capsys):
     assert [entry["priority"] for entry in entries] == [0, 1, 2]
 
 
+def test_interactive_auth_menu_exposes_switch(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-a",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-primary",
+                    },
+                    {
+                        "id": "cred-b",
+                        "label": "backup",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-backup",
+                    },
+                ]
+            },
+        },
+    )
+    answers = iter(["3", "openrouter", "backup"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    from hermes_cli.auth_commands import _interactive_auth
+
+    _interactive_auth()
+
+    out = capsys.readouterr().out
+    assert "3. Switch active credential for a provider" in out
+    assert 'Switched openrouter to credential "backup" (now #1)' in out
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert [entry["label"] for entry in payload["credential_pool"]["openrouter"]] == [
+        "backup",
+        "primary",
+    ]
+
+
 def test_auth_switch_accepts_id_target(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.setattr(

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -514,6 +514,7 @@ hermes auth list openrouter                              # Show specific provide
 hermes auth add openrouter --api-key sk-or-v1-xxx        # Add API key
 hermes auth add anthropic --type oauth                   # Add OAuth credential
 hermes auth remove openrouter 2                          # Remove by index
+hermes auth switch openrouter 2                          # Move credential #2 to first
 hermes auth reset openrouter                             # Clear cooldowns
 hermes auth status anthropic                             # Show auth status for a provider
 hermes auth logout anthropic                             # Log out and clear stored auth state

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -115,6 +115,7 @@ Type [1/2]:
 | `hermes auth add <provider> --type api-key --api-key <key>` | Add an API key non-interactively |
 | `hermes auth add <provider> --type oauth` | Add an OAuth credential via browser login |
 | `hermes auth remove <provider> <index>` | Remove credential by 1-based index |
+| `hermes auth switch <provider> <target>` | Move an index, id, or exact-label credential to #1 (the next choice under `fill_first`) |
 | `hermes auth reset <provider>` | Clear all cooldowns/exhaustion status |
 
 ## Rotation Strategies

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -116,8 +116,10 @@ Type [1/2]:
 | `hermes auth add <provider> --type api-key --api-key <key>` | Add an API key non-interactively |
 | `hermes auth add <provider> --type oauth` | Add an OAuth credential via browser login |
 | `hermes auth remove <provider> <index>` | Remove credential by 1-based index |
-| `hermes auth switch <provider> <target>` | Move an index, id, or exact-label credential to #1 (the next choice under `fill_first`) |
+| `hermes auth switch <provider> <target>` | Move an index, id, or exact-label credential to #1 (preferred by `fill_first`) |
 | `hermes auth reset <provider>` | Clear all cooldowns/exhaustion status |
+
+`auth switch` reorders the credential pool stored on disk. Rotation strategies such as `round_robin`, `least_used`, and `random` may still choose another healthy credential. Existing Gateway sessions may also keep using an API key cached by a prior `/model` override; start a `/new` session or restart the Gateway before expecting the reordered pool to take effect there.
 
 ## Rotation Strategies
 

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -90,9 +90,10 @@ This shows your full pool status and offers a menu:
 What would you like to do?
   1. Add a credential
   2. Remove a credential
-  3. Reset cooldowns for a provider
-  4. Set rotation strategy for a provider
-  5. Exit
+  3. Switch active credential for a provider
+  4. Reset cooldowns for a provider
+  5. Set rotation strategy for a provider
+  6. Exit
 ```
 
 For providers that support both API keys and OAuth (Anthropic, Nous, Codex), the add flow asks which type:


### PR DESCRIPTION
## What does this PR do?

Adds a focused `hermes auth switch <provider> <target>` command for choosing which credential in a same-provider pool should be preferred first.

This is a current-main salvage of #45513 (itself a refreshed alternative to #17527). The first two commits retain @hanzckernel's original authorship; the follow-up commit carries the review fixes and regression coverage from @eonewg.

The command:

- accepts a 1-based index, credential id, or exact label
- persists the selected entry at priority `0`, without introducing a second active-credential state
- exposes the same operation in the interactive `hermes auth` menu
- warns when `round_robin`, `least_used`, or `random` may select another credential later
- preserves exhausted/dead health state instead of silently resetting it

For `openai-codex`, switching an OAuth entry also synchronizes the legacy singleton Codex auth block under the auth-store lock. It promotes the selected account to `device_code`, demotes the previous singleton-backed account to `manual:device_code`, preserves `active_provider`, and fails clearly if required OAuth token material is absent.

Existing Gateway sessions may still retain a credential cached by a prior `/model` override. This PR documents `/new` or Gateway restart as the current remedy. #65180 is the complementary provider-generic live session rebind path and is intentionally not bundled here.

## Related Issue

Related: #22407, #37224, #65180, #62467.

Supersedes the stale/conflicting implementations in #45513 and #17527. This PR does **not** claim a durable pin contract across non-`fill_first` rotation strategies.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `CredentialPool.activate_index()` with persisted priority reordering
- add CLI parser/dispatch and interactive-menu support for `auth switch`
- atomically synchronize selected Codex OAuth pool state with singleton auth state
- materialize profile-inherited global Codex pools into the active profile before switching
- rebuild Codex singleton token payloads so stale account metadata cannot cross accounts
- preserve concurrently added credentials, health state, and global active provider
- add diagnostics for ambiguous labels and missing Codex access/refresh tokens
- document strategy and existing-session behavior
- add focused regression coverage for generic and Codex credential pools

## How to Test

1. Add at least two credentials for one provider: `hermes auth list <provider>`.
2. Run `hermes auth switch <provider> <index|id|label>`.
3. Run `hermes auth list <provider>` again and verify the selected credential is now `#1`.
4. For a live Gateway session with a cached `/model` credential, use `/new` or restart before expecting the reordered pool to apply.

Automated verification on current `main` (`f099b469d`):

- `scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py tests/gateway/test_session_model_override_credential_pool.py -q` → **187 passed** across 4 files in a clean CI-style environment
- `ruff check .` → passed
- `python scripts/check-windows-footguns.py --all` → passed (778 files scanned)
- `python -m py_compile agent/credential_pool.py hermes_cli/auth_commands.py hermes_cli/subcommands/auth.py hermes_cli/_parser.py` → passed
- `git diff --check origin/main...HEAD` → passed
- CLI smoke with a temporary `HERMES_HOME` reordered `['primary', 'backup']` to `['backup', 'primary']`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs; this explicitly salvages/supersedes #45513 and #17527
- [x] My PR contains only changes related to this feature
- [ ] I've run the entire `pytest tests/ -q` suite locally
- [x] I've added tests for my changes
- [x] I've tested on WSL2/Linux with Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A (no config key added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] I've considered cross-platform impact and ran the Windows-footgun checker
- [x] Tool descriptions/schemas are N/A
