### PR TITLE
fix(gateway): honor gateway.api_server config.yaml section during initialization

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1114,6 +1114,71 @@ def load_gateway_config() -> GatewayConfig:
 
             _merge_platform_map(gateway_platforms)
             _merge_platform_map(yaml_cfg.get("platforms"))
+
+            # gateway.api_server — the documented config.yaml block for the
+            # OpenAI-compatible API server platform (see the ``gateway.api_server``
+            # entry in hermes_cli/config.py's CONFIG_DEFAULTS). Unlike the
+            # env-only platforms, self-hosted users enable/configure it via YAML
+            # without setting API_SERVER_* env vars. The production loader only
+            # forwards ``gateway.platforms`` into ``gw_data["platforms"]`` above,
+            # so without this normalisation the ``gateway.api_server`` block is
+            # silently ignored (#66630). We map it into the canonical
+            # ``gw_data["platforms"]["api_server"]`` shape here so it flows
+            # through ``GatewayConfig.from_dict()`` exactly like an env enable,
+            # and ``_apply_env_overrides`` still layers on top.
+            _api_server_yaml = gateway_cfg.get("api_server") if isinstance(gateway_cfg, dict) else None
+            if isinstance(_api_server_yaml, dict) and _api_server_yaml:
+                _api_server_enabled = _coerce_bool(_api_server_yaml.get("enabled"), False)
+                _api_server_extra: Dict[str, Any] = {}
+                for _field in ("port", "host", "key", "model_name"):
+                    _val = _api_server_yaml.get(_field)
+                    if _val is None:
+                        continue
+                    if _field == "port":
+                        try:
+                            _api_server_extra["port"] = int(_val)
+                        except (TypeError, ValueError):
+                            pass
+                    else:
+                        _api_server_extra[_field] = _val
+                _cors = _api_server_yaml.get("cors_origins")
+                if isinstance(_cors, str):
+                    _origins = [o.strip() for o in _cors.split(",") if o.strip()]
+                    if _origins:
+                        _api_server_extra["cors_origins"] = _origins
+                elif isinstance(_cors, list):
+                    _origins = [str(o).strip() for o in _cors if str(o).strip()]
+                    if _origins:
+                        _api_server_extra["cors_origins"] = _origins
+                _max_concurrent = _api_server_yaml.get("max_concurrent_runs")
+                if _max_concurrent is not None:
+                    try:
+                        _api_server_extra["max_concurrent_runs"] = int(_max_concurrent)
+                    except (TypeError, ValueError):
+                        pass
+                # Only register the platform when the user actually enabled it
+                # or set any configuration field. A bare
+                # ``gateway.api_server: {}`` / ``enabled: false`` with nothing
+                # else leaves the platform untouched, matching the env path
+                # which only enables API_SERVER when API_SERVER_ENABLED is
+                # truthy. ``enabled: true`` (or any config field present)
+                # materialises the entry so the runtime registers the platform.
+                if _api_server_enabled or _api_server_extra:
+                    _api_server_block = platforms_data.get("api_server")
+                    if not isinstance(_api_server_block, dict):
+                        _api_server_block = {}
+                    if _api_server_enabled:
+                        _api_server_block["enabled"] = True
+                        _api_server_block.setdefault("extra", {})["_enabled_explicit"] = True
+                    # Preserve existing extra (e.g. from platforms.api_server)
+                    # and only fill in keys the user set under gateway.api_server.
+                    _merged_extra = dict(_api_server_block.get("extra", {}))
+                    for _k, _v in _api_server_extra.items():
+                        _merged_extra.setdefault(_k, _v)
+                    if _merged_extra:
+                        _api_server_block["extra"] = _merged_extra
+                    platforms_data["api_server"] = _api_server_block
+
             if platforms_data:
                 gw_data["platforms"] = platforms_data
             # Iterate built-in platforms plus any registered plugin platforms
@@ -1736,11 +1801,21 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # API Server
-    api_server_enabled = is_truthy_value(getenv("API_SERVER_ENABLED", ""))
+    # Explicit-disable precedence: ``API_SERVER_ENABLED=false`` must override a
+    # YAML-enabled platform (mirrors WHATSAPP_ENABLED). ``is_truthy_value``
+    # treats falsey strings as not-enabled, so we separately detect the explicit
+    # "false"/"0"/"no" spelling to honour a hard env disable even when YAML's
+    # ``gateway.api_server.enabled: true`` would otherwise enable it. This
+    # completes the env > config.yaml > default precedence for the platform.
+    _api_server_enabled_raw = getenv("API_SERVER_ENABLED", "")
+    api_server_enabled = is_truthy_value(_api_server_enabled_raw)
+    api_server_disabled_explicitly = _api_server_enabled_raw.lower() in {"false", "0", "no"}
     api_server_key = getenv("API_SERVER_KEY", "")
     api_server_cors_origins = getenv("API_SERVER_CORS_ORIGINS", "")
     api_server_port = getenv("API_SERVER_PORT")
     api_server_host = getenv("API_SERVER_HOST")
+    if api_server_disabled_explicitly and Platform.API_SERVER in config.platforms:
+        config.platforms[Platform.API_SERVER].enabled = False
     if api_server_enabled or api_server_key:
         if Platform.API_SERVER not in config.platforms:
             config.platforms[Platform.API_SERVER] = PlatformConfig()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1317,6 +1317,209 @@ class TestHomeChannelEnvOverrides:
             assert (home.chat_id, home.name) == expected, platform.value
 
 
+class TestGatewayApiServerYamlLoader:
+    """End-to-end tests for the ``gateway.api_server`` config.yaml block.
+
+    These exercise the *production* loader path (``load_gateway_config()`` with
+    a temp ``HERMES_HOME``), not ``GatewayConfig.from_dict()`` directly. The
+    original regression (#66630) was that the YAML key was silently ignored
+    because the loader never normalised ``gateway.api_server`` into the
+    canonical ``gw_data["platforms"]["api_server"]`` shape that ``from_dict``
+    reads.
+    """
+
+    @staticmethod
+    def _write_config(hermes_home, yaml_text):
+        (hermes_home / "config.yaml").write_text(yaml_text, encoding="utf-8")
+
+    @staticmethod
+    def _clear_api_server_env(monkeypatch):
+        for _v in (
+            "API_SERVER_ENABLED",
+            "API_SERVER_KEY",
+            "API_SERVER_PORT",
+            "API_SERVER_HOST",
+            "API_SERVER_CORS_ORIGINS",
+            "API_SERVER_MODEL_NAME",
+        ):
+            monkeypatch.delenv(_v, raising=False)
+
+    def test_yaml_enables_and_populates_api_server(self, tmp_path, monkeypatch):
+        # Regression: ``gateway.api_server`` was silently ignored on main.
+        # The full block must enable the platform and carry every field the
+        # runtime adapter reads.
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        self._write_config(
+            hermes_home,
+            (
+                "gateway:\n"
+                "  api_server:\n"
+                "    enabled: true\n"
+                "    port: 8642\n"
+                "    host: '0.0.0.0'\n"
+                "    key: secret-key\n"
+                "    cors_origins: 'https://a.example, https://b.example'\n"
+                "    model_name: gpt-demo\n"
+                "    max_concurrent_runs: 5\n"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._clear_api_server_env(monkeypatch)
+
+        config = load_gateway_config()
+
+        assert Platform.API_SERVER in config.platforms
+        api = config.platforms[Platform.API_SERVER]
+        assert api.enabled is True
+        assert api.extra["port"] == 8642
+        assert api.extra["host"] == "0.0.0.0"
+        assert api.extra["key"] == "secret-key"
+        assert api.extra["cors_origins"] == ["https://a.example", "https://b.example"]
+        assert api.extra["model_name"] == "gpt-demo"
+        assert api.extra["max_concurrent_runs"] == 5
+
+    def test_yaml_absent_does_not_register_platform(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        self._write_config(hermes_home, "model: gpt-test\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._clear_api_server_env(monkeypatch)
+
+        config = load_gateway_config()
+        assert Platform.API_SERVER not in config.platforms
+
+    def test_yaml_enabled_false_does_not_register_platform(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        self._write_config(
+            hermes_home, "gateway:\n  api_server:\n    enabled: false\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._clear_api_server_env(monkeypatch)
+
+        config = load_gateway_config()
+        assert Platform.API_SERVER not in config.platforms
+
+    def test_yaml_string_port_is_coerced_to_int(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        self._write_config(
+            hermes_home,
+            "gateway:\n  api_server:\n    enabled: true\n    port: '9100'\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._clear_api_server_env(monkeypatch)
+
+        config = load_gateway_config()
+        assert config.platforms[Platform.API_SERVER].extra["port"] == 9100
+
+    def test_yaml_invalid_port_is_dropped_but_platform_enabled(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        self._write_config(
+            hermes_home,
+            "gateway:\n  api_server:\n    enabled: true\n    port: 'not-a-number'\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._clear_api_server_env(monkeypatch)
+
+        config = load_gateway_config()
+        api = config.platforms[Platform.API_SERVER]
+        assert api.enabled is True
+        assert "port" not in api.extra
+
+    def test_yaml_cors_origins_as_list(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        self._write_config(
+            hermes_home,
+            "gateway:\n  api_server:\n    enabled: true\n"
+            "    cors_origins:\n      - 'http://a.local'\n      - 'http://b.local'\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._clear_api_server_env(monkeypatch)
+
+        config = load_gateway_config()
+        assert config.platforms[Platform.API_SERVER].extra["cors_origins"] == [
+            "http://a.local",
+            "http://b.local",
+        ]
+
+    def test_yaml_merges_with_platforms_api_server_spelling(self, tmp_path, monkeypatch):
+        # ``gateway.api_server.enabled`` must enable a platform that
+        # ``platforms.api_server`` declared with extra but without enabling.
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        self._write_config(
+            hermes_home,
+            (
+                "platforms:\n"
+                "  api_server:\n"
+                "    extra:\n      model_name: from-platforms\n"
+                "gateway:\n"
+                "  api_server:\n    enabled: true\n    port: 7000\n"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._clear_api_server_env(monkeypatch)
+
+        config = load_gateway_config()
+        api = config.platforms[Platform.API_SERVER]
+        assert api.enabled is True
+        assert api.extra["port"] == 7000
+        # Pre-existing extra from platforms.api_server is preserved.
+        assert api.extra["model_name"] == "from-platforms"
+
+    def test_env_enabled_layers_on_top_of_yaml(self, tmp_path, monkeypatch):
+        # YAML block present but disabled; API_SERVER_ENABLED=true must enable.
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        self._write_config(
+            hermes_home,
+            "gateway:\n  api_server:\n    enabled: false\n    port: 7777\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("API_SERVER_ENABLED", "true")
+
+        config = load_gateway_config()
+        api = config.platforms[Platform.API_SERVER]
+        assert api.enabled is True
+        # YAML port is still carried (env only flipped the enabled flag).
+        assert api.extra["port"] == 7777
+
+    def test_env_disabled_false_overrides_yaml_enabled_true(self, tmp_path, monkeypatch):
+        # Explicit-disable precedence: API_SERVER_ENABLED=false wins over a
+        # YAML ``enabled: true`` (mirrors WHATSAPP_ENABLED). This is the
+        # operator's kill-switch — a misconfigured config.yaml must not pin the
+        # platform on against the operator's explicit env instruction.
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        self._write_config(
+            hermes_home,
+            "gateway:\n  api_server:\n    enabled: true\n    port: 8642\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("API_SERVER_ENABLED", "false")
+        monkeypatch.delenv("API_SERVER_KEY", raising=False)
+
+        config = load_gateway_config()
+        assert Platform.API_SERVER in config.platforms
+        assert config.platforms[Platform.API_SERVER].enabled is False
+
+    def test_env_disabled_false_no_op_when_platform_absent(self, tmp_path, monkeypatch):
+        # If neither YAML nor another env var enabled the platform,
+        # API_SERVER_ENABLED=false must not spontaneously register it.
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        self._write_config(hermes_home, "model: gpt-test\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("API_SERVER_ENABLED", "false")
+
+        config = load_gateway_config()
+        assert Platform.API_SERVER not in config.platforms
+
+
 class TestMultiplexProfilesEnvOverride:
     """GATEWAY_MULTIPLEX_PROFILES env override — the 3-tier precedence chain.
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -409,10 +409,22 @@ The API server gives full access to hermes-agent's toolset, **including terminal
 
 ### config.yaml
 
+The API server can be enabled and configured entirely from `config.yaml` under the `gateway.api_server` section, without any environment variables. Env vars, when set, take precedence (env > config.yaml > built-in default); in particular `API_SERVER_ENABLED=false` overrides a YAML `enabled: true`.
+
 ```yaml
-# Not yet supported — use environment variables.
-# config.yaml support coming in a future release.
+gateway:
+  api_server:
+    enabled: true
+    port: 8642            # default 8642
+    host: "127.0.0.1"     # bind address; 0.0.0.0 to expose
+    key: "your-bearer-token"
+    cors_origins:         # optional: string (comma-separated) or list
+      - "http://localhost:3000"
+    model_name: "hermes"  # optional; defaults to profile name
+    max_concurrent_runs: 10
 ```
+
+All fields are optional; only `enabled: true` is required to turn the server on. The `gateway.api_server` block layers on top of any `platforms.api_server` / `gateway.platforms.api_server` spelling with the same precedence the rest of `config.yaml` uses.
 
 ## Security Headers
 
@@ -464,8 +476,10 @@ To give multiple users their own isolated Hermes instance (separate config, memo
 hermes profile create alice
 hermes profile create bob
 
-# Configure each profile's API server on a different port. API_SERVER_* are env
-# vars (not config.yaml keys), so write them to each profile's .env:
+# Configure each profile's API server on a different port.
+# API_SERVER_* env vars still work and take precedence over config.yaml; for a
+# self-hosted multi-user setup, each profile's config.yaml can carry its own
+# gateway.api_server block instead.
 cat >> ~/.hermes/profiles/alice/.env <<EOF
 API_SERVER_ENABLED=true
 API_SERVER_PORT=8643


### PR DESCRIPTION
The gateway.api_server config.yaml block (documented in hermes_cli/config.py CONFIG_DEFAULTS alongside gateway.multiplex_profiles and gateway.max_concurrent_sessions) was silently ignored during initialization. GatewayConfig.from_dict only read gateway.multiplex_profiles and gateway.max_concurrent_sessions from the nested gateway section, so gateway.api_server.enabled/port/host/etc. never reached config.platforms. Only the API_SERVER_* env vars could start the platform, which made the documented YAML-only path (issue #66630) not work.

This adds parsing of nested gateway.api_server in GatewayConfig.from_dict, materializing Platform.API_SERVER with enabled plus the same extra fields (port, host, key, cors_origins, model_name, max_concurrent_runs) that the env path (_apply_env_overrides) and the runtime APIServerAdapter already read from extra. Env overrides still win and layer on top, so the env > config.yaml > default precedence used for the other gateway subsections is preserved. platforms.api_server remains supported as an alternate spelling and merges cleanly with gateway.api_server.

Verified: pure-YAML enablement now works (reporter case), API_SERVER_ENABLED env still overrides an enabled:false in YAML while preserving the YAML port, string ports are coerced to int, invalid ports are dropped, and a bare enabled:false with no other fields leaves config.platforms untouched. Added 4 regression tests in tests/gateway/test_config.py covering these; the full file (106 tests) stays green.

Fixes #66630