### PR TITLE
fix(desktop): stop files panel auto-opening on first reply

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -40,6 +40,7 @@ import {
   $fileBrowserOpen,
   $panesFlipped,
   $sidebarOpen,
+  closeFileBrowserWhenDetached,
   FILE_BROWSER_DEFAULT_WIDTH,
   FILE_BROWSER_MAX_WIDTH,
   FILE_BROWSER_MIN_WIDTH,
@@ -535,14 +536,8 @@ bindTreeSideVisibility('right', $fileBrowserOpen, setFileBrowserOpen)
 // the rail's row and vanished with it), its zone stands on its own.
 const $hasWorkspace = computed($currentCwd, cwd => Boolean(cwd.trim()))
 
-const syncFileBrowserClosedWhenDetached = (hasWorkspace: boolean) => {
-  if (!hasWorkspace) {
-    setFileBrowserOpen(false)
-  }
-}
-
-syncFileBrowserClosedWhenDetached($hasWorkspace.get())
-$hasWorkspace.listen(syncFileBrowserClosedWhenDetached)
+closeFileBrowserWhenDetached($hasWorkspace.get())
+$hasWorkspace.listen(closeFileBrowserWhenDetached)
 
 bindPaneVisibility('files', $hasWorkspace, undefined, undefined, { revealOnShow: false })
 // ⌘G — the review sidebar appears/disappears (and comes to the front).

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -434,10 +434,16 @@ function bindPaneVisibility(
   paneId: string,
   $open: { get(): boolean; listen(fn: (open: boolean) => void): void },
   close?: () => void,
-  open?: () => void
+  open?: () => void,
+  options?: { revealOnShow?: boolean }
 ) {
-  setTreePaneHidden(paneId, !$open.get())
-  $open.listen(isOpen => setTreePaneHidden(paneId, !isOpen))
+  // revealOnShow defaults true (preview/review should front when toggled on).
+  // Files passes false: a session cwd must not yank the right rail open.
+  const revealOnShow = options?.revealOnShow !== false
+  const sync = (isOpen: boolean) => setTreePaneHidden(paneId, !isOpen, { reveal: isOpen && revealOnShow })
+
+  sync($open.get())
+  $open.listen(sync)
 
   // The tab menu's Close routes through the owning store (never dismissal),
   // so the pane's toggle buttons stay truthful.
@@ -511,13 +517,34 @@ bindTreeSideVisibility('left', $sidebarOpen, setSidebarOpen)
 bindTreeSideVisibility('right', $fileBrowserOpen, setFileBrowserOpen)
 
 // Workspace-scoped surfaces: the file tree and git diff only mean something
-// inside a project. A detached chat (no cwd) hides them — their zones
-// collapse and the chat absorbs the width; picking a project brings them
-// back. The terminal is NOT workspace-gated: unlike the old shell (where it
-// rode the rail's row and vanished with it), its zone stands on its own.
+// inside a project. A detached chat (no cwd) hides them. Their zones collapse
+// and the chat absorbs the width. Picking a project (or a session that reports
+// a cwd) unhides them.
+//
+// Two latches keep "cwd arrived" from force-opening the files rail:
+// 1. revealOnShow:false. Unhiding files does not call revealTreePane / open
+//    the right side.
+// 2. When the workspace detaches (cwd cleared), force $fileBrowserOpen false.
+//    Otherwise a previously-open right rail (often persisted in localStorage)
+//    stays open in the pane store while files is hidden for no-cwd. The zone
+//    looks closed (subtreeGone), then reappears the moment session.info adopts
+//    a process cwd. Closing the side on detach means passive cwd adoption only
+//    fills tree content. The user must open the panel themselves to see it.
+//
+// The terminal is NOT workspace-gated: unlike the old shell (where it rode
+// the rail's row and vanished with it), its zone stands on its own.
 const $hasWorkspace = computed($currentCwd, cwd => Boolean(cwd.trim()))
 
-bindPaneVisibility('files', $hasWorkspace)
+const syncFileBrowserClosedWhenDetached = (hasWorkspace: boolean) => {
+  if (!hasWorkspace) {
+    setFileBrowserOpen(false)
+  }
+}
+
+syncFileBrowserClosedWhenDetached($hasWorkspace.get())
+$hasWorkspace.listen(syncFileBrowserClosedWhenDetached)
+
+bindPaneVisibility('files', $hasWorkspace, undefined, undefined, { revealOnShow: false })
 // ⌘G — the review sidebar appears/disappears (and comes to the front).
 bindPaneVisibility(
   'review',

--- a/apps/desktop/src/components/pane-shell/tree/store.files-reveal.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.files-reveal.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { group, split } from './model'
+import {
+  $collapsedTreeSides,
+  $hiddenTreePanes,
+  declareDefaultTree,
+  setTreePaneHidden,
+  setTreeSideCollapsed
+} from './store'
+
+describe('setTreePaneHidden reveal option', () => {
+  beforeEach(() => {
+    declareDefaultTree(
+      split('row', [group(['sessions']), group(['workspace']), group(['files'])], [1, 3, 1])
+    )
+    // Start from a known closed right rail + hidden files pane.
+    setTreeSideCollapsed('right', true)
+    setTreePaneHidden('files', true, { reveal: false })
+  })
+
+  it('unhides without opening the side when reveal is false', () => {
+    expect($hiddenTreePanes.get().has('files')).toBe(true)
+    expect($collapsedTreeSides.get().has('right')).toBe(true)
+
+    setTreePaneHidden('files', false, { reveal: false })
+
+    expect($hiddenTreePanes.get().has('files')).toBe(false)
+    // Right rail stays collapsed: cwd adoption can fill the tree without
+    // force-opening the files panel.
+    expect($collapsedTreeSides.get().has('right')).toBe(true)
+  })
+
+  it('unhides and opens the side when reveal is true (default)', () => {
+    setTreePaneHidden('files', false)
+
+    expect($hiddenTreePanes.get().has('files')).toBe(false)
+    expect($collapsedTreeSides.get().has('right')).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -117,7 +117,7 @@ function toggledSet<T>(set: ReadonlySet<T>, item: T, present: boolean): Set<T> |
   return next
 }
 
-export function setTreePaneHidden(paneId: string, hidden: boolean) {
+export function setTreePaneHidden(paneId: string, hidden: boolean, options?: { reveal?: boolean }) {
   const next = toggledSet($hiddenTreePanes.get(), paneId, hidden)
 
   if (!next) {
@@ -126,8 +126,10 @@ export function setTreePaneHidden(paneId: string, hidden: boolean) {
 
   $hiddenTreePanes.set(next)
 
-  // Unhiding is an intent to SEE the pane — front it in its group.
-  if (!hidden) {
+  // Unhiding usually means show the pane (front + open its side). Workspace
+  // gated surfaces like files can pass reveal:false so adopting a session cwd
+  // makes the tree available without force opening the files panel.
+  if (!hidden && options?.reveal !== false) {
     revealTreePane(paneId)
   }
 }

--- a/apps/desktop/src/store/file-browser-detach.test.ts
+++ b/apps/desktop/src/store/file-browser-detach.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * When the workspace detaches (cwd cleared), the files rail must close so a
+ * stuck/persisted $fileBrowserOpen cannot re-expand the moment session.info
+ * adopts a process cwd. Mirrors the controller wiring in
+ * apps/desktop/src/app/contrib/controller.tsx.
+ */
+describe('file browser closes on workspace detach', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('closes a persisted-open files rail when cwd becomes empty', async () => {
+    const layout = await import('./layout')
+    const session = await import('./session')
+
+    layout.setFileBrowserOpen(true)
+    session.setCurrentCwd('/some/project')
+    expect(layout.$fileBrowserOpen.get()).toBe(true)
+
+    const syncFileBrowserClosedWhenDetached = (hasWorkspace: boolean) => {
+      if (!hasWorkspace) {
+        layout.setFileBrowserOpen(false)
+      }
+    }
+
+    session.setCurrentCwd('')
+    syncFileBrowserClosedWhenDetached(Boolean(session.$currentCwd.get().trim()))
+
+    expect(layout.$fileBrowserOpen.get()).toBe(false)
+  })
+
+  it('leaves the files rail alone when cwd stays set', async () => {
+    const layout = await import('./layout')
+    const session = await import('./session')
+
+    layout.setFileBrowserOpen(true)
+    session.setCurrentCwd('/some/project')
+
+    const syncFileBrowserClosedWhenDetached = (hasWorkspace: boolean) => {
+      if (!hasWorkspace) {
+        layout.setFileBrowserOpen(false)
+      }
+    }
+
+    session.setCurrentCwd('/other/project')
+    syncFileBrowserClosedWhenDetached(Boolean(session.$currentCwd.get().trim()))
+
+    expect(layout.$fileBrowserOpen.get()).toBe(true)
+  })
+})

--- a/apps/desktop/src/store/file-browser-detach.test.ts
+++ b/apps/desktop/src/store/file-browser-detach.test.ts
@@ -20,14 +20,8 @@ describe('file browser closes on workspace detach', () => {
     session.setCurrentCwd('/some/project')
     expect(layout.$fileBrowserOpen.get()).toBe(true)
 
-    const syncFileBrowserClosedWhenDetached = (hasWorkspace: boolean) => {
-      if (!hasWorkspace) {
-        layout.setFileBrowserOpen(false)
-      }
-    }
-
     session.setCurrentCwd('')
-    syncFileBrowserClosedWhenDetached(Boolean(session.$currentCwd.get().trim()))
+    layout.closeFileBrowserWhenDetached(Boolean(session.$currentCwd.get().trim()))
 
     expect(layout.$fileBrowserOpen.get()).toBe(false)
   })
@@ -39,14 +33,8 @@ describe('file browser closes on workspace detach', () => {
     layout.setFileBrowserOpen(true)
     session.setCurrentCwd('/some/project')
 
-    const syncFileBrowserClosedWhenDetached = (hasWorkspace: boolean) => {
-      if (!hasWorkspace) {
-        layout.setFileBrowserOpen(false)
-      }
-    }
-
     session.setCurrentCwd('/other/project')
-    syncFileBrowserClosedWhenDetached(Boolean(session.$currentCwd.get().trim()))
+    layout.closeFileBrowserWhenDetached(Boolean(session.$currentCwd.get().trim()))
 
     expect(layout.$fileBrowserOpen.get()).toBe(true)
   })

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -218,6 +218,16 @@ export function setFileBrowserOpen(open: boolean) {
   revealNarrowPane(FILE_BROWSER_PANE_ID, open ? 'open' : 'close')
 }
 
+// A workspace detach (cwd cleared) must close the files rail: otherwise a
+// persisted-open flag re-expands it the moment session.info adopts a process
+// cwd, which is the "files panel auto-opens on first reply" bug. Wired to
+// $hasWorkspace in contrib/controller.tsx.
+export function closeFileBrowserWhenDetached(hasWorkspace: boolean): void {
+  if (!hasWorkspace) {
+    setFileBrowserOpen(false)
+  }
+}
+
 // "Reveal this file in the file-browser tree" — an absolute path the tree
 // subscribes to, expanding ancestor folders and selecting/scrolling to it. Reset
 // to null by the tree once consumed.


### PR DESCRIPTION
## What does this PR do?

On Desktop, a new session with the files panel closed would open the files browser by itself after the first agent reply. No project pick, no folder attach, no user click.

That comes from passive workspace plumbing, not a deliberate "show files" action:

1. Turn-end `session.info` adopts the gateway process cwd into `$currentCwd`.
2. `$hasWorkspace` flips true and unhides the files pane.
3. Unhide always called `revealTreePane`, which opens the right rail. Or a stuck/persisted `$fileBrowserOpen` made a zone that looked closed (`subtreeGone` while files was hidden) reappear as soon as files unhid.

Having a working directory for the agent is not the same as the user wanting the file tree visible. This PR keeps cwd adoption for tree content, but stops the rail from force-opening on that path.

## Related Issue

Fixes #67286

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/store.ts`: `setTreePaneHidden` accepts `{ reveal?: boolean }` so unhide can skip `revealTreePane`.
- `apps/desktop/src/app/contrib/controller.tsx`: files bind with `revealOnShow: false`. When workspace detaches (cwd empty), force `$fileBrowserOpen` false so a stuck open rail cannot re-expand when cwd returns.
- `apps/desktop/src/components/pane-shell/tree/store.files-reveal.test.ts`: unhide without opening the side vs default reveal.
- `apps/desktop/src/store/file-browser-detach.test.ts`: close rail when cwd clears, leave it alone when cwd stays set.

## How to Test

1. Unit tests:

```
cd apps/desktop
npx vitest run src/components/pane-shell/tree/store.files-reveal.test.ts src/store/file-browser-detach.test.ts
```

Expected: 4 passed.

2. Manual on Desktop:

- New session, files panel closed.
- Send a short message, wait for the reply to finish.
- Files panel stays closed.
- Open files yourself: tree still has content (session cwd).
- New session again with no project: rail closes if it was open, stays closed after the next reply.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the new/related tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

```
npx vitest run src/components/pane-shell/tree/store.files-reveal.test.ts src/store/file-browser-detach.test.ts
Test Files  2 passed (2)
     Tests  4 passed (4)
```