### PR TITLE
fix(auth): preserve provider during xAI reauthentication

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1065,6 +1065,10 @@ class CredentialPool:
                         tokens["refresh_token"] = entry.refresh_token
                     if entry.last_refresh:
                         state["last_refresh"] = entry.last_refresh
+                    # A successful pool refresh supersedes any terminal error
+                    # persisted for the previous grant. Clear it before profile
+                    # and global-root write-through so both stores agree.
+                    state.pop("last_auth_error", None)
                     _store_provider_state(auth_store, "xai-oauth", state, set_active=False)
 
                 else:
@@ -1099,8 +1103,9 @@ class CredentialPool:
                 if self.provider == "openai-codex"
                 else self._sync_xai_oauth_entry_from_pool_store
             )
-            with _auth_store_lock(
-                timeout_seconds=self._single_use_refresh_lock_timeout()
+            with auth_mod._provider_state_transaction(
+                self.provider,
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
             ):
                 synced = sync_entry(entry)
                 if self.provider == "openai-codex":
@@ -1289,9 +1294,11 @@ class CredentialPool:
                         "xAI OAuth refresh token is terminally invalid; clearing local token state"
                     )
                     try:
-                        with _auth_store_lock():
-                            auth_store = _load_auth_store()
-                            state = _load_provider_state(auth_store, "xai-oauth") or {}
+                        with auth_mod._provider_state_transaction(
+                            "xai-oauth",
+                            timeout_seconds=self._single_use_refresh_lock_timeout(),
+                        ) as (auth_store, source_state, source_path):
+                            state = source_state or {}
                             if isinstance(state, dict):
                                 tokens = state.get("tokens") or {}
                                 if isinstance(tokens, dict):
@@ -1309,8 +1316,13 @@ class CredentialPool:
                                             "relogin_required": True,
                                             "at": datetime.now(timezone.utc).isoformat(),
                                         }
-                                        _save_provider_state(auth_store, "xai-oauth", state)
-                                        _save_auth_store(auth_store)
+                                        auth_mod._save_provider_state_to_source(
+                                            auth_store,
+                                            "xai-oauth",
+                                            state,
+                                            source_path,
+                                            set_active=False,
+                                        )
                     except Exception as clear_exc:
                         logger.debug(
                             "Failed to clear terminal xAI OAuth state: %s", clear_exc

--- a/contributors/emails/andrew@chalkley.org
+++ b/contributors/emails/andrew@chalkley.org
@@ -1,0 +1,1 @@
+chalkers

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6673,15 +6673,16 @@ def _update_config_for_provider(
     provider_id: str,
     inference_base_url: str,
     default_model: Optional[str] = None,
+    *,
+    replace_default_model: bool = False,
 ) -> Path:
     """Update config.yaml and auth.json to reflect the active provider.
 
-    When *default_model* is provided the function also writes it as the
-    ``model.default`` value.  This prevents a race condition where the
-    gateway (which re-reads config per-message) picks up the new provider
-    before the caller has finished model selection, resulting in a
-    mismatched model/provider (e.g. ``anthropic/claude-opus-4.6`` sent to
-    MiniMax's API).
+    When *default_model* is provided the function can also write it as the
+    ``model.default`` value in the same config transaction. By default an
+    existing direct-provider model is preserved for compatibility; an
+    explicit model-selection flow must pass *replace_default_model* so the
+    selected model, provider, and endpoint become visible together.
     """
     # Set active_provider in auth.json so auto-resolution picks this provider
     with _auth_store_lock():
@@ -6723,7 +6724,7 @@ def _update_config_for_provider(
     # "anthropic/claude-opus-4.6" will fail on direct-API providers.
     if default_model:
         cur_default = model_cfg.get("default", "")
-        if not cur_default or "/" in cur_default:
+        if replace_default_model or not cur_default or "/" in cur_default:
             model_cfg["default"] = default_model
 
     config["model"] = model_cfg

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1233,7 +1233,11 @@ def _load_provider_state_with_source(
 
 
 @contextmanager
-def _provider_state_transaction(provider_id: str):
+def _provider_state_transaction(
+    provider_id: str,
+    *,
+    timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS,
+):
     """Lock the active auth store and any global fallback source in order.
 
     Profile-backed refresh paths must take the global auth-store lock before
@@ -1241,7 +1245,7 @@ def _provider_state_transaction(provider_id: str):
     target lock is acquired prevents both stale refreshes and whole-file lost
     updates without inverting the documented auth -> shared lock order.
     """
-    with _auth_store_lock():
+    with _auth_store_lock(timeout_seconds=timeout_seconds):
         auth_store = _load_auth_store()
         state, source_path = _load_provider_state_with_source(
             auth_store,
@@ -1252,7 +1256,10 @@ def _provider_state_transaction(provider_id: str):
             yield auth_store, state, source_path
             return
 
-        with _auth_store_lock(target_path=source_path):
+        with _auth_store_lock(
+            timeout_seconds=timeout_seconds,
+            target_path=source_path,
+        ):
             source_store = _load_auth_store(source_path)
             source_providers = source_store.get("providers")
             source_state = None
@@ -1292,6 +1299,8 @@ def _save_provider_state_to_source(
     provider_id: str,
     state: Dict[str, Any],
     source_path: Optional[Path],
+    *,
+    set_active: bool = True,
 ) -> None:
     """Persist provider state back to the auth store it was read from."""
     active_path = _auth_file_path()
@@ -1302,7 +1311,12 @@ def _save_provider_state_to_source(
     except Exception:
         same_store = source_path == active_path
     if same_store:
-        _save_provider_state(auth_store, provider_id, state)
+        _store_provider_state(
+            auth_store,
+            provider_id,
+            state,
+            set_active=set_active,
+        )
         _save_auth_store(auth_store)
         return
 
@@ -1310,7 +1324,7 @@ def _save_provider_state_to_source(
         provider_id,
         state,
         source_path,
-        set_active=True,
+        set_active=set_active,
     )
 
 
@@ -4113,6 +4127,7 @@ def _save_xai_oauth_tokens(
     redirect_uri: str = "",
     last_refresh: Optional[str] = None,
     auth_mode: str = "oauth_device_code",
+    set_active: bool = True,
 ) -> None:
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -4125,13 +4140,17 @@ def _save_xai_oauth_tokens(
         write_through_to_root = not _profile_has_own_xai_oauth_state(auth_store)
         state = _load_provider_state(auth_store, "xai-oauth") or {}
         state["tokens"] = tokens
+        # A successful login or refresh supersedes a terminal error from the
+        # previous grant. Leaving the marker behind makes healthy auth state
+        # continue to claim that re-login is required.
+        state.pop("last_auth_error", None)
         state["last_refresh"] = last_refresh
         state["auth_mode"] = auth_mode
         if discovery:
             state["discovery"] = discovery
         if redirect_uri:
             state["redirect_uri"] = redirect_uri
-        _save_provider_state(auth_store, "xai-oauth", state)
+        _store_provider_state(auth_store, "xai-oauth", state, set_active=set_active)
         _save_auth_store(auth_store)
         if write_through_to_root:
             _write_through_xai_oauth_to_global_root(state)
@@ -4469,6 +4488,10 @@ def _refresh_xai_oauth_tokens(
         redirect_uri=redirect_uri,
         last_refresh=refreshed["last_refresh"],
         auth_mode=auth_mode,
+        # Refreshing credentials is maintenance, not provider selection. A
+        # status check or background runtime refresh must not change the
+        # user's active provider.
+        set_active=False,
     )
     return updated_tokens
 
@@ -4496,7 +4519,13 @@ def resolve_xai_oauth_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
     if should_refresh:
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+        with _provider_state_transaction(
+            "xai-oauth",
+            timeout_seconds=max(
+                float(AUTH_LOCK_TIMEOUT_SECONDS),
+                refresh_timeout_seconds + 5.0,
+            ),
+        ) as (_source_auth_store, _source_state, _source_path):
             data = _read_xai_oauth_tokens(_lock=False)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
@@ -4528,8 +4557,7 @@ def resolve_xai_oauth_runtime_credentials(
                         # Clear dead tokens from auth.json so subsequent sessions fail fast
                         # without a network retry. Mirrors credential_pool.py quarantine.
                         try:
-                            _q_store = _load_auth_store()
-                            _q_state = _load_provider_state(_q_store, "xai-oauth") or {}
+                            _q_state = dict(_source_state or {})
                             _q_tokens = dict(_q_state.get("tokens") or {})
                             _q_tokens.pop("access_token", None)
                             _q_tokens.pop("refresh_token", None)
@@ -4542,8 +4570,13 @@ def resolve_xai_oauth_runtime_credentials(
                                 "relogin_required": True,
                                 "at": datetime.now(timezone.utc).isoformat(),
                             }
-                            _store_provider_state(_q_store, "xai-oauth", _q_state, set_active=False)
-                            _save_auth_store(_q_store)
+                            _save_provider_state_to_source(
+                                _source_auth_store,
+                                "xai-oauth",
+                                _q_state,
+                                _source_path,
+                                set_active=False,
+                            )
                         except Exception as _save_exc:
                             logger.debug(
                                 "xAI OAuth: failed to persist quarantined state: %s", _save_exc,
@@ -7106,6 +7139,7 @@ def _login_xai_oauth(
     pconfig: ProviderConfig,
     *,
     force_new_login: bool = False,
+    update_config: bool = True,
 ) -> None:
     del pconfig
 
@@ -7120,13 +7154,16 @@ def _login_xai_oauth(
                 except (EOFError, KeyboardInterrupt):
                     reuse = "y"
                 if reuse in {"", "y", "yes"}:
-                    config_path = _update_config_for_provider(
-                        "xai-oauth",
-                        existing.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL),
-                    )
+                    config_path = None
+                    if update_config:
+                        config_path = _update_config_for_provider(
+                            "xai-oauth",
+                            existing.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL),
+                        )
                     print()
                     print("Login successful!")
-                    print(f"  Config updated: {config_path} (model.provider=xai-oauth)")
+                    if config_path is not None:
+                        print(f"  Config updated: {config_path} (model.provider=xai-oauth)")
                     return
         except AuthError:
             pass
@@ -7151,6 +7188,7 @@ def _login_xai_oauth(
         redirect_uri=creds.get("redirect_uri", ""),
         last_refresh=creds.get("last_refresh"),
         auth_mode="oauth_device_code",
+        set_active=update_config,
     )
     # An explicit interactive re-login is a strong signal the user wants the
     # xAI credential re-enabled. ``hermes auth remove xai-oauth`` leaves a
@@ -7161,12 +7199,18 @@ def _login_xai_oauth(
     # of ``_save_xai_oauth_tokens`` on purpose — that helper is shared with the
     # refresh hot path, which must never mutate suppression state.
     unsuppress_credential_source("xai-oauth", "device_code")
-    config_path = _update_config_for_provider("xai-oauth", creds.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL))
+    config_path = None
+    if update_config:
+        config_path = _update_config_for_provider(
+            "xai-oauth",
+            creds.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL),
+        )
     print()
     print("Login successful!")
     from hermes_constants import display_hermes_home as _dhh
     print(f"  Auth state: {_dhh()}/auth.json")
-    print(f"  Config updated: {config_path} (model.provider=xai-oauth)")
+    if config_path is not None:
+        print(f"  Config updated: {config_path} (model.provider=xai-oauth)")
 
 
 def _xai_oauth_request_device_code(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1290,6 +1290,26 @@ def _provider_state_transaction(
             provider_id,
         )
         active_path = _auth_file_path()
+        if provider_id == "xai-oauth":
+            # Match _read_xai_oauth_tokens' usability decision while retaining
+            # exact provenance for refresh persistence and quarantine. A
+            # metadata-only/partial profile block must not claim ownership of
+            # usable root credentials. Conversely, usable tokens supplied by
+            # the active profile's credential pool belong to the profile.
+            provider_state_usable = _xai_oauth_state_has_usable_tokens(state)
+            resolved_state = _xai_oauth_state_from_store(auth_store)
+            if _xai_oauth_state_has_usable_tokens(resolved_state):
+                state = resolved_state
+                if not provider_state_usable:
+                    source_path = active_path
+            else:
+                global_path = _global_auth_file_path()
+                global_state = _xai_oauth_state_from_store(
+                    _load_global_auth_store()
+                )
+                if _xai_oauth_state_has_usable_tokens(global_state):
+                    state = global_state
+                    source_path = global_path
         if source_path is None or _same_path(source_path, active_path):
             yield auth_store, state, source_path
             return
@@ -1305,6 +1325,10 @@ def _provider_state_transaction(
                 raw_state = source_providers.get(provider_id)
                 if isinstance(raw_state, dict):
                     source_state = dict(raw_state)
+            if provider_id == "xai-oauth":
+                resolved_source_state = _xai_oauth_state_from_store(source_store)
+                if _xai_oauth_state_has_usable_tokens(resolved_source_state):
+                    source_state = resolved_source_state
             yield auth_store, source_state, source_path
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -18,6 +18,7 @@ Nous authentication paths:
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -1200,6 +1201,43 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     except OSError:
         pass
     return auth_file
+
+
+def _restore_auth_store_snapshot(
+    auth_file: Path,
+    *,
+    existed: bool,
+    payload: bytes,
+) -> None:
+    """Restore exact auth.json bytes after a coordinated write fails."""
+    if not existed:
+        auth_file.unlink(missing_ok=True)
+    else:
+        tmp_path = auth_file.with_name(
+            f"{auth_file.name}.rollback.{os.getpid()}.{uuid.uuid4().hex}"
+        )
+        try:
+            fd = os.open(
+                str(tmp_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            real_path = atomic_replace(tmp_path, auth_file)
+            os.chmod(real_path, stat.S_IRUSR | stat.S_IWUSR)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+    try:
+        dir_fd = os.open(str(auth_file.parent), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
 
 
 def _load_provider_state_with_source(
@@ -4458,15 +4496,15 @@ def _refresh_xai_oauth_tokens(
     token_endpoint: str,
     redirect_uri: str = "",
     timeout_seconds: float,
+    source_auth_store: Dict[str, Any],
+    source_state: Dict[str, Any],
+    source_path: Optional[Path],
 ) -> Dict[str, Any]:
     # Re-persist whatever auth_mode is already stored (legacy pre-device-code
     # logins may still carry ``oauth_pkce``): the refresh hot path must not
     # relabel how the grant was originally obtained.
-    try:
-        state = _load_provider_state(_load_auth_store(), "xai-oauth") or {}
-        auth_mode = str(state.get("auth_mode") or "oauth_device_code")
-    except Exception:
-        auth_mode = "oauth_device_code"
+    state = copy.deepcopy(source_state)
+    auth_mode = str(state.get("auth_mode") or "oauth_device_code")
     refreshed = refresh_xai_oauth_pure(
         str(tokens.get("access_token", "") or ""),
         str(tokens.get("refresh_token", "") or ""),
@@ -4482,15 +4520,21 @@ def _refresh_xai_oauth_tokens(
         updated_tokens["expires_in"] = refreshed["expires_in"]
     if refreshed.get("token_type"):
         updated_tokens["token_type"] = refreshed["token_type"]
-    _save_xai_oauth_tokens(
-        updated_tokens,
-        discovery={"token_endpoint": token_endpoint},
-        redirect_uri=redirect_uri,
-        last_refresh=refreshed["last_refresh"],
-        auth_mode=auth_mode,
-        # Refreshing credentials is maintenance, not provider selection. A
-        # status check or background runtime refresh must not change the
-        # user's active provider.
+    state["tokens"] = updated_tokens
+    state.pop("last_auth_error", None)
+    state["last_refresh"] = refreshed["last_refresh"]
+    state["auth_mode"] = auth_mode
+    discovery = dict(state.get("discovery") or {})
+    discovery["token_endpoint"] = token_endpoint
+    state["discovery"] = discovery
+    if redirect_uri:
+        state["redirect_uri"] = redirect_uri
+    _save_provider_state_to_source(
+        source_auth_store,
+        "xai-oauth",
+        state,
+        source_path,
+        # Refreshing credentials is maintenance, not provider selection.
         set_active=False,
     )
     return updated_tokens
@@ -4549,6 +4593,9 @@ def resolve_xai_oauth_runtime_credentials(
                         token_endpoint=token_endpoint,
                         redirect_uri=redirect_uri,
                         timeout_seconds=refresh_timeout_seconds,
+                        source_auth_store=_source_auth_store,
+                        source_state=_source_state or {},
+                        source_path=_source_path,
                     )
                     access_token = str(tokens.get("access_token", "") or "").strip()
                 except AuthError as exc:
@@ -6684,12 +6731,6 @@ def _update_config_for_provider(
     explicit model-selection flow must pass *replace_default_model* so the
     selected model, provider, and endpoint become visible together.
     """
-    # Set active_provider in auth.json so auto-resolution picks this provider
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
-        auth_store["active_provider"] = provider_id
-        _save_auth_store(auth_store)
-
     # Update config.yaml model section
     config_path = get_config_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -6729,7 +6770,25 @@ def _update_config_for_provider(
 
     config["model"] = model_cfg
 
-    atomic_yaml_write(config_path, config, sort_keys=False)
+    # Keep auth.json and config.yaml coherent across the durable config-write
+    # boundary. Holding the auth lock prevents rollback from overwriting a
+    # concurrent auth update.
+    with _auth_store_lock():
+        auth_file = _auth_file_path()
+        auth_existed = auth_file.exists()
+        auth_snapshot = auth_file.read_bytes() if auth_existed else b""
+        auth_store = _load_auth_store()
+        auth_store["active_provider"] = provider_id
+        _save_auth_store(auth_store)
+        try:
+            atomic_yaml_write(config_path, config, sort_keys=False)
+        except BaseException:
+            _restore_auth_store_snapshot(
+                auth_file,
+                existed=auth_existed,
+                payload=auth_snapshot,
+            )
+            raise
     return config_path
 
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -647,7 +647,6 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
     from hermes_cli.auth import (
         get_xai_oauth_auth_status,
         _prompt_model_selection,
-        _save_model_choice,
         _update_config_for_provider,
         resolve_xai_oauth_runtime_credentials,
         _login_xai_oauth,
@@ -722,8 +721,12 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
     models = list(_PROVIDER_MODELS.get("xai-oauth") or _PROVIDER_MODELS.get("xai") or [])
     selected = _prompt_model_selection(models, current_model=current_model or (models[0] if models else "grok-build-0.1"))
     if selected:
-        _save_model_choice(selected)
-        _update_config_for_provider("xai-oauth", base_url)
+        _update_config_for_provider(
+            "xai-oauth",
+            base_url,
+            default_model=selected,
+            replace_default_model=True,
+        )
         print(f"Default model set to: {selected} (via xAI Grok OAuth — SuperGrok / Premium+)")
     else:
         print("No change.")

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -676,6 +676,7 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
                     mock_args,
                     PROVIDER_REGISTRY["xai-oauth"],
                     force_new_login=True,
+                    update_config=False,
                 )
             except SystemExit:
                 print("Login cancelled or failed.")
@@ -693,7 +694,11 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
                 no_browser=bool(getattr(args, "no_browser", False)),
                 timeout=getattr(args, "timeout", None),
             )
-            _login_xai_oauth(mock_args, PROVIDER_REGISTRY["xai-oauth"])
+            _login_xai_oauth(
+                mock_args,
+                PROVIDER_REGISTRY["xai-oauth"],
+                update_config=False,
+            )
         except SystemExit:
             print("Login cancelled or failed.")
             return

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -113,6 +113,57 @@ def test_pool_refresh_writes_through_to_root_when_profile_reads_root(
     assert root["providers"][provider]["tokens"]["refresh_token"] == "new-refresh"
 
 
+def test_xai_pool_refresh_clears_stale_error_without_activating_provider(
+    profile_and_root,
+):
+    profile_path, root_path = profile_and_root
+    _write_store(
+        profile_path,
+        {"version": 1, "active_provider": "openrouter", "providers": {}},
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "active_provider": "openai-codex",
+            "providers": {
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                    },
+                    "last_auth_error": {
+                        "provider": "xai-oauth",
+                        "reason": "credential_pool_refresh_failure",
+                        "relogin_required": True,
+                    },
+                }
+            },
+        },
+    )
+
+    pool = CredentialPool("xai-oauth", [])
+    pool._sync_device_code_entry_to_auth_store(
+        _entry(
+            "xai-oauth",
+            id="xai-stale-error",
+            access_token="new-access",
+            refresh_token="new-refresh",
+        )
+    )
+
+    profile = _read_store(profile_path)
+    root = _read_store(root_path)
+    assert profile["active_provider"] == "openrouter"
+    assert root["active_provider"] == "openai-codex"
+    assert "last_auth_error" not in profile["providers"]["xai-oauth"]
+    assert "last_auth_error" not in root["providers"]["xai-oauth"]
+    assert (
+        root["providers"]["xai-oauth"]["tokens"]["refresh_token"]
+        == "new-refresh"
+    )
+
+
 @pytest.mark.parametrize(
     "provider",
     ["openai-codex", "xai-oauth"],

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -281,6 +281,107 @@ def test_save_and_read_xai_oauth_tokens_roundtrip(tmp_path, monkeypatch):
     assert data["discovery"]["token_endpoint"] == "https://auth.x.ai/oauth2/token"
 
 
+def test_save_xai_oauth_tokens_clears_stale_auth_error(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "openai-codex",
+                "providers": {
+                    "xai-oauth": {
+                        "tokens": {},
+                        "last_auth_error": {
+                            "provider": "xai-oauth",
+                            "reason": "credential_pool_refresh_failure",
+                            "relogin_required": True,
+                        },
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_xai_oauth_tokens(
+        {
+            "access_token": "at-new",
+            "refresh_token": "rt-new",
+            "id_token": "",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+        set_active=False,
+    )
+
+    auth_store = json.loads(auth_path.read_text())
+    state = auth_store["providers"]["xai-oauth"]
+    assert state["tokens"]["access_token"] == "at-new"
+    assert "last_auth_error" not in state
+    assert auth_store["active_provider"] == "openai-codex"
+
+
+def test_xai_model_flow_cancel_after_refresh_preserves_active_provider(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import main as main_mod
+
+    hermes_home = tmp_path / "hermes"
+    expired = _jwt_with_exp(int(time.time()) - 10)
+    auth_path = _setup_hermes_auth(
+        hermes_home,
+        access_token=expired,
+        refresh_token="rt-old",
+        discovery={"token_endpoint": "https://auth.x.ai/oauth2/token"},
+    )
+    auth_store = json.loads(auth_path.read_text())
+    auth_store["active_provider"] = "openrouter"
+    auth_store["suppressed_sources"] = {"xai-oauth": ["device_code"]}
+    auth_store["providers"]["xai-oauth"]["last_auth_error"] = {
+        "provider": "xai-oauth",
+        "reason": "credential_pool_refresh_failure",
+        "relogin_required": True,
+    }
+    auth_path.write_text(json.dumps(auth_store, indent=2))
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        "model:\n  provider: openrouter\n  default: openai/gpt-5.6-sol\n"
+    )
+    original_config = config_path.read_text()
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_XAI_BASE_URL", raising=False)
+    monkeypatch.delenv("XAI_BASE_URL", raising=False)
+    fresh = _jwt_with_exp(int(time.time()) + 2 * 60 * 60)
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_xai_oauth_pure",
+        lambda *args, **kwargs: {
+            "access_token": fresh,
+            "refresh_token": "rt-new",
+            "id_token": "",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-18T20:00:00Z",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_setup_flows._prompt_auth_credentials_choice",
+        lambda *args, **kwargs: "cancel",
+    )
+
+    main_mod._model_flow_xai_oauth({}, current_model="openai/gpt-5.6-sol")
+
+    updated = json.loads(auth_path.read_text())
+    xai_state = updated["providers"]["xai-oauth"]
+    assert xai_state["tokens"]["access_token"] == fresh
+    assert "last_auth_error" not in xai_state
+    assert updated["active_provider"] == "openrouter"
+    assert config_path.read_text() == original_config
+
+
 def test_read_xai_oauth_tokens_missing(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
@@ -1219,6 +1320,71 @@ def test_login_xai_oauth_relogin_clears_suppression_and_reseeds(tmp_path, monkey
     assert pool.has_credentials()
     entry = next(e for e in pool.entries() if e.source == "device_code")
     assert entry.access_token == new_access
+
+
+def test_login_xai_oauth_config_failure_is_not_reported_as_success(
+    tmp_path, monkeypatch, capsys
+):
+    from types import SimpleNamespace
+
+    from hermes_cli.auth import _login_xai_oauth
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "active_provider": "openrouter", "providers": {}})
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        lambda: {"api_key": "fresh-token", "base_url": DEFAULT_XAI_OAUTH_BASE_URL},
+    )
+    monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "y")
+    monkeypatch.setattr(
+        "hermes_cli.auth._update_config_for_provider",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("config failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="config failed"):
+        _login_xai_oauth(SimpleNamespace(), PROVIDER_REGISTRY["xai-oauth"])
+
+    assert "Login successful!" not in capsys.readouterr().out
+
+
+def test_login_xai_oauth_auth_only_reuses_credentials_without_switching_provider(
+    tmp_path, monkeypatch, capsys
+):
+    from types import SimpleNamespace
+
+    from hermes_cli.auth import _login_xai_oauth
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps({"version": 1, "active_provider": "openrouter", "providers": {}})
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        lambda: {"api_key": "fresh-token", "base_url": DEFAULT_XAI_OAUTH_BASE_URL},
+    )
+    monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "y")
+    monkeypatch.setattr(
+        "hermes_cli.auth._update_config_for_provider",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("auth-only login must not update config")
+        ),
+    )
+
+    _login_xai_oauth(
+        SimpleNamespace(),
+        PROVIDER_REGISTRY["xai-oauth"],
+        update_config=False,
+    )
+
+    assert json.loads(auth_path.read_text())["active_provider"] == "openrouter"
+    assert "Login successful!" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -6,6 +6,7 @@ isinstance(model, dict)) to silently fail — leaving the provider unset and
 falling back to auto-detection.
 """
 
+import json
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -76,6 +77,21 @@ class TestProviderPersistsAfterModelSave:
 
         config_path = config_home / "config.yaml"
         original_text = config_path.read_text(encoding="utf-8")
+        auth_path = config_home / "auth.json"
+        auth_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "updated_at": "2026-07-19T00:00:00+00:00",
+                    "active_provider": "openrouter",
+                    "providers": {},
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        original_auth = auth_path.read_bytes()
 
         def _boom(path, data, **kwargs):
             assert path == config_path
@@ -95,6 +111,7 @@ class TestProviderPersistsAfterModelSave:
 
         assert mock_write.call_count == 1
         assert config_path.read_text(encoding="utf-8") == original_text
+        assert auth_path.read_bytes() == original_auth
 
     def test_api_key_provider_saved_when_model_was_string(self, config_home, monkeypatch):
         """_model_flow_api_key_provider must persist the provider even when

--- a/tests/hermes_cli/test_xai_model_flow.py
+++ b/tests/hermes_cli/test_xai_model_flow.py
@@ -128,6 +128,69 @@ def test_xai_model_flow_selection_switches_config_and_active_provider(
     assert auth_store["active_provider"] == "xai-oauth"
 
 
+def test_xai_model_flow_selection_uses_one_coherent_config_write(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import main as main_mod
+    from utils import atomic_yaml_write as real_atomic_yaml_write
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "active_provider": "openrouter", "providers": {}})
+    )
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        "model:\n"
+        "  provider: openrouter\n"
+        "  base_url: https://openrouter.ai/api/v1\n"
+        "  default: existing-direct-model\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        auth_mod, "get_xai_oauth_auth_status", lambda: {"logged_in": True}
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_setup_flows._prompt_auth_credentials_choice",
+        lambda *args, **kwargs: "use",
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "resolve_xai_oauth_runtime_credentials",
+        lambda *args, **kwargs: {"base_url": "https://api.x.ai/v1/"},
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "_prompt_model_selection",
+        lambda *args, **kwargs: "grok-4.5",
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "_save_model_choice",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("xAI selection must not perform a separate model write")
+        ),
+    )
+
+    writes = []
+
+    def _recording_write(path, data, **kwargs):
+        writes.append(yaml.safe_load(yaml.safe_dump(data)))
+        return real_atomic_yaml_write(path, data, **kwargs)
+
+    monkeypatch.setattr(auth_mod, "atomic_yaml_write", _recording_write)
+
+    main_mod._model_flow_xai_oauth({}, current_model="existing-direct-model")
+
+    assert len(writes) == 1
+    written_model = writes[0]["model"]
+    assert written_model["provider"] == "xai-oauth"
+    assert written_model["base_url"] == "https://api.x.ai/v1"
+    assert written_model["default"] == "grok-4.5"
+    assert yaml.safe_load(config_path.read_text())["model"] == written_model
+
+
 def test_xai_model_flow_cancel_skips_reauth(monkeypatch):
     from hermes_cli import main as main_mod
 

--- a/tests/hermes_cli/test_xai_model_flow.py
+++ b/tests/hermes_cli/test_xai_model_flow.py
@@ -1,4 +1,7 @@
 import argparse
+import json
+
+import yaml
 
 
 def test_xai_model_flow_reauth_uses_standard_radio_prompt(monkeypatch):
@@ -15,9 +18,10 @@ def test_xai_model_flow_reauth_uses_standard_radio_prompt(monkeypatch):
         lambda title, choices, default, description=None: 1,
     )
 
-    def _fake_login(args, provider, force_new_login=False):
+    def _fake_login(args, provider, force_new_login=False, update_config=True):
         captured["login_calls"] += 1
         captured["force_new_login"] = force_new_login
+        captured["update_config"] = update_config
         captured["args"] = args
 
     monkeypatch.setattr("hermes_cli.auth._login_xai_oauth", _fake_login)
@@ -38,8 +42,90 @@ def test_xai_model_flow_reauth_uses_standard_radio_prompt(monkeypatch):
 
     assert captured["login_calls"] == 1
     assert captured["force_new_login"] is True
+    assert captured["update_config"] is False
     assert captured["args"].no_browser is True
     assert captured["args"].timeout == 3
+
+
+def test_xai_model_flow_initial_login_is_auth_only_until_model_selection(monkeypatch):
+    from hermes_cli import main as main_mod
+
+    captured = {}
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_xai_oauth_auth_status",
+        lambda: {"logged_in": False},
+    )
+
+    def _fake_login(args, provider, force_new_login=False, update_config=True):
+        captured["force_new_login"] = force_new_login
+        captured["update_config"] = update_config
+
+    monkeypatch.setattr("hermes_cli.auth._login_xai_oauth", _fake_login)
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        lambda *args, **kwargs: {"base_url": "https://api.x.ai/v1"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda model_ids, current_model="": None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._update_config_for_provider",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("skipping model selection must preserve global provider")
+        ),
+    )
+
+    main_mod._model_flow_xai_oauth(
+        {},
+        current_model="gpt-5.6-sol",
+        args=argparse.Namespace(no_browser=True, timeout=3),
+    )
+
+    assert captured["force_new_login"] is False
+    assert captured["update_config"] is False
+
+
+def test_xai_model_flow_selection_switches_config_and_active_provider(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import main as main_mod
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps({"version": 1, "active_provider": "openrouter", "providers": {}})
+    )
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        "model:\n  provider: openrouter\n  default: openai/gpt-5.6-sol\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_xai_oauth_auth_status",
+        lambda: {"logged_in": True},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_setup_flows._prompt_auth_credentials_choice",
+        lambda *args, **kwargs: "use",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        lambda *args, **kwargs: {"base_url": "https://api.x.ai/v1"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda *args, **kwargs: "grok-4.5",
+    )
+
+    main_mod._model_flow_xai_oauth({}, current_model="openai/gpt-5.6-sol")
+
+    config = yaml.safe_load(config_path.read_text())
+    auth_store = json.loads(auth_path.read_text())
+    assert config["model"]["provider"] == "xai-oauth"
+    assert config["model"]["default"] == "grok-4.5"
+    assert auth_store["active_provider"] == "xai-oauth"
 
 
 def test_xai_model_flow_cancel_skips_reauth(monkeypatch):
@@ -63,6 +149,93 @@ def test_xai_model_flow_cancel_skips_reauth(monkeypatch):
     )
 
     main_mod._model_flow_xai_oauth({}, current_model="grok-build-0.1")
+
+
+def test_xai_model_flow_terminal_root_pool_refresh_then_cancel_preserves_route(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import CredentialPool
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import main as main_mod
+
+    hermes_home = tmp_path / "hermes"
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "root" / "auth.json"
+    profile_path.parent.mkdir(parents=True)
+    root_path.parent.mkdir(parents=True)
+    hermes_home.mkdir(parents=True)
+    profile_path.write_text(
+        json.dumps(
+            {"version": 1, "active_provider": "openrouter", "providers": {}}
+        )
+    )
+    root_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "openai-codex",
+                "providers": {
+                    "xai-oauth": {
+                        "tokens": {
+                            "access_token": "dead-access",
+                            "refresh_token": "dead-refresh",
+                        },
+                        "discovery": {
+                            "client_id": "xai-client",
+                            "token_endpoint": "https://auth.x.ai/oauth/token",
+                            "redirect_uri": "http://localhost:1455/auth/callback",
+                        },
+                    }
+                },
+            }
+        )
+    )
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        "model:\n  provider: openrouter\n  default: openai/gpt-5.6-sol\n"
+    )
+    config_before = config_path.read_bytes()
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    monkeypatch.setattr(auth_mod, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth_mod, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setattr(CredentialPool, "_entry_needs_refresh", lambda *_args: True)
+
+    def _terminal_refresh(*_args, **_kwargs):
+        raise auth_mod.AuthError(
+            "Refresh session has been revoked",
+            provider="xai-oauth",
+            code="xai_refresh_failed",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth_mod, "refresh_xai_oauth_pure", _terminal_refresh)
+    login_calls = []
+
+    def _cancel_login(*_args, **_kwargs):
+        login_calls.append(True)
+        raise SystemExit(1)
+
+    monkeypatch.setattr(auth_mod, "_login_xai_oauth", _cancel_login)
+
+    main_mod._model_flow_xai_oauth(
+        {},
+        current_model="openai/gpt-5.6-sol",
+        args=argparse.Namespace(no_browser=True, timeout=3),
+    )
+
+    assert login_calls == [True]
+    assert config_path.read_bytes() == config_before
+    profile = json.loads(profile_path.read_text())
+    root = json.loads(root_path.read_text())
+    assert profile["active_provider"] == "openrouter"
+    assert "xai-oauth" not in profile["providers"]
+    assert root["active_provider"] == "openai-codex"
+    root_state = root["providers"]["xai-oauth"]
+    assert not root_state["tokens"].get("access_token")
+    assert not root_state["tokens"].get("refresh_token")
+    assert root_state["last_auth_error"]["reason"] == "credential_pool_refresh_failure"
 
 
 def test_auth_credentials_choice_falls_back_to_numbered_prompt(monkeypatch):

--- a/tests/hermes_cli/test_xai_oauth_writethrough.py
+++ b/tests/hermes_cli/test_xai_oauth_writethrough.py
@@ -222,6 +222,72 @@ def test_singleton_refresh_holds_root_source_lock_and_preserves_active_providers
     assert root["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "new-refresh"
 
 
+def test_two_root_owned_rotations_do_not_create_profile_shadow_and_reach_sibling(
+    tmp_path, monkeypatch
+):
+    profile_one = tmp_path / "profiles" / "one" / "auth.json"
+    profile_two = tmp_path / "profiles" / "two" / "auth.json"
+    root_path = tmp_path / "root" / "auth.json"
+    active_profile = [profile_one]
+    monkeypatch.setattr(auth, "_auth_file_path", lambda: active_profile[0])
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    for profile_path in (profile_one, profile_two):
+        _write_store(
+            profile_path,
+            {"version": 1, "active_provider": "openrouter", "providers": {}},
+        )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "active_provider": "openai-codex",
+            "providers": {
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "access-0",
+                        "refresh_token": "refresh-0",
+                    },
+                    "discovery": {
+                        "token_endpoint": "https://auth.x.ai/oauth/token"
+                    },
+                }
+            },
+        },
+    )
+    refresh_inputs = []
+
+    def _rotate(_access_token, refresh_token, **_kwargs):
+        refresh_inputs.append(refresh_token)
+        generation = len(refresh_inputs)
+        return {
+            "access_token": f"access-{generation}",
+            "refresh_token": f"refresh-{generation}",
+            "token_type": "Bearer",
+            "last_refresh": f"2026-07-19T0{generation}:00:00+00:00",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", _rotate)
+
+    first = auth.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+    second = auth.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+
+    assert first["api_key"] == "access-1"
+    assert second["api_key"] == "access-2"
+    assert refresh_inputs == ["refresh-0", "refresh-1"]
+    assert "xai-oauth" not in _read_store(profile_one)["providers"]
+    root = _read_store(root_path)
+    assert root["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "refresh-2"
+
+    active_profile[0] = profile_two
+    sibling = auth.resolve_xai_oauth_runtime_credentials(
+        force_refresh=False,
+        refresh_if_expiring=False,
+    )
+    assert sibling["api_key"] == "access-2"
+    assert "xai-oauth" not in _read_store(profile_two)["providers"]
+
+
 def test_terminal_pool_refresh_quarantines_root_without_activation(
     profile_and_root, monkeypatch
 ):

--- a/tests/hermes_cli/test_xai_oauth_writethrough.py
+++ b/tests/hermes_cli/test_xai_oauth_writethrough.py
@@ -167,3 +167,117 @@ def test_write_through_failure_does_not_break_profile_save(profile_and_root, mon
 
     profile = _read_store(profile_path)
     assert profile["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "r"
+
+
+def test_singleton_refresh_holds_root_source_lock_and_preserves_active_providers(
+    profile_and_root, monkeypatch
+):
+    profile_path, root_path = profile_and_root
+    _write_store(
+        profile_path,
+        {"version": 1, "active_provider": "openrouter", "providers": {}},
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "active_provider": "openai-codex",
+            "providers": {
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                    },
+                    "discovery": {
+                        "client_id": "xai-client",
+                        "token_endpoint": "https://auth.x.ai/oauth/token",
+                        "redirect_uri": "http://localhost:1455/auth/callback",
+                    },
+                }
+            },
+        },
+    )
+
+    lock_observed = []
+
+    def _refresh(*_args, **_kwargs):
+        holder = auth._auth_lock_holder_for(root_path)
+        lock_observed.append(getattr(holder, "depth", 0) > 0)
+        return {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-19T04:00:00+00:00",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", _refresh)
+
+    resolved = auth.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+
+    assert resolved["api_key"] == "new-access"
+    assert lock_observed == [True]
+    assert _read_store(profile_path)["active_provider"] == "openrouter"
+    root = _read_store(root_path)
+    assert root["active_provider"] == "openai-codex"
+    assert root["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "new-refresh"
+
+
+def test_terminal_pool_refresh_quarantines_root_without_activation(
+    profile_and_root, monkeypatch
+):
+    from agent.credential_pool import load_pool
+
+    profile_path, root_path = profile_and_root
+    _write_store(
+        profile_path,
+        {"version": 1, "active_provider": "openrouter", "providers": {}},
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "active_provider": "openai-codex",
+            "providers": {
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "dead-access",
+                        "refresh_token": "dead-refresh",
+                    },
+                    "discovery": {
+                        "client_id": "xai-client",
+                        "token_endpoint": "https://auth.x.ai/oauth/token",
+                        "redirect_uri": "http://localhost:1455/auth/callback",
+                    },
+                }
+            },
+        },
+    )
+
+    pool = load_pool("xai-oauth")
+    assert pool.select() is not None
+    lock_observed = []
+
+    def _terminal_refresh(*_args, **_kwargs):
+        holder = auth._auth_lock_holder_for(root_path)
+        lock_observed.append(getattr(holder, "depth", 0) > 0)
+        raise auth.AuthError(
+            "Refresh session has been revoked",
+            provider="xai-oauth",
+            code="xai_refresh_failed",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", _terminal_refresh)
+
+    assert pool.try_refresh_current() is None
+
+    assert lock_observed == [True]
+    profile = _read_store(profile_path)
+    root = _read_store(root_path)
+    assert profile["active_provider"] == "openrouter"
+    assert "xai-oauth" not in profile["providers"]
+    assert root["active_provider"] == "openai-codex"
+    root_state = root["providers"]["xai-oauth"]
+    assert not root_state["tokens"].get("access_token")
+    assert not root_state["tokens"].get("refresh_token")
+    assert root_state["last_auth_error"]["reason"] == "credential_pool_refresh_failure"

--- a/tests/hermes_cli/test_xai_oauth_writethrough.py
+++ b/tests/hermes_cli/test_xai_oauth_writethrough.py
@@ -288,6 +288,138 @@ def test_two_root_owned_rotations_do_not_create_profile_shadow_and_reach_sibling
     assert "xai-oauth" not in _read_store(profile_two)["providers"]
 
 
+@pytest.mark.parametrize(
+    "profile_state",
+    [
+        {
+            "auth_mode": "oauth_pkce",
+            "discovery": {"client_id": "profile-metadata-only"},
+        },
+        {
+            "tokens": {"access_token": "partial-access"},
+            "discovery": {"client_id": "profile-partial"},
+        },
+        {
+            "tokens": {},
+            "last_auth_error": {
+                "code": "xai_refresh_failed",
+                "relogin_required": True,
+            },
+        },
+    ],
+    ids=["metadata-only", "partial-token", "quarantined"],
+)
+def test_unusable_profile_state_does_not_own_root_refresh(
+    profile_and_root, monkeypatch, profile_state
+):
+    profile_path, root_path = profile_and_root
+    profile_store = {
+        "version": 1,
+        "active_provider": "openrouter",
+        "providers": {"xai-oauth": profile_state},
+    }
+    _write_store(profile_path, profile_store)
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "active_provider": "openai-codex",
+            "providers": {
+                "xai-oauth": {
+                    "auth_mode": "oauth_device_code",
+                    "tokens": {
+                        "access_token": "root-access",
+                        "refresh_token": "root-refresh",
+                    },
+                    "discovery": {
+                        "token_endpoint": "https://auth.x.ai/oauth/token"
+                    },
+                }
+            },
+        },
+    )
+    refresh_inputs = []
+
+    def _rotate(_access_token, refresh_token, **_kwargs):
+        refresh_inputs.append(refresh_token)
+        return {
+            "access_token": "root-access-new",
+            "refresh_token": "root-refresh-new",
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-19T08:00:00+00:00",
+        }
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", _rotate)
+
+    resolved = auth.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+
+    assert resolved["api_key"] == "root-access-new"
+    assert refresh_inputs == ["root-refresh"]
+    assert _read_store(profile_path) == profile_store
+    root = _read_store(root_path)
+    assert root["active_provider"] == "openai-codex"
+    assert root["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "root-refresh-new"
+
+
+def test_terminal_root_refresh_does_not_quarantine_unusable_profile_state(
+    profile_and_root, monkeypatch
+):
+    profile_path, root_path = profile_and_root
+    profile_store = {
+        "version": 1,
+        "active_provider": "openrouter",
+        "providers": {
+            "xai-oauth": {
+                "tokens": {},
+                "last_auth_error": {
+                    "code": "prior_profile_failure",
+                    "relogin_required": True,
+                },
+            }
+        },
+    }
+    _write_store(profile_path, profile_store)
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "active_provider": "openai-codex",
+            "providers": {
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "dead-root-access",
+                        "refresh_token": "dead-root-refresh",
+                    },
+                    "discovery": {
+                        "token_endpoint": "https://auth.x.ai/oauth/token"
+                    },
+                }
+            },
+        },
+    )
+
+    def _terminal_refresh(*_args, **_kwargs):
+        raise auth.AuthError(
+            "Root refresh grant was revoked",
+            provider="xai-oauth",
+            code="xai_refresh_failed",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", _terminal_refresh)
+
+    with pytest.raises(auth.AuthError, match="revoked"):
+        auth.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+
+    assert _read_store(profile_path) == profile_store
+    root = _read_store(root_path)
+    assert root["active_provider"] == "openai-codex"
+    root_state = root["providers"]["xai-oauth"]
+    assert not root_state["tokens"].get("access_token")
+    assert not root_state["tokens"].get("refresh_token")
+    assert root_state["last_auth_error"]["reason"] == "runtime_refresh_failure"
+
+
 def test_terminal_pool_refresh_quarantines_root_without_activation(
     profile_and_root, monkeypatch
 ):


### PR DESCRIPTION
## Problem

Running xAI OAuth authentication through `hermes model` could change the global provider before model selection completed. If the existing default model belonged to another provider, concurrent gateway or cron work could observe a mismatched pair such as `xai-oauth` with an OpenAI Codex model.

A second path existed during the initial status check: refreshing an expired xAI singleton could update `auth.json.active_provider` even if the user immediately chose **Cancel**. Successful token replacement also retained a stale terminal `last_auth_error`, making healthy credentials continue to look quarantined.

## Expected behavior

Authenticating or refreshing xAI credentials from the model picker must not select xAI by itself. The current provider and model should remain unchanged until the user explicitly selects an xAI model. Direct xAI login should retain its existing provider-selection behavior.

A successful token save or refresh should clear any terminal error associated with the superseded grant.

## Fix

- Add auth-only xAI login support for the model-selection flow.
- Preserve `auth.json.active_provider` while saving credentials in auth-only mode.
- Make xAI credential refresh non-activating; refresh is maintenance, not provider selection.
- Clear stale terminal errors on both singleton and credential-pool refresh paths, including profile-to-root write-through.
- Lock the auth store that owns a rotating grant across re-read, refresh POST, and write-back/quarantine.
- Quarantine terminal root-fallback failures in the root source store without changing either store's active provider.
- Keep direct `_login_xai_oauth` behavior unchanged by default.
- Report direct-login success only after its config update succeeds.
- Add regressions for initial login, reauthentication, expired-token refresh followed by Cancel, direct auth-only reuse, explicit Grok selection, stale-error cleanup, and active-provider preservation.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_xai*.py tests/hermes_cli/test_auth_xai_oauth_provider.py tests/hermes_cli/test_auth_profile_fallback.py tests/hermes_cli/test_migrate_xai.py tests/hermes_cli/test_auth_commands.py tests/agent/test_credential_pool_oauth_writethrough.py tests/agent/test_credential_pool.py tests/run_agent/test_codex_xai_oauth_recovery.py tests/agent/test_auxiliary_client_xai_oauth_recovery.py -q`
  - **384 passed**
- `scripts/run_tests.sh tests/hermes_cli -q`
  - **8,954 passed**
  - Three unrelated `os.link()` tests fail with `EXDEV` in this local worktree because the existing virtualenv and pytest temp directory are on different filesystems. The same failures reproduce on clean `origin/main`; all three pass with a same-filesystem pytest `--basetemp`.
- Ruff: passed
- Windows footgun checker: passed
- Contributor-map tests: **12 passed**
- Python compilation and `git diff --check`: passed
