### PR TITLE
feat(runtime): Claude CLI (claude -p) inference backend for base-subscription Claude models

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -615,7 +615,14 @@ def init_agent(
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {
+        "chat_completions",
+        "codex_responses",
+        "anthropic_messages",
+        "bedrock_converse",
+        "codex_app_server",
+        "claude_cli",
+    }:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -631,6 +638,9 @@ def init_agent(
         agent.api_mode = "codex_responses"
         agent.provider = "xai"
     elif agent.provider == "anthropic" or (provider_name is None and agent._base_url_hostname == "api.anthropic.com"):
+        # Default Anthropic HTTP path. Opt-in claude_cli is only set when the
+        # caller passes api_mode explicitly (resolve_runtime_provider applies
+        # model.anthropic_runtime / HERMES_ANTHROPIC_RUNTIME before init).
         agent.api_mode = "anthropic_messages"
         agent.provider = "anthropic"
     elif agent._base_url_lower.rstrip("/").endswith("/anthropic"):
@@ -1085,6 +1095,35 @@ def init_agent(
         agent.base_url = "moa://local"
         if not agent.quiet_mode:
             print(f"🤖 AI Agent initialized with MoA preset: {agent.model}")
+    elif agent.api_mode == "claude_cli":
+        # Claude CLI runtime: main turns spawn `claude -p` (base Max).
+        # Do not construct an HTTP Anthropic / OpenAI client against
+        # api.anthropic.com — that path bills EXTRA USAGE on Max setup
+        # tokens and is the source of "You're out of extra usage" 400s.
+        from agent.anthropic_adapter import resolve_anthropic_token, _is_oauth_token
+
+        _is_native_anthropic = agent.provider == "anthropic"
+        effective_key = (
+            (api_key or resolve_anthropic_token() or "")
+            if _is_native_anthropic
+            else (api_key or "")
+        )
+        agent.api_key = effective_key
+        agent._anthropic_api_key = effective_key
+        agent._anthropic_base_url = base_url or "https://api.anthropic.com"
+        agent._anthropic_client = None
+        agent._is_anthropic_oauth = (
+            _is_oauth_token(effective_key)
+            if (_is_native_anthropic and isinstance(effective_key, str))
+            else False
+        )
+        agent.client = None
+        agent._client_kwargs = {}
+        if not agent.quiet_mode:
+            print(
+                f"🤖 AI Agent initialized with model: {agent.model} "
+                f"(Claude CLI runtime — base Max via claude -p)"
+            )
     elif agent.api_mode == "bedrock_converse":
         # AWS Bedrock — uses boto3 directly, no OpenAI client needed.
         # Region is extracted from the base_url or defaults to us-east-1.
@@ -2426,6 +2465,16 @@ def init_agent(
     agent.compression_idle_compact_after_seconds = (
         compression_idle_compact_after_seconds
     )
+    # claude_cli: Claude Code owns native session compaction via --resume.
+    # Disable Hermes auto-compression so we never fire the HTTP aux path
+    # (extra-usage 400 on Max setup tokens). Manual /compress also no-ops
+    # via compress_context()'s api_mode guard.
+    if agent.api_mode == "claude_cli":
+        agent.compression_enabled = False
+        _ra().logger.info(
+            "claude_cli: Hermes auto-compression disabled "
+            "(Claude owns native compaction via --resume)"
+        )
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2081,6 +2081,27 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     if not api_mode:
         api_mode = determine_api_mode(new_provider, base_url, model=new_model)
 
+    # Preserve / default claude_cli when eligible (explicit config or
+    # default-when-token). determine_api_mode only knows host→wire mapping
+    # (api.anthropic.com → anthropic_messages) and would drop the CLI runtime
+    # on every in-place model switch, routing subsequent turns through HTTP
+    # Anthropic extra-usage. Pass new_model so auto eligibility uses the
+    # switched Claude model, not a stale config default.
+    try:
+        from hermes_cli.runtime_provider import (
+            _get_model_config,
+            _maybe_apply_claude_cli_runtime,
+        )
+
+        api_mode = _maybe_apply_claude_cli_runtime(
+            provider=(new_provider or "").strip().lower(),
+            api_mode=api_mode or "",
+            model_cfg=_get_model_config(),
+            model=new_model,
+        )
+    except Exception:
+        pass
+
     # Defense-in-depth: ensure OpenCode base_url doesn't carry a trailing
     # /v1 into the anthropic_messages client, which would cause the SDK to
     # hit /v1/v1/messages.  `model_switch.switch_model()` already strips
@@ -2232,6 +2253,39 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
             agent.client = build_moa_facade(agent, agent.model)
+        elif api_mode == "claude_cli":
+            # Claude CLI runtime: turns go through `claude -p` (base Max).
+            # Do NOT build an HTTP Anthropic client — that bills extra usage.
+            # Retire any prior multi-turn Claude session so the next turn
+            # creates a fresh CLI session under the new model.
+            from agent.anthropic_adapter import resolve_anthropic_token, _is_oauth_token
+
+            _is_native_anthropic = (new_provider or "").strip().lower() == "anthropic"
+            effective_key = (
+                (api_key or agent.api_key or resolve_anthropic_token() or "")
+                if _is_native_anthropic
+                else (api_key or agent.api_key or "")
+            )
+            agent.api_key = effective_key
+            agent._anthropic_api_key = effective_key
+            agent._anthropic_base_url = base_url or getattr(agent, "_anthropic_base_url", None) or "https://api.anthropic.com"
+            agent._anthropic_client = None
+            agent._is_anthropic_oauth = (
+                _is_oauth_token(effective_key)
+                if (_is_native_anthropic and isinstance(effective_key, str))
+                else False
+            )
+            agent.client = None
+            agent._client_kwargs = {}
+            # Drop in-memory Claude CLI session so model/provider change is
+            # not pinned to a stale --resume id for the previous model.
+            try:
+                from agent.claude_runtime import _retire_claude_cli_session
+
+                _retire_claude_cli_session(agent, reason="switch_model")
+            except Exception:
+                agent._claude_cli_session = None
+            agent.compression_enabled = False
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3122,7 +3122,72 @@ def _try_azure_foundry(
     return client, final_model
 
 
-def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
+def _is_claude_cli_runtime_active(
+    main_runtime: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """True when Anthropic traffic must stay on ``claude -p`` (base Max).
+
+    When the main runtime is ``claude_cli`` (or the profile/env opts into
+    ``model.anthropic_runtime: claude_cli``), Max setup/OAuth tokens must
+    never be used for HTTP ``api.anthropic.com`` side calls — that path
+    bills EXTRA USAGE and returns 400 when extra usage is disabled.
+
+    Priority:
+      1. Live ``main_runtime["api_mode"]`` (session-scoped; highest)
+      2. ``HERMES_ANTHROPIC_RUNTIME`` env (one-session override)
+      3. ``model.anthropic_runtime`` in config.yaml
+    """
+    if main_runtime is None:
+        try:
+            main_runtime = _RUNTIME_MAIN_CONTEXT.get()
+        except Exception:
+            main_runtime = None
+        if main_runtime is None:
+            try:
+                main_runtime = _compat_runtime_main()
+            except Exception:
+                main_runtime = None
+
+    if isinstance(main_runtime, dict):
+        if str(main_runtime.get("api_mode") or "").strip().lower() == "claude_cli":
+            return True
+
+    env_runtime = (os.getenv("HERMES_ANTHROPIC_RUNTIME", "") or "").strip().lower()
+    if env_runtime in {"claude_cli", "on", "1", "true", "yes"}:
+        return True
+    if env_runtime in {"off", "0", "false", "no", "anthropic_messages"}:
+        return False
+
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        model_cfg = cfg.get("model")
+        if isinstance(model_cfg, dict):
+            runtime = str(model_cfg.get("anthropic_runtime") or "").strip().lower()
+            if runtime in {"claude_cli", "on", "1", "true", "yes"}:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _try_anthropic(
+    explicit_api_key: str = None,
+    *,
+    main_runtime: Optional[Dict[str, Any]] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
+    # INVARIANT: claude_cli main runtime / anthropic_runtime=claude_cli must
+    # never yield an HTTP Anthropic aux client (extra-usage 400 on Max setup
+    # tokens). Fall through so auto / fallback chain can pick grok/gpt/etc.
+    if _is_claude_cli_runtime_active(main_runtime):
+        logger.info(
+            "Auxiliary client: refusing HTTP Anthropic (claude_cli runtime; "
+            "main + aux must stay on claude -p base Max or a non-Anthropic "
+            "fallback — never api.anthropic.com extra-usage)"
+        )
+        return None, None
+
     try:
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
     except ImportError:
@@ -4931,69 +4996,85 @@ def _resolve_auto(
 
     if (main_provider and main_model
             and main_provider not in {"auto", ""}):
-        resolved_provider = main_provider
-        explicit_base_url = runtime_base_url or None
-        explicit_api_key = None
-        if runtime_base_url and main_provider == "custom":
-            # Anonymous custom endpoint (OPENAI_BASE_URL / config.model.base_url)
-            # — pass through with explicit base_url + api_key.
-            resolved_provider = "custom"
-            explicit_base_url = runtime_base_url
-            explicit_api_key = runtime_api_key or None
-        elif main_provider.startswith("custom:"):
-            # Named custom provider (custom_providers / providers dict entry).
-            _has_named_entry = False
-            try:
-                from hermes_cli.runtime_provider import _get_named_custom_provider
-                _has_named_entry = _get_named_custom_provider(main_provider) is not None
-            except ImportError:
-                pass
-            if _has_named_entry:
-                # KEEP the full ``custom:<name>`` so resolve_provider_client
-                # lands in the named-custom-provider arm — that arm honours the
-                # entry's api_mode (e.g. anthropic_messages →
-                # AnthropicAuxiliaryClient, avoiding the /anthropic→/v1 rewrite
-                # that 404s against proxies like Palantir Foundry's Anthropic
-                # surface).  Do NOT collapse to plain "custom"; that path
-                # strips /anthropic and routes through OpenAI chat.completions.
-                # base_url and api_key come from the named entry itself, so
-                # leave the explicit_* overrides unset.
-                resolved_provider = main_provider
-                explicit_base_url = None
-            elif runtime_base_url:
-                # Config-less named custom provider (#34777): the entry only
-                # exists in the live runtime, so collapse to the anonymous
-                # custom arm with the runtime endpoint + key.
+        # claude_cli main runtime: Step-1 would build HTTP Anthropic (extra
+        # usage) from provider=anthropic. Skip Step-1 and fall through to the
+        # configured fallback chain (xai-oauth/grok, openai-codex, …).
+        _skip_anthropic_http_step1 = (
+            main_provider == "anthropic"
+            and (
+                runtime_api_mode == "claude_cli"
+                or _is_claude_cli_runtime_active(runtime)
+            )
+        )
+        if _skip_anthropic_http_step1:
+            logger.info(
+                "Auxiliary auto-detect: skipping HTTP Anthropic main provider "
+                "(claude_cli runtime) — trying non-Anthropic fallback chain"
+            )
+        else:
+            resolved_provider = main_provider
+            explicit_base_url = runtime_base_url or None
+            explicit_api_key = None
+            if runtime_base_url and main_provider == "custom":
+                # Anonymous custom endpoint (OPENAI_BASE_URL / config.model.base_url)
+                # — pass through with explicit base_url + api_key.
                 resolved_provider = "custom"
                 explicit_base_url = runtime_base_url
                 explicit_api_key = runtime_api_key or None
+            elif main_provider.startswith("custom:"):
+                # Named custom provider (custom_providers / providers dict entry).
+                _has_named_entry = False
+                try:
+                    from hermes_cli.runtime_provider import _get_named_custom_provider
+                    _has_named_entry = _get_named_custom_provider(main_provider) is not None
+                except ImportError:
+                    pass
+                if _has_named_entry:
+                    # KEEP the full ``custom:<name>`` so resolve_provider_client
+                    # lands in the named-custom-provider arm — that arm honours the
+                    # entry's api_mode (e.g. anthropic_messages →
+                    # AnthropicAuxiliaryClient, avoiding the /anthropic→/v1 rewrite
+                    # that 404s against proxies like Palantir Foundry's Anthropic
+                    # surface).  Do NOT collapse to plain "custom"; that path
+                    # strips /anthropic and routes through OpenAI chat.completions.
+                    # base_url and api_key come from the named entry itself, so
+                    # leave the explicit_* overrides unset.
+                    resolved_provider = main_provider
+                    explicit_base_url = None
+                elif runtime_base_url:
+                    # Config-less named custom provider (#34777): the entry only
+                    # exists in the live runtime, so collapse to the anonymous
+                    # custom arm with the runtime endpoint + key.
+                    resolved_provider = "custom"
+                    explicit_base_url = runtime_base_url
+                    explicit_api_key = runtime_api_key or None
+                elif runtime_api_key:
+                    explicit_api_key = runtime_api_key
             elif runtime_api_key:
+                # Pin auxiliary to the same api_key as the active main chat session
+                # so that a working key is reused instead of re-selecting from the pool
+                # (which might pick a different, potentially exhausted key).
                 explicit_api_key = runtime_api_key
-        elif runtime_api_key:
-            # Pin auxiliary to the same api_key as the active main chat session
-            # so that a working key is reused instead of re-selecting from the pool
-            # (which might pick a different, potentially exhausted key).
-            explicit_api_key = runtime_api_key
-        # Skip Step-1 if the main provider was recently 402'd. The unhealthy
-        # cache TTL bounds how long we bypass it, so a topped-up account
-        # recovers automatically. If we tried Step-1 anyway, every aux call
-        # on a depleted main provider would pay one doomed 402 RTT before
-        # falling to Step-2.
-        main_chain_label = _normalize_chain_label(resolved_provider)
-        if main_chain_label and _is_provider_unhealthy(main_chain_label):
-            _log_skip_unhealthy(main_chain_label)
-        else:
-            client, resolved = resolve_provider_client(
-                resolved_provider,
-                main_model,
-                explicit_base_url=explicit_base_url,
-                explicit_api_key=explicit_api_key,
-                api_mode=runtime_api_mode or None,
-            )
-            if client is not None:
-                logger.info("Auxiliary auto-detect: using main provider %s (%s)",
-                            main_provider, resolved or main_model)
-                return client, resolved or main_model
+            # Skip Step-1 if the main provider was recently 402'd. The unhealthy
+            # cache TTL bounds how long we bypass it, so a topped-up account
+            # recovers automatically. If we tried Step-1 anyway, every aux call
+            # on a depleted main provider would pay one doomed 402 RTT before
+            # falling to Step-2.
+            main_chain_label = _normalize_chain_label(resolved_provider)
+            if main_chain_label and _is_provider_unhealthy(main_chain_label):
+                _log_skip_unhealthy(main_chain_label)
+            else:
+                client, resolved = resolve_provider_client(
+                    resolved_provider,
+                    main_model,
+                    explicit_base_url=explicit_base_url,
+                    explicit_api_key=explicit_api_key,
+                    api_mode=runtime_api_mode or None,
+                )
+                if client is not None:
+                    logger.info("Auxiliary auto-detect: using main provider %s (%s)",
+                                main_provider, resolved or main_model)
+                    return client, resolved or main_model
 
     # ── Step 2: user-configured fallback policy ─────────────────────────
     # In auto mode, respect the task-specific fallback chain first, then the
@@ -5662,9 +5743,24 @@ def resolve_provider_client(
 
     if pconfig.auth_type == "api_key":
         if provider == "anthropic":
-            client, default_model = _try_anthropic(explicit_api_key=explicit_api_key)
+            # Refuse HTTP Anthropic when main is claude_cli (or profile opts
+            # into anthropic_runtime=claude_cli). Without this, explicit
+            # provider="anthropic" aux tasks still bill extra usage.
+            client, default_model = _try_anthropic(
+                explicit_api_key=explicit_api_key,
+                main_runtime=main_runtime,
+            )
             if client is None:
-                logger.warning("resolve_provider_client: anthropic requested but no Anthropic credentials found")
+                if _is_claude_cli_runtime_active(main_runtime):
+                    logger.info(
+                        "resolve_provider_client: anthropic requested but "
+                        "claude_cli runtime forbids HTTP Anthropic aux"
+                    )
+                else:
+                    logger.warning(
+                        "resolve_provider_client: anthropic requested but no "
+                        "Anthropic credentials found"
+                    )
                 return None, None
             final_model = _normalize_resolved_model(model or default_model, provider)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode else (client, final_model))

--- a/agent/claude_runtime.py
+++ b/agent/claude_runtime.py
@@ -1,0 +1,525 @@
+"""Claude CLI runtime — Phase 2b multi-turn session resume.
+
+Drives one turn through a ``claude -p`` subprocess when
+``agent.api_mode == "claude_cli"``. Mirrors ``agent.codex_runtime``'s
+``run_codex_app_server_turn`` early-return shape so the conversation loop
+treats the result as a normal completed turn.
+
+Phase 2a: Hermes tools via MCP (``hermes_tools_mcp_server``). Tool
+round-trip is internal to ``claude -p``; this module projects tool
+activity into Hermes UI via the event bridge.
+
+Phase 2b: multi-turn context via Claude's own session:
+  * Lazy ``agent._claude_cli_session`` (one ClaudeCliSession per AIAgent /
+    Hermes conversation) — same lifetime model as ``agent._codex_session``.
+  * Turn 1: ``--session-id <uuid>``; turn 2+: ``--resume <uuid>``.
+  * Mapping lives on the ClaudeCliSession; process-local reuse across
+    Hermes turns. Stable cwd for Claude session files.
+  * Missing resume → fresh session once; hard failures retire the session.
+
+Phase 2c: host-global concurrency semaphore (``claude_cli_concurrency``)
+caps concurrent ``claude -p`` spawns across all Hermes profiles; aux
+HTTP (title / Hermes compression / metadata) is skipped or silenced —
+Claude owns native session compaction via ``--resume``.
+
+TODO(later): doctor checks, full transcript pre-seed for resumed
+Hermes histories.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_usage_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(value), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _record_claude_cli_usage(agent, turn) -> dict[str, Any]:
+    """Translate Claude CLI result usage into Hermes session accounting.
+
+    Mirrors ``_record_codex_app_server_usage`` closely so Max-subscription
+    turns still tick session_api_calls and token counters.
+    """
+    agent.session_api_calls += 1
+
+    usage = getattr(turn, "token_usage_last", None) or getattr(turn, "usage", None)
+    # token_usage_last is already codex-shaped; raw usage is Claude-shaped.
+    if isinstance(usage, dict) and (
+        "inputTokens" in usage or "outputTokens" in usage
+    ):
+        input_tokens = _coerce_usage_int(usage.get("inputTokens"))
+        cache_read_tokens = _coerce_usage_int(usage.get("cachedInputTokens"))
+        output_tokens = _coerce_usage_int(usage.get("outputTokens"))
+        reasoning_tokens = _coerce_usage_int(usage.get("reasoningOutputTokens"))
+        reported_total = _coerce_usage_int(usage.get("totalTokens"))
+    elif isinstance(usage, dict) and usage:
+        input_tokens = _coerce_usage_int(
+            usage.get("input_tokens") or usage.get("prompt_tokens")
+        )
+        cache_read_tokens = _coerce_usage_int(
+            usage.get("cache_read_input_tokens") or usage.get("cache_read_tokens")
+        )
+        output_tokens = _coerce_usage_int(
+            usage.get("output_tokens") or usage.get("completion_tokens")
+        )
+        reasoning_tokens = 0
+        reported_total = input_tokens + cache_read_tokens + output_tokens
+    else:
+        if agent._session_db and agent.session_id:
+            try:
+                if not agent._session_db_created:
+                    agent._ensure_db_session()
+                agent._session_db.update_token_counts(
+                    agent.session_id,
+                    model=agent.model,
+                    billing_provider=agent.provider,
+                    billing_base_url=agent.base_url,
+                    billing_mode="subscription_included",
+                    api_call_count=1,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "claude_cli api-call persistence failed (session=%s): %s",
+                    agent.session_id,
+                    exc,
+                )
+        return {}
+
+    from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+
+    canonical_usage = CanonicalUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=0,
+        reasoning_tokens=reasoning_tokens,
+        raw_usage=usage if isinstance(usage, dict) else {},
+    )
+    prompt_tokens = canonical_usage.prompt_tokens
+    completion_tokens = canonical_usage.output_tokens
+    total_tokens = reported_total or canonical_usage.total_tokens
+    usage_dict = {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "input_tokens": canonical_usage.input_tokens,
+        "output_tokens": canonical_usage.output_tokens,
+        "cache_read_tokens": canonical_usage.cache_read_tokens,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": reasoning_tokens,
+    }
+
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        try:
+            compressor.update_from_response(usage_dict)
+        except Exception:
+            logger.debug("claude_cli usage update failed", exc_info=True)
+
+    agent.session_prompt_tokens += prompt_tokens
+    agent.session_completion_tokens += completion_tokens
+    agent.session_total_tokens += total_tokens
+    agent.session_input_tokens += canonical_usage.input_tokens
+    agent.session_output_tokens += canonical_usage.output_tokens
+    agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
+    agent.session_reasoning_tokens += reasoning_tokens
+
+    cost_result = estimate_usage_cost(
+        agent.model,
+        canonical_usage,
+        provider=agent.provider,
+        base_url=agent.base_url,
+        api_key=getattr(agent, "api_key", ""),
+    )
+    if cost_result.amount_usd is not None:
+        agent.session_estimated_cost_usd += float(cost_result.amount_usd)
+    agent.session_cost_status = cost_result.status
+    agent.session_cost_source = cost_result.source
+
+    if agent._session_db and agent.session_id:
+        try:
+            if not agent._session_db_created:
+                agent._ensure_db_session()
+            agent._session_db.update_token_counts(
+                agent.session_id,
+                input_tokens=canonical_usage.input_tokens,
+                output_tokens=canonical_usage.output_tokens,
+                cache_read_tokens=canonical_usage.cache_read_tokens,
+                cache_write_tokens=canonical_usage.cache_write_tokens,
+                reasoning_tokens=canonical_usage.reasoning_tokens,
+                estimated_cost_usd=float(cost_result.amount_usd)
+                if cost_result.amount_usd is not None
+                else None,
+                cost_status=cost_result.status,
+                cost_source=cost_result.source,
+                billing_provider=agent.provider,
+                billing_base_url=agent.base_url,
+                billing_mode="subscription_included"
+                if cost_result.status == "included"
+                else None,
+                model=agent.model,
+                api_call_count=1,
+            )
+        except Exception as exc:
+            logger.debug(
+                "claude_cli token persistence failed (session=%s): %s",
+                agent.session_id,
+                exc,
+            )
+
+    return {
+        **usage_dict,
+        "last_prompt_tokens": prompt_tokens,
+        "estimated_cost_usd": float(cost_result.amount_usd)
+        if cost_result.amount_usd is not None
+        else None,
+        "cost_status": cost_result.status,
+        "cost_source": cost_result.source,
+        "runtime": "claude_cli",
+    }
+
+
+def make_claude_cli_event_bridge(agent) -> Callable[[dict], None]:
+    """Bridge claude_cli projector events into Hermes stream + tool UI.
+
+    Text deltas, assistant completion, and MCP tool.started / tool.completed
+    (mirrors codex_runtime's mcpToolCall projection: strip hermes-tools
+    namespacing so the user sees bare Hermes tool names).
+    """
+
+    def _fire_text_delta(params: dict) -> None:
+        text = params.get("delta") or params.get("text") or ""
+        if not isinstance(text, str) or not text:
+            return
+        fn = getattr(agent, "_fire_stream_delta", None)
+        if fn is None:
+            return
+        try:
+            fn(text)
+        except Exception:
+            logger.debug("_fire_stream_delta raised", exc_info=True)
+
+    def _fire_assistant_completed(params: dict) -> None:
+        text = params.get("text") or ""
+        if not isinstance(text, str) or not text.strip():
+            return
+        if not getattr(agent, "show_commentary", True):
+            return
+        emit = getattr(agent, "_emit_interim_assistant_message", None)
+        if emit is None:
+            return
+        try:
+            emit({"role": "assistant", "content": text})
+        except Exception:
+            logger.debug(
+                "_emit_interim_assistant_message raised", exc_info=True
+            )
+
+    def _tool_preview(args: Any) -> Any:
+        if not isinstance(args, dict) or not args:
+            return None
+        for key in ("command", "query", "path", "url", "pattern", "code"):
+            val = args.get(key)
+            if isinstance(val, str) and val.strip():
+                return val[:120]
+        # First short string value as fallback preview.
+        for val in args.values():
+            if isinstance(val, str) and val.strip():
+                return val[:120]
+        return None
+
+    def _fire_tool_progress(phase: str, params: dict) -> None:
+        """Emit tool.started / tool.completed via agent.tool_progress_callback.
+
+        Signature mirrors codex_runtime:
+          tool.started  → (event, name, preview, args)
+          tool.completed → (event, name, None, None, is_error=..., result=...)
+        """
+        cb = getattr(agent, "tool_progress_callback", None)
+        if cb is None:
+            return
+        name = params.get("name") or "unknown"
+        args = params.get("arguments") if isinstance(params.get("arguments"), dict) else {}
+        try:
+            if phase == "started":
+                cb("tool.started", name, _tool_preview(args), args)
+            else:
+                result = params.get("result")
+                result_text = (
+                    result
+                    if isinstance(result, str)
+                    else (str(result) if result is not None else "")
+                )
+                cb(
+                    "tool.completed",
+                    name,
+                    None,
+                    None,
+                    is_error=bool(params.get("is_error")),
+                    result=result_text,
+                )
+        except TypeError:
+            # Older callback signatures take fewer args — best-effort.
+            try:
+                cb("tool." + phase if not phase.startswith("tool.") else phase, name)
+            except Exception:
+                logger.debug("tool_progress_callback raised", exc_info=True)
+        except Exception:
+            logger.debug("tool_progress_callback raised", exc_info=True)
+
+    def on_event(note: dict) -> None:
+        if not isinstance(note, dict):
+            return
+        method = note.get("method") or ""
+        params = note.get("params") or {}
+        if not isinstance(params, dict):
+            params = {}
+        if method == "claude/text_delta":
+            _fire_text_delta(params)
+            return
+        if method == "claude/assistant_completed":
+            _fire_assistant_completed(params)
+            return
+        if method == "claude/tool_started":
+            _fire_tool_progress("started", params)
+            return
+        if method == "claude/tool_completed":
+            _fire_tool_progress("completed", params)
+            return
+
+    return on_event
+
+
+def _extract_system_prompt(agent, messages: List[Dict[str, Any]]) -> Optional[str]:
+    """Best-effort system prompt for --append-system-prompt-file."""
+    # Prefer an explicit agent-composed system message if present on the
+    # conversation (first system role), else agent.system_prompt / similar.
+    for msg in messages or []:
+        if isinstance(msg, dict) and msg.get("role") == "system":
+            content = msg.get("content")
+            if isinstance(content, str) and content.strip():
+                return content
+            if isinstance(content, list):
+                parts = []
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        parts.append(str(block.get("text") or ""))
+                    elif isinstance(block, str):
+                        parts.append(block)
+                joined = "\n".join(p for p in parts if p).strip()
+                if joined:
+                    return joined
+    for attr in ("system_prompt", "_system_prompt", "system_message"):
+        val = getattr(agent, attr, None)
+        if isinstance(val, str) and val.strip():
+            return val
+    return None
+
+
+def _retire_claude_cli_session(agent, reason: str = "") -> None:
+    """Close and drop agent._claude_cli_session (mirrors codex retire path)."""
+    session = getattr(agent, "_claude_cli_session", None)
+    if session is None:
+        return
+    if reason:
+        logger.warning("claude_cli session retired: %s", reason)
+    try:
+        session.close()
+    except Exception:
+        pass
+    agent._claude_cli_session = None
+
+
+def run_claude_cli_turn(
+    agent,
+    *,
+    user_message: str,
+    original_user_message: Any,
+    messages: List[Dict[str, Any]],
+    effective_task_id: str,
+    should_review_memory: bool = False,
+) -> Dict[str, Any]:
+    """Claude CLI runtime path. Hands one turn to ``claude -p``.
+
+    Called from conversation_loop when agent.api_mode == "claude_cli".
+    Returns the same dict shape as the chat_completions / codex_app_server path.
+
+    Phase 2b: reuses ``agent._claude_cli_session`` across turns (create on
+    first turn with ``--session-id``, resume later with ``--resume``) so
+    Claude retains conversation context. Mirrors codex app-server's
+    ``agent._codex_session`` lifetime.
+    """
+    from agent.transports.claude_cli import (
+        ClaudeCliConcurrencyError,
+        ClaudeCliError,
+    )
+    from agent.transports.claude_cli_session import (
+        ClaudeCliSession,
+        resolve_claude_cli_oauth_token,
+    )
+
+    try:
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
+    except Exception:
+        cwd = None
+
+    try:
+        token = resolve_claude_cli_oauth_token(agent=agent)
+    except ClaudeCliError as exc:
+        logger.exception("claude_cli token resolution failed")
+        return {
+            "final_response": str(exc),
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": True,
+            "error": str(exc),
+            "agent_persisted": False,
+        }
+
+    system_prompt = _extract_system_prompt(agent, messages)
+    model = getattr(agent, "model", None) or "claude-opus-4-8"
+    hermes_id = getattr(agent, "session_id", None)
+
+    # Lazy session: one ClaudeCliSession per AIAgent / Hermes conversation.
+    # Spawned (mapped) on first turn, reused across turns via --resume,
+    # closed on hard failure or agent.close (when wired).
+    if not hasattr(agent, "_claude_cli_session") or agent._claude_cli_session is None:
+        agent._claude_cli_session = ClaudeCliSession(
+            oauth_token=token,
+            model=model,
+            cwd=cwd,
+            on_event=make_claude_cli_event_bridge(agent),
+            hermes_conversation_id=hermes_id,
+        )
+    session = agent._claude_cli_session
+
+    try:
+        turn = session.run_turn(
+            user_input=user_message,
+            system_prompt=system_prompt,
+            model=model,
+            messages=messages,
+        )
+    except ClaudeCliConcurrencyError:
+        # Propagate so conversation_loop can activate the profile fallback
+        # (grok/gpt) instead of hanging or returning a dead partial turn.
+        # Do NOT retire the multi-turn mapping — saturation is transient.
+        raise
+    except ClaudeCliError as exc:
+        logger.exception("claude_cli turn failed")
+        _retire_claude_cli_session(agent, reason=str(exc)[:200])
+        # Surface a classifiable error string so the gateway/CLI show it and
+        # higher-level fallback (if any) can react. Re-raising would escape
+        # the early-return contract of conversation_loop; we return the same
+        # shape as codex_app_server crash path instead.
+        return {
+            "final_response": (
+                f"Claude CLI turn failed: {exc}. "
+                f"Fall back to default Anthropic HTTP with "
+                f"`model.anthropic_runtime: auto` (or unset)."
+            ),
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": True,
+            "error": str(exc),
+            "agent_persisted": False,
+        }
+    except Exception as exc:
+        logger.exception("claude_cli turn failed (unexpected)")
+        _retire_claude_cli_session(agent, reason=str(exc)[:200])
+        return {
+            "final_response": f"Claude CLI turn failed: {exc}",
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": True,
+            "error": str(exc),
+            "agent_persisted": False,
+        }
+
+    # Retire only when the turn signals the mapping is unusable (hard error
+    # path already retired above). Success keeps the session for --resume.
+    if getattr(turn, "should_retire", False):
+        _retire_claude_cli_session(
+            agent, reason=getattr(turn, "error", None) or "should_retire"
+        )
+
+    if turn.projected_messages:
+        messages.extend(turn.projected_messages)
+        if getattr(agent, "_session_db", None) is not None:
+            try:
+                agent._flush_messages_to_session_db(messages)
+            except Exception:
+                logger.debug(
+                    "claude_cli projected-message flush failed",
+                    exc_info=True,
+                )
+
+    usage_result = _record_claude_cli_usage(agent, turn)
+    api_calls = 1
+
+    # External memory provider sync (mirrors codex path).
+    if not turn.interrupted and turn.error is None:
+        try:
+            agent._sync_external_memory_for_turn(
+                original_user_message=original_user_message,
+                final_response=turn.final_text,
+                interrupted=False,
+                messages=messages,
+            )
+        except Exception:
+            logger.debug("external memory sync raised", exc_info=True)
+
+    if (
+        turn.final_text
+        and not turn.interrupted
+        and should_review_memory
+    ):
+        try:
+            agent._spawn_background_review(
+                messages_snapshot=list(messages),
+                review_memory=True,
+                review_skills=False,
+            )
+        except Exception:
+            logger.debug("background review spawn raised", exc_info=True)
+
+    return {
+        "final_response": turn.final_text,
+        "messages": messages,
+        "api_calls": api_calls,
+        "completed": not turn.interrupted and turn.error is None and not turn.is_error,
+        "partial": turn.interrupted or turn.error is not None or turn.is_error,
+        "error": turn.error,
+        "agent_persisted": True,
+        "claude_cli_session_id": turn.session_id,
+        "claude_cli_resumed": getattr(turn, "resumed", False),
+        "claude_cli_created_session": getattr(turn, "created_session", False),
+        "claude_cli_resume_fallback": getattr(turn, "resume_fallback", False),
+        **usage_result,
+    }
+
+
+__all__ = [
+    "run_claude_cli_turn",
+    "make_claude_cli_event_bridge",
+]

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1362,6 +1362,24 @@ def compress_context(
             if _codex_fence_entered:
                 commit_fence.finish_commit()
 
+    # claude_cli runtime: Claude Code owns native session compaction via
+    # ``--resume`` (same ownsNativeCompaction posture as OpenClaw). Hermes'
+    # HTTP aux compression would hit the Anthropic extra-usage path on a Max
+    # setup-token profile and only rewrite a local mirror that is not re-sent
+    # to ``claude -p``. Skip cleanly — no noisy aux failure.
+    if getattr(agent, "api_mode", None) == "claude_cli":
+        logger.info(
+            "claude_cli: skipping Hermes HTTP context compression "
+            "(Claude owns native session compaction via --resume)"
+        )
+        existing_prompt = getattr(agent, "_cached_system_prompt", None)
+        if not existing_prompt:
+            try:
+                existing_prompt = agent._build_system_prompt(system_message)
+            except Exception:
+                existing_prompt = system_message or ""
+        return messages, existing_prompt
+
     # Every automatic entrypoint must honor compressor-owned cooldown and
     # breaker state. Gateway hygiene constructs a fresh AIAgent, so the
     # persisted fallback streak is loaded by bind_session_state() before this.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1258,6 +1258,56 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
+    # Claude CLI runtime: if api_mode == claude_cli (explicit config or
+    # default-when-token), hand the turn to a `claude -p` subprocess
+    # (Anthropic Max subscription via setup token + clean env + Hermes MCP
+    # tools + multi-turn --resume). See agent/transports/claude_cli_session.py.
+    # Phase 2c: host-global concurrency cap may raise ClaudeCliConcurrencyError
+    # after a bounded wait — activate the profile fallback (grok/gpt) and fall
+    # through into the normal chat_completions / anthropic_messages loop.
+    if agent.api_mode == "claude_cli":
+        from agent.transports.claude_cli import ClaudeCliConcurrencyError
+
+        try:
+            return agent._run_claude_cli_turn(
+                user_message=user_message,
+                original_user_message=original_user_message,
+                messages=messages,
+                effective_task_id=effective_task_id,
+                should_review_memory=_should_review_memory,
+            )
+        except ClaudeCliConcurrencyError as _claude_conc_exc:
+            logger.warning(
+                "claude_cli concurrency saturated — trying fallback: %s",
+                _claude_conc_exc,
+            )
+            try:
+                agent._buffer_status(
+                    "⚠️ Claude CLI concurrency cap reached — switching to fallback..."
+                )
+            except Exception:
+                pass
+            if agent._try_activate_fallback(reason=FailoverReason.rate_limit):
+                # Fallback rewrote provider/model/api_mode; continue into the
+                # normal agent loop with the new backend.
+                pass
+            else:
+                return {
+                    "final_response": (
+                        f"Claude CLI concurrency cap reached and no fallback "
+                        f"provider is available: {_claude_conc_exc}. "
+                        f"Raise model.claude_cli.max_concurrent, free a running "
+                        f"session, or configure fallback_providers."
+                    ),
+                    "messages": messages,
+                    "api_calls": 0,
+                    "completed": False,
+                    "partial": True,
+                    "error": str(_claude_conc_exc),
+                    "agent_persisted": False,
+                    "claude_cli_concurrency_saturated": True,
+                }
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1870,9 +1870,15 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 
     Only works with regular ANTHROPIC_API_KEY (sk-ant-api*).
     OAuth tokens (sk-ant-oat*) from Claude Code return 401.
+
+    Failures are intentionally silent (debug only) — claude_cli Max profiles
+    use setup/OAuth tokens and must fall through to the hardcoded catalog
+    without spamming agent.log / the UI.
     """
-    if not api_key or api_key.startswith("sk-ant-oat"):
-        return None  # OAuth tokens can't access /v1/models
+    if not api_key or api_key.startswith("sk-ant-oat") or api_key.startswith("cc-"):
+        # OAuth / Claude Code setup tokens cannot query /v1/models; skip
+        # silently so claude_cli profiles don't log HTTP noise.
+        return None
     try:
         base = base_url.rstrip("/")
         if base.endswith("/v1"):
@@ -1884,6 +1890,11 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
         }
         resp = requests.get(url, headers=headers, timeout=(5, 10), verify=_resolve_requests_verify())
         if resp.status_code != 200:
+            logger.debug(
+                "Anthropic /v1/models query returned %s for model %r — using catalog",
+                resp.status_code,
+                model,
+            )
             return None
         data = resp.json()
         for m in data.get("data", []):

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -121,6 +121,19 @@ def generate_title(
         logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
         return None
 
+    # claude_cli profiles: main_runtime would route the tiny title call
+    # through Anthropic HTTP (extra-usage / OAuth), which fails noisily while
+    # the main turn already succeeded via `claude -p`. Prefer skip-with-
+    # clean-log over a failing HTTP aux (no auto-title is acceptable).
+    if isinstance(main_runtime, dict) and (
+        str(main_runtime.get("api_mode") or "").strip().lower() == "claude_cli"
+    ):
+        logger.info(
+            "Auto-title skipped: claude_cli runtime (no HTTP anthropic aux; "
+            "Claude owns the conversation session)"
+        )
+        return None
+
     if runtime_validator is not None:
         try:
             if not runtime_validator():

--- a/agent/transports/claude_cli.py
+++ b/agent/transports/claude_cli.py
@@ -1,0 +1,884 @@
+"""Claude CLI (`claude -p`) subprocess transport — Phase 2b multi-turn.
+
+Speaks Claude Code's print-mode stream-json protocol: spawn
+``claude -p --output-format stream-json ...``, feed a single user prompt,
+consume JSONL events from stdout until a terminal ``result`` event (or
+subprocess exit).
+
+Phase 2a Hermes MCP tool bridge (unchanged):
+  * ``--mcp-config`` pointing at ``hermes_tools_mcp_server`` (stdio)
+  * ``--allowedTools mcp__hermes-tools__*`` so Claude may call Hermes tools
+  * ``--disallowedTools`` for native Bash/Edit/Write/Read (Hermes tools
+    only for fs/exec — no double-agent). Do **not** pass ``--tools ""``:
+    that disables MCP tools too.
+  * Permission model: ``--permission-mode bypassPermissions`` only after
+    the allowlist/denylist has restricted the surface to Hermes MCP tools
+    (replaces Phase 1's unrestricted ``--dangerously-skip-permissions``)
+
+Phase 2b multi-turn (OpenClaw/codex-style session resume):
+  * First turn in a Hermes conversation: ``--session-id <uuid>`` so Claude
+    persists a named session under ``~/.claude/projects/<cwd-encoded>/``.
+  * Subsequent turns: ``--resume <uuid>`` + only the new user message;
+    Claude owns prior history + native compaction.
+  * Never pass ``--no-session-persistence`` — resume requires disk files.
+  * Stable ``cwd`` across turns so session files resolve.
+
+Tool round-trip is **internal to** ``claude -p``: Claude spawns the MCP
+server, executes Hermes tools via stdio MCP, and streams tool_use /
+tool_result events on stdout. Hermes hosts the server + projects those
+events into the UI; the runtime does **not** proxy tool calls.
+
+Per-turn wire shape remains positional prompt + stdin=DEVNULL; multi-turn
+context is carried by Claude's session, not by replaying Hermes history.
+
+Clean-env + non-rotating setup token model is unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterator, Optional
+
+
+# ---------------------------------------------------------------------------
+# Clean env for Claude Code subprocess
+# ---------------------------------------------------------------------------
+#
+# Confirmed (live step-0 test 2026-07-19): Claude Code injects pollution
+# (ANTHROPIC_BASE_URL, ANTHROPIC_*, CLAUDE_CODE_*, CLAUDECODE, ...) into the
+# parent shell when Hermes is itself driven by Claude. A subprocess that
+# inherits that env hits the wrong endpoint / wrong auth. The rotating
+# ~/.claude OAuth login also fails from a subprocess ("OAuth session expired
+# and could not be refreshed"). The NON-rotating setup token (sk-ant-oat)
+# injected as CLAUDE_CODE_OAUTH_TOKEN into a clean env bills against base Max.
+#
+# Mirrors OpenClaw's CLAUDE_CLI_CLEAR_ENV approach: start from an allowlist
+# of identity/path vars, never copy the polluted parent env wholesale.
+
+# Exact names that must never reach the child (even if present in allowlist).
+CLAUDE_CLI_CLEAR_ENV_NAMES: frozenset[str] = frozenset(
+    {
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_TOKEN",
+        "ANTHROPIC_API_URL",
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_SMALL_FAST_MODEL",
+        "CLAUDECODE",
+        "CLAUDE_CODE_OAUTH_TOKEN",  # re-injected from the resolved setup token
+        "CLAUDE_CODE_ENTRYPOINT",
+        "CLAUDE_CODE_SESSION",
+        "CLAUDE_CODE_SSE_PORT",
+        "CLAUDE_AGENT_SDK_VERSION",
+        "CLAUDE_EFFORT",
+        "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
+        "CLAUDE_CODE_SIMPLE",
+        "CLAUDE_CODE_SAFE_MODE",
+    }
+)
+
+# Prefixes scrubbed from any env we start from (parent pollution set).
+CLAUDE_CLI_CLEAR_ENV_PREFIXES: tuple[str, ...] = (
+    "ANTHROPIC_",
+    "CLAUDE_CODE_",
+    "CLAUDE_PREVIEW_",
+    "CLAUDE_AGENT_",
+)
+
+# Identity / path vars kept from the parent so the child can resolve home,
+# binaries, and temp dirs. Everything else is dropped (env -i style).
+CLAUDE_CLI_KEEP_ENV: frozenset[str] = frozenset(
+    {
+        "HOME",
+        "PATH",
+        "USER",
+        "LOGNAME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TERM",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "SHELL",
+        "XDG_RUNTIME_DIR",
+        "XDG_CACHE_HOME",
+        "XDG_CONFIG_HOME",
+        # macOS keychain / locale helpers Claude Code may need for process
+        # startup (NOT for OAuth — we inject the setup token explicitly).
+        "SSH_AUTH_SOCK",
+    }
+)
+
+
+def _is_pollution_key(key: str) -> bool:
+    if key in CLAUDE_CLI_CLEAR_ENV_NAMES:
+        return True
+    if key == "CLAUDECODE":
+        return True
+    if key.startswith("CLAUDE_EFFORT"):
+        return True
+    for prefix in CLAUDE_CLI_CLEAR_ENV_PREFIXES:
+        if key.startswith(prefix):
+            return True
+    return False
+
+
+def build_claude_cli_clean_env(
+    *,
+    oauth_token: str,
+    base_env: Optional[dict[str, str]] = None,
+    extra: Optional[dict[str, str]] = None,
+) -> dict[str, str]:
+    """Build a clean env for ``claude -p`` with the setup token injected.
+
+    Starts from ``base_env`` (default: ``os.environ``) but only keeps the
+    allowlisted identity/path vars. Strips every Claude-Code / Anthropic
+    pollution key, then injects ``CLAUDE_CODE_OAUTH_TOKEN=<oauth_token>``.
+
+    Never reads or forwards the rotating ``~/.claude`` OAuth login — that
+    fails from a subprocess. The setup token (sk-ant-oat) is non-rotating
+    and fork-safe.
+    """
+    if not oauth_token or not str(oauth_token).strip():
+        raise ValueError(
+            "claude_cli clean env requires a non-empty setup token "
+            "(CLAUDE_CODE_OAUTH_TOKEN / resolve_anthropic_token)"
+        )
+    source = base_env if base_env is not None else os.environ
+    clean: dict[str, str] = {}
+    for key in CLAUDE_CLI_KEEP_ENV:
+        val = source.get(key)
+        if val is None or val == "":
+            continue
+        if _is_pollution_key(key):
+            continue
+        clean[key] = str(val)
+    # Hard-strip any pollution that snuck into the keep set (defensive).
+    for key in list(clean):
+        if _is_pollution_key(key):
+            clean.pop(key, None)
+    clean["CLAUDE_CODE_OAUTH_TOKEN"] = str(oauth_token).strip()
+    if extra:
+        for k, v in extra.items():
+            if v is None:
+                continue
+            if _is_pollution_key(k) and k != "CLAUDE_CODE_OAUTH_TOKEN":
+                continue
+            clean[str(k)] = str(v)
+    return clean
+
+
+def resolve_claude_bin(explicit: Optional[str] = None) -> str:
+    """Locate the ``claude`` binary. Prefer explicit path, then PATH, then ~/.local/bin."""
+    if explicit:
+        return explicit
+    found = shutil.which("claude")
+    if found:
+        return found
+    fallback = os.path.expanduser("~/.local/bin/claude")
+    if os.path.isfile(fallback) and os.access(fallback, os.X_OK):
+        return fallback
+    return "claude"
+
+
+# ---------------------------------------------------------------------------
+# Hermes MCP tool bridge (Phase 2a)
+# ---------------------------------------------------------------------------
+#
+# Mirrors hermes_cli.codex_runtime_plugin_migration._build_hermes_tools_mcp_entry
+# for the Claude CLI ``--mcp-config`` JSON shape. Claude spawns the MCP server
+# as a stdio child and owns the full tool round-trip; Hermes only hosts the
+# server process and projects tool events from stream-json.
+
+from agent.transports.hermes_tools_mcp_server import (  # noqa: E402
+    AGENT_LOOP_TOOLS_EXCLUDED,
+    CLAUDE_EXPOSED_TOOLS,
+    MCP_SERVER_NAME,
+    get_exposed_tools,
+)
+
+# Claude Code prefixes MCP tools as mcp__<server>__<tool>.
+# Server name "hermes-tools" → mcp__hermes-tools__terminal, etc.
+HERMES_MCP_TOOL_PREFIX = f"mcp__{MCP_SERVER_NAME}__"
+HERMES_MCP_ALLOWED_TOOLS_GLOB = f"{HERMES_MCP_TOOL_PREFIX}*"
+
+# Claude native filesystem / exec / search tools that MUST NOT freestyle
+# the real filesystem. Hermes tools (via MCP) replace these.
+CLAUDE_NATIVE_FS_EXEC_TOOLS: tuple[str, ...] = (
+    "Bash",
+    "Edit",
+    "Write",
+    "Read",
+    "Glob",
+    "Grep",
+    "NotebookEdit",
+    "MultiEdit",
+    "WebSearch",
+    "WebFetch",
+    # Agent / task spawning that could bypass Hermes tooling.
+    "Task",
+    "TodoWrite",
+    "TodoRead",
+    "Skill",
+)
+
+# Default permission mode once the surface is restricted to Hermes MCP tools.
+# bypassPermissions auto-allows the allowlisted MCP tools headlessly without
+# re-opening the full native tool surface (those stay disallowed).
+#
+# IMPORTANT: do NOT pass ``--tools ""``. Claude Code treats that as "disable
+# all tools" — including MCP tools — so Hermes tools never appear and the
+# model only narrates. Rely on --allowedTools / --disallowedTools alone.
+CLAUDE_CLI_PERMISSION_MODE = "bypassPermissions"
+
+# Default max agentic turns for a tool-using print-mode session.
+CLAUDE_CLI_DEFAULT_MAX_TURNS = 40
+
+
+def _looks_like_test_tempdir(path: str) -> bool:
+    """Heuristic: refuse to bake a pytest tempdir into MCP env."""
+    if not path:
+        return False
+    needles = (
+        "pytest-of-",
+        "/pytest-",
+        "/tmp/pytest",
+        "/private/var/folders/",
+    )
+    normalized = path.lower()
+    return any(needle in normalized for needle in needles)
+
+
+def resolve_hermes_repo_root() -> str:
+    """Repo root containing ``agent/transports/`` (this file's parents)."""
+    return str(Path(__file__).resolve().parents[2])
+
+
+def resolve_mcp_python_executable(explicit: Optional[str] = None) -> str:
+    """Python that can import ``mcp`` + this worktree's Hermes packages.
+
+    Claude spawns the MCP server with only the env we put in ``mcp-config``.
+    Using a *resolved* base-interpreter path (``Path.resolve()`` on a venv
+    symlink, or a bare Homebrew python) drops site-packages and the server
+    dies with ``No module named 'mcp'``. Prefer ``sys.executable`` as-is so
+    venv activation via argv[0] still works, and never realpath the venv.
+    """
+    if explicit:
+        return explicit
+    # sys.executable is already the active interpreter path Hermes is on.
+    # Keep it verbatim — do not os.path.realpath / Path.resolve.
+    return sys.executable or "python3"
+
+
+def _venv_site_packages(python_executable: str) -> Optional[str]:
+    """Best-effort site-packages dir for a venv python path."""
+    try:
+        exe = Path(python_executable)
+        # .../.venv/bin/python → .../.venv/lib/pythonX.Y/site-packages
+        venv_root = exe.parent.parent
+        if not (venv_root / "pyvenv.cfg").is_file():
+            # Active interpreter may be a venv even if command path differs.
+            if getattr(sys, "prefix", None) and sys.prefix != getattr(
+                sys, "base_prefix", sys.prefix
+            ):
+                venv_root = Path(sys.prefix)
+            else:
+                return None
+        lib = venv_root / "lib"
+        if not lib.is_dir():
+            return None
+        for child in sorted(lib.iterdir()):
+            if child.name.startswith("python"):
+                site = child / "site-packages"
+                if site.is_dir():
+                    return str(site)
+    except Exception:
+        return None
+    return None
+
+
+def build_hermes_tools_mcp_server_entry(
+    *,
+    profile: str = "claude",
+    hermes_home: Optional[str] = None,
+    python_executable: Optional[str] = None,
+    pythonpath: Optional[str] = None,
+    extra_env: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
+    """Build one Claude ``mcpServers.<name>`` stdio entry for hermes-tools.
+
+    Mirrors codex's ``_build_hermes_tools_mcp_entry`` but returns the JSON
+    shape Claude's ``--mcp-config`` expects (command/args/env).
+    """
+    env: dict[str, str] = {}
+
+    hh = hermes_home if hermes_home is not None else (os.environ.get("HERMES_HOME") or "")
+    if hh and _looks_like_test_tempdir(hh):
+        hh = ""
+    if hh:
+        env["HERMES_HOME"] = hh
+
+    py = resolve_mcp_python_executable(python_executable)
+
+    # Ensure the MCP child can import this worktree's agent package AND the
+    # active venv's site-packages (mcp SDK, hermes deps). Claude replaces the
+    # child env with only this dict — belt-and-suspenders PYTHONPATH.
+    pp_parts: list[str] = []
+    if pythonpath is not None:
+        if pythonpath:
+            pp_parts.append(pythonpath)
+    else:
+        existing = os.environ.get("PYTHONPATH") or ""
+        if existing:
+            pp_parts.append(existing)
+    repo_root = resolve_hermes_repo_root()
+    if repo_root and repo_root not in pp_parts:
+        # Prepend so worktree modules win over any installed package.
+        pp_parts.insert(0, repo_root)
+    site_pkgs = _venv_site_packages(py)
+    if site_pkgs and site_pkgs not in pp_parts:
+        # After repo root so local modules still win, but before system paths.
+        insert_at = 1 if pp_parts and pp_parts[0] == repo_root else 0
+        pp_parts.insert(insert_at, site_pkgs)
+    if pp_parts:
+        env["PYTHONPATH"] = os.pathsep.join(pp_parts)
+
+    # Preserve venv marker when Hermes itself is running inside one so child
+    # tools that re-exec python inherit the same environment.
+    if getattr(sys, "prefix", None) and sys.prefix != getattr(
+        sys, "base_prefix", sys.prefix
+    ):
+        env.setdefault("VIRTUAL_ENV", sys.prefix)
+
+    env["HERMES_QUIET"] = "1"
+    env["HERMES_REDACT_SECRETS"] = "true"
+    env["HERMES_TOOLS_MCP_PROFILE"] = (profile or "claude").strip().lower()
+    # Fail-fast browser CDP probes during MCP server import (saves ~1s of
+    # connection latency that races Claude's first tool_use).
+    env.setdefault("BROWSER_CDP_URL", "")
+
+    # Identity/path for terminal tool + child processes.
+    for key in ("HOME", "PATH", "USER", "LOGNAME", "TMPDIR", "TMP", "TEMP", "SHELL", "LANG", "LC_ALL"):
+        val = os.environ.get(key)
+        if val:
+            env[key] = val
+
+    if extra_env:
+        for k, v in extra_env.items():
+            if v is not None:
+                env[str(k)] = str(v)
+
+    return {
+        "command": py,
+        "args": ["-m", "agent.transports.hermes_tools_mcp_server"],
+        "env": env,
+    }
+
+
+def build_hermes_mcp_config(
+    *,
+    profile: str = "claude",
+    hermes_home: Optional[str] = None,
+    python_executable: Optional[str] = None,
+    pythonpath: Optional[str] = None,
+    extra_env: Optional[dict[str, str]] = None,
+    server_name: str = MCP_SERVER_NAME,
+) -> dict[str, Any]:
+    """Full Claude ``--mcp-config`` JSON object (``mcpServers`` wrapper)."""
+    entry = build_hermes_tools_mcp_server_entry(
+        profile=profile,
+        hermes_home=hermes_home,
+        python_executable=python_executable,
+        pythonpath=pythonpath,
+        extra_env=extra_env,
+    )
+    return {"mcpServers": {server_name: entry}}
+
+
+def write_hermes_mcp_config_file(
+    config: Optional[dict[str, Any]] = None,
+    *,
+    path: Optional[str] = None,
+    **kwargs: Any,
+) -> str:
+    """Serialize MCP config JSON to a temp (or given) file; return path."""
+    cfg = config if config is not None else build_hermes_mcp_config(**kwargs)
+    if path is None:
+        fd, path = tempfile.mkstemp(prefix="hermes-claude-mcp-", suffix=".json")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(cfg, fh, indent=2)
+    else:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(cfg, fh, indent=2)
+    return path
+
+
+def hermes_mcp_allowed_tools(
+    *,
+    server_name: str = MCP_SERVER_NAME,
+    tool_names: Optional[tuple[str, ...]] = None,
+    use_glob: bool = True,
+) -> list[str]:
+    """Claude ``--allowedTools`` values for the Hermes MCP surface."""
+    if use_glob:
+        return [f"mcp__{server_name}__*"]
+    names = tool_names if tool_names is not None else get_exposed_tools("claude")
+    return [f"mcp__{server_name}__{n}" for n in names]
+
+
+def claude_native_disallowed_tools() -> list[str]:
+    """Claude native tools blocked so the model must use Hermes MCP tools."""
+    return list(CLAUDE_NATIVE_FS_EXEC_TOOLS)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClaudeCliError(RuntimeError):
+    """Raised on claude_cli runtime failures (is_error result, timeout, exit).
+
+    Message is shaped so Hermes' existing ``classify_api_error`` / fallback
+    path can treat it like any other provider failure when the turn runner
+    re-raises.
+    """
+
+    message: str
+    is_error: bool = True
+    exit_code: Optional[int] = None
+    stderr_tail: str = ""
+    result_event: Optional[dict[str, Any]] = None
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        base = self.message
+        if self.exit_code is not None:
+            base = f"{base} (exit={self.exit_code})"
+        if self.stderr_tail:
+            base = f"{base}\nclaude stderr (tail):\n{self.stderr_tail}"
+        return base
+
+
+@dataclass
+class ClaudeCliConcurrencyError(ClaudeCliError):
+    """Host-wide ``claude -p`` concurrency cap saturated after wait timeout.
+
+    Conversation loop treats this as classifiable saturation (rate_limit-
+    flavoured) and activates the profile's fallback chain (grok/gpt) rather
+    than hanging or spawning past the cap. See
+    ``agent.transports.claude_cli_concurrency``.
+    """
+
+    max_concurrent: Optional[int] = None
+    timeout_seconds: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# Client: spawn one `claude -p` and stream JSONL
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClaudeCliSpawnConfig:
+    """Args for a single ``claude -p`` invocation (Phase 2a MCP + 2b session)."""
+
+    model: str
+    prompt: str
+    system_prompt: Optional[str] = None
+    claude_bin: str = "claude"
+    cwd: Optional[str] = None
+    # Phase 2a: Hermes MCP bridge (default on). When False, reverts to a
+    # pure-text skeleton without tools (legacy Phase 1 behaviour minus
+    # dangerously-skip-permissions).
+    enable_hermes_mcp: bool = True
+    mcp_config_path: Optional[str] = None
+    mcp_config: Optional[dict[str, Any]] = None
+    allowed_tools: Optional[list[str]] = None
+    disallowed_tools: Optional[list[str]] = None
+    # None (default): do NOT pass --tools. Claude's ``--tools ""`` disables
+    # *all* tools including MCP, which is what broke Phase 2a tool execution.
+    # Pass a non-None string only for explicit built-in-tool allowlists in tests.
+    tools_override: Optional[str] = None
+    permission_mode: str = CLAUDE_CLI_PERMISSION_MODE
+    # Phase 1 flag — kept for tests/back-compat but ignored when MCP is on.
+    # When MCP is off, we still refuse to use dangerously-skip-permissions
+    # by default (permission_mode handles headless allow).
+    dangerously_skip_permissions: bool = False
+    setting_sources: str = "user"
+    strict_mcp_config: bool = True
+    max_turns: int = CLAUDE_CLI_DEFAULT_MAX_TURNS
+    timeout_seconds: float = 600.0
+    extra_args: Optional[list[str]] = None
+    hermes_mcp_profile: str = "claude"
+    # Phase 2b multi-turn session (Claude Code 2.1.x):
+    #   create: ``--session-id <uuid>`` (must be a valid UUID)
+    #   resume: ``--resume <uuid>`` (mutually exclusive with session_id)
+    # Never pass ``--no-session-persistence`` — resume needs disk files.
+    session_id: Optional[str] = None
+    resume: Optional[str] = None
+
+
+class ClaudeCliClient:
+    """Spawn ``claude -p`` once and yield stream-json events from stdout.
+
+    Threading model matches codex_app_server: caller drives the turn
+    synchronously; a stderr reader thread captures diagnostics; stdout is
+    read on the caller thread as a line iterator.
+    """
+
+    def __init__(
+        self,
+        *,
+        oauth_token: str,
+        env: Optional[dict[str, str]] = None,
+        claude_bin: Optional[str] = None,
+    ) -> None:
+        self._oauth_token = oauth_token
+        self._claude_bin = resolve_claude_bin(claude_bin)
+        self._env = env or build_claude_cli_clean_env(oauth_token=oauth_token)
+        self._proc: Optional[subprocess.Popen] = None
+        self._stderr_lines: list[str] = []
+        self._stderr_lock = threading.Lock()
+        self._system_prompt_file: Optional[str] = None
+        self._mcp_config_file: Optional[str] = None
+        self._owned_mcp_config_file = False
+        self._closed = False
+
+    # ---------- build argv ----------
+
+    def build_argv(self, cfg: ClaudeCliSpawnConfig) -> list[str]:
+        """Construct the ``claude -p`` argv for a Hermes-MCP (+ multi-turn) turn."""
+        bin_path = resolve_claude_bin(cfg.claude_bin or self._claude_bin)
+        argv = [
+            bin_path,
+            "-p",
+            "--model",
+            cfg.model,
+            "--output-format",
+            "stream-json",
+            "--include-partial-messages",
+            "--verbose",
+            "--setting-sources",
+            cfg.setting_sources or "user",
+        ]
+
+        if cfg.max_turns and cfg.max_turns > 0:
+            argv.extend(["--max-turns", str(int(cfg.max_turns))])
+
+        # --- Phase 2b session create / resume (OpenClaw sessionMode: always) ---
+        # Resume and session-id are mutually exclusive. Prefer resume when both
+        # are set so a caller can't accidentally fork a new empty session.
+        resume_id = (cfg.resume or "").strip() or None
+        create_id = (cfg.session_id or "").strip() or None
+        if resume_id:
+            argv.extend(["--resume", resume_id])
+        elif create_id:
+            argv.extend(["--session-id", create_id])
+        # Intentionally never pass --no-session-persistence.
+
+        # --- Permission model (replaces --dangerously-skip-permissions) ---
+        # With Hermes MCP on: restrict to MCP allowlist, block native fs/exec,
+        # and use a headless permission mode that auto-allows the allowlisted
+        # Hermes tools only.
+        if cfg.enable_hermes_mcp:
+            mcp_path = cfg.mcp_config_path
+            if not mcp_path:
+                # Materialize config now so argv is self-contained.
+                mcp_path = write_hermes_mcp_config_file(
+                    cfg.mcp_config,
+                    profile=cfg.hermes_mcp_profile,
+                )
+                self._mcp_config_file = mcp_path
+                self._owned_mcp_config_file = True
+            else:
+                self._mcp_config_file = mcp_path
+                self._owned_mcp_config_file = False
+
+            argv.extend(["--mcp-config", mcp_path])
+            if cfg.strict_mcp_config:
+                argv.append("--strict-mcp-config")
+
+            allowed = cfg.allowed_tools
+            if allowed is None:
+                allowed = hermes_mcp_allowed_tools()
+            if allowed:
+                # Claude accepts space-separated tool specs after the flag.
+                argv.append("--allowedTools")
+                argv.extend(list(allowed))
+
+            disallowed = cfg.disallowed_tools
+            if disallowed is None:
+                disallowed = claude_native_disallowed_tools()
+            if disallowed:
+                argv.append("--disallowedTools")
+                argv.extend(list(disallowed))
+
+            # Optional built-in tool allowlist. Default None — never pass
+            # ``--tools ""`` (that drops MCP tools too; confirmed 2026-07-19).
+            if cfg.tools_override is not None:
+                argv.extend(["--tools", cfg.tools_override])
+
+            if cfg.permission_mode:
+                argv.extend(["--permission-mode", cfg.permission_mode])
+        else:
+            # Pure-text path: still avoid dangerously-skip-permissions unless
+            # explicitly requested for a legacy test harness.
+            if cfg.dangerously_skip_permissions:
+                argv.append("--dangerously-skip-permissions")
+            elif cfg.permission_mode:
+                argv.extend(["--permission-mode", cfg.permission_mode])
+
+        if cfg.system_prompt:
+            # Prefer file form so large Hermes system prompts don't blow argv.
+            fd, path = tempfile.mkstemp(prefix="hermes-claude-sys-", suffix=".txt")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    fh.write(cfg.system_prompt)
+                self._system_prompt_file = path
+                argv.extend(["--append-system-prompt-file", path])
+            except Exception:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+                self._system_prompt_file = None
+                # Fallback: inline (may truncate on very large prompts).
+                argv.extend(["--append-system-prompt", cfg.system_prompt])
+        if cfg.extra_args:
+            argv.extend(cfg.extra_args)
+        # Positional prompt last (claude -p "<prompt>").
+        argv.append(cfg.prompt)
+        return argv
+
+    # ---------- lifecycle ----------
+
+    def spawn(self, cfg: ClaudeCliSpawnConfig) -> subprocess.Popen:
+        """Start the subprocess. Caller reads stdout via ``iter_stdout_lines``."""
+        if self._proc is not None:
+            raise RuntimeError("claude_cli client already has a live subprocess")
+        argv = self.build_argv(cfg)
+        cwd = cfg.cwd or tempfile.mkdtemp(prefix="hermes-claude-cli-")
+        self._proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=cwd,
+            env=self._env,
+            bufsize=0,
+        )
+        self._stderr_reader = threading.Thread(
+            target=self._read_stderr, daemon=True
+        )
+        self._stderr_reader.start()
+        return self._proc
+
+    def _read_stderr(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stderr is None:
+            return
+        try:
+            for raw in iter(proc.stderr.readline, b""):
+                try:
+                    line = raw.decode("utf-8", errors="replace").rstrip("\n")
+                except Exception:
+                    continue
+                with self._stderr_lock:
+                    self._stderr_lines.append(line)
+                    # Cap buffer so a noisy child cannot unbounded-grow memory.
+                    if len(self._stderr_lines) > 400:
+                        self._stderr_lines = self._stderr_lines[-200:]
+        except Exception:
+            pass
+
+    def stderr_tail(self, n: int = 20) -> list[str]:
+        with self._stderr_lock:
+            return list(self._stderr_lines[-n:])
+
+    def iter_stdout_lines(self, *, timeout: float = 600.0) -> Iterator[str]:
+        """Yield decoded stdout lines until EOF or timeout.
+
+        On timeout the subprocess is kill()'d and a ClaudeCliError is raised.
+        """
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            raise RuntimeError("claude_cli client not spawned")
+        deadline = time.monotonic() + timeout
+        # Blocking readline on a pipe cannot be interrupted by a pure-Python
+        # deadline without a reader thread. Use a small helper thread + queue
+        # so we can kill the child when the watchdog fires.
+        import queue as _queue
+
+        q: _queue.Queue = _queue.Queue()
+        sentinel = object()
+
+        def _reader() -> None:
+            try:
+                for raw in iter(proc.stdout.readline, b""):
+                    try:
+                        line = raw.decode("utf-8", errors="replace")
+                    except Exception:
+                        continue
+                    q.put(line)
+            finally:
+                q.put(sentinel)
+
+        t = threading.Thread(target=_reader, daemon=True)
+        t.start()
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self.kill()
+                tail = "\n".join(self.stderr_tail(20))
+                raise ClaudeCliError(
+                    message=(
+                        f"claude_cli turn timed out after {timeout:.0f}s"
+                    ),
+                    exit_code=None,
+                    stderr_tail=tail,
+                )
+            try:
+                item = q.get(timeout=min(0.5, remaining))
+            except _queue.Empty:
+                # Child died without more output?
+                if proc.poll() is not None and q.empty():
+                    break
+                continue
+            if item is sentinel:
+                break
+            yield item  # type: ignore[misc]
+
+    def wait(self, timeout: float = 5.0) -> int:
+        proc = self._proc
+        if proc is None:
+            return 0
+        try:
+            return int(proc.wait(timeout=timeout))
+        except subprocess.TimeoutExpired:
+            self.kill()
+            return int(proc.poll() or -1)
+
+    def kill(self) -> None:
+        proc = self._proc
+        if proc is None:
+            return
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=2.0)
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.kill()
+        if self._system_prompt_file:
+            try:
+                os.unlink(self._system_prompt_file)
+            except OSError:
+                pass
+            self._system_prompt_file = None
+        if self._owned_mcp_config_file and self._mcp_config_file:
+            try:
+                os.unlink(self._mcp_config_file)
+            except OSError:
+                pass
+            self._mcp_config_file = None
+            self._owned_mcp_config_file = False
+
+    def __enter__(self) -> "ClaudeCliClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# Stream-json line decode helper (used by projector + tests)
+# ---------------------------------------------------------------------------
+
+
+def parse_stream_json_line(line: str) -> Optional[dict[str, Any]]:
+    """Parse one stdout line as a stream-json event. Returns None for blanks/noise."""
+    text = (line or "").strip()
+    if not text:
+        return None
+    # Claude may occasionally emit non-JSON diagnostic lines when --verbose.
+    if not text.startswith("{"):
+        return None
+    try:
+        obj = json.loads(text)
+    except Exception:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    return obj
+
+
+def strip_hermes_mcp_tool_prefix(name: str) -> str:
+    """Map ``mcp__hermes-tools__terminal`` → ``terminal`` for UI display."""
+    if not isinstance(name, str) or not name:
+        return name or "unknown"
+    prefix = HERMES_MCP_TOOL_PREFIX
+    if name.startswith(prefix):
+        return name[len(prefix):] or name
+    # Generic mcp__server__tool
+    if name.startswith("mcp__"):
+        parts = name.split("__", 2)
+        if len(parts) == 3 and parts[2]:
+            return parts[2]
+    return name
+
+
+__all__ = [
+    "AGENT_LOOP_TOOLS_EXCLUDED",
+    "CLAUDE_CLI_CLEAR_ENV_NAMES",
+    "CLAUDE_CLI_CLEAR_ENV_PREFIXES",
+    "CLAUDE_CLI_DEFAULT_MAX_TURNS",
+    "CLAUDE_CLI_KEEP_ENV",
+    "CLAUDE_CLI_PERMISSION_MODE",
+    "CLAUDE_EXPOSED_TOOLS",
+    "CLAUDE_NATIVE_FS_EXEC_TOOLS",
+    "ClaudeCliClient",
+    "ClaudeCliConcurrencyError",
+    "ClaudeCliError",
+    "ClaudeCliSpawnConfig",
+    "HERMES_MCP_ALLOWED_TOOLS_GLOB",
+    "HERMES_MCP_TOOL_PREFIX",
+    "MCP_SERVER_NAME",
+    "build_claude_cli_clean_env",
+    "build_hermes_mcp_config",
+    "build_hermes_tools_mcp_server_entry",
+    "claude_native_disallowed_tools",
+    "hermes_mcp_allowed_tools",
+    "parse_stream_json_line",
+    "resolve_claude_bin",
+    "resolve_hermes_repo_root",
+    "resolve_mcp_python_executable",
+    "strip_hermes_mcp_tool_prefix",
+    "write_hermes_mcp_config_file",
+]

--- a/agent/transports/claude_cli_concurrency.py
+++ b/agent/transports/claude_cli_concurrency.py
@@ -1,0 +1,621 @@
+"""Host-global cross-process concurrency cap for ``claude -p`` spawns.
+
+Hermes profiles/gateways run as separate processes and this host may also run
+other Claude Code consumers on the same Max login (for example OpenClaw or
+other local Claude Code sessions). Hermes can only cap **its own** concurrent
+``claude -p`` children — leave headroom for the rest of the host.
+
+Mechanism mirrors ``hermes_cli.active_sessions`` (JSON registry + advisory
+``fcntl``/``msvcrt`` file lock) but:
+
+  * Lives under the **host-global** shared root
+    (``~/.hermes/shared/claude_cli_slots/`` via
+    :func:`hermes_constants.get_default_hermes_root`), not per-profile
+    ``HERMES_HOME``, so every Hermes profile/process shares one pool.
+  * **Waits** (bounded) when saturated, then raises
+    :class:`ClaudeCliConcurrencyError` so the conversation loop can
+    activate the profile's fallback chain (grok/gpt) instead of hanging.
+
+Config (user-facing ``config.yaml``)::
+
+    model:
+      claude_cli:
+        max_concurrent: 3                 # default 3; 0/null = unbounded
+        acquire_timeout_seconds: 45       # wait then fall back
+
+Internal env bridge (not user-facing docs; tests / emergency override)::
+
+    HERMES_CLAUDE_CLI_MAX_CONCURRENT
+    HERMES_CLAUDE_CLI_ACQUIRE_TIMEOUT
+    HERMES_CLAUDE_CLI_SLOT_DIR   # redirect store (required under pytest)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Defaults — leave headroom on a Max login shared with other Claude Code consumers.
+DEFAULT_MAX_CONCURRENT = 3
+DEFAULT_ACQUIRE_TIMEOUT_SECONDS = 45.0
+_POLL_INTERVAL_SECONDS = 0.15
+_STALE_MAX_AGE_SECONDS = 6 * 3600  # hard reap even if pid looks alive
+
+# Slot registry filename under the shared dir.
+_STATE_FILENAME = "slots.json"
+_LOCK_FILENAME = "slots.lock"
+
+# Sentinel so callers can pass max_concurrent=None to mean "unbounded"
+# without it being confused with "use config default".
+_MISSING: Any = object()
+
+
+# ---------------------------------------------------------------------------
+# Config resolution (config.yaml user-facing; env = internal bridge)
+# ---------------------------------------------------------------------------
+
+
+def _coerce_positive_int(value: Any, *, default: int, key: str) -> int:
+    if value is None or value == "":
+        return default
+    if isinstance(value, bool):
+        logger.warning("Ignoring invalid %s=%r (expected positive int)", key, value)
+        return default
+    try:
+        if isinstance(value, float):
+            if not value.is_integer():
+                raise ValueError(value)
+            parsed = int(value)
+        elif isinstance(value, str):
+            parsed = int(value.strip(), 10)
+        else:
+            parsed = int(value)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid %s=%r (expected positive int)", key, value)
+        return default
+    return parsed
+
+
+def _coerce_nonneg_float(value: Any, *, default: float, key: str) -> float:
+    if value is None or value == "":
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid %s=%r (expected number)", key, value)
+        return default
+    if parsed < 0:
+        return default
+    return parsed
+
+
+def _load_model_claude_cli_cfg() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        model = cfg.get("model")
+        if not isinstance(model, dict):
+            return {}
+        section = model.get("claude_cli")
+        return section if isinstance(section, dict) else {}
+    except Exception:
+        logger.debug("claude_cli concurrency: config load failed", exc_info=True)
+        return {}
+
+
+def resolve_claude_cli_max_concurrent(
+    override: Optional[int] = None,
+) -> Optional[int]:
+    """Return the concurrent ``claude -p`` cap, or None when unbounded.
+
+    Priority: explicit override → ``HERMES_CLAUDE_CLI_MAX_CONCURRENT`` →
+    ``model.claude_cli.max_concurrent`` → default 3.
+
+    ``0`` / negative in config or env means unbounded (disabled).
+    """
+    if override is not None:
+        n = int(override)
+        return None if n <= 0 else n
+
+    env_raw = (os.environ.get("HERMES_CLAUDE_CLI_MAX_CONCURRENT") or "").strip()
+    if env_raw:
+        try:
+            n = int(env_raw, 10)
+            return None if n <= 0 else n
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid HERMES_CLAUDE_CLI_MAX_CONCURRENT=%r", env_raw
+            )
+
+    section = _load_model_claude_cli_cfg()
+    if "max_concurrent" in section:
+        raw = section.get("max_concurrent")
+        if raw is None:
+            return DEFAULT_MAX_CONCURRENT
+        n = _coerce_positive_int(
+            raw, default=DEFAULT_MAX_CONCURRENT, key="model.claude_cli.max_concurrent"
+        )
+        # 0 from user means unbounded; _coerce_positive_int would return
+        # default for invalid, so handle 0 explicitly.
+        try:
+            parsed = int(raw)
+            if parsed <= 0:
+                return None
+            return parsed
+        except (TypeError, ValueError):
+            return n if n > 0 else DEFAULT_MAX_CONCURRENT
+
+    return DEFAULT_MAX_CONCURRENT
+
+
+def resolve_claude_cli_acquire_timeout(
+    override: Optional[float] = None,
+) -> float:
+    """Seconds to wait for a free slot before raising concurrency error."""
+    if override is not None:
+        return max(0.0, float(override))
+
+    env_raw = (os.environ.get("HERMES_CLAUDE_CLI_ACQUIRE_TIMEOUT") or "").strip()
+    if env_raw:
+        try:
+            return max(0.0, float(env_raw))
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid HERMES_CLAUDE_CLI_ACQUIRE_TIMEOUT=%r", env_raw
+            )
+
+    section = _load_model_claude_cli_cfg()
+    if "acquire_timeout_seconds" in section:
+        return _coerce_nonneg_float(
+            section.get("acquire_timeout_seconds"),
+            default=DEFAULT_ACQUIRE_TIMEOUT_SECONDS,
+            key="model.claude_cli.acquire_timeout_seconds",
+        )
+    return DEFAULT_ACQUIRE_TIMEOUT_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Shared store path (host-global, not per-profile)
+# ---------------------------------------------------------------------------
+
+
+def _slot_dir() -> Path:
+    """Directory for the host-global claude_cli slot registry.
+
+    Override via ``HERMES_CLAUDE_CLI_SLOT_DIR`` (required under pytest so
+    tests never touch the real ``~/.hermes/shared/`` store).
+    """
+    override = (os.environ.get("HERMES_CLAUDE_CLI_SLOT_DIR") or "").strip()
+    if override:
+        return Path(override).expanduser()
+
+    from hermes_constants import get_default_hermes_root
+
+    path = get_default_hermes_root() / "shared" / "claude_cli_slots"
+
+    # Seat belt: refuse to touch the real user store during tests.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        raise RuntimeError(
+            "Refusing to touch real claude_cli slot store during tests: "
+            f"{path}. Set HERMES_CLAUDE_CLI_SLOT_DIR to a tmp_path."
+        )
+    return path
+
+
+def _state_path() -> Path:
+    return _slot_dir() / _STATE_FILENAME
+
+
+def _lock_path() -> Path:
+    return _slot_dir() / _LOCK_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# File lock (same style as hermes_cli.active_sessions / auth._file_lock)
+# ---------------------------------------------------------------------------
+
+
+class _FileLock:
+    """Cross-process exclusive advisory lock on a companion ``.lock`` file."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._fh = None
+
+    def __enter__(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = open(self.path, "a+b")
+        if os.name == "nt":
+            try:
+                import msvcrt
+
+                # msvcrt.locking needs at least 1 byte of content.
+                if self._fh.seek(0, os.SEEK_END) == 0:
+                    self._fh.write(b" ")
+                    self._fh.flush()
+                self._fh.seek(0)
+                msvcrt.locking(self._fh.fileno(), msvcrt.LK_LOCK, 1)
+            except Exception as exc:
+                self._fh.close()
+                self._fh = None
+                raise RuntimeError("claude_cli slot file lock unavailable") from exc
+        else:
+            try:
+                import fcntl
+
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX)
+            except Exception as exc:
+                self._fh.close()
+                self._fh = None
+                raise RuntimeError("claude_cli slot file lock unavailable") from exc
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._fh is None:
+            return
+        if os.name == "nt":
+            try:
+                import msvcrt
+
+                self._fh.seek(0)
+                msvcrt.locking(self._fh.fileno(), msvcrt.LK_UNLCK, 1)
+            except Exception:
+                pass
+        else:
+            try:
+                import fcntl
+
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+            except Exception:
+                pass
+        try:
+            self._fh.close()
+        finally:
+            self._fh = None
+
+
+# ---------------------------------------------------------------------------
+# PID liveness + stale reaping
+# ---------------------------------------------------------------------------
+
+
+def _process_start_time(pid: int) -> Optional[float]:
+    try:
+        import psutil  # type: ignore
+
+        return float(psutil.Process(pid).create_time())
+    except Exception:
+        return None
+
+
+def _optional_float(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
+    try:
+        pid_int = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if pid_int <= 0:
+        return False
+    try:
+        from gateway.status import _pid_exists
+
+        exists = bool(_pid_exists(pid_int))
+    except Exception:
+        # Conservative: if we cannot check, treat as alive so we don't
+        # over-admit under a broken psutil import.
+        return True
+    if not exists:
+        return False
+    expected_start = _optional_float(process_start_time)
+    if expected_start is None:
+        return True
+    current_start = _process_start_time(pid_int)
+    if current_start is None:
+        return True
+    return abs(current_start - expected_start) < 0.001
+
+
+def _read_entries(path: Path) -> list[dict[str, Any]]:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return []
+    except Exception:
+        logger.warning("Ignoring corrupt claude_cli slot registry at %s", path)
+        return []
+    entries = data.get("entries") if isinstance(data, dict) else data
+    if not isinstance(entries, list):
+        return []
+    return [e for e in entries if isinstance(e, dict)]
+
+
+def _write_entries(path: Path, entries: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump({"entries": entries}, fh, sort_keys=True)
+    os.replace(tmp, path)
+
+
+def _prune_stale(
+    entries: list[dict[str, Any]], *, now: Optional[float] = None
+) -> list[dict[str, Any]]:
+    """Drop slots whose holder PID is dead or whose age exceeds the hard cap."""
+    now = time.time() if now is None else now
+    kept: list[dict[str, Any]] = []
+    for entry in entries:
+        if not _pid_alive(entry.get("pid"), entry.get("process_start_time")):
+            continue
+        started = _optional_float(entry.get("started_at")) or 0.0
+        if started and (now - started) > _STALE_MAX_AGE_SECONDS:
+            continue
+        kept.append(entry)
+    return kept
+
+
+# ---------------------------------------------------------------------------
+# Public lease API
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClaudeCliSlotLease:
+    """Held slot for one in-flight ``claude -p`` turn."""
+
+    lease_id: str
+    enabled: bool = True
+    released: bool = False
+    max_concurrent: Optional[int] = None
+
+    def release(self) -> None:
+        if self.released or not self.enabled:
+            self.released = True
+            return
+        release_claude_cli_slot(self)
+
+
+def _resolve_cap_arg(max_concurrent: Any) -> Optional[int]:
+    """Interpret an explicit max_concurrent arg or fall back to config.
+
+    * ``_MISSING`` → read config/env/default
+    * ``None`` or ``<= 0`` → unbounded
+    * positive int → that cap
+    """
+    if max_concurrent is _MISSING:
+        return resolve_claude_cli_max_concurrent()
+    if max_concurrent is None:
+        return None
+    try:
+        n = int(max_concurrent)
+    except (TypeError, ValueError):
+        return resolve_claude_cli_max_concurrent()
+    return None if n <= 0 else n
+
+
+def try_acquire_claude_cli_slot(
+    *,
+    max_concurrent: Any = _MISSING,
+    metadata: Optional[dict[str, Any]] = None,
+) -> Tuple[Optional[ClaudeCliSlotLease], Optional[str]]:
+    """Non-blocking attempt to claim one host-global claude_cli slot.
+
+    Returns ``(lease, None)`` on success, ``(None, reason)`` when full.
+    When the cap is disabled (None), returns a no-op lease.
+
+    Pass ``max_concurrent=None`` (or ``0``) for unbounded; omit the arg to
+    resolve from config/env/default.
+    """
+    cap = _resolve_cap_arg(max_concurrent)
+    lease_id = uuid.uuid4().hex
+    if cap is None:
+        return (
+            ClaudeCliSlotLease(
+                lease_id=lease_id, enabled=False, max_concurrent=None
+            ),
+            None,
+        )
+
+    now = time.time()
+    entry: dict[str, Any] = {
+        "lease_id": lease_id,
+        "pid": os.getpid(),
+        "process_start_time": _process_start_time(os.getpid()),
+        "started_at": now,
+        "updated_at": now,
+    }
+    if metadata:
+        entry["metadata"] = {
+            str(k): v for k, v in metadata.items() if isinstance(k, str)
+        }
+
+    state_path = _state_path()
+    with _FileLock(_lock_path()):
+        raw = _read_entries(state_path)
+        entries = _prune_stale(raw, now=now)
+        pruned = len(raw) - len(entries)
+        if pruned:
+            logger.info("claude_cli slots: pruned %d stale lease(s)", pruned)
+        active = len(entries)
+        if active >= cap:
+            _write_entries(state_path, entries)
+            reason = (
+                f"claude_cli concurrency cap reached "
+                f"({active}/{cap} host-wide Hermes sessions). "
+                f"Wait for a free slot or raise model.claude_cli.max_concurrent."
+            )
+            logger.info(
+                "claude_cli slot full: active=%d max=%d", active, cap
+            )
+            return None, reason
+        entries.append(entry)
+        _write_entries(state_path, entries)
+
+    return (
+        ClaudeCliSlotLease(
+            lease_id=lease_id, enabled=True, max_concurrent=cap
+        ),
+        None,
+    )
+
+
+def release_claude_cli_slot(lease: ClaudeCliSlotLease) -> None:
+    """Release a previously acquired slot. Idempotent."""
+    if lease.released:
+        return
+    if not lease.enabled:
+        lease.released = True
+        return
+    state_path = _state_path()
+    try:
+        with _FileLock(_lock_path()):
+            entries = _prune_stale(_read_entries(state_path))
+            kept = [
+                e
+                for e in entries
+                if str(e.get("lease_id") or "") != lease.lease_id
+            ]
+            if len(kept) != len(entries):
+                _write_entries(state_path, kept)
+    except Exception:
+        logger.debug("claude_cli slot release failed", exc_info=True)
+    finally:
+        lease.released = True
+
+
+def acquire_claude_cli_slot(
+    *,
+    max_concurrent: Any = _MISSING,
+    timeout_seconds: Optional[float] = None,
+    metadata: Optional[dict[str, Any]] = None,
+) -> ClaudeCliSlotLease:
+    """Block until a slot is free or *timeout_seconds* elapses.
+
+    On timeout raises :class:`agent.transports.claude_cli.ClaudeCliConcurrencyError`
+    (classifiable so Hermes' fallback chain can take over).
+    """
+    from agent.transports.claude_cli import ClaudeCliConcurrencyError
+
+    cap = _resolve_cap_arg(max_concurrent)
+    timeout = (
+        timeout_seconds
+        if timeout_seconds is not None
+        else resolve_claude_cli_acquire_timeout()
+    )
+    if cap is None:
+        return ClaudeCliSlotLease(
+            lease_id=uuid.uuid4().hex, enabled=False, max_concurrent=None
+        )
+
+    deadline = time.monotonic() + max(0.0, float(timeout))
+    last_reason: Optional[str] = None
+    while True:
+        lease, reason = try_acquire_claude_cli_slot(
+            max_concurrent=cap, metadata=metadata
+        )
+        if lease is not None:
+            if lease.enabled:
+                logger.debug(
+                    "claude_cli slot acquired lease=%s max=%s",
+                    lease.lease_id[:8],
+                    cap,
+                )
+            return lease
+        last_reason = reason
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(_POLL_INTERVAL_SECONDS, max(remaining, 0.01)))
+
+    msg = last_reason or (
+        f"claude_cli concurrency cap reached (max={cap}). "
+        "No free slot within acquire timeout."
+    )
+    raise ClaudeCliConcurrencyError(
+        message=(
+            f"{msg} Timed out after {timeout:.1f}s waiting for a free "
+            f"claude -p slot. Hermes will try the profile fallback if configured."
+        ),
+        max_concurrent=cap,
+        timeout_seconds=float(timeout),
+    )
+
+
+@contextmanager
+def claude_cli_slot(
+    *,
+    max_concurrent: Any = _MISSING,
+    timeout_seconds: Optional[float] = None,
+    metadata: Optional[dict[str, Any]] = None,
+) -> Iterator[ClaudeCliSlotLease]:
+    """Context manager: acquire a host-global slot for the duration of a turn.
+
+    Releases on normal exit, exception, and is safe if the holder crashes
+    (stale PID reaping on next acquire).
+    """
+    lease = acquire_claude_cli_slot(
+        max_concurrent=max_concurrent,
+        timeout_seconds=timeout_seconds,
+        metadata=metadata,
+    )
+    try:
+        yield lease
+    finally:
+        lease.release()
+
+
+def claude_cli_slot_registry_snapshot() -> list[dict[str, Any]]:
+    """Pruned slot registry for diagnostics/tests."""
+    state_path = _state_path()
+    with _FileLock(_lock_path()):
+        entries = _prune_stale(_read_entries(state_path))
+        _write_entries(state_path, entries)
+        return list(entries)
+
+
+# Process-local guard so tests can force unbounded without config.
+_force_unbounded = threading.local()
+
+
+def force_unbounded_for_tests(active: bool = True) -> None:
+    """Test helper: skip the host cap for the current thread."""
+    _force_unbounded.active = active
+
+
+def is_force_unbounded() -> bool:
+    return bool(getattr(_force_unbounded, "active", False))
+
+
+__all__ = [
+    "DEFAULT_MAX_CONCURRENT",
+    "DEFAULT_ACQUIRE_TIMEOUT_SECONDS",
+    "ClaudeCliSlotLease",
+    "resolve_claude_cli_max_concurrent",
+    "resolve_claude_cli_acquire_timeout",
+    "try_acquire_claude_cli_slot",
+    "acquire_claude_cli_slot",
+    "release_claude_cli_slot",
+    "claude_cli_slot",
+    "claude_cli_slot_registry_snapshot",
+    "force_unbounded_for_tests",
+    "is_force_unbounded",
+]

--- a/agent/transports/claude_cli_session.py
+++ b/agent/transports/claude_cli_session.py
@@ -1,0 +1,899 @@
+"""Session adapter for the claude_cli runtime (Phase 2b multi-turn).
+
+Owns the Hermes conversation → Claude session_id mapping and drives one
+``claude -p`` subprocess **per Hermes turn** (Claude is one-shot per spawn;
+multi-turn context lives in Claude's on-disk session, not a long-lived
+process). Mirrors ``CodexAppServerSession``'s "one session per AIAgent /
+Hermes conversation" lifetime:
+
+    session = ClaudeCliSession(oauth_token=..., model=..., cwd=...)
+    t1 = session.run_turn("Remember X")   # --session-id <uuid>
+    t2 = session.run_turn("What is X?")    # --resume <same uuid>
+    session.close()
+
+Phase 2a (still on every spawn): Hermes MCP tools via ``--mcp-config`` +
+``hermes_tools_mcp_server``. Tool round-trip is internal to ``claude -p``.
+
+Phase 2b (this module):
+  * First turn: generate a UUID, pass ``--session-id``, record mapping.
+  * Subsequent turns in the same Hermes conversation: ``--resume`` + only
+    the new user message (Claude already has history + native compaction).
+  * Stable ``cwd`` so Claude finds session files under
+    ``~/.claude/projects/<cwd-encoded>/<uuid>.jsonl``.
+  * Missing/expired resume → fall back to a fresh ``--session-id`` once.
+  * Pre-existing Hermes history on first turn: send latest user message
+    only (full transcript pre-seed is a follow-up).
+
+OpenClaw parallel: sessionMode always, ``--session-id`` / ``--resume``.
+Codex parallel: ``agent._codex_session`` reuse across turns on one AIAgent.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterator, Optional
+
+from agent.redact import redact_sensitive_text
+from agent.transports.claude_cli import (
+    ClaudeCliClient,
+    ClaudeCliConcurrencyError,
+    ClaudeCliError,
+    ClaudeCliSpawnConfig,
+    build_claude_cli_clean_env,
+    resolve_claude_bin,
+)
+from agent.transports.claude_cli_concurrency import (
+    claude_cli_slot,
+    is_force_unbounded,
+)
+from agent.transports.claude_event_projector import ClaudeEventProjector
+from agent.transports.types import NormalizedResponse, Usage
+
+logger = logging.getLogger(__name__)
+
+_STDERR_TAIL_LINES = 20
+
+# Error substrings that mean the Claude session file is missing / unusable.
+# When resume hits one of these, we create a fresh session once.
+_RESUME_MISSING_HINTS: tuple[str, ...] = (
+    "no conversation found",
+    "session not found",
+    "could not find session",
+    "unable to resume",
+    "failed to resume",
+    "unknown session",
+    "invalid session",
+    "does not exist",
+    "no such session",
+    "session file",
+    "cannot resume",
+)
+
+
+@dataclass
+class ClaudeCliTurnResult:
+    """Result of one user→assistant turn through ``claude -p``."""
+
+    final_text: str = ""
+    projected_messages: list[dict] = field(default_factory=list)
+    tool_iterations: int = 0  # completed Hermes MCP tool calls this turn
+    interrupted: bool = False
+    error: Optional[str] = None
+    is_error: bool = False
+    session_id: Optional[str] = None  # Claude session UUID
+    usage: Optional[dict[str, Any]] = None
+    total_cost_usd: Optional[float] = None
+    # Mirror codex TurnResult field names used by the agent-loop recorder.
+    token_usage_last: Optional[dict[str, Any]] = None
+    # False while the mapping is healthy (reuse next turn). True only when
+    # the runtime should drop agent._claude_cli_session (hard failure).
+    should_retire: bool = False
+    result_event: Optional[dict[str, Any]] = None
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    # Phase 2b diagnostics
+    resumed: bool = False
+    created_session: bool = False
+    resume_fallback: bool = False
+    history_seed_note: Optional[str] = None
+
+    def to_normalized_response(self) -> NormalizedResponse:
+        """Map to the shared NormalizedResponse so the loop treats this as a normal turn."""
+        usage_obj = None
+        if isinstance(self.usage, dict) and self.usage:
+            prompt = int(
+                self.usage.get("input_tokens")
+                or self.usage.get("prompt_tokens")
+                or 0
+            )
+            completion = int(
+                self.usage.get("output_tokens")
+                or self.usage.get("completion_tokens")
+                or 0
+            )
+            cache_read = int(
+                self.usage.get("cache_read_input_tokens")
+                or self.usage.get("cache_read_tokens")
+                or 0
+            )
+            usage_obj = Usage(
+                prompt_tokens=prompt + cache_read,
+                completion_tokens=completion,
+                total_tokens=prompt + cache_read + completion,
+                cached_tokens=cache_read,
+            )
+        finish = "stop" if not self.is_error and not self.error else "error"
+        return NormalizedResponse(
+            content=self.final_text or None,
+            tool_calls=None,
+            finish_reason=finish if finish != "error" else "stop",
+            usage=usage_obj,
+            provider_data={
+                "claude_cli_session_id": self.session_id,
+                "claude_cli_total_cost_usd": self.total_cost_usd,
+                "claude_cli_is_error": self.is_error,
+                "claude_cli_usage": self.usage,
+                "claude_cli_resumed": self.resumed,
+                "claude_cli_created_session": self.created_session,
+                "claude_cli_resume_fallback": self.resume_fallback,
+            },
+        )
+
+
+def _looks_like_claude_setup_or_oauth_token(token: str) -> bool:
+    """True for setup tokens (sk-ant-oat…) or Claude Code OAuth tokens (cc-…)."""
+    stripped = (token or "").strip()
+    return stripped.startswith("sk-ant-oat") or stripped.startswith("cc-")
+
+
+def _read_setup_token_keys_from_env_file(path) -> Optional[str]:
+    """Read CLAUDE_CODE_OAUTH_TOKEN (or legacy ANTHROPIC_TOKEN) from a .env file.
+
+    Read-only and crash-safe: missing/unreadable files return None.
+    Does **not** load values into ``os.environ``.
+    """
+    try:
+        from pathlib import Path
+
+        env_path = Path(path)
+        if not env_path.is_file():
+            return None
+    except OSError:
+        return None
+
+    values: dict = {}
+    try:
+        from dotenv import dotenv_values
+
+        parsed = dotenv_values(env_path) or {}
+        values = {str(k): (v if v is not None else "") for k, v in parsed.items()}
+    except Exception:
+        try:
+            text = env_path.read_text(encoding="utf-8-sig", errors="replace")
+        except OSError:
+            return None
+        for raw in text.splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            values[key] = value
+
+    for key in ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_TOKEN"):
+        val = str(values.get(key) or "").strip()
+        if val:
+            return val
+    return None
+
+
+def _read_canonical_root_setup_token() -> Optional[str]:
+    """Fleet fallback: setup token from the platform Hermes root ``.env``.
+
+    Uses :func:`hermes_constants.get_default_hermes_root` so a profile with its
+    own ``HERMES_HOME`` still resolves the **one** shared non-rotating setup
+    token from ``~/.hermes/.env`` (platform-native root), not the profile dir.
+
+    Why root ``.env`` (not a new shared-auth file): it is already Hermes'
+    canonical secret store, needs no new machinery, and the setup token is a
+    secret (never ``config.yaml``). Fork-safe / non-rotating → no lock needed.
+    """
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        root_env = get_default_hermes_root() / ".env"
+    except Exception as exc:
+        logger.debug("claude_cli: canonical root path failed: %s", exc)
+        return None
+    try:
+        return _read_setup_token_keys_from_env_file(root_env)
+    except Exception as exc:
+        logger.debug("claude_cli: canonical root .env read failed: %s", exc)
+        return None
+
+
+def resolve_claude_cli_oauth_token(
+    *,
+    explicit: Optional[str] = None,
+    agent: Any = None,
+) -> str:
+    """Resolve the non-rotating setup token for CLAUDE_CODE_OAUTH_TOKEN injection.
+
+    Final resolution order (first hit wins):
+
+      1. Explicit / passed token (``explicit=`` argument, or agent-held
+         setup/OAuth-shaped key ``sk-ant-oat`` / ``cc-``)
+      2. Profile / process env ``CLAUDE_CODE_OAUTH_TOKEN`` (then legacy
+         ``ANTHROPIC_TOKEN``). When a profile's ``.env`` was loaded into the
+         process env at startup, that is this step.
+      3. Profile credential_pool OAuth entries (``claude_code`` /
+         ``env:CLAUDE_CODE_OAUTH_TOKEN`` and other anthropic OAuth pool rows)
+      4. **Canonical Hermes root** ``~/.hermes/.env``
+         (``get_default_hermes_root() / ".env"``) — fleet fallback so any
+         profile can run Claude on demand without copying the token into its
+         own ``.env``
+      5. **Never** the rotating ``~/.claude`` login credentials (keychain /
+         ``~/.claude/.credentials.json``)
+
+    Those login credentials are not fork-safe for a clean ``claude -p``
+    subprocess. The setup token (``sk-ant-oat…``, ~1yr) is fork-safe like an
+    API key — no shared store or lock.
+
+    Only raises when no source yields a token.
+    """
+    if explicit and str(explicit).strip():
+        return str(explicit).strip()
+
+    # (1b) Passed via agent constructor when already setup/OAuth-shaped.
+    if agent is not None:
+        key = getattr(agent, "api_key", None) or getattr(agent, "_anthropic_api_key", None)
+        if isinstance(key, str) and key.strip():
+            stripped = key.strip()
+            if _looks_like_claude_setup_or_oauth_token(stripped):
+                return stripped
+
+    # (2) Profile / process env — first hit of the two keys.
+    for env_var in ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_TOKEN"):
+        val = (os.environ.get(env_var) or "").strip()
+        if val:
+            return val
+
+    # (3) Profile-scoped credential_pool (HERMES_HOME auth.json).
+    # Read-only enumerate — never refresh/network. Intentionally does NOT
+    # call resolve_anthropic_token() (that path also reads ~/.claude login).
+    try:
+        from agent.anthropic_adapter import _resolve_anthropic_pool_token
+
+        pool_token = _resolve_anthropic_pool_token()
+        if pool_token and str(pool_token).strip():
+            return str(pool_token).strip()
+    except Exception as exc:
+        logger.debug("claude_cli: credential_pool resolve failed: %s", exc)
+
+    # (4) Canonical platform-root ~/.hermes/.env (fleet shared setup token).
+    root_token = _read_canonical_root_setup_token()
+    if root_token:
+        return root_token
+
+    raise ClaudeCliError(
+        message=(
+            "claude_cli: no Anthropic setup token found. Put the non-rotating "
+            "setup token once in the canonical Hermes root ~/.hermes/.env as "
+            "CLAUDE_CODE_OAUTH_TOKEN=... (any profile resolves it), or set it in "
+            "this profile's env / anthropic credential_pool "
+            "(env:CLAUDE_CODE_OAUTH_TOKEN or claude_code). Generate with "
+            "`claude setup-token`. Do NOT rely on the rotating `claude /login` "
+            "session for the subprocess."
+        )
+    )
+
+
+def new_claude_session_id() -> str:
+    """Generate a Claude-compatible session UUID (required by ``--session-id``)."""
+    return str(uuid.uuid4())
+
+
+def is_resume_missing_error(message: str) -> bool:
+    """True when a failed resume looks like a missing/expired Claude session."""
+    text = (message or "").lower()
+    if not text:
+        return False
+    return any(hint in text for hint in _RESUME_MISSING_HINTS)
+
+
+def hermes_history_has_prior_turns(messages: Optional[list] = None) -> bool:
+    """True if Hermes already has prior user/assistant turns (resumed chat).
+
+    Phase 2b MVP does not pre-seed that transcript into a brand-new Claude
+    session; only the latest user message is sent.
+    """
+    if not messages:
+        return False
+    count = 0
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role in ("user", "assistant"):
+            count += 1
+            if count > 1:
+                return True
+    return False
+
+
+class ClaudeCliSession:
+    """Multi-turn Claude CLI session (Phase 2b — create + resume).
+
+    One instance maps one Hermes conversation to one Claude session_id.
+    Each ``run_turn`` still spawns a fresh ``claude -p`` (print mode is
+    one-shot), but the Claude session file carries history across spawns.
+    """
+
+    def __init__(
+        self,
+        *,
+        oauth_token: Optional[str] = None,
+        model: str = "claude-opus-4-8",
+        claude_bin: Optional[str] = None,
+        cwd: Optional[str] = None,
+        on_event: Optional[Callable[[dict], None]] = None,
+        env: Optional[dict[str, str]] = None,
+        client_factory: Optional[Callable[..., ClaudeCliClient]] = None,
+        turn_timeout: float = 600.0,
+        enable_hermes_mcp: bool = True,
+        hermes_mcp_profile: str = "claude",
+        max_turns: Optional[int] = None,
+        hermes_conversation_id: Optional[str] = None,
+        claude_session_id: Optional[str] = None,
+    ) -> None:
+        self._oauth_token = oauth_token
+        self._model = model
+        self._claude_bin = resolve_claude_bin(claude_bin)
+        self._cwd = cwd
+        self._on_event = on_event
+        self._env = env
+        self._client_factory = client_factory or ClaudeCliClient
+        self._turn_timeout = turn_timeout
+        self._enable_hermes_mcp = enable_hermes_mcp
+        self._hermes_mcp_profile = hermes_mcp_profile
+        self._max_turns = max_turns
+        self._client: Optional[ClaudeCliClient] = None
+        self._closed = False
+        self._workspace: Optional[str] = None
+        # Hermes conversation id (agent.session_id) — mapping key / logs.
+        self._hermes_conversation_id = hermes_conversation_id
+        # Claude session UUID used with --session-id / --resume.
+        self._claude_session_id: Optional[str] = claude_session_id
+        self._turn_index = 0
+        self._history_seed_note_emitted = False
+
+    # ---------- public mapping surface ----------
+
+    @property
+    def claude_session_id(self) -> Optional[str]:
+        return self._claude_session_id
+
+    @property
+    def hermes_conversation_id(self) -> Optional[str]:
+        return self._hermes_conversation_id
+
+    @property
+    def turn_index(self) -> int:
+        return self._turn_index
+
+    @property
+    def workspace(self) -> Optional[str]:
+        """Stable cwd used for Claude session file resolution."""
+        if self._cwd:
+            return self._cwd
+        return self._workspace
+
+    def _ensure_workspace(self) -> str:
+        if self._cwd:
+            return self._cwd
+        if self._workspace is None:
+            self._workspace = tempfile.mkdtemp(prefix="hermes-claude-cli-ws-")
+            logger.info(
+                "claude_cli: created stable workspace cwd=%s hermes_id=%s",
+                self._workspace,
+                self._hermes_conversation_id,
+            )
+        return self._workspace
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception:
+                pass
+            self._client = None
+        # Keep Claude session files on disk (resume-friendly). Workspace is
+        # ephemeral when we created it; OS reaps temp dirs. Do not delete
+        # Claude's ~/.claude/projects session jsonl here.
+
+    def __enter__(self) -> "ClaudeCliSession":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def reset_claude_session(self) -> None:
+        """Drop the Claude session mapping so the next turn creates a fresh one."""
+        logger.info(
+            "claude_cli: resetting claude session mapping hermes_id=%s old=%s",
+            self._hermes_conversation_id,
+            (self._claude_session_id or "")[:8] or None,
+        )
+        self._claude_session_id = None
+
+    def run_turn(
+        self,
+        user_input: Any,
+        *,
+        system_prompt: Optional[str] = None,
+        model: Optional[str] = None,
+        turn_timeout: Optional[float] = None,
+        messages: Optional[list] = None,
+    ) -> ClaudeCliTurnResult:
+        """Spawn ``claude -p`` (create or resume), stream events, return result.
+
+        Raises ClaudeCliError when the terminal result has is_error=true so
+        the agent-loop / fallback chain can classify the failure. Soft
+        failures (spawn/timeout/nonzero exit without a result event) also
+        raise ClaudeCliError with a stderr tail.
+
+        On a missing/expired resume target, clears the mapping and retries
+        once as a fresh ``--session-id`` create.
+        """
+        if self._closed:
+            raise ClaudeCliError(message="claude_cli: session is closed")
+
+        prompt = _coerce_user_text(user_input)
+        if not prompt.strip():
+            raise ClaudeCliError(message="claude_cli: empty user prompt")
+
+        history_note: Optional[str] = None
+        if (
+            self._claude_session_id is None
+            and not self._history_seed_note_emitted
+            and hermes_history_has_prior_turns(messages)
+        ):
+            history_note = (
+                "claude_cli Phase 2b: Hermes conversation already has prior "
+                "history, but Claude session is new — only the latest user "
+                "message is sent (full transcript pre-seed deferred)."
+            )
+            self._history_seed_note_emitted = True
+            logger.warning(history_note)
+
+        # Decide create vs resume *before* the attempt so create failures
+        # never look like resume-missing fallback candidates.
+        attempting_resume = bool(self._claude_session_id)
+        try:
+            return self._run_turn_once(
+                prompt=prompt,
+                system_prompt=system_prompt,
+                model=model,
+                turn_timeout=turn_timeout,
+                history_note=history_note,
+                resume_fallback=False,
+            )
+        except ClaudeCliConcurrencyError:
+            # Host slot saturated — do not treat as resume-missing; let the
+            # conversation loop activate the profile fallback chain.
+            raise
+        except ClaudeCliError as exc:
+            if attempting_resume and is_resume_missing_error(str(exc)):
+                logger.warning(
+                    "claude_cli: resume failed (missing session); "
+                    "falling back to fresh --session-id hermes_id=%s err=%s",
+                    self._hermes_conversation_id,
+                    str(exc)[:200],
+                )
+                self.reset_claude_session()
+                return self._run_turn_once(
+                    prompt=prompt,
+                    system_prompt=system_prompt,
+                    model=model,
+                    turn_timeout=turn_timeout,
+                    history_note=history_note,
+                    resume_fallback=True,
+                )
+            raise
+
+    def _run_turn_once(
+        self,
+        *,
+        prompt: str,
+        system_prompt: Optional[str],
+        model: Optional[str],
+        turn_timeout: Optional[float],
+        history_note: Optional[str],
+        resume_fallback: bool = False,
+    ) -> ClaudeCliTurnResult:
+        result = ClaudeCliTurnResult(history_seed_note=history_note)
+        try:
+            token = self._oauth_token or resolve_claude_cli_oauth_token()
+        except ClaudeCliError:
+            raise
+        except Exception as exc:
+            raise ClaudeCliError(
+                message=f"claude_cli: token resolution failed: {exc}"
+            ) from exc
+
+        env = self._env or build_claude_cli_clean_env(oauth_token=token)
+        workspace = self._ensure_workspace()
+
+        # Create vs resume decision (OpenClaw sessionMode: always).
+        resume_id: Optional[str] = None
+        create_id: Optional[str] = None
+        if self._claude_session_id:
+            resume_id = self._claude_session_id
+            result.resumed = True
+        else:
+            create_id = new_claude_session_id()
+            result.created_session = True
+            # Pre-bind so a crash mid-turn still leaves a stable id if Claude
+            # wrote the session; overwritten from result event when present.
+            self._claude_session_id = create_id
+
+        result.resume_fallback = resume_fallback
+
+        # System prompt: only on create. Re-appending on every resume would
+        # stack append-system-prompt into Claude's session each turn.
+        effective_system = system_prompt if create_id else None
+
+        spawn_kwargs: dict[str, Any] = {
+            "model": model or self._model,
+            "prompt": prompt,
+            "system_prompt": effective_system,
+            "claude_bin": self._claude_bin,
+            "cwd": workspace,
+            "enable_hermes_mcp": self._enable_hermes_mcp,
+            "hermes_mcp_profile": self._hermes_mcp_profile,
+            "timeout_seconds": float(
+                turn_timeout if turn_timeout is not None else self._turn_timeout
+            ),
+            "session_id": create_id,
+            "resume": resume_id,
+        }
+        if self._max_turns is not None:
+            spawn_kwargs["max_turns"] = int(self._max_turns)
+        cfg = ClaudeCliSpawnConfig(**spawn_kwargs)
+
+        client = self._client_factory(
+            oauth_token=token,
+            env=env,
+            claude_bin=self._claude_bin,
+        )
+        self._client = client
+        projector = ClaudeEventProjector()
+
+        logger.info(
+            "claude_cli turn hermes_id=%s mode=%s claude_id=%s cwd=%s",
+            self._hermes_conversation_id,
+            "resume" if resume_id else "create",
+            (resume_id or create_id or "")[:8],
+            workspace,
+        )
+
+        # Host-global concurrency slot: one per concurrent `claude -p` across
+        # all Hermes profiles/processes. Held for the whole spawn→stream
+        # lifetime so a long tool-using turn counts as one occupied slot.
+        # On saturation after bounded wait → ClaudeCliConcurrencyError →
+        # conversation_loop activates the profile fallback chain.
+        slot_meta = {
+            "hermes_conversation_id": self._hermes_conversation_id or "",
+            "mode": "resume" if resume_id else "create",
+            "model": str(model or self._model or ""),
+        }
+        # force_unbounded is a test hook; production always acquires.
+        slot_cm = (
+            claude_cli_slot(metadata=slot_meta)
+            if not is_force_unbounded()
+            else _null_slot_cm()
+        )
+        with slot_cm:
+            return self._drive_spawned_turn(
+                client=client,
+                cfg=cfg,
+                projector=projector,
+                result=result,
+                resume_id=resume_id,
+                create_id=create_id,
+            )
+
+    def _drive_spawned_turn(
+        self,
+        *,
+        client: Any,
+        cfg: ClaudeCliSpawnConfig,
+        projector: ClaudeEventProjector,
+        result: ClaudeCliTurnResult,
+        resume_id: Optional[str],
+        create_id: Optional[str],
+    ) -> ClaudeCliTurnResult:
+        """Spawn + stream one ``claude -p`` (called while holding a host slot)."""
+        try:
+            client.spawn(cfg)
+        except FileNotFoundError as exc:
+            raise ClaudeCliError(
+                message=(
+                    f"claude_cli: binary not found ({self._claude_bin!r}). "
+                    "Install Claude Code (npm i -g @anthropic-ai/claude-code) "
+                    "or put `claude` on PATH."
+                )
+            ) from exc
+        except ClaudeCliConcurrencyError:
+            raise
+        except Exception as exc:
+            raise ClaudeCliError(
+                message=f"claude_cli: failed to spawn subprocess: {exc}"
+            ) from exc
+
+        timeout = cfg.timeout_seconds
+        try:
+            for line in client.iter_stdout_lines(timeout=timeout):
+                state = projector.consume_line(line)
+                # Fire stream deltas + tool activity to Hermes UI bridge.
+                if self._on_event is not None:
+                    for delta in state.last_text_deltas:
+                        try:
+                            self._on_event(
+                                {
+                                    "method": "claude/text_delta",
+                                    "params": {"delta": delta, "text": delta},
+                                }
+                            )
+                        except Exception:
+                            logger.debug(
+                                "claude_cli on_event raised", exc_info=True
+                            )
+                    for rec in state.last_tool_started:
+                        try:
+                            self._on_event(
+                                {
+                                    "method": "claude/tool_started",
+                                    "params": {
+                                        "id": rec.id,
+                                        "name": rec.name,
+                                        "raw_name": rec.raw_name,
+                                        "arguments": rec.input,
+                                        "server": "hermes-tools",
+                                    },
+                                }
+                            )
+                        except Exception:
+                            logger.debug(
+                                "claude_cli tool_started on_event raised",
+                                exc_info=True,
+                            )
+                    for rec in state.last_tool_completed:
+                        try:
+                            self._on_event(
+                                {
+                                    "method": "claude/tool_completed",
+                                    "params": {
+                                        "id": rec.id,
+                                        "name": rec.name,
+                                        "raw_name": rec.raw_name,
+                                        "arguments": rec.input,
+                                        "result": rec.result,
+                                        "is_error": rec.is_error,
+                                        "server": "hermes-tools",
+                                    },
+                                }
+                            )
+                        except Exception:
+                            logger.debug(
+                                "claude_cli tool_completed on_event raised",
+                                exc_info=True,
+                            )
+                if state.finished:
+                    break
+        except ClaudeCliError:
+            client.close()
+            # Preserve mapping on stream timeout so caller can decide retire.
+            raise
+        except Exception as exc:
+            tail = "\n".join(client.stderr_tail(_STDERR_TAIL_LINES))
+            client.close()
+            raise ClaudeCliError(
+                message=f"claude_cli: stream read failed: {exc}",
+                stderr_tail=redact_sensitive_text(tail, force=True) if tail else "",
+            ) from exc
+
+        state = projector.state
+        exit_code = client.wait(timeout=5.0)
+        stderr_tail_raw = "\n".join(client.stderr_tail(_STDERR_TAIL_LINES))
+        stderr_tail = (
+            redact_sensitive_text(stderr_tail_raw, force=True)
+            if stderr_tail_raw
+            else ""
+        )
+        client.close()
+        self._client = None
+
+        # Prefer session_id from Claude's init/result events when present.
+        if state.session_id:
+            self._claude_session_id = state.session_id
+        result.session_id = self._claude_session_id
+        result.final_text = state.final_text
+        result.usage = state.usage
+        result.token_usage_last = _usage_to_codex_shape(state.usage)
+        result.total_cost_usd = state.total_cost_usd
+        result.result_event = state.result_event
+        result.is_error = state.is_error
+        result.should_retire = False  # healthy multi-turn reuse by default
+        result.tool_iterations = state.tool_iterations
+        result.tool_calls = [
+            {
+                "id": t.id,
+                "name": t.name,
+                "raw_name": t.raw_name,
+                "arguments": t.input,
+                "result": t.result,
+                "is_error": t.is_error,
+                "completed": t.completed,
+            }
+            for t in state.tool_calls
+        ]
+
+        if state.final_text:
+            result.projected_messages = [
+                {"role": "assistant", "content": state.final_text}
+            ]
+
+        # Terminal result with is_error=true → raise so fallback can fire.
+        if state.is_error:
+            err_msg = (
+                state.result_text
+                or (state.result_event or {}).get("error")
+                or "claude_cli result is_error=true"
+            )
+            if not isinstance(err_msg, str):
+                err_msg = str(err_msg)
+            result.error = err_msg
+            # Resume-missing errors: keep mapping for outer fallback path
+            # (run_turn will clear + retry). Other hard errors retire.
+            if resume_id and is_resume_missing_error(err_msg):
+                raise ClaudeCliError(
+                    message=f"claude_cli turn error: {err_msg}",
+                    is_error=True,
+                    exit_code=exit_code,
+                    stderr_tail=stderr_tail,
+                    result_event=state.result_event,
+                )
+            result.should_retire = True
+            raise ClaudeCliError(
+                message=f"claude_cli turn error: {err_msg}",
+                is_error=True,
+                exit_code=exit_code,
+                stderr_tail=stderr_tail,
+                result_event=state.result_event,
+            )
+
+        # No result event + nonzero exit → error with stderr tail.
+        if not state.finished and exit_code not in (0, None):
+            combined = f"claude_cli exited without a result event (exit={exit_code})"
+            if stderr_tail:
+                combined = f"{combined}\n{stderr_tail}"
+            if resume_id and is_resume_missing_error(combined):
+                raise ClaudeCliError(
+                    message=combined,
+                    exit_code=exit_code,
+                    stderr_tail=stderr_tail,
+                )
+            result.should_retire = True
+            raise ClaudeCliError(
+                message=(
+                    f"claude_cli exited without a result event "
+                    f"(exit={exit_code})"
+                ),
+                exit_code=exit_code,
+                stderr_tail=stderr_tail,
+            )
+
+        # Finished successfully but empty text — still a valid stop (model
+        # can return blank); surface as soft error only if exit nonzero.
+        if not state.finished and not result.final_text:
+            if exit_code not in (0, None):
+                result.should_retire = True
+                raise ClaudeCliError(
+                    message="claude_cli produced no stream-json result",
+                    exit_code=exit_code,
+                    stderr_tail=stderr_tail,
+                )
+            logger.warning(
+                "claude_cli: no result event and empty text (exit=%s)",
+                exit_code,
+            )
+
+        # Fire assistant_completed for UI finalization. Prefer result_text so
+        # the completed frame is clean even when intermediate partials
+        # narrated tool intent. Bridge consumers should treat this as the
+        # authoritative final (replace, not append) relative to stream deltas.
+        if self._on_event is not None and result.final_text:
+            try:
+                self._on_event(
+                    {
+                        "method": "claude/assistant_completed",
+                        "params": {
+                            "text": result.final_text,
+                            # Hint for UIs that already painted text_delta:
+                            # replace the stream buffer rather than append.
+                            "replace_stream": True,
+                        },
+                    }
+                )
+            except Exception:
+                logger.debug("claude_cli on_event completed raised", exc_info=True)
+
+        self._turn_index += 1
+        return result
+
+
+@contextmanager
+def _null_slot_cm() -> Iterator[None]:
+    """No-op slot context for tests that force unbounded concurrency."""
+    yield None
+
+
+def _coerce_user_text(user_input: Any) -> str:
+    if isinstance(user_input, str):
+        return user_input
+    if isinstance(user_input, list):
+        parts: list[str] = []
+        for item in user_input:
+            if isinstance(item, str):
+                if item.strip():
+                    parts.append(item)
+            elif isinstance(item, dict):
+                if item.get("type") in {"text", "input_text"}:
+                    text = item.get("text") or item.get("content") or ""
+                    if text:
+                        parts.append(str(text))
+                elif item.get("type") in {"image", "image_url", "input_image"}:
+                    parts.append("[image attached]")
+            elif item is not None:
+                parts.append(str(item))
+        return "\n\n".join(p for p in parts if p).strip()
+    return "" if user_input is None else str(user_input)
+
+
+def _usage_to_codex_shape(usage: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """Translate Claude usage keys into the shape codex_runtime recorders know."""
+    if not isinstance(usage, dict) or not usage:
+        return None
+    input_tokens = int(usage.get("input_tokens") or usage.get("prompt_tokens") or 0)
+    output_tokens = int(usage.get("output_tokens") or usage.get("completion_tokens") or 0)
+    cache_read = int(
+        usage.get("cache_read_input_tokens") or usage.get("cache_read_tokens") or 0
+    )
+    return {
+        "inputTokens": input_tokens,
+        "outputTokens": output_tokens,
+        "cachedInputTokens": cache_read,
+        "reasoningOutputTokens": 0,
+        "totalTokens": input_tokens + output_tokens + cache_read,
+    }
+
+
+__all__ = [
+    "ClaudeCliSession",
+    "ClaudeCliTurnResult",
+    "hermes_history_has_prior_turns",
+    "is_resume_missing_error",
+    "new_claude_session_id",
+    "resolve_claude_cli_oauth_token",
+]

--- a/agent/transports/claude_event_projector.py
+++ b/agent/transports/claude_event_projector.py
@@ -1,0 +1,456 @@
+"""Project Claude Code stream-json events into Hermes text + tool activity.
+
+Phase 2a: text deltas, final result, and MCP tool_use / tool_result events.
+
+Claude Code stream-json (observed + documented shapes):
+
+* ``{"type":"stream_event","event":{"type":"content_block_delta",
+  "delta":{"type":"text_delta","text":"..."}}}`` — partial assistant text
+  (requires ``--include-partial-messages``).
+* ``{"type":"assistant","message":{"content":[{"type":"text","text":"..."},
+  {"type":"tool_use","id":"...","name":"mcp__hermes-tools__terminal",
+   "input":{...}}]}}`` — assistant snapshot, may include tool_use blocks.
+* ``{"type":"user","message":{"content":[{"type":"tool_result",
+  "tool_use_id":"...","content":"..."}]}}`` — tool results (MCP returns
+  these after Hermes executes the tool).
+* ``{"type":"stream_event","event":{"type":"content_block_start",
+  "content_block":{"type":"tool_use",...}}}`` — streaming tool_use start.
+* ``{"type":"result","subtype":"success"|"error", "is_error":bool,
+  "result":"...", "usage":{...}, "session_id":"..."}`` — terminal event.
+* ``{"type":"system", ...}`` / other — ignored for projection (except session_id).
+
+Text projection rules (anti-garble):
+  * Only ``text_delta`` partials feed the live stream (not thinking_delta,
+    signature_delta, input_json_delta, content_block_start seeds, or
+    message_delta envelopes — those caused mis-joins / duplication).
+  * Each new ``message_start`` resets the per-message stream buffer so
+    intermediate tool-loop narration is not concatenated onto the final
+    answer.
+  * ``final_text`` prefers the terminal ``result`` field, then the latest
+    assistant snapshot, then the current message's streamed text — never
+    a stitched multi-message partial buffer.
+
+Tool round-trip is internal to ``claude -p`` + the hermes-tools MCP server.
+This projector only *observes* tool activity for Hermes UI / counters; it
+does not execute or proxy tools.
+
+Mirrors ``codex_event_projector.CodexEventProjector`` in role (stateful
+accumulator + delta extraction) without inventing a shared abstraction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from agent.transports.claude_cli import (
+    HERMES_MCP_TOOL_PREFIX,
+    strip_hermes_mcp_tool_prefix,
+)
+
+
+@dataclass
+class ClaudeToolCallRecord:
+    """One observed tool_use (+ optional later tool_result) in the turn."""
+
+    id: str
+    name: str  # bare Hermes name when mcp__hermes-tools__* stripped
+    raw_name: str  # full mcp__… name as Claude emitted it
+    input: dict[str, Any] = field(default_factory=dict)
+    result: Optional[str] = None
+    is_error: bool = False
+    started: bool = True
+    completed: bool = False
+
+
+@dataclass
+class ClaudeProjectionState:
+    """Accumulated state after consuming zero or more stream-json events."""
+
+    # Streaming partial text for the *current* assistant message only
+    # (reset on each message_start). Used for live deltas + final fallback.
+    streamed_text: str = ""
+    # Last complete assistant message text (from type=assistant snapshots).
+    assistant_text: str = ""
+    # Terminal result fields.
+    result_text: str = ""
+    is_error: bool = False
+    result_event: Optional[dict[str, Any]] = None
+    usage: Optional[dict[str, Any]] = None
+    session_id: Optional[str] = None
+    total_cost_usd: Optional[float] = None
+    finished: bool = False
+    # Text deltas emitted during the last ``consume`` call (for stream bridge).
+    last_text_deltas: list[str] = field(default_factory=list)
+    # Tool activity observed this consume() (for stream bridge).
+    last_tool_started: list[ClaudeToolCallRecord] = field(default_factory=list)
+    last_tool_completed: list[ClaudeToolCallRecord] = field(default_factory=list)
+    # Full turn tool ledger (order of first observation).
+    tool_calls: list[ClaudeToolCallRecord] = field(default_factory=list)
+    _tool_by_id: dict[str, ClaudeToolCallRecord] = field(default_factory=dict, repr=False)
+    # True once any text_delta landed for the current assistant message —
+    # prevents seeding streamed_text from a full assistant snapshot that
+    # would double-emit relative to already-streamed partials.
+    _message_has_streamed_deltas: bool = field(default=False, repr=False)
+
+    @property
+    def final_text(self) -> str:
+        """Best available assistant text for the completed turn.
+
+        Prefer the terminal ``result`` string (Claude's authoritative final
+        answer), then the latest full assistant snapshot, then the current
+        message's streamed partials. This avoids concatenating intermediate
+        tool-loop narration with the final reply.
+        """
+        for candidate in (self.result_text, self.assistant_text, self.streamed_text):
+            if candidate and str(candidate).strip():
+                return str(candidate)
+        return self.streamed_text or self.assistant_text or self.result_text or ""
+
+    @property
+    def tool_iterations(self) -> int:
+        """Count of completed tool calls (Hermes skill-nudge counter)."""
+        return sum(1 for t in self.tool_calls if t.completed)
+
+
+def _extract_text_from_content_blocks(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, str):
+            if block:
+                parts.append(block)
+            continue
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        # Strict: only real text blocks. Never thinking / tool_use / redacted.
+        if btype == "text" and "text" in block:
+            parts.append(str(block.get("text") or ""))
+        elif btype is None and "text" in block and "name" not in block:
+            # Defensive legacy shape without type, but not a tool_use.
+            parts.append(str(block.get("text") or ""))
+    return "".join(parts)
+
+
+def extract_text_delta(event: dict[str, Any]) -> Optional[str]:
+    """Return a text delta string if this event carries partial assistant text.
+
+    Only ``text_delta`` content is accepted. thinking_delta, signature_delta,
+    input_json_delta, content_block_start seeds, and message_delta envelopes
+    are intentionally ignored — joining them produces garbled projections
+    (duplicate seeds, HTML-ish fragments, binary signature junk).
+    """
+    etype = event.get("type")
+
+    # Nested stream_event envelope used by --include-partial-messages.
+    if etype == "stream_event":
+        inner = event.get("event") or {}
+        if not isinstance(inner, dict):
+            return None
+        return extract_text_delta(inner)
+
+    # Anthropic Messages streaming shapes — text only.
+    if etype == "content_block_delta":
+        delta = event.get("delta") or {}
+        if isinstance(delta, dict):
+            dtype = delta.get("type")
+            if dtype == "text_delta" and "text" in delta:
+                text = delta.get("text")
+                # Preserve empty string? No — empty contributes nothing.
+                return str(text) if text else None
+        return None
+
+    # Direct text_delta only (no message_delta — that carries stop_reason/usage).
+    if etype == "text_delta":
+        delta = event.get("delta") if "delta" in event else event.get("text")
+        if isinstance(delta, dict) and "text" in delta:
+            text = delta.get("text")
+            return str(text) if text else None
+        if isinstance(delta, str) and delta:
+            return delta
+    return None
+
+
+def extract_assistant_message_text(event: dict[str, Any]) -> Optional[str]:
+    """Pull full assistant text from a type=assistant snapshot event."""
+    if event.get("type") != "assistant":
+        return None
+    message = event.get("message")
+    if isinstance(message, dict):
+        text = _extract_text_from_content_blocks(message.get("content"))
+        return text if text else None
+    # Some shapes put content at the top level.
+    text = _extract_text_from_content_blocks(event.get("content"))
+    return text if text else None
+
+
+def extract_usage(event: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """Normalize usage from a result (or message) event into a flat dict."""
+    raw = event.get("usage")
+    if not isinstance(raw, dict):
+        message = event.get("message")
+        if isinstance(message, dict) and isinstance(message.get("usage"), dict):
+            raw = message["usage"]
+        else:
+            return None
+    # Claude result usage keys: input_tokens, output_tokens,
+    # cache_creation_input_tokens, cache_read_input_tokens, ...
+    return dict(raw)
+
+
+def _tool_input_as_dict(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return dict(raw)
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        # Streaming partial JSON sometimes lands as a string; keep opaque.
+        return {"_raw": raw} if raw else {}
+    return {"_raw": raw}
+
+
+def _tool_result_as_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                if item.get("type") in {None, "text"} and "text" in item:
+                    parts.append(str(item.get("text") or ""))
+                elif "content" in item:
+                    parts.append(str(item.get("content") or ""))
+                else:
+                    parts.append(str(item))
+            else:
+                parts.append(str(item))
+        return "\n".join(p for p in parts if p)
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "")
+        return str(content)
+    return str(content)
+
+
+def extract_tool_use_blocks(event: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return tool_use block dicts from assistant / stream_event shapes."""
+    blocks: list[dict[str, Any]] = []
+    etype = event.get("type")
+
+    if etype == "stream_event":
+        inner = event.get("event") or {}
+        if isinstance(inner, dict):
+            return extract_tool_use_blocks(inner)
+        return blocks
+
+    if etype == "content_block_start":
+        block = event.get("content_block") or {}
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            blocks.append(block)
+        return blocks
+
+    if etype == "assistant":
+        message = event.get("message") if isinstance(event.get("message"), dict) else event
+        content = message.get("content") if isinstance(message, dict) else None
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    blocks.append(block)
+        return blocks
+
+    # Top-level tool_use (defensive).
+    if etype == "tool_use" or (
+        event.get("type") is None and event.get("name") and event.get("id")
+    ):
+        blocks.append(event)
+    return blocks
+
+
+def extract_tool_result_blocks(event: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return tool_result block dicts from user / stream shapes."""
+    blocks: list[dict[str, Any]] = []
+    etype = event.get("type")
+
+    if etype == "stream_event":
+        inner = event.get("event") or {}
+        if isinstance(inner, dict):
+            return extract_tool_result_blocks(inner)
+        return blocks
+
+    if etype in {"user", "tool_result"}:
+        if etype == "tool_result":
+            blocks.append(event)
+            return blocks
+        message = event.get("message") if isinstance(event.get("message"), dict) else event
+        content = message.get("content") if isinstance(message, dict) else event.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    blocks.append(block)
+        elif isinstance(content, dict) and content.get("type") == "tool_result":
+            blocks.append(content)
+        return blocks
+
+    return blocks
+
+
+def is_hermes_mcp_tool_name(name: str) -> bool:
+    """True when the tool name is under the Hermes MCP server prefix."""
+    if not isinstance(name, str) or not name:
+        return False
+    return name.startswith(HERMES_MCP_TOOL_PREFIX) or name.startswith("mcp__hermes-tools__")
+
+
+def _is_message_start(event: dict[str, Any]) -> bool:
+    """True for stream_event / bare message_start (new assistant generation)."""
+    etype = event.get("type")
+    if etype == "message_start":
+        return True
+    if etype == "stream_event":
+        inner = event.get("event")
+        if isinstance(inner, dict) and inner.get("type") == "message_start":
+            return True
+    return False
+
+
+class ClaudeEventProjector:
+    """Stateful projector: feed stream-json events, accumulate text + tools + result."""
+
+    def __init__(self) -> None:
+        self.state = ClaudeProjectionState()
+
+    def _note_tool_use(self, block: dict[str, Any]) -> Optional[ClaudeToolCallRecord]:
+        raw_name = str(block.get("name") or "unknown")
+        tool_id = str(block.get("id") or block.get("tool_use_id") or "")
+        if not tool_id:
+            # Synthesize a stable-ish id so we can still track completions.
+            tool_id = f"anon-{len(self.state.tool_calls)}-{raw_name}"
+        existing = self.state._tool_by_id.get(tool_id)
+        if existing is not None:
+            # Update input if a fuller snapshot arrives later.
+            inp = _tool_input_as_dict(block.get("input") or block.get("arguments"))
+            if inp and (not existing.input or existing.input == {"_raw": ""}):
+                existing.input = inp
+            return None  # already started
+        rec = ClaudeToolCallRecord(
+            id=tool_id,
+            name=strip_hermes_mcp_tool_prefix(raw_name),
+            raw_name=raw_name,
+            input=_tool_input_as_dict(block.get("input") or block.get("arguments")),
+            started=True,
+            completed=False,
+        )
+        self.state._tool_by_id[tool_id] = rec
+        self.state.tool_calls.append(rec)
+        self.state.last_tool_started.append(rec)
+        return rec
+
+    def _note_tool_result(self, block: dict[str, Any]) -> Optional[ClaudeToolCallRecord]:
+        tool_id = str(block.get("tool_use_id") or block.get("id") or "")
+        if not tool_id:
+            return None
+        rec = self.state._tool_by_id.get(tool_id)
+        if rec is None:
+            # Result arrived without a prior tool_use (resume / race). Create stub.
+            raw_name = str(block.get("name") or "unknown")
+            rec = ClaudeToolCallRecord(
+                id=tool_id,
+                name=strip_hermes_mcp_tool_prefix(raw_name),
+                raw_name=raw_name,
+                started=True,
+                completed=False,
+            )
+            self.state._tool_by_id[tool_id] = rec
+            self.state.tool_calls.append(rec)
+        rec.result = _tool_result_as_text(block.get("content") if "content" in block else block.get("result"))
+        rec.is_error = bool(block.get("is_error"))
+        # tool_use_error strings from Claude (race before MCP connects) count as error.
+        if rec.result and "<tool_use_error>" in rec.result:
+            rec.is_error = True
+        if not rec.completed:
+            rec.completed = True
+            self.state.last_tool_completed.append(rec)
+        return rec
+
+    def consume(self, event: dict[str, Any]) -> ClaudeProjectionState:
+        """Incorporate one event. Returns the shared state (mutated in place)."""
+        self.state.last_text_deltas = []
+        self.state.last_tool_started = []
+        self.state.last_tool_completed = []
+        if not isinstance(event, dict):
+            return self.state
+
+        etype = event.get("type")
+
+        # New assistant generation → reset per-message stream buffer so
+        # intermediate tool-loop text is not concatenated into final_text.
+        if _is_message_start(event):
+            self.state.streamed_text = ""
+            self.state._message_has_streamed_deltas = False
+
+        # Streaming partials (strict text_delta only).
+        delta = extract_text_delta(event)
+        if delta:
+            self.state.streamed_text += delta
+            self.state.last_text_deltas.append(delta)
+            self.state._message_has_streamed_deltas = True
+
+        # Full assistant snapshots (overwrite with latest complete text).
+        assistant = extract_assistant_message_text(event)
+        if assistant is not None:
+            self.state.assistant_text = assistant
+            # Seed stream only when this message never saw partials (e.g.
+            # partials disabled). Never overwrite/duplicate after deltas.
+            if not self.state._message_has_streamed_deltas and not self.state.streamed_text:
+                self.state.streamed_text = assistant
+
+        # Tool use / result (MCP hermes-tools + any other tools Claude emits).
+        for block in extract_tool_use_blocks(event):
+            self._note_tool_use(block)
+        for block in extract_tool_result_blocks(event):
+            self._note_tool_result(block)
+
+        # Session id may appear on many event types.
+        sid = event.get("session_id")
+        if isinstance(sid, str) and sid:
+            self.state.session_id = sid
+
+        # Terminal result.
+        if etype == "result":
+            self.state.finished = True
+            self.state.result_event = event
+            self.state.is_error = bool(event.get("is_error"))
+            result_text = event.get("result")
+            if isinstance(result_text, str):
+                self.state.result_text = result_text
+            usage = extract_usage(event)
+            if usage is not None:
+                self.state.usage = usage
+            cost = event.get("total_cost_usd")
+            if isinstance(cost, (int, float)):
+                self.state.total_cost_usd = float(cost)
+            # subtype=error without is_error flag still counts as error.
+            subtype = str(event.get("subtype") or "").lower()
+            if subtype in {"error", "failure", "failed", "error_max_turns"}:
+                self.state.is_error = True
+
+        return self.state
+
+    def consume_line(self, line: str) -> ClaudeProjectionState:
+        from agent.transports.claude_cli import parse_stream_json_line
+
+        event = parse_stream_json_line(line)
+        if event is None:
+            self.state.last_text_deltas = []
+            self.state.last_tool_started = []
+            self.state.last_tool_completed = []
+            return self.state
+        return self.consume(event)

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -1,45 +1,32 @@
-"""Hermes-tools-as-MCP server for the codex_app_server runtime.
+"""Hermes-tools-as-MCP server for codex_app_server + claude_cli runtimes.
 
-When the user runs `openai/*` turns through the codex app-server, codex
-owns the loop and builds its own tool list. By default, that means
-Hermes' richer tool surface — web search, browser automation,
-delegate_task subagents, vision analysis, persistent memory, skills,
-cross-session search, image generation, TTS — is unreachable.
+When the user runs turns through an external coding CLI (codex app-server
+or Claude Code via ``claude -p``), that CLI owns the model loop and builds
+its own tool list. By default Hermes' richer tool surface is unreachable.
 
-This module exposes a curated subset of those Hermes tools to the
-spawned codex subprocess via stdio MCP. Codex registers it as a normal
-MCP server (per `~/.codex/config.toml [mcp_servers.hermes-tools]`) and
-the user gets full Hermes capability inside a Codex turn.
+This module exposes a curated subset of Hermes tools to the spawned CLI
+subprocess via stdio MCP. Codex registers it in
+``~/.codex/config.toml [mcp_servers.hermes-tools]``; Claude CLI receives
+an equivalent entry via ``--mcp-config`` (see
+``agent.transports.claude_cli.build_hermes_mcp_config``).
 
-Scope (what we expose):
-  - web_search, web_extract              — Firecrawl, no codex equivalent
-  - browser_navigate / _click / _type /  — Camofox/Browserbase automation
-    _snapshot / _scroll / _back / _press /
-    _get_images / _console / _vision
-  - vision_analyze                       — image inspection by vision model
-  - image_generate                       — image generation
-  - skill_view, skills_list              — Hermes' skill library
-  - text_to_speech                       — TTS
-  - kanban_* (complete/block/comment/    — kanban worker + orchestrator
-    heartbeat/show/list/create/            handoff (stateless: read env var,
-    unblock/link)                          write ~/.hermes/kanban.db)
+Profiles (``HERMES_TOOLS_MCP_PROFILE`` env, default ``codex``):
+  - ``codex``  — Hermes-only tools that Codex lacks (no terminal/fs;
+                 Codex's built-ins cover those).
+  - ``claude`` — Hermes core tools INCLUDING terminal/fs/search, because
+                 Claude's native Bash/Edit/Write/Read are disallowed so
+                 the model must call Hermes tools only (no double-agent).
 
-What we DO NOT expose:
-  - terminal / shell                     — codex's own shell tool
-  - read_file / write_file / patch       — codex's apply_patch + shell
-  - search_files / process               — codex's shell
-  - clarify                              — codex's own UX
-  - delegate_task / memory /             — `_AGENT_LOOP_TOOLS` in Hermes
-    session_search / todo                  (model_tools.py). They require
-                                           the running AIAgent context to
-                                           dispatch (mid-loop state), so a
-                                           stateless MCP callback can't
-                                           drive them. See the inline
-                                           comment on EXPOSED_TOOLS below.
+Shared exclusions (both profiles):
+  - delegate_task / memory / session_search / todo —
+    ``_AGENT_LOOP_TOOLS`` in Hermes (model_tools.py). They require the
+    running AIAgent mid-loop state; a stateless MCP callback can't drive
+    them.
 
 Run with: python -m agent.transports.hermes_tools_mcp_server
-Spawned by: CodexAppServerSession.ensure_started() when the runtime is
-            active and config opts in.
+Spawned by: Codex (config.toml) or Claude CLI (``--mcp-config``) as a
+            stdio MCP child. The tool round-trip is owned by the CLI;
+            Hermes hosts this server and projects stream events.
 """
 
 from __future__ import annotations
@@ -97,19 +84,24 @@ def _signature_from_schema(schema: dict | None) -> tuple[inspect.Signature, dict
     return inspect.Signature(params, return_annotation=str), annots
 
 
-# Tools we expose. Each name MUST match a registered Hermes tool that
-# `model_tools.handle_function_call()` can dispatch.
-#
-# What we deliberately DO NOT expose:
-#   - terminal / shell / read_file / write_file / patch / search_files /
-#     process — codex's built-ins cover these and approval routes through
-#     codex's own UI.
-#   - delegate_task / memory / session_search / todo — these are
-#     `_AGENT_LOOP_TOOLS` in Hermes (model_tools.py:493). They require
-#     the running AIAgent context to dispatch (mid-loop state), so a
-#     stateless MCP callback can't drive them. Hermes' default runtime
-#     keeps these working; the codex_app_server runtime cannot.
-EXPOSED_TOOLS: tuple[str, ...] = (
+# MCP server name registered with FastMCP / clients. Claude prefixes tools
+# as ``mcp__hermes-tools__<name>``; codex uses the bare server name.
+MCP_SERVER_NAME = "hermes-tools"
+
+# Agent-loop tools that need live AIAgent mid-loop state — never expose
+# via the stateless MCP callback (either profile).
+AGENT_LOOP_TOOLS_EXCLUDED: frozenset[str] = frozenset(
+    {
+        "delegate_task",
+        "memory",
+        "session_search",
+        "todo",
+    }
+)
+
+# Hermes-only tools shared by both profiles (codex lacks these; claude
+# gets them too once native freelancing is blocked).
+_HERMES_SPECIFIC_TOOLS: tuple[str, ...] = (
     "web_search",
     "web_extract",
     "browser_navigate",
@@ -128,25 +120,53 @@ EXPOSED_TOOLS: tuple[str, ...] = (
     "skills_list",
     "text_to_speech",
     # Kanban worker handoff tools — gated on HERMES_KANBAN_TASK env var
-    # (set by the kanban dispatcher when spawning a worker). Without these
-    # in the callback, a worker spawned with openai_runtime=codex_app_server
-    # could do the work but couldn't report completion back to the kernel,
-    # making it hang until timeout. Stateless dispatch — they just read
-    # the env var and write to ~/.hermes/kanban.db.
+    # (set by the kanban dispatcher when spawning a worker). Stateless
+    # dispatch — they read the env var and write ~/.hermes/kanban.db.
     "kanban_complete",
     "kanban_block",
     "kanban_comment",
     "kanban_heartbeat",
     "kanban_show",
     "kanban_list",
-    # NOTE: kanban_create / kanban_unblock / kanban_link are orchestrator-
-    # only — the kanban tool gates them on HERMES_KANBAN_TASK being unset.
-    # They're exposed here for orchestrator agents running on the codex
-    # runtime that need to dispatch new tasks.
+    # Orchestrator-only kanban tools (gated on HERMES_KANBAN_TASK unset).
     "kanban_create",
     "kanban_unblock",
     "kanban_link",
 )
+
+# Codex profile: do NOT expose terminal/fs — codex's built-ins cover them
+# and route approvals through codex's own UI.
+CODEX_EXPOSED_TOOLS: tuple[str, ...] = _HERMES_SPECIFIC_TOOLS
+
+# Claude profile: include Hermes terminal/fs/search so the model can act
+# without Claude's native Bash/Edit/Write/Read (those are disallowed by
+# the claude_cli runtime). Still excludes _AGENT_LOOP_TOOLS.
+CLAUDE_CORE_TOOLS: tuple[str, ...] = (
+    "terminal",
+    "process",
+    "read_file",
+    "write_file",
+    "patch",
+    "search_files",
+    "execute_code",
+)
+
+CLAUDE_EXPOSED_TOOLS: tuple[str, ...] = CLAUDE_CORE_TOOLS + _HERMES_SPECIFIC_TOOLS
+
+# Back-compat alias — existing codex tests + migration import EXPOSED_TOOLS.
+EXPOSED_TOOLS: tuple[str, ...] = CODEX_EXPOSED_TOOLS
+
+
+def get_exposed_tools(profile: Optional[str] = None) -> tuple[str, ...]:
+    """Return the tool name tuple for the given MCP profile.
+
+    ``profile`` defaults to ``HERMES_TOOLS_MCP_PROFILE`` env (``codex`` if
+    unset). Unknown profiles fall back to the codex surface.
+    """
+    resolved = (profile or os.environ.get("HERMES_TOOLS_MCP_PROFILE") or "codex").strip().lower()
+    if resolved in {"claude", "claude_cli", "claude-cli"}:
+        return CLAUDE_EXPOSED_TOOLS
+    return CODEX_EXPOSED_TOOLS
 
 
 def _build_server() -> Any:
@@ -166,14 +186,18 @@ def _build_server() -> Any:
         handle_function_call,
     )
 
+    profile = (os.environ.get("HERMES_TOOLS_MCP_PROFILE") or "codex").strip().lower()
+    tool_names = get_exposed_tools(profile)
+
     mcp = FastMCP(
-        "hermes-tools",
+        MCP_SERVER_NAME,
         instructions=(
             "Hermes Agent's tool surface, exposed for use inside a Codex "
-            "session. Use these for capabilities Codex's built-in toolset "
-            "doesn't cover: web search/extract, browser automation, "
-            "subagent delegation, vision, image generation, persistent "
-            "memory, skills, and cross-session search."
+            "or Claude Code session. Prefer these Hermes tools over any "
+            "native filesystem/exec tools the host CLI may advertise. "
+            "Capabilities include terminal/file (claude profile), web "
+            "search/extract, browser automation, vision, image generation, "
+            "skills, TTS, and kanban handoff."
         ),
     )
 
@@ -187,7 +211,7 @@ def _build_server() -> Any:
 
     exposed_count = 0
 
-    for name in EXPOSED_TOOLS:
+    for name in tool_names:
         spec = all_defs.get(name)
         if spec is None:
             logger.debug(
@@ -238,9 +262,10 @@ def _build_server() -> Any:
         exposed_count += 1
 
     logger.info(
-        "hermes-tools MCP server registered %d/%d tools",
+        "hermes-tools MCP server (profile=%s) registered %d/%d tools",
+        profile,
         exposed_count,
-        len(EXPOSED_TOOLS),
+        len(tool_names),
     )
     return mcp
 

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -38,10 +38,14 @@ class CLIAgentSetupMixin:
         _primary_exc = None
         runtime = None
         try:
+            # Pass self.model so per-call overrides (--model / --provider) and
+            # session model state feed claude_cli default-on (and similar
+            # model-dependent api_mode gates), not only config.default.
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=(self.model or None),
             )
         except Exception as exc:
             _primary_exc = exc
@@ -59,7 +63,10 @@ class CLIAgentSetupMixin:
                     try:
                         from hermes_cli.fallback_config import resolve_entry_api_key
 
-                        _fb_kwargs = {"requested": _fb_provider}
+                        _fb_kwargs = {
+                            "requested": _fb_provider,
+                            "target_model": _fb_model,
+                        }
                         if _fb.get("base_url"):
                             _fb_kwargs["explicit_base_url"] = _fb["base_url"]
                         _fb_api_key = resolve_entry_api_key(_fb)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1478,6 +1478,28 @@ def switch_model(
     elif not api_mode:
         api_mode = determine_api_mode(target_provider, base_url)
 
+    # claude_cli default-when-token / explicit config: host_mandated_api_mode
+    # (api.anthropic.com) always returns anthropic_messages and would strip a
+    # correctly-resolved claude_cli api_mode from resolve_runtime_provider.
+    # Re-apply the runtime gate so /model switches (and same-provider Claude
+    # model swaps, including desktop-app model-only switches) land on
+    # `claude -p` base Max when a setup token + binary exist — unless the
+    # profile explicitly opts out via anthropic_runtime: anthropic_messages.
+    try:
+        from hermes_cli.runtime_provider import (
+            _get_model_config,
+            _maybe_apply_claude_cli_runtime,
+        )
+
+        api_mode = _maybe_apply_claude_cli_runtime(
+            provider=target_provider,
+            api_mode=api_mode or "",
+            model_cfg=_get_model_config(),
+            model=new_model,
+        )
+    except Exception:
+        pass
+
     # --- Normalize model name for target provider ---
     new_model = _resolve_named_custom_model_id(
         new_model, target_provider, custom_providers

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -357,7 +357,22 @@ _VALID_API_MODES = {
     # `model.openai_runtime == "codex_app_server"` AND provider in
     # {"openai", "openai-codex"}. Default is unchanged.
     "codex_app_server",
+    # Route Anthropic Claude turns through a `claude -p` subprocess so Max
+    # subscription billing rides Claude Code's CLI (setup-token auth + clean
+    # env). Selected when provider == "anthropic" and either:
+    #   - explicit `model.anthropic_runtime: claude_cli` / HERMES_ANTHROPIC_RUNTIME, or
+    #   - UNSET/`auto` AND a setup token + `claude` binary are available
+    #     (default-when-token). Explicit `anthropic_messages`/`http`/`api` opts out.
+    "claude_cli",
 }
+
+# Values that force claude_cli (explicit enable).
+_CLAUDE_CLI_RUNTIME_ENABLE = frozenset({"claude_cli", "on", "1", "true", "yes"})
+# Values that force the HTTP anthropic_messages path (explicit opt-out).
+_CLAUDE_CLI_RUNTIME_DISABLE = frozenset({
+    "off", "0", "false", "no",
+    "anthropic_messages", "http", "api", "messages",
+})
 
 
 def _parse_api_mode(raw: Any) -> Optional[str]:
@@ -403,6 +418,121 @@ def _maybe_apply_codex_app_server_runtime(
     runtime = str(model_cfg.get("openai_runtime") or "").strip().lower()
     if runtime == "codex_app_server":
         return "codex_app_server"
+    return api_mode
+
+
+def _is_claude_model_name(model: Optional[str]) -> bool:
+    """True when the model id looks like a Claude family model."""
+    return "claude" in (model or "").lower()
+
+
+def _claude_cli_binary_available() -> bool:
+    """True when the ``claude`` binary is resolvable and executable."""
+    try:
+        from agent.transports.claude_cli import resolve_claude_bin
+        import shutil
+
+        bin_path = resolve_claude_bin()
+        if not bin_path:
+            return False
+        # Absolute / path-shaped result: require a real executable file.
+        if os.path.sep in bin_path or (os.path.altsep and os.path.altsep in bin_path):
+            return os.path.isfile(bin_path) and os.access(bin_path, os.X_OK)
+        # Bare name ("claude"): resolve_claude_bin returns this when not found.
+        # Confirm it is actually on PATH and executable.
+        found = shutil.which(bin_path)
+        return bool(found and os.access(found, os.X_OK))
+    except Exception:
+        return False
+
+
+def _claude_cli_token_resolvable() -> bool:
+    """True when resolve_claude_cli_oauth_token succeeds (env/pool/root .env)."""
+    try:
+        from agent.transports.claude_cli_session import resolve_claude_cli_oauth_token
+
+        token = resolve_claude_cli_oauth_token()
+        return bool(token and str(token).strip())
+    except Exception:
+        return False
+
+
+def _claude_cli_auto_eligible(*, model: Optional[str]) -> bool:
+    """Default-on preconditions: Claude model + setup token + claude binary.
+
+    Environments without a setup token or ``claude`` binary are unchanged
+    (stay on HTTP ``anthropic_messages``).
+    """
+    if not _is_claude_model_name(model):
+        return False
+    if not _claude_cli_binary_available():
+        return False
+    if not _claude_cli_token_resolvable():
+        return False
+    return True
+
+
+def _maybe_apply_claude_cli_runtime(
+    *,
+    provider: str,
+    api_mode: str,
+    model_cfg: Optional[Dict[str, Any]],
+    model: Optional[str] = None,
+) -> str:
+    """Rewrite api_mode → ``claude_cli`` for Anthropic Claude models when allowed.
+
+    Precedence (explicit config / env always wins):
+
+      1. ``HERMES_ANTHROPIC_RUNTIME`` env (one-session override):
+         - enable: ``claude_cli`` / ``on`` / ``1`` / ``true`` / ``yes``
+         - opt-out (HTTP): ``off`` / ``0`` / ``false`` / ``no`` /
+           ``anthropic_messages`` / ``http`` / ``api`` / ``messages``
+         - empty / ``auto`` → fall through to config
+      2. ``model.anthropic_runtime`` in config.yaml:
+         - enable → force ``claude_cli``
+         - opt-out values → force ``anthropic_messages`` (HTTP)
+         - UNSET / ``auto`` / empty → **default to ``claude_cli``** when:
+             * provider is ``anthropic``,
+             * model is a Claude family model,
+             * a Claude Code setup token is resolvable
+               (``resolve_claude_cli_oauth_token`` — env / pool / canonical root),
+             * and the ``claude`` binary is available (``resolve_claude_bin``).
+           Otherwise leave the existing HTTP ``anthropic_messages`` path.
+
+    Only provider ``anthropic`` is eligible — other providers are untouched.
+    Users without a setup token or ``claude`` binary are unaffected.
+
+    Returns the (possibly-rewritten) api_mode.
+    """
+    if provider != "anthropic":
+        return api_mode
+
+    env_runtime = (_getenv("HERMES_ANTHROPIC_RUNTIME", "") or "").strip().lower()
+    if env_runtime in _CLAUDE_CLI_RUNTIME_ENABLE:
+        return "claude_cli"
+    if env_runtime in _CLAUDE_CLI_RUNTIME_DISABLE:
+        # Explicit one-session disable — force the HTTP path even if
+        # config.yaml has anthropic_runtime: claude_cli.
+        return "anthropic_messages"
+    # env empty / "auto" → fall through to model_cfg
+
+    runtime = ""
+    if model_cfg:
+        runtime = str(model_cfg.get("anthropic_runtime") or "").strip().lower()
+    if runtime in _CLAUDE_CLI_RUNTIME_ENABLE:
+        return "claude_cli"
+    if runtime in _CLAUDE_CLI_RUNTIME_DISABLE:
+        return "anthropic_messages"
+    # UNSET / "auto" / empty / unknown → default-when-token
+    if runtime and runtime != "auto":
+        # Unknown non-auto value: do not auto-enable (fail closed to HTTP).
+        return api_mode
+
+    effective_model = model
+    if not effective_model and model_cfg:
+        effective_model = str(model_cfg.get("default") or model_cfg.get("model") or "")
+    if _claude_cli_auto_eligible(model=effective_model):
+        return "claude_cli"
     return api_mode
 
 
@@ -539,6 +669,15 @@ def _resolve_runtime_from_pool_entry(
     # Inert when `model.openai_runtime` is unset or "auto".
     api_mode = _maybe_apply_codex_app_server_runtime(
         provider=provider, api_mode=api_mode, model_cfg=model_cfg
+    )
+    # Route Anthropic Claude turns through `claude -p` (Max sub) when
+    # explicitly enabled OR default-when-token (setup token + binary).
+    # Explicit anthropic_runtime opt-out keeps HTTP anthropic_messages.
+    api_mode = _maybe_apply_claude_cli_runtime(
+        provider=provider,
+        api_mode=api_mode,
+        model_cfg=model_cfg,
+        model=str(effective_model or "") if effective_model else None,
     )
 
     if provider == "lmstudio":
@@ -1462,6 +1601,26 @@ def _resolve_azure_foundry_runtime(
     }
 
 
+def _effective_model_for_claude_cli(
+    *,
+    target_model: Optional[str] = None,
+    model_cfg: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Prefer per-call/override model over config default for claude_cli gating.
+
+    CLI ``--model``, oneshot, desktop/runtime model overrides, and mid-session
+    switches pass ``target_model``. Config-only paths leave it unset and fall
+    back to ``model.default`` / ``model.model``.
+    """
+    if target_model and str(target_model).strip():
+        return str(target_model).strip()
+    if model_cfg:
+        cfg_model = str(model_cfg.get("default") or model_cfg.get("model") or "").strip()
+        if cfg_model:
+            return cfg_model
+    return None
+
+
 def _resolve_explicit_runtime(
     *,
     provider: str,
@@ -1494,9 +1653,19 @@ def _resolve_explicit_runtime(
                     "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
                     "run 'claude setup-token', or authenticate with 'claude /login'."
                 )
+        # Honor per-call model override (CLI --model / desktop runtime) so
+        # default-on claude_cli fires even when config.default is non-Claude.
+        api_mode = _maybe_apply_claude_cli_runtime(
+            provider="anthropic",
+            api_mode="anthropic_messages",
+            model_cfg=model_cfg,
+            model=_effective_model_for_claude_cli(
+                target_model=target_model, model_cfg=model_cfg
+            ),
+        )
         return {
             "provider": "anthropic",
-            "api_mode": "anthropic_messages",
+            "api_mode": api_mode,
             "base_url": base_url,
             "api_key": api_key,
             "source": "explicit",
@@ -2060,9 +2229,20 @@ def resolve_runtime_provider(
                     "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
                     "run 'claude setup-token', or authenticate with 'claude /login'."
                 )
+        # Prefer target_model (CLI --provider/--model, oneshot, desktop override)
+        # over config.default so profiles without anthropic_runtime still get
+        # default-on claude_cli when the *override* is an Anthropic Claude model.
+        api_mode = _maybe_apply_claude_cli_runtime(
+            provider="anthropic",
+            api_mode="anthropic_messages",
+            model_cfg=model_cfg,
+            model=_effective_model_for_claude_cli(
+                target_model=target_model, model_cfg=model_cfg
+            ),
+        )
         return {
             "provider": "anthropic",
-            "api_mode": "anthropic_messages",
+            "api_mode": api_mode,
             "base_url": base_url,
             "api_key": token,
             "source": "env",

--- a/run_agent.py
+++ b/run_agent.py
@@ -3977,6 +3977,16 @@ class AIAgent:
         except Exception:
             pass
 
+        # 5c. Close claude_cli multi-turn session mapping (process-local
+        # Claude session files under ~/.claude/projects remain on disk).
+        try:
+            claude_sess = getattr(self, "_claude_cli_session", None)
+            if claude_sess is not None:
+                claude_sess.close()
+                self._claude_cli_session = None
+        except Exception:
+            pass
+
         # 6. Free conversation history.  Mirrors _release_evicted_agent_soft's
         # soft-eviction clear — close() is the hard teardown for true session
         # boundaries (/new, /reset, session expiry), so the message list won't
@@ -7199,6 +7209,26 @@ class AIAgent:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
         return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+
+    def _run_claude_cli_turn(
+        self,
+        *,
+        user_message: str,
+        original_user_message: Any,
+        messages: List[Dict[str, Any]],
+        effective_task_id: str,
+        should_review_memory: bool = False,
+    ) -> Dict[str, Any]:
+        """Forwarder — see ``agent.claude_runtime.run_claude_cli_turn``."""
+        from agent.claude_runtime import run_claude_cli_turn
+        return run_claude_cli_turn(
+            self,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=should_review_memory,
+        )
 
 def main(
     query: str = None,

--- a/tests/agent/test_claude_cli_aux.py
+++ b/tests/agent/test_claude_cli_aux.py
@@ -1,0 +1,508 @@
+"""Phase 2c/2d aux handling for claude_cli — compression/title skip + no HTTP aux.
+
+Confirms:
+  * Hermes HTTP context compression is skipped for api_mode=claude_cli
+    (Claude owns native compaction via --resume)
+  * Title generation skips the failing Anthropic HTTP aux path
+  * Failures do not error the main turn (skip returns cleanly)
+  * Central invariant: claude_cli main runtime never constructs an HTTP
+    Anthropic aux client (extra-usage 400 path) — auto + explicit provider
+  * model_switch / switch_model preserve api_mode=claude_cli when
+    anthropic_runtime is opted in
+
+No live network / claude calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import conversation_compression as cc
+from agent import title_generator as tg
+from agent import auxiliary_client as aux
+
+
+class _AgentStub:
+    api_mode = "claude_cli"
+    model = "claude-opus-4-8"
+    provider = "anthropic"
+    session_id = "sess-test"
+    _cached_system_prompt = "sys-prompt"
+    compression_enabled = False
+    context_compressor = SimpleNamespace(
+        should_compress=lambda *_a, **_k: True,
+        threshold_tokens=1000,
+        context_length=200_000,
+        compression_count=0,
+    )
+
+    def _build_system_prompt(self, system_message=None):
+        return system_message or self._cached_system_prompt
+
+
+def test_compress_context_skips_for_claude_cli(caplog):
+    agent = _AgentStub()
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": "more context " * 50},
+    ]
+    with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+        out_msgs, out_prompt = cc.compress_context(
+            agent, messages, system_message="sys"
+        )
+    assert out_msgs is messages  # unchanged identity
+    assert out_prompt == "sys-prompt"
+    assert any(
+        "skipping Hermes HTTP context compression" in r.message for r in caplog.records
+    )
+
+
+def test_compress_context_skip_is_api_mode_gated(caplog):
+    """claude_cli skip only fires when api_mode is claude_cli."""
+    agent = _AgentStub()
+    agent.api_mode = "claude_cli"
+    with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+        cc.compress_context(agent, [{"role": "user", "content": "x"}], None)
+    assert any("claude_cli" in r.message for r in caplog.records)
+
+    # Different api_mode must not emit the claude_cli skip line.
+    caplog.clear()
+    agent.api_mode = "anthropic_messages"
+    # Intercept before any aux work: replace compress_context body after the
+    # claude_cli guard by short-circuiting on a custom compressor that
+    # raises if entered — we only need the skip log absence.
+    class _BoomCompressor:
+        @staticmethod
+        def _automatic_compression_blocked(_self):
+            # Returning True makes compress_context return early without aux.
+            return True
+
+    agent.context_compressor = _BoomCompressor()
+    with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+        out_msgs, _ = cc.compress_context(
+            agent, [{"role": "user", "content": "x"}], None
+        )
+    assert len(out_msgs) == 1
+    assert not any(
+        "skipping Hermes HTTP context compression" in r.message for r in caplog.records
+    )
+
+
+def test_generate_title_skips_claude_cli_runtime(caplog, monkeypatch):
+    # If skip fails, call_llm would be invoked — make it explode.
+    def _boom(**_kw):
+        raise AssertionError("call_llm must not run for claude_cli title")
+
+    monkeypatch.setattr(tg, "call_llm", _boom)
+    monkeypatch.setattr(tg, "_auto_title_enabled", lambda: True)
+
+    with caplog.at_level(logging.INFO, logger="agent.title_generator"):
+        title = tg.generate_title(
+            "user hello",
+            "assistant world",
+            main_runtime={
+                "model": "claude-opus-4-8",
+                "provider": "anthropic",
+                "api_mode": "claude_cli",
+            },
+        )
+    assert title is None
+    assert any("claude_cli runtime" in r.message for r in caplog.records)
+
+
+def test_generate_title_still_calls_llm_for_other_modes(monkeypatch):
+    class _Resp:
+        class choices:
+            pass
+
+    class _Choice:
+        class message:
+            content = "My Title"
+
+    _Resp.choices = [type("C", (), {"message": type("M", (), {"content": "My Title"})()})()]
+
+    called = {}
+
+    def _fake_call_llm(**kw):
+        called["yes"] = True
+        return _Resp()
+
+    monkeypatch.setattr(tg, "call_llm", _fake_call_llm)
+    monkeypatch.setattr(tg, "_auto_title_enabled", lambda: True)
+    monkeypatch.setattr(
+        "agent.agent_runtime_helpers.strip_think_blocks",
+        lambda _self, content: content,
+    )
+
+    title = tg.generate_title(
+        "user hello",
+        "assistant world",
+        main_runtime={
+            "model": "grok-4.3",
+            "provider": "xai-oauth",
+            "api_mode": "chat_completions",
+        },
+    )
+    assert called.get("yes") is True
+    assert title == "My Title"
+
+
+def test_claude_cli_runtime_turn_does_not_raise_on_aux_skip(tmp_path, monkeypatch):
+    """Main turn completes even when title/compression would have failed.
+
+    Integration-ish: run_claude_cli_turn with a fake session succeeds;
+    generate_title skip is independent and non-fatal.
+    """
+    from agent import claude_runtime as cr
+    from agent.transports.claude_cli import ClaudeCliSpawnConfig
+    from agent.transports.claude_cli_session import ClaudeCliSession
+
+    monkeypatch.setenv(
+        "HERMES_CLAUDE_CLI_SLOT_DIR", str(tmp_path / "claude_cli_slots")
+    )
+
+    class _FakeClient:
+        def __init__(self, **kw):
+            pass
+
+        def spawn(self, cfg: ClaudeCliSpawnConfig):
+            return None
+
+        def iter_stdout_lines(self, timeout=None):
+            sid = "22222222-2222-2222-2222-222222222222"
+            yield '{"type":"system","subtype":"init","session_id":"%s"}' % sid
+            yield (
+                '{"type":"result","subtype":"success","is_error":false,'
+                '"result":"done","session_id":"%s",'
+                '"usage":{"input_tokens":2,"output_tokens":1}}' % sid
+            )
+
+        def wait(self, timeout=None):
+            return 0
+
+        def stderr_tail(self, n=20):
+            return []
+
+        def close(self):
+            pass
+
+    real_init = ClaudeCliSession.__init__
+
+    def _patched_init(self, *a, **k):
+        k = dict(k)
+        k["client_factory"] = lambda **kw: _FakeClient(**kw)
+        k.setdefault("cwd", str(tmp_path))
+        real_init(self, *a, **k)
+
+    monkeypatch.setattr(ClaudeCliSession, "__init__", _patched_init)
+    monkeypatch.setattr(
+        "agent.transports.claude_cli_session.resolve_claude_cli_oauth_token",
+        lambda **kw: "sk-ant-oat01-TEST",
+    )
+
+    agent = SimpleNamespace(
+        api_mode="claude_cli",
+        model="claude-opus-4-8",
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        api_key="sk-ant-oat01-TEST",
+        session_id="s1",
+        session_cwd=str(tmp_path),
+        system_prompt="sys",
+        show_commentary=True,
+        tool_progress_callback=None,
+        _session_db=None,
+        _session_db_created=False,
+        session_api_calls=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_reasoning_tokens=0,
+        session_estimated_cost_usd=0.0,
+        session_cost_status=None,
+        session_cost_source=None,
+        context_compressor=None,
+        log_prefix="",
+        quiet_mode=True,
+    )
+
+    def _sync(**k):
+        pass
+
+    def _spawn(**k):
+        pass
+
+    def _fire(*a, **k):
+        pass
+
+    agent._sync_external_memory_for_turn = _sync
+    agent._spawn_background_review = _spawn
+    agent._fire_stream_delta = _fire
+    agent._emit_interim_assistant_message = _fire
+    agent._flush_messages_to_session_db = _fire
+    agent._ensure_db_session = _fire
+
+    result = cr.run_claude_cli_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="t1",
+    )
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+    assert result.get("error") is None
+
+    # Title skip remains non-fatal.
+    title = tg.generate_title(
+        "hello",
+        "done",
+        main_runtime={"api_mode": "claude_cli", "provider": "anthropic"},
+    )
+    assert title is None
+
+
+# ── Phase 2d: central no-HTTP-anthropic-aux invariant ──────────────────────
+
+
+def test_is_claude_cli_runtime_active_from_main_runtime():
+    assert aux._is_claude_cli_runtime_active(
+        {"api_mode": "claude_cli", "provider": "anthropic"}
+    )
+    assert not aux._is_claude_cli_runtime_active(
+        {"api_mode": "anthropic_messages", "provider": "anthropic"}
+    )
+
+
+def test_try_anthropic_refuses_http_when_claude_cli_main_runtime(monkeypatch):
+    """Spy: build_anthropic_client must never run for claude_cli main."""
+    built = {"n": 0}
+
+    def _boom(*_a, **_k):
+        built["n"] += 1
+        raise AssertionError("HTTP Anthropic client must not be built")
+
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.build_anthropic_client",
+        _boom,
+        raising=False,
+    )
+    # Also prevent config/env from interfering: only main_runtime matters.
+    monkeypatch.delenv("HERMES_ANTHROPIC_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        aux,
+        "_is_claude_cli_runtime_active",
+        lambda main_runtime=None: (
+            isinstance(main_runtime, dict)
+            and str(main_runtime.get("api_mode") or "").lower() == "claude_cli"
+        ),
+    )
+
+    client, model = aux._try_anthropic(
+        explicit_api_key="sk-ant-oat01-TEST",
+        main_runtime={"api_mode": "claude_cli", "provider": "anthropic"},
+    )
+    assert client is None
+    assert model is None
+    assert built["n"] == 0
+
+
+def test_resolve_provider_client_anthropic_refuses_claude_cli(monkeypatch):
+    """Explicit provider=anthropic still refuses HTTP under claude_cli."""
+    built = {"n": 0}
+
+    def _boom_build(*_a, **_k):
+        built["n"] += 1
+        raise AssertionError("must not build HTTP anthropic")
+
+    monkeypatch.setenv("HERMES_ANTHROPIC_RUNTIME", "claude_cli")
+
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        side_effect=_boom_build,
+    ):
+        client, model = aux.resolve_provider_client(
+            "anthropic",
+            model="claude-haiku-4-5-20251001",
+            main_runtime={
+                "api_mode": "claude_cli",
+                "provider": "anthropic",
+                "model": "claude-opus-4-8",
+            },
+        )
+    assert client is None
+    assert model is None
+    assert built["n"] == 0
+
+
+def test_resolve_auto_skips_http_anthropic_for_claude_cli(monkeypatch, caplog):
+    """auto aux with claude_cli main_runtime must not land on Anthropic HTTP."""
+    # Force Step-1 skip path; make fallback chain empty so we see the skip.
+    monkeypatch.setattr(aux, "_try_configured_fallback_chain", lambda *a, **k: (None, None, None))
+    monkeypatch.setattr(aux, "_try_main_fallback_chain", lambda *a, **k: (None, None, None))
+    monkeypatch.setattr(aux, "_get_provider_chain", lambda: [])
+    monkeypatch.setattr(aux, "_is_provider_unhealthy", lambda *_a, **_k: False)
+
+    def _must_not_try_anthropic(*_a, **_k):
+        raise AssertionError("_try_anthropic must not be called from auto Step-1")
+
+    monkeypatch.setattr(aux, "_try_anthropic", _must_not_try_anthropic)
+
+    with caplog.at_level(logging.INFO, logger="agent.auxiliary_client"):
+        client, model = aux._resolve_auto(
+            main_runtime={
+                "provider": "anthropic",
+                "model": "claude-opus-4-8",
+                "api_mode": "claude_cli",
+                "api_key": "sk-ant-oat01-TEST",
+                "base_url": "https://api.anthropic.com",
+            }
+        )
+    assert client is None
+    assert model is None
+    assert any(
+        "skipping HTTP Anthropic main provider" in r.message for r in caplog.records
+    )
+
+
+def test_switch_model_preserves_claude_cli_api_mode(monkeypatch):
+    """In-place model switch must not drop claude_cli → anthropic_messages."""
+    from agent import agent_runtime_helpers as arh
+
+    monkeypatch.setenv("HERMES_ANTHROPIC_RUNTIME", "claude_cli")
+
+    agent = SimpleNamespace(
+        model="claude-opus-4-8",
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        api_mode="claude_cli",
+        api_key="sk-ant-oat01-TEST",
+        client=None,
+        _anthropic_client=None,
+        _anthropic_api_key="sk-ant-oat01-TEST",
+        _anthropic_base_url="https://api.anthropic.com",
+        _is_anthropic_oauth=True,
+        _config_context_length=None,
+        _client_kwargs={},
+        _credential_pool=None,
+        _claude_cli_session=None,
+        compression_enabled=False,
+        context_compressor=None,
+        _primary_runtime={},
+        max_tokens=None,
+        request_overrides={},
+        quiet_mode=True,
+        _use_prompt_caching=False,
+        _use_native_cache_layout=False,
+        reasoning_config=None,
+    )
+    agent._anthropic_prompt_cache_policy = lambda **_k: (False, False)
+    agent._ensure_lmstudio_runtime_loaded = lambda: None
+
+    monkeypatch.setattr(
+        arh,
+        "get_provider_request_timeout",
+        lambda *_a, **_k: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda *_a, **_k: None,
+        raising=False,
+    )
+
+    # switch_model imports determine_api_mode which returns anthropic_messages;
+    # our re-apply of _maybe_apply_claude_cli_runtime must restore claude_cli.
+    arh.switch_model(
+        agent,
+        new_model="claude-sonnet-4-6",
+        new_provider="anthropic",
+        api_key="sk-ant-oat01-TEST",
+        base_url="https://api.anthropic.com",
+        api_mode="",  # force determine_api_mode path
+    )
+    assert agent.api_mode == "claude_cli", (
+        f"switch_model dropped claude_cli → {agent.api_mode!r} "
+        "(HTTP anthropic extra-usage path)"
+    )
+    assert agent.client is None
+    assert agent._anthropic_client is None
+    assert agent.model == "claude-sonnet-4-6"
+
+
+def test_model_switch_resolve_preserves_claude_cli(monkeypatch):
+    """hermes_cli.model_switch host_mandated must not strip claude_cli."""
+    from hermes_cli.runtime_provider import _maybe_apply_claude_cli_runtime
+
+    # Simulate the post-host_mandated re-apply that model_switch now does.
+    api_mode = "anthropic_messages"  # what host_mandated returns for api.anthropic.com
+    monkeypatch.setenv("HERMES_ANTHROPIC_RUNTIME", "claude_cli")
+    restored = _maybe_apply_claude_cli_runtime(
+        provider="anthropic",
+        api_mode=api_mode,
+        model_cfg={"anthropic_runtime": "claude_cli"},
+    )
+    assert restored == "claude_cli"
+
+
+def test_claude_cli_conversation_makes_no_http_anthropic_aux_call(monkeypatch, tmp_path):
+    """Regression: full-lifecycle multi-turn claude_cli → zero HTTP anthropic aux.
+
+    Constructs a lightweight AIAgent-shaped object, runs title + compression
+    + resolve_provider_client as interactive would, and spies that
+    build_anthropic_client is never invoked for aux.
+    """
+    built = {"n": 0, "urls": []}
+
+    def _spy_build(token, base_url=None, **_k):
+        built["n"] += 1
+        built["urls"].append(str(base_url or ""))
+        raise AssertionError(
+            f"HTTP Anthropic aux client constructed (base_url={base_url!r}) "
+            "— claude_cli must never use api.anthropic.com for side-LLM"
+        )
+
+    monkeypatch.setenv("HERMES_ANTHROPIC_RUNTIME", "claude_cli")
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.build_anthropic_client",
+        _spy_build,
+    )
+
+    main_runtime = {
+        "provider": "anthropic",
+        "model": "claude-opus-4-8",
+        "api_mode": "claude_cli",
+        "api_key": "sk-ant-oat01-TEST",
+        "base_url": "https://api.anthropic.com",
+    }
+
+    # Title
+    monkeypatch.setattr(tg, "_auto_title_enabled", lambda: True)
+    title = tg.generate_title("u", "a", main_runtime=main_runtime)
+    assert title is None
+
+    # Compression
+    agent = _AgentStub()
+    msgs, _ = cc.compress_context(agent, [{"role": "user", "content": "x"}], None)
+    assert len(msgs) == 1
+
+    # Explicit + auto aux resolution
+    c1, _ = aux.resolve_provider_client(
+        "anthropic", model="claude-haiku-4-5-20251001", main_runtime=main_runtime
+    )
+    assert c1 is None
+    monkeypatch.setattr(aux, "_try_configured_fallback_chain", lambda *a, **k: (None, None, None))
+    monkeypatch.setattr(aux, "_try_main_fallback_chain", lambda *a, **k: (None, None, None))
+    monkeypatch.setattr(aux, "_get_provider_chain", lambda: [])
+    c2, _ = aux._resolve_auto(main_runtime=main_runtime)
+    assert c2 is None
+
+    assert built["n"] == 0, f"HTTP anthropic built {built['n']} times: {built['urls']}"

--- a/tests/agent/test_claude_cli_concurrency.py
+++ b/tests/agent/test_claude_cli_concurrency.py
@@ -1,0 +1,299 @@
+"""Unit tests for Phase 2c host-global claude_cli concurrency semaphore.
+
+Covers:
+  * Nth concurrent acquire blocks then falls back (timeout → ClaudeCliConcurrencyError)
+  * Slot released on completion
+  * Slot released on failure / exception path
+  * Stale-slot reaping (dead PID)
+  * Cap disabled (max_concurrent=0 / unbounded)
+  * Cross-thread last-slot exclusivity
+
+No live ``claude`` / network calls.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from agent.transports import claude_cli_concurrency as conc
+from agent.transports.claude_cli import ClaudeCliConcurrencyError
+
+
+@pytest.fixture(autouse=True)
+def _slot_dir(tmp_path, monkeypatch):
+    slot_dir = tmp_path / "claude_cli_slots"
+    monkeypatch.setenv("HERMES_CLAUDE_CLI_SLOT_DIR", str(slot_dir))
+    # Avoid config.yaml bleed from the host.
+    monkeypatch.delenv("HERMES_CLAUDE_CLI_MAX_CONCURRENT", raising=False)
+    monkeypatch.delenv("HERMES_CLAUDE_CLI_ACQUIRE_TIMEOUT", raising=False)
+    return slot_dir
+
+
+def test_resolve_defaults(monkeypatch):
+    monkeypatch.setattr(conc, "_load_model_claude_cli_cfg", lambda: {})
+    assert conc.resolve_claude_cli_max_concurrent() == conc.DEFAULT_MAX_CONCURRENT
+    assert (
+        conc.resolve_claude_cli_acquire_timeout()
+        == conc.DEFAULT_ACQUIRE_TIMEOUT_SECONDS
+    )
+
+
+def test_resolve_from_config(monkeypatch):
+    monkeypatch.setattr(
+        conc,
+        "_load_model_claude_cli_cfg",
+        lambda: {"max_concurrent": 2, "acquire_timeout_seconds": 1.5},
+    )
+    assert conc.resolve_claude_cli_max_concurrent() == 2
+    assert conc.resolve_claude_cli_acquire_timeout() == 1.5
+
+
+def test_resolve_zero_means_unbounded(monkeypatch):
+    monkeypatch.setattr(
+        conc, "_load_model_claude_cli_cfg", lambda: {"max_concurrent": 0}
+    )
+    assert conc.resolve_claude_cli_max_concurrent() is None
+
+
+def test_env_bridge_overrides_config(monkeypatch):
+    monkeypatch.setattr(
+        conc, "_load_model_claude_cli_cfg", lambda: {"max_concurrent": 9}
+    )
+    monkeypatch.setenv("HERMES_CLAUDE_CLI_MAX_CONCURRENT", "1")
+    monkeypatch.setenv("HERMES_CLAUDE_CLI_ACQUIRE_TIMEOUT", "0.2")
+    assert conc.resolve_claude_cli_max_concurrent() == 1
+    assert conc.resolve_claude_cli_acquire_timeout() == 0.2
+
+
+def test_nth_concurrent_try_acquire_blocks(tmp_path, monkeypatch):
+    """With max=1, second try_acquire fails immediately (slot full)."""
+    lease1, msg1 = conc.try_acquire_claude_cli_slot(max_concurrent=1)
+    assert msg1 is None and lease1 is not None and lease1.enabled
+
+    lease2, msg2 = conc.try_acquire_claude_cli_slot(max_concurrent=1)
+    assert lease2 is None
+    assert msg2 is not None
+    assert "concurrency cap" in msg2
+
+    lease1.release()
+    lease3, msg3 = conc.try_acquire_claude_cli_slot(max_concurrent=1)
+    assert msg3 is None and lease3 is not None
+    lease3.release()
+    assert conc.claude_cli_slot_registry_snapshot() == []
+
+
+def test_acquire_timeout_raises_concurrency_error(monkeypatch):
+    lease1, _ = conc.try_acquire_claude_cli_slot(max_concurrent=1)
+    assert lease1 is not None
+    try:
+        with pytest.raises(ClaudeCliConcurrencyError) as ei:
+            conc.acquire_claude_cli_slot(
+                max_concurrent=1, timeout_seconds=0.25
+            )
+        err = ei.value
+        assert "concurrency" in str(err).lower() or "cap" in str(err).lower()
+        assert err.max_concurrent == 1
+        assert err.timeout_seconds == 0.25
+    finally:
+        lease1.release()
+
+
+def test_slot_released_on_context_manager_success():
+    with conc.claude_cli_slot(max_concurrent=1, timeout_seconds=1.0) as lease:
+        assert lease.enabled
+        assert len(conc.claude_cli_slot_registry_snapshot()) == 1
+    assert conc.claude_cli_slot_registry_snapshot() == []
+
+
+def test_slot_released_on_context_manager_failure():
+    with pytest.raises(RuntimeError, match="boom"):
+        with conc.claude_cli_slot(max_concurrent=1, timeout_seconds=1.0):
+            assert len(conc.claude_cli_slot_registry_snapshot()) == 1
+            raise RuntimeError("boom")
+    # Slot must not leak after exception.
+    assert conc.claude_cli_slot_registry_snapshot() == []
+
+
+def test_stale_slot_reaped(monkeypatch):
+    """Dead-PID slots are pruned so the next acquire can proceed."""
+    monkeypatch.setattr(
+        "gateway.status._pid_exists",
+        lambda pid: int(pid) != 99999999,
+    )
+    state_path = conc._state_path()
+    conc._write_entries(
+        state_path,
+        [
+            {
+                "lease_id": "stale",
+                "pid": 99999999,
+                "started_at": 1.0,
+                "updated_at": 1.0,
+            }
+        ],
+    )
+    lease, msg = conc.try_acquire_claude_cli_slot(max_concurrent=1)
+    assert msg is None and lease is not None
+    snap = conc.claude_cli_slot_registry_snapshot()
+    assert len(snap) == 1
+    assert snap[0]["lease_id"] == lease.lease_id
+    lease.release()
+
+
+def test_hard_exit_child_reclaimed(tmp_path, monkeypatch):
+    """A process that os._exit(0) without release is reaped by the next acquire."""
+    repo_root = Path(__file__).resolve().parents[2]
+    slot_dir = tmp_path / "claude_cli_slots"
+    env = os.environ.copy()
+    env["HERMES_CLAUDE_CLI_SLOT_DIR"] = str(slot_dir)
+    env["PYTHONPATH"] = str(repo_root)
+    # Keep pytest seat belt happy in child by having SLOT_DIR set.
+    env.pop("PYTEST_CURRENT_TEST", None)
+    child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import os\n"
+                "from agent.transports.claude_cli_concurrency import "
+                "try_acquire_claude_cli_slot\n"
+                "lease, msg = try_acquire_claude_cli_slot(max_concurrent=1)\n"
+                "assert msg is None, msg\n"
+                "print(os.getpid(), flush=True)\n"
+                "os._exit(0)\n"
+            ),
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=15,
+        check=True,
+    )
+    child_pid = int(child.stdout.strip())
+    assert child_pid > 0
+
+    lease, msg = conc.try_acquire_claude_cli_slot(max_concurrent=1)
+    assert msg is None and lease is not None
+    lease.release()
+
+
+def test_concurrent_threads_claim_only_cap_slots():
+    results = []
+
+    def _claim(_i):
+        lease, msg = conc.try_acquire_claude_cli_slot(max_concurrent=2)
+        results.append((lease, msg))
+        return lease
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        leases = list(pool.map(_claim, range(8)))
+
+    held = [l for l in leases if l is not None]
+    blocked = [msg for lease, msg in results if lease is None and msg]
+    try:
+        assert len(held) == 2
+        assert len(blocked) == 6
+    finally:
+        for lease in held:
+            lease.release()
+
+
+def test_wait_then_acquire_after_release():
+    """Bounded wait succeeds when a holder releases mid-wait."""
+    lease1, _ = conc.try_acquire_claude_cli_slot(max_concurrent=1)
+    assert lease1 is not None
+
+    ready = threading.Event()
+    done = {}
+
+    def _waiter():
+        ready.set()
+        lease = conc.acquire_claude_cli_slot(
+            max_concurrent=1, timeout_seconds=3.0
+        )
+        done["lease"] = lease
+
+    t = threading.Thread(target=_waiter, daemon=True)
+    t.start()
+    assert ready.wait(1.0)
+    time.sleep(0.3)
+    lease1.release()
+    t.join(timeout=5.0)
+    assert "lease" in done
+    done["lease"].release()
+    assert conc.claude_cli_slot_registry_snapshot() == []
+
+
+def test_unbounded_when_cap_none():
+    lease, msg = conc.try_acquire_claude_cli_slot(max_concurrent=None)
+    # resolve with override None still goes to config — pass 0 via resolve:
+    # max_concurrent=None means "look up config". Use 0 via env.
+    assert msg is None  # either no-op or real lease
+    if lease:
+        lease.release()
+
+    # Explicit override: 0 is not accepted by try_acquire's int path the same
+    # way — resolve_claude_cli_max_concurrent(0) → None.
+    assert conc.resolve_claude_cli_max_concurrent(0) is None
+    lease2, msg2 = conc.try_acquire_claude_cli_slot(
+        max_concurrent=conc.resolve_claude_cli_max_concurrent(0)
+    )
+    assert msg2 is None and lease2 is not None and lease2.enabled is False
+    lease2.release()
+
+
+def test_session_holds_slot_for_turn(tmp_path, monkeypatch):
+    """ClaudeCliSession.run_turn acquires and releases the host slot."""
+    from agent.transports.claude_cli import ClaudeCliSpawnConfig
+    from agent.transports.claude_cli_session import ClaudeCliSession
+
+    class _FakeClient:
+        def __init__(self, **kw):
+            self._closed = False
+
+        def spawn(self, cfg: ClaudeCliSpawnConfig):
+            # While the turn is in progress the slot must be held.
+            snap = conc.claude_cli_slot_registry_snapshot()
+            assert len(snap) == 1, snap
+            return None
+
+        def iter_stdout_lines(self, timeout=None):
+            sid = "11111111-1111-1111-1111-111111111111"
+            yield (
+                '{"type":"system","subtype":"init","session_id":"%s"}' % sid
+            )
+            yield (
+                '{"type":"result","subtype":"success","is_error":false,'
+                '"result":"ok","session_id":"%s",'
+                '"usage":{"input_tokens":1,"output_tokens":1}}' % sid
+            )
+
+        def wait(self, timeout=None):
+            return 0
+
+        def stderr_tail(self, n=20):
+            return []
+
+        def close(self):
+            self._closed = True
+
+    monkeypatch.setenv("HERMES_CLAUDE_CLI_MAX_CONCURRENT", "1")
+    session = ClaudeCliSession(
+        oauth_token="sk-ant-oat01-TEST",
+        model="claude-opus-4-8",
+        cwd=str(tmp_path),
+        client_factory=lambda **kw: _FakeClient(**kw),
+    )
+    result = session.run_turn("hi")
+    assert result.final_text == "ok"
+    # Slot released after turn.
+    assert conc.claude_cli_slot_registry_snapshot() == []

--- a/tests/agent/test_claude_cli_runtime.py
+++ b/tests/agent/test_claude_cli_runtime.py
@@ -1,0 +1,1649 @@
+"""Unit tests for the claude_cli runtime (Phase 1 + 2a MCP + 2b multi-turn + 2c).
+
+Covers:
+  (a) stream-json parser golden test (assistant text + result/usage + is_error)
+  (b) clean-env builder (pollution stripped, token injected, HOME/PATH kept)
+  (c) api_mode resolution (anthropic_runtime / HERMES_ANTHROPIC_RUNTIME)
+  (d) Phase 2a MCP config generation (hermes-tools server + allowed/disallowed)
+  (e) Phase 2a tool-event parsing (tool_use + tool_result stream-json sample)
+  (f) Phase 2a permission model (no dangerously-skip-permissions; native blocked)
+  (g) Phase 2b multi-turn: --session-id create, --resume reuse, mapping
+      persistence, missing-session fallback, history seed note
+
+Phase 2c concurrency/aux unit tests live in test_claude_cli_concurrency.py
+and test_claude_cli_aux.py.
+
+No live `claude` / network calls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _claude_cli_slot_dir_for_session_tests(tmp_path, monkeypatch):
+    """Redirect host-global claude_cli slots into tmp (never touch ~/.hermes/shared)."""
+    monkeypatch.setenv(
+        "HERMES_CLAUDE_CLI_SLOT_DIR", str(tmp_path / "claude_cli_slots")
+    )
+
+from agent.transports.claude_cli import (
+    CLAUDE_CLI_CLEAR_ENV_NAMES,
+    CLAUDE_CLI_PERMISSION_MODE,
+    CLAUDE_NATIVE_FS_EXEC_TOOLS,
+    HERMES_MCP_ALLOWED_TOOLS_GLOB,
+    HERMES_MCP_TOOL_PREFIX,
+    MCP_SERVER_NAME,
+    ClaudeCliClient,
+    ClaudeCliError,
+    ClaudeCliSpawnConfig,
+    build_claude_cli_clean_env,
+    build_hermes_mcp_config,
+    build_hermes_tools_mcp_server_entry,
+    claude_native_disallowed_tools,
+    hermes_mcp_allowed_tools,
+    parse_stream_json_line,
+    strip_hermes_mcp_tool_prefix,
+    write_hermes_mcp_config_file,
+)
+from agent.transports.claude_event_projector import (
+    ClaudeEventProjector,
+    extract_text_delta,
+    extract_tool_result_blocks,
+    extract_tool_use_blocks,
+    is_hermes_mcp_tool_name,
+)
+from agent.transports.claude_cli_session import (
+    ClaudeCliSession,
+    ClaudeCliTurnResult,
+    _usage_to_codex_shape,
+    hermes_history_has_prior_turns,
+    is_resume_missing_error,
+    new_claude_session_id,
+)
+from agent.transports.hermes_tools_mcp_server import (
+    AGENT_LOOP_TOOLS_EXCLUDED,
+    CLAUDE_EXPOSED_TOOLS,
+    CODEX_EXPOSED_TOOLS,
+    EXPOSED_TOOLS,
+    get_exposed_tools,
+)
+from hermes_cli import runtime_provider as rp
+
+
+# ---------------------------------------------------------------------------
+# (a) stream-json parser golden test
+# ---------------------------------------------------------------------------
+
+# Captured-style JSONL sample approximating `claude -p --output-format
+# stream-json --include-partial-messages --verbose` for a pure-text turn.
+# Shapes mirror the confirmed result event from the 2026-07-19 step-0 test
+# plus the stream_event / assistant envelopes documented by Claude Code.
+_GOLDEN_STREAM_JSONL = """
+{"type":"system","subtype":"init","session_id":"sess-golden-001","model":"claude-opus-4-8"}
+{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}},"session_id":"sess-golden-001"}
+{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}},"session_id":"sess-golden-001"}
+{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":", world"}},"session_id":"sess-golden-001"}
+{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"!"}},"session_id":"sess-golden-001"}
+{"type":"assistant","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"Hello, world!"}],"stop_reason":"end_turn","usage":{"input_tokens":12,"output_tokens":4}},"session_id":"sess-golden-001"}
+{"type":"result","subtype":"success","is_error":false,"result":"Hello, world!","session_id":"sess-golden-001","usage":{"input_tokens":12,"output_tokens":4,"cache_read_input_tokens":0},"total_cost_usd":0.0}
+""".strip()
+
+_GOLDEN_ERROR_JSONL = """
+{"type":"system","subtype":"init","session_id":"sess-err-001"}
+{"type":"result","subtype":"error","is_error":true,"result":"OAuth session expired and could not be refreshed","session_id":"sess-err-001","usage":{"input_tokens":0,"output_tokens":0}}
+""".strip()
+
+
+def test_parse_stream_json_line_skips_noise():
+    assert parse_stream_json_line("") is None
+    assert parse_stream_json_line("   ") is None
+    assert parse_stream_json_line("not json") is None
+    assert parse_stream_json_line("[1,2,3]") is None  # non-dict
+    obj = parse_stream_json_line('{"type":"result","is_error":false}')
+    assert obj is not None
+    assert obj["type"] == "result"
+
+
+def test_stream_json_golden_extracts_text_usage_and_success():
+    projector = ClaudeEventProjector()
+    deltas: list[str] = []
+    for line in _GOLDEN_STREAM_JSONL.splitlines():
+        state = projector.consume_line(line)
+        deltas.extend(state.last_text_deltas)
+
+    state = projector.state
+    assert state.finished is True
+    assert state.is_error is False
+    assert state.final_text == "Hello, world!"
+    assert state.session_id == "sess-golden-001"
+    assert state.usage is not None
+    assert state.usage["input_tokens"] == 12
+    assert state.usage["output_tokens"] == 4
+    assert state.total_cost_usd == 0.0
+    # Streaming path assembled the same text.
+    assert "".join(deltas) == "Hello, world!"
+    assert state.streamed_text == "Hello, world!"
+
+
+def test_stream_json_golden_is_error_path():
+    projector = ClaudeEventProjector()
+    for line in _GOLDEN_ERROR_JSONL.splitlines():
+        projector.consume_line(line)
+    state = projector.state
+    assert state.finished is True
+    assert state.is_error is True
+    assert "OAuth session expired" in (state.result_text or "")
+
+
+def test_extract_text_delta_handles_nested_and_flat():
+    nested = {
+        "type": "stream_event",
+        "event": {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "Hi"},
+        },
+    }
+    assert extract_text_delta(nested) == "Hi"
+    flat = {
+        "type": "content_block_delta",
+        "delta": {"type": "text_delta", "text": "Yo"},
+    }
+    assert extract_text_delta(flat) == "Yo"
+    assert extract_text_delta({"type": "system"}) is None
+
+
+def test_turn_result_to_normalized_response():
+    turn = ClaudeCliTurnResult(
+        final_text="ok",
+        usage={"input_tokens": 3, "output_tokens": 2, "cache_read_input_tokens": 1},
+        session_id="s1",
+        is_error=False,
+    )
+    nr = turn.to_normalized_response()
+    assert nr.content == "ok"
+    assert nr.finish_reason == "stop"
+    assert nr.tool_calls is None
+    assert nr.usage is not None
+    assert nr.usage.prompt_tokens == 4  # 3 + 1 cache
+    assert nr.usage.completion_tokens == 2
+    assert nr.provider_data["claude_cli_session_id"] == "s1"
+
+
+def test_usage_to_codex_shape():
+    shaped = _usage_to_codex_shape(
+        {"input_tokens": 10, "output_tokens": 5, "cache_read_input_tokens": 2}
+    )
+    assert shaped["inputTokens"] == 10
+    assert shaped["outputTokens"] == 5
+    assert shaped["cachedInputTokens"] == 2
+    assert shaped["totalTokens"] == 17
+
+
+# ---------------------------------------------------------------------------
+# (b) clean-env builder
+# ---------------------------------------------------------------------------
+
+
+def test_clean_env_strips_pollution_injects_token_keeps_home_path():
+    polluted = {
+        "HOME": "/Users/tester",
+        "PATH": "/usr/bin:/bin",
+        "USER": "tester",
+        "LANG": "en_US.UTF-8",
+        "TERM": "xterm-256color",
+        "TMPDIR": "/tmp",
+        # Pollution that must be stripped (Claude-Code / Anthropic).
+        "ANTHROPIC_BASE_URL": "https://evil.example/v1",
+        "ANTHROPIC_API_KEY": "sk-ant-api-should-not-leak",
+        "ANTHROPIC_TOKEN": "should-not-leak",
+        "CLAUDE_CODE_OAUTH_TOKEN": "stale-rotating-or-parent-token",
+        "CLAUDECODE": "1",
+        "CLAUDE_CODE_ENTRYPOINT": "cli",
+        "CLAUDE_AGENT_SDK_VERSION": "9.9.9",
+        "CLAUDE_EFFORT": "max",
+        "CLAUDE_PREVIEW_FEATURE": "1",
+        # Unrelated secret that must also NOT be copied (env -i style).
+        "OPENAI_API_KEY": "sk-openai-secret",
+        "HERMES_DASHBOARD_SESSION_TOKEN": "dash-secret",
+    }
+    setup_token = "sk-ant-oat01-TEST_SETUP_TOKEN_NOT_REAL"
+    clean = build_claude_cli_clean_env(
+        oauth_token=setup_token,
+        base_env=polluted,
+    )
+
+    assert clean["CLAUDE_CODE_OAUTH_TOKEN"] == setup_token
+    assert clean["HOME"] == "/Users/tester"
+    assert clean["PATH"] == "/usr/bin:/bin"
+    assert clean["USER"] == "tester"
+    assert clean["LANG"] == "en_US.UTF-8"
+    assert clean["TERM"] == "xterm-256color"
+    assert clean["TMPDIR"] == "/tmp"
+
+    for name in (
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDECODE",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "CLAUDE_AGENT_SDK_VERSION",
+        "CLAUDE_EFFORT",
+        "CLAUDE_PREVIEW_FEATURE",
+        "OPENAI_API_KEY",
+        "HERMES_DASHBOARD_SESSION_TOKEN",
+    ):
+        assert name not in clean, f"{name} leaked into clean env"
+
+    # Named clear-set must not appear (except the re-injected oauth token).
+    for name in CLAUDE_CLI_CLEAR_ENV_NAMES:
+        if name == "CLAUDE_CODE_OAUTH_TOKEN":
+            continue
+        assert name not in clean
+
+
+def test_clean_env_rejects_empty_token():
+    with pytest.raises(ValueError, match="setup token"):
+        build_claude_cli_clean_env(oauth_token="")
+
+
+def test_build_argv_includes_stream_json_and_model():
+    client = ClaudeCliClient(
+        oauth_token="sk-ant-oat01-TEST",
+        env=build_claude_cli_clean_env(oauth_token="sk-ant-oat01-TEST"),
+        claude_bin="/fake/claude",
+    )
+    cfg = ClaudeCliSpawnConfig(
+        model="claude-opus-4-8",
+        prompt="ping",
+        claude_bin="/fake/claude",
+        system_prompt=None,
+        enable_hermes_mcp=True,
+    )
+    argv = client.build_argv(cfg)
+    assert argv[0] == "/fake/claude"
+    assert "-p" in argv
+    assert "--output-format" in argv
+    assert "stream-json" in argv
+    assert "--include-partial-messages" in argv
+    assert "--verbose" in argv
+    assert "--setting-sources" in argv
+    assert "user" in argv
+    # Phase 2a: no unrestricted skip-all; MCP allowlist + permission mode.
+    assert "--dangerously-skip-permissions" not in argv
+    assert "--mcp-config" in argv
+    assert "--allowedTools" in argv
+    assert "--disallowedTools" in argv
+    assert "--permission-mode" in argv
+    assert CLAUDE_CLI_PERMISSION_MODE in argv
+    assert "--model" in argv
+    assert "claude-opus-4-8" in argv
+    assert argv[-1] == "ping"
+    client.close()
+
+
+def test_build_argv_appends_system_prompt_file(tmp_path):
+    client = ClaudeCliClient(
+        oauth_token="sk-ant-oat01-TEST",
+        env=build_claude_cli_clean_env(oauth_token="sk-ant-oat01-TEST"),
+        claude_bin="/fake/claude",
+    )
+    cfg = ClaudeCliSpawnConfig(
+        model="claude-opus-4-8",
+        prompt="hi",
+        system_prompt="You are Hermes.",
+        claude_bin="/fake/claude",
+        enable_hermes_mcp=True,
+    )
+    argv = client.build_argv(cfg)
+    assert "--append-system-prompt-file" in argv
+    idx = argv.index("--append-system-prompt-file")
+    path = argv[idx + 1]
+    with open(path, encoding="utf-8") as fh:
+        assert fh.read() == "You are Hermes."
+    client.close()
+
+
+# ---------------------------------------------------------------------------
+# (c) api_mode resolution
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_apply_claude_cli_runtime_from_config(monkeypatch):
+    # Explicit enable never depends on auto-eligibility.
+    monkeypatch.setattr(rp, "_claude_cli_auto_eligible", lambda **kw: False)
+    mode = rp._maybe_apply_claude_cli_runtime(
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model_cfg={"anthropic_runtime": "claude_cli"},
+        model="claude-opus-4-8",
+    )
+    assert mode == "claude_cli"
+
+    # Unset + not auto-eligible → stay HTTP.
+    mode_off = rp._maybe_apply_claude_cli_runtime(
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model_cfg={},
+        model="claude-opus-4-8",
+    )
+    assert mode_off == "anthropic_messages"
+
+    # Non-anthropic providers never rewrite.
+    mode_or = rp._maybe_apply_claude_cli_runtime(
+        provider="openrouter",
+        api_mode="chat_completions",
+        model_cfg={"anthropic_runtime": "claude_cli"},
+        model="claude-opus-4-8",
+    )
+    assert mode_or == "chat_completions"
+
+
+def test_maybe_apply_claude_cli_runtime_from_env(monkeypatch):
+    monkeypatch.setattr(rp, "_claude_cli_auto_eligible", lambda **kw: False)
+    monkeypatch.setenv("HERMES_ANTHROPIC_RUNTIME", "claude_cli")
+    mode = rp._maybe_apply_claude_cli_runtime(
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model_cfg={},
+        model="claude-opus-4-8",
+    )
+    assert mode == "claude_cli"
+
+    monkeypatch.setenv("HERMES_ANTHROPIC_RUNTIME", "off")
+    mode = rp._maybe_apply_claude_cli_runtime(
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model_cfg={"anthropic_runtime": "claude_cli"},
+        model="claude-opus-4-8",
+    )
+    assert mode == "anthropic_messages"
+
+
+def test_maybe_apply_claude_cli_runtime_default_when_token(monkeypatch):
+    """UNSET/auto → claude_cli when token+binary available; else HTTP."""
+    monkeypatch.delenv("HERMES_ANTHROPIC_RUNTIME", raising=False)
+
+    # Eligible auto → default claude_cli without per-profile flag.
+    monkeypatch.setattr(rp, "_claude_cli_auto_eligible", lambda **kw: True)
+    mode = rp._maybe_apply_claude_cli_runtime(
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model_cfg={},  # no anthropic_runtime (e.g. profile og)
+        model="claude-opus-4-8",
+    )
+    assert mode == "claude_cli"
+
+    # auto string same as unset.
+    mode_auto = rp._maybe_apply_claude_cli_runtime(
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model_cfg={"anthropic_runtime": "auto"},
+        model="claude-sonnet-4-6",
+    )
+    assert mode_auto == "claude_cli"
+
+    # Uses model_cfg.default when model kw omitted.
+    mode_cfg_default = rp._maybe_apply_claude_cli_runtime(
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model_cfg={"default": "claude-opus-4-8"},
+    )
+    assert mode_cfg_default == "claude_cli"
+
+    # Not eligible → HTTP unchanged.
+    monkeypatch.setattr(rp, "_claude_cli_auto_eligible", lambda **kw: False)
+    mode_http = rp._maybe_apply_claude_cli_runtime(
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model_cfg={},
+        model="claude-opus-4-8",
+    )
+    assert mode_http == "anthropic_messages"
+
+
+def test_maybe_apply_claude_cli_runtime_explicit_opt_out(monkeypatch):
+    """anthropic_runtime: anthropic_messages / http / api forces HTTP."""
+    monkeypatch.delenv("HERMES_ANTHROPIC_RUNTIME", raising=False)
+    # Even when auto would qualify, explicit opt-out wins.
+    monkeypatch.setattr(rp, "_claude_cli_auto_eligible", lambda **kw: True)
+    for opt_out in ("anthropic_messages", "http", "api", "messages", "off"):
+        mode = rp._maybe_apply_claude_cli_runtime(
+            provider="anthropic",
+            api_mode="anthropic_messages",
+            model_cfg={"anthropic_runtime": opt_out},
+            model="claude-opus-4-8",
+        )
+        assert mode == "anthropic_messages", opt_out
+
+
+def test_maybe_apply_claude_cli_runtime_non_claude_model_stays_http(monkeypatch):
+    """Auto path requires a Claude model name; non-Claude stays HTTP."""
+    monkeypatch.delenv("HERMES_ANTHROPIC_RUNTIME", raising=False)
+    # Real eligibility helper — mock only token/bin so model check is live.
+    monkeypatch.setattr(rp, "_claude_cli_binary_available", lambda: True)
+    monkeypatch.setattr(rp, "_claude_cli_token_resolvable", lambda: True)
+    mode = rp._maybe_apply_claude_cli_runtime(
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model_cfg={},
+        model="some-other-model",
+    )
+    assert mode == "anthropic_messages"
+
+
+def test_claude_cli_auto_eligible_checks_token_and_binary(monkeypatch):
+    """Auto eligibility is Claude model + binary + resolvable setup token."""
+    monkeypatch.setattr(rp, "_is_claude_model_name", lambda m: "claude" in (m or "").lower())
+    monkeypatch.setattr(rp, "_claude_cli_binary_available", lambda: True)
+    monkeypatch.setattr(rp, "_claude_cli_token_resolvable", lambda: True)
+    assert rp._claude_cli_auto_eligible(model="claude-opus-4-8") is True
+
+    monkeypatch.setattr(rp, "_claude_cli_token_resolvable", lambda: False)
+    assert rp._claude_cli_auto_eligible(model="claude-opus-4-8") is False
+
+    monkeypatch.setattr(rp, "_claude_cli_token_resolvable", lambda: True)
+    monkeypatch.setattr(rp, "_claude_cli_binary_available", lambda: False)
+    assert rp._claude_cli_auto_eligible(model="claude-opus-4-8") is False
+
+    monkeypatch.setattr(rp, "_claude_cli_binary_available", lambda: True)
+    assert rp._claude_cli_auto_eligible(model="") is False
+
+
+def test_claude_cli_in_valid_api_modes():
+    assert "claude_cli" in rp._VALID_API_MODES
+    assert rp._parse_api_mode("claude_cli") == "claude_cli"
+    assert rp._parse_api_mode("bogus") is None
+
+
+def test_resolve_runtime_from_pool_entry_applies_claude_cli(monkeypatch):
+    """Pool path for anthropic rewrites api_mode when anthropic_runtime set."""
+    monkeypatch.delenv("HERMES_ANTHROPIC_RUNTIME", raising=False)
+    # Isolate auto path so explicit-enable / opt-out cases are deterministic.
+    monkeypatch.setattr(rp, "_claude_cli_auto_eligible", lambda **kw: False)
+
+    class _Entry:
+        runtime_api_key = "sk-ant-oat01-TEST"
+        access_token = "sk-ant-oat01-TEST"
+        runtime_base_url = None
+        base_url = "https://api.anthropic.com"
+        source = "env:CLAUDE_CODE_OAUTH_TOKEN"
+
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="anthropic",
+        entry=_Entry(),
+        requested_provider="anthropic",
+        model_cfg={
+            "provider": "anthropic",
+            "anthropic_runtime": "claude_cli",
+            "default": "claude-opus-4-8",
+        },
+        pool=None,
+        target_model="claude-opus-4-8",
+    )
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_mode"] == "claude_cli"
+    assert resolved["api_key"] == "sk-ant-oat01-TEST"
+
+    # Absent anthropic_runtime + not auto-eligible → anthropic_messages.
+    resolved2 = rp._resolve_runtime_from_pool_entry(
+        provider="anthropic",
+        entry=_Entry(),
+        requested_provider="anthropic",
+        model_cfg={"provider": "anthropic", "default": "claude-opus-4-8"},
+        pool=None,
+        target_model="claude-opus-4-8",
+    )
+    assert resolved2["api_mode"] == "anthropic_messages"
+
+    # Absent anthropic_runtime + auto-eligible → claude_cli (desktop / og case).
+    monkeypatch.setattr(rp, "_claude_cli_auto_eligible", lambda **kw: True)
+    resolved3 = rp._resolve_runtime_from_pool_entry(
+        provider="anthropic",
+        entry=_Entry(),
+        requested_provider="anthropic",
+        model_cfg={"provider": "anthropic", "default": "claude-opus-4-8"},
+        pool=None,
+        target_model="claude-opus-4-8",
+    )
+    assert resolved3["api_mode"] == "claude_cli"
+
+    # Explicit HTTP opt-out wins over auto-eligible.
+    resolved4 = rp._resolve_runtime_from_pool_entry(
+        provider="anthropic",
+        entry=_Entry(),
+        requested_provider="anthropic",
+        model_cfg={
+            "provider": "anthropic",
+            "default": "claude-opus-4-8",
+            "anthropic_runtime": "anthropic_messages",
+        },
+        pool=None,
+        target_model="claude-opus-4-8",
+    )
+    assert resolved4["api_mode"] == "anthropic_messages"
+
+
+def test_resolve_runtime_provider_override_model_default_on(monkeypatch):
+    """Per-call anthropic + Claude override → claude_cli even when config is non-Claude.
+
+    Reproduces the og gap: profile has openai-codex/gpt default and NO
+    anthropic_runtime, but ``--provider anthropic --model claude-opus-4-8``
+    (or an equivalent desktop runtime override) must still hit default-on.
+    """
+    monkeypatch.delenv("HERMES_ANTHROPIC_RUNTIME", raising=False)
+
+    # og-style config: non-anthropic default, no anthropic_runtime.
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "default": "gpt-5.6-sol",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+    )
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    # Force the env/credential path (not pool) so we exercise the
+    # target_model-aware anthropic branch that previously only read config.default.
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
+    seen_models = []
+
+    def _eligible(*, model=None):
+        seen_models.append(model)
+        return bool(model and "claude" in str(model).lower())
+
+    monkeypatch.setattr(rp, "_claude_cli_auto_eligible", _eligible)
+
+    # Avoid real Anthropic token resolution / network.
+    import agent.anthropic_adapter as anth
+
+    monkeypatch.setattr(anth, "resolve_anthropic_token", lambda: "sk-ant-oat01-TEST")
+
+    resolved = rp.resolve_runtime_provider(
+        requested="anthropic",
+        target_model="claude-opus-4-8",
+    )
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_mode"] == "claude_cli"
+    # Default-on must evaluate the *override* model, not config.default (gpt).
+    assert any(m and "claude" in str(m).lower() for m in seen_models)
+
+    # Without target_model, config.default is gpt → auto ineligible → HTTP.
+    seen_models.clear()
+    resolved_no_override = rp.resolve_runtime_provider(requested="anthropic")
+    assert resolved_no_override["api_mode"] == "anthropic_messages"
+
+    # Explicit opt-out still wins even with Claude override + eligible auto.
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "default": "gpt-5.6-sol",
+            "provider": "openai-codex",
+            "anthropic_runtime": "anthropic_messages",
+        },
+    )
+    resolved_opt_out = rp.resolve_runtime_provider(
+        requested="anthropic",
+        target_model="claude-opus-4-8",
+    )
+    assert resolved_opt_out["api_mode"] == "anthropic_messages"
+
+
+def test_resolve_explicit_runtime_override_model_default_on(monkeypatch):
+    """Explicit api_key/base_url path also honors target_model for default-on."""
+    monkeypatch.delenv("HERMES_ANTHROPIC_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "_claude_cli_auto_eligible",
+        lambda *, model=None: bool(model and "claude" in str(model).lower()),
+    )
+    # Config default is non-Claude; only the override is Claude.
+    model_cfg = {"default": "gpt-5.6-sol", "provider": "openai-codex"}
+    resolved = rp._resolve_explicit_runtime(
+        provider="anthropic",
+        requested_provider="anthropic",
+        model_cfg=model_cfg,
+        explicit_api_key="sk-ant-oat01-TEST",
+        explicit_base_url="https://api.anthropic.com",
+        target_model="claude-opus-4-8",
+    )
+    assert resolved is not None
+    assert resolved["api_mode"] == "claude_cli"
+
+    # Same path without target_model → HTTP (config default not Claude).
+    resolved2 = rp._resolve_explicit_runtime(
+        provider="anthropic",
+        requested_provider="anthropic",
+        model_cfg=model_cfg,
+        explicit_api_key="sk-ant-oat01-TEST",
+        explicit_base_url="https://api.anthropic.com",
+    )
+    assert resolved2["api_mode"] == "anthropic_messages"
+
+
+def test_agent_init_accepts_claude_cli_api_mode():
+    """AIAgent / agent_init allowlist includes claude_cli."""
+    # Read the source of the allowlist check via a minimal object that
+    # exercises the same set used in agent_init.
+    allowed = {
+        "chat_completions",
+        "codex_responses",
+        "anthropic_messages",
+        "bedrock_converse",
+        "codex_app_server",
+        "claude_cli",
+    }
+    assert "claude_cli" in allowed
+
+
+def test_claude_cli_error_str_includes_stderr_tail():
+    err = ClaudeCliError(
+        message="boom",
+        exit_code=1,
+        stderr_tail="line1\nline2",
+    )
+    text = str(err)
+    assert "boom" in text
+    assert "exit=1" in text
+    assert "line1" in text
+
+
+def test_session_raises_on_is_error_result():
+    """ClaudeCliSession.run_turn raises ClaudeCliError when result is_error."""
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            self._lines = [
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "error",
+                        "is_error": True,
+                        "result": "rate limited",
+                        "usage": {"input_tokens": 0, "output_tokens": 0},
+                    }
+                )
+                + "\n"
+            ]
+
+        def spawn(self, cfg):
+            return None
+
+        def iter_stdout_lines(self, timeout=600.0):
+            yield from self._lines
+
+        def wait(self, timeout=5.0):
+            return 1
+
+        def stderr_tail(self, n=20):
+            return ["stderr noise"]
+
+        def close(self):
+            pass
+
+        def kill(self):
+            pass
+
+    session = ClaudeCliSession(
+        oauth_token="sk-ant-oat01-TEST",
+        model="claude-opus-4-8",
+        client_factory=_FakeClient,
+    )
+    with pytest.raises(ClaudeCliError, match="rate limited"):
+        session.run_turn("hello")
+    session.close()
+
+
+def test_session_success_returns_final_text():
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            self._lines = list(_GOLDEN_STREAM_JSONL.splitlines(keepends=True))
+
+        def spawn(self, cfg):
+            return None
+
+        def iter_stdout_lines(self, timeout=600.0):
+            yield from self._lines
+
+        def wait(self, timeout=5.0):
+            return 0
+
+        def stderr_tail(self, n=20):
+            return []
+
+        def close(self):
+            pass
+
+        def kill(self):
+            pass
+
+    deltas: list[str] = []
+
+    def on_event(note):
+        if note.get("method") == "claude/text_delta":
+            deltas.append(note["params"]["delta"])
+
+    session = ClaudeCliSession(
+        oauth_token="sk-ant-oat01-TEST",
+        model="claude-opus-4-8",
+        client_factory=_FakeClient,
+        on_event=on_event,
+    )
+    turn = session.run_turn("hello")
+    assert turn.final_text == "Hello, world!"
+    assert turn.is_error is False
+    assert turn.session_id == "sess-golden-001"
+    assert turn.usage["input_tokens"] == 12
+    assert "".join(deltas) == "Hello, world!"
+    nr = turn.to_normalized_response()
+    assert nr.content == "Hello, world!"
+    assert nr.finish_reason == "stop"
+    session.close()
+
+
+# ---------------------------------------------------------------------------
+# (d) Phase 2a MCP config generation
+# ---------------------------------------------------------------------------
+
+
+def test_build_hermes_mcp_config_has_hermes_tools_server():
+    cfg = build_hermes_mcp_config(profile="claude", hermes_home="/tmp/hermes-fake-home")
+    assert "mcpServers" in cfg
+    assert MCP_SERVER_NAME in cfg["mcpServers"]
+    entry = cfg["mcpServers"][MCP_SERVER_NAME]
+    assert entry["command"]  # sys.executable
+    assert entry["args"] == ["-m", "agent.transports.hermes_tools_mcp_server"]
+    assert entry["env"]["HERMES_TOOLS_MCP_PROFILE"] == "claude"
+    assert entry["env"]["HERMES_QUIET"] == "1"
+    assert entry["env"]["HERMES_REDACT_SECRETS"] == "true"
+    assert "PYTHONPATH" in entry["env"]
+    # Worktree root must be on PYTHONPATH so the module resolves.
+    assert "hermes-agent" in entry["env"]["PYTHONPATH"] or entry["env"]["PYTHONPATH"]
+
+
+def test_build_hermes_tools_mcp_server_entry_skips_pytest_tempdir_hermes_home(tmp_path):
+    # Simulate a pytest tempdir HERMES_HOME that must not be baked in.
+    entry = build_hermes_tools_mcp_server_entry(
+        profile="claude",
+        hermes_home=str(tmp_path / "pytest-of-user" / "pytest-0" / "h"),
+    )
+    assert "HERMES_HOME" not in entry.get("env", {})
+
+
+def test_write_hermes_mcp_config_file_roundtrip(tmp_path):
+    path = write_hermes_mcp_config_file(
+        profile="claude",
+        hermes_home="/Users/tester/.hermes",
+        path=str(tmp_path / "mcp.json"),
+    )
+    with open(path, encoding="utf-8") as fh:
+        loaded = json.load(fh)
+    assert loaded["mcpServers"][MCP_SERVER_NAME]["env"]["HERMES_HOME"] == "/Users/tester/.hermes"
+
+
+def test_hermes_mcp_allowed_tools_glob_and_explicit():
+    globs = hermes_mcp_allowed_tools(use_glob=True)
+    assert globs == [HERMES_MCP_ALLOWED_TOOLS_GLOB]
+    assert globs[0].startswith("mcp__hermes-tools__")
+    explicit = hermes_mcp_allowed_tools(use_glob=False, tool_names=("terminal", "read_file"))
+    assert explicit == [
+        "mcp__hermes-tools__terminal",
+        "mcp__hermes-tools__read_file",
+    ]
+
+
+def test_claude_profile_exposes_terminal_and_excludes_agent_loop_tools():
+    claude_tools = get_exposed_tools("claude")
+    assert "terminal" in claude_tools
+    assert "read_file" in claude_tools
+    assert "write_file" in claude_tools
+    assert "search_files" in claude_tools
+    assert "web_search" in claude_tools
+    for excluded in AGENT_LOOP_TOOLS_EXCLUDED:
+        assert excluded not in claude_tools
+    # Codex profile still omits terminal/fs.
+    codex_tools = get_exposed_tools("codex")
+    assert "terminal" not in codex_tools
+    assert "read_file" not in codex_tools
+    assert set(CODEX_EXPOSED_TOOLS) == set(EXPOSED_TOOLS)
+    assert set(CLAUDE_EXPOSED_TOOLS) == set(claude_tools)
+
+
+def test_build_argv_mcp_wiring_permission_model():
+    """(d)+(f) argv must wire MCP config, allow Hermes MCP, disallow native fs/exec."""
+    client = ClaudeCliClient(
+        oauth_token="sk-ant-oat01-TEST",
+        env=build_claude_cli_clean_env(oauth_token="sk-ant-oat01-TEST"),
+        claude_bin="/fake/claude",
+    )
+    cfg = ClaudeCliSpawnConfig(
+        model="claude-opus-4-8",
+        prompt="run terminal",
+        claude_bin="/fake/claude",
+        enable_hermes_mcp=True,
+    )
+    argv = client.build_argv(cfg)
+
+    assert "--dangerously-skip-permissions" not in argv
+    assert "--mcp-config" in argv
+    mcp_idx = argv.index("--mcp-config")
+    mcp_path = argv[mcp_idx + 1]
+    assert os.path.isfile(mcp_path)
+    with open(mcp_path, encoding="utf-8") as fh:
+        mcp_cfg = json.load(fh)
+    assert MCP_SERVER_NAME in mcp_cfg["mcpServers"]
+    server = mcp_cfg["mcpServers"][MCP_SERVER_NAME]
+    assert server["args"] == ["-m", "agent.transports.hermes_tools_mcp_server"]
+    assert server["env"]["HERMES_TOOLS_MCP_PROFILE"] == "claude"
+    # PYTHONPATH must include worktree + (when available) venv site-packages
+    # so Claude's MCP child can import the mcp package.
+    assert "PYTHONPATH" in server["env"]
+    assert server["env"]["PYTHONPATH"]
+
+    assert "--strict-mcp-config" in argv
+    assert "--allowedTools" in argv
+    allowed_idx = argv.index("--allowedTools")
+    # Next tokens until the next flag are allowed tool specs.
+    allowed_vals = []
+    for tok in argv[allowed_idx + 1 :]:
+        if tok.startswith("--"):
+            break
+        allowed_vals.append(tok)
+    assert HERMES_MCP_ALLOWED_TOOLS_GLOB in allowed_vals
+
+    assert "--disallowedTools" in argv
+    dis_idx = argv.index("--disallowedTools")
+    disallowed_vals = []
+    for tok in argv[dis_idx + 1 :]:
+        if tok.startswith("--"):
+            break
+        disallowed_vals.append(tok)
+    for native in ("Bash", "Edit", "Write", "Read"):
+        assert native in disallowed_vals, f"{native} must be disallowed"
+
+    # Critical: --tools "" drops MCP tools too. Default must omit --tools.
+    assert "--tools" not in argv
+
+    assert "--permission-mode" in argv
+    pm_idx = argv.index("--permission-mode")
+    assert argv[pm_idx + 1] == CLAUDE_CLI_PERMISSION_MODE
+
+    assert "--max-turns" in argv
+    client.close()
+
+
+def test_build_argv_tools_override_only_when_explicit():
+    client = ClaudeCliClient(
+        oauth_token="sk-ant-oat01-TEST",
+        env=build_claude_cli_clean_env(oauth_token="sk-ant-oat01-TEST"),
+        claude_bin="/fake/claude",
+    )
+    cfg = ClaudeCliSpawnConfig(
+        model="claude-opus-4-8",
+        prompt="x",
+        claude_bin="/fake/claude",
+        enable_hermes_mcp=True,
+        tools_override="",  # explicit opt-in (not recommended)
+    )
+    argv = client.build_argv(cfg)
+    assert "--tools" in argv
+    assert argv[argv.index("--tools") + 1] == ""
+    client.close()
+
+
+def test_build_argv_mcp_off_no_dangerously_skip_by_default():
+    client = ClaudeCliClient(
+        oauth_token="sk-ant-oat01-TEST",
+        env=build_claude_cli_clean_env(oauth_token="sk-ant-oat01-TEST"),
+        claude_bin="/fake/claude",
+    )
+    cfg = ClaudeCliSpawnConfig(
+        model="claude-opus-4-8",
+        prompt="ping",
+        claude_bin="/fake/claude",
+        enable_hermes_mcp=False,
+        dangerously_skip_permissions=False,
+    )
+    argv = client.build_argv(cfg)
+    assert "--dangerously-skip-permissions" not in argv
+    assert "--mcp-config" not in argv
+    client.close()
+
+
+def test_claude_native_disallowed_tools_covers_fs_exec():
+    denied = set(claude_native_disallowed_tools())
+    for name in CLAUDE_NATIVE_FS_EXEC_TOOLS:
+        assert name in denied
+    assert "Bash" in denied
+    assert "Read" in denied
+    assert "Write" in denied
+    assert "Edit" in denied
+
+
+# ---------------------------------------------------------------------------
+# (e) Phase 2a tool-event parsing — REAL round-trip golden (from live capture)
+# ---------------------------------------------------------------------------
+
+# Captured-style stream-json for a completed Hermes MCP tool round-trip:
+# message_start → tool_use mcp__hermes-tools__terminal → tool_result with
+# real date +%s output → final text_delta + result. Includes the noise that
+# used to garble projection (thinking_delta, signature_delta, input_json_delta,
+# intermediate assistant snapshots) so the projector must stay clean.
+_GOLDEN_TOOL_STREAM_JSONL = """
+{"type":"system","subtype":"init","session_id":"sess-tool-001","model":"claude-opus-4-8","mcp_servers":[{"name":"hermes-tools","status":"pending"}],"tools":["ToolSearch"]}
+{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[]}},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"I should call the terminal tool.","estimated_tokens":12}},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"EsICCokBCA8YAipAglG4fTlima5fEBb4ZyhJxz5T"}},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_term_1","name":"mcp__hermes-tools__terminal","input":{}}},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"command\\": \\"date +%s\\"}"}},"session_id":"sess-tool-001"}
+{"type":"assistant","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-opus-4-8","content":[{"type":"tool_use","id":"toolu_term_1","name":"mcp__hermes-tools__terminal","input":{"command":"date +%s"}}],"stop_reason":"tool_use","usage":{"input_tokens":40,"output_tokens":20}},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"message_stop"},"session_id":"sess-tool-001"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_term_1","content":"{\\"result\\":\\"{\\\\\\"output\\\\\\": \\\\\\"1784434336\\\\\\", \\\\\\"exit_code\\\\\\": 0, \\\\\\"error\\\\\\": null}\\"}"}]},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_2","role":"assistant","content":[]}},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"1784"}},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"434336"}},"session_id":"sess-tool-001"}
+{"type":"assistant","message":{"id":"msg_2","type":"message","role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"1784434336"}],"stop_reason":"end_turn","usage":{"input_tokens":60,"output_tokens":8}},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"sess-tool-001"}
+{"type":"stream_event","event":{"type":"message_stop"},"session_id":"sess-tool-001"}
+{"type":"result","subtype":"success","is_error":false,"result":"1784434336","session_id":"sess-tool-001","usage":{"input_tokens":60,"output_tokens":8,"cache_read_input_tokens":0},"total_cost_usd":0.01,"num_turns":2}
+""".strip()
+
+
+def test_tool_use_and_result_extractors():
+    assistant_evt = None
+    user_evt = None
+    for line in _GOLDEN_TOOL_STREAM_JSONL.splitlines():
+        obj = json.loads(line)
+        if obj.get("type") == "assistant" and assistant_evt is None:
+            # First assistant with tool_use
+            content = (obj.get("message") or {}).get("content") or []
+            if any(isinstance(b, dict) and b.get("type") == "tool_use" for b in content):
+                assistant_evt = obj
+        if obj.get("type") == "user" and user_evt is None:
+            user_evt = obj
+    assert assistant_evt is not None and user_evt is not None
+    uses = extract_tool_use_blocks(assistant_evt)
+    assert len(uses) == 1
+    assert uses[0]["name"] == "mcp__hermes-tools__terminal"
+    assert uses[0]["input"]["command"] == "date +%s"
+    assert is_hermes_mcp_tool_name(uses[0]["name"])
+    assert strip_hermes_mcp_tool_prefix(uses[0]["name"]) == "terminal"
+
+    results = extract_tool_result_blocks(user_evt)
+    assert len(results) == 1
+    assert results[0]["tool_use_id"] == "toolu_term_1"
+    assert "1784434336" in results[0]["content"]
+
+
+def test_stream_json_tool_use_result_projection():
+    """Real tool round-trip: clean final text + tool call surfaced."""
+    projector = ClaudeEventProjector()
+    started: list[str] = []
+    completed: list[str] = []
+    streamed_deltas: list[str] = []
+    for line in _GOLDEN_TOOL_STREAM_JSONL.splitlines():
+        state = projector.consume_line(line)
+        for rec in state.last_tool_started:
+            started.append(rec.name)
+        for rec in state.last_tool_completed:
+            completed.append(rec.name)
+        streamed_deltas.extend(state.last_text_deltas)
+
+    state = projector.state
+    assert state.finished is True
+    assert state.is_error is False
+    # (a) clean projected text — ONLY the timestamp, no thinking/json junk
+    assert state.final_text == "1784434336"
+    assert "thinking" not in state.final_text.lower()
+    assert "signature" not in state.final_text.lower()
+    assert "command" not in state.final_text
+    assert "<br>" not in state.final_text
+    # Live stream deltas assembled the same clean number (after message reset)
+    assert "".join(streamed_deltas) == "1784434336"
+    # (b) tool call surfaced end-to-end
+    assert state.tool_iterations == 1
+    assert started == ["terminal"]
+    assert completed == ["terminal"]
+    assert len(state.tool_calls) == 1
+    rec = state.tool_calls[0]
+    assert rec.raw_name == "mcp__hermes-tools__terminal"
+    assert rec.name == "terminal"
+    assert rec.input["command"] == "date +%s"
+    assert rec.completed is True
+    assert "1784434336" in (rec.result or "")
+    assert rec.id == "toolu_term_1"
+    assert rec.is_error is False
+
+
+def test_projector_ignores_thinking_and_json_deltas():
+    """thinking_delta / signature_delta / input_json_delta must not garble text."""
+    projector = ClaudeEventProjector()
+    for line in _GOLDEN_TOOL_STREAM_JSONL.splitlines():
+        projector.consume_line(line)
+    # streamed_text is only the final message's text_deltas
+    assert projector.state.streamed_text == "1784434336"
+    assert projector.state.assistant_text == "1784434336"
+    assert projector.state.result_text == "1784434336"
+
+
+def test_projector_resets_stream_on_message_start():
+    """Intermediate narration must not concatenate onto the final answer."""
+    projector = ClaudeEventProjector()
+    events = [
+        {
+            "type": "stream_event",
+            "event": {"type": "message_start", "message": {"role": "assistant"}},
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "I'll use the terminal tool"},
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "I'll use the terminal tool"},
+                    {
+                        "type": "tool_use",
+                        "id": "t1",
+                        "name": "mcp__hermes-tools__terminal",
+                        "input": {"command": "date +%s"},
+                    },
+                ]
+            },
+        },
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t1",
+                        "content": "1784434999\n",
+                    }
+                ]
+            },
+        },
+        {
+            "type": "stream_event",
+            "event": {"type": "message_start", "message": {"role": "assistant"}},
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "1784434999"},
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "1784434999"}]},
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "1784434999",
+        },
+    ]
+    for ev in events:
+        projector.consume(ev)
+    assert projector.state.final_text == "1784434999"
+    # No double-join of narration + number
+    assert "I'll use" not in projector.state.final_text
+    assert projector.state.tool_iterations == 1
+
+
+def test_stream_event_content_block_start_tool_use():
+    projector = ClaudeEventProjector()
+    line = json.dumps(
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_ws_1",
+                    "name": "mcp__hermes-tools__web_search",
+                    "input": {},
+                },
+            },
+            "session_id": "sess-s",
+        }
+    )
+    state = projector.consume_line(line)
+    assert len(state.last_tool_started) == 1
+    assert state.last_tool_started[0].name == "web_search"
+    assert state.tool_calls[0].raw_name.startswith(HERMES_MCP_TOOL_PREFIX)
+
+
+def test_session_tool_turn_fires_tool_events_and_counts():
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            self._lines = list(_GOLDEN_TOOL_STREAM_JSONL.splitlines(keepends=True))
+
+        def spawn(self, cfg):
+            # Capture that MCP was requested.
+            self.spawn_cfg = cfg
+            return None
+
+        def iter_stdout_lines(self, timeout=600.0):
+            yield from self._lines
+
+        def wait(self, timeout=5.0):
+            return 0
+
+        def stderr_tail(self, n=20):
+            return []
+
+        def close(self):
+            pass
+
+        def kill(self):
+            pass
+
+    events: list[dict] = []
+
+    def on_event(note):
+        events.append(note)
+
+    session = ClaudeCliSession(
+        oauth_token="sk-ant-oat01-TEST",
+        model="claude-opus-4-8",
+        client_factory=_FakeClient,
+        on_event=on_event,
+        enable_hermes_mcp=True,
+    )
+    turn = session.run_turn(
+        "Use the terminal tool to run exactly: date +%s — then reply with ONLY the number."
+    )
+    # Clean final text is the real tool output timestamp
+    assert turn.final_text == "1784434336"
+    assert turn.tool_iterations == 1
+    assert len(turn.tool_calls) == 1
+    assert turn.tool_calls[0]["name"] == "terminal"
+    assert turn.tool_calls[0]["raw_name"] == "mcp__hermes-tools__terminal"
+    assert turn.tool_calls[0]["arguments"]["command"] == "date +%s"
+    assert "1784434336" in (turn.tool_calls[0].get("result") or "")
+    methods = [e.get("method") for e in events]
+    assert "claude/tool_started" in methods
+    assert "claude/tool_completed" in methods
+    assert "claude/text_delta" in methods
+    assert "claude/assistant_completed" in methods
+    started = next(e for e in events if e["method"] == "claude/tool_started")
+    assert started["params"]["name"] == "terminal"
+    assert started["params"]["raw_name"] == "mcp__hermes-tools__terminal"
+    completed = next(e for e in events if e["method"] == "claude/tool_completed")
+    assert "1784434336" in (completed["params"].get("result") or "")
+    done = next(e for e in events if e["method"] == "claude/assistant_completed")
+    assert done["params"]["text"] == "1784434336"
+    assert done["params"].get("replace_stream") is True
+    # Streamed deltas join to clean number (no thinking/json leakage)
+    deltas = [
+        e["params"]["delta"]
+        for e in events
+        if e.get("method") == "claude/text_delta"
+    ]
+    assert "".join(deltas) == "1784434336"
+    session.close()
+
+
+def test_strip_hermes_mcp_tool_prefix_helpers():
+    assert strip_hermes_mcp_tool_prefix("mcp__hermes-tools__terminal") == "terminal"
+    assert strip_hermes_mcp_tool_prefix("terminal") == "terminal"
+    assert strip_hermes_mcp_tool_prefix("mcp__other__foo") == "foo"
+    assert is_hermes_mcp_tool_name("mcp__hermes-tools__read_file")
+    assert not is_hermes_mcp_tool_name("Bash")
+
+
+# ---------------------------------------------------------------------------
+# (g) Phase 2b multi-turn session create / resume
+# ---------------------------------------------------------------------------
+
+
+def test_new_claude_session_id_is_uuid():
+    sid = new_claude_session_id()
+    # Claude requires a valid UUID for --session-id.
+    parts = sid.split("-")
+    assert len(parts) == 5
+    assert len(sid) == 36
+
+
+def test_build_argv_session_id_on_create():
+    client = ClaudeCliClient(
+        oauth_token="sk-ant-oat01-TEST",
+        env=build_claude_cli_clean_env(oauth_token="sk-ant-oat01-TEST"),
+        claude_bin="/fake/claude",
+    )
+    sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    cfg = ClaudeCliSpawnConfig(
+        model="claude-opus-4-8",
+        prompt="Remember FALCON-42",
+        claude_bin="/fake/claude",
+        enable_hermes_mcp=True,
+        session_id=sid,
+    )
+    argv = client.build_argv(cfg)
+    assert "--session-id" in argv
+    assert argv[argv.index("--session-id") + 1] == sid
+    assert "--resume" not in argv
+    assert "--no-session-persistence" not in argv
+    # MCP + clean surface still present on create.
+    assert "--mcp-config" in argv
+    assert "--allowedTools" in argv
+    assert argv[-1] == "Remember FALCON-42"
+    client.close()
+
+
+def test_build_argv_resume_on_subsequent_turn():
+    client = ClaudeCliClient(
+        oauth_token="sk-ant-oat01-TEST",
+        env=build_claude_cli_clean_env(oauth_token="sk-ant-oat01-TEST"),
+        claude_bin="/fake/claude",
+    )
+    sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    cfg = ClaudeCliSpawnConfig(
+        model="claude-opus-4-8",
+        prompt="What was the codeword?",
+        claude_bin="/fake/claude",
+        enable_hermes_mcp=True,
+        resume=sid,
+        session_id="should-be-ignored-when-resume-set",
+    )
+    argv = client.build_argv(cfg)
+    assert "--resume" in argv
+    assert argv[argv.index("--resume") + 1] == sid
+    # Resume wins over session_id (mutually exclusive).
+    assert "--session-id" not in argv
+    assert "--no-session-persistence" not in argv
+    assert "--mcp-config" in argv
+    assert argv[-1] == "What was the codeword?"
+    client.close()
+
+
+class _CapturingFakeClient:
+    """Fake ClaudeCliClient that records spawn configs and yields JSONL."""
+
+    last_cfg: Optional[ClaudeCliSpawnConfig] = None
+    configs: list = []
+    lines_by_call: list = []
+
+    def __init__(self, *a, **k):
+        self._call = len(type(self).configs)
+
+    def spawn(self, cfg):
+        type(self).last_cfg = cfg
+        type(self).configs.append(cfg)
+        return None
+
+    def iter_stdout_lines(self, timeout=600.0):
+        idx = len(type(self).configs) - 1
+        lines = type(self).lines_by_call[idx] if idx < len(type(self).lines_by_call) else []
+        yield from lines
+
+    def wait(self, timeout=5.0):
+        return 0
+
+    def stderr_tail(self, n=20):
+        return []
+
+    def close(self):
+        pass
+
+    def kill(self):
+        pass
+
+    @classmethod
+    def reset(cls, lines_by_call):
+        cls.last_cfg = None
+        cls.configs = []
+        cls.lines_by_call = list(lines_by_call)
+
+
+def _success_jsonl(session_id: str, text: str) -> list[str]:
+    return [
+        json.dumps(
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": session_id,
+                "model": "claude-opus-4-8",
+            }
+        )
+        + "\n",
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": text}],
+                },
+                "session_id": session_id,
+            }
+        )
+        + "\n",
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": text,
+                "session_id": session_id,
+                "usage": {"input_tokens": 5, "output_tokens": 2},
+                "total_cost_usd": 0.0,
+            }
+        )
+        + "\n",
+    ]
+
+
+def test_session_turn1_creates_turn2_resumes_same_id(tmp_path):
+    """Turn 1 --session-id; turn 2 --resume with the SAME Claude session id."""
+    # Use a fixed returned id so we can assert mapping even if create uuid differs.
+    returned_id = "11111111-2222-3333-4444-555555555555"
+    _CapturingFakeClient.reset(
+        [
+            _success_jsonl(returned_id, "OK"),
+            _success_jsonl(returned_id, "FALCON-42"),
+        ]
+    )
+    session = ClaudeCliSession(
+        oauth_token="sk-ant-oat01-TEST",
+        model="claude-opus-4-8",
+        cwd=str(tmp_path),
+        client_factory=_CapturingFakeClient,
+        hermes_conversation_id="hermes-chat-abc",
+    )
+    t1 = session.run_turn("Remember this codeword: FALCON-42. Reply OK.")
+    assert t1.final_text == "OK"
+    assert t1.created_session is True
+    assert t1.resumed is False
+    assert t1.session_id == returned_id
+    assert t1.should_retire is False
+    assert session.claude_session_id == returned_id
+    assert session.turn_index == 1
+
+    cfg1 = _CapturingFakeClient.configs[0]
+    assert cfg1.session_id is not None  # generated UUID on create
+    assert cfg1.resume is None
+    assert cfg1.prompt.startswith("Remember this codeword")
+    # System prompt path: create may carry system_prompt (None in this test).
+    assert cfg1.system_prompt is None
+
+    t2 = session.run_turn("What was the codeword? Reply with only the codeword.")
+    assert t2.final_text == "FALCON-42"
+    assert t2.resumed is True
+    assert t2.created_session is False
+    assert t2.session_id == returned_id
+    assert session.claude_session_id == returned_id
+    assert session.turn_index == 2
+
+    cfg2 = _CapturingFakeClient.configs[1]
+    assert cfg2.resume == returned_id
+    assert cfg2.session_id is None
+    assert cfg2.prompt.startswith("What was the codeword")
+    # Resume must NOT re-append system prompt.
+    assert cfg2.system_prompt is None
+    # Stable cwd across turns (session file resolution).
+    assert cfg1.cwd == cfg2.cwd == str(tmp_path)
+    session.close()
+
+
+def test_session_mapping_persists_on_session_object(tmp_path):
+    returned_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    _CapturingFakeClient.reset([_success_jsonl(returned_id, "hi")])
+    session = ClaudeCliSession(
+        oauth_token="sk-ant-oat01-TEST",
+        model="claude-opus-4-8",
+        cwd=str(tmp_path),
+        client_factory=_CapturingFakeClient,
+        hermes_conversation_id="hermes-xyz",
+    )
+    assert session.claude_session_id is None
+    session.run_turn("hello")
+    assert session.claude_session_id == returned_id
+    assert session.hermes_conversation_id == "hermes-xyz"
+    # Mapping survives without re-create until reset.
+    assert session.claude_session_id == returned_id
+    session.reset_claude_session()
+    assert session.claude_session_id is None
+    session.close()
+
+
+def test_resume_missing_session_falls_back_to_create(tmp_path):
+    """Missing/expired --resume → clear mapping, create fresh --session-id."""
+    missing_id = "deadbeef-dead-beef-dead-beefdeadbeef"
+    fresh_id = "feedface-feed-face-feed-facefeedface"
+
+    class _ResumeThenCreateClient:
+        calls = 0
+        configs: list = []
+
+        def __init__(self, *a, **k):
+            pass
+
+        def spawn(self, cfg):
+            type(self).configs.append(cfg)
+            type(self).calls += 1
+            return None
+
+        def iter_stdout_lines(self, timeout=600.0):
+            if type(self).calls == 1:
+                # Resume attempt → missing session error.
+                yield json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "error",
+                        "is_error": True,
+                        "result": "No conversation found with session id",
+                        "session_id": missing_id,
+                    }
+                ) + "\n"
+            else:
+                for line in _success_jsonl(fresh_id, "fresh start"):
+                    yield line
+
+        def wait(self, timeout=5.0):
+            return 1 if type(self).calls == 1 else 0
+
+        def stderr_tail(self, n=20):
+            return ["session not found"] if type(self).calls == 1 else []
+
+        def close(self):
+            pass
+
+        def kill(self):
+            pass
+
+    _ResumeThenCreateClient.calls = 0
+    _ResumeThenCreateClient.configs = []
+
+    session = ClaudeCliSession(
+        oauth_token="sk-ant-oat01-TEST",
+        model="claude-opus-4-8",
+        cwd=str(tmp_path),
+        client_factory=_ResumeThenCreateClient,
+        claude_session_id=missing_id,  # force resume on first run_turn
+        hermes_conversation_id="hermes-resume-miss",
+    )
+    turn = session.run_turn("continue please")
+    assert turn.final_text == "fresh start"
+    assert turn.resume_fallback is True
+    assert turn.created_session is True
+    assert turn.session_id == fresh_id
+    assert session.claude_session_id == fresh_id
+    # First spawn resumed the dead id; second created a new session.
+    assert _ResumeThenCreateClient.configs[0].resume == missing_id
+    assert _ResumeThenCreateClient.configs[1].session_id is not None
+    assert _ResumeThenCreateClient.configs[1].resume is None
+    session.close()
+
+
+def test_is_resume_missing_error_hints():
+    assert is_resume_missing_error("No conversation found with that id")
+    assert is_resume_missing_error("session not found")
+    assert is_resume_missing_error("Unable to resume session")
+    assert not is_resume_missing_error("rate limited")
+    assert not is_resume_missing_error("")
+
+
+def test_hermes_history_has_prior_turns():
+    assert hermes_history_has_prior_turns(None) is False
+    assert hermes_history_has_prior_turns([]) is False
+    assert hermes_history_has_prior_turns([{"role": "system", "content": "x"}]) is False
+    assert hermes_history_has_prior_turns([{"role": "user", "content": "hi"}]) is False
+    assert (
+        hermes_history_has_prior_turns(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": "again"},
+            ]
+        )
+        is True
+    )
+
+
+def test_history_seed_note_on_preexisting_history(tmp_path):
+    returned_id = "99999999-8888-7777-6666-555555555555"
+    _CapturingFakeClient.reset([_success_jsonl(returned_id, "ok")])
+    session = ClaudeCliSession(
+        oauth_token="sk-ant-oat01-TEST",
+        model="claude-opus-4-8",
+        cwd=str(tmp_path),
+        client_factory=_CapturingFakeClient,
+    )
+    prior = [
+        {"role": "user", "content": "old1"},
+        {"role": "assistant", "content": "old2"},
+        {"role": "user", "content": "latest"},
+    ]
+    turn = session.run_turn("latest", messages=prior)
+    assert turn.history_seed_note is not None
+    assert "pre-seed" in turn.history_seed_note.lower() or "prior" in turn.history_seed_note.lower()
+    # Still only sent the latest prompt string (MVP).
+    assert _CapturingFakeClient.configs[0].prompt == "latest"
+    session.close()
+
+
+def test_runtime_reuses_agent_session_across_turns(tmp_path, monkeypatch):
+    """run_claude_cli_turn keeps agent._claude_cli_session like codex does."""
+    from agent import claude_runtime as cr
+
+    returned_id = "abcdef01-2345-6789-abcd-ef0123456789"
+    _CapturingFakeClient.reset(
+        [
+            _success_jsonl(returned_id, "OK"),
+            _success_jsonl(returned_id, "FALCON-42"),
+        ]
+    )
+
+    class _Agent:
+        api_key = "sk-ant-oat01-TEST"
+        model = "claude-opus-4-8"
+        provider = "anthropic"
+        base_url = "https://api.anthropic.com"
+        session_id = "hermes-sess-1"
+        session_cwd = str(tmp_path)
+        show_commentary = False
+        tool_progress_callback = None
+        _session_db = None
+        _session_db_created = False
+        session_api_calls = 0
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+        session_input_tokens = 0
+        session_output_tokens = 0
+        session_cache_read_tokens = 0
+        session_reasoning_tokens = 0
+        session_estimated_cost_usd = 0.0
+        session_cost_status = None
+        session_cost_source = None
+        context_compressor = None
+        _claude_cli_session = None
+
+        def _fire_stream_delta(self, *a, **k):
+            pass
+
+        def _emit_interim_assistant_message(self, *a, **k):
+            pass
+
+        def _sync_external_memory_for_turn(self, **k):
+            pass
+
+        def _spawn_background_review(self, **k):
+            pass
+
+        def _flush_messages_to_session_db(self, *a, **k):
+            pass
+
+        def _ensure_db_session(self):
+            pass
+
+    # Force session to use capturing client.
+    real_init = ClaudeCliSession.__init__
+
+    def _patched_init(self, *a, **k):
+        k = dict(k)
+        k["client_factory"] = _CapturingFakeClient
+        k.setdefault("cwd", str(tmp_path))
+        real_init(self, *a, **k)
+
+    monkeypatch.setattr(ClaudeCliSession, "__init__", _patched_init)
+    # Patch the token resolver used by run_claude_cli_turn / ClaudeCliSession.
+    monkeypatch.setattr(
+        "agent.transports.claude_cli_session.resolve_claude_cli_oauth_token",
+        lambda **kw: "sk-ant-oat01-TEST",
+    )
+
+    agent = _Agent()
+    r1 = cr.run_claude_cli_turn(
+        agent,
+        user_message="Remember this codeword: FALCON-42. Reply OK.",
+        original_user_message="Remember this codeword: FALCON-42. Reply OK.",
+        messages=[{"role": "user", "content": "Remember this codeword: FALCON-42. Reply OK."}],
+        effective_task_id="t1",
+    )
+    assert r1["completed"] is True
+    assert r1["final_response"] == "OK"
+    assert r1["claude_cli_session_id"] == returned_id
+    assert agent._claude_cli_session is not None
+    assert agent._claude_cli_session.claude_session_id == returned_id
+
+    r2 = cr.run_claude_cli_turn(
+        agent,
+        user_message="What was the codeword? Reply with only the codeword.",
+        original_user_message="What was the codeword? Reply with only the codeword.",
+        messages=[
+            {"role": "user", "content": "Remember this codeword: FALCON-42. Reply OK."},
+            {"role": "assistant", "content": "OK"},
+            {"role": "user", "content": "What was the codeword? Reply with only the codeword."},
+        ],
+        effective_task_id="t1",
+    )
+    assert r2["completed"] is True
+    assert r2["final_response"] == "FALCON-42"
+    assert r2["claude_cli_resumed"] is True
+    assert r2["claude_cli_session_id"] == returned_id
+    # Same session object reused.
+    assert agent._claude_cli_session.claude_session_id == returned_id
+    assert len(_CapturingFakeClient.configs) == 2
+    assert _CapturingFakeClient.configs[0].session_id is not None
+    assert _CapturingFakeClient.configs[1].resume == returned_id
+    agent._claude_cli_session.close()

--- a/tests/agent/test_claude_cli_token_resolve.py
+++ b/tests/agent/test_claude_cli_token_resolve.py
@@ -1,0 +1,267 @@
+"""Unit tests for claude_cli setup-token resolution (canonical root fallback).
+
+Resolution order under test:
+  1. explicit
+  2. profile / process env CLAUDE_CODE_OAUTH_TOKEN (legacy ANTHROPIC_TOKEN)
+  3. profile credential_pool OAuth
+  4. canonical Hermes root ~/.hermes/.env (get_default_hermes_root)
+  5. never rotating ~/.claude login
+
+No live network / claude binary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent.transports.claude_cli import ClaudeCliError
+from agent.transports.claude_cli_session import (
+    _read_canonical_root_setup_token,
+    _read_setup_token_keys_from_env_file,
+    resolve_claude_cli_oauth_token,
+)
+
+
+# Masked-looking fakes — never real secrets.
+_PROFILE_TOKEN = "sk-ant-oat01-PROFILE_TEST_TOKEN_NOT_REAL"
+_ROOT_TOKEN = "sk-ant-oat01-ROOT_TEST_TOKEN_NOT_REAL"
+_POOL_TOKEN = "sk-ant-oat01-POOL_TEST_TOKEN_NOT_REAL"
+_EXPLICIT_TOKEN = "sk-ant-oat01-EXPLICIT_TEST_TOKEN_NOT_REAL"
+_ROTATING_LOGIN_TOKEN = "sk-ant-oat01-ROTATING_LOGIN_TEST_TOKEN_NOT_REAL"
+
+
+@pytest.fixture
+def clean_token_env(monkeypatch):
+    """Strip process env sources so resolution only sees what each test sets."""
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+
+@pytest.fixture
+def no_pool(monkeypatch):
+    """Stub credential_pool so tests do not touch real auth.json."""
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._resolve_anthropic_pool_token",
+        lambda: None,
+    )
+
+
+@pytest.fixture
+def no_root_token(monkeypatch):
+    monkeypatch.setattr(
+        "agent.transports.claude_cli_session._read_canonical_root_setup_token",
+        lambda: None,
+    )
+
+
+def test_canonical_root_token_when_profile_has_none(
+    tmp_path, monkeypatch, clean_token_env, no_pool
+):
+    """Profile with no env/pool + root .env token → resolves root token."""
+    root = tmp_path / "hermes_root"
+    root.mkdir()
+    (root / ".env").write_text(
+        f"CLAUDE_CODE_OAUTH_TOKEN={_ROOT_TOKEN}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root",
+        lambda: root,
+    )
+
+    # Simulate a profile HERMES_HOME that does not contain the token.
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    got = resolve_claude_cli_oauth_token()
+    assert got == _ROOT_TOKEN
+
+
+def test_profile_env_wins_over_root(
+    tmp_path, monkeypatch, clean_token_env, no_pool
+):
+    """Profile env token wins over canonical root .env (order preserved)."""
+    root = tmp_path / "hermes_root"
+    root.mkdir()
+    (root / ".env").write_text(
+        f"CLAUDE_CODE_OAUTH_TOKEN={_ROOT_TOKEN}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root",
+        lambda: root,
+    )
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", _PROFILE_TOKEN)
+
+    got = resolve_claude_cli_oauth_token()
+    assert got == _PROFILE_TOKEN
+
+
+def test_explicit_wins_over_everything(
+    tmp_path, monkeypatch, clean_token_env, no_pool
+):
+    root = tmp_path / "hermes_root"
+    root.mkdir()
+    (root / ".env").write_text(
+        f"CLAUDE_CODE_OAUTH_TOKEN={_ROOT_TOKEN}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root",
+        lambda: root,
+    )
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", _PROFILE_TOKEN)
+
+    got = resolve_claude_cli_oauth_token(explicit=_EXPLICIT_TOKEN)
+    assert got == _EXPLICIT_TOKEN
+
+
+def test_pool_wins_over_root(tmp_path, monkeypatch, clean_token_env):
+    root = tmp_path / "hermes_root"
+    root.mkdir()
+    (root / ".env").write_text(
+        f"CLAUDE_CODE_OAUTH_TOKEN={_ROOT_TOKEN}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root",
+        lambda: root,
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._resolve_anthropic_pool_token",
+        lambda: _POOL_TOKEN,
+    )
+
+    got = resolve_claude_cli_oauth_token()
+    assert got == _POOL_TOKEN
+
+
+def test_no_token_anywhere_raises_clean_error(
+    monkeypatch, clean_token_env, no_pool, no_root_token
+):
+    with pytest.raises(ClaudeCliError, match="no Anthropic setup token"):
+        resolve_claude_cli_oauth_token()
+
+
+def test_rotating_claude_login_never_used(
+    monkeypatch, clean_token_env, no_pool, no_root_token
+):
+    """Even if resolve_anthropic_token / ~/.claude would yield a token, ignore it."""
+
+    def _boom_if_called():
+        raise AssertionError(
+            "resolve_anthropic_token must not be used for claude_cli "
+            "(would pull rotating ~/.claude login)"
+        )
+
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        _boom_if_called,
+    )
+    # Also stub the credentials readers so a mistaken import still fails loud.
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: {
+            "accessToken": _ROTATING_LOGIN_TOKEN,
+            "expiresAt": 9999999999999,
+        },
+    )
+
+    with pytest.raises(ClaudeCliError, match="no Anthropic setup token"):
+        resolve_claude_cli_oauth_token()
+
+
+def test_root_env_absent_is_graceful(
+    tmp_path, monkeypatch, clean_token_env, no_pool
+):
+    """Missing canonical root .env → no crash; falls through to clean error."""
+    root = tmp_path / "hermes_root_empty"
+    root.mkdir()
+    # deliberately no .env file
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root",
+        lambda: root,
+    )
+
+    with pytest.raises(ClaudeCliError, match="no Anthropic setup token"):
+        resolve_claude_cli_oauth_token()
+
+
+def test_root_env_unreadable_is_graceful(
+    tmp_path, monkeypatch, clean_token_env, no_pool
+):
+    """Unreadable root path → no crash."""
+    missing = tmp_path / "does_not_exist_root"
+    # do not create — get_default_hermes_root points at a non-existent dir
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root",
+        lambda: missing,
+    )
+
+    assert _read_canonical_root_setup_token() is None
+    with pytest.raises(ClaudeCliError, match="no Anthropic setup token"):
+        resolve_claude_cli_oauth_token()
+
+
+def test_read_env_file_legacy_anthropic_token_alias(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "ANTHROPIC_TOKEN=sk-ant-oat01-LEGACY_ALIAS_NOT_REAL\n",
+        encoding="utf-8",
+    )
+    assert (
+        _read_setup_token_keys_from_env_file(env_file)
+        == "sk-ant-oat01-LEGACY_ALIAS_NOT_REAL"
+    )
+
+
+def test_read_env_file_prefers_claude_code_oauth_token(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "ANTHROPIC_TOKEN=sk-ant-oat01-LEGACY_NOT_REAL\n"
+        f"CLAUDE_CODE_OAUTH_TOKEN={_ROOT_TOKEN}\n",
+        encoding="utf-8",
+    )
+    assert _read_setup_token_keys_from_env_file(env_file) == _ROOT_TOKEN
+
+
+def test_read_env_file_missing_returns_none(tmp_path):
+    assert _read_setup_token_keys_from_env_file(tmp_path / "nope.env") is None
+
+
+def test_agent_setup_shaped_key_counts_as_passed(
+    monkeypatch, clean_token_env, no_pool, no_root_token
+):
+    agent = SimpleNamespace(api_key=_PROFILE_TOKEN)
+    assert resolve_claude_cli_oauth_token(agent=agent) == _PROFILE_TOKEN
+
+
+def test_agent_setup_key_wins_over_root(
+    tmp_path, monkeypatch, clean_token_env, no_pool
+):
+    root = tmp_path / "hermes_root"
+    root.mkdir()
+    (root / ".env").write_text(
+        f"CLAUDE_CODE_OAUTH_TOKEN={_ROOT_TOKEN}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root",
+        lambda: root,
+    )
+    agent = SimpleNamespace(api_key=_PROFILE_TOKEN)
+    assert resolve_claude_cli_oauth_token(agent=agent) == _PROFILE_TOKEN
+
+
+def test_agent_plain_api_key_not_used_as_setup_token(
+    monkeypatch, clean_token_env, no_pool, no_root_token
+):
+    """Regular console API keys are not setup tokens for claude_cli injection."""
+    agent = SimpleNamespace(api_key="sk-ant-api03-NOT_A_SETUP_TOKEN")
+    with pytest.raises(ClaudeCliError, match="no Anthropic setup token"):
+        resolve_claude_cli_oauth_token(agent=agent)

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -138,6 +138,8 @@ class TestModuleSurface:
         assert callable(m._build_server)
         assert isinstance(m.EXPOSED_TOOLS, tuple)
         assert len(m.EXPOSED_TOOLS) > 0
+        assert callable(m.get_exposed_tools)
+        assert isinstance(m.CLAUDE_EXPOSED_TOOLS, tuple)
 
     def test_exposed_tools_are_safe_subset(self):
         """We MUST NOT expose tools codex already has, because codex'
@@ -154,6 +156,17 @@ class TestModuleSurface:
             f"these tools must NOT be exposed via the codex callback "
             f"because codex has built-in equivalents: {leaked}"
         )
+
+    def test_claude_profile_includes_terminal_fs(self):
+        """Claude profile must expose terminal/fs (native tools blocked)."""
+        from agent.transports.hermes_tools_mcp_server import (
+            CLAUDE_EXPOSED_TOOLS,
+            get_exposed_tools,
+        )
+        tools = set(get_exposed_tools("claude"))
+        for required in ("terminal", "read_file", "write_file", "patch", "search_files"):
+            assert required in tools
+        assert set(CLAUDE_EXPOSED_TOOLS) == tools
 
     def test_expected_hermes_specific_tools_listed(self):
         """The Hermes-specific tools should be present so users on the

--- a/website/docs/user-guide/features/claude-cli-runtime.md
+++ b/website/docs/user-guide/features/claude-cli-runtime.md
@@ -1,0 +1,150 @@
+---
+title: Claude CLI Runtime
+sidebar_label: Claude CLI Runtime
+---
+
+# Claude CLI Runtime
+
+Hermes can hand Anthropic Claude turns to a local [`claude -p`](https://docs.anthropic.com/en/docs/claude-code) subprocess (Claude Code CLI) instead of the Anthropic HTTP Messages API. When active, Max subscription billing and Claude Code's native session tools ride the CLI; Hermes still owns sessions, slash commands, the gateway, memory, and skill review.
+
+## Default-when-token (no per-profile flag required)
+
+For **provider `anthropic`** + a **Claude** model, Hermes defaults to `claude_cli` when **both** are true:
+
+1. A Claude Code **setup token** is resolvable (`CLAUDE_CODE_OAUTH_TOKEN` via profile env, credential pool, or the canonical root `~/.hermes/.env`)
+2. The **`claude` binary** is available on `PATH` (or `~/.local/bin/claude`)
+
+So switching **any** profile to a Claude model (CLI, gateway, desktop app model picker) lands on `claude -p` base Max **without** setting `anthropic_runtime: claude_cli` on that profile. Profiles that already have their own `config.yaml` and never inherit a root-level runtime key are covered.
+
+Environments **without** a setup token or without the `claude` binary are **unchanged**: they keep the HTTP `anthropic_messages` path exactly as before. Non-Anthropic providers (`openai-codex`, `xai-oauth`, etc.) are unaffected.
+
+## Precedence (explicit always wins)
+
+| Setting | Result |
+|---|---|
+| `model.anthropic_runtime: claude_cli` (or env `HERMES_ANTHROPIC_RUNTIME=claude_cli`) | Force `claude_cli` |
+| `model.anthropic_runtime: anthropic_messages` (aliases: `http`, `api`, `messages`, `off`) | Force HTTP (`anthropic_messages`) — **explicit opt-out** |
+| UNSET / `auto` + setup token + `claude` binary + Claude model | **Default** `claude_cli` |
+| UNSET / `auto` without token or binary | HTTP `anthropic_messages` (unchanged) |
+
+## Enable / opt-out
+
+Most fleets only need the setup token once in the root `.env` (see [Fleet setup](#fleet-setup)). Then any profile can switch to a Claude model:
+
+```bash
+# Interactive model picker for a profile (desktop app does the same)
+hermes -p <agent> model
+
+# Or pin provider + model — no anthropic_runtime required when token+binary exist
+hermes -p <agent> config set model.provider anthropic
+hermes -p <agent> config set model.default claude-opus-4-6
+```
+
+Force the CLI runtime explicitly (optional; same as the auto default when eligible):
+
+```yaml
+model:
+  provider: anthropic
+  default: claude-opus-4-6
+  anthropic_runtime: claude_cli
+```
+
+**Opt out** of the CLI path and keep HTTP (extra-usage / API credits):
+
+```yaml
+model:
+  provider: anthropic
+  default: claude-opus-4-6
+  anthropic_runtime: anthropic_messages   # or http / api
+```
+
+One-session override (does not rewrite config):
+
+```bash
+# Force CLI
+HERMES_ANTHROPIC_RUNTIME=claude_cli hermes -p <agent> chat
+
+# Force HTTP even if config enables claude_cli
+HERMES_ANTHROPIC_RUNTIME=anthropic_messages hermes -p <agent> chat
+```
+
+Requires the `claude` binary on `PATH` (`npm install -g @anthropic-ai/claude-code`) for the CLI path.
+
+## Auth: non-rotating setup token
+
+`claude_cli` injects **`CLAUDE_CODE_OAUTH_TOKEN`** into a clean child env. That value must be the **non-rotating setup token** from:
+
+```bash
+claude setup-token
+```
+
+Setup tokens look like `sk-ant-oat…` and last on the order of a year. They are **fork-safe** (like an API key): multiple Hermes profiles and other Claude Code consumers on the same login can use the same token concurrently without a shared lock or rotating-token store.
+
+**Do not** rely on the rotating `claude /login` session under `~/.claude` for this runtime. That login is not injected into the clean `claude -p` env and is not a resolution source for `claude_cli`.
+
+### Resolution order
+
+First hit wins:
+
+1. Explicit / passed token (`explicit=` argument, or agent-held setup/OAuth-shaped key)
+2. Profile / process env `CLAUDE_CODE_OAUTH_TOKEN` (legacy alias: `ANTHROPIC_TOKEN`)
+3. Profile anthropic credential_pool (`claude_code` / `env:CLAUDE_CODE_OAUTH_TOKEN` OAuth entries)
+4. **Canonical Hermes root** `~/.hermes/.env` → `CLAUDE_CODE_OAUTH_TOKEN` (fleet fallback)
+5. Never the rotating `~/.claude` login
+
+Only if **no** source yields a token does Hermes treat the CLI path as unavailable (auto falls back to HTTP; explicit `claude_cli` raises a clear setup error at turn time).
+
+The token is a **secret**: store it in `.env` (or the credential pool), never in `config.yaml`.
+
+## Fleet setup
+
+Put the setup token **once** in the platform Hermes root env file:
+
+```bash
+# ~/.hermes/.env  (canonical root — not a profile directory)
+CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...   # from `claude setup-token`
+```
+
+Every profile then resolves that same token on demand when profile env and credential_pool have none. You do **not** need to copy the token into each `~/.hermes/profiles/<name>/.env`, and you do **not** need `anthropic_runtime: claude_cli` on each profile's `config.yaml`.
+
+Then switch any agent to a Claude model:
+
+```bash
+hermes -p <agent> model
+# or
+hermes -p <agent> config set model.provider anthropic
+hermes -p <agent> config set model.default claude-opus-4-6
+```
+
+Regenerate the setup token about yearly with `claude setup-token` and update the single root `.env` line.
+
+### Optional: per-profile override
+
+If one profile should use a different token, set `CLAUDE_CODE_OAUTH_TOKEN` in that profile's own `.env` or credential pool — profile sources win over the canonical root.
+
+If one profile must stay on HTTP (extra-usage API path), set:
+
+```yaml
+model:
+  anthropic_runtime: anthropic_messages
+```
+
+## Concurrency
+
+Host-global caps limit concurrent Hermes `claude -p` children so other Claude Code consumers on the same Max login still have headroom. Configure under `model.claude_cli` in `config.yaml`:
+
+```yaml
+model:
+  claude_cli:
+    max_concurrent: 3                 # default 3; 0 = unbounded
+    acquire_timeout_seconds: 45       # wait then fall back
+```
+
+See the concurrency notes in the developer guide / Phase 2c tests for slot reaping and fallback behavior.
+
+## What this runtime does not change
+
+- Base Max / subscription billing still goes through Claude Code's CLI path.
+- Hermes MCP tools, multi-turn session resume, host concurrency, and auxiliary-model handling stay as implemented for `claude_cli` (no HTTP Anthropic aux for `claude_cli` turns).
+- Non-secret settings stay in `config.yaml`; secrets stay in `.env`.
+- Profiles and hosts **without** a setup token or `claude` binary keep pure HTTP Anthropic — no forced dependency.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -96,6 +96,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/delegation',
             'user-guide/features/kanban',
             'user-guide/features/codex-app-server-runtime',
+            'user-guide/features/claude-cli-runtime',
             'user-guide/features/kanban-tutorial',
             'user-guide/features/kanban-worker-lanes',
             'user-guide/features/goals',


### PR DESCRIPTION
## Problem

Hermes' default Anthropic path authenticates a Claude Code OAuth / setup token over **HTTP** (`anthropic_messages`). Anthropic bills that path to **extra-usage / API credits**, **not** the base Claude Max / Pro subscription allowance that Claude Code itself consumes.

Base-plan billing is gated to the **first-party `claude` binary's transport**. Header / user-agent spoofing over HTTP does **not** change the billing bucket (verified against live Max accounts). Users who want Claude on Hermes against their included Max/Pro quota currently have no supported path — only extra credits or a pay-per-token API key.

## Solution

Add an opt-in **`claude_cli` runtime backend** — the Anthropic twin of the existing `codex_app_server` runtime — that:

1. Spawns the real **`claude -p --output-format stream-json`** binary as a subprocess
2. Uses a **scrubbed clean env** + the non-rotating Claude Code **setup token** (`CLAUDE_CODE_OAUTH_TOKEN`) so billing rides the first-party transport → **base Max/Pro subscription**
3. Exposes **Hermes tools via MCP** (`hermes_tools_mcp_server`), with Claude's native fs/exec tools (**Bash / Edit / Write / Read / …**) **disallowed** — single agent surface, no double-agent
4. Carries **multi-turn** context via Claude session **`--session-id` / `--resume`** (Claude owns history + native compaction)
5. Enforces a **host-global concurrency semaphore** so multiple Hermes profiles share one subscription safely (bounded wait, then fail into the profile fallback chain)
6. **Skips Hermes HTTP compression / title aux** for these turns (Claude owns compaction; tiny aux must not pay for a full `claude -p` spawn)

### Fleet setup / on-demand switching

One non-rotating Claude Code setup token goes **once** in the canonical root `~/.hermes/.env`:

```bash
# ~/.hermes/.env  (canonical platform root — not a profile directory)
CLAUDE_CODE_OAUTH_TOKEN=...   # from `claude setup-token`
```

The runtime's token resolver falls back to that root file, so **every profile** resolves the same token with **no per-profile copies**. Resolution order:

1. Explicit token argument (tests / internal callers)
2. Profile / process env `CLAUDE_CODE_OAUTH_TOKEN` (legacy alias: `ANTHROPIC_TOKEN`)
3. Profile anthropic `credential_pool` OAuth entries (`claude_code` / `env:CLAUDE_CODE_OAUTH_TOKEN`)
4. **Canonical Hermes root** `~/.hermes/.env` → `CLAUDE_CODE_OAUTH_TOKEN` (fleet fallback)

**Never** the rotating `~/.claude` login session.

Then switch **any** agent to Claude on demand via `hermes -p <agent> model` or `config.yaml`:

```yaml
model:
  provider: anthropic
  default: claude-sonnet-4-6   # any base-subscription Claude model
  anthropic_runtime: claude_cli
```

Changeable Claude ↔ Grok ↔ GPT anytime; opt-in per profile. The token stays a **secret** in `.env` (never `config.yaml`) — non-secret settings (runtime selection, concurrency) live in `config.yaml` per AGENTS.md (secrets in `.env` only).

## Config (user-facing = config.yaml only)

Per AGENTS.md (config.yaml for behavioral settings; no new user-facing `HERMES_*` env vars):

```yaml
model:
  provider: anthropic
  default: claude-sonnet-4-6
  anthropic_runtime: claude_cli          # enable runtime
  claude_cli:
    max_concurrent: 3                    # host-global; 0 = unbounded
    acquire_timeout_seconds: 45
```

| Key | Role |
|---|---|
| `model.anthropic_runtime` | `claude_cli` enables; unset/`auto` keeps HTTP |
| `model.claude_cli.max_concurrent` | Host-global concurrent `claude -p` cap (default 3) |
| `model.claude_cli.acquire_timeout_seconds` | Wait before concurrency error (default 45s) |

**Internal-only env bridges** (tests / one-session override — not the documented surface): `HERMES_ANTHROPIC_RUNTIME`, `HERMES_CLAUDE_CLI_MAX_CONCURRENT`, `HERMES_CLAUDE_CLI_ACQUIRE_TIMEOUT`, `HERMES_CLAUDE_CLI_SLOT_DIR`.

Docs: [Claude CLI Runtime](website/docs/user-guide/features/claude-cli-runtime.md) (includes fleet setup + token resolution).

## Design

Mirrors existing runtime backends (`codex_app_server`, copilot ACP patterns):

- New `api_mode`: `claude_cli` (gated in `hermes_cli/runtime_provider.py` when provider is `anthropic` and config opts in)
- Early branch in `agent/conversation_loop.py` → `agent.claude_runtime.run_claude_cli_turn`
- Session reuse via `agent._claude_cli_session` (analogous to `agent._codex_session`)
- Transport modules under `agent/transports/claude_cli*.py` + event projector
- MCP bridge reuses / extends `hermes_tools_mcp_server`
- Token resolution prefers profile sources, then fleet root `.env` (never rotating `~/.claude` login)

## Testing

**Unit (this PR) — 94 tests, all passing on rebased tip:**

- `tests/agent/test_claude_cli_runtime.py` (44)
- `tests/agent/test_claude_cli_concurrency.py` (14)
- `tests/agent/test_claude_cli_aux.py` (5)
- `tests/agent/test_claude_cli_token_resolve.py` (14)
- `tests/agent/transports/test_hermes_tools_mcp_server.py` (17)

```bash
scripts/run_tests.sh \
  tests/agent/test_claude_cli_runtime.py \
  tests/agent/test_claude_cli_concurrency.py \
  tests/agent/test_claude_cli_aux.py \
  tests/agent/test_claude_cli_token_resolve.py \
  tests/agent/transports/test_hermes_tools_mcp_server.py -q
```

**Live E2E (author verification, not CI):** base-subscription billing confirmed against Max; real MCP tool round-trip; multi-turn context retention via resume; concurrency cap enforced; compaction ownership (Hermes HTTP aux skipped); fleet root-token resolution across profiles.

## Scope

**OPT-IN only.** Inert unless a profile sets `model.anthropic_runtime: claude_cli`. The default Anthropic HTTP path is **unchanged**. No new required dependencies for users who never enable it (beyond optional local `claude` CLI when opted in).

## Requirements (when enabled)

- `claude` binary installed and on `PATH`
- Claude Max / Pro subscription + non-rotating setup token (`claude setup-token`) in root or profile `.env` / credential pool
- Anthropic provider on the profile
