### PR TITLE
fix(desktop): poll session list for cross-client mutations

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -1,0 +1,148 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useBackgroundSync } from './use-background-sync'
+import type { GatewayRequester } from '../types'
+
+const noopRequestGateway: GatewayRequester = (() => Promise.resolve({})) as GatewayRequester
+
+function Harness({
+  activeIsMessaging = false,
+  activeSessionId = null,
+  freshDraftReady = false,
+  gatewayState = 'open',
+  refreshActiveMessagingTranscript = vi.fn(),
+  refreshCronJobs = vi.fn(),
+  refreshCurrentModel = vi.fn(),
+  refreshHermesConfig = vi.fn(),
+  refreshMessagingSessions = vi.fn(),
+  refreshSessions = vi.fn(),
+  requestGateway = noopRequestGateway
+}: Partial<Parameters<typeof useBackgroundSync>[0]> = {}) {
+  useBackgroundSync({
+    activeIsMessaging,
+    activeSessionId,
+    freshDraftReady,
+    gatewayState,
+    refreshActiveMessagingTranscript,
+    refreshCronJobs,
+    refreshCurrentModel,
+    refreshHermesConfig,
+    refreshMessagingSessions,
+    refreshSessions,
+    requestGateway
+  })
+
+  return null
+}
+
+describe('useBackgroundSync — session list poll', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // jsdom defaults to 'visible'
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible'
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('polls refreshSessions on an interval while the gateway is open and the tab is visible', () => {
+    const refreshSessions = vi.fn(async () => undefined)
+
+    render(<Harness gatewayState="open" refreshSessions={refreshSessions} />)
+
+    // The initial gateway-open effect calls refreshSessions once immediately
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+
+    // Advance past the poll interval (15s)
+    act(() => {
+      vi.advanceTimersByTime(15_000)
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(2)
+
+    act(() => {
+      vi.advanceTimersByTime(15_000)
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not poll when the gateway is not open', () => {
+    const refreshSessions = vi.fn(async () => undefined)
+
+    render(<Harness gatewayState="connecting" refreshSessions={refreshSessions} />)
+
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    // The gateway-open reseed effect doesn't fire, and the poll doesn't start
+    expect(refreshSessions).not.toHaveBeenCalled()
+  })
+
+  it('stops polling after unmount', () => {
+    const refreshSessions = vi.fn(async () => undefined)
+
+    const { unmount } = render(<Harness gatewayState="open" refreshSessions={refreshSessions} />)
+
+    // Initial reseed
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call refreshSessions when the tab is hidden', () => {
+    const refreshSessions = vi.fn(async () => undefined)
+
+    render(<Harness gatewayState="open" refreshSessions={refreshSessions} />)
+
+    // Initial reseed from the gateway-open effect
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden'
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(30_000)
+    })
+
+    // The poll interval fires but the visibility gate suppresses the call
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows rejections from refreshSessions without surfacing unhandled promise rejections', async () => {
+    const refreshSessions = vi.fn(async () => {
+      throw new Error('transient')
+    })
+
+    const handler = vi.fn()
+    window.addEventListener('unhandledrejection', handler)
+
+    render(<Harness gatewayState="open" refreshSessions={refreshSessions} />)
+
+    await act(async () => {
+      vi.advanceTimersByTime(15_000)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(2)
+    expect(handler).not.toHaveBeenCalled()
+
+    window.removeEventListener('unhandledrejection', handler)
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -11,6 +11,13 @@ import type { GatewayRequester } from '../types'
 const CRON_POLL_INTERVAL_MS = 30_000
 const MESSAGING_POLL_INTERVAL_MS = 10_000
 const ACTIVE_MESSAGING_SESSION_POLL_INTERVAL_MS = 5_000
+// Local session metadata (title, updated_at, message_count, working state) can
+// change when another client (mobile app, WebUI, a second Desktop window over a
+// remote gateway) drives a turn on the same backend. The desktop's own WebSocket
+// never sees those events — the gateway routes them to the session's owning
+// transport, not to every connected socket. Poll the recents list so cross-client
+// mutations surface without a manual restart.
+const SESSIONS_POLL_INTERVAL_MS = 15_000
 
 interface BackgroundSyncParams {
   activeIsMessaging: boolean
@@ -108,6 +115,18 @@ export function useBackgroundSync({
 
     return visiblePoll(MESSAGING_POLL_INTERVAL_MS, () => void refreshMessagingSessions())
   }, [gatewayState, refreshMessagingSessions])
+
+  // Keep local session metadata live across clients: another client (Conduit,
+  // WebUI, remote Desktop) driving a turn on the same backend updates
+  // title/updated_at/message_count in state.db, but the desktop's own WebSocket
+  // never receives those events (no fan-out to non-owning transports).
+  useEffect(() => {
+    if (gatewayState !== 'open') {
+      return
+    }
+
+    return visiblePoll(SESSIONS_POLL_INTERVAL_MS, () => void refreshSessions().catch(() => undefined))
+  }, [gatewayState, refreshSessions])
 
   // Only the open messaging transcript needs its own poll — local chats are
   // live over the websocket already.


### PR DESCRIPTION
## Summary

The desktop app does not auto-refresh its sidebar session list when another client modifies a session on the same backend.

**Root cause:** The gateway routes WebSocket events (message deltas, session title updates, etc.) to the session's **owning transport** only — there is no fan-out to other connected sockets. When a second client (mobile app, WebUI, another Desktop window over a remote gateway) drives a turn, the desktop's WebSocket never sees any of those events. Session metadata (title, `updated_at`, `message_count`, working state) changes in `state.db`, but the desktop's cached sidebar list is never invalidated.

**Existing polls only cover specific sources:**
- Cron jobs: 30s poll (`refreshCronJobs`)
- Messaging platforms (Telegram/Discord/WeChat): 10s poll (`refreshMessagingSessions`)
- Active messaging transcript: 5s poll

Local "recents" sessions — the main sidebar list — have no poll. They refresh only on: app boot, gateway reconnect, user actions (Load More, profile switch, session switch), or `BroadcastChannel` messages from another window in the **same** Electron process (which does not cross process boundaries).

## Fix

Add a visibility-gated 15-second poll for `refreshSessions()`, using the existing `visiblePoll` helper. Identical pattern to the cron and messaging polls already in this file. No new infrastructure, no new imports, no backend changes.

```typescript
const SESSIONS_POLL_INTERVAL_MS = 15_000

// ...inside useBackgroundSync:
useEffect(() => {
  if (gatewayState !== 'open') {
    return
  }

  return visiblePoll(SESSIONS_POLL_INTERVAL_MS, () => void refreshSessions())
}, [gatewayState, refreshSessions])
```

## Why 15s?

Between the existing messaging poll (10s) and cron poll (30s). The `refreshSessions` call hits the read-only `/api/profiles/sessions/sidebar` endpoint, which opens each profile's `state.db` directly from disk — no backend process spawn. The frontend's `mergeSessionPage` preserves reference identity on no-op responses, so unchanged data doesn't trigger React re-renders.

## Scope

This complements — does not replace — the per-session-switch refresh that was added to handle stale state when navigating between chats. That fix covers the "I clicked into a stale session" case. This poll covers the "sessions changed while I wasn't looking" case.

Addresses #37919.
