### PR TITLE
fix(terminal): tolerate macOS TCC PermissionError in _safe_getcwd

### DIFF
--- a/tests/tools/test_safe_getcwd_permission_error.py
+++ b/tests/tools/test_safe_getcwd_permission_error.py
@@ -1,0 +1,91 @@
+"""Regression tests for _safe_getcwd() PermissionError handling (macOS TCC).
+
+Background: on macOS, when the process CWD is under a TCC-protected location
+(``~/Documents``, ``~/Desktop``, ``~/Downloads``) and the calling process
+lacks Full Disk Access, ``os.getcwd()`` raises ``PermissionError: [Errno 1]
+Operation not permitted`` — not ``FileNotFoundError``.
+
+Before the fix, ``_safe_getcwd`` only caught ``FileNotFoundError``, so the
+terminal-tool cleanup thread (which calls ``_get_env_config()`` →
+``_safe_getcwd()`` every 60 s) logged a full stack trace on every tick,
+accumulating hundreds of MB of noise in ``mcp-stderr.log`` without breaking
+functionality. After the fix, ``PermissionError`` falls back to
+``TERMINAL_CWD`` or ``$HOME`` just like a deleted CWD already does.
+"""
+
+import os
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+class _GetcwdPatcher:
+    """Context manager that temporarily replaces ``os.getcwd`` with *fn*."""
+
+    def __init__(self, fn):
+        self.fn = fn
+        self._original = None
+
+    def __enter__(self):
+        self._original = os.getcwd
+        os.getcwd = self.fn
+        return self
+
+    def __exit__(self, *exc):
+        os.getcwd = self._original
+
+
+def _raise(exc):
+    def _fn():
+        raise exc
+
+    return _fn
+
+
+def test_permission_error_falls_back_to_home(monkeypatch):
+    """macOS TCC EPERM on os.getcwd() must fall back to $HOME, not propagate."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    with _GetcwdPatcher(_raise(PermissionError(1, "Operation not permitted"))):
+        result = terminal_tool._safe_getcwd()
+
+    assert result == os.path.expanduser("~")
+
+
+def test_permission_error_prefers_terminal_cwd(monkeypatch):
+    """TERMINAL_CWD takes priority over $HOME when the live CWD is TCC-blocked."""
+    monkeypatch.setenv("TERMINAL_CWD", "/custom/from/env")
+
+    with _GetcwdPatcher(_raise(PermissionError(1, "Operation not permitted"))):
+        result = terminal_tool._safe_getcwd()
+
+    assert result == "/custom/from/env"
+
+
+def test_file_not_found_still_handled(monkeypatch):
+    """Regression guard: the existing FileNotFoundError path must keep working."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    with _GetcwdPatcher(_raise(FileNotFoundError(2, "No such file or directory"))):
+        result = terminal_tool._safe_getcwd()
+
+    assert result == os.path.expanduser("~")
+
+
+def test_happy_path_unchanged():
+    """Normal os.getcwd() must pass through untouched."""
+    # Don't patch getcwd — use the real one
+    result = terminal_tool._safe_getcwd()
+    assert result == os.getcwd()
+
+
+def test_os_error_not_swallowed(monkeypatch):
+    """Unrelated OSError subclasses must still propagate (don't over-catch)."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    # NotADirectoryError is an OSError but neither FileNotFoundError nor
+    # PermissionError — it should escape so callers see the real problem.
+    with pytest.raises(OSError):
+        with _GetcwdPatcher(_raise(NotADirectoryError(20, "Not a directory"))):
+            terminal_tool._safe_getcwd()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1246,16 +1246,21 @@ def _parse_env_var(name: str, default: str, converter: Any = int, type_label: st
 
 
 def _safe_getcwd() -> str:
-    """Return the current working directory, tolerating a deleted CWD.
+    """Return the current working directory, tolerating a deleted or
+    permission-restricted CWD.
 
     ``os.getcwd()`` raises FileNotFoundError when the process's working
     directory has been removed out from under it (e.g. a scratch workspace
-    that was cleaned up mid-session). Fall back to TERMINAL_CWD, then the
-    user's home directory, so terminal setup never crashes on a stale CWD.
+    that was cleaned up mid-session). On macOS with TCC (Transparency,
+    Consent, and Control), it raises PermissionError (EPERM) when the CWD
+    is under a protected location (~/Documents, ~/Desktop, ~/Downloads)
+    and the calling process lacks Full Disk Access. Fall back to
+    TERMINAL_CWD, then the user's home directory, so terminal setup never
+    crashes on a stale or TCC-blocked CWD.
     """
     try:
         return os.getcwd()
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
 
 


### PR DESCRIPTION
## Problem

On macOS with TCC (Transparency, Consent, and Control), `os.getcwd()` raises `PermissionError: [Errno 1] Operation not permitted` — **not** `FileNotFoundError` — when the process CWD is under a protected location (`~/Documents`, `~/Desktop`, `~/Downloads`) and the calling process lacks Full Disk Access.

`_safe_getcwd()` in `tools/terminal_tool.py` only caught `FileNotFoundError` (the deleted-CWD case from #17558). The terminal-tool cleanup thread, which calls `_get_env_config()` → `_safe_getcwd()` every 60 s, logged a full stack trace on every tick via `exc_info=True`. This accumulated **hundreds of MB of log noise** (observed 184 MB in `mcp-stderr.log` on a single-day session) without breaking functionality — the outer `try/except Exception` in `_cleanup_thread_worker` swallowed the exception, but the traceback kept being emitted.

## Reproduction

```bash
# Launch Hermes (or any process) with CWD inside ~/Documents from a
# terminal app WITHOUT Full Disk Access:
cd ~/Documents/myproject
hermes

# Tail the log — every 60s you get:
#   WARNING tools.terminal_tool: Error in cleanup thread: [Errno 1] Operation not permitted
#   PermissionError: [Errno 1] Operation not permitted
#   Traceback (most recent call last):
#     File ".../tools/terminal_tool.py", line 1702, in _cleanup_thread_worker
#       config = _get_env_config()
#     ...
#     File ".../tools/terminal_tool.py", line 1257, in _safe_getcwd
#       return os.getcwd()
#            ^^^^^^^^^^^
#   PermissionError: [Errno 1] Operation not permitted
```

## Fix

Add `PermissionError` to the existing `except` clause so the fallback chain (`TERMINAL_CWD` → home directory) runs, matching the existing pattern for deleted-CWD recovery (#17558).

```python
# Before:
try:
    return os.getcwd()
except FileNotFoundError:
    return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")

# After:
try:
    return os.getcwd()
except (FileNotFoundError, PermissionError):
    return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
```

One-line change + docstring update explaining the macOS TCC failure mode.

## Relationship to #66306

Complementary, not a duplicate. #66306 handles `PermissionError` from `subprocess.Popen(cwd=...)` when the **configured** cwd is inaccessible to the current user on Linux (e.g. `/root` leaking from a root CLI session). This PR handles the distinct case where the **live process CWD itself** is blocked by macOS TCC — the process already has a CWD, but the kernel refuses to reveal its path.

## Tests

New file `tests/tools/test_safe_getcwd_permission_error.py` (5 tests):

| Test | What it verifies |
|------|------------------|
| `test_permission_error_falls_back_to_home` | macOS TCC EPERM falls back to home directory |
| `test_permission_error_prefers_terminal_cwd` | `TERMINAL_CWD` env var takes priority over home |
| `test_file_not_found_still_handled` | Regression: existing `FileNotFoundError` path still works |
| `test_happy_path_unchanged` | Normal `os.getcwd()` passes through untouched |
| `test_os_error_not_swallowed` | Unrelated `OSError` subclasses still propagate (no over-catching) |

All 5 new tests pass, plus the 19 existing cwd/terminal tests still pass:

```
tests/tools/test_safe_getcwd_permission_error.py .....  [5/5]
tests/tools/test_terminal_task_cwd.py ................  [12/12]
tests/tools/test_local_cwd_permission_fallback.py ...  [7/7]
24 passed in 1.24s
```

## User-facing workarounds (for users who hit this before the fix)

- **Grant Full Disk Access** to the binary that launches Hermes (Terminal.app, iTerm2, or a custom launcher) in System Settings → Privacy & Security → Full Disk Access.
- **Launch from home directory** instead of `~/Documents/...` (`cd ~ && hermes`).

This PR makes the fallback automatic so the log stays clean even without those workarounds.

## Checklist

- [x] Reproduction included
- [x] Fix is minimal — follows existing pattern
- [x] Regression tests added (new file)
- [x] Related upstream work (#66306) checked for overlap
- [x] Existing tests still pass (24/24)
