### PR TITLE
fix(desktop): reseed new chats from profile defaults, guarded against concurrent picks (supersedes #67207)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeSessionId } from '@/store/session'
+
+import { useBackgroundSync } from './use-background-sync'
+
+vi.mock('@/store/profile', () => ({ refreshActiveProfile: vi.fn() }))
+
+function setup(overrides: Partial<Parameters<typeof useBackgroundSync>[0]> = {}) {
+  const params: Parameters<typeof useBackgroundSync>[0] = {
+    activeIsMessaging: false,
+    activeSessionId: null,
+    freshDraftReady: false,
+    gatewayState: 'open',
+    refreshActiveMessagingTranscript: vi.fn(),
+    refreshCronJobs: vi.fn(),
+    refreshCurrentModel: vi.fn(),
+    refreshHermesConfig: vi.fn(),
+    refreshMessagingSessions: vi.fn(),
+    refreshSessions: vi.fn(),
+    requestGateway: vi.fn(),
+    ...overrides
+  }
+
+  renderHook(() => useBackgroundSync(params))
+
+  return params
+}
+
+describe('useBackgroundSync model reseeding', () => {
+  beforeEach(() => {
+    $activeSessionId.set(null)
+  })
+
+  it('force-reseeds the composer when booting onto a fresh draft', () => {
+    const { refreshCurrentModel } = setup()
+
+    expect(refreshCurrentModel).toHaveBeenCalledWith(true)
+  })
+
+  it('does not force-reseed when booting with a live session', () => {
+    $activeSessionId.set('runtime-1')
+    const { refreshCurrentModel } = setup({ activeSessionId: 'runtime-1' })
+
+    expect(refreshCurrentModel).toHaveBeenCalledTimes(1)
+    expect(refreshCurrentModel).toHaveBeenCalledWith(false)
+  })
+
+  it('force-reseeds when a new-session draft becomes ready', () => {
+    const { refreshCurrentModel, refreshHermesConfig } = setup({ freshDraftReady: true })
+
+    expect(refreshCurrentModel).toHaveBeenCalledWith(true)
+    expect(refreshHermesConfig).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -68,7 +68,9 @@ export function useBackgroundSync({
       return
     }
 
-    void refreshCurrentModel()
+    // Opening onto a fresh draft must discard the previous chat's sticky
+    // composer pick. A live session keeps its session-scoped selection.
+    void refreshCurrentModel(!$activeSessionId.get())
     void refreshActiveProfile()
     void refreshSessions()
 
@@ -130,7 +132,7 @@ export function useBackgroundSync({
   // model + config so the composer pill reflects the profile default.
   useEffect(() => {
     if (gatewayState === 'open' && !activeSessionId && freshDraftReady) {
-      void refreshCurrentModel()
+      void refreshCurrentModel(true)
       void refreshHermesConfig()
     }
   }, [activeSessionId, freshDraftReady, gatewayState, refreshCurrentModel, refreshHermesConfig])

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -93,7 +93,7 @@ describe('useModelControls', () => {
     expect(getCurrentModelSource()).toBe('default')
   })
 
-  it('does not clobber the active session footer state with global model info', async () => {
+  it('does not clobber the active session footer state even when force-reseeded', async () => {
     setCurrentModel('deepseek/deepseek-v4-pro')
     setCurrentProvider('deepseek')
     $activeSessionId.set('runtime-1')
@@ -109,7 +109,7 @@ describe('useModelControls', () => {
       })
     )
 
-    await result.current.refreshCurrentModel()
+    await result.current.refreshCurrentModel(true)
 
     expect($currentModel.get()).toBe('deepseek/deepseek-v4-pro')
     expect($currentProvider.get()).toBe('deepseek')
@@ -201,10 +201,13 @@ describe('useModelControls', () => {
     setCurrentProvider('anthropic')
     await result.current.refreshCurrentModel()
     expect($currentModel.get()).toBe('anthropic/claude-sonnet-4.6')
+    expect($currentProvider.get()).toBe('anthropic')
 
     // A profile swap forces a reseed to the new profile's default.
     await result.current.refreshCurrentModel(true)
     expect($currentModel.get()).toBe('openai/gpt-5.5')
+    expect($currentProvider.get()).toBe('openai-codex')
+    expect(getCurrentModelSource()).toBe('default')
   })
 
   it('refreshes legacy/default-derived composer state from the profile default', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -210,6 +210,37 @@ describe('useModelControls', () => {
     expect(getCurrentModelSource()).toBe('default')
   })
 
+  it('a manual pick made during a new-chat reseed wins over the resolved default', async () => {
+    // The new-chat reseed's model lookup is async; hold it open so a picker
+    // selection can land while it is in flight (the AGENTS "guard against the
+    // past" case teknium1 flagged).
+    let resolveInfo: (value: { model: string; provider: string }) => void = () => {}
+    vi.mocked(getGlobalModelInfo).mockImplementation(
+      () => new Promise(resolve => (resolveInfo = resolve))
+    )
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    // A fresh draft force-reseeds; its default lookup is now pending.
+    const reseed = result.current.refreshCurrentModel(true)
+
+    // The user picks a model before that lookup resolves.
+    await result.current.selectModel({ model: 'anthropic/claude-sonnet-4.6', provider: 'anthropic' })
+
+    // The stale default resolves last — it must NOT overwrite the newer pick.
+    resolveInfo({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+    await reseed
+
+    expect($currentModel.get()).toBe('anthropic/claude-sonnet-4.6')
+    expect($currentProvider.get()).toBe('anthropic')
+    expect(getCurrentModelSource()).toBe('manual')
+  })
+
   it('refreshes legacy/default-derived composer state from the profile default', async () => {
     setCurrentModel('openai/gpt-5.5')
     setCurrentProvider('nous')

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -9,6 +9,8 @@ import {
   $currentModel,
   $currentProvider,
   getCurrentModelSource,
+  manualModelPickSeq,
+  markManualModelPick,
   setCurrentModel,
   setCurrentModelSource,
   setCurrentProvider
@@ -62,9 +64,18 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         return
       }
 
+      // `force` (a new-chat reseed) deliberately overrides a PRE-EXISTING manual
+      // pick, but must still yield to a NEWER one: capture the manual-pick token
+      // before the async lookup and bail if it moves while we wait, so a pick
+      // made mid-reseed wins (AGENTS.md: guard against the past).
+      const pickSeq = manualModelPickSeq()
       const result = await getGlobalModelInfo()
 
-      if ($activeSessionId.get() || (!force && $currentModel.get() && getCurrentModelSource() === 'manual')) {
+      if ($activeSessionId.get() || manualModelPickSeq() !== pickSeq) {
+        return
+      }
+
+      if (!force && $currentModel.get() && getCurrentModelSource() === 'manual') {
         return
       }
 
@@ -104,6 +115,9 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
       setCurrentModelSource('manual')
+      // Bump the manual-pick token so an in-flight new-chat reseed yields to
+      // this newer intent instead of clobbering it when its lookup resolves.
+      markManualModelPick()
       updateModelOptionsCache(selection.provider, selection.model, !liveSessionId)
 
       // No live session yet: the pick is pure UI state. session.create reads

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -258,12 +258,9 @@ export function useSessionActions({
       })
       setSessionStartedAt(null)
       setTurnStartedAt(null)
-      // The composer's model/effort/fast is sticky UI state (persisted in
-      // localStorage) — a new chat FOLLOWS your last pick instead of snapping
-      // back to the profile default, so we deliberately don't reset it here. The
-      // profile default still owns first-run seeding and profile switches (see
-      // refreshCurrentModel). Only $currentServiceTier (a live-session mirror)
-      // is cleared.
+      // Model/provider reseeding happens after this transition, once the fresh
+      // draft is ready (see useBackgroundSync). Effort/fast remain sticky UI
+      // state. Only $currentServiceTier (a live-session mirror) is cleared here.
       setCurrentServiceTier('')
       setYoloActive(false)
       setNewChatWorkspaceTarget(hasWorkspaceTarget ? workspaceTarget : undefined)

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -375,6 +375,19 @@ export const setCurrentModelSource = (source: ComposerModelSource) => {
   $currentModelSource.set(source)
 }
 
+// Monotonic token bumped on every committed manual composer pick. A new-chat
+// force-reseed captures it before its async model lookup and bails if it moved
+// while pending, so a pick made mid-reseed wins over the resolved default
+// (AGENTS.md: "guard against the past — a stale response must never overwrite
+// newer intent"). Deliberately not persisted: it only orders in-process races.
+let _manualModelPickSeq = 0
+
+export const markManualModelPick = () => {
+  _manualModelPickSeq += 1
+}
+
+export const manualModelPickSeq = (): number => _manualModelPickSeq
+
 export const setCurrentReasoningEffort = (next: Updater<string>) => {
   updateAtom($currentReasoningEffort, next)
   persistString(COMPOSER_EFFORT_KEY, $currentReasoningEffort.get() || null)


### PR DESCRIPTION
## Summary

Salvages #67207 (@deniqlab) for #65300 — a fresh Desktop chat should seed from the `config.yaml` default, not silently reuse the previous chat's sticky composer model. Adds the race guard @teknium1's review asked for.

## Behavior

- **New chat / fresh draft → reseed from profile default** (`refreshCurrentModel(true)` on fresh-draft-ready + boot-onto-fresh-draft). This is the cross-surface-consistent behavior: CLI and Telegram already seed each session from config; Desktop's localStorage stickiness was the outlier (#65300, and the earlier owl-alpha/#58498 thread).
- **Incidental refreshes still never clobber a manual pick** — the non-`force` path from #65896 is unchanged, so boot/focus/session-event refreshes preserve an in-context selection.
- **A live session keeps its session-scoped model** (guarded by `$activeSessionId`).

## The race guard (teknium1's review)

@deniqlab's version used `refreshCurrentModel(true)`, which bypasses **both** manual-state guards — so a picker selection made *while the reseed's async `getGlobalModelInfo()` was in flight* got overwritten by the resolved default, violating `apps/desktop/AGENTS.md`'s *"guard against the past: a stale response must never overwrite newer intent."*

Fix: a monotonic **manual-pick token** (`session.ts`). `selectModel` bumps it; the reseed captures it before the await and bails if it moved while pending. So `force` still overrides a **pre-existing** manual pick (new chat resets to default), but a **newer** pick made mid-reseed wins. Added a deferred-result regression test proving the post-start pick survives.

## Note on the #65896 relationship

This intentionally drops #65896's *cross-chat* manual stickiness (a pick no longer bleeds into the next new chat) while keeping its genuinely important part — the stale-guard against incidental refreshes. Net: manual intent wins within a chat and against in-flight reseeds; a brand-new chat honors your configured default.

## Test plan

- [x] `vitest run --project ui` — 189 files, 1530 pass / 1 skip (incl. new deferred-pick guard test + `use-background-sync.test.tsx`)
- [x] `npm run typecheck` — clean
- [x] `eslint` changed files — clean
- [x] `npm run build` — success
- [ ] Manual: pick a non-default model, Cmd+N → composer shows the config default; pick a model immediately as a new chat opens → your pick sticks (not overwritten by the reseed).

Fixes #65300