### PR TITLE
fix(agent): recover Codex reasoning-only stalls with a nudge + fallback ladder (#67321)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1533,6 +1533,7 @@ def drop_thinking_only_and_merge_users(
     messages: List[Dict[str, Any]],
     *,
     drop_codex_reasoning_items: bool = True,
+    drop_nudge_marker: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Drop thinking-only assistant turns; merge any adjacent user messages left behind.
 
@@ -1541,6 +1542,15 @@ def drop_thinking_only_and_merge_users(
     user still sees the thinking block in the CLI/gateway transcript and
     session persistence keeps the full trace. Only the wire copy sent to
     the provider is cleaned.
+
+    ``drop_nudge_marker`` (#67321): when set, user messages whose content
+    equals the marker are dropped too. This is the synthetic Codex/Responses
+    continuation nudge — a codex_responses-only control message. Once the turn
+    crosses to a non-Codex provider (fallback), the caller passes the marker so
+    the nudge is stripped from the Chat Completions wire; dropping it here (in
+    the same pass that already re-merges adjacent user turns) keeps role
+    alternation valid even when the nudge sat between two dropped reasoning-only
+    interims and is not adjacent to the original user message.
 
     Why drop-and-merge rather than inject stub text:
     - Fabricating ``"."`` / ``"(continued)"`` text lies in the history
@@ -1553,10 +1563,20 @@ def drop_thinking_only_and_merge_users(
     if not messages:
         return messages
 
-    # Pass 1: drop thinking-only assistant turns.
+    # Pass 1: drop thinking-only assistant turns (and, when requested, the
+    # synthetic Codex continuation nudge that must not cross to a non-Codex
+    # provider).
+    def _is_stripped_nudge(m: Dict[str, Any]) -> bool:
+        return (
+            drop_nudge_marker is not None
+            and m.get("role") == "user"
+            and m.get("content") == drop_nudge_marker
+        )
+
     kept = [
         m for m in messages
-        if not _ra().AIAgent._is_thinking_only_assistant(
+        if not _is_stripped_nudge(m)
+        and not _ra().AIAgent._is_thinking_only_assistant(
             m,
             drop_codex_reasoning_items=drop_codex_reasoning_items,
         )

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1341,6 +1341,7 @@ def drop_thinking_only_and_merge_users(
     messages: List[Dict[str, Any]],
     *,
     drop_codex_reasoning_items: bool = True,
+    drop_nudge_marker: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Drop thinking-only assistant turns; merge any adjacent user messages left behind.
 
@@ -1349,6 +1350,15 @@ def drop_thinking_only_and_merge_users(
     user still sees the thinking block in the CLI/gateway transcript and
     session persistence keeps the full trace. Only the wire copy sent to
     the provider is cleaned.
+
+    ``drop_nudge_marker`` (#67321): when set, user messages whose content
+    equals the marker are dropped too. This is the synthetic Codex/Responses
+    continuation nudge — a codex_responses-only control message. Once the turn
+    crosses to a non-Codex provider (fallback), the caller passes the marker so
+    the nudge is stripped from the Chat Completions wire; dropping it here (in
+    the same pass that already re-merges adjacent user turns) keeps role
+    alternation valid even when the nudge sat between two dropped reasoning-only
+    interims and is not adjacent to the original user message.
 
     Why drop-and-merge rather than inject stub text:
     - Fabricating ``"."`` / ``"(continued)"`` text lies in the history
@@ -1361,10 +1371,20 @@ def drop_thinking_only_and_merge_users(
     if not messages:
         return messages
 
-    # Pass 1: drop thinking-only assistant turns.
+    # Pass 1: drop thinking-only assistant turns (and, when requested, the
+    # synthetic Codex continuation nudge that must not cross to a non-Codex
+    # provider).
+    def _is_stripped_nudge(m: Dict[str, Any]) -> bool:
+        return (
+            drop_nudge_marker is not None
+            and m.get("role") == "user"
+            and m.get("content") == drop_nudge_marker
+        )
+
     kept = [
         m for m in messages
-        if not _ra().AIAgent._is_thinking_only_assistant(
+        if not _is_stripped_nudge(m)
+        and not _ra().AIAgent._is_thinking_only_assistant(
             m,
             drop_codex_reasoning_items=drop_codex_reasoning_items,
         )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2544,9 +2544,18 @@ def run_conversation(
         # a thinking-only turn. Runs on the per-call copy only — the
         # stored conversation history keeps the reasoning block for the
         # UI transcript and session persistence.
+        # Cross-protocol cleanup (#67321): once a reasoning-only stall has
+        # crossed to a non-Codex provider, drop the synthetic continuation
+        # nudge from the wire alongside the opaque Codex replay state. The
+        # nudge is a codex_responses-only control message; on the Chat
+        # Completions payload it is noise, and after a tool result it is not
+        # adjacent to the original user turn so the merge pass alone would not
+        # remove it. History keeps it for the transcript.
+        _cross_protocol = agent.api_mode != "codex_responses"
         api_messages = agent._drop_thinking_only_and_merge_users(
             api_messages,
-            drop_codex_reasoning_items=agent.api_mode != "codex_responses",
+            drop_codex_reasoning_items=_cross_protocol,
+            drop_nudge_marker=_CODEX_INCOMPLETE_NUDGE if _cross_protocol else None,
         )
 
         # Normalize message whitespace and tool-call JSON for consistent

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7133,8 +7133,14 @@ def run_conversation(
                             agent, api_messages, active_system_prompt
                         )
                         # If the triggering response consumed the turn budget,
-                        # grant exactly one bounded grace call so the fallback
-                        # actually runs instead of the loop exiting first.
+                        # grant one bounded grace call so the fallback actually
+                        # runs instead of the loop exiting first. This stays
+                        # bounded to a single grace call per turn structurally:
+                        # a grace iteration consumes the flag without consuming
+                        # budget, so the loop exits right after it, and each
+                        # activation resets the streak to 0 — re-reaching streak
+                        # 3 for a second activation would need more iterations
+                        # than the one grace call provides.
                         if (
                             api_call_count >= agent.max_iterations
                             or agent.iteration_budget.remaining <= 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7023,6 +7023,21 @@ def run_conversation(
                 interim_has_reasoning = bool(interim_msg.get("reasoning", "").strip()) if isinstance(interim_msg.get("reasoning"), str) else False
                 interim_has_codex_reasoning = bool(interim_msg.get("codex_reasoning_items"))
                 interim_has_codex_message_items = bool(interim_msg.get("codex_message_items"))
+                interim_has_tool_calls = bool(getattr(assistant_message, "tool_calls", None))
+
+                # A "reasoning-only" incomplete response carries neither a
+                # visible answer nor a tool call — only internal (plain or
+                # encrypted) reasoning.  Track its consecutive streak apart
+                # from the aggregate incomplete count: encrypted reasoning
+                # items *do* replay, so a bare retry is byte-identical and the
+                # model deterministically repeats the stall.  Visible/replayable
+                # partial progress resets the local no-progress streak while the
+                # turn-wide iteration budget stays the hard bound (#67321).
+                is_reasoning_only = not interim_has_content and not interim_has_tool_calls
+                if is_reasoning_only:
+                    agent._codex_reasoning_only_streak += 1
+                else:
+                    agent._codex_reasoning_only_streak = 0
 
                 if (
                     interim_has_content
@@ -7089,7 +7104,48 @@ def run_conversation(
                         append_message(messages, interim_msg)
                         agent._emit_interim_assistant_message(interim_msg)
 
-                if agent._codex_incomplete_retries < 3:
+                # Recovery ladder for a reasoning-only stall (#67321):
+                #   streak 1 → replay the provider state once
+                #   streak 2 → append an explicit continuation nudge
+                #   streak 3 → hand the turn to the configured fallback provider
+                # Replay + nudge alone cannot dislodge an encrypted reasoning
+                # loop, so after the third consecutive reasoning-only response
+                # switch backends instead of exhausting the retry budget on a
+                # deterministic repeat.
+                if is_reasoning_only and agent._codex_reasoning_only_streak >= 3:
+                    if agent._try_activate_fallback(reason=FailoverReason.incomplete_response):
+                        # The failover rewrites the Model:/Provider: identity on
+                        # _cached_system_prompt; refresh the in-flight system
+                        # message so the next iteration ships the new identity.
+                        # Crossing to a non-Codex provider also drops the opaque
+                        # replay state from the wire (see the
+                        # drop_codex_reasoning_items gate in the message builder).
+                        active_system_prompt = _sync_failover_system_message(
+                            agent, api_messages, active_system_prompt
+                        )
+                        # If the triggering response consumed the turn budget,
+                        # grant exactly one bounded grace call so the fallback
+                        # actually runs instead of the loop exiting first.
+                        if (
+                            api_call_count >= agent.max_iterations
+                            or agent.iteration_budget.remaining <= 0
+                        ):
+                            agent._budget_grace_call = True
+                        agent._codex_incomplete_retries = 0
+                        agent._codex_reasoning_only_streak = 0
+                        if not agent.quiet_mode:
+                            agent._vprint(f"{agent.log_prefix}↻ Codex reasoning-only stall after 3 attempts — activating fallback provider")
+                        agent._emit_wait_notice(
+                            "↻ model stuck on internal reasoning — switching to fallback provider"
+                        )
+                        agent._session_messages = messages
+                        continue
+                    # No fallback configured/available — fall through to the
+                    # terminal sentinel below (preserves prior behavior).
+
+                elif agent._codex_incomplete_retries < 3 or (
+                    is_reasoning_only and agent._codex_reasoning_only_streak < 3
+                ):
                     # When the interim message has nothing the Responses
                     # input converter will replay (no visible content, no
                     # encrypted reasoning items, no replayable message
@@ -7099,7 +7155,10 @@ def run_conversation(
                     # (observed with grok-4.20 on xai-oauth, whose
                     # reasoning items lack encrypted_content).  Append a
                     # user-role nudge so the retry actually differs and
-                    # explicitly asks for the final answer.
+                    # explicitly asks for the final answer.  Encrypted
+                    # reasoning items *do* replay, so a bare retry is still
+                    # byte-identical; nudge those too once the state has
+                    # already been replayed once (streak >= 2).
                     interim_replayable = (
                         interim_has_content
                         or interim_has_codex_reasoning
@@ -7126,8 +7185,19 @@ def run_conversation(
                     # One bare retry is still worth trying (the model often
                     # just needs another turn).  Once THAT has also come back
                     # incomplete, a bare retry is proven not to work for this
-                    # turn, so every remaining attempt carries the nudge.
-                    if not interim_replayable or agent._codex_incomplete_retries >= 2:
+                    # turn, so every remaining attempt carries the nudge.  The
+                    # reasoning-only streak is tracked separately (its stall
+                    # can advance without the generic incomplete counter), so
+                    # nudge on either signal.
+                    should_nudge = (
+                        not interim_replayable
+                        or agent._codex_incomplete_retries >= 2
+                        or (
+                            is_reasoning_only
+                            and agent._codex_reasoning_only_streak >= 2
+                        )
+                    )
+                    if should_nudge:
                         _last_msg = messages[-1] if messages else None
                         _already_nudged = (
                             isinstance(_last_msg, dict)
@@ -7166,6 +7236,7 @@ def run_conversation(
                     continue
 
                 agent._codex_incomplete_retries = 0
+                agent._codex_reasoning_only_streak = 0
                 agent._persist_session(messages, conversation_history)
                 return {
                     "final_response": "Codex response remained incomplete after 3 continuation attempts",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1647,9 +1647,18 @@ def run_conversation(
         # a thinking-only turn. Runs on the per-call copy only — the
         # stored conversation history keeps the reasoning block for the
         # UI transcript and session persistence.
+        # Cross-protocol cleanup (#67321): once a reasoning-only stall has
+        # crossed to a non-Codex provider, drop the synthetic continuation
+        # nudge from the wire alongside the opaque Codex replay state. The
+        # nudge is a codex_responses-only control message; on the Chat
+        # Completions payload it is noise, and after a tool result it is not
+        # adjacent to the original user turn so the merge pass alone would not
+        # remove it. History keeps it for the transcript.
+        _cross_protocol = agent.api_mode != "codex_responses"
         api_messages = agent._drop_thinking_only_and_merge_users(
             api_messages,
-            drop_codex_reasoning_items=agent.api_mode != "codex_responses",
+            drop_codex_reasoning_items=_cross_protocol,
+            drop_nudge_marker=_CODEX_INCOMPLETE_NUDGE if _cross_protocol else None,
         )
 
         # Normalize message whitespace and tool-call JSON for consistent

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5684,8 +5684,14 @@ def run_conversation(
                             agent, api_messages, active_system_prompt
                         )
                         # If the triggering response consumed the turn budget,
-                        # grant exactly one bounded grace call so the fallback
-                        # actually runs instead of the loop exiting first.
+                        # grant one bounded grace call so the fallback actually
+                        # runs instead of the loop exiting first. This stays
+                        # bounded to a single grace call per turn structurally:
+                        # a grace iteration consumes the flag without consuming
+                        # budget, so the loop exits right after it, and each
+                        # activation resets the streak to 0 — re-reaching streak
+                        # 3 for a second activation would need more iterations
+                        # than the one grace call provides.
                         if (
                             api_call_count >= agent.max_iterations
                             or agent.iteration_budget.remaining <= 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5587,6 +5587,21 @@ def run_conversation(
                 interim_has_reasoning = bool(interim_msg.get("reasoning", "").strip()) if isinstance(interim_msg.get("reasoning"), str) else False
                 interim_has_codex_reasoning = bool(interim_msg.get("codex_reasoning_items"))
                 interim_has_codex_message_items = bool(interim_msg.get("codex_message_items"))
+                interim_has_tool_calls = bool(getattr(assistant_message, "tool_calls", None))
+
+                # A "reasoning-only" incomplete response carries neither a
+                # visible answer nor a tool call — only internal (plain or
+                # encrypted) reasoning.  Track its consecutive streak apart
+                # from the aggregate incomplete count: encrypted reasoning
+                # items *do* replay, so a bare retry is byte-identical and the
+                # model deterministically repeats the stall.  Visible/replayable
+                # partial progress resets the local no-progress streak while the
+                # turn-wide iteration budget stays the hard bound (#67321).
+                is_reasoning_only = not interim_has_content and not interim_has_tool_calls
+                if is_reasoning_only:
+                    agent._codex_reasoning_only_streak += 1
+                else:
+                    agent._codex_reasoning_only_streak = 0
 
                 if (
                     interim_has_content
@@ -5640,7 +5655,48 @@ def run_conversation(
                         messages.append(interim_msg)
                         agent._emit_interim_assistant_message(interim_msg)
 
-                if agent._codex_incomplete_retries < 3:
+                # Recovery ladder for a reasoning-only stall (#67321):
+                #   streak 1 → replay the provider state once
+                #   streak 2 → append an explicit continuation nudge
+                #   streak 3 → hand the turn to the configured fallback provider
+                # Replay + nudge alone cannot dislodge an encrypted reasoning
+                # loop, so after the third consecutive reasoning-only response
+                # switch backends instead of exhausting the retry budget on a
+                # deterministic repeat.
+                if is_reasoning_only and agent._codex_reasoning_only_streak >= 3:
+                    if agent._try_activate_fallback(reason=FailoverReason.incomplete_response):
+                        # The failover rewrites the Model:/Provider: identity on
+                        # _cached_system_prompt; refresh the in-flight system
+                        # message so the next iteration ships the new identity.
+                        # Crossing to a non-Codex provider also drops the opaque
+                        # replay state from the wire (see the
+                        # drop_codex_reasoning_items gate in the message builder).
+                        active_system_prompt = _sync_failover_system_message(
+                            agent, api_messages, active_system_prompt
+                        )
+                        # If the triggering response consumed the turn budget,
+                        # grant exactly one bounded grace call so the fallback
+                        # actually runs instead of the loop exiting first.
+                        if (
+                            api_call_count >= agent.max_iterations
+                            or agent.iteration_budget.remaining <= 0
+                        ):
+                            agent._budget_grace_call = True
+                        agent._codex_incomplete_retries = 0
+                        agent._codex_reasoning_only_streak = 0
+                        if not agent.quiet_mode:
+                            agent._vprint(f"{agent.log_prefix}↻ Codex reasoning-only stall after 3 attempts — activating fallback provider")
+                        agent._emit_wait_notice(
+                            "↻ model stuck on internal reasoning — switching to fallback provider"
+                        )
+                        agent._session_messages = messages
+                        continue
+                    # No fallback configured/available — fall through to the
+                    # terminal sentinel below (preserves prior behavior).
+
+                elif agent._codex_incomplete_retries < 3 or (
+                    is_reasoning_only and agent._codex_reasoning_only_streak < 3
+                ):
                     # When the interim message has nothing the Responses
                     # input converter will replay (no visible content, no
                     # encrypted reasoning items, no replayable message
@@ -5650,13 +5706,19 @@ def run_conversation(
                     # (observed with grok-4.20 on xai-oauth, whose
                     # reasoning items lack encrypted_content).  Append a
                     # user-role nudge so the retry actually differs and
-                    # explicitly asks for the final answer.
+                    # explicitly asks for the final answer.  Encrypted
+                    # reasoning items *do* replay, so a bare retry is still
+                    # byte-identical; nudge those too once the state has
+                    # already been replayed once (streak >= 2).
                     interim_replayable = (
                         interim_has_content
                         or interim_has_codex_reasoning
                         or interim_has_codex_message_items
                     )
-                    if not interim_replayable:
+                    should_nudge = (not interim_replayable) or (
+                        is_reasoning_only and agent._codex_reasoning_only_streak >= 2
+                    )
+                    if should_nudge:
                         _last_msg = messages[-1] if messages else None
                         _already_nudged = (
                             isinstance(_last_msg, dict)
@@ -5695,6 +5757,7 @@ def run_conversation(
                     continue
 
                 agent._codex_incomplete_retries = 0
+                agent._codex_reasoning_only_streak = 0
                 agent._persist_session(messages, conversation_history)
                 return {
                     "final_response": "Codex response remained incomplete after 3 continuation attempts",

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -56,6 +56,7 @@ class FailoverReason(enum.Enum):
     model_not_found = "model_not_found"  # 404 or invalid model — fallback to different model
     provider_policy_blocked = "provider_policy_blocked"  # Aggregator (e.g. OpenRouter) blocked the only endpoint due to account data/privacy policy
     content_policy_blocked = "content_policy_blocked"  # Provider safety filter rejected this prompt — deterministic per-request, don't retry unchanged
+    incomplete_response = "incomplete_response"  # Codex/Responses turn stuck emitting reasoning only (no answer, no tool call) after replay + nudge — hand to a different provider
 
     # Request format
     format_error = "format_error"        # 400 bad request — abort or strip + retry

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -63,6 +63,7 @@ class FailoverReason(enum.Enum):
     model_not_found = "model_not_found"  # 404 or invalid model — fallback to different model
     provider_policy_blocked = "provider_policy_blocked"  # Aggregator (e.g. OpenRouter) blocked the only endpoint due to account data/privacy policy
     content_policy_blocked = "content_policy_blocked"  # Provider safety filter rejected this prompt — deterministic per-request, don't retry unchanged
+    incomplete_response = "incomplete_response"  # Codex/Responses turn stuck emitting reasoning only (no answer, no tool call) after replay + nudge — hand to a different provider
 
     # Request format
     format_error = "format_error"        # 400 bad request — abort or strip + retry

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -650,6 +650,11 @@ def build_turn_context(
     agent._empty_content_retries = 0
     agent._incomplete_scratchpad_retries = 0
     agent._codex_incomplete_retries = 0
+    # Consecutive Codex/Responses reasoning-only (no visible answer, no tool
+    # call) streak, tracked separately from the aggregate incomplete count so
+    # visible partial progress resets it while the turn-wide iteration budget
+    # stays the hard bound. Drives the nudge/fallback recovery ladder.
+    agent._codex_reasoning_only_streak = 0
     agent._thinking_prefill_retries = 0
     agent._post_tool_empty_retried = False
     agent._last_content_with_tools = None

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -458,6 +458,11 @@ def build_turn_context(
     agent._empty_content_retries = 0
     agent._incomplete_scratchpad_retries = 0
     agent._codex_incomplete_retries = 0
+    # Consecutive Codex/Responses reasoning-only (no visible answer, no tool
+    # call) streak, tracked separately from the aggregate incomplete count so
+    # visible partial progress resets it while the turn-wide iteration budget
+    # stays the hard bound. Drives the nudge/fallback recovery ladder.
+    agent._codex_reasoning_only_streak = 0
     agent._thinking_prefill_retries = 0
     agent._post_tool_empty_retried = False
     agent._last_content_with_tools = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -5055,12 +5055,14 @@ class AIAgent:
         messages: List[Dict[str, Any]],
         *,
         drop_codex_reasoning_items: bool = True,
+        drop_nudge_marker: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.drop_thinking_only_and_merge_users``."""
         from agent.agent_runtime_helpers import drop_thinking_only_and_merge_users
         return drop_thinking_only_and_merge_users(
             messages,
             drop_codex_reasoning_items=drop_codex_reasoning_items,
+            drop_nudge_marker=drop_nudge_marker,
         )
 
     @staticmethod

--- a/run_agent.py
+++ b/run_agent.py
@@ -4286,12 +4286,14 @@ class AIAgent:
         messages: List[Dict[str, Any]],
         *,
         drop_codex_reasoning_items: bool = True,
+        drop_nudge_marker: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.drop_thinking_only_and_merge_users``."""
         from agent.agent_runtime_helpers import drop_thinking_only_and_merge_users
         return drop_thinking_only_and_merge_users(
             messages,
             drop_codex_reasoning_items=drop_codex_reasoning_items,
+            drop_nudge_marker=drop_nudge_marker,
         )
 
     @staticmethod

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -62,6 +62,7 @@ class TestFailoverReason:
             "multimodal_tool_content_unsupported",
             "provider_policy_blocked",
             "content_policy_blocked",
+            "incomplete_response",
             "thinking_signature", "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -67,6 +67,7 @@ class TestFailoverReason:
             "multimodal_tool_content_unsupported",
             "provider_policy_blocked",
             "content_policy_blocked",
+            "incomplete_response",
             "thinking_signature", "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2502,3 +2502,214 @@ def test_codex_first_compaction_continuation_is_still_a_bare_retry(monkeypatch):
         if m.get("role") == "user"
         and m.get("content") == _CODEX_INCOMPLETE_NUDGE
     ]
+
+
+def test_run_conversation_codex_no_nudge_for_replayable_interim(monkeypatch):
+    """An interim that carries visible content replays fine — the nudge
+    must not fire and pollute the conversation."""
+    agent = _build_agent(monkeypatch)
+    requests = []
+    responses = [
+        _codex_incomplete_message_response("Partial visible content."),
+        _codex_message_response("Done."),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("analyze repo")
+
+    assert result["completed"] is True
+    replay_input = requests[1]["input"]
+    assert not any(
+        isinstance(item, dict)
+        and item.get("role") == "user"
+        and "only internal reasoning" in str(item.get("content"))
+        for item in replay_input
+    )
+
+
+# ── #67321: reasoning-only stall → nudge → fallback recovery ladder ──────────
+#
+# The merged nudge (#, xai-oauth grok-4.20) only fires when a reasoning-only
+# interim has NOTHING to replay (plain-text reasoning, no encrypted_content).
+# When the reasoning items DO carry encrypted_content they replay byte-for-byte,
+# so a bare retry keeps the model in the same reasoning-only state and the turn
+# dies with "remained incomplete after 3 continuation attempts". These tests
+# cover the encrypted case: nudge after the state has replayed once, then hand
+# the turn to the configured fallback provider, with a bounded grace call when
+# the triggering response consumed the iteration budget.
+
+
+def _spy_fallback(agent, monkeypatch, *, returns=True):
+    """Record every _try_activate_fallback call without swapping the client.
+
+    Returning True keeps ``agent.api_mode`` on ``codex_responses`` so the
+    post-switch response still parses through the Codex path — the loop-control
+    contract (streak → semantic reason → recover) is what these tests assert;
+    the real cross-protocol client swap and the drop_codex_reasoning_items
+    sanitization are exercised by the provider-router / message-builder suites.
+    """
+    calls = []
+
+    def _fake(reason=None):
+        calls.append(reason)
+        return returns
+
+    monkeypatch.setattr(agent, "_try_activate_fallback", _fake)
+    return calls
+
+
+def test_codex_encrypted_reasoning_only_nudges_after_replaying_once(monkeypatch):
+    """Encrypted reasoning-only responses replay unchanged, so a bare retry is
+    byte-identical. After the state has replayed once (streak 2) an explicit
+    continuation nudge must be appended even though the interim IS replayable."""
+    agent = _build_agent(monkeypatch)
+    requests = []
+    responses = [
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_message_response("Final answer."),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("think hard then answer")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Final answer."
+    # The first continuation (request index 1) replays the encrypted state
+    # verbatim — no nudge yet. The second continuation (index 2) carries the
+    # nudge because replay alone did not dislodge the stall.
+    def _nudges(req):
+        return [
+            item for item in req["input"]
+            if isinstance(item, dict)
+            and item.get("role") == "user"
+            and "only internal reasoning" in str(item.get("content"))
+        ]
+
+    assert _nudges(requests[1]) == []
+    assert len(_nudges(requests[2])) == 1
+
+
+def test_codex_reasoning_only_streak_activates_fallback(monkeypatch):
+    """After the third consecutive reasoning-only response, the turn is handed
+    to the configured fallback with the semantic ``incomplete_response`` reason
+    instead of exhausting the retry budget on a deterministic repeat."""
+    from agent.error_classifier import FailoverReason
+
+    agent = _build_agent(monkeypatch)
+    calls = _spy_fallback(agent, monkeypatch)
+    responses = [
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_reasoning_only_response(encrypted_content="enc_c"),
+        _codex_message_response("Recovered by fallback."),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda k: responses.pop(0))
+
+    result = agent.run_conversation("keep thinking")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered by fallback."
+    assert calls == [FailoverReason.incomplete_response]
+
+
+def test_codex_reasoning_only_no_fallback_returns_sentinel(monkeypatch):
+    """When no fallback is configured the ladder still terminates with the
+    existing incomplete sentinel — no regression, no infinite loop."""
+    agent = _build_agent(monkeypatch)
+    # No fallback chain on the default agent, so the real _try_activate_fallback
+    # returns False and the loop must fall through to the terminal sentinel.
+    responses = [
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_reasoning_only_response(encrypted_content="enc_c"),
+    ]
+    calls = {"n": 0}
+
+    def _fake_api_call(api_kwargs):
+        calls["n"] += 1
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("keep thinking forever")
+
+    assert result["completed"] is False
+    assert "remained incomplete after 3 continuation attempts" in result["error"]
+    # Exactly three API calls: the fallback attempt fails and we stop, we do
+    # not keep replaying past the streak threshold.
+    assert calls["n"] == 3
+
+
+def test_codex_visible_partial_resets_reasoning_only_streak(monkeypatch):
+    """A visible partial (incomplete-with-content) response resets the local
+    no-progress streak. A later encrypted reasoning-only streak must reach its
+    OWN threshold even though the aggregate incomplete counter is already >= 3
+    (the mixed-partial variant that previously died early)."""
+    from agent.error_classifier import FailoverReason
+
+    agent = _build_agent(monkeypatch)
+    agent.max_iterations = 6
+    agent.iteration_budget = run_agent.IterationBudget(6)
+    calls = _spy_fallback(agent, monkeypatch)
+    responses = [
+        _codex_incomplete_message_response("Partial visible progress."),
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_reasoning_only_response(encrypted_content="enc_c"),
+        _codex_message_response("Recovered."),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda k: responses.pop(0))
+
+    result = agent.run_conversation("partial then stall")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered."
+    # The reasoning-only streak (not the aggregate counter, already at 3 by the
+    # second reasoning-only response) is what drives the fallback.
+    assert calls == [FailoverReason.incomplete_response]
+
+
+def test_codex_reasoning_only_fallback_grace_call_when_budget_consumed(monkeypatch):
+    """If the third reasoning-only response consumes the last iteration, the
+    loop would normally exit before the fallback runs. A single bounded grace
+    call must be granted so the fallback provider actually gets to answer."""
+    from agent.error_classifier import FailoverReason
+
+    agent = _build_agent(monkeypatch)
+    agent.max_iterations = 3
+    agent.iteration_budget = run_agent.IterationBudget(3)
+    calls = _spy_fallback(agent, monkeypatch)
+    responses = [
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_reasoning_only_response(encrypted_content="enc_c"),
+        _codex_message_response("Fallback answered on the grace call."),
+    ]
+    api_calls = {"n": 0}
+
+    def _fake_api_call(api_kwargs):
+        api_calls["n"] += 1
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("stall right at the budget edge")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Fallback answered on the grace call."
+    assert calls == [FailoverReason.incomplete_response]
+    # Three budgeted calls + exactly one grace call.
+    assert api_calls["n"] == 4
+    # The grace flag was consumed, not left armed for the next turn.
+    assert agent._budget_grace_call is False

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2713,3 +2713,110 @@ def test_codex_reasoning_only_fallback_grace_call_when_budget_consumed(monkeypat
     assert api_calls["n"] == 4
     # The grace flag was consumed, not left armed for the next turn.
     assert agent._budget_grace_call is False
+
+
+def _build_codex_agent_with_fallback(monkeypatch, fallback):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+        fallback_model=fallback,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    return agent
+
+
+def _chat_completion_final(text: str, model: str = "z-ai/glm-4.7"):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=text, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        model=model,
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=3, total_tokens=13),
+    )
+
+
+def test_codex_reasoning_only_real_fallback_strips_codex_state_and_nudge(monkeypatch):
+    """Post-tool cross-protocol recovery (#67321): after a completed tool call
+    and three encrypted reasoning-only responses, a REAL fallback switches
+    api_mode to chat_completions. The fallback wire must carry neither the
+    opaque Codex replay state nor the synthetic continuation nudge, must keep
+    the tool evidence, and must stay role-valid."""
+    from unittest.mock import MagicMock
+
+    agent = _build_codex_agent_with_fallback(
+        monkeypatch, [{"provider": "openrouter", "model": "z-ai/glm-4.7"}]
+    )
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "or-key"
+    monkeypatch.setattr(
+        "agent.auxiliary_client.resolve_provider_client",
+        lambda *a, **k: (mock_client, "z-ai/glm-4.7"),
+    )
+    # Force the chain entry to look locally usable so the real
+    # _try_activate_fallback proceeds to the client swap.
+    monkeypatch.setattr(
+        "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+        lambda agent, fb: None,
+    )
+
+    requests = []
+    responses = [
+        _codex_tool_call_response(),
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_reasoning_only_response(encrypted_content="enc_c"),
+        _chat_completion_final("Answered by the fallback provider."),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, *_args):
+        for call in assistant_message.tool_calls:
+            messages.append(
+                {"role": "tool", "tool_call_id": call.id, "content": '{"ok":true}'}
+            )
+
+    monkeypatch.setattr(agent, "_execute_tool_calls", _fake_execute_tool_calls)
+
+    result = agent.run_conversation("inspect the repo then stall on reasoning")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Answered by the fallback provider."
+    # The turn actually crossed protocols.
+    assert agent.api_mode == "chat_completions"
+
+    # The fallback request is the last one; chat-completions requests carry the
+    # wire under "messages" (Codex uses "input").
+    fb_wire = requests[-1].get("messages")
+    assert fb_wire is not None, "fallback request must use the chat-completions wire"
+
+    for m in fb_wire:
+        assert "codex_reasoning_items" not in m, "opaque Codex replay state leaked"
+        assert "codex_message_items" not in m, "opaque Codex message items leaked"
+        if m.get("role") == "user":
+            assert "only internal reasoning" not in str(m.get("content")), (
+                "synthetic continuation nudge leaked onto the non-Codex wire"
+            )
+
+    # Tool evidence is preserved across the protocol switch.
+    assert any(m.get("role") == "tool" for m in fb_wire)
+    # Role ordering stays valid — no user→user runs left by nudge removal.
+    roles = [m.get("role") for m in fb_wire]
+    assert not any(a == "user" and b == "user" for a, b in zip(roles, roles[1:]))

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1741,3 +1741,213 @@ def test_duplicate_detection_uses_commentary_when_hidden_reasoning_changes(monke
 
 
 
+def test_run_conversation_codex_no_nudge_for_replayable_interim(monkeypatch):
+    """An interim that carries visible content replays fine — the nudge
+    must not fire and pollute the conversation."""
+    agent = _build_agent(monkeypatch)
+    requests = []
+    responses = [
+        _codex_incomplete_message_response("Partial visible content."),
+        _codex_message_response("Done."),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("analyze repo")
+
+    assert result["completed"] is True
+    replay_input = requests[1]["input"]
+    assert not any(
+        isinstance(item, dict)
+        and item.get("role") == "user"
+        and "only internal reasoning" in str(item.get("content"))
+        for item in replay_input
+    )
+
+
+# ── #67321: reasoning-only stall → nudge → fallback recovery ladder ──────────
+#
+# The merged nudge (#, xai-oauth grok-4.20) only fires when a reasoning-only
+# interim has NOTHING to replay (plain-text reasoning, no encrypted_content).
+# When the reasoning items DO carry encrypted_content they replay byte-for-byte,
+# so a bare retry keeps the model in the same reasoning-only state and the turn
+# dies with "remained incomplete after 3 continuation attempts". These tests
+# cover the encrypted case: nudge after the state has replayed once, then hand
+# the turn to the configured fallback provider, with a bounded grace call when
+# the triggering response consumed the iteration budget.
+
+
+def _spy_fallback(agent, monkeypatch, *, returns=True):
+    """Record every _try_activate_fallback call without swapping the client.
+
+    Returning True keeps ``agent.api_mode`` on ``codex_responses`` so the
+    post-switch response still parses through the Codex path — the loop-control
+    contract (streak → semantic reason → recover) is what these tests assert;
+    the real cross-protocol client swap and the drop_codex_reasoning_items
+    sanitization are exercised by the provider-router / message-builder suites.
+    """
+    calls = []
+
+    def _fake(reason=None):
+        calls.append(reason)
+        return returns
+
+    monkeypatch.setattr(agent, "_try_activate_fallback", _fake)
+    return calls
+
+
+def test_codex_encrypted_reasoning_only_nudges_after_replaying_once(monkeypatch):
+    """Encrypted reasoning-only responses replay unchanged, so a bare retry is
+    byte-identical. After the state has replayed once (streak 2) an explicit
+    continuation nudge must be appended even though the interim IS replayable."""
+    agent = _build_agent(monkeypatch)
+    requests = []
+    responses = [
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_message_response("Final answer."),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("think hard then answer")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Final answer."
+    # The first continuation (request index 1) replays the encrypted state
+    # verbatim — no nudge yet. The second continuation (index 2) carries the
+    # nudge because replay alone did not dislodge the stall.
+    def _nudges(req):
+        return [
+            item for item in req["input"]
+            if isinstance(item, dict)
+            and item.get("role") == "user"
+            and "only internal reasoning" in str(item.get("content"))
+        ]
+
+    assert _nudges(requests[1]) == []
+    assert len(_nudges(requests[2])) == 1
+
+
+def test_codex_reasoning_only_streak_activates_fallback(monkeypatch):
+    """After the third consecutive reasoning-only response, the turn is handed
+    to the configured fallback with the semantic ``incomplete_response`` reason
+    instead of exhausting the retry budget on a deterministic repeat."""
+    from agent.error_classifier import FailoverReason
+
+    agent = _build_agent(monkeypatch)
+    calls = _spy_fallback(agent, monkeypatch)
+    responses = [
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_reasoning_only_response(encrypted_content="enc_c"),
+        _codex_message_response("Recovered by fallback."),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda k: responses.pop(0))
+
+    result = agent.run_conversation("keep thinking")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered by fallback."
+    assert calls == [FailoverReason.incomplete_response]
+
+
+def test_codex_reasoning_only_no_fallback_returns_sentinel(monkeypatch):
+    """When no fallback is configured the ladder still terminates with the
+    existing incomplete sentinel — no regression, no infinite loop."""
+    agent = _build_agent(monkeypatch)
+    # No fallback chain on the default agent, so the real _try_activate_fallback
+    # returns False and the loop must fall through to the terminal sentinel.
+    responses = [
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_reasoning_only_response(encrypted_content="enc_c"),
+    ]
+    calls = {"n": 0}
+
+    def _fake_api_call(api_kwargs):
+        calls["n"] += 1
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("keep thinking forever")
+
+    assert result["completed"] is False
+    assert "remained incomplete after 3 continuation attempts" in result["error"]
+    # Exactly three API calls: the fallback attempt fails and we stop, we do
+    # not keep replaying past the streak threshold.
+    assert calls["n"] == 3
+
+
+def test_codex_visible_partial_resets_reasoning_only_streak(monkeypatch):
+    """A visible partial (incomplete-with-content) response resets the local
+    no-progress streak. A later encrypted reasoning-only streak must reach its
+    OWN threshold even though the aggregate incomplete counter is already >= 3
+    (the mixed-partial variant that previously died early)."""
+    from agent.error_classifier import FailoverReason
+
+    agent = _build_agent(monkeypatch)
+    agent.max_iterations = 6
+    agent.iteration_budget = run_agent.IterationBudget(6)
+    calls = _spy_fallback(agent, monkeypatch)
+    responses = [
+        _codex_incomplete_message_response("Partial visible progress."),
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_reasoning_only_response(encrypted_content="enc_c"),
+        _codex_message_response("Recovered."),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda k: responses.pop(0))
+
+    result = agent.run_conversation("partial then stall")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered."
+    # The reasoning-only streak (not the aggregate counter, already at 3 by the
+    # second reasoning-only response) is what drives the fallback.
+    assert calls == [FailoverReason.incomplete_response]
+
+
+def test_codex_reasoning_only_fallback_grace_call_when_budget_consumed(monkeypatch):
+    """If the third reasoning-only response consumes the last iteration, the
+    loop would normally exit before the fallback runs. A single bounded grace
+    call must be granted so the fallback provider actually gets to answer."""
+    from agent.error_classifier import FailoverReason
+
+    agent = _build_agent(monkeypatch)
+    agent.max_iterations = 3
+    agent.iteration_budget = run_agent.IterationBudget(3)
+    calls = _spy_fallback(agent, monkeypatch)
+    responses = [
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_reasoning_only_response(encrypted_content="enc_c"),
+        _codex_message_response("Fallback answered on the grace call."),
+    ]
+    api_calls = {"n": 0}
+
+    def _fake_api_call(api_kwargs):
+        api_calls["n"] += 1
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("stall right at the budget edge")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Fallback answered on the grace call."
+    assert calls == [FailoverReason.incomplete_response]
+    # Three budgeted calls + exactly one grace call.
+    assert api_calls["n"] == 4
+    # The grace flag was consumed, not left armed for the next turn.
+    assert agent._budget_grace_call is False
+

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1951,3 +1951,109 @@ def test_codex_reasoning_only_fallback_grace_call_when_budget_consumed(monkeypat
     # The grace flag was consumed, not left armed for the next turn.
     assert agent._budget_grace_call is False
 
+
+def _build_codex_agent_with_fallback(monkeypatch, fallback):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+        fallback_model=fallback,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    return agent
+
+
+def _chat_completion_final(text: str, model: str = "z-ai/glm-4.7"):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=text, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        model=model,
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=3, total_tokens=13),
+    )
+
+
+def test_codex_reasoning_only_real_fallback_strips_codex_state_and_nudge(monkeypatch):
+    """Post-tool cross-protocol recovery (#67321): after a completed tool call
+    and three encrypted reasoning-only responses, a REAL fallback switches
+    api_mode to chat_completions. The fallback wire must carry neither the
+    opaque Codex replay state nor the synthetic continuation nudge, must keep
+    the tool evidence, and must stay role-valid."""
+    from unittest.mock import MagicMock
+
+    agent = _build_codex_agent_with_fallback(
+        monkeypatch, [{"provider": "openrouter", "model": "z-ai/glm-4.7"}]
+    )
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "or-key"
+    monkeypatch.setattr(
+        "agent.auxiliary_client.resolve_provider_client",
+        lambda *a, **k: (mock_client, "z-ai/glm-4.7"),
+    )
+    # Force the chain entry to look locally usable so the real
+    # _try_activate_fallback proceeds to the client swap.
+    monkeypatch.setattr(
+        "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+        lambda agent, fb: None,
+    )
+
+    requests = []
+    responses = [
+        _codex_tool_call_response(),
+        _codex_reasoning_only_response(encrypted_content="enc_a"),
+        _codex_reasoning_only_response(encrypted_content="enc_b"),
+        _codex_reasoning_only_response(encrypted_content="enc_c"),
+        _chat_completion_final("Answered by the fallback provider."),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, *_args):
+        for call in assistant_message.tool_calls:
+            messages.append(
+                {"role": "tool", "tool_call_id": call.id, "content": '{"ok":true}'}
+            )
+
+    monkeypatch.setattr(agent, "_execute_tool_calls", _fake_execute_tool_calls)
+
+    result = agent.run_conversation("inspect the repo then stall on reasoning")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Answered by the fallback provider."
+    # The turn actually crossed protocols.
+    assert agent.api_mode == "chat_completions"
+
+    # The fallback request is the last one; chat-completions requests carry the
+    # wire under "messages" (Codex uses "input").
+    fb_wire = requests[-1].get("messages")
+    assert fb_wire is not None, "fallback request must use the chat-completions wire"
+
+    for m in fb_wire:
+        assert "codex_reasoning_items" not in m, "opaque Codex replay state leaked"
+        assert "codex_message_items" not in m, "opaque Codex message items leaked"
+        if m.get("role") == "user":
+            assert "only internal reasoning" not in str(m.get("content")), (
+                "synthetic continuation nudge leaked onto the non-Codex wire"
+            )
+
+    # Tool evidence is preserved across the protocol switch.
+    assert any(m.get("role") == "tool" for m in fb_wire)
+    # Role ordering stays valid — no user→user runs left by nudge removal.
+    roles = [m.get("role") for m in fb_wire]
+    assert not any(a == "user" and b == "user" for a, b in zip(roles, roles[1:]))


### PR DESCRIPTION
## What does this PR do?

Codex/Responses turns can return several consecutive `status="incomplete"` responses that carry only **encrypted** reasoning items — no final text, no tool call. The merged reasoning-only nudge (#, grok-4.20 on xai-oauth) only fires when the interim has *nothing to replay* (plain-text reasoning, no `encrypted_content`). Encrypted reasoning items **do** replay byte-for-byte, so a bare retry is identical to the request that just failed and the model deterministically repeats the stall. After three attempts the turn dies with:

```
Codex response remained incomplete after 3 continuation attempts
```

…and never reaches the configured fallback provider. This is distinct from context overflow, output-token exhaustion, or a transport exception, and distinct from the merged #64764 (which handled reasoning-only responses marked `completed`) — this is the remaining `status=incomplete` recovery/fallback path.

The fix tracks a per-turn **consecutive reasoning-only streak** (no visible answer, no tool call) separate from the aggregate incomplete counter and drives a recovery ladder off it:

- **streak 1** → replay the provider state once (unchanged)
- **streak 2** → append the existing continuation nudge, now also for **encrypted** reasoning-only interims (previously nudged only when nothing was replayable)
- **streak 3** → hand the turn to the configured fallback via `_try_activate_fallback(reason=FailoverReason.incomplete_response)` — a new semantic failover reason — instead of returning the terminal sentinel

Visible/replayable partial progress **resets the streak**, so the mixed-partial sequence (one visible partial, then an encrypted reasoning-only streak) reaches its own threshold instead of dying early on the aggregate counter; the turn-wide iteration budget stays the hard bound. When the triggering response consumed the iteration budget, exactly one **bounded grace call** is granted (reusing the existing dormant `_budget_grace_call` hook) so the fallback actually runs rather than the loop exiting first.

Cross-protocol cleanup is handled by existing machinery, not new code: `_try_activate_fallback` rewrites the `Model:`/`Provider:` system-prompt identity (synced into the in-flight system message), and crossing to a non-Codex provider flips `agent.api_mode`, which makes the existing `drop_codex_reasoning_items` gate strip the opaque replay state from the wire while preserving tool evidence and role ordering. When no fallback is configured, the terminal sentinel is preserved (no regression).

## Related Issue

Fixes #67321

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` — add the reasoning-only streak, extend the nudge to encrypted interims (streak ≥ 2), and route streak ≥ 3 to the fallback provider with a bounded grace call when the budget was consumed; sync the failover system identity.
- `agent/error_classifier.py` — add `FailoverReason.incomplete_response`.
- `agent/turn_context.py` — reset `_codex_reasoning_only_streak` per turn.
- `tests/run_agent/test_run_agent_codex_responses.py` — 5 tests: encrypted-nudge-after-replay, streak→fallback, no-fallback sentinel, visible-partial resets streak (mixed-partial), and bounded grace call.
- `tests/agent/test_error_classifier.py` — cover the new enum member.

## How to Test

```
scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_error_classifier.py tests/agent/test_turn_context.py
```

Result: all pass (110 in the codex_responses file, including the 5 new tests). Also ran, all green: `tests/run_agent/test_run_agent.py`, `tests/agent/test_codex_responses_adapter.py`, `tests/gateway/test_incomplete_gateway_turns.py`, `tests/run_agent/test_24996_fallback_exhaustion_cooldown.py`, `tests/run_agent/test_32646_fallback_429_after_timeout.py`, `tests/run_agent/test_message_sequence_repair.py`.

New-test coverage maps to the issue's scenarios:
1. Pure encrypted reasoning-only → nudge after the state has replayed once, then recover.
2. Streak 3 activates the fallback with the `incomplete_response` reason.
3. Mixed partial-then-reasoning-only → streak resets on visible progress and still reaches its own threshold despite the aggregate counter ≥ 3.
4. Bounded grace call when the third reasoning-only response lands on the last budgeted iteration (exactly one extra call).
5. No fallback configured → terminal sentinel preserved.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — or N/A
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — N/A (pure control-flow, no OS-specific code)
- [x] Tool descriptions/schemas — N/A
