### PR TITLE
fix(tools): match foreground shell contract for background terminal (#67200)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1127,6 +1127,17 @@ DEFAULT_CONFIG = {
         # this off if your rc files misbehave when sourced
         # non-interactively (e.g. one that hard-exits on TTY checks).
         "auto_source_bashrc": True,
+        # When True, background ``terminal(background=true)`` processes
+        # are spawned through the user's login shell (``$SHELL -lic``),
+        # mirroring the foreground ``init_session`` snapshot path so the
+        # captured PATH / aliases / functions carry through. **Default is
+        # False** because login shells also pick up user-defined aliases
+        # (``alias rm='rsync …'``) and ``exec``-swap wrappers, which
+        # silently rewrite otherwise ordinary agent commands and diverge
+        # from the foreground ``bash -c`` contract (#67200). Opt in only
+        # when your tools genuinely depend on login-shell PATH or env —
+        # the per-process spawn path stays unchanged otherwise.
+        "background_login_shell": False,
         "docker_image": "nikolaik/python-nodejs:python3.11-nodejs20",
         "docker_forward_env": [],
         # Explicit environment variables to set inside Docker containers.

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -827,6 +827,81 @@ class TestBackgroundShellMode:
         # Use the registry_mod import so the linter doesn't complain.
         _ = registry_mod
 
+    def _spawn_pty_args(self, registry, *, config_override=None):
+        """Run spawn_local with use_pty=True and capture the PtyProcess.spawn argv.
+
+        Synthesises a fake ptyprocess module via sys.modules so the
+        PTY import path succeeds on hosts without the optional dep, then
+        captures the argv passed to PtyProcess.spawn for assertion.
+        Returns [shell, flags, command].
+        """
+        import sys as _sys
+        import types
+
+        captured = {}
+
+        class _FakePty:
+            def __init__(self):
+                self.pid = 4321
+
+            @classmethod
+            def spawn(cls, argv, **kwargs):
+                captured["argv"] = argv
+                return cls()
+
+        # Fake both POSIX (ptyprocess) and Windows (winpty) so the
+        # platform-specific import in process_registry always succeeds.
+        fake_pty_module = types.ModuleType("ptyprocess")
+        fake_pty_module.PtyProcess = _FakePty
+        fake_winpty_module = types.ModuleType("winpty")
+        fake_winpty_module.PtyProcess = _FakePty
+
+        fake_thread = MagicMock()
+
+        if config_override is not None:
+            config_patch = patch(
+                "hermes_cli.config.load_config",
+                return_value={"terminal": config_override},
+            )
+        else:
+            config_patch = patch(
+                "hermes_cli.config.load_config", return_value={}
+            )
+
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=True),             patch.dict(_sys.modules, {"ptyprocess": fake_pty_module, "winpty": fake_winpty_module}),             patch("tools.process_registry._find_shell", return_value="/bin/bash"),             patch("threading.Thread", return_value=fake_thread),             patch.object(registry, "_write_checkpoint"),             config_patch:
+            registry.spawn_local(
+                "echo hello",
+                cwd="/tmp",
+                use_pty=True,
+            )
+
+        return captured["argv"]
+
+    def test_pty_default_uses_non_login_shell(self, registry):
+        """The PTY branch matches the standard Popen default: ``-c``, not ``-lic``.
+
+        Without this coverage the same regression the Popen default-guard
+        prevents could slip back in via the PTY path. Both branches MUST
+        share the same shell-flag contract so agent commands behave
+        identically regardless of which spawn path is taken.
+        """
+        argv = self._spawn_pty_args(registry)
+        assert argv[0] == "/bin/bash"
+        assert argv[1] == "-c", (
+            f"PTY default must be non-login (-c), got {argv[1]!r} — aliases "
+            "and exec-swap wrappers would silently rewrite agent commands"
+        )
+        assert "-l" not in argv[1]
+        assert argv[2].startswith("set +m; ")
+
+    def test_pty_opt_in_login_shell_when_config_set(self, registry):
+        """PTY branch honours the same ``background_login_shell`` opt-in."""
+        argv = self._spawn_pty_args(
+            registry, config_override={"background_login_shell": True}
+        )
+        assert argv[0] == "/bin/bash"
+        assert argv[1] == "-lic"
+
     def test_spawn_via_env_uses_backend_temp_dir_for_artifacts(self, registry):
         class FakeEnv:
             def __init__(self):

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -17,6 +17,7 @@ from tools.process_registry import (
     FINISHED_TTL_SECONDS,
     MAX_PROCESSES,
     MAX_ACTIVE_PROCESS_AGE,
+    _background_login_shell_enabled,
 )
 
 
@@ -698,6 +699,133 @@ class TestSpawnEnvSanitization:
         assert "FIRECRAWL_API_KEY" not in env
         assert f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}TELEGRAM_BOT_TOKEN" not in env
         assert env["PYTHONUNBUFFERED"] == "1"
+
+
+class TestBackgroundShellMode:
+    """Regression for #67200 — background commands must NOT silently inherit
+    user-defined aliases from rc/profile files.
+
+    Foreground ``LocalEnvironment._run_bash`` runs commands through a
+    non-interactive shell (``[bash, "-c", cmd]``) so the foreground
+    contract is the deterministic one. Background was previously invoked
+    as ``[user_shell, "-lic", cmd]`` (login + interactive + set +m), which
+    sources ``~/.bash_profile`` / ``~/.zprofile`` and pulls in user
+    aliases — so an agent-written ``rm -f <path>`` could resolve to
+    ``rsync …`` (or worse, an ``exec``-swap shell wrapper) and the
+    foreground/background contracts would diverge silently.
+
+    Default is non-login (``-c``). Users who genuinely need login-shell
+    PATH or env can opt in via ``terminal.background_login_shell: true``.
+    """
+
+    def _spawn_popen_args(self, registry, *, config_override=None):
+        """Run spawn_local with everything mocked out, return the Popen call args."""
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            proc = MagicMock()
+            proc.pid = 4321
+            proc.stdout = iter([])
+            proc.stdin = MagicMock()
+            proc.poll.return_value = None
+            return proc
+
+        fake_thread = MagicMock()
+
+        if config_override is not None:
+            config_patch = patch(
+                "hermes_cli.config.load_config",
+                return_value={"terminal": config_override},
+            )
+        else:
+            config_patch = patch(
+                "hermes_cli.config.load_config", return_value={}
+            )
+
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=True), \
+            patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+            patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"), \
+            config_patch:
+            registry.spawn_local("echo hello", cwd="/tmp")
+
+        return captured["cmd"], captured["kwargs"]
+
+    def test_default_uses_non_login_shell(self, registry):
+        """No config → background matches the foreground non-interactive shape.
+
+        ``-lic`` would source ``~/.bash_profile`` (the #67200 trigger).
+        The default ``-c`` matches ``LocalEnvironment._run_bash`` so
+        agent commands resolve identically regardless of how they were
+        spawned.
+        """
+        cmd, _ = self._spawn_popen_args(registry)
+        # Popen argv is [shell, flags, command]
+        assert cmd[0] == "/bin/bash"
+        assert cmd[1] == "-c", f"expected non-login -c, got {cmd[1]!r}"
+        assert "-l" not in cmd[1], "login shell must be opt-in, not default"
+        assert cmd[2].startswith("set +m; ")
+
+    def test_opt_in_login_shell_when_config_set(self, registry):
+        """``terminal.background_login_shell: true`` preserves the old shape.
+
+        Documents the opt-in contract so users who relied on the prior
+        login behaviour (custom tool PATH, ``exec``-swap wrappers) can
+        recover it explicitly rather than via implicit ``-lic`` defaults.
+        """
+        cmd, _ = self._spawn_popen_args(
+            registry, config_override={"background_login_shell": True}
+        )
+        assert cmd[0] == "/bin/bash"
+        assert cmd[1] == "-lic", (
+            "opt-in flag must restore the prior login + interactive shape"
+        )
+
+    def test_helper_defaults_to_false_on_config_failure(self, monkeypatch):
+        """The config helper must not raise into the spawn path on failure."""
+        # First-run before config exists, malformed YAML, missing key —
+        # every code path returns False (the safer default).
+        import tools.process_registry as registry_mod
+
+        # No config at all.
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: None
+        )
+        assert _background_login_shell_enabled() is False
+
+        # Config raises during load.
+        def raise_load_config():
+            raise RuntimeError("config broken")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", raise_load_config
+        )
+        assert _background_login_shell_enabled() is False
+
+        # Terminal key absent.
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {"terminal": {}}
+        )
+        assert _background_login_shell_enabled() is False
+
+        # Explicitly off.
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"terminal": {"background_login_shell": False}},
+        )
+        assert _background_login_shell_enabled() is False
+
+        # Explicitly on.
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"terminal": {"background_login_shell": True}},
+        )
+        assert _background_login_shell_enabled() is True
+
+        # Use the registry_mod import so the linter doesn't complain.
+        _ = registry_mod
 
     def test_spawn_via_env_uses_backend_temp_dir_for_artifacts(self, registry):
         class FakeEnv:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -51,6 +51,31 @@ from hermes_cli.config import get_hermes_home
 logger = logging.getLogger(__name__)
 
 
+def _background_login_shell_enabled() -> bool:
+    """Read ``terminal.background_login_shell`` from config; default False.
+
+    Issue #67200: background ``terminal`` calls previously used ``-lic``
+    (login + interactive + set +m) which sources the user's rc/profile
+    files and silently rewrites agent-authored commands with user-defined
+    aliases (``alias rm='rsync …'``, ``exec /bin/zsh -l``, etc.). The
+    foreground path already uses the non-interactive shape (``[bash,
+    "-c", cmd]``); this knob lets background match it by default while
+    preserving the old login behaviour as an explicit opt-in for users
+    whose tools genuinely depend on login-shell PATH or env.
+
+    Best-effort: any config read failure (missing key, malformed YAML,
+    first-run before config exists) returns False — the safer default
+    — and never raises into the spawn path.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+    except Exception:
+        return False
+    terminal_cfg = cfg.get("terminal") or {}
+    return bool(terminal_cfg.get("background_login_shell", False))
+
+
 # Checkpoint file for crash recovery (gateway only)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
 
@@ -715,10 +740,14 @@ class ProcessRegistry:
                 else:
                     from ptyprocess import PtyProcess as _PtyProcessCls
                 user_shell = _find_shell()
+                use_login = _background_login_shell_enabled()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
+                # Match the non-PTY path: only invoke login-shell mode when
+                # the user has opted in via ``terminal.background_login_shell``.
+                pty_flags = "-lic" if use_login else "-c"
                 pty_proc = _PtyProcessCls.spawn(
-                    [user_shell, "-lic", f"set +m; {command}"],
+                    [user_shell, pty_flags, f"set +m; {command}"],
                     cwd=session.cwd,
                     env=pty_env,
                     dimensions=(30, 120),
@@ -751,9 +780,21 @@ class ProcessRegistry:
                 logger.warning("PTY spawn failed (%s), falling back to pipe mode", e)
 
         # Standard Popen path (non-PTY or PTY fallback)
-        # Use the user's login shell for consistency with LocalEnvironment --
-        # ensures rc files are sourced and user tools are available.
+        # Use the user's $SHELL — preferring it over /bin/bash preserves
+        # the #42203 macOS background-process fix — but invoke WITHOUT
+        # ``-l`` (login) so the shell does NOT source ``~/.bash_profile``
+        # / ``~/.zprofile`` / ``~/.profile``. Login shells pick up
+        # user-defined aliases (``alias rm='...'``) and ``exec``-swap
+        # wrappers that silently rewrite otherwise ordinary commands,
+        # turning the foreground-vs-background contract into a guessing
+        # game (issue #67200). Foreground ``LocalEnvironment._run_bash``
+        # uses the same non-interactive shape (``[bash, "-c", cmd]``),
+        # so agent-authored commands resolve predictably regardless of
+        # whether they were spawned foreground or background. Users who
+        # genuinely need login-shell PATH / tool availability can opt
+        # in via ``terminal.background_login_shell: true`` in config.
         user_shell = _find_shell()
+        use_login = _background_login_shell_enabled()
         # Force unbuffered output for Python scripts so progress is visible
         # during background execution (libraries like tqdm/datasets buffer when
         # stdout is a pipe, hiding output from process(action="poll")).
@@ -761,8 +802,9 @@ class ProcessRegistry:
         bg_env["PYTHONUNBUFFERED"] = "1"
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
+        shell_flags = "-lic" if use_login else "-c"
         proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {command}"],
+            [user_shell, shell_flags, f"set +m; {command}"],
             text=True,
             cwd=session.cwd,
             env=bg_env,


### PR DESCRIPTION
# PR body for #67200 (use with the gh pr create command in COMMANDS.sh)

# Title

```
fix(tools): match foreground shell contract for background terminal (#67200)
```

# Body

## Problem

Background `terminal(background=true)` invoked the shell as `[user_shell, "-lic", cmd]` (login + interactive + `set +m`). That sources `~/.bash_profile` / `~/.zprofile` / `~/.profile`, which is where users put interactive aliases (`alias rm='rsync …'`) and `exec`-swap wrappers. So an agent-written `rm -f <path>` could resolve to `rsync …` (or fail silently through an exec-swap) when spawned background but succeed cleanly when foreground — a hidden divergence in the agent command contract.

The foreground `LocalEnvironment._run_bash` path uses the non-interactive `[bash, "-c", cmd]` shape.

### Reproduction (from the issue)

On a host with the following in `~/.zshrc` and `SHELL=/usr/bin/zsh`:

```sh
alias rm='move1(){ rsync -avcPh $@ ~/backup/ && /bin/rm $@ -rvf; };move1 $@'
```

- **Foreground** `terminal(background=false)` running `rm -f /tmp/x` → exit 0, `FOREGROUND_SUCCESS`.
- **Background** `terminal(background=true, notify_on_complete=true)` running the same `rm -f /tmp/x` → fails before the first marker with rsync filter syntax errors.

Two authoritative Rust gate launches were misclassified as process failures from this divergence.

## Fix

Drop `-l` from the background shell invocation by default. New module-level helper:

```python
def _background_login_shell_enabled() -> bool:
    """Read terminal.background_login_shell from config; default False."""
    ...
```

When `False` (new default) → spawn uses `[user_shell, "-c", "set +m; cmd"]`, matching the foreground contract.

When `True` (opt-in via `terminal.background_login_shell: true`) → prior `[user_shell, "-lic", ...]` shape is preserved for users whose tools genuinely depend on login-shell PATH or env.

This keeps the macOS #42203 fix intact (`_find_shell` still prefers `$SHELL` over `/bin/bash`); the original bug was bash 3.2 with `-l` and a `~/.bash_profile` `exec`, not the `-i`/`-c` distinction.

## Files changed

- `tools/process_registry.py`:
  - `_background_login_shell_enabled()` — new module-level helper, best-effort config read returning `False` on any failure.
  - `spawn_local` PTY branch: replace hard-coded `"-lic"` with `pty_flags = "-lic" if use_login else "-c"`.
  - `spawn_local` standard Popen branch: same swap.
- `tests/tools/test_process_registry.py`:
  - `TestBackgroundShellMode::test_default_uses_non_login_shell` — no config → `-c`, matches foreground.
  - `TestBackgroundShellMode::test_opt_in_login_shell_when_config_set` — opt-in restores `-lic`.
  - `TestBackgroundShellMode::test_helper_defaults_to_false_on_config_failure` — covers `load_config` returning `None` / raising / missing key / explicit `False` / explicit `True`.

## Acceptance criteria

- [x] Foreground and background non-PTY execution have declared parity (both use the non-interactive shell contract by default).
- [x] The macOS #42203 case remains covered (`_find_shell` still prefers `$SHELL`; no regression in the existing `TestMacosLoginShellSwallowRegression`).
- [x] Background process receipts still work as before (PTY fallback, env sanitization, etc. unchanged).
- [x] Users who genuinely need login-shell PATH / tools can opt back in via `terminal.background_login_shell: true` in `config.yaml`.

## Test plan

1. Set up the reproduction from the issue (`alias rm='...'` in `~/.zshrc`, `SHELL=/usr/bin/zsh`).
2. Run the same `rm -f <path>` via foreground and via `terminal(background=true, notify_on_complete=true)`.
3. With this PR applied, both must resolve to the bare `rm` binary — the same exit code, the same output.

## Risk

The behavioral change is intentionally opt-out (default flipped from login to non-login), so users who relied on login-shell behaviour will notice. The opt-in knob lets them restore the prior shape with a single config line. The macOS #42203 fix is preserved.

Closes #67200
