### PR TITLE
fix(desktop): restore tooltip-wrapped action-menu + dialog trigger clicks (supersedes #66109)

### DIFF
--- a/apps/desktop/src/app/overlays/panel.test.tsx
+++ b/apps/desktop/src/app/overlays/panel.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { PanelRowMenu } from './panel'
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.releasePointerCapture ??= () => undefined
+  Element.prototype.setPointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+describe('PanelRowMenu', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('opens its actions menu when the trigger has a tooltip', async () => {
+    const onSelect = vi.fn()
+
+    render(<PanelRowMenu items={[{ label: 'Rename', onSelect }]} />)
+
+    const trigger = screen.getByRole('button', { name: 'Actions' })
+
+    fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
+    expect((await screen.findByRole('tooltip')).textContent).toContain('Actions')
+
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerType: 'mouse' })
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rename' }))
+
+    expect(onSelect).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/overlays/panel.tsx
+++ b/apps/desktop/src/app/overlays/panel.tsx
@@ -217,8 +217,8 @@ export function PanelRowMenu({ items, label = 'Actions' }: { items: PanelMenuIte
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Tip label={label}>
+      <Tip label={label}>
+        <DropdownMenuTrigger asChild>
           <Button
             aria-label={label}
             className="size-5 rounded-[4px] bg-transparent text-(--ui-text-tertiary) opacity-0 transition-colors duration-100 hover:bg-(--ui-control-active-background) hover:text-foreground focus-visible:opacity-100 focus-visible:ring-0 group-hover/row:opacity-100 data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground data-[state=open]:opacity-100 [&_svg]:size-3.5!"
@@ -227,8 +227,8 @@ export function PanelRowMenu({ items, label = 'Actions' }: { items: PanelMenuIte
           >
             <Codicon name="kebab-vertical" size="0.875rem" />
           </Button>
-        </Tip>
-      </DropdownMenuTrigger>
+        </DropdownMenuTrigger>
+      </Tip>
       <DropdownMenuContent align="end" className="w-40" sideOffset={6}>
         {items.map(item => (
           <DropdownMenuItem

--- a/apps/desktop/src/app/starmap/share-controls.test.tsx
+++ b/apps/desktop/src/app/starmap/share-controls.test.tsx
@@ -1,0 +1,24 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ShareControls } from './share-controls'
+
+describe('ShareControls', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('opens its dialog when the trigger has a tooltip', async () => {
+    render(<ShareControls shareCode="map-code" />)
+
+    const trigger = screen.getByRole('button', { name: 'Import / export map' })
+
+    fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
+    expect((await screen.findByRole('tooltip')).textContent).toContain('Import / export map')
+
+    fireEvent.click(trigger)
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByRole('heading', { name: 'Import / export map' })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/starmap/share-controls.tsx
+++ b/apps/desktop/src/app/starmap/share-controls.tsx
@@ -76,8 +76,8 @@ export function ShareControls({ imported = false, onImport, onResetMap, shareCod
         }}
         open={open}
       >
-        <DialogTrigger asChild>
-          <Tip label={t.starmap.shareTitle}>
+        <Tip label={t.starmap.shareTitle}>
+          <DialogTrigger asChild>
             <Button
               aria-label={t.starmap.shareTitle}
               className="text-muted-foreground hover:text-foreground"
@@ -86,8 +86,8 @@ export function ShareControls({ imported = false, onImport, onResetMap, shareCod
             >
               <Upload className="size-3.5" />
             </Button>
-          </Tip>
-        </DialogTrigger>
+          </DialogTrigger>
+        </Tip>
 
         <DialogContent className="max-w-md">
           <DialogHeader>


### PR DESCRIPTION
## Summary

Salvages the still-needed part of #66109 (@AmAzing129) — fixes the Cron (and any `PanelRowMenu`) three-dot menu not opening on Desktop, reported on Win 11. Root cause: a Radix `asChild` trigger merges its behavior props onto its single child, but the child was the `<Tip>` tooltip wrapper — so the trigger/click props landed on the tooltip, not the `Button`, and the click couldn't open the menu. Fix inverts the nesting to `<Tip><Trigger asChild><Button/></Trigger></Tip>` so the trigger props reach the button while the tooltip still wraps.

Applied at the two sites still broken on `main`:
- `PanelRowMenu` (`overlays/panel.tsx`) — the Cron row action menu from the report
- `ShareControls` (`starmap/share-controls.tsx`) — same pattern on a `DialogTrigger`

Each with a focused regression test asserting the tooltip **and** the control both work.

## Why supersede (and what was dropped)

#66109 also fixed the shared dialog **close button** (`components/ui/dialog.tsx` + `dialog.test.tsx`), but that fix **already landed on `main`** independently (main already has `<Tip><DialogPrimitive.Close asChild>` + a more comprehensive `dialog.test.tsx` covering the `preventCloseButtonAutoFocus` tooltip case). Cherry-picking the whole PR add/add-conflicted on `dialog.test.tsx` and no-op'd on `dialog.tsx`. So this drops the redundant dialog commit and keeps only the two still-broken sites — AmAzing129's authorship preserved via cherry-pick of the trigger-behavior commit.

The original PR also had **no CI run**; verified locally.

## Test plan

- [x] `vitest --project ui panel.test.tsx share-controls.test.tsx` — 2 pass (tooltip shows + menu/dialog opens)
- [x] `npm run typecheck` — clean
- [x] `eslint` changed files — clean

Fixes the Cron three-dot menu regression.