### PR TITLE
fix(approval): restore session approval for Tirith-flagged commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19942,6 +19942,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 description=desc,
                                 metadata=_status_thread_metadata,
                                 allow_permanent=approval_data.get("allow_permanent", True),
+                                allow_session=approval_data.get("allow_session", True),
                                 smart_denied=approval_data.get("smart_denied", False),
                             ),
                             _loop_for_step,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -958,6 +958,7 @@ class MatrixAdapter(BasePlatformAdapter):
         # Matrix reaction-based dangerous command approvals.
         self._approval_reaction_map = {
             "✅": "once",
+            "🌀": "session",
             "♾️": "always",
             "♾": "always",
             "\u267e\ufe0f": "always",
@@ -2025,6 +2026,7 @@ class MatrixAdapter(BasePlatformAdapter):
         description: str = "dangerous command",
         metadata: Optional[dict] = None,
         allow_permanent: bool = True,
+        allow_session: bool = True,
         smart_denied: bool = False,
     ) -> SendResult:
         """Send a reaction-based exec approval prompt for Matrix."""
@@ -2037,17 +2039,24 @@ class MatrixAdapter(BasePlatformAdapter):
         if smart_denied:
             scope_choices = "Smart DENY: owner override applies to this one operation only.\n"
         else:
-            scope_choices = "Reply `!approve session` to approve this pattern for the session, "
+            scope_choices = ""
+            if allow_session:
+                scope_choices += "Reply `!approve session` to approve this pattern for the session, "
             if allow_permanent:
                 scope_choices += "`!approve always` to approve permanently, "
+        reaction_legend_parts = ["✅ = approve once"]
+        if allow_session:
+            reaction_legend_parts.append("🌀 = approve for this session")
+            if allow_permanent:
+                reaction_legend_parts.append("♾️ = approve always")
+        reaction_legend_parts.append("❎ = deny")
         text = (
             "⚠️ **Dangerous command requires approval**\n"
             f"```\n{cmd_preview}\n```\n"
             f"Reason: {description}\n\n"
             f"{scope_choices}Reply `!approve` to execute once, or `!deny` to cancel.\n\n"
             "You can also click the reaction to approve:\n"
-            "✅ = approve\n"
-            "❎ = deny"
+            + "\n".join(reaction_legend_parts)
         )
 
         result = await self.send(chat_id, text, metadata=metadata)
@@ -2067,7 +2076,12 @@ class MatrixAdapter(BasePlatformAdapter):
         self._approval_prompts_by_event[result.message_id] = prompt
         self._approval_prompt_by_session[session_key] = result.message_id
 
-        reactions = ("✅", "❌") if smart_denied or not allow_permanent else ("✅", "♾️", "❌")
+        if not allow_session:
+            reactions = ("✅", "❌")
+        elif not allow_permanent:
+            reactions = ("✅", "🌀", "❌")
+        else:
+            reactions = ("✅", "🌀", "♾️", "❌")
         for emoji in reactions:
             try:
                 reaction_result = await self._send_reaction(chat_id, result.message_id, emoji)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3446,8 +3446,11 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_keys": all_keys,
                 "description": redact_sensitive_text(combined_desc),
                 # Smart DENY overrides are one-operation decisions, so the UI
-                # must not offer a permanent scope.
+                # must not offer a permanent scope. Tirith warnings are already
+                # enforced at the persistence layer — "always" degrades to
+                # session (see the choice handler below).
                 "allow_permanent": not has_tirith and not smart_denied_for_owner,
+                "allow_session": not smart_denied_for_owner,
             }
             if smart_denied_for_owner:
                 approval_data["smart_denied"] = True


### PR DESCRIPTION
## Problem

When the Tirith security scanner flags a command, `allow_permanent` is set to `False` — which collapses approval reactions/buttons to only "approve once" and "deny" on Matrix, Discord, Slack, and other platforms. This unnecessarily hides both session-scoped (🌀) and permanent (♾️) approval options.

## Root Cause

In `tools/approval.py`, `allow_permanent` was gated on `not has_tirith`. A single boolean controlled both the session and permanent scopes, forcing downstream adapters into a binary choice: show the full set or show only approve/deny.

## Fix

Introduce a separate `allow_session` flag:

- **`allow_session`**: `True` unless `smart_denied` (owner override of a Smart DENY). Session approval is safe regardless of why the command was flagged.
- **`allow_permanent`**: remains `False` when Tirith fires — hiding ♾️ is correct because the persistence layer downgrades it to session anyway.
- The Matrix adapter now uses `allow_session` to show 🌀 independently from ♾️.
- The gateway dispatcher (`run.py`) forwards both flags to `adapter.send_exec_approval`.

This gives three tiers:
| Scenario | Options shown |
|---|---|
| Smart DENY override | approve, deny |
| Tirith warning | approve, session, deny |
| Normal, no warnings | approve, session, always, deny |