### PR TITLE
fix(desktop): navigate to session when clicking most-recent from non-Chat tab

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,7 +72,7 @@ import { PetGenerateOverlay } from '../pet-generate/pet-generate-overlay'
 import { FileActionDialogs } from '../right-sidebar/file-actions'
 import { RemoteFolderPicker } from '../right-sidebar/files/remote-picker'
 import { PersistentTerminal } from '../right-sidebar/terminal/persistent'
-import { CRON_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE, syncWorkspaceIsPage } from '../routes'
+import { appViewForPath, CRON_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE, syncWorkspaceIsPage } from '../routes'
 import { SessionPickerOverlay } from '../session-picker-overlay'
 import { SessionSwitcher } from '../session-switcher'
 import { useBackgroundQueueDrain } from '../session/hooks/use-background-queue-drain'
@@ -750,9 +750,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onRemoveAttachment: id => void composer.removeAttachment(id),
     onRestoreToMessage: restoreToMessage,
     // Already on screen (open tile, or the main session)? Jump to its tab;
-    // otherwise load it into main.
+    // otherwise load it into main. When we're on a non-Chat page (Plugins,
+    // Artifacts, etc.) the "already selected" path in focusOpenSession only
+    // focuses the workspace pane without navigating — force the route change
+    // so clicking the most-recent session actually switches back to Chat (#66875).
     onResumeSession: sessionId => {
       if (!focusOpenSession(sessionId)) {
+        navigate(sessionRoute(sessionId))
+      } else if (appViewForPath(location.pathname) !== 'chat') {
         navigate(sessionRoute(sessionId))
       }
     },


### PR DESCRIPTION
## Problem

When viewing a non-Chat tab (Plugins, Artifacts, Capabilities, Messaging) and clicking the **most recent** session in the sidebar, nothing happened — the view stayed on the current page (`/plugins`, `/artifacts`, etc.).

Clicking any *other* session worked fine: it switched to Chat with that session loaded.

## Root Cause

The `onResumeSession` callback at `wiring.tsx:753` calls `focusOpenSession(sessionId)` first. When the clicked session matches `$selectedStoredSessionId` (i.e. it's the most recent / last-opened session), `focusOpenSession` returns `true` after calling `revealTreePane('workspace')` and `noteActiveTreeGroup(null)` — but it does **not** navigate the router. Since the user is on a non-Chat page, the workspace pane doesn't show chat, so nothing visible happens.

For sessions that differ from `$selectedStoredSessionId` (all but the topmost), `focusOpenSession` returns `false`, and `navigate(sessionRoute(sessionId))` runs as expected.

## Fix

After `focusOpenSession` returns `true` but the current route is NOT a chat view, still call `navigate(sessionRoute(sessionId))` to force the route change. This is a 2-line addition in the existing handler.

## Test

TypeScript compiles cleanly (`npx tsc --noEmit` passes). No test coverage exists for this specific wiring handler path.

Closes #66875