### PR TITLE
fix(kanban): preserve budget handoff before hard stop

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -712,6 +712,36 @@ def run_conversation(
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+        # Kanban workers need a usable handoff before the hard turn limit.
+        # Long-running goal cards were reaching 60/60 after useful work, then
+        # closing with an empty task_run.summary because the model had no tool
+        # budget left to persist its own kanban_comment/block. Stop a few calls
+        # early in Kanban mode so the post-loop finalizer can ask for a no-tools
+        # summary and persist it on the run before the dispatcher records the
+        # timeout/gave_up outcome. Non-Kanban sessions and tiny unit-test budgets
+        # are intentionally unaffected.
+        if (
+            os.environ.get("HERMES_KANBAN_TASK")
+            and not agent._budget_grace_call
+            and agent.max_iterations >= 10
+        ):
+            try:
+                _prestop_remaining = int(
+                    os.environ.get("HERMES_KANBAN_BUDGET_PRESTOP_REMAINING", "5")
+                )
+            except (TypeError, ValueError):
+                _prestop_remaining = 5
+            if _prestop_remaining > 0 and api_call_count >= max(1, agent.max_iterations - _prestop_remaining):
+                _turn_exit_reason = (
+                    f"kanban_pre_stop_budget_guard({api_call_count}/{agent.max_iterations})"
+                )
+                if not agent.quiet_mode:
+                    agent._safe_print(
+                        "\n⚠️  Kanban pre-stop budget guard reached "
+                        f"({api_call_count}/{agent.max_iterations}); requesting handoff summary"
+                    )
+                break
+
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -66,15 +66,21 @@ def finalize_turn(
     """
     from agent.conversation_loop import logger
 
+    _kanban_pre_stop_budget_guard = str(_turn_exit_reason).startswith(
+        "kanban_pre_stop_budget_guard("
+    )
     budget_exhausted = (
         api_call_count >= agent.max_iterations
         or agent.iteration_budget.remaining <= 0
     )
     budget_fallback_eligible = (
-        budget_exhausted
+        (budget_exhausted or _kanban_pre_stop_budget_guard)
         and not interrupted
         and not failed
-        and str(_turn_exit_reason) in {"unknown", "budget_exhausted"}
+        and (
+            str(_turn_exit_reason) in {"unknown", "budget_exhausted"}
+            or _kanban_pre_stop_budget_guard
+        )
     )
     continuation_budget_exhausted = (
         final_response is None
@@ -98,14 +104,15 @@ def finalize_turn(
         # Budget exhausted — ask the model for a summary via one extra
         # API call with tools stripped.  _handle_max_iterations injects a
         # user message and makes a single toolless request.
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        if not _kanban_pre_stop_budget_guard:
+            _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
         agent._emit_status(
-            f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
+            f"⚠️ Iteration budget handoff ({api_call_count}/{agent.max_iterations}) "
             "— asking model to summarise"
         )
         if not agent.quiet_mode:
             agent._safe_print(
-                f"\n⚠️  Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
+                f"\n⚠️  Iteration budget handoff ({api_call_count}/{agent.max_iterations}) "
                 "— requesting summary..."
             )
         final_response = agent._handle_max_iterations(messages, api_call_count)
@@ -127,21 +134,41 @@ def finalize_turn(
                 from hermes_cli import kanban_db as _kb
                 _conn = _kb.connect()
                 try:
+                    _handoff_summary = (final_response or "").strip()
+                    if _handoff_summary:
+                        try:
+                            _kb.add_comment(
+                                _conn,
+                                _kanban_task,
+                                "kanban-budget-guard",
+                                (
+                                    f"Budget handoff at {api_call_count}/{agent.max_iterations}.\n\n"
+                                    f"{_handoff_summary[:4000]}"
+                                ),
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Failed to add budget handoff comment for task %s",
+                                _kanban_task,
+                                exc_info=True,
+                            )
                     _kb._record_task_failure(
                         _conn,
                         _kanban_task,
                         error=(
-                            f"Iteration budget exhausted "
+                            f"Iteration budget exhausted/handoff "
                             f"({api_call_count}/{agent.max_iterations}) — "
                             "task could not complete within the allowed "
                             "iterations"
                         ),
                         outcome="timed_out",
+                        summary=_handoff_summary or None,
                         release_claim=True,
                         end_run=True,
                         event_payload_extra={
                             "budget_used": api_call_count,
                             "budget_max": agent.max_iterations,
+                            "pre_stop_guard": _kanban_pre_stop_budget_guard,
                         },
                     )
                     logger.info(
@@ -165,6 +192,7 @@ def finalize_turn(
     completed = (
         final_response is not None
         and not failed
+        and not _kanban_pre_stop_budget_guard
         and (
             api_call_count < agent.max_iterations
             or normal_text_response

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7025,6 +7025,7 @@ def _record_task_failure(
     error: str,
     *,
     outcome: str,
+    summary: Optional[str] = None,
     failure_limit: int = None,
     force_trip: bool = False,
     release_claim: bool = False,
@@ -7126,12 +7127,14 @@ def _record_task_failure(
                 run_id = _end_run(
                     conn, task_id,
                     outcome="gave_up", status="gave_up",
+                    summary=summary,
                     error=error[:500],
                     metadata={
                         "failures": failures,
                         "trigger_outcome": outcome,
                         "effective_limit": effective_limit,
                         "limit_source": limit_source,
+                        **({"handoff_summary_len": len(summary)} if summary else {}),
                     },
                 )
             payload = {
@@ -7171,8 +7174,12 @@ def _record_task_failure(
                 run_id = _end_run(
                     conn, task_id,
                     outcome=outcome, status=outcome,
+                    summary=summary,
                     error=error[:500],
-                    metadata={"failures": failures},
+                    metadata={
+                        "failures": failures,
+                        **({"handoff_summary_len": len(summary)} if summary else {}),
+                    },
                 )
                 _append_event(
                     conn, task_id, outcome,

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -245,6 +245,38 @@ def test_per_task_max_retries_overrides_dispatcher_limit(kanban_home, all_assign
         conn.close()
 
 
+def test_failure_handoff_summary_is_persisted_on_run(kanban_home, all_assignees_spawnable):
+    """Budget guards should leave an exploitable run summary, not an
+    empty timed_out/gave_up row after useful work.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="long worker", assignee="worker", max_retries=1)
+        kb.claim_task(conn, tid)
+        summary = "Partial handoff: files inspected, next action is split card."
+        tripped = kb._record_task_failure(
+            conn,
+            tid,
+            error="Iteration budget exhausted/handoff (55/60)",
+            outcome="timed_out",
+            summary=summary,
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={"budget_used": 55, "budget_max": 60},
+        )
+        assert tripped is True
+        run = conn.execute(
+            "SELECT status, outcome, summary, error, metadata FROM task_runs WHERE task_id = ?",
+            (tid,),
+        ).fetchone()
+        assert run["status"] == "gave_up"
+        assert run["outcome"] == "gave_up"
+        assert run["summary"] == summary
+        assert "handoff_summary_len" in json.loads(run["metadata"])
+    finally:
+        conn.close()
+
+
 def test_per_task_max_retries_allows_more_than_default(kanban_home, all_assignees_spawnable):
     """A task with ``max_retries=5`` does NOT auto-block at the default
     limit of 2 — it must reach the per-task override first."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5587,12 +5587,14 @@ class TestRunConversation:
         ]
 
         mock_record_failure = MagicMock(return_value=False)
+        mock_add_comment = MagicMock(return_value=1)
         mock_connect = MagicMock(return_value=MagicMock())
 
         with (
             patch("run_agent.handle_function_call", return_value="ok"),
             patch("hermes_cli.kanban_db._record_task_failure",
                   mock_record_failure),
+            patch("hermes_cli.kanban_db.add_comment", mock_add_comment),
             patch("hermes_cli.kanban_db.connect", mock_connect),
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
@@ -5616,7 +5618,57 @@ class TestRunConversation:
         assert call.kwargs.get("outcome") == "timed_out"
         assert call.kwargs.get("release_claim") is True
         assert call.kwargs.get("end_run") is True
+        assert call.kwargs.get("summary") == "Could not finish — budget exhausted."
         assert "Iteration budget exhausted" in call.kwargs.get("error", "")
+        assert mock_add_comment.call_count == 1
+        assert "Could not finish" in mock_add_comment.call_args.args[3]
+
+    def test_kanban_pre_stop_budget_guard_records_handoff_before_hard_limit(self, agent, monkeypatch):
+        """Kanban workers stop before the hard budget edge (default 5 calls
+        early), ask for a no-tools summary, and persist that handoff on the
+        run-failure bridge.
+        """
+        self._setup_agent(agent)
+        agent.max_iterations = 10
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test_task_456")
+        monkeypatch.setenv("HERMES_KANBAN_BUDGET_PRESTOP_REMAINING", "5")
+
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        tool_resp = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[tc],
+        )
+        summary_resp = _mock_response(
+            content="Pre-stop handoff: partial work is usable.", finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            tool_resp, tool_resp, tool_resp, tool_resp, tool_resp, summary_resp,
+        ]
+
+        mock_record_failure = MagicMock(return_value=False)
+        mock_add_comment = MagicMock(return_value=1)
+        mock_connect = MagicMock(return_value=MagicMock())
+
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch("hermes_cli.kanban_db._record_task_failure",
+                  mock_record_failure),
+            patch("hermes_cli.kanban_db.add_comment", mock_add_comment),
+            patch("hermes_cli.kanban_db.connect", mock_connect),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("do the long kanban work")
+
+        assert result["completed"] is False
+        assert result["api_calls"] == 5
+        assert result["turn_exit_reason"] == "kanban_pre_stop_budget_guard(5/10)"
+        call = mock_record_failure.call_args_list[0]
+        assert call.args[1] == "t_test_task_456"
+        assert call.kwargs.get("summary") == "Pre-stop handoff: partial work is usable."
+        assert call.kwargs["event_payload_extra"]["pre_stop_guard"] is True
+        assert mock_add_comment.call_count == 1
 
     def test_no_kanban_block_when_not_in_kanban_mode(self, agent, monkeypatch):
         """The exhaustion bridge must NOT fire when HERMES_KANBAN_TASK


### PR DESCRIPTION
## Summary
- Adds a Kanban-only pre-stop budget guard so workers preserve tool budget for a no-tools handoff summary before the hard iteration cap.
- Persists that handoff as a `kanban-budget-guard` comment and `task_runs.summary` on timed_out/gave_up paths.
- Extends targeted regression coverage for the pre-stop guard and failure summary persistence.

## Scope hygiene
- Includes only the approved budget pre-stop files:
  - `agent/conversation_loop.py`
  - `agent/turn_finalizer.py`
  - `hermes_cli/kanban_db.py`
  - `tests/run_agent/test_run_agent.py`
  - `tests/hermes_cli/test_kanban_core_functionality.py`
- Explicitly excludes pre-existing OA dispatch-guardrail drift (`hermes_cli/kanban.py`, `tests/hermes_cli/test_oa_dispatch_guardrails.py`, and unrelated dispatch guard hunks).

## Verification
- `python -m py_compile agent/conversation_loop.py agent/turn_finalizer.py hermes_cli/kanban_db.py` — passed
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py -k 'kanban_block_called_on_iteration_exhaustion or kanban_pre_stop_budget_guard_records_handoff_before_hard_limit or no_kanban_block_when_not_in_kanban_mode' tests/hermes_cli/test_kanban_core_functionality.py::test_failure_handoff_summary_is_persisted_on_run -q` — 3 passed (wrapper did not include nodeid target in same invocation)
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py -k 'test_failure_handoff_summary_is_persisted_on_run' -q` — 1 passed
- `python -m pytest tests/run_agent/test_run_agent.py -k 'kanban_block_called_on_iteration_exhaustion or kanban_pre_stop_budget_guard_records_handoff_before_hard_limit or no_kanban_block_when_not_in_kanban_mode' tests/hermes_cli/test_kanban_core_functionality.py::test_failure_handoff_summary_is_persisted_on_run -q -o 'addopts='` — 3 passed, 435 deselected
- `python -m pytest tests/agent/test_turn_finalizer_cleanup_guard.py tests/run_agent/test_run_agent.py -k 'kanban_block_called_on_iteration_exhaustion or kanban_pre_stop_budget_guard_records_handoff_before_hard_limit or no_kanban_block_when_not_in_kanban_mode or cleanup' tests/hermes_cli/test_kanban_core_functionality.py::test_failure_handoff_summary_is_persisted_on_run -q -o 'addopts='` — 9 passed, 435 deselected
- `git diff --check` — passed

## Review context
Kanban task: `t_91a87c0f`
Source gate: `/home/omar/.hermes/kanban/artifacts/t_4cfeb5a6/review_result.json` (`pass_with_nits`, no blockers)
