### PR TITLE
fix(kanban): preserve notification handoffs end to end

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -353,22 +353,40 @@ class GatewayKanbanWatchersMixin:
                             payload_summary = None
                             if ev.payload and ev.payload.get("summary"):
                                 payload_summary = str(ev.payload["summary"])
+                            # A completion summary is the worker's handoff —
+                            # deliver it whole, like block reasons below: cap
+                            # well under Telegram's 4096 limit with a marker +
+                            # pointer to the card instead of a silent mid-word
+                            # cut at 200 chars.
                             if payload_summary:
-                                lines = payload_summary.strip().splitlines()
-                                h = lines[0][:200] if lines else payload_summary[:200]
-                                handoff = f"\n{h}"
+                                raw = payload_summary.strip()
+                                clipped = raw[:3500]
+                                if len(raw) > 3500:
+                                    clipped += " …[truncated — full summary on the card]"
+                                handoff = f"\n{clipped}"
                             elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
-                                handoff = f"\n{r}"
+                                raw = task.result.strip()
+                                clipped = raw[:3500]
+                                if len(raw) > 3500:
+                                    clipped += " …[truncated — full result on the card]"
+                                handoff = f"\n{clipped}"
                             msg = (
                                 f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
                                 f" — {title}{handoff}"
                             )
                         elif kind == "blocked":
+                            # A block reason (esp. kind=needs_input) IS the
+                            # actionable payload the subscriber must answer, so
+                            # deliver it near-whole. Cap well under Telegram's
+                            # 4096 limit, with a marker + pointer to the card
+                            # when a pathologically long reason is clipped.
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
-                                reason = f": {str(ev.payload['reason'])[:160]}"
+                                raw = str(ev.payload["reason"])
+                                clipped = raw[:3500]
+                                if len(raw) > 3500:
+                                    clipped += " …[truncated — full reason on the card]"
+                                reason = f": {clipped}"
                             msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
                             err = ""

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -24,6 +24,18 @@ from agent.i18n import t
 # "gateway.run") so extracted log records keep their original logger name.
 logger = logging.getLogger("gateway.run")
 
+KANBAN_NOTIFICATION_HANDOFF_MAX_CHARS = 3500
+
+
+def _notification_excerpt(text: Any, label: str) -> str:
+    """Preserve actionable handoffs and mark the rare bounded message."""
+    value = str(text or "").strip()
+    if len(value) <= KANBAN_NOTIFICATION_HANDOFF_MAX_CHARS:
+        return value
+    suffix = f" …[truncated — full {label} on the card]"
+    keep = KANBAN_NOTIFICATION_HANDOFF_MAX_CHARS - len(suffix)
+    return value[:keep].rstrip() + suffix
+
 
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
@@ -359,17 +371,9 @@ class GatewayKanbanWatchersMixin:
                             # pointer to the card instead of a silent mid-word
                             # cut at 200 chars.
                             if payload_summary:
-                                raw = payload_summary.strip()
-                                clipped = raw[:3500]
-                                if len(raw) > 3500:
-                                    clipped += " …[truncated — full summary on the card]"
-                                handoff = f"\n{clipped}"
+                                handoff = f"\n{_notification_excerpt(payload_summary, 'summary')}"
                             elif task and task.result:
-                                raw = task.result.strip()
-                                clipped = raw[:3500]
-                                if len(raw) > 3500:
-                                    clipped += " …[truncated — full result on the card]"
-                                handoff = f"\n{clipped}"
+                                handoff = f"\n{_notification_excerpt(task.result, 'result')}"
                             msg = (
                                 f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
                                 f" — {title}{handoff}"
@@ -382,11 +386,7 @@ class GatewayKanbanWatchersMixin:
                             # when a pathologically long reason is clipped.
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
-                                raw = str(ev.payload["reason"])
-                                clipped = raw[:3500]
-                                if len(raw) > 3500:
-                                    clipped += " …[truncated — full reason on the card]"
-                                reason = f": {clipped}"
+                                reason = f": {_notification_excerpt(ev.payload['reason'], 'reason')}"
                             msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
                             err = ""

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -136,6 +136,17 @@ VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
+KANBAN_EVENT_HANDOFF_MAX_CHARS = 3500
+
+
+def _event_handoff_excerpt(text: Optional[str]) -> str:
+    """Keep actionable event handoffs while bounding the SQLite payload."""
+    value = str(text or "").strip()
+    if len(value) <= KANBAN_EVENT_HANDOFF_MAX_CHARS:
+        return value
+    suffix = "\n…[truncated — full handoff on the card]"
+    keep = KANBAN_EVENT_HANDOFF_MAX_CHARS - len(suffix)
+    return value[:keep].rstrip() + suffix
 
 
 def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None:
@@ -4228,12 +4239,12 @@ def complete_task(
                 summary=summary if summary is not None else result,
                 metadata=metadata,
             )
-        # Carry the handoff summary in the event payload so gateway
+        # Carry the actionable handoff in the event payload so gateway
         # notifiers and dashboard WS consumers can render it without a
-        # second SQL round-trip. First line only, 400 char cap — the
-        # full summary stays on the run row.
+        # second SQL round-trip. Keep normal multi-line summaries intact;
+        # oversized payloads retain an explicit pointer to the full run row.
         ev_summary = (summary if summary is not None else result) or ""
-        ev_summary = ev_summary.strip().splitlines()[0][:400] if ev_summary else ""
+        ev_summary = _event_handoff_excerpt(ev_summary)
         completed_payload: dict = {
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
@@ -4854,10 +4865,7 @@ def edit_completed_task_result(
                     "UPDATE task_runs SET metadata = ? WHERE id = ?",
                     (json.dumps(metadata, ensure_ascii=False), run_id),
                 )
-        ev_summary = (
-            handoff_summary.strip().splitlines()[0][:400]
-            if handoff_summary else ""
-        )
+        ev_summary = _event_handoff_excerpt(handoff_summary)
         _append_event(
             conn, task_id, "edited",
             {

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2081,8 +2081,43 @@ def test_completed_event_payload_carries_summary(kanban_home):
         events = kb.list_events(conn, tid)
         comp = [e for e in events if e.kind == "completed"]
         assert len(comp) == 1
-        # First-line-only, within the 400-char cap, preserved verbatim.
-        assert comp[0].payload["summary"] == "handoff line 1"
+        assert comp[0].payload is not None
+        assert comp[0].payload["summary"] == "handoff line 1\nextra"
+    finally:
+        conn.close()
+
+
+def test_completed_event_payload_marks_oversized_summary(kanban_home):
+    """Event consumers get a bounded payload with an explicit truncation marker."""
+    summary = "handoff\n" + ("x" * 5000)
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, tid)
+        kb.complete_task(conn, tid, summary=summary)
+        event = [e for e in kb.list_events(conn, tid) if e.kind == "completed"][0]
+        assert event.payload is not None
+        payload_summary = event.payload["summary"]
+        assert len(payload_summary) <= kb.KANBAN_EVENT_HANDOFF_MAX_CHARS
+        assert "truncated" in payload_summary
+        assert "full handoff on the card" in payload_summary
+    finally:
+        conn.close()
+
+
+def test_edit_completed_event_preserves_multiline_summary(kanban_home):
+    """The edit/backfill sibling path follows the same handoff contract."""
+    summary = "updated decision\nverification and rollback"
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        kb.complete_task(conn, tid)
+        assert kb.edit_completed_task_result(
+            conn, tid, result=summary, summary=summary
+        )
+        event = [e for e in kb.list_events(conn, tid) if e.kind == "edited"][-1]
+        assert event.payload is not None
+        assert event.payload["summary"] == summary
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -79,6 +79,100 @@ async def test_notifier_unsubs_after_completed_event(kanban_home):
 
 
 @pytest.mark.asyncio
+async def test_notifier_preserves_multiline_completion_handoff(kanban_home):
+    """The completion event must not clip the handoff before notification delivery."""
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    summary = (
+        "QA is GO for merge. Architecture and migration gates passed.\n"
+        "Verification: build clean; unit 8/8; Playwright 3/3; runtime smoke passed.\n"
+        + "Residual risk and rollback details: "
+        + ("x" * 500)
+    )
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="full handoff", assignee="worker1")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        kb.complete_task(conn, tid, result=summary, summary=summary)
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+    fake_adapter = MagicMock()
+
+    async def _send_and_stop(chat_id, msg, metadata=None):
+        runner._running = False
+
+    fake_adapter.send = AsyncMock(side_effect=_send_and_stop)
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await asyncio.wait_for(runner._kanban_notifier_watcher(interval=1), timeout=10.0)
+
+    delivered = fake_adapter.send.call_args[0][1]
+    assert summary in delivered
+    assert "Residual risk and rollback details" in delivered
+
+
+@pytest.mark.asyncio
+async def test_notifier_preserves_actionable_block_reason(kanban_home):
+    """A needs-input question set must reach the subscriber intact."""
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    reason = "Choose a deployment target:\n" + "\n".join(
+        f"Option {index}: details and trade-offs" for index in range(20)
+    )
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="decision", assignee="worker1")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+    fake_adapter = MagicMock()
+
+    async def _send_and_stop(chat_id, msg, metadata=None):
+        runner._running = False
+
+    fake_adapter.send = AsyncMock(side_effect=_send_and_stop)
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await asyncio.wait_for(runner._kanban_notifier_watcher(interval=1), timeout=10.0)
+
+    delivered = fake_adapter.send.call_args[0][1]
+    assert reason in delivered
+    assert "Option 19" in delivered
+
+
+def test_notification_excerpt_bounds_total_length_with_marker():
+    from gateway.kanban_watchers import (
+        KANBAN_NOTIFICATION_HANDOFF_MAX_CHARS,
+        _notification_excerpt,
+    )
+
+    excerpt = _notification_excerpt("x" * 5000, "summary")
+    assert len(excerpt) == KANBAN_NOTIFICATION_HANDOFF_MAX_CHARS
+    assert excerpt.endswith("…[truncated — full summary on the card]")
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize('kind', ["gave_up", "crashed", "timed_out"])
 async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
     """

--- a/tests/stress/test_atypical_scenarios.py
+++ b/tests/stress/test_atypical_scenarios.py
@@ -194,8 +194,8 @@ def _(home, kb):
 def _(home, kb):
     """Summaries with newlines, tabs, and shell metachars.
 
-    The notifier truncates to first line — verify that's right, not
-    that the kernel loses data."""
+    The event payload preserves the actionable handoff for notifier and
+    dashboard consumers without another SQL round-trip."""
     kb.init_db()
     conn = kb.connect()
     try:
@@ -205,12 +205,9 @@ def _(home, kb):
         kb.complete_task(conn, tid, summary=multi)
         run = kb.latest_run(conn, tid)
         assert run.summary == multi, "full summary should survive in kernel"
-        # Event payload takes first line (for notifier brevity)
         events = [e for e in kb.list_events(conn, tid) if e.kind == "completed"]
-        assert events[0].payload["summary"] == "line 1", (
-            f"event payload should be first line, got {events[0].payload['summary']!r}"
-        )
-        print("  multiline summary preserved on run; first line in event")
+        assert events[0].payload["summary"] == multi
+        print("  multiline summary preserved on run and event")
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary

- preserve normal multi-line Kanban completion handoffs through the full `complete_task()` event → gateway notification path
- preserve the same contract for post-completion edit/backfill events
- deliver actionable completion summaries and `needs_input` block reasons up to a bounded 3,500-character budget
- add an explicit truncation marker for pathological payloads instead of silently clipping mid-word
- add end-to-end notifier coverage plus event-payload and sibling-path regression tests

This incorporates and preserves Salim's original commit from #59861, then fixes the upstream event-payload layer that still reduced completion summaries to `splitlines()[0][:400]` before the gateway could see them.

## Reproduction

Before the follow-up commit, a worker could complete with a multi-line handoff such as:

```text
QA is GO for merge...
Verification: ...
Residual risk and rollback: ...
```

`hermes_cli.kanban_db.complete_task()` stored the full summary on the run row, but emitted only the first line's first 400 characters in the `completed` event. Even with the gateway-side truncation removed, the subscriber still received only that first line. The new end-to-end notifier test fails on that behavior and passes with this patch.

## Verification

- `python -m pytest tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_core_functionality.py -q -o 'addopts='` → **190 passed**
- `python -m ruff check gateway/kanban_watchers.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_core_functionality.py tests/stress/test_atypical_scenarios.py` → **passed**
- `git diff --check origin/main...HEAD` → **passed**
- changed `newlines_in_summary` atypical scenario → **passed**

The full atypical-scenario script still reports two unrelated baseline failures (`Task.spawn_failures` attribute drift and archived-parent status expectation); both reproduce unchanged on current `origin/main`.

## Risk / rollback

The behavior change is limited to Kanban event payload excerpts and subscription notification text. Payloads remain bounded at 3,500 characters with an explicit marker and pointer to the card. Rollback is a straight revert of the two commits.
