### PR TITLE
fix(skills): sort disk hashes by relative path

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1168,6 +1168,30 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_hash_matches_disk_with_sibling_prefix(self, tmp_path):
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content",
+                "references/styles.md": "style index\n",
+                "references/styles/minimal.md": "minimal style\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        (skill_dir / "references" / "styles").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "references" / "styles.md").write_text("style index\n")
+        (skill_dir / "references" / "styles" / "minimal.md").write_text(
+            "minimal style\n"
+        )
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
     def test_bundle_content_hash_accepts_binary_files(self):
         bundle = SkillBundle(
             name="demo-binary-skill",

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -692,11 +692,14 @@ def _content_digest(skill_path: Path) -> str:
     """Canonical SHA-256 over relative paths and exact file bytes."""
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for file_path in sorted(skill_path.rglob("*")):
-            if file_path.is_file():
-                rel = file_path.relative_to(skill_path).as_posix()
-                h.update(rel.encode("utf-8") + b"\x00")
-                h.update(file_path.read_bytes())
+        files = (file_path for file_path in skill_path.rglob("*") if file_path.is_file())
+        for file_path in sorted(
+            files,
+            key=lambda path: path.relative_to(skill_path).as_posix(),
+        ):
+            rel = file_path.relative_to(skill_path).as_posix()
+            h.update(rel.encode("utf-8") + b"\x00")
+            h.update(file_path.read_bytes())
     else:
         h.update(skill_path.read_bytes())
     return h.hexdigest()


### PR DESCRIPTION
## What

- Sort installed skill files by their relative POSIX paths before hashing.
- Add a regression for a sibling file and directory that share a prefix.

## Why

Path object ordering is component-aware, while bundle hashing sorts path strings. A bundle containing references/styles.md and references/styles/minimal.md therefore received different disk and bundle hashes even when every byte matched. Hermes then reported the skill as update_available after each successful update.

## Verification

- scripts/run_tests.sh tests/tools/test_skills_hub.py
- scripts/run_tests.sh tests/tools/test_skills_guard.py tests/tools/test_pr_6656_regressions.py
- Ruff on the two changed files
- Reproduced against the installed official baoyu-article-illustrator bundle: disk and bundle hashes both resolve to sha256:15694c74d4ec835e

Tested on macOS 26.5.1 with Python 3.11.13.