### PR TITLE
fix(google-meet): preserve nested import failures

### DIFF
--- a/plugins/google_meet/node/client.py
+++ b/plugins/google_meet/node/client.py
@@ -39,6 +39,11 @@ class NodeClient:
         try:
             from websockets.sync.client import connect  # type: ignore
         except ImportError as exc:
+            missing_websockets = exc.name == "websockets" or (
+                exc.name is not None and exc.name.startswith("websockets.")
+            )
+            if not missing_websockets:
+                raise
             raise RuntimeError(
                 "NodeClient requires the 'websockets' package. "
                 "Install it with: pip install websockets"

--- a/plugins/google_meet/node/server.py
+++ b/plugins/google_meet/node/server.py
@@ -177,6 +177,11 @@ class NodeServer:
         try:
             import websockets  # type: ignore
         except ImportError as exc:
+            missing_websockets = exc.name == "websockets" or (
+                exc.name is not None and exc.name.startswith("websockets.")
+            )
+            if not missing_websockets:
+                raise
             raise RuntimeError(
                 "NodeServer.serve requires the 'websockets' package. "
                 "Install it with: pip install websockets"

--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -29,6 +29,11 @@ def _require_websockets():
     try:
         from websockets.sync.client import connect as _connect  # type: ignore
     except ImportError as exc:  # pragma: no cover - exercised via test
+        missing_websockets = exc.name == "websockets" or (
+            exc.name is not None and exc.name.startswith("websockets.")
+        )
+        if not missing_websockets:
+            raise
         raise RuntimeError(
             "websockets package is required for OpenAI Realtime; "
             "install with: pip install websockets"

--- a/tests/plugins/test_google_meet_node.py
+++ b/tests/plugins/test_google_meet_node.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import builtins
 import json
 from pathlib import Path
 
@@ -436,6 +437,40 @@ def test_server_handle_request_wraps_pm_exceptions(tmp_path, monkeypatch):
     assert "kaboom" in resp["error"]
 
 
+def _patch_import_failure(monkeypatch, target_name, missing_name):
+    real_import = builtins.__import__
+
+    def _import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == target_name:
+            raise ImportError(f"missing {missing_name}", name=missing_name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+
+
+def test_server_serve_reports_missing_websockets(tmp_path, monkeypatch):
+    from plugins.google_meet.node.server import NodeServer
+
+    _patch_import_failure(monkeypatch, "websockets", "websockets")
+
+    server = NodeServer(token_path=tmp_path / "t.json")
+    with pytest.raises(RuntimeError, match="pip install websockets"):
+        asyncio.run(server.serve())
+
+
+@pytest.mark.parametrize("missing_name", ["some_dependency", "websockets_extra", None])
+def test_server_serve_preserves_nested_websockets_import_error(
+    tmp_path, monkeypatch, missing_name
+):
+    from plugins.google_meet.node.server import NodeServer
+
+    _patch_import_failure(monkeypatch, "websockets", missing_name)
+
+    server = NodeServer(token_path=tmp_path / "t.json")
+    with pytest.raises(ImportError, match=f"missing {missing_name}"):
+        asyncio.run(server.serve())
+
+
 # ---------------------------------------------------------------------------
 # client.py
 # ---------------------------------------------------------------------------
@@ -474,6 +509,25 @@ def _install_fake_ws(monkeypatch, reply_builder):
     import websockets.sync.client as wsc  # type: ignore
     monkeypatch.setattr(wsc, "connect", _connect)
     return fake_ws_holder
+
+
+def test_client_rpc_reports_missing_websockets(monkeypatch):
+    from plugins.google_meet.node.client import NodeClient
+
+    _patch_import_failure(monkeypatch, "websockets.sync.client", "websockets.sync")
+
+    with pytest.raises(RuntimeError, match="pip install websockets"):
+        NodeClient("ws://x", "t")._rpc("ping", {})
+
+
+@pytest.mark.parametrize("missing_name", ["some_dependency", "websockets_extra", None])
+def test_client_rpc_preserves_nested_websockets_import_error(monkeypatch, missing_name):
+    from plugins.google_meet.node.client import NodeClient
+
+    _patch_import_failure(monkeypatch, "websockets.sync.client", missing_name)
+
+    with pytest.raises(ImportError, match=f"missing {missing_name}"):
+        NodeClient("ws://x", "t")._rpc("ping", {})
 
 
 def test_client_rpc_sends_correct_envelope_and_parses_response(monkeypatch):

--- a/tests/plugins/test_google_meet_realtime.py
+++ b/tests/plugins/test_google_meet_realtime.py
@@ -6,6 +6,7 @@ Uses a scripted fake WebSocket — no network, no API key required.
 from __future__ import annotations
 
 import base64
+import builtins
 import json
 import sys
 import types
@@ -217,6 +218,24 @@ def test_connect_raises_clean_error_when_websockets_missing(monkeypatch):
         sess.connect()
 
 
+@pytest.mark.parametrize("missing_name", ["some_dependency", "websockets_extra", None])
+def test_connect_preserves_nested_websockets_import_error(monkeypatch, missing_name):
+    from plugins.google_meet.realtime.openai_client import RealtimeSession
+
+    real_import = builtins.__import__
+
+    def _import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "websockets.sync.client":
+            raise ImportError("broken transitive dependency", name=missing_name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+
+    sess = RealtimeSession(api_key="sk-test")
+    with pytest.raises(ImportError, match="broken transitive dependency"):
+        sess.connect()
+
+
 # ---------------------------------------------------------------------------
 # RealtimeSpeaker
 # ---------------------------------------------------------------------------
@@ -253,9 +272,9 @@ def test_speaker_run_until_stopped_processes_queue(tmp_path):
     assert stub.spoken == ["hello one", "hello two"]
 
     # Processed file has both entries, in order.
-    lines = [json.loads(l) for l in processed.read_text().splitlines() if l.strip()]
-    assert [l["id"] for l in lines] == ["a", "b"]
-    assert all(l["result"]["ok"] for l in lines)
+    lines = [json.loads(line) for line in processed.read_text().splitlines() if line.strip()]
+    assert [line["id"] for line in lines] == ["a", "b"]
+    assert all(line["result"]["ok"] for line in lines)
 
     # Queue is empty (possibly empty string) after processing.
     assert queue.read_text().strip() == ""


### PR DESCRIPTION
## Summary
- report a friendly missing-dependency error only when `websockets` or a `websockets.*` submodule is actually missing
- preserve unrelated, prefix-collision, and nameless nested `ImportError` failures
- add regression coverage across realtime, node client, and node server import sites

## Verification
- `pytest tests/plugins/test_google_meet_realtime.py tests/plugins/test_google_meet_node.py -q` — 62 passed
- Ruff E/F/W (excluding E501) — passed
- `py_compile` and `git diff --check` — passed
- direct 21-case call-site boundary probe — passed
- independent final code review — PASS