### PR TITLE
fix(desktop): don't repaint rejected submit text into a switched-away session's composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.restore-scoping.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.restore-scoping.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useComposerSubmit } from './use-composer-submit'
+
+vi.mock('@/lib/chat-runtime', () => ({ SLASH_COMMAND_RE: /^\/\S/ }))
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: () => {} }))
+vi.mock('@/store/composer', () => ({ clearSessionDraft: vi.fn() }))
+vi.mock('@/store/composer-input-history', () => ({ resetBrowseState: () => {} }))
+vi.mock('@/store/composer-queue', () => ({ enqueueQueuedPrompt: vi.fn() }))
+vi.mock('../composer-utils', () => ({ cloneAttachments: (a: unknown[]) => a }))
+vi.mock('../focus', () => ({ onComposerSubmitRequest: () => () => {} }))
+vi.mock('../rich-editor', () => ({ composerPlainText: () => '' }))
+vi.mock('../scope', () => ({ useComposerScope: () => ({ attachments: { clear: () => {} } }) }))
+
+import { clearSessionDraft } from '@/store/composer'
+
+const flushMicrotasks = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+function buildArgs(overrides: Partial<Parameters<typeof useComposerSubmit>[0]> = {}) {
+  return {
+    activeQueueSessionKey: 'session-a',
+    activeQueueSessionKeyRef: { current: 'session-a' as string | null },
+    attachments: [],
+    busy: false,
+    canSteer: false,
+    clearDraft: vi.fn(),
+    disabled: false,
+    draftRef: { current: '' },
+    drainNextQueued: vi.fn().mockResolvedValue(false),
+    editorRef: { current: null },
+    exitQueuedEdit: vi.fn().mockReturnValue(false),
+    focusInput: vi.fn(),
+    inputDisabled: false,
+    loadIntoComposer: vi.fn(),
+    onCancel: vi.fn(),
+    onSteer: undefined,
+    onSubmit: vi.fn(),
+    queueCurrentDraft: vi.fn().mockReturnValue(false),
+    queueEdit: null,
+    queuedPrompts: [],
+    sessionId: 'session-a',
+    setComposerText: vi.fn(),
+    stashAt: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('useComposerSubmit dispatchSubmit restore scoping (#66661)', () => {
+  it('repaints the composer when the submitting session is still active', async () => {
+    const args = buildArgs({ onSubmit: vi.fn().mockResolvedValue(false) })
+    const { result } = renderHook(() => useComposerSubmit(args))
+
+    result.current.dispatchSubmit('rejected text')
+    await flushMicrotasks()
+
+    expect(args.loadIntoComposer).toHaveBeenCalledWith('rejected text', [])
+    expect(args.stashAt).toHaveBeenCalledWith('session-a', 'rejected text', [])
+  })
+
+  it('does NOT repaint the live composer after a session switch — only stashes to the submitted scope', async () => {
+    const args = buildArgs({ onSubmit: vi.fn().mockResolvedValue(false) })
+    const { result } = renderHook(() => useComposerSubmit(args))
+
+    result.current.dispatchSubmit('rejected text')
+    // User switches to another session while the gateway is still processing.
+    args.activeQueueSessionKeyRef.current = 'session-b'
+    await flushMicrotasks()
+
+    // The rejected text must not be painted into session B's live composer…
+    expect(args.loadIntoComposer).not.toHaveBeenCalled()
+    // …but it must survive in session A's stash.
+    expect(args.stashAt).toHaveBeenCalledWith('session-a', 'rejected text', [])
+  })
+
+  it('applies the same guard when onSubmit throws instead of returning false', async () => {
+    const args = buildArgs({ onSubmit: vi.fn().mockRejectedValue(new Error('gateway down')) })
+    const { result } = renderHook(() => useComposerSubmit(args))
+
+    result.current.dispatchSubmit('rejected text')
+    args.activeQueueSessionKeyRef.current = 'session-b'
+    await flushMicrotasks()
+
+    expect(args.loadIntoComposer).not.toHaveBeenCalled()
+    expect(args.stashAt).toHaveBeenCalledWith('session-a', 'rejected text', [])
+  })
+
+  it('clears the submitted scope draft on acceptance, without repainting or stashing', async () => {
+    const args = buildArgs({ onSubmit: vi.fn().mockResolvedValue(true) })
+    const { result } = renderHook(() => useComposerSubmit(args))
+
+    result.current.dispatchSubmit('accepted text')
+    await flushMicrotasks()
+
+    expect(clearSessionDraft).toHaveBeenCalledWith('session-a')
+    expect(args.loadIntoComposer).not.toHaveBeenCalled()
+    expect(args.stashAt).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.restore-scoping.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.restore-scoping.test.tsx
@@ -24,6 +24,7 @@ function buildArgs(overrides: Partial<Parameters<typeof useComposerSubmit>[0]> =
     attachments: [],
     busy: false,
     canSteer: false,
+    compacting: false,
     clearDraft: vi.fn(),
     disabled: false,
     draftRef: { current: '' },

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -81,10 +81,22 @@ export function useComposerSubmit({
     const submittedAttachments = attachments ?? []
 
     const restore = () => {
-      loadIntoComposer(text, submittedAttachments)
+      // Only repaint the live composer while the submitting session is still
+      // the active one — the gateway can reject well after the user has
+      // switched away, and painting then would drop the rejected text into
+      // the OTHER session's composer, where the paint-triggered sync stashes
+      // it under the now-active key (#66661). Known trade-off: a stored-key →
+      // runtime-id rotation (a submit that triggers a resume) also fails this
+      // key comparison, so a rejection of THAT submit isn't repainted — the
+      // text still survives in the submitted scope's stash below and is
+      // restored the next time that stored session's key is active, matching
+      // the stash-side semantics #54527 already chose.
+      if (activeQueueSessionKeyRef.current === submittedScope) {
+        loadIntoComposer(text, submittedAttachments)
+      }
+
       // Use the scope captured at dispatch, not whatever session is focused
-      // now — the gateway can reject well after the user has switched away,
-      // and re-stashing into the currently-focused session would overwrite
+      // now — re-stashing into the currently-focused session would overwrite
       // its draft with the rejected text from a different session (#54527).
       stashAt(submittedScope, text, submittedAttachments)
     }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -85,10 +85,22 @@ export function useComposerSubmit({
     const submittedAttachments = attachments ?? []
 
     const restore = () => {
-      loadIntoComposer(text, submittedAttachments)
+      // Only repaint the live composer while the submitting session is still
+      // the active one — the gateway can reject well after the user has
+      // switched away, and painting then would drop the rejected text into
+      // the OTHER session's composer, where the paint-triggered sync stashes
+      // it under the now-active key (#66661). Known trade-off: a stored-key →
+      // runtime-id rotation (a submit that triggers a resume) also fails this
+      // key comparison, so a rejection of THAT submit isn't repainted — the
+      // text still survives in the submitted scope's stash below and is
+      // restored the next time that stored session's key is active, matching
+      // the stash-side semantics #54527 already chose.
+      if (activeQueueSessionKeyRef.current === submittedScope) {
+        loadIntoComposer(text, submittedAttachments)
+      }
+
       // Use the scope captured at dispatch, not whatever session is focused
-      // now — the gateway can reject well after the user has switched away,
-      // and re-stashing into the currently-focused session would overwrite
+      // now — re-stashing into the currently-focused session would overwrite
       // its draft with the rejected text from a different session (#54527).
       stashAt(submittedScope, text, submittedAttachments)
     }


### PR DESCRIPTION
## What does this PR do?

When the gateway rejects a submit **after the user has switched sessions**, `dispatchSubmit`'s `restore()` in `use-composer-submit.ts` painted the rejected text into the live DOM composer unconditionally. The paint-triggered runtime sync then stashed that text under the now-active session's key, permanently contaminating the other session's draft.

The stash side of `restore()` already used the scope captured at dispatch (#54527); this PR applies the same discipline to the repaint side: only load the text back into the live composer when the submitting session is still the active one. The rejected text always survives in the submitted scope's stash either way — nothing is lost, it just stops landing in the wrong session.

## Related Issue

Fixes #66661

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts` — guard `loadIntoComposer` in `restore()` with `activeQueueSessionKeyRef.current === submittedScope`; `stashAt(submittedScope, …)` unchanged.
  - Documented trade-off (in-code comment): a stored-key → runtime-id rotation (a submit that itself triggers a resume) also fails the key comparison, so a rejection of *that* submit isn't repainted — the text is restored from the submitted scope's stash the next time that stored session's key is active, matching the stash-side semantics #54527 already chose.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx` — new; 4 tests: still-active repaint, switched-away no-repaint (both the `accepted === false` and thrown-error paths), and acceptance clearing the submitted scope's draft. The two switched-away tests fail against the previous code.

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/app/chat/composer/hooks/use-composer-submit.test.tsx`
2. Manual repro (from the issue): open sessions A and B → type in A and send → switch to B while the gateway is processing → force a rejection (e.g. rate limit) → B's composer stays untouched; A's draft still holds the rejected text.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#67197 addresses the sibling `__new__`-key issue #66662 with no file overlap)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the affected test suite — composer suites: 15 files / 71 tests green (`vitest run --project ui src/app/chat/composer src/store/composer.test.ts`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (jsdom vitest `ui` project)

### Documentation & Housekeeping

- [x] Docstrings/comments updated — the trade-off is documented at the guard site — or N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (renderer-only TypeScript, no OS-touching code)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
$ npx vitest run --project ui src/app/chat/composer/hooks/use-composer-submit.test.tsx
 Test Files  1 passed (1)
      Tests  4 passed (4)

# Against the unfixed code (regression proof):
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)