### PR TITLE
fix(dashboard): restore pending clarify prompts on session return (#67265)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6311,6 +6311,32 @@ def _session_pending_kind(sid: str) -> str:
     return ""
 
 
+def _session_pending_payload(sid: str) -> dict | None:
+    """Return the pending prompt payload for a session, if any.
+
+    The payload carries enough detail for the frontend to recreate the
+    in-progress prompt overlay (clarify choices, approval command, etc.)
+    when switching back to a waiting session.
+    """
+    for rid, (owner_sid, _ev) in list(_pending.items()):
+        if owner_sid != sid:
+            continue
+        event, payload = _pending_prompt_payloads.get(rid, ("input.request", {}))
+        result: dict = {
+            "kind": str(event).removesuffix(".request"),
+            "request_id": rid,
+        }
+        # Copy prompt-specific fields: clarify.question/choices, approval.command/
+        # description/choices, secret.prompt/env_var, etc.  The ``question`` key
+        # is universal enough for most prompt types; others are conditional.
+        for k in ("question", "choices", "command", "description", "prompt", "env_var",
+                  "allow_permanent", "smart_denied"):
+            if k in payload:
+                result[k] = payload[k]
+        return result
+    return None
+
+
 def _session_live_status(sid: str, session: dict) -> str:
     if _session_pending_kind(sid):
         return "waiting"
@@ -6430,6 +6456,9 @@ def _live_session_payload(
         "started_at": float(session.get("created_at") or time.time()),
         "status": _session_live_status(sid, session),
     }
+    pending = _session_pending_payload(sid)
+    if pending:
+        payload["pending_prompt"] = pending
     if inflight:
         payload["inflight"] = inflight
     return payload

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -13,6 +13,7 @@ import type {
   SessionCloseResponse,
   SessionCreateResponse,
   SessionInflightTurn,
+  SessionPendingPrompt,
   SessionResumeResponse,
   SessionTitleResponse,
   SetupStatusResponse
@@ -66,6 +67,43 @@ export const hydrateLiveSessionInflight = (inflight?: null | SessionInflightTurn
   }
 
   turnController.hydrateStreamingText(assistant)
+}
+
+/** Restore a pending prompt overlay (clarify, approval, sudo, secret) from
+ *  a session resume/activate response so the picker is visible when the user
+ *  returns to a waiting session. */
+const restorePendingPromptOverlay = (pp: SessionPendingPrompt) => {
+  if (pp.kind === 'clarify') {
+    patchOverlayState({
+      clarify: { choices: pp.choices ?? null, question: pp.question ?? '', requestId: pp.request_id }
+    })
+    return
+  }
+
+  if (pp.kind === 'approval') {
+    patchOverlayState({
+      approval: {
+        allowPermanent: pp.allow_permanent !== false,
+        choices: pp.choices ?? [],
+        command: pp.command ?? '',
+        description: pp.description ?? '',
+        smartDenied: pp.smart_denied === true
+      }
+    })
+    return
+  }
+
+  if (pp.kind === 'sudo') {
+    patchOverlayState({ sudo: { requestId: pp.request_id } })
+    return
+  }
+
+  if (pp.kind === 'secret') {
+    patchOverlayState({
+      secret: { envVar: pp.env_var ?? '', prompt: pp.prompt ?? '', requestId: pp.request_id }
+    })
+    return
+  }
 }
 
 export const signalFreshSessionBoundary = (
@@ -340,6 +378,11 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             usage: usageFrom(info)
           })
           hydrateLiveSessionInflight(r.inflight)
+          // Restore pending prompt overlay (clarify / approval / sudo / secret)
+          // that may have been cleared while switching sessions.
+          if (r.pending_prompt) {
+            restorePendingPromptOverlay(r.pending_prompt)
+          }
           cancelResumeScrollRef.current?.()
           cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
         })
@@ -394,6 +437,11 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               usage: usageFrom(info)
             })
             hydrateLiveSessionInflight(r.inflight)
+            // Restore pending prompt overlay (clarify / approval / sudo / secret)
+            // that may have been cleared while switching sessions.
+            if (r.pending_prompt) {
+              restorePendingPromptOverlay(r.pending_prompt)
+            }
             cancelResumeScrollRef.current?.()
             cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -232,6 +232,7 @@ export interface SessionResumeResponse {
   info?: SessionInfo
   message_count?: number
   messages: GatewayTranscriptMessage[]
+  pending_prompt?: null | SessionPendingPrompt
   resumed?: string
   running?: boolean
   session_id: string
@@ -264,11 +265,30 @@ export interface SessionInflightTurn {
   user?: string
 }
 
+/**
+ * Pending prompt payload carried when a session is waiting on user input
+ * (clarify, approval, sudo, secret). The frontend uses this to restore the
+ * corresponding overlay when revisiting a live session.
+ */
+export interface SessionPendingPrompt {
+  allow_permanent?: boolean
+  choices?: string[] | null
+  command?: string
+  description?: string
+  env_var?: string
+  kind: string
+  prompt?: string
+  question?: string
+  request_id: string
+  smart_denied?: boolean
+}
+
 export interface SessionActivateResponse {
   inflight?: null | SessionInflightTurn
   info?: SessionInfo
   message_count?: number
   messages: GatewayTranscriptMessage[]
+  pending_prompt?: null | SessionPendingPrompt
   running?: boolean
   session_id: string
   session_key?: string


### PR DESCRIPTION
## Summary

Fixes #67265: Dashboard Chat loses pending clarify prompts when returning to a session.

### Problem

When a session is waiting on a clarify prompt (A–E choices), switching to another chat and returning would lose the picker. The gateway reported `status: "waiting"` but omitted the pending prompt payload, and the frontend cleared its overlay during session switch without restoring it.

### Changes

**`tui_gateway/server.py`**
- Added `_session_pending_payload()` — serializes the pending prompt state (kind, request_id, question, choices, command, description, prompt, env_var, allow_permanent, smart_denied) for any waiting session.
- Included `pending_prompt` in `_live_session_payload()` so both `session.activate` and `session.resume` (when reusing a live session) carry the payload.

**`ui-tui/src/gatewayTypes.ts`**
- Added `SessionPendingPrompt` interface to type the pending-prompt payload from the gateway.
- Added optional `pending_prompt` field to `SessionActivateResponse` and `SessionResumeResponse`.

**`ui-tui/src/app/useSessionLifecycle.ts`**
- Added `restorePendingPromptOverlay()` helper that restores the appropriate overlay for clarify, approval, sudo, and secret prompts.
- In both `activateLiveSession()` and `resumeById()`, check for `r.pending_prompt` and restore the overlay via `patchOverlayState()`.

### Validation

Manual Dashboard test: create a fresh pending clarify prompt, switch to another chat, return, and select an option. The picker is restored and the run continues.

Fixes #67265