### PR TITLE
fix(webhook): load skills from correct profile in multiplexing (#67277)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+_skill_commands_home: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -323,11 +324,12 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands, _skill_commands_platform
+    global _skill_commands, _skill_commands_platform, _skill_commands_home
     _skill_commands_platform = _resolve_skill_commands_platform()
+    _skill_commands_home = str(get_hermes_home())
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
+        from tools.skills_tool import _skills_dir, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
@@ -335,8 +337,9 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
 
         # Scan local dir first, then external dirs
         dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        active_skills_dir = _skills_dir()
+        if active_skills_dir.exists():
+            dirs_to_scan.append(active_skills_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
@@ -418,11 +421,14 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
 
     Rescans when the active platform scope changes (e.g. a gateway
     process serving Telegram and Discord concurrently) so each platform
-    sees its own ``skills.platform_disabled`` view (#14536).
+    sees its own ``skills.platform_disabled`` view (#14536), or when
+    the active profile home changes (e.g. webhook multiplexing routes
+    to a non-default profile — #67277).
     """
     if (
         not _skill_commands
         or _skill_commands_platform != _resolve_skill_commands_platform()
+        or _skill_commands_home != str(get_hermes_home())
     ):
         scan_skill_commands()
     return _skill_commands

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -42,6 +42,7 @@ import subprocess
 import sys
 import time
 from collections import deque
+from contextlib import nullcontext
 from typing import Any, Deque, Dict, List, Optional
 
 try:
@@ -702,20 +703,35 @@ class WebhookAdapter(BasePlatformAdapter):
                     get_skill_commands,
                 )
 
-                skill_cmds = get_skill_commands()
-                for skill_name in skills:
-                    cmd_key = f"/{skill_name}"
-                    if cmd_key in skill_cmds:
-                        skill_content = build_skill_invocation_message(
-                            cmd_key, user_instruction=prompt
+                # When multiplexing routes to a non-default profile,
+                # enter that profile's scope so skill loading reads
+                # from the correct <profile>/skills/ directory (#67277).
+                _scope_ctx = nullcontext()
+                if profile and isinstance(profile, str):
+                    try:
+                        from hermes_cli.profiles import get_profile_dir
+                        from gateway.run import _profile_runtime_scope
+                        _scope_ctx = _profile_runtime_scope(
+                            get_profile_dir(profile)
                         )
-                        if skill_content:
-                            prompt = skill_content
-                            break  # Load the first matching skill
-                    else:
-                        logger.warning(
-                            "[webhook] Skill '%s' not found", skill_name
-                        )
+                    except Exception:
+                        pass  # Fall back to default profile's skills
+
+                with _scope_ctx:
+                    skill_cmds = get_skill_commands()
+                    for skill_name in skills:
+                        cmd_key = f"/{skill_name}"
+                        if cmd_key in skill_cmds:
+                            skill_content = build_skill_invocation_message(
+                                cmd_key, user_instruction=prompt
+                            )
+                            if skill_content:
+                                prompt = skill_content
+                                break  # Load the first matching skill
+                        else:
+                            logger.warning(
+                                "[webhook] Skill '%s' not found", skill_name
+                            )
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 


### PR DESCRIPTION
## Summary

Fixes #67277: Webhook multiplexing loads default profile's skills instead of the URL-resolved profile's skills.

## Root Cause

When `gateway.multiplex_profiles` is enabled, a webhook POST to `/p/<profile>/webhooks/<route>` correctly resolves the profile from the URL for session/credential scoping, but `scan_skill_commands()` always scanned the process-default profile's skills directory because:

1. **`scan_skill_commands()` used the module-level `SKILLS_DIR` variable** — this is set at import time from `get_hermes_home()` and never updated when the profile changes during multiplexing.
2. **`get_skill_commands()` had no profile-home-aware cache invalidation** — it only invalidated on platform changes, so once populated with the default profile's skills, it would return stale data even when `get_hermes_home()` changed.

## Changes

### `agent/skill_commands.py`
- **Added `_skill_commands_home` global**: Tracks which profile home was used to populate the skill commands cache.
- **`scan_skill_commands()`**: Uses `_skills_dir()` (dynamic, respects `get_hermes_home()` override) instead of the static `SKILLS_DIR` module-level variable. Stores the current profile home in `_skill_commands_home`.
- **`get_skill_commands()`**: Added profile home change detection alongside the existing platform change detection — rescans when `_skill_commands_home != str(get_hermes_home())`.

### `gateway/platforms/webhook.py`
- **Profile-scoped skill loading**: When a webhook resolves a non-default profile from the URL, enters that profile's runtime scope (`_profile_runtime_scope`) before calling `get_skill_commands()` and `build_skill_invocation_message()`, ensuring skills are read from `<profile_home>/skills/` rather than `~/.hermes/skills/`.

## Testing

- Two profiles (`default` and `coder`) each with a custom skill of the same name but different content
- `gateway.multiplex_profiles: true`
- POST to `/p/coder/webhooks/<route>` now loads the `coder` profile's skill content instead of `default`'s