### PR TITLE
fix(cron): sync terminal config for standalone runs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3038,6 +3038,23 @@ def run_job(
         reset_secret_source_cache()
         load_hermes_dotenv(hermes_home=_get_hermes_home())
 
+        # ``load_hermes_dotenv`` intentionally uses override=True for the
+        # profile's .env.  Re-assert config.yaml afterwards: terminal tools
+        # read only TERMINAL_* and config.yaml is authoritative whenever it
+        # contains a terminal section.  This is especially important for
+        # standalone ``hermes cron run``, which has no gateway/TUI startup
+        # bridge, but placing it at the shared execution boundary also keeps
+        # tick and external-provider fires from drifting.
+        from hermes_cli.config import apply_terminal_config_to_env
+        apply_terminal_config_to_env()
+
+        # A job-scoped workdir is more specific than terminal.cwd.  Both the
+        # dotenv reload and the canonical config bridge above can replace the
+        # value installed before the lock was acquired, so restore it before
+        # any agent/tool initialization.
+        if _job_workdir:
+            os.environ["TERMINAL_CWD"] = _job_workdir
+
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
             _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(delivery_target["platform"])

--- a/tests/cron/test_terminal_config_sync.py
+++ b/tests/cron/test_terminal_config_sync.py
@@ -1,0 +1,145 @@
+"""Cron execution must preserve the authoritative terminal config."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from types import ModuleType
+
+
+def test_run_job_terminal_config_wins_after_dotenv_reload(tmp_path, monkeypatch):
+    """A stale .env must not clobber config.yaml before terminal tools run."""
+    import cron.scheduler as sched
+    import hermes_cli.env_loader as env_loader
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+
+    hermes_home = tmp_path / "hermes-home"
+    job_workdir = tmp_path / "job-workdir"
+    configured_cwd = tmp_path / "configured-cwd"
+    hermes_home.mkdir()
+    job_workdir.mkdir()
+    configured_cwd.mkdir()
+
+    volumes = ["/srv/data:/output:ro", "/srv/cache:/cache"]
+    (hermes_home / "config.yaml").write_text(
+        json.dumps(
+            {
+                "terminal": {
+                    "backend": "docker",
+                    "docker_image": "example/hermes-cron:test",
+                    "container_cpu": 3.5,
+                    "container_memory": 7168,
+                    "docker_volumes": volumes,
+                    "cwd": str(configured_cwd),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (hermes_home / ".env").write_text(
+        "\n".join(
+            (
+                "TERMINAL_ENV=local",
+                "TERMINAL_DOCKER_IMAGE=stale/image:old",
+                "TERMINAL_CONTAINER_CPU=1",
+                "TERMINAL_CONTAINER_MEMORY=5120",
+                "TERMINAL_DOCKER_VOLUMES=[]",
+                "TERMINAL_CWD=/from-stale-dotenv",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # Register every env mutation with monkeypatch: the canonical helper
+    # writes directly to os.environ and otherwise its merged defaults could
+    # leak into later tests in this worker.
+    for env_var in TERMINAL_CONFIG_ENV_MAP.values():
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+    monkeypatch.setenv("TERMINAL_CWD", "/original-cwd")
+    monkeypatch.setattr(sched, "_hermes_home", hermes_home)
+
+    # Exercise the real profile .env loader, but isolate unrelated external
+    # secret/managed-scope integrations from this terminal-config contract.
+    monkeypatch.setattr(env_loader, "reset_secret_source_cache", lambda: None)
+    monkeypatch.setattr(
+        env_loader, "_apply_external_secret_sources", lambda *_a: None
+    )
+    monkeypatch.setattr(env_loader, "_apply_managed_env", lambda: None)
+
+    observed = {}
+
+    class FakeAgent:
+        def __init__(self, **_kwargs):
+            from tools.terminal_tool import _get_env_config
+
+            observed.update(_get_env_config())
+            observed["raw_terminal_cwd"] = os.environ.get("TERMINAL_CWD")
+
+        def run_conversation(self, *_args, **_kwargs):
+            return {"final_response": "done", "messages": []}
+
+        def get_activity_summary(self):
+            return {"seconds_since_activity": 0.0}
+
+        def close(self):
+            return None
+
+    fake_run_agent = ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    fake_hermes_state = ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = lambda: None
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
+
+    fake_mcp_tool = ModuleType("tools.mcp_tool")
+    fake_mcp_tool.discover_mcp_tools = lambda: []
+    monkeypatch.setitem(sys.modules, "tools.mcp_tool", fake_mcp_tool)
+
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "test",
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(sched, "_build_job_prompt", lambda *_a, **_kw: "prompt")
+    monkeypatch.setattr(sched, "_resolve_origin", lambda _job: None)
+    monkeypatch.setattr(sched, "_resolve_delivery_target", lambda _job: None)
+    monkeypatch.setattr(sched, "_resolve_cron_enabled_toolsets", lambda *_a: None)
+    monkeypatch.setattr(sched, "_resolve_cron_disabled_toolsets", lambda *_a: None)
+    monkeypatch.setattr(
+        sched,
+        "_teardown_cron_agent",
+        lambda agent, _job_id: agent.close() if agent is not None else None,
+    )
+
+    success, _output, response, error = sched.run_job(
+        {
+            "id": "standalone-run",
+            "name": "standalone run",
+            "prompt": "check cleanup",
+            "model": "test-model",
+            "workdir": str(job_workdir),
+            "schedule_display": "manual",
+        }
+    )
+
+    assert success is True, error
+    assert response == "done"
+    assert observed["env_type"] == "docker"
+    assert observed["docker_image"] == "example/hermes-cron:test"
+    assert observed["container_cpu"] == 3.5
+    assert observed["container_memory"] == 7168
+    assert observed["docker_volumes"] == volumes
+    assert observed["raw_terminal_cwd"] == str(job_workdir)
+    assert os.environ["TERMINAL_CWD"] == "/original-cwd"

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -2,7 +2,7 @@
 
 terminal_tool._get_env_config() reads ALL terminal settings from os.environ
 (TERMINAL_*).  config.yaml values therefore have to be bridged into env vars
-at startup, by THREE separate code paths:
+at startup or cron execution, by FOUR separate code paths:
 
   1. cli.py            -> ``env_mappings`` dict (CLI / TUI startup)
   2. gateway/run.py    -> ``_terminal_env_map`` dict (gateway / messaging
@@ -10,17 +10,21 @@ at startup, by THREE separate code paths:
   3. hermes_cli/config.py:set_config_value
                        -> bridges via the canonical ``TERMINAL_CONFIG_ENV_MAP``
                           (one-shot when the user runs ``hermes config set …``)
+  4. cron/scheduler.py -> calls the canonical bridge after its per-run .env
+                          reload (standalone run, tick, and provider fires)
 
 If any one of these is missing a key, the corresponding config.yaml setting
 silently does nothing for that entry-point.  This bug already shipped once
 for ``docker_run_as_host_user`` (gateway and CLI maps) and once for
 ``docker_mount_cwd_to_workspace`` (gateway map).
 
-This test guards against future drift by extracting all three maps via source
-inspection and asserting they all bridge the same set of writable
+This test guards against future drift by extracting the three map-bearing
+paths via source inspection and asserting they all bridge the same writable
 ``terminal.*`` keys.  Source inspection (rather than importing the live
 dicts) keeps the test independent of the user's ~/.hermes/config.yaml and
 mirrors the pattern used in tests/hermes_cli/test_config_drift.py.
+The fourth path's execution ordering is covered behaviorally in
+tests/cron/test_terminal_config_sync.py.
 """
 
 import ast


### PR DESCRIPTION
## What does this PR do?

Reapplies the selected terminal configuration after standalone cron startup loads `$HERMES_HOME/.env`, then restores a job-specific `TERMINAL_CWD`. This prevents override-style dotenv loading from replacing the backend and terminal settings chosen by profile configuration.

The cleanup incident that exposed this also had a root-owned rootless-Docker sandbox directory; that operational ownership problem was repaired locally and is intentionally not included in this focused code change.

## Related Issue

Fixes #67323

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Reapply terminal config after `load_hermes_dotenv()` in `cron/scheduler.py`.
- Preserve the cron job's explicit working directory after the config bridge.
- Add standalone ordering and cwd regression coverage.
- Strengthen terminal environment synchronization cleanup in existing tests.

## How to Test

1. Run `scripts/run_tests.sh tests/cron/test_terminal_config_sync.py tests/tools/test_terminal_config_env_sync.py`.
2. Configure conflicting terminal values in profile config and `.env`, then trigger a standalone cron job.
3. Confirm the profile backend wins while the job-specific `TERMINAL_CWD` remains unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux with rootless Docker

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused branch verification: 11 tests passed.

An actual standalone run of `weekly-workspace-cleanup` completed successfully after the operational ownership repair and scheduler fix; durable execution `befd2aa…` reached `completed`.