### PR TITLE
fix(telegram): advance reply anchor to latest message_id when batching stacked prompts

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9030,6 +9030,10 @@ class TelegramAdapter(BasePlatformAdapter):
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            # Advance reply anchor to the latest message so the bot replies to
+            # the most recent user message when stacked prompts are batched.
+            if event.message_id:
+                existing.message_id = event.message_id
             # Merge any media that might be attached
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -159,3 +159,36 @@ class TestTextBatching:
         assert adapter._media_group_events == {}
         assert adapter._media_group_tasks == {}
         assert adapter._polling_error_task is None
+
+    @pytest.mark.asyncio
+    async def test_stacked_prompts_reply_anchor_advances_to_last_message(self):
+        """Reply anchor must track the latest message_id when user stacks prompts.
+
+        When two distinct user messages arrive quickly (stacked prompts, not
+        Telegram split-chunks), the batched event should carry the *last*
+        message_id so the bot replies to the most recent message the user sent,
+        not the first one.
+        """
+        adapter = _make_adapter()
+
+        event1 = _make_event("first prompt")
+        event1.message_id = "100"
+        event2 = _make_event("second prompt")
+        event2.message_id = "101"
+
+        adapter._enqueue_text_event(event1)
+        await asyncio.sleep(0.02)  # within batch window
+        adapter._enqueue_text_event(event2)
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        # Text must be merged
+        assert "first prompt" in dispatched.text
+        assert "second prompt" in dispatched.text
+        # Reply anchor must be the LAST message, not the first
+        assert dispatched.message_id == "101", (
+            f"Expected reply anchor '101' (last message) but got {dispatched.message_id!r}. "
+            "Bot would have replied to the wrong message."
+        )


### PR DESCRIPTION
Supersedes #43787, which targeted `gateway/platforms/telegram.py` before that module was moved to `plugins/platforms/telegram/adapter.py` in `5600105478ffde29d7566b45421b100eaa29c4ef`. Per @teknium1's sweeper review on #43787, the original PR no longer changes the live code path. This PR ports the identical fix to the current adapter location.

## Problem
When a user sends stacked prompts (two distinct messages arriving within the batch window), `_enqueue_text_event` merges the text but leaves `existing.message_id` pointed at the *first* message. The Telegram reply anchor (`gateway/platforms/base.py`) uses that event's `message_id`, so the bot's reply lands under the wrong user message.

## Fix
Advance `existing.message_id` to the latest event's `message_id` on each merge in `plugins/platforms/telegram/adapter.py` (guarded on truthiness), so the reply anchor always tracks the most recent message in the batch.

## Test
Added `test_stacked_prompts_reply_anchor_advances_to_last_message` to `tests/gateway/test_telegram_text_batching.py` (ported verbatim from #43787's test, which needed no changes). Full file: 15/15 passing.

Diff: 4 lines production (`plugins/platforms/telegram/adapter.py`), 33 lines test. No other files touched.