### PR TITLE
feat(discord): add persistent workspace header cards

### DIFF
--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -191,7 +191,11 @@ class OperatorCard:
             raise OperatorCardValidationError("kind must be operator_card")
         if "version" not in payload:
             raise OperatorCardValidationError("missing required field: version")
-        if isinstance(payload["version"], bool) or payload["version"] != 1:
+        # Require the exact integer 1 — reject bools, floats (``1.0``), and
+        # numeric strings.  ``1.0 == 1`` in Python, so an equality-only check
+        # would silently admit a float version the contract does not define.
+        version = payload["version"]
+        if isinstance(version, bool) or type(version) is not int or version != 1:
             raise OperatorCardValidationError("version must be 1")
 
         card_type = _bounded_string(payload, "card_type", max_length=32)

--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -1,0 +1,268 @@
+"""Platform-agnostic operator-card contract and plaintext fallback.
+
+Operator cards carry bounded, human-readable control-surface metadata between
+the gateway and platform adapters.  This module intentionally contains no
+Discord (or other platform) dependency; adapters decide whether to render the
+validated contract richly or use :func:`render_operator_card_text`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+
+CARD_TYPES = frozenset(
+    {
+        "approval",
+        "task_run",
+        "digest",
+        "deal",
+        "capture",
+        "ops_alert",
+        "thread_header",
+    }
+)
+SEVERITIES = frozenset({"done", "info", "needs_review", "blocked", "critical"})
+ACTION_STYLES = frozenset({"primary", "secondary", "success", "danger", "link"})
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "kind",
+        "version",
+        "card_type",
+        "title",
+        "severity",
+        "summary",
+        "fields",
+        "actions",
+        "links",
+        "state_ref",
+    }
+)
+_ACTION_ID_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_STATE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$")
+
+_SEVERITY_DISPLAY = {
+    "done": ("✅", "Done"),
+    "info": ("🔵", "Info"),
+    "needs_review": ("🟡", "Needs review"),
+    "blocked": ("🔴", "Blocked"),
+    "critical": ("🚨", "Critical"),
+}
+
+
+class OperatorCardValidationError(ValueError):
+    """Raised when untrusted operator-card data violates the contract."""
+
+
+def _mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise OperatorCardValidationError(f"{field_name} must be an object")
+    return value
+
+
+def _bounded_string(
+    source: Mapping[str, Any],
+    field_name: str,
+    *,
+    max_length: int,
+) -> str:
+    if field_name not in source:
+        raise OperatorCardValidationError(f"missing required field: {field_name}")
+    value = source[field_name]
+    if not isinstance(value, str) or not value.strip():
+        raise OperatorCardValidationError(f"{field_name} must be a non-empty string")
+    value = value.strip()
+    if len(value) > max_length:
+        raise OperatorCardValidationError(
+            f"{field_name} exceeds the {max_length}-character limit"
+        )
+    return value
+
+
+def _object_list(source: Mapping[str, Any], field_name: str, *, max_items: int) -> list[Mapping[str, Any]]:
+    value = source.get(field_name, [])
+    if not isinstance(value, list):
+        raise OperatorCardValidationError(f"{field_name} must be a list")
+    if len(value) > max_items:
+        raise OperatorCardValidationError(f"{field_name} exceeds the {max_items}-item limit")
+    return [_mapping(item, f"{field_name}[{index}]") for index, item in enumerate(value)]
+
+
+def _reject_unknown_fields(source: Mapping[str, Any], allowed: set[str] | frozenset[str], context: str) -> None:
+    unknown = set(source) - set(allowed)
+    if unknown:
+        rendered = ", ".join(sorted(str(name) for name in unknown))
+        raise OperatorCardValidationError(f"{context} has unknown fields: {rendered}")
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCardField:
+    label: str
+    value: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "OperatorCardField":
+        _reject_unknown_fields(payload, {"label", "value"}, "field")
+        return cls(
+            label=_bounded_string(payload, "label", max_length=80),
+            value=_bounded_string(payload, "value", max_length=1024),
+        )
+
+    def to_mapping(self) -> dict[str, str]:
+        return {"label": self.label, "value": self.value}
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCardAction:
+    id: str
+    label: str
+    style: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "OperatorCardAction":
+        _reject_unknown_fields(payload, {"id", "label", "style"}, "action")
+        action_id = _bounded_string(payload, "id", max_length=64)
+        if not _ACTION_ID_RE.fullmatch(action_id):
+            raise OperatorCardValidationError("action id must use lowercase letters, digits, hyphens, or underscores")
+        style = _bounded_string(payload, "style", max_length=16)
+        if style not in ACTION_STYLES:
+            raise OperatorCardValidationError(f"unsupported action style: {style}")
+        return cls(
+            id=action_id,
+            label=_bounded_string(payload, "label", max_length=80),
+            style=style,
+        )
+
+    def to_mapping(self) -> dict[str, str]:
+        return {"id": self.id, "label": self.label, "style": self.style}
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCardLink:
+    label: str
+    url: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "OperatorCardLink":
+        _reject_unknown_fields(payload, {"label", "url"}, "link")
+        url = _bounded_string(payload, "url", max_length=2048)
+        parsed = urlsplit(url)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise OperatorCardValidationError("link url must be an http(s) URL without credentials")
+        return cls(
+            label=_bounded_string(payload, "label", max_length=80),
+            url=url,
+        )
+
+    def to_mapping(self) -> dict[str, str]:
+        return {"label": self.label, "url": self.url}
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCard:
+    card_type: str
+    title: str
+    severity: str
+    summary: str
+    fields: tuple[OperatorCardField, ...]
+    actions: tuple[OperatorCardAction, ...]
+    links: tuple[OperatorCardLink, ...]
+    state_ref: str
+    kind: str = "operator_card"
+    version: int = 1
+
+    @classmethod
+    def from_mapping(cls, raw_payload: Mapping[str, Any]) -> "OperatorCard":
+        payload = _mapping(raw_payload, "operator_card")
+        _reject_unknown_fields(payload, _TOP_LEVEL_FIELDS, "operator_card")
+
+        if "kind" not in payload:
+            raise OperatorCardValidationError("missing required field: kind")
+        if payload["kind"] != "operator_card":
+            raise OperatorCardValidationError("kind must be operator_card")
+        if "version" not in payload:
+            raise OperatorCardValidationError("missing required field: version")
+        if isinstance(payload["version"], bool) or payload["version"] != 1:
+            raise OperatorCardValidationError("version must be 1")
+
+        card_type = _bounded_string(payload, "card_type", max_length=32)
+        if card_type not in CARD_TYPES:
+            raise OperatorCardValidationError(f"unsupported card_type: {card_type}")
+        severity = _bounded_string(payload, "severity", max_length=32)
+        if severity not in SEVERITIES:
+            raise OperatorCardValidationError(f"unsupported severity: {severity}")
+
+        fields = tuple(
+            OperatorCardField.from_mapping(item)
+            for item in _object_list(payload, "fields", max_items=12)
+        )
+        actions = tuple(
+            OperatorCardAction.from_mapping(item)
+            for item in _object_list(payload, "actions", max_items=5)
+        )
+        action_ids = [action.id for action in actions]
+        if len(action_ids) != len(set(action_ids)):
+            raise OperatorCardValidationError("action ids must be unique")
+        links = tuple(
+            OperatorCardLink.from_mapping(item)
+            for item in _object_list(payload, "links", max_items=5)
+        )
+
+        state_ref = _bounded_string(payload, "state_ref", max_length=200)
+        if not _STATE_REF_RE.fullmatch(state_ref):
+            raise OperatorCardValidationError("state_ref must be an opaque identifier")
+
+        return cls(
+            card_type=card_type,
+            title=_bounded_string(payload, "title", max_length=120),
+            severity=severity,
+            summary=_bounded_string(payload, "summary", max_length=500),
+            fields=fields,
+            actions=actions,
+            links=links,
+            state_ref=state_ref,
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "version": self.version,
+            "card_type": self.card_type,
+            "title": self.title,
+            "severity": self.severity,
+            "summary": self.summary,
+            "fields": [field.to_mapping() for field in self.fields],
+            "actions": [action.to_mapping() for action in self.actions],
+            "links": [link.to_mapping() for link in self.links],
+            "state_ref": self.state_ref,
+        }
+
+
+def render_operator_card_text(card: OperatorCard, *, max_length: int = 2000) -> str:
+    """Render a compact Markdown fallback shared by non-rich platforms."""
+    emoji, severity_label = _SEVERITY_DISPLAY[card.severity]
+    lines = [f"{emoji} **{severity_label} — {card.title}**", card.summary]
+    lines.extend(f"{field.label}: {field.value}" for field in card.fields)
+    if card.actions:
+        lines.append("Actions: " + " · ".join(action.label for action in card.actions))
+    if card.links:
+        links = " · ".join(f"[{link.label}]({link.url})" for link in card.links)
+        lines.append(f"Links: {links}")
+
+    rendered = "\n".join(lines)
+    if len(rendered) <= max_length:
+        return rendered
+    if max_length <= 0:
+        return ""
+    if max_length == 1:
+        return "…"
+    return rendered[: max_length - 1].rstrip() + "…"

--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -54,6 +54,11 @@ _SEVERITY_DISPLAY = {
 }
 
 
+def operator_card_severity_display(severity: str) -> tuple[str, str]:
+    """Return the shared emoji and label for a validated severity."""
+    return _SEVERITY_DISPLAY[severity]
+
+
 class OperatorCardValidationError(ValueError):
     """Raised when untrusted operator-card data violates the contract."""
 
@@ -153,7 +158,7 @@ class OperatorCardLink:
         parsed = urlsplit(url)
         if (
             parsed.scheme not in {"http", "https"}
-            or not parsed.netloc
+            or not parsed.hostname
             or parsed.username is not None
             or parsed.password is not None
         ):
@@ -261,7 +266,7 @@ def render_operator_card_text(
     Passing ``None`` returns the complete fallback so an adapter with native
     message chunking can preserve every field and link across messages.
     """
-    emoji, severity_label = _SEVERITY_DISPLAY[card.severity]
+    emoji, severity_label = operator_card_severity_display(card.severity)
     lines = [f"{emoji} **{severity_label} — {card.title}**", card.summary]
     lines.extend(f"{field.label}: {field.value}" for field in card.fields)
     if card.actions:

--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -251,8 +251,16 @@ class OperatorCard:
         }
 
 
-def render_operator_card_text(card: OperatorCard, *, max_length: int = 2000) -> str:
-    """Render a compact Markdown fallback shared by non-rich platforms."""
+def render_operator_card_text(
+    card: OperatorCard,
+    *,
+    max_length: int | None = 2000,
+) -> str:
+    """Render a compact Markdown fallback shared by non-rich platforms.
+
+    Passing ``None`` returns the complete fallback so an adapter with native
+    message chunking can preserve every field and link across messages.
+    """
     emoji, severity_label = _SEVERITY_DISPLAY[card.severity]
     lines = [f"{emoji} **{severity_label} — {card.title}**", card.summary]
     lines.extend(f"{field.label}: {field.value}" for field in card.fields)
@@ -263,7 +271,7 @@ def render_operator_card_text(card: OperatorCard, *, max_length: int = 2000) -> 
         lines.append(f"Links: {links}")
 
     rendered = "\n".join(lines)
-    if len(rendered) <= max_length:
+    if max_length is None or len(rendered) <= max_length:
         return rendered
     if max_length <= 0:
         return ""

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -175,31 +175,83 @@ _DISCORD_OPERATOR_CARD_SEVERITY_LABELS = {
     "critical": "Critical",
 }
 
+# Discord embed budgets, measured in UTF-16 code units (Discord's own unit for
+# these limits).  A contract-valid operator card can still exceed them — e.g.
+# up to 12 fields at the 1024-char field ceiling, or a link block wider than a
+# single field — and Discord rejects an oversized embed wholesale (HTTP 400,
+# error code 50035), which would drop the entire message.  We bound each part
+# and stop once the running aggregate would overflow.
+_DISCORD_EMBED_TITLE_LIMIT = 256
+_DISCORD_EMBED_DESCRIPTION_LIMIT = 4096
+_DISCORD_EMBED_FOOTER_LIMIT = 2048
+_DISCORD_EMBED_FIELD_NAME_LIMIT = 256
+_DISCORD_EMBED_FIELD_VALUE_LIMIT = 1024
+_DISCORD_EMBED_TOTAL_LIMIT = 6000
+_DISCORD_EMBED_MAX_FIELDS = 25
+
 
 def _build_operator_card_embed(card: OperatorCard) -> Any:
-    """Render a validated operator card as a bounded Discord embed."""
-    embed = discord.Embed(
-        title=card.title,
-        description=card.summary,
-        color=_DISCORD_OPERATOR_CARD_COLORS[card.severity],
+    """Render a validated operator card as an embed bounded to Discord's limits.
+
+    Every part is truncated to its per-element ceiling and fields are dropped
+    once the running aggregate would exceed Discord's 6000-code-unit budget, so
+    the embed is always API-valid.  Nothing the operator needs is lost: the
+    plaintext fallback (``render_operator_card_text``) still carries the full
+    card as the message content alongside this embed.
+    """
+    title = _truncate_discord_component_text(card.title, _DISCORD_EMBED_TITLE_LIMIT)
+    description = _truncate_discord_component_text(
+        card.summary, _DISCORD_EMBED_DESCRIPTION_LIMIT
     )
-    for field in card.fields:
-        embed.add_field(name=field.label, value=field.value, inline=False)
-    if card.actions:
-        embed.add_field(
-            name="Actions",
-            value=" · ".join(action.label for action in card.actions),
-            inline=False,
-        )
-    if card.links:
-        embed.add_field(
-            name="Links",
-            value="\n".join(f"[{link.label}]({link.url})" for link in card.links),
-            inline=False,
-        )
     card_type_label = card.card_type.replace("_", " ").title()
     severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[card.severity]
-    embed.set_footer(text=f"{card_type_label} · {severity_label}")
+    footer = _truncate_discord_component_text(
+        f"{card_type_label} · {severity_label}", _DISCORD_EMBED_FOOTER_LIMIT
+    )
+
+    embed = discord.Embed(
+        title=title,
+        description=description,
+        color=_DISCORD_OPERATOR_CARD_COLORS[card.severity],
+    )
+
+    # Title, description, and footer always count against the 6000 aggregate.
+    remaining = _DISCORD_EMBED_TOTAL_LIMIT - (
+        utf16_len(title) + utf16_len(description) + utf16_len(footer)
+    )
+
+    def _add_bounded_field(name: str, value: str) -> None:
+        nonlocal remaining
+        if len(embed.fields) >= _DISCORD_EMBED_MAX_FIELDS or remaining <= 0:
+            return
+        name = _truncate_discord_component_text(
+            name, min(_DISCORD_EMBED_FIELD_NAME_LIMIT, remaining)
+        )
+        if not name:
+            return
+        remaining -= utf16_len(name)
+        if remaining <= 0:
+            return
+        value = _truncate_discord_component_text(
+            value, min(_DISCORD_EMBED_FIELD_VALUE_LIMIT, remaining)
+        )
+        if not value:
+            return
+        remaining -= utf16_len(value)
+        embed.add_field(name=name, value=value, inline=False)
+
+    for field in card.fields:
+        _add_bounded_field(field.label, field.value)
+    if card.actions:
+        _add_bounded_field(
+            "Actions", " · ".join(action.label for action in card.actions)
+        )
+    if card.links:
+        _add_bounded_field(
+            "Links", "\n".join(f"[{link.label}]({link.url})" for link in card.links)
+        )
+
+    embed.set_footer(text=footer)
     return embed
 
 
@@ -2889,9 +2941,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
                     operator_card.severity
                 ]
-                operator_card_thread_name = (
-                    f"{severity_label} — {operator_card.title}"
-                )[:100]
+                # Discord's 100-char thread-name cap is measured in UTF-16 code
+                # units; a naive ``[:100]`` slice counts code points and can
+                # emit a name Discord rejects.  Use the shared UTF-16-aware
+                # component truncator like every other Discord label.
+                operator_card_thread_name = _truncate_discord_component_text(
+                    f"{severity_label} — {operator_card.title}", 100
+                )
 
             # Determine target channel: thread_id in metadata takes precedence.
             thread_id = None

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -141,6 +141,31 @@ def _truncate_discord_component_text(text: str, limit: int) -> str:
     return _prefix_within_utf16_limit(str(text or ""), max(0, limit))
 
 
+def _chunk_discord_lossless_text(text: str, limit: int) -> list[str]:
+    """Split text on Discord's UTF-16 budget without changing its content.
+
+    Operator-card fallbacks are evidence-bearing data.  Generic message
+    chunking adds page indicators and trims boundary whitespace, which can
+    corrupt a long URL.  These chunks intentionally omit presentation markers
+    so joining them reproduces the exact validated fallback.
+    """
+    text = str(text or "")
+    limit = max(1, int(limit))
+    if utf16_len(text) <= limit:
+        return [text]
+
+    chunks: list[str] = []
+    remaining = text
+    while utf16_len(remaining) > limit:
+        chunk = _prefix_within_utf16_limit(remaining, limit)
+        if not chunk:  # Defensive only: Discord's real limit is 2,000 units.
+            chunk = remaining[0]
+        chunks.append(chunk)
+        remaining = remaining[len(chunk):]
+    chunks.append(remaining)
+    return chunks
+
+
 def _abort_discord_websocket_transport(websocket: Any) -> bool:
     """Abort the active aiohttp transport after a bounded close times out."""
     socket = getattr(websocket, "socket", None)
@@ -2978,6 +3003,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     content,
                     embed=operator_card_embed,
                     thread_name=operator_card_thread_name,
+                    preserve_content=operator_card is not None,
                 )
                 await asyncio.to_thread(
                     self._record_discord_response,
@@ -2990,7 +3016,11 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Format and split message if needed
             formatted = self.format_message(content)
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            chunks = (
+                _chunk_discord_lossless_text(formatted, self.MAX_MESSAGE_LENGTH)
+                if operator_card is not None
+                else self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            )
 
             message_ids = []
             reference = None
@@ -3084,6 +3114,7 @@ class DiscordAdapter(BasePlatformAdapter):
         *,
         embed: Any = None,
         thread_name: Optional[str] = None,
+        preserve_content: bool = False,
     ) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
@@ -3097,7 +3128,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # module — no cross-module import needed.
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        chunks = (
+            _chunk_discord_lossless_text(formatted, self.MAX_MESSAGE_LENGTH)
+            if preserve_content
+            else self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        )
 
         thread_name = thread_name or _derive_forum_thread_name(content)
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -18,6 +18,7 @@ import logging
 import math
 import os
 import re
+import secrets
 import struct
 import subprocess
 import tempfile
@@ -116,6 +117,12 @@ from gateway.operator_cards import (
     OperatorCard,
     operator_card_severity_display,
     render_operator_card_text,
+)
+from plugins.platforms.discord.workspace_headers import (
+    WorkspaceHeaderResult,
+    WorkspaceHeaderState,
+    WorkspaceHeaderStore,
+    WorkspaceHeaderStoreError,
 )
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
@@ -996,6 +1003,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
         self._threads = ThreadParticipationTracker("discord")
+        # One durable header per Discord thread workspace. Identity is
+        # partitioned by canonical guild scope_id; locks close a create/create
+        # race when per-user thread sessions are enabled.
+        self._workspace_headers = WorkspaceHeaderStore()
+        self._workspace_header_locks: Dict[tuple[str, str], asyncio.Lock] = {}
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
@@ -2920,15 +2932,25 @@ class DiscordAdapter(BasePlatformAdapter):
             event,
             outcome,
         )
-        if not self._reactions_enabled():
-            return
-        message = event.raw_message
-        if hasattr(message, "add_reaction"):
-            await self._remove_reaction(message, "👀")
-            if outcome == ProcessingOutcome.SUCCESS:
-                await self._add_reaction(message, "✅")
-            elif outcome == ProcessingOutcome.FAILURE:
-                await self._add_reaction(message, "❌")
+        if self._reactions_enabled():
+            message = event.raw_message
+            if hasattr(message, "add_reaction"):
+                await self._remove_reaction(message, "👀")
+                if outcome == ProcessingOutcome.SUCCESS:
+                    await self._add_reaction(message, "✅")
+                elif outcome == ProcessingOutcome.FAILURE:
+                    await self._add_reaction(message, "❌")
+        if outcome == ProcessingOutcome.SUCCESS:
+            # This hook runs after final delivery, so headers only appear for
+            # completed assistant turns. Header I/O remains non-fatal to chat.
+            try:
+                await self.ensure_workspace_header(event.source)
+            except Exception:
+                logger.debug(
+                    "[%s] Failed to refresh Discord workspace header",
+                    self.name,
+                    exc_info=True,
+                )
 
     async def send(
         self,
@@ -5670,6 +5692,18 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            scope_id=(str(getattr(interaction, "guild_id", "") or "") or None),
+            parent_chat_id=(
+                str(
+                    getattr(
+                        getattr(interaction, "channel", None),
+                        "parent_id",
+                        "",
+                    )
+                    or ""
+                )
+                or None
+            ),
         )
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
@@ -5764,6 +5798,21 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            scope_id=(
+                str(getattr(getattr(interaction, "guild", None), "id", "") or "")
+                or None
+            ),
+            parent_chat_id=(
+                str(
+                    getattr(
+                        self._thread_parent_channel(_chan),
+                        "id",
+                        "",
+                    )
+                    or ""
+                )
+                or None
+            ),
         )
 
         _parent_channel = self._thread_parent_channel(getattr(interaction, "channel", None))
@@ -6497,6 +6546,204 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception:
             logger.debug("[%s] Failed to rename Discord thread %s", self.name, thread_id, exc_info=True)
             return False
+
+    @staticmethod
+    def _workspace_header_message_missing(error: BaseException) -> bool:
+        """True only when Discord definitively says the tracked message is gone."""
+        code = getattr(error, "code", None)
+        status = getattr(error, "status", None)
+        text = str(error).casefold()
+        return code == 10008 or (status == 404 and "unknown message" in text)
+
+    def _build_workspace_header_card(
+        self,
+        source: Any,
+        thread: Any,
+        state: WorkspaceHeaderState,
+    ) -> OperatorCard:
+        """Build the standard thread-header operator card."""
+        scope_id = str(source.scope_id)
+        thread_id = str(source.thread_id)
+        thread_name = (
+            " ".join(str(getattr(thread, "name", "") or "").split()) or "Hermes"
+        )
+        return OperatorCard.from_mapping(
+            {
+                "kind": "operator_card",
+                "version": 1,
+                "card_type": "thread_header",
+                "title": f"Workspace · {thread_name}",
+                "severity": "info",
+                "summary": "Persistent Hermes context for this Discord thread.",
+                "fields": [
+                    {"label": "Owner", "value": state.owner},
+                    {"label": "Status", "value": state.status},
+                    {"label": "Thread", "value": f"<#{thread_id}>"},
+                    {
+                        "label": "Linked issue / artifact",
+                        "value": state.linked_issue_or_artifact,
+                    },
+                    {"label": "Last decision", "value": state.last_decision},
+                    {"label": "Next action", "value": state.next_action},
+                ],
+                "actions": [],
+                "links": [],
+                "state_ref": f"discord-workspace:{scope_id}:{thread_id}",
+            }
+        )
+
+    async def ensure_workspace_header(self, source: Any) -> WorkspaceHeaderResult:
+        """Create or edit the one persistent header for a Discord thread.
+
+        The method fails closed when canonical scope is missing/mismatched. A
+        tracked message is recreated only after Discord definitively reports
+        Unknown Message; transient fetch failures never risk a duplicate.
+        """
+        if (
+            getattr(source, "platform", None) != Platform.DISCORD
+            or getattr(source, "chat_type", None) != "thread"
+            or not getattr(source, "scope_id", None)
+            or not getattr(source, "thread_id", None)
+            or self._client is None
+        ):
+            return WorkspaceHeaderResult(
+                False, "skipped", error="not a scoped Discord thread"
+            )
+
+        scope_id = str(source.scope_id)
+        thread_id = str(source.thread_id)
+        try:
+            thread_id_int = int(thread_id)
+            thread = self._client.get_channel(thread_id_int)
+            if thread is None:
+                thread = await self._client.fetch_channel(thread_id_int)
+        except Exception as error:
+            return WorkspaceHeaderResult(False, "failed", error=str(error))
+        live_scope_id = str(
+            getattr(getattr(thread, "guild", None), "id", "") or ""
+        )
+        if live_scope_id != scope_id:
+            return WorkspaceHeaderResult(
+                False, "skipped", error="live guild scope mismatch"
+            )
+
+        lock_key = (scope_id, thread_id)
+        lock = self._workspace_header_locks.setdefault(lock_key, asyncio.Lock())
+        async with lock:
+            try:
+                binding = self._workspace_headers.get(scope_id, thread_id)
+                state = self._workspace_headers.get_state(scope_id, thread_id)
+            except WorkspaceHeaderStoreError as error:
+                return WorkspaceHeaderResult(False, "failed", error=str(error))
+            state = state or WorkspaceHeaderState()
+            card = self._build_workspace_header_card(source, thread, state)
+            content = render_operator_card_text(
+                card, max_length=self.MAX_MESSAGE_LENGTH
+            )
+            embed = _build_operator_card_embed(card)
+            action = "created"
+            expected_message_id: Optional[str] = None
+
+            if binding is not None:
+                if binding.pending or not binding.message_id:
+                    return WorkspaceHeaderResult(
+                        False,
+                        "failed",
+                        error="workspace header creation is pending in the registry",
+                    )
+                try:
+                    message = await thread.fetch_message(int(binding.message_id))
+                except Exception as error:
+                    if not self._workspace_header_message_missing(error):
+                        return WorkspaceHeaderResult(
+                            False,
+                            "failed",
+                            message_id=binding.message_id,
+                            error=str(error),
+                        )
+                    expected_message_id = binding.message_id
+                    action = "recreated"
+                else:
+                    try:
+                        await message.edit(content=content, embed=embed)
+                    except Exception as error:
+                        return WorkspaceHeaderResult(
+                            False,
+                            "failed",
+                            message_id=binding.message_id,
+                            error=str(error),
+                        )
+                    self._nonconversational_messages.mark_many(
+                        [binding.message_id]
+                    )
+                    return WorkspaceHeaderResult(
+                        True, "updated", message_id=binding.message_id
+                    )
+
+            reservation_token = secrets.token_hex(16)
+            try:
+                reserved = self._workspace_headers.reserve_creation(
+                    scope_id,
+                    thread_id,
+                    token=reservation_token,
+                    expected_message_id=expected_message_id,
+                )
+            except WorkspaceHeaderStoreError as error:
+                return WorkspaceHeaderResult(False, "failed", error=str(error))
+            if not reserved:
+                return WorkspaceHeaderResult(
+                    False,
+                    "failed",
+                    error="workspace header identity changed before creation",
+                )
+
+            try:
+                message = await thread.send(content=content, embed=embed)
+            except Exception as error:
+                try:
+                    self._workspace_headers.cancel_creation(
+                        scope_id, thread_id, token=reservation_token
+                    )
+                except WorkspaceHeaderStoreError:
+                    logger.debug(
+                        "[%s] Failed to release Discord workspace header reservation",
+                        self.name,
+                        exc_info=True,
+                    )
+                return WorkspaceHeaderResult(False, "failed", error=str(error))
+            message_id = str(getattr(message, "id", "") or "")
+            if not message_id:
+                try:
+                    self._workspace_headers.cancel_creation(
+                        scope_id, thread_id, token=reservation_token
+                    )
+                except WorkspaceHeaderStoreError:
+                    logger.debug(
+                        "[%s] Failed to release Discord workspace header reservation",
+                        self.name,
+                        exc_info=True,
+                    )
+                return WorkspaceHeaderResult(
+                    False, "failed", error="Discord send returned no message id"
+                )
+            self._nonconversational_messages.mark_many([message_id])
+            try:
+                self._workspace_headers.complete_creation(
+                    scope_id,
+                    thread_id,
+                    token=reservation_token,
+                    message_id=message_id,
+                )
+            except WorkspaceHeaderStoreError as error:
+                # The persisted pending reservation deliberately remains. A
+                # later turn fails closed instead of emitting a duplicate.
+                return WorkspaceHeaderResult(
+                    False,
+                    "failed",
+                    message_id=message_id,
+                    error=str(error),
+                )
+            return WorkspaceHeaderResult(True, action, message_id=message_id)
 
     async def create_handoff_thread(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2940,17 +2940,46 @@ class DiscordAdapter(BasePlatformAdapter):
                     await self._add_reaction(message, "✅")
                 elif outcome == ProcessingOutcome.FAILURE:
                     await self._add_reaction(message, "❌")
-        if outcome == ProcessingOutcome.SUCCESS:
-            # This hook runs after final delivery, so headers only appear for
-            # completed assistant turns. Header I/O remains non-fatal to chat.
-            try:
-                await self.ensure_workspace_header(event.source)
-            except Exception:
-                logger.debug(
-                    "[%s] Failed to refresh Discord workspace header",
-                    self.name,
-                    exc_info=True,
+        # The processing lifecycle is the concrete status producer for the
+        # persistent workspace card. Successful turns may create the header;
+        # failures and cancellations only edit an already-tracked message.
+        # Header I/O remains non-fatal to chat.
+        try:
+            source = event.source
+            binding = None
+            if (
+                source is not None
+                and source.scope_id
+                and source.thread_id
+            ):
+                binding = self._workspace_headers.get(
+                    source.scope_id,
+                    source.thread_id,
                 )
+            if outcome == ProcessingOutcome.SUCCESS or binding is not None:
+                if outcome == ProcessingOutcome.SUCCESS:
+                    status = "Active"
+                    next_action = "Awaiting next assistant turn"
+                elif outcome == ProcessingOutcome.FAILURE:
+                    status = "Needs attention"
+                    next_action = "Retry the last request"
+                else:
+                    status = "Paused"
+                    next_action = "Awaiting next instruction"
+                if source is not None and source.scope_id and source.thread_id:
+                    self._workspace_headers.update_state(
+                        source.scope_id,
+                        source.thread_id,
+                        status=status,
+                        next_action=next_action,
+                    )
+                await self.ensure_workspace_header(source)
+        except Exception:
+            logger.debug(
+                "[%s] Failed to refresh Discord workspace header",
+                self.name,
+                exc_info=True,
+            )
 
     async def send(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2935,7 +2935,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 operator_card = OperatorCard.from_mapping(metadata["operator_card"])
                 content = render_operator_card_text(
                     operator_card,
-                    max_length=self.MAX_MESSAGE_LENGTH,
+                    max_length=None,
                 )
                 operator_card_embed = _build_operator_card_embed(operator_card)
                 severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
@@ -8959,13 +8959,13 @@ def _probe_is_forum_cached(chat_id: str) -> Optional[bool]:
 
 
 def _derive_forum_thread_name(message: str) -> str:
-    """Derive a thread name from the first line of the message, capped at 100 chars."""
+    """Derive a thread name within Discord's 100 UTF-16-unit limit."""
     first_line = message.strip().split("\n", 1)[0].strip()
     # Strip common markdown heading prefixes
     first_line = first_line.lstrip("#").strip()
     if not first_line:
         first_line = "New Post"
-    return first_line[:100]
+    return _truncate_discord_component_text(first_line, 100)
 
 
 def _standalone_sanitize_error(text) -> str:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -112,7 +112,11 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
-from gateway.operator_cards import OperatorCard, render_operator_card_text
+from gateway.operator_cards import (
+    OperatorCard,
+    operator_card_severity_display,
+    render_operator_card_text,
+)
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
 from utils import atomic_json_write, env_float, env_int
@@ -192,14 +196,6 @@ _DISCORD_OPERATOR_CARD_COLORS = {
     "blocked": 0xE74C3C,
     "critical": 0x992D22,
 }
-_DISCORD_OPERATOR_CARD_SEVERITY_LABELS = {
-    "done": "Done",
-    "info": "Info",
-    "needs_review": "Needs review",
-    "blocked": "Blocked",
-    "critical": "Critical",
-}
-
 # Discord embed budgets, measured in UTF-16 code units (Discord's own unit for
 # these limits).  A contract-valid operator card can still exceed them — e.g.
 # up to 12 fields at the 1024-char field ceiling, or a link block wider than a
@@ -229,7 +225,7 @@ def _build_operator_card_embed(card: OperatorCard) -> Any:
         card.summary, _DISCORD_EMBED_DESCRIPTION_LIMIT
     )
     card_type_label = card.card_type.replace("_", " ").title()
-    severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[card.severity]
+    _, severity_label = operator_card_severity_display(card.severity)
     footer = _truncate_discord_component_text(
         f"{card_type_label} · {severity_label}", _DISCORD_EMBED_FOOTER_LIMIT
     )
@@ -2963,9 +2959,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     max_length=None,
                 )
                 operator_card_embed = _build_operator_card_embed(operator_card)
-                severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
+                _, severity_label = operator_card_severity_display(
                     operator_card.severity
-                ]
+                )
                 # Discord's 100-char thread-name cap is measured in UTF-16 code
                 # units; a naive ``[:100]`` slice counts code points and can
                 # emit a name Discord rejects.  Use the shared UTF-16-aware

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -112,6 +112,7 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.operator_cards import OperatorCard, render_operator_card_text
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
 from utils import atomic_json_write, env_float, env_int
@@ -157,6 +158,49 @@ def _abort_discord_websocket_transport(websocket: Any) -> bool:
         return False
     abort()
     return True
+
+
+_DISCORD_OPERATOR_CARD_COLORS = {
+    "done": 0x2ECC71,
+    "info": 0x3498DB,
+    "needs_review": 0xF1C40F,
+    "blocked": 0xE74C3C,
+    "critical": 0x992D22,
+}
+_DISCORD_OPERATOR_CARD_SEVERITY_LABELS = {
+    "done": "Done",
+    "info": "Info",
+    "needs_review": "Needs review",
+    "blocked": "Blocked",
+    "critical": "Critical",
+}
+
+
+def _build_operator_card_embed(card: OperatorCard) -> Any:
+    """Render a validated operator card as a bounded Discord embed."""
+    embed = discord.Embed(
+        title=card.title,
+        description=card.summary,
+        color=_DISCORD_OPERATOR_CARD_COLORS[card.severity],
+    )
+    for field in card.fields:
+        embed.add_field(name=field.label, value=field.value, inline=False)
+    if card.actions:
+        embed.add_field(
+            name="Actions",
+            value=" · ".join(action.label for action in card.actions),
+            inline=False,
+        )
+    if card.links:
+        embed.add_field(
+            name="Links",
+            value="\n".join(f"[{link.label}]({link.url})" for link in card.links),
+            inline=False,
+        )
+    card_type_label = card.card_type.replace("_", " ").title()
+    severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[card.severity]
+    embed.set_footer(text=f"{card_type_label} · {severity_label}")
+    return embed
 
 
 async def _wait_for_ready_or_bot_exit(
@@ -2832,6 +2876,23 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            operator_card = None
+            operator_card_embed = None
+            operator_card_thread_name = None
+            if metadata and "operator_card" in metadata:
+                operator_card = OperatorCard.from_mapping(metadata["operator_card"])
+                content = render_operator_card_text(
+                    operator_card,
+                    max_length=self.MAX_MESSAGE_LENGTH,
+                )
+                operator_card_embed = _build_operator_card_embed(operator_card)
+                severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
+                    operator_card.severity
+                ]
+                operator_card_thread_name = (
+                    f"{severity_label} — {operator_card.title}"
+                )[:100]
+
             # Determine target channel: thread_id in metadata takes precedence.
             thread_id = None
             if metadata and metadata.get("thread_id"):
@@ -2856,7 +2917,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
-                result = await self._send_to_forum(channel, content)
+                result = await self._send_to_forum(
+                    channel,
+                    content,
+                    embed=operator_card_embed,
+                    thread_name=operator_card_thread_name,
+                )
                 await asyncio.to_thread(
                     self._record_discord_response,
                     reply_to=reply_to,
@@ -2889,10 +2955,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                    )
+                    send_kwargs: Dict[str, Any] = {
+                        "content": chunk,
+                        "reference": chunk_reference,
+                    }
+                    if i == 0 and operator_card_embed is not None:
+                        send_kwargs["embed"] = operator_card_embed
+                    msg = await channel.send(**send_kwargs)
                 except Exception as e:
                     err_text = str(e)
                     if (
@@ -2911,10 +2980,8 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )
+                        send_kwargs["reference"] = None
+                        msg = await channel.send(**send_kwargs)
                     else:
                         raise
                 message_ids.append(str(msg.id))
@@ -2954,7 +3021,14 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return result
 
-    async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
+    async def _send_to_forum(
+        self,
+        forum_channel: Any,
+        content: str,
+        *,
+        embed: Any = None,
+        thread_name: Optional[str] = None,
+    ) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
         Forum channels (type 15) don't support direct messages.  Instead we
@@ -2969,15 +3043,18 @@ class DiscordAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-        thread_name = _derive_forum_thread_name(content)
+        thread_name = thread_name or _derive_forum_thread_name(content)
 
         starter_content = chunks[0] if chunks else thread_name
 
         try:
-            thread = await forum_channel.create_thread(
-                name=thread_name,
-                content=starter_content,
-            )
+            create_kwargs: Dict[str, Any] = {
+                "name": thread_name,
+                "content": starter_content,
+            }
+            if embed is not None:
+                create_kwargs["embed"] = embed
+            thread = await forum_channel.create_thread(**create_kwargs)
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
             return SendResult(success=False, error=f"Forum thread creation failed: {e}")

--- a/plugins/platforms/discord/workspace_headers.py
+++ b/plugins/platforms/discord/workspace_headers.py
@@ -1,0 +1,522 @@
+"""Persistent identity and safe backfill planning for Discord workspaces.
+
+A Discord thread is the user-visible workspace. Header identity and the small
+workspace context map are profile-local and partitioned first by canonical
+Discord guild ``SessionSource.scope_id`` and then by thread id. Registry reads
+fail closed, and every read-modify-write transaction holds both an in-process
+lock and an OS file lock so gateway and backfill processes cannot lose each
+other's bindings.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Optional
+
+from utils import atomic_json_write
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
+
+
+_STATE_VERSION = 1
+_STATE_FILENAME = "discord_workspace_headers.json"
+_KNOWN_HERMES_PLACEHOLDER_TITLES = frozenset(
+    {"hermes", "hermes chat", "new post"}
+)
+_LOCAL_LOCKS_GUARD = threading.Lock()
+_LOCAL_LOCKS: dict[str, threading.RLock] = {}
+
+
+class WorkspaceHeaderStoreError(RuntimeError):
+    """Raised when registry identity cannot be read or safely persisted."""
+
+
+def _clean_id(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _clean_workspace_text(value: Any, field_name: str) -> str:
+    text = " ".join(str(value or "").split())
+    if not text:
+        raise ValueError(f"{field_name} must be non-empty")
+    if len(text) > 1024:
+        raise ValueError(f"{field_name} exceeds the 1024-character limit")
+    return text
+
+
+def _thread_scope_id(thread: Any) -> str:
+    guild = getattr(thread, "guild", None)
+    return _clean_id(getattr(guild, "id", None))
+
+
+def is_known_hermes_placeholder_title(title: Any) -> bool:
+    """Return whether a title is one of Hermes' exact generic placeholders."""
+    normalized = " ".join(str(title or "").split()).casefold()
+    return normalized in _KNOWN_HERMES_PLACEHOLDER_TITLES
+
+
+def _local_registry_lock(path: Path) -> threading.RLock:
+    key = str(path.resolve())
+    with _LOCAL_LOCKS_GUARD:
+        return _LOCAL_LOCKS.setdefault(key, threading.RLock())
+
+
+@contextmanager
+def _exclusive_registry_lock(path: Path) -> Iterator[None]:
+    """Hold a blocking cross-process lock for one registry transaction."""
+    lock_path = path.with_name(f".{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with _local_registry_lock(lock_path):
+        with lock_path.open("a+b") as handle:
+            if os.name == "nt":
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write(b"\0")
+                    handle.flush()
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                if os.name == "nt":
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceHeaderState:
+    owner: str = "Hermes"
+    status: str = "Active"
+    linked_issue_or_artifact: str = "Not linked"
+    last_decision: str = "No decision recorded"
+    next_action: str = "Awaiting next assistant turn"
+
+    @classmethod
+    def from_mapping(cls, payload: Any) -> "WorkspaceHeaderState":
+        if payload is None:
+            return cls()
+        if not isinstance(payload, dict):
+            raise WorkspaceHeaderStoreError("workspace state must be an object")
+        unknown = set(payload) - {
+            "owner",
+            "status",
+            "linked_issue_or_artifact",
+            "last_decision",
+            "next_action",
+        }
+        if unknown:
+            raise WorkspaceHeaderStoreError(
+                "workspace state has unknown fields: " + ", ".join(sorted(unknown))
+            )
+        defaults = cls()
+        try:
+            return cls(
+                owner=_clean_workspace_text(payload.get("owner", defaults.owner), "owner"),
+                status=_clean_workspace_text(payload.get("status", defaults.status), "status"),
+                linked_issue_or_artifact=_clean_workspace_text(
+                    payload.get(
+                        "linked_issue_or_artifact",
+                        defaults.linked_issue_or_artifact,
+                    ),
+                    "linked_issue_or_artifact",
+                ),
+                last_decision=_clean_workspace_text(
+                    payload.get("last_decision", defaults.last_decision),
+                    "last_decision",
+                ),
+                next_action=_clean_workspace_text(
+                    payload.get("next_action", defaults.next_action),
+                    "next_action",
+                ),
+            )
+        except ValueError as error:
+            raise WorkspaceHeaderStoreError(str(error)) from error
+
+    def to_mapping(self) -> dict[str, str]:
+        return {
+            "owner": self.owner,
+            "status": self.status,
+            "linked_issue_or_artifact": self.linked_issue_or_artifact,
+            "last_decision": self.last_decision,
+            "next_action": self.next_action,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceHeaderBinding:
+    scope_id: str
+    thread_id: str
+    message_id: Optional[str]
+    pending: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceHeaderResult:
+    success: bool
+    action: str
+    message_id: Optional[str] = None
+    error: Optional[str] = None
+
+
+_WorkspaceRecord = dict[str, Any]
+_WorkspaceRegistry = dict[str, dict[str, _WorkspaceRecord]]
+
+
+class WorkspaceHeaderStore:
+    """Locked atomic registry for header identity and tiny workspace state."""
+
+    def __init__(self, path: Optional[Path] = None):
+        if path is None:
+            from hermes_constants import get_hermes_home
+
+            path = get_hermes_home() / "gateway" / _STATE_FILENAME
+        self.path = Path(path)
+
+    @staticmethod
+    def _default_record() -> _WorkspaceRecord:
+        return {
+            "message_id": None,
+            "pending_token": None,
+            "state": WorkspaceHeaderState().to_mapping(),
+        }
+
+    def _read_unlocked(self) -> _WorkspaceRegistry:
+        if not self.path.exists():
+            return {}
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except Exception as error:
+            raise WorkspaceHeaderStoreError(
+                f"workspace header registry is unreadable: {type(error).__name__}"
+            ) from error
+        if not isinstance(payload, dict):
+            raise WorkspaceHeaderStoreError("workspace header registry must be an object")
+        if payload.get("version") != _STATE_VERSION:
+            raise WorkspaceHeaderStoreError("workspace header registry version is unsupported")
+        raw_workspaces = payload.get("workspaces")
+        if not isinstance(raw_workspaces, dict):
+            raise WorkspaceHeaderStoreError("workspace header registry has invalid workspaces")
+
+        workspaces: _WorkspaceRegistry = {}
+        for raw_scope_id, raw_threads in raw_workspaces.items():
+            scope_id = _clean_id(raw_scope_id)
+            if not scope_id or not isinstance(raw_threads, dict):
+                raise WorkspaceHeaderStoreError("workspace header registry has invalid scope")
+            threads: dict[str, _WorkspaceRecord] = {}
+            for raw_thread_id, raw_record in raw_threads.items():
+                thread_id = _clean_id(raw_thread_id)
+                if not thread_id:
+                    raise WorkspaceHeaderStoreError("workspace header registry has invalid thread id")
+                # Accept the initial message-id-only shape written by early
+                # OE-178 builds, but always rewrite it in the richer shape.
+                if isinstance(raw_record, str):
+                    message_id = _clean_id(raw_record)
+                    if not message_id:
+                        raise WorkspaceHeaderStoreError(
+                            "workspace header registry has an empty message id"
+                        )
+                    record = self._default_record()
+                    record["message_id"] = message_id
+                elif isinstance(raw_record, dict):
+                    unknown = set(raw_record) - {
+                        "message_id",
+                        "pending_token",
+                        "state",
+                    }
+                    if unknown:
+                        raise WorkspaceHeaderStoreError(
+                            "workspace header registry record has unknown fields"
+                        )
+                    message_id = _clean_id(raw_record.get("message_id")) or None
+                    pending_token = _clean_id(raw_record.get("pending_token")) or None
+                    if message_id and pending_token:
+                        raise WorkspaceHeaderStoreError(
+                            "workspace header registry record has conflicting identity"
+                        )
+                    state = WorkspaceHeaderState.from_mapping(
+                        raw_record.get("state")
+                    )
+                    record = {
+                        "message_id": message_id,
+                        "pending_token": pending_token,
+                        "state": state.to_mapping(),
+                    }
+                else:
+                    raise WorkspaceHeaderStoreError(
+                        "workspace header registry record must be an object"
+                    )
+                threads[thread_id] = record
+            if threads:
+                workspaces[scope_id] = threads
+        return workspaces
+
+    def _write_unlocked(self, workspaces: _WorkspaceRegistry) -> None:
+        try:
+            atomic_json_write(
+                self.path,
+                {"version": _STATE_VERSION, "workspaces": workspaces},
+                indent=2,
+            )
+        except Exception as error:
+            raise WorkspaceHeaderStoreError(
+                f"workspace header registry write failed: {type(error).__name__}"
+            ) from error
+
+    @staticmethod
+    def _keys(scope_id: Any, thread_id: Any) -> tuple[str, str]:
+        scope_key = _clean_id(scope_id)
+        thread_key = _clean_id(thread_id)
+        if not scope_key or not thread_key:
+            raise ValueError("scope_id and thread_id are required")
+        return scope_key, thread_key
+
+    @staticmethod
+    def _record(
+        workspaces: _WorkspaceRegistry,
+        scope_key: str,
+        thread_key: str,
+    ) -> Optional[_WorkspaceRecord]:
+        return workspaces.get(scope_key, {}).get(thread_key)
+
+    def get(self, scope_id: Any, thread_id: Any) -> Optional[WorkspaceHeaderBinding]:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        with _exclusive_registry_lock(self.path):
+            record = self._record(self._read_unlocked(), scope_key, thread_key)
+        if record is None:
+            return None
+        message_id = record.get("message_id")
+        pending = bool(record.get("pending_token"))
+        if not message_id and not pending:
+            return None
+        return WorkspaceHeaderBinding(scope_key, thread_key, message_id, pending)
+
+    def get_state(
+        self, scope_id: Any, thread_id: Any
+    ) -> Optional[WorkspaceHeaderState]:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        with _exclusive_registry_lock(self.path):
+            record = self._record(self._read_unlocked(), scope_key, thread_key)
+        if record is None:
+            return None
+        return WorkspaceHeaderState.from_mapping(record.get("state"))
+
+    def put(
+        self, scope_id: Any, thread_id: Any, message_id: Any
+    ) -> WorkspaceHeaderBinding:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        message_key = _clean_id(message_id)
+        if not message_key:
+            raise ValueError("message_id is required")
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            record = self._record(workspaces, scope_key, thread_key)
+            if record is None:
+                record = self._default_record()
+                workspaces.setdefault(scope_key, {})[thread_key] = record
+            record["message_id"] = message_key
+            record["pending_token"] = None
+            self._write_unlocked(workspaces)
+        return WorkspaceHeaderBinding(scope_key, thread_key, message_key)
+
+    def update_state(
+        self,
+        scope_id: Any,
+        thread_id: Any,
+        *,
+        owner: Any = None,
+        status: Any = None,
+        linked_issue_or_artifact: Any = None,
+        last_decision: Any = None,
+        next_action: Any = None,
+    ) -> WorkspaceHeaderState:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            record = self._record(workspaces, scope_key, thread_key)
+            if record is None:
+                record = self._default_record()
+                workspaces.setdefault(scope_key, {})[thread_key] = record
+            current = WorkspaceHeaderState.from_mapping(record.get("state"))
+            changes = {
+                "owner": current.owner if owner is None else owner,
+                "status": current.status if status is None else status,
+                "linked_issue_or_artifact": (
+                    current.linked_issue_or_artifact
+                    if linked_issue_or_artifact is None
+                    else linked_issue_or_artifact
+                ),
+                "last_decision": (
+                    current.last_decision if last_decision is None else last_decision
+                ),
+                "next_action": current.next_action if next_action is None else next_action,
+            }
+            state = WorkspaceHeaderState.from_mapping(changes)
+            record["state"] = state.to_mapping()
+            self._write_unlocked(workspaces)
+        return state
+
+    def reserve_creation(
+        self,
+        scope_id: Any,
+        thread_id: Any,
+        *,
+        token: Any,
+        expected_message_id: Any = None,
+    ) -> bool:
+        """Reserve one create/recreate before Discord receives a send."""
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        token_key = _clean_id(token)
+        expected_key = _clean_id(expected_message_id) or None
+        if not token_key:
+            raise ValueError("reservation token is required")
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            record = self._record(workspaces, scope_key, thread_key)
+            if record is None:
+                if expected_key is not None:
+                    return False
+                record = self._default_record()
+                workspaces.setdefault(scope_key, {})[thread_key] = record
+            current_message_id = record.get("message_id")
+            if record.get("pending_token") or current_message_id != expected_key:
+                return False
+            record["message_id"] = None
+            record["pending_token"] = token_key
+            self._write_unlocked(workspaces)
+        return True
+
+    def complete_creation(
+        self,
+        scope_id: Any,
+        thread_id: Any,
+        *,
+        token: Any,
+        message_id: Any,
+    ) -> WorkspaceHeaderBinding:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        token_key = _clean_id(token)
+        message_key = _clean_id(message_id)
+        if not token_key or not message_key:
+            raise ValueError("reservation token and message_id are required")
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            record = self._record(workspaces, scope_key, thread_key)
+            if record is None or record.get("pending_token") != token_key:
+                raise WorkspaceHeaderStoreError(
+                    "workspace header creation reservation was lost"
+                )
+            record["message_id"] = message_key
+            record["pending_token"] = None
+            self._write_unlocked(workspaces)
+        return WorkspaceHeaderBinding(scope_key, thread_key, message_key)
+
+    def cancel_creation(
+        self, scope_id: Any, thread_id: Any, *, token: Any
+    ) -> bool:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        token_key = _clean_id(token)
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            record = self._record(workspaces, scope_key, thread_key)
+            if record is None or record.get("pending_token") != token_key:
+                return False
+            record["pending_token"] = None
+            self._write_unlocked(workspaces)
+        return True
+
+    def remove(self, scope_id: Any, thread_id: Any) -> None:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            threads = workspaces.get(scope_key)
+            if not threads or thread_key not in threads:
+                return
+            del threads[thread_key]
+            if not threads:
+                workspaces.pop(scope_key, None)
+            self._write_unlocked(workspaces)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceHeaderCandidate:
+    scope_id: str
+    thread_id: str
+    observed_title: str
+    reasons: tuple[str, ...]
+    proposed_title: None = None
+
+
+def collect_workspace_header_candidates(
+    threads: Iterable[Any],
+    *,
+    participated_thread_ids: Iterable[Any],
+    store: WorkspaceHeaderStore,
+) -> list[WorkspaceHeaderCandidate]:
+    """Plan only known Hermes workspaces; never propose a title mutation."""
+    participated = {_clean_id(value) for value in participated_thread_ids}
+    candidates: list[WorkspaceHeaderCandidate] = []
+    for thread in threads:
+        thread_id = _clean_id(getattr(thread, "id", None))
+        scope_id = _thread_scope_id(thread)
+        if not thread_id or not scope_id or thread_id not in participated:
+            continue
+        title = " ".join(str(getattr(thread, "name", "") or "").split())
+        reasons: list[str] = []
+        if is_known_hermes_placeholder_title(title):
+            reasons.append("placeholder_title")
+        if store.get(scope_id, thread_id) is None:
+            reasons.append("header_missing")
+        if reasons:
+            candidates.append(
+                WorkspaceHeaderCandidate(
+                    scope_id=scope_id,
+                    thread_id=thread_id,
+                    observed_title=title,
+                    reasons=tuple(reasons),
+                )
+            )
+    candidates.sort(key=lambda item: (item.scope_id, item.thread_id))
+    return candidates
+
+
+def revalidate_workspace_header_candidate(
+    candidate: WorkspaceHeaderCandidate,
+    *,
+    live_thread: Any,
+    participated_thread_ids: Iterable[Any],
+    store: WorkspaceHeaderStore,
+) -> bool:
+    """Fail closed if any live fact changed since the dry-run observation."""
+    thread_id = _clean_id(getattr(live_thread, "id", None))
+    scope_id = _thread_scope_id(live_thread)
+    live_title = " ".join(str(getattr(live_thread, "name", "") or "").split())
+    participated = {_clean_id(value) for value in participated_thread_ids}
+    if (
+        thread_id != candidate.thread_id
+        or scope_id != candidate.scope_id
+        or thread_id not in participated
+        or live_title != candidate.observed_title
+    ):
+        return False
+    if "placeholder_title" in candidate.reasons and not is_known_hermes_placeholder_title(
+        live_title
+    ):
+        return False
+    if (
+        "header_missing" in candidate.reasons
+        and store.get(scope_id, thread_id) is not None
+    ):
+        return False
+    return True

--- a/scripts/backfill_discord_workspace_headers.py
+++ b/scripts/backfill_discord_workspace_headers.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Safely backfill persistent headers for known Hermes Discord workspaces.
+
+The default is a read-only dry run. ``--apply`` is required for message
+creation/editing, and every planned candidate is re-fetched and revalidated
+immediately before that write. This script never renames threads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from typing import Any
+
+from gateway.config import Platform, load_gateway_config
+from gateway.session import SessionSource
+from hermes_constants import get_hermes_home
+from plugins.platforms.discord.adapter import DiscordAdapter, discord
+from plugins.platforms.discord.workspace_headers import (
+    WorkspaceHeaderStore,
+    collect_workspace_header_candidates,
+    revalidate_workspace_header_candidate,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Plan or apply Discord workspace-header backfill."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Create/edit headers after live revalidation (default: dry run).",
+    )
+    parser.add_argument(
+        "--guild-id",
+        action="append",
+        default=[],
+        help="Limit reads/writes to this Discord guild id (repeatable).",
+    )
+    return parser
+
+
+def _load_participated_thread_ids() -> set[str]:
+    path = get_hermes_home() / "discord_threads.json"
+    if not path.exists():
+        return set()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return set()
+    if not isinstance(payload, list):
+        return set()
+    return {str(value) for value in payload if str(value).strip()}
+
+
+def _active_threads(client: Any, allowed_guild_ids: set[str]) -> list[Any]:
+    threads: list[Any] = []
+    for guild in list(getattr(client, "guilds", []) or []):
+        guild_id = str(getattr(guild, "id", "") or "")
+        if allowed_guild_ids and guild_id not in allowed_guild_ids:
+            continue
+        threads.extend(list(getattr(guild, "threads", []) or []))
+    return threads
+
+
+async def _run(args: argparse.Namespace) -> int:
+    config = load_gateway_config()
+    discord_config = config.platforms.get(Platform.DISCORD)
+    token = str(getattr(discord_config, "token", "") or "").strip()
+    if discord_config is None or not token:
+        print(json.dumps({"ok": False, "error": "Discord is not configured"}))
+        return 2
+
+    intents = getattr(discord, "Intents").none()
+    intents.guilds = True
+    client = getattr(discord, "Client")(intents=intents)
+    store = WorkspaceHeaderStore()
+    adapter = DiscordAdapter(discord_config)
+    adapter._client = client
+    allowed_guild_ids = {str(value) for value in args.guild_id}
+    outcome: dict[str, Any] = {
+        "mode": "apply" if args.apply else "dry-run",
+        "candidates": [],
+        "results": [],
+    }
+
+    @client.event
+    async def on_ready() -> None:
+        participated = _load_participated_thread_ids()
+        candidates = collect_workspace_header_candidates(
+            _active_threads(client, allowed_guild_ids),
+            participated_thread_ids=participated,
+            store=store,
+        )
+        outcome["candidates"] = [
+            {
+                "scope_id": candidate.scope_id,
+                "thread_id": candidate.thread_id,
+                "observed_title": candidate.observed_title,
+                "reasons": list(candidate.reasons),
+                "proposed_title": candidate.proposed_title,
+            }
+            for candidate in candidates
+        ]
+
+        if args.apply:
+            for candidate in candidates:
+                try:
+                    live_thread = client.get_channel(int(candidate.thread_id))
+                    if live_thread is None:
+                        live_thread = await client.fetch_channel(
+                            int(candidate.thread_id)
+                        )
+                except Exception as error:
+                    outcome["results"].append(
+                        {
+                            "thread_id": candidate.thread_id,
+                            "action": "skipped",
+                            "error": f"live fetch failed: {type(error).__name__}",
+                        }
+                    )
+                    continue
+
+                participated_now = _load_participated_thread_ids()
+                if not revalidate_workspace_header_candidate(
+                    candidate,
+                    live_thread=live_thread,
+                    participated_thread_ids=participated_now,
+                    store=store,
+                ):
+                    outcome["results"].append(
+                        {
+                            "thread_id": candidate.thread_id,
+                            "action": "skipped",
+                            "error": "live state changed after planning",
+                        }
+                    )
+                    continue
+
+                source = SessionSource(
+                    platform=Platform.DISCORD,
+                    chat_id=candidate.thread_id,
+                    chat_name=candidate.observed_title,
+                    chat_type="thread",
+                    thread_id=candidate.thread_id,
+                    scope_id=candidate.scope_id,
+                    parent_chat_id=(
+                        str(getattr(live_thread, "parent_id", "") or "") or None
+                    ),
+                )
+                result = await adapter.ensure_workspace_header(source)
+                outcome["results"].append(
+                    {
+                        "thread_id": candidate.thread_id,
+                        "action": result.action,
+                        "success": result.success,
+                        "message_id": result.message_id,
+                        "error": result.error,
+                    }
+                )
+
+        await client.close()
+
+    try:
+        await client.start(token, reconnect=False)
+    finally:
+        if not client.is_closed():
+            await client.close()
+
+    outcome["ok"] = True
+    outcome["candidate_count"] = len(outcome["candidates"])
+    print(json.dumps(outcome, indent=2, sort_keys=True))
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_run(build_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_discord_operator_cards_real.py
+++ b/tests/gateway/test_discord_operator_cards_real.py
@@ -1,0 +1,60 @@
+"""Integration coverage for operator cards with the real discord.py types."""
+
+import importlib
+import sys
+
+from gateway.operator_cards import OperatorCard
+
+
+def _load_real_discord_adapter():
+    """Replace the gateway test shim with the installed discord.py package."""
+    for module_name in tuple(sys.modules):
+        if module_name == "discord" or module_name.startswith("discord."):
+            sys.modules.pop(module_name)
+    sys.modules.pop("plugins.platforms.discord.adapter", None)
+    discord_module = importlib.import_module("discord")
+    adapter_module = importlib.import_module("plugins.platforms.discord.adapter")
+    return discord_module, adapter_module
+
+
+def test_operator_card_serializes_through_real_discord_embed():
+    discord_module, adapter_module = _load_real_discord_adapter()
+    card = OperatorCard.from_mapping(
+        {
+            "kind": "operator_card",
+            "version": 1,
+            "card_type": "approval",
+            "title": "Approve source sync",
+            "severity": "needs_review",
+            "summary": "A second source is ready to normalize.",
+            "fields": [{"label": "Issue", "value": "OE-222"}],
+            "actions": [
+                {"id": "approve", "label": "Approve", "style": "success"}
+            ],
+            "links": [
+                {
+                    "label": "Open issue",
+                    "url": "https://linear.app/example/issue/OE-222",
+                }
+            ],
+            "state_ref": "oe-222:approval:1",
+        }
+    )
+
+    embed = adapter_module._build_operator_card_embed(card)
+    serialized = embed.to_dict()
+
+    assert isinstance(embed, discord_module.Embed)
+    assert serialized["title"] == "Approve source sync"
+    assert serialized["description"] == "A second source is ready to normalize."
+    assert serialized["fields"] == [
+        {"inline": False, "name": "Issue", "value": "OE-222"},
+        {"inline": False, "name": "Actions", "value": "Approve"},
+        {
+            "inline": False,
+            "name": "Links",
+            "value": "[Open issue](https://linear.app/example/issue/OE-222)",
+        },
+    ]
+    assert serialized["footer"]["text"] == "Approval · Needs review"
+    assert serialized["color"] == 0xF1C40F

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -281,6 +281,49 @@ async def test_send_operator_card_creates_forum_thread_with_embed(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_operator_card_forum_chunks_preserve_maximum_length_url(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    thread_channel = SimpleNamespace(
+        id=889,
+        send=AsyncMock(return_value=SimpleNamespace(id=7004)),
+    )
+    thread = SimpleNamespace(
+        id=889,
+        message=SimpleNamespace(id=7003),
+        thread=thread_channel,
+    )
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(return_value=thread)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    payload = _operator_card_payload()
+    payload["fields"] = [
+        {"label": f"Field {index}", "value": str(index) * 1024}
+        for index in range(3)
+    ]
+    url_prefix = "https://example.com/"
+    trailing_url = url_prefix + "u" * (2048 - len(url_prefix))
+    payload["links"] = [{"label": "Trailing link", "url": trailing_url}]
+
+    result = await adapter.send(
+        "999",
+        "ignored",
+        metadata={"operator_card": payload},
+    )
+
+    assert result.success is True
+    sent_chunks = [forum_channel.create_thread.await_args.kwargs["content"]]
+    sent_chunks.extend(call.kwargs["content"] for call in thread_channel.send.await_args_list)
+    assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in sent_chunks)
+    assert trailing_url in "".join(sent_chunks)
+
+
+@pytest.mark.asyncio
 async def test_send_rejects_invalid_operator_card_without_platform_write():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     channel = SimpleNamespace(send=AsyncMock())
@@ -366,7 +409,8 @@ async def test_send_chunks_full_operator_card_fallback_without_losing_trailing_l
         {"label": f"Field {index}", "value": str(index) * 1024}
         for index in range(3)
     ]
-    trailing_url = "https://example.com/operator-card-tail"
+    url_prefix = "https://example.com/"
+    trailing_url = url_prefix + "u" * (2048 - len(url_prefix))
     payload["links"] = [{"label": "Trailing link", "url": trailing_url}]
 
     result = await adapter.send(

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -161,6 +161,145 @@ async def test_send_does_not_retry_on_unrelated_errors():
 
 
 # ---------------------------------------------------------------------------
+# Operator card rendering
+# ---------------------------------------------------------------------------
+
+
+def _operator_card_payload():
+    return {
+        "kind": "operator_card",
+        "version": 1,
+        "card_type": "approval",
+        "title": "Approve source sync",
+        "severity": "needs_review",
+        "summary": "A second source is ready to normalize.",
+        "fields": [{"label": "Issue", "value": "OE-222"}],
+        "actions": [{"id": "approve", "label": "Approve", "style": "success"}],
+        "links": [{"label": "Open issue", "url": "https://linear.app/example/issue/OE-222"}],
+        "state_ref": "oe-222:approval:1",
+    }
+
+
+class _FakeEmbed:
+    def __init__(self, *, title, description, color):
+        self.title = title
+        self.description = description
+        self.color = color
+        self.fields = []
+        self.footer = None
+
+    def add_field(self, *, name, value, inline):
+        self.fields.append({"name": name, "value": value, "inline": inline})
+
+    def set_footer(self, *, text):
+        self.footer = text
+
+
+@pytest.mark.asyncio
+async def test_send_renders_valid_operator_card_as_embed_with_text_fallback(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7001)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    result = await adapter.send(
+        "555",
+        "untrusted presentation text",
+        metadata={"operator_card": _operator_card_payload()},
+    )
+
+    assert result.success is True
+    kwargs = channel.send.await_args.kwargs
+    assert kwargs["content"].startswith("🟡 **Needs review — Approve source sync**")
+    assert len(kwargs["content"]) <= adapter.MAX_MESSAGE_LENGTH
+    assert kwargs["embed"].title == "Approve source sync"
+    assert kwargs["embed"].description == "A second source is ready to normalize."
+    assert kwargs["embed"].fields[0] == {"name": "Issue", "value": "OE-222", "inline": False}
+    assert kwargs["embed"].footer == "Approval · Needs review"
+
+
+@pytest.mark.asyncio
+async def test_send_operator_card_targets_requested_thread(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    parent = SimpleNamespace(send=AsyncMock())
+    thread = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7002)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else parent,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    result = await adapter.send(
+        "555",
+        "ignored",
+        metadata={"thread_id": "777", "operator_card": _operator_card_payload()},
+    )
+
+    assert result.success is True
+    assert thread.send.await_count == 1
+    assert parent.send.await_count == 0
+    assert isinstance(thread.send.await_args.kwargs["embed"], _FakeEmbed)
+
+
+@pytest.mark.asyncio
+async def test_send_operator_card_creates_forum_thread_with_embed(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    thread_channel = SimpleNamespace(id=888, send=AsyncMock())
+    thread = SimpleNamespace(id=888, message=SimpleNamespace(id=7003), thread=thread_channel)
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(return_value=thread)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    result = await adapter.send(
+        "999",
+        "ignored",
+        metadata={"operator_card": _operator_card_payload()},
+    )
+
+    assert result.success is True
+    kwargs = forum_channel.create_thread.await_args.kwargs
+    assert kwargs["name"] == "Needs review — Approve source sync"
+    assert isinstance(kwargs["embed"], _FakeEmbed)
+    assert len(kwargs["content"]) <= adapter.MAX_MESSAGE_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_invalid_operator_card_without_platform_write():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    payload = _operator_card_payload()
+    payload["unexpected"] = "fail closed"
+
+    result = await adapter.send(
+        "555",
+        "must not be sent",
+        metadata={"operator_card": payload},
+    )
+
+    assert result.success is False
+    assert "unknown fields" in (result.error or "")
+    assert channel.send.await_count == 0
+
+
+# ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -42,7 +42,10 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _derive_forum_thread_name,
+)
 
 
 @pytest.mark.asyncio
@@ -329,7 +332,8 @@ async def test_send_bounds_contract_valid_but_oversized_card_to_discord_limits(m
 
     # The card is delivered (safe fallback), not dropped by a Discord 400.
     assert result.success is True
-    embed = channel.send.await_args.kwargs["embed"]
+    first_send = channel.send.await_args_list[0]
+    embed = first_send.kwargs["embed"]
     # Per-field invariants.
     assert all(len(field["value"]) <= 1024 for field in embed.fields)
     assert all(0 < len(field["name"]) <= 256 for field in embed.fields)
@@ -338,7 +342,46 @@ async def test_send_bounds_contract_valid_but_oversized_card_to_discord_limits(m
     total += sum(len(field["name"]) + len(field["value"]) for field in embed.fields)
     assert total <= 6000
     # The full card still reaches the operator via the plaintext content.
-    assert channel.send.await_args.kwargs["content"].startswith("🟡")
+    assert first_send.kwargs["content"].startswith("🟡")
+    assert "https://example.com/" in "".join(
+        call.kwargs["content"] for call in channel.send.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_chunks_full_operator_card_fallback_without_losing_trailing_links(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7010)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    payload = _operator_card_payload()
+    payload["fields"] = [
+        {"label": f"Field {index}", "value": str(index) * 1024}
+        for index in range(3)
+    ]
+    trailing_url = "https://example.com/operator-card-tail"
+    payload["links"] = [{"label": "Trailing link", "url": trailing_url}]
+
+    result = await adapter.send(
+        "555",
+        "ignored",
+        metadata={"operator_card": payload},
+    )
+
+    assert result.success is True
+    assert channel.send.await_count >= 2
+    sent_chunks = [call.kwargs["content"] for call in channel.send.await_args_list]
+    assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in sent_chunks)
+    assert trailing_url in "".join(sent_chunks)
+    assert "embed" in channel.send.await_args_list[0].kwargs
+    assert all("embed" not in call.kwargs for call in channel.send.await_args_list[1:])
 
 
 # ---------------------------------------------------------------------------
@@ -404,6 +447,15 @@ async def test_send_to_forum_creates_thread_post():
     assert result.success is True
     assert result.message_id == "500"
     forum_channel.create_thread.assert_awaited_once()
+
+
+def test_forum_thread_name_obeys_discord_utf16_limit_for_astral_text():
+    title = "🚀" * 60
+
+    thread_name = _derive_forum_thread_name(title)
+
+    assert thread_name == "🚀" * 50
+    assert len(thread_name.encode("utf-16-le")) // 2 <= 100
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -299,6 +299,48 @@ async def test_send_rejects_invalid_operator_card_without_platform_write():
     assert channel.send.await_count == 0
 
 
+@pytest.mark.asyncio
+async def test_send_bounds_contract_valid_but_oversized_card_to_discord_limits(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7009)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    # Every part below is within the operator-card contract, yet the embed it
+    # would naively produce blows past Discord's 1024 per-field and 6000
+    # aggregate ceilings (12 fields at the field limit + a wide link block).
+    payload = _operator_card_payload()
+    payload["fields"] = [{"label": f"Field {i}", "value": "x" * 1024} for i in range(12)]
+    payload["links"] = [
+        {"label": "L" * 80, "url": "https://example.com/" + "y" * 2000} for _ in range(5)
+    ]
+
+    result = await adapter.send(
+        "555",
+        "ignored",
+        metadata={"operator_card": payload},
+    )
+
+    # The card is delivered (safe fallback), not dropped by a Discord 400.
+    assert result.success is True
+    embed = channel.send.await_args.kwargs["embed"]
+    # Per-field invariants.
+    assert all(len(field["value"]) <= 1024 for field in embed.fields)
+    assert all(0 < len(field["name"]) <= 256 for field in embed.fields)
+    # Aggregate invariant: whole embed stays within the 6000 budget.
+    total = len(embed.title) + len(embed.description) + len(embed.footer or "")
+    total += sum(len(field["name"]) + len(field["value"]) for field in embed.fields)
+    assert total <= 6000
+    # The full card still reaches the operator via the plaintext content.
+    assert channel.send.await_args.kwargs["content"].startswith("🟡")
+
+
 # ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_discord_workspace_headers.py
+++ b/tests/gateway/test_discord_workspace_headers.py
@@ -1,0 +1,370 @@
+"""Behavior contracts for persistent Discord thread workspace headers."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+from gateway.session import SessionSource
+from plugins.platforms.discord.adapter import DiscordAdapter
+from plugins.platforms.discord.workspace_headers import (
+    WorkspaceHeaderStore,
+    WorkspaceHeaderStoreError,
+    collect_workspace_header_candidates,
+    revalidate_workspace_header_candidate,
+)
+
+
+def _source(*, scope_id="111", thread_id="222") -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=thread_id,
+        chat_name="MMG / launch-plan",
+        chat_type="thread",
+        user_id="333",
+        user_name="Martin",
+        thread_id=thread_id,
+        scope_id=scope_id,
+        parent_chat_id="444",
+    )
+
+
+@pytest.fixture
+def adapter(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {
+            "card_type": card.card_type,
+            "state_ref": card.state_ref,
+            "fields": {field.label: field.value for field in card.fields},
+        },
+    )
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_workspace_header_creates_once_then_edits_same_message(adapter, tmp_path):
+    header_message = SimpleNamespace(id=7001, edit=AsyncMock())
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        send=AsyncMock(return_value=header_message),
+        fetch_message=AsyncMock(return_value=header_message),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 222 else None,
+        fetch_channel=AsyncMock(),
+    )
+
+    created = await adapter.ensure_workspace_header(_source())
+    updated = await adapter.ensure_workspace_header(_source())
+
+    assert created.success is True
+    assert created.action == "created"
+    assert updated.success is True
+    assert updated.action == "updated"
+    assert thread.send.await_count == 1
+    thread.fetch_message.assert_awaited_once_with(7001)
+    assert header_message.edit.await_count == 1
+    assert header_message.edit.await_args.kwargs["embed"]["card_type"] == "thread_header"
+    assert header_message.edit.await_args.kwargs["content"].startswith("🔵")
+    assert header_message.edit.await_args.kwargs["embed"]["state_ref"] == "discord-workspace:111:222"
+    assert header_message.edit.await_args.kwargs["embed"]["fields"] == {
+        "Owner": "Hermes",
+        "Status": "Active",
+        "Thread": "<#222>",
+        "Linked issue / artifact": "Not linked",
+        "Last decision": "No decision recorded",
+        "Next action": "Awaiting next assistant turn",
+    }
+
+    persisted = WorkspaceHeaderStore().get("111", "222")
+    assert persisted is not None
+    assert persisted.message_id == "7001"
+    assert (tmp_path / "gateway" / "discord_workspace_headers.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_workspace_header_identity_survives_adapter_restart(adapter, tmp_path, monkeypatch):
+    adapter._workspace_headers.put("111", "222", "7001")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    restarted = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    binding = restarted._workspace_headers.get("111", "222")
+    assert binding is not None
+    assert binding.message_id == "7001"
+
+
+@pytest.mark.asyncio
+async def test_workspace_header_persists_and_renders_thread_context(adapter, tmp_path, monkeypatch):
+    adapter._workspace_headers.update_state(
+        "111",
+        "222",
+        owner="Martin + Hermes",
+        status="Needs review",
+        linked_issue_or_artifact="OE-178 · docs/proofs/header.md",
+        last_decision="Keep the human-renamed thread title",
+        next_action="Review the backfill dry run",
+    )
+    header_message = SimpleNamespace(id=7001)
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        send=AsyncMock(return_value=header_message),
+    )
+    adapter._client = SimpleNamespace(get_channel=lambda _id: thread, fetch_channel=AsyncMock())
+
+    created = await adapter.ensure_workspace_header(_source())
+
+    assert created.success is True
+    fields = thread.send.await_args.kwargs["embed"]["fields"]
+    assert fields["Owner"] == "Martin + Hermes"
+    assert fields["Status"] == "Needs review"
+    assert fields["Linked issue / artifact"] == "OE-178 · docs/proofs/header.md"
+    assert fields["Last decision"] == "Keep the human-renamed thread title"
+    assert fields["Next action"] == "Review the backfill dry run"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    restarted = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    state = restarted._workspace_headers.get_state("111", "222")
+    assert state is not None
+    assert state.linked_issue_or_artifact == "OE-178 · docs/proofs/header.md"
+    assert state.last_decision == "Keep the human-renamed thread title"
+    assert state.next_action == "Review the backfill dry run"
+
+
+@pytest.mark.asyncio
+async def test_workspace_header_requires_canonical_scope_and_matching_live_guild(adapter):
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=999),
+        send=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(get_channel=lambda _id: thread, fetch_channel=AsyncMock())
+
+    missing_scope = await adapter.ensure_workspace_header(_source(scope_id=None))
+    mismatched_scope = await adapter.ensure_workspace_header(_source(scope_id="111"))
+
+    assert missing_scope.success is False
+    assert missing_scope.action == "skipped"
+    assert mismatched_scope.success is False
+    assert mismatched_scope.action == "skipped"
+    thread.send.assert_not_awaited()
+
+
+class _UnknownMessage(RuntimeError):
+    status = 404
+    code = 10008
+
+
+@pytest.mark.asyncio
+async def test_deleted_header_is_recreated_but_transient_fetch_failure_never_duplicates(adapter):
+    adapter._workspace_headers.put("111", "222", "7001")
+    replacement = SimpleNamespace(id=7002)
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        send=AsyncMock(return_value=replacement),
+        fetch_message=AsyncMock(side_effect=_UnknownMessage("Unknown Message")),
+    )
+    adapter._client = SimpleNamespace(get_channel=lambda _id: thread, fetch_channel=AsyncMock())
+
+    recreated = await adapter.ensure_workspace_header(_source())
+
+    assert recreated.success is True
+    assert recreated.action == "recreated"
+    assert thread.send.await_count == 1
+    assert adapter._workspace_headers.get("111", "222").message_id == "7002"
+
+    adapter._workspace_headers.put("111", "222", "7003")
+    thread.fetch_message = AsyncMock(side_effect=RuntimeError("temporary transport failure"))
+    thread.send.reset_mock()
+
+    failed = await adapter.ensure_workspace_header(_source())
+
+    assert failed.success is False
+    assert failed.action == "failed"
+    thread.send.assert_not_awaited()
+    assert adapter._workspace_headers.get("111", "222").message_id == "7003"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "registry_payload",
+    ["not json", '{"version": 999, "workspaces": {}}'],
+)
+async def test_corrupt_or_unknown_registry_fails_closed_without_duplicate(
+    adapter, tmp_path, registry_payload
+):
+    registry = tmp_path / "gateway" / "discord_workspace_headers.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(registry_payload, encoding="utf-8")
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        send=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(get_channel=lambda _id: thread, fetch_channel=AsyncMock())
+
+    result = await adapter.ensure_workspace_header(_source())
+
+    assert result.success is False
+    assert result.action == "failed"
+    assert "registry" in (result.error or "")
+    thread.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_send_persistence_failure_leaves_reservation_and_never_duplicates(
+    adapter, monkeypatch
+):
+    sent = SimpleNamespace(id=7001)
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        send=AsyncMock(return_value=sent),
+    )
+    adapter._client = SimpleNamespace(get_channel=lambda _id: thread, fetch_channel=AsyncMock())
+    monkeypatch.setattr(
+        adapter._workspace_headers,
+        "complete_creation",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            WorkspaceHeaderStoreError("simulated persistence failure")
+        ),
+    )
+
+    first = await adapter.ensure_workspace_header(_source())
+    second = await adapter.ensure_workspace_header(_source())
+
+    assert first.success is False
+    assert first.message_id == "7001"
+    assert second.success is False
+    assert "pending" in (second.error or "")
+    assert thread.send.await_count == 1
+
+
+def test_two_store_instances_serialize_read_modify_write_without_lost_binding(tmp_path, monkeypatch):
+    path = tmp_path / "headers.json"
+    first = WorkspaceHeaderStore(path=path)
+    second = WorkspaceHeaderStore(path=path)
+    first_read = Event()
+    allow_first_write = Event()
+    original_read = first._read_unlocked
+
+    def delayed_read():
+        payload = original_read()
+        first_read.set()
+        assert allow_first_write.wait(timeout=2)
+        return payload
+
+    monkeypatch.setattr(first, "_read_unlocked", delayed_read)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_put = executor.submit(first.put, "111", "222", "7001")
+        assert first_read.wait(timeout=2)
+        second_put = executor.submit(second.put, "111", "333", "7002")
+        assert second_put.done() is False
+        allow_first_write.set()
+        first_put.result(timeout=2)
+        second_put.result(timeout=2)
+
+    assert WorkspaceHeaderStore(path=path).get("111", "222").message_id == "7001"
+    assert WorkspaceHeaderStore(path=path).get("111", "333").message_id == "7002"
+
+
+@pytest.mark.asyncio
+async def test_successful_turn_refreshes_header_without_changing_participation(adapter):
+    adapter.ensure_workspace_header = AsyncMock()
+    source = _source()
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message=SimpleNamespace(id=123),
+    )
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    adapter.ensure_workspace_header.assert_awaited_once_with(source)
+    assert "222" not in adapter._threads
+
+    adapter.ensure_workspace_header.reset_mock()
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+    adapter.ensure_workspace_header.assert_not_awaited()
+
+
+def test_backfill_candidates_are_known_workspaces_and_do_not_propose_title_changes(tmp_path):
+    store = WorkspaceHeaderStore(path=tmp_path / "headers.json")
+    store.put("111", "10", "9000")
+    store.put("111", "13", "9003")
+    threads = [
+        SimpleNamespace(id=10, name="Hermes", guild=SimpleNamespace(id=111)),
+        SimpleNamespace(id=11, name="Human-renamed launch", guild=SimpleNamespace(id=111)),
+        SimpleNamespace(id=12, name="Hermes", guild=SimpleNamespace(id=111)),
+        SimpleNamespace(id=13, name="Human-renamed retained", guild=SimpleNamespace(id=111)),
+    ]
+
+    candidates = collect_workspace_header_candidates(
+        threads,
+        participated_thread_ids={"10", "11", "13"},
+        store=store,
+    )
+
+    assert [(item.thread_id, item.reasons) for item in candidates] == [
+        ("10", ("placeholder_title",)),
+        ("11", ("header_missing",)),
+    ]
+    assert all(item.proposed_title is None for item in candidates)
+
+
+def test_backfill_apply_revalidates_title_participation_scope_and_missing_state(tmp_path):
+    store = WorkspaceHeaderStore(path=tmp_path / "headers.json")
+    planned_thread = SimpleNamespace(id=22, name="Hermes", guild=SimpleNamespace(id=111))
+    candidate = collect_workspace_header_candidates(
+        [planned_thread], participated_thread_ids={"22"}, store=store
+    )[0]
+
+    assert revalidate_workspace_header_candidate(
+        candidate,
+        live_thread=planned_thread,
+        participated_thread_ids={"22"},
+        store=store,
+    ) is True
+    assert revalidate_workspace_header_candidate(
+        candidate,
+        live_thread=SimpleNamespace(id=22, name="Human renamed", guild=SimpleNamespace(id=111)),
+        participated_thread_ids={"22"},
+        store=store,
+    ) is False
+    assert revalidate_workspace_header_candidate(
+        candidate,
+        live_thread=planned_thread,
+        participated_thread_ids=set(),
+        store=store,
+    ) is False
+    assert revalidate_workspace_header_candidate(
+        candidate,
+        live_thread=SimpleNamespace(id=22, name="Hermes", guild=SimpleNamespace(id=999)),
+        participated_thread_ids={"22"},
+        store=store,
+    ) is False
+
+    store.put("111", "22", "9000")
+    assert revalidate_workspace_header_candidate(
+        candidate,
+        live_thread=planned_thread,
+        participated_thread_ids={"22"},
+        store=store,
+    ) is False

--- a/tests/gateway/test_discord_workspace_headers.py
+++ b/tests/gateway/test_discord_workspace_headers.py
@@ -305,6 +305,53 @@ async def test_successful_turn_refreshes_header_without_changing_participation(a
     adapter.ensure_workspace_header.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_processing_outcome_updates_existing_workspace_header_before_edit(adapter):
+    adapter._workspace_headers.put("111", "222", "7001")
+    header_message = SimpleNamespace(id=7001, edit=AsyncMock())
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        fetch_message=AsyncMock(return_value=header_message),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 222 else None,
+        fetch_channel=AsyncMock(),
+    )
+    source = _source()
+    event = MessageEvent(
+        text="ship the reviewed plan",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message=SimpleNamespace(id=123),
+    )
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    persisted = adapter._workspace_headers.get_state("111", "222")
+    assert persisted is not None
+    assert persisted.status == "Needs attention"
+    assert persisted.next_action == "Retry the last request"
+    header_message.edit.assert_awaited_once()
+    assert header_message.edit.await_args.kwargs["embed"]["fields"] == {
+        "Owner": "Hermes",
+        "Status": "Needs attention",
+        "Thread": "<#222>",
+        "Linked issue / artifact": "Not linked",
+        "Last decision": "No decision recorded",
+        "Next action": "Retry the last request",
+    }
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    recovered = adapter._workspace_headers.get_state("111", "222")
+    assert recovered is not None
+    assert recovered.status == "Active"
+    assert recovered.next_action == "Awaiting next assistant turn"
+    assert header_message.edit.await_count == 2
+
+
 def test_backfill_candidates_are_known_workspaces_and_do_not_propose_title_changes(tmp_path):
     store = WorkspaceHeaderStore(path=tmp_path / "headers.json")
     store.put("111", "10", "9000")

--- a/tests/gateway/test_operator_cards.py
+++ b/tests/gateway/test_operator_cards.py
@@ -84,6 +84,7 @@ def test_every_severity_has_a_mobile_readable_label(severity, label):
         ({"state_ref": ""}, "state_ref"),
         ({"actions": [{"id": "approve", "label": "Approve", "style": "neon"}]}, "style"),
         ({"links": [{"label": "Bad", "url": "javascript:alert(1)"}]}, "url"),
+        ({"links": [{"label": "Bad", "url": "https://:443"}]}, "url"),
     ],
 )
 def test_invalid_values_fail_closed(change, message):

--- a/tests/gateway/test_operator_cards.py
+++ b/tests/gateway/test_operator_cards.py
@@ -1,0 +1,129 @@
+"""Behavior contract for platform-agnostic operator cards."""
+
+import pytest
+
+from gateway.operator_cards import (
+    CARD_TYPES,
+    SEVERITIES,
+    OperatorCard,
+    OperatorCardValidationError,
+    render_operator_card_text,
+)
+
+
+def _payload(**overrides):
+    payload = {
+        "kind": "operator_card",
+        "version": 1,
+        "card_type": "approval",
+        "title": "Contract redlines",
+        "severity": "needs_review",
+        "summary": "Legal language changed in the indemnity section.",
+        "fields": [
+            {"label": "Impact", "value": "The liability boundary changed."},
+            {"label": "Next", "value": "Approve or ask for revision."},
+        ],
+        "actions": [
+            {"id": "approve", "label": "Approve", "style": "success"},
+            {"id": "revise", "label": "Revise", "style": "secondary"},
+            {"id": "escalate", "label": "Escalate", "style": "danger"},
+        ],
+        "links": [{"label": "Linear", "url": "https://linear.app/example"}],
+        "state_ref": "opaque-state-ref",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_round_trip_preserves_the_contract_without_platform_fields():
+    card = OperatorCard.from_mapping(_payload())
+
+    assert card.to_mapping() == _payload()
+    assert "discord" not in repr(card).lower()
+
+
+@pytest.mark.parametrize("card_type", sorted(CARD_TYPES))
+def test_every_card_type_uses_the_same_plaintext_contract(card_type):
+    rendered = render_operator_card_text(OperatorCard.from_mapping(_payload(card_type=card_type)))
+
+    assert "Contract redlines" in rendered
+    assert "Legal language changed" in rendered
+    assert "Impact: The liability boundary changed." in rendered
+    assert "Actions: Approve · Revise · Escalate" in rendered
+    assert "[Linear](https://linear.app/example)" in rendered
+
+
+@pytest.mark.parametrize(
+    ("severity", "label"),
+    [
+        ("done", "Done"),
+        ("info", "Info"),
+        ("needs_review", "Needs review"),
+        ("blocked", "Blocked"),
+        ("critical", "Critical"),
+    ],
+)
+def test_every_severity_has_a_mobile_readable_label(severity, label):
+    rendered = render_operator_card_text(OperatorCard.from_mapping(_payload(severity=severity)))
+
+    assert label in rendered.splitlines()[0]
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        ({"kind": "message"}, "kind"),
+        ({"version": 2}, "version"),
+        ({"card_type": "unknown"}, "card_type"),
+        ({"severity": "warning"}, "severity"),
+        ({"title": ""}, "title"),
+        ({"summary": ""}, "summary"),
+        ({"state_ref": ""}, "state_ref"),
+        ({"actions": [{"id": "approve", "label": "Approve", "style": "neon"}]}, "style"),
+        ({"links": [{"label": "Bad", "url": "javascript:alert(1)"}]}, "url"),
+    ],
+)
+def test_invalid_values_fail_closed(change, message):
+    with pytest.raises(OperatorCardValidationError, match=message):
+        OperatorCard.from_mapping(_payload(**change))
+
+
+@pytest.mark.parametrize("missing", ["kind", "version", "card_type", "title", "severity", "summary", "state_ref"])
+def test_missing_required_fields_fail_closed(missing):
+    payload = _payload()
+    payload.pop(missing)
+
+    with pytest.raises(OperatorCardValidationError, match=missing):
+        OperatorCard.from_mapping(payload)
+
+
+def test_unknown_top_level_fields_cannot_leak_to_downstream_renderers():
+    payload = _payload(provider_payload={"private": "must-not-pass"})
+
+    with pytest.raises(OperatorCardValidationError, match="unknown fields"):
+        OperatorCard.from_mapping(payload)
+
+
+def test_plaintext_renderer_is_bounded_without_splitting_the_status_header():
+    card = OperatorCard.from_mapping(
+        _payload(summary="x" * 500, fields=[{"label": "Impact", "value": "y" * 1000}])
+    )
+
+    rendered = render_operator_card_text(card, max_length=240)
+
+    assert len(rendered) <= 240
+    assert rendered.startswith("🟡 **Needs review — Contract redlines**")
+    assert rendered.endswith("…")
+
+
+def test_constant_sets_match_the_values_accepted_by_the_parser():
+    assert CARD_TYPES == {
+        "approval",
+        "task_run",
+        "digest",
+        "deal",
+        "capture",
+        "ops_alert",
+        "thread_header",
+    }
+    assert SEVERITIES == {"done", "info", "needs_review", "blocked", "critical"}

--- a/tests/gateway/test_operator_cards.py
+++ b/tests/gateway/test_operator_cards.py
@@ -74,6 +74,9 @@ def test_every_severity_has_a_mobile_readable_label(severity, label):
     [
         ({"kind": "message"}, "kind"),
         ({"version": 2}, "version"),
+        ({"version": 1.0}, "version"),
+        ({"version": True}, "version"),
+        ({"version": "1"}, "version"),
         ({"card_type": "unknown"}, "card_type"),
         ({"severity": "warning"}, "severity"),
         ({"title": ""}, "title"),
@@ -116,14 +119,23 @@ def test_plaintext_renderer_is_bounded_without_splitting_the_status_header():
     assert rendered.endswith("…")
 
 
-def test_constant_sets_match_the_values_accepted_by_the_parser():
-    assert CARD_TYPES == {
-        "approval",
-        "task_run",
-        "digest",
-        "deal",
-        "capture",
-        "ops_alert",
-        "thread_header",
-    }
-    assert SEVERITIES == {"done", "info", "needs_review", "blocked", "critical"}
+@pytest.mark.parametrize("card_type", sorted(CARD_TYPES))
+def test_every_declared_card_type_is_accepted_by_the_parser(card_type):
+    # Invariant: the accept-list constant and the parser agree — each declared
+    # card_type round-trips instead of being frozen against a literal set.
+    assert OperatorCard.from_mapping(_payload(card_type=card_type)).card_type == card_type
+
+
+@pytest.mark.parametrize("severity", sorted(SEVERITIES))
+def test_every_declared_severity_is_accepted_by_the_parser(severity):
+    assert OperatorCard.from_mapping(_payload(severity=severity)).severity == severity
+
+
+def test_parser_rejects_values_outside_the_declared_sets():
+    assert "totally-made-up" not in CARD_TYPES
+    with pytest.raises(OperatorCardValidationError, match="card_type"):
+        OperatorCard.from_mapping(_payload(card_type="totally-made-up"))
+
+    assert "totally-made-up" not in SEVERITIES
+    with pytest.raises(OperatorCardValidationError, match="severity"):
+        OperatorCard.from_mapping(_payload(severity="totally-made-up"))

--- a/tests/scripts/test_backfill_discord_workspace_headers.py
+++ b/tests/scripts/test_backfill_discord_workspace_headers.py
@@ -1,0 +1,15 @@
+"""CLI safety contract for the Discord workspace-header backfill."""
+
+from scripts.backfill_discord_workspace_headers import build_parser
+
+
+def test_backfill_defaults_to_read_only_dry_run():
+    args = build_parser().parse_args([])
+
+    assert args.apply is False
+
+
+def test_backfill_requires_explicit_apply_flag_for_mutation():
+    args = build_parser().parse_args(["--apply"])
+
+    assert args.apply is True


### PR DESCRIPTION
## Summary

- persist one Discord workspace-header identity per canonical guild/thread workspace
- create once and edit idempotently across gateway restarts
- drive header `status` and `next_action` from the real production `ProcessingOutcome` lifecycle before each edit
- prevent failure/cancellation paths from creating a new header
- provide dry-run-first backfill with explicit apply and revalidation that preserves human-renamed threads

## Stack

Depends on operator-card PR #67224 and is restacked onto its exact refreshed head `c3307506ad5258dec9f70828e7ff440c390a55b9`.

Exact OE-178 head: `bcf5e7e254bbdb0f3423c2c7479d6e208d4d48b0`.

## Verification

- focused workspace-header/operator-card slice: 63/63 passed
- full Discord gateway slice: 616/616 passed
- Ruff, bytecode compilation, Windows-footgun scan, diff, and ancestry checks passed
- independent Spec and Standards reviews approved the exact restacked head with zero findings
- the earlier `update_state()` production-caller review thread is resolved

One rebase conflict was limited to the adapter import block; the resolution retains both the shared operator-card severity helper and workspace-header imports. The fixed-point production lifecycle commit is patch-equivalent to the reviewed pre-restack commit.

Fork CI remains `action_required` with zero jobs until a NousResearch maintainer approves the workflow run.