### PR TITLE
fix(file_tools): strip doubled base prefix for cwd-shaped relative paths (#67185)

### DIFF
--- a/tests/tools/test_file_tools_doubled_path.py
+++ b/tests/tools/test_file_tools_doubled_path.py
@@ -1,0 +1,164 @@
+"""Regression tests for #67185 — write_file doubled-path fix.
+
+When a model emits a relative path that textually mirrors the working
+directory (e.g. ``home/user/dev/notes/x.md`` — an absolute path missing its
+leading ``/``), ``_resolve_path_for_task`` silently creates a doubled path
+like ``/home/user/dev/home/user/dev/notes/x.md``.  The fix detects this
+pattern and strips the duplicated prefix so the write lands where the model
+intended.  A heuristic warning also fires for bare-absolute inputs.
+"""
+
+import os
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+import tools.file_tools as ft
+import tools.terminal_tool as terminal_tool
+
+
+@pytest.fixture
+def _workspace(tmp_path, monkeypatch):
+    """Set up a workspace with known structure and record its cwd."""
+    workspace = tmp_path / "home" / "user" / "dev"
+    workspace.mkdir(parents=True)
+    (workspace / "notes").mkdir()
+    (workspace / "notes" / "existing.md").write_text("hello\n")
+    monkeypatch.chdir(tmp_path)
+    terminal_tool.record_session_cwd("default", str(workspace))
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {"default": str(workspace)})
+    return workspace
+
+
+# ── _strip_doubled_base_prefix unit tests ──────────────────────────────────
+
+
+class TestStripDoubledBasePrefix:
+    def test_strips_full_doubled_prefix(self):
+        base = Path("/home/user/dev")
+        resolved = Path("/home/user/dev/home/user/dev/notes/file.md")
+        result = ft._strip_doubled_base_prefix(base, resolved)
+        assert result == Path("/home/user/dev/notes/file.md")
+
+    def test_strips_partial_doubled_prefix(self):
+        base = Path("/home/user/dev")
+        resolved = Path("/home/user/dev/home/user/file.md")
+        result = ft._strip_doubled_base_prefix(base, resolved)
+        assert result == Path("/home/user/dev/file.md")
+
+    def test_no_strip_for_normal_relative_path(self):
+        base = Path("/home/user/dev")
+        resolved = Path("/home/user/dev/src/main.py")
+        result = ft._strip_doubled_base_prefix(base, resolved)
+        assert result is None
+
+    def test_no_strip_for_absolute_input(self):
+        base = Path("/home/user/dev")
+        resolved = Path("/etc/hosts")
+        result = ft._strip_doubled_base_prefix(base, resolved)
+        assert result is None
+
+    def test_no_strip_for_single_segment_overlap(self):
+        base = Path("/home/user/dev")
+        resolved = Path("/home/other/file.md")
+        result = ft._strip_doubled_base_prefix(base, resolved)
+        assert result is None
+
+    def test_strips_when_input_is_base_itself(self):
+        base = Path("/home/user/dev")
+        resolved = Path("/home/user/dev/home/user/dev")
+        result = ft._strip_doubled_base_prefix(base, resolved)
+        assert result == Path("/home/user/dev")
+
+    def test_no_strip_when_resolved_shorter_than_base(self):
+        base = Path("/home/user/dev/very/long/path")
+        resolved = Path("/home/user/dev")
+        result = ft._strip_doubled_base_prefix(base, resolved)
+        assert result is None
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="PurePosixPath str uses / but WindowsPath str uses \\",
+    )
+    def test_posix_pure_path_base(self):
+        base = PurePosixPath("/home/user/dev")
+        resolved = Path("/home/user/dev/home/user/dev/notes/file.md")
+        result = ft._strip_doubled_base_prefix(base, resolved)
+        assert result == Path("/home/user/dev/notes/file.md")
+
+
+# ── _resolve_path_for_task integration tests ───────────────────────────────
+
+
+class TestResolvePathDoubledPrefix:
+    def test_cwd_shaped_relative_path_strips_prefix(self, _workspace):
+        """The core bug: home/user/dev/notes/file.md must resolve correctly."""
+        resolved = ft._resolve_path_for_task(
+            "home/user/dev/notes/file.md", task_id="default"
+        )
+        assert resolved == (_workspace / "notes" / "file.md")
+
+    def test_cwd_shaped_deep_path_strips_prefix(self, _workspace):
+        """Deeper nesting: home/user/dev/a/b/c/file.py."""
+        resolved = ft._resolve_path_for_task(
+            "home/user/dev/a/b/c/file.py", task_id="default"
+        )
+        assert resolved == (_workspace / "a" / "b" / "c" / "file.py")
+
+    def test_normal_relative_path_unchanged(self, _workspace):
+        """A normal relative path like src/main.py must not be altered."""
+        ( _workspace / "src").mkdir()
+        resolved = ft._resolve_path_for_task("src/main.py", task_id="default")
+        assert resolved == (_workspace / "src" / "main.py")
+
+    def test_absolute_path_unchanged(self, _workspace):
+        """An absolute input path is never re-anchored."""
+        abs_path = str(_workspace / "notes" / "existing.md")
+        resolved = ft._resolve_path_for_task(abs_path, task_id="default")
+        assert resolved == Path(abs_path).resolve()
+
+    def test_tilde_path_not_affected(self, _workspace):
+        """Tilde expansion happens before the doubled-prefix check."""
+        # ~ expansion is handled by _expand_tilde; after expansion the
+        # result should be treated as absolute and pass through.
+        # This test just verifies tilde paths don't crash.
+        resolved = ft._resolve_path_for_task("~/notes/file.md", task_id="default")
+        # Should resolve under HOME, not be mangled by the prefix stripper.
+        assert resolved.is_absolute()
+
+
+# ── _path_resolution_warning bare-absolute heuristic tests ─────────────────
+
+
+class TestBareAbsoluteWarning:
+    def test_warns_for_bare_absolute_home_path(self, _workspace):
+        """home/user/dev/file.md should trigger the bare-absolute warning."""
+        resolved = _workspace / "file.md"
+        warn = ft._path_resolution_warning(
+            "home/user/dev/file.md", resolved, task_id="default"
+        )
+        assert warn is not None
+        assert "missing" in warn.lower() or "leading /" in warn
+
+    def test_warns_for_bare_absolute_tmp_path(self, _workspace):
+        """tmp/foo/bar.py should trigger the bare-absolute warning."""
+        resolved = Path("/tmp/foo/bar.py")
+        warn = ft._path_resolution_warning("tmp/foo/bar.py", resolved, task_id="default")
+        assert warn is not None
+
+    def test_no_warning_for_normal_relative_path(self, _workspace):
+        """src/main.py should NOT trigger the bare-absolute warning."""
+        warn = ft._path_resolution_warning(
+            "src/main.py", _workspace / "src" / "main.py", task_id="default"
+        )
+        # Should be None (inside workspace) — no bare-absolute heuristic fires.
+        assert warn is None
+
+    def test_no_warning_for_absolute_input(self, _workspace):
+        """An absolute path should never trigger any warning."""
+        warn = ft._path_resolution_warning(
+            str(_workspace / "file.md"),
+            _workspace / "file.md",
+            task_id="default",
+        )
+        assert warn is None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -361,15 +361,92 @@ def _resolve_base_dir(
     return base.resolve()
 
 
+def _strip_doubled_base_prefix(base: Path | PurePosixPath, resolved: Path) -> Path | None:
+    """Detect and strip a doubled base-directory prefix in *resolved*.
+
+    When a model emits a relative path that textually mirrors the working
+    directory (e.g. ``home/user/dev/notes/x.md`` — an absolute path missing
+    its leading ``/``), joining it onto the base produces a doubled prefix::
+
+        /home/user/dev / home/user/dev/notes/x.md
+        ─── base ───   ───── doubled input ──────
+
+    ``Path.resolve()`` / ``os.path.normpath`` cannot collapse this because
+    each component is legitimate.  This helper detects the pattern and
+    returns the corrected path (with the duplicate stripped) so the write
+    lands where the model intended, or ``None`` when no duplication is
+    detected.
+    """
+    try:
+        base_str = str(base).rstrip("/\\")
+        resolved_str = str(resolved)
+        if not base_str or not resolved_str.lower().startswith(base_str.lower()):
+            return None
+        remainder = resolved_str[len(base_str):]
+        if not remainder or remainder[0] not in ("/", "\\"):
+            return None
+        # remainder starts with the separator then the input path components.
+        input_part = remainder[1:]
+        if not input_part:
+            return None
+        # Get the non-root parts of the base (skip '/' or '\\' root component).
+        base_parts = list(Path(base_str).parts)
+        if base_parts and base_parts[0] in ("/", "\\"):
+            base_parts = base_parts[1:]
+        input_parts = list(Path(input_part).parts)
+        if not base_parts or not input_parts:
+            return None
+        # Two detection strategies, take the best match:
+        #
+        # 1. Common prefix: input starts with the same sequence as the base's
+        #    non-root parts (works on POSIX where base_parts=[home,user,dev]
+        #    and input_parts=[home,user,dev,...]).
+        #
+        # 2. Suffix-of-base: input starts with a suffix of the base's
+        #    non-root parts (works on Windows where base_parts include the
+        #    drive prefix, e.g. [Users,Hp,...,home,user,dev] and
+        #    input_parts=[home,user,dev,...]).
+        overlap = 0
+        # Strategy 1: common prefix
+        common = 0
+        for i in range(min(len(base_parts), len(input_parts))):
+            if base_parts[i].lower() == input_parts[i].lower():
+                common += 1
+            else:
+                break
+        overlap = max(overlap, common)
+        # Strategy 2: suffix of base matching prefix of input
+        for suffix_len in range(min(len(base_parts), len(input_parts)), 1, -1):
+            if all(
+                base_parts[-suffix_len + i].lower() == input_parts[i].lower()
+                for i in range(suffix_len)
+            ):
+                overlap = max(overlap, suffix_len)
+                break
+        if overlap < 2:
+            return None
+        remaining = input_parts[overlap:]
+        if not remaining:
+            return Path(base_str)
+        return Path(base_str) / Path(*remaining)
+    except Exception:
+        return None
+
+
 def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
     """Resolve *filepath* against the task's absolute base directory.
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
     paths are returned resolved-but-unanchored.
 
+    When a relative input path textually mirrors the working directory
+    (e.g. ``home/user/dev/file.md`` — an absolute path missing its leading
+    ``/``), the doubled prefix is automatically stripped so the write lands
+    where the model intended.
+
     On native Windows, Git Bash / MSYS drive paths (``/c/Users/...``) are
     translated to ``C:\\Users\\...`` before resolution so file tools don't
-    treat them as relative ``\\c\\Users\\...`` under the process cwd.
+    treat them as relative ``\\c\\Users``... under the process cwd.
     """
     container_paths = _uses_container_paths(task_id)
     if container_paths:
@@ -388,14 +465,24 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
 
         if ntpath.isabs(expanded):
             return Path(ntpath.normpath(expanded))
-        joined = ntpath.join(str(_resolve_base_dir(task_id, container_paths=False)), expanded)
-        return Path(ntpath.normpath(joined))
+        base = _resolve_base_dir(task_id, container_paths=False)
+        joined = ntpath.join(str(base), expanded)
+        resolved = Path(ntpath.normpath(joined))
+        stripped = _strip_doubled_base_prefix(base, resolved)
+        return stripped if stripped is not None else resolved
 
     p = Path(expanded)
     if p.is_absolute():
         return p.resolve()
-    resolved = _resolve_base_dir(task_id, container_paths=False) / p
-    return resolved.resolve()
+    base = _resolve_base_dir(task_id, container_paths=False)
+    resolved = (base / p).resolve()
+    stripped = _strip_doubled_base_prefix(base.resolve(), resolved)
+    return stripped if stripped is not None else resolved
+
+
+_BARE_ABSOLUTE_ROOT_SEGS = frozenset({
+    "home", "Users", "tmp", "var", "opt", "usr", "etc", "mnt", "srv", "root",
+})
 
 
 def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
@@ -408,6 +495,12 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
     target. ``None`` when the path is absolute, the base is unknown, or the
     resolved path is correctly under the workspace root.
 
+    Also warns when the relative input looks like an absolute path missing its
+    leading ``/`` (e.g. ``home/user/dev/file.md``), which local models
+    commonly produce.  The doubled-base prefix is auto-stripped by
+    :func:`_resolve_path_for_task`, but the warning surfaces the anomaly so
+    the caller knows the input was corrected.
+
     The workspace root is the live terminal cwd when known, else a registered
     task/session cwd override, else a sentinel-free absolute ``$TERMINAL_CWD``
     — so a worktree or Desktop session whose terminal registry is still empty
@@ -416,6 +509,15 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
     try:
         if Path(_expand_tilde(filepath)).is_absolute():
             return None
+        # Heuristic: detect bare-absolute paths (missing leading /).
+        first_seg = Path(filepath).parts[0] if Path(filepath).parts else ""
+        if first_seg in _BARE_ABSOLUTE_ROOT_SEGS:
+            return (
+                f"Relative path {filepath!r} looks like an absolute path missing "
+                f"its leading / (resolved to {str(resolved)!r}). The doubled "
+                f"directory prefix was auto-stripped. In future, pass the "
+                f"absolute path with a leading / to avoid this correction."
+            )
         workspace_root = _authoritative_workspace_root(task_id)
         if not workspace_root:
             return None  # No authoritative workspace root to compare against.


### PR DESCRIPTION
## Problem

When a model emits a relative path that textually mirrors the working directory (e.g. `home/user/dev/notes/file.md` — an absolute path missing its leading `/`), `_resolve_path_for_task` silently creates a doubled path like `/home/user/dev/home/user/dev/notes/file.md` instead of failing or writing to the intended location.

## Fix

Add `_strip_doubled_base_prefix()` to detect and strip the duplicated prefix using two strategies (common prefix + suffix-matching) that work on both POSIX and Windows. Integrated into `_resolve_path_for_task` for both path branches. Also adds a heuristic warning in `_path_resolution_warning` for bare-absolute paths whose first segment matches known root directories (`home`, `Users`, `tmp`, `var`, etc.).

## Files changed

- `tools/file_tools.py` — new helper + integration into resolve + heuristic warning (~60 LOC)
- `tests/tools/test_file_tools_doubled_path.py` — new test file (17 tests)

## Tests

- `_strip_doubled_base_prefix`: full strip, partial strip, no-strip for normal/absolute/single-segment paths, POSIX path
- `_resolve_path_for_task`: cwd-shaped path, deep nesting, normal relative, absolute, tilde
- `_path_resolution_warning`: bare-absolute `home/...` and `tmp/...` warn, normal relative/absolute don't

Fixes #67185